### PR TITLE
fix(dashboard): remove rounding in avgPerHour calculation

### DIFF
--- a/app/static/index.js
+++ b/app/static/index.js
@@ -788,7 +788,7 @@
 			typeof windowMinutes === "number" && windowMinutes > 0
 				? windowMinutes / 60
 				: 24 * 7;
-		return Math.round(numeric / hours);
+		return numeric / hours;
 	};
 
 	const countByStatus = (accounts) =>


### PR DESCRIPTION
## Summary
- Remove `Math.round()` from `avgPerHour` function that was causing incorrect hourly cost display
- Previously showed only $0.00 or whole dollar amounts ($1.00, $2.00) due to integer rounding
- Now displays accurate decimal values (e.g., $0.30, $0.89) formatted by `currencyFormatter`

Fixes #26

## Test plan
- [x] Verify dashboard shows accurate "Avg per hour" values with decimal places
- [x] Confirm values like $0.30/hour display correctly instead of $0.00
- [x] Check that the currency formatting still applies correctly (2 decimal places)