### PR TITLE
Align rate-limit backoff and account reset handling

### DIFF
--- a/app/core/utils/retry.py
+++ b/app/core/utils/retry.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import random
 import re
 
 _RETRY_PATTERN = re.compile(r"(?i)try again in\s*(\d+(?:\.\d+)?)\s*(s|ms|seconds?)")
+_BACKOFF_INITIAL_DELAY_MS = 200
+_BACKOFF_FACTOR = 2.0
+_BACKOFF_JITTER_MIN = 0.9
+_BACKOFF_JITTER_MAX = 1.1
 
 
 def parse_retry_after(message: str) -> float | None:
@@ -14,3 +19,12 @@ def parse_retry_after(message: str) -> float | None:
     if unit == "ms":
         return value / 1000
     return value
+
+
+def backoff_seconds(attempt: int) -> float:
+    if attempt < 1:
+        attempt = 1
+    exponent = _BACKOFF_FACTOR ** (attempt - 1)
+    base_ms = _BACKOFF_INITIAL_DELAY_MS * exponent
+    jitter = random.uniform(_BACKOFF_JITTER_MIN, _BACKOFF_JITTER_MAX)
+    return (base_ms * jitter) / 1000.0

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -20,7 +20,7 @@ from app.modules.usage.repository import UsageRepository
 
 @dataclass
 class RuntimeState:
-    reset_at: int | None = None
+    reset_at: float | None = None
     last_error_at: float | None = None
     last_selected_at: float | None = None
     error_count: int = 0
@@ -179,10 +179,10 @@ def _apply_secondary_quota(
     *,
     status: AccountStatus,
     primary_used: float | None,
-    runtime_reset: int | None,
+    runtime_reset: float | None,
     secondary_used: float | None,
     secondary_reset: int | None,
-) -> tuple[AccountStatus, float | None, int | None]:
+) -> tuple[AccountStatus, float | None, float | None]:
     used_percent = primary_used
     reset_at = runtime_reset
 

--- a/app/static/index.js
+++ b/app/static/index.js
@@ -569,16 +569,9 @@
 			return acc;
 		}, {});
 
-	const mergeUsageIntoAccounts = (
-		accounts,
-		primaryUsage,
-		secondaryUsage,
-		summary,
-	) => {
+	const mergeUsageIntoAccounts = (accounts, primaryUsage, secondaryUsage) => {
 		const primaryMap = buildUsageIndex(primaryUsage || []);
 		const secondaryMap = buildUsageIndex(secondaryUsage || []);
-		const resetAtPrimary = summary?.primaryWindow?.resetAt ?? null;
-		const resetAtSecondary = summary?.secondaryWindow?.resetAt ?? null;
 		return accounts.map((account) => {
 			const primaryRow = primaryMap[account.id];
 			const secondaryRow = secondaryMap[account.id];
@@ -598,8 +591,8 @@
 						account.usage?.secondaryRemainingPercent ??
 						0,
 				},
-				resetAtPrimary: resetAtPrimary ?? account.resetAtPrimary ?? null,
-				resetAtSecondary: resetAtSecondary ?? account.resetAtSecondary ?? null,
+				resetAtPrimary: account.resetAtPrimary ?? null,
+				resetAtSecondary: account.resetAtSecondary ?? null,
 			};
 		});
 	};
@@ -1191,7 +1184,6 @@
 						accountsResult.value,
 						primaryUsage,
 						secondaryUsage,
-						summary,
 					);
 					this.applyData(
 						{


### PR DESCRIPTION
## Summary
- keep per-account quota reset timestamps in the dashboard merge
- match Codex rate-limit delay behavior (parse "try again in" or fall back to backoff)
- add regression tests for account reset timestamps and rate-limit delays

## Testing
- pytest tests/unit/test_load_balancer.py
- pytest tests/integration/test_accounts_api_extended.py -k reset