### PR TITLE
fix(accounts): handle OAuth re-link with duplicate email

### DIFF
--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -19,18 +19,18 @@ class AccountsRepository:
     async def upsert(self, account: Account) -> Account:
         existing = await self._session.get(Account, account.id)
         if existing:
-            existing.chatgpt_account_id = account.chatgpt_account_id
-            existing.email = account.email
-            existing.plan_type = account.plan_type
-            existing.access_token_encrypted = account.access_token_encrypted
-            existing.refresh_token_encrypted = account.refresh_token_encrypted
-            existing.id_token_encrypted = account.id_token_encrypted
-            existing.last_refresh = account.last_refresh
-            existing.status = account.status
-            existing.deactivation_reason = account.deactivation_reason
+            _apply_account_updates(existing, account)
             await self._session.commit()
             await self._session.refresh(existing)
             return existing
+
+        result = await self._session.execute(select(Account).where(Account.email == account.email))
+        existing_by_email = result.scalar_one_or_none()
+        if existing_by_email:
+            _apply_account_updates(existing_by_email, account)
+            await self._session.commit()
+            await self._session.refresh(existing_by_email)
+            return existing_by_email
 
         self._session.add(account)
         await self._session.commit()
@@ -89,3 +89,15 @@ class AccountsRepository:
         )
         await self._session.commit()
         return result.scalar_one_or_none() is not None
+
+
+def _apply_account_updates(target: Account, source: Account) -> None:
+    target.chatgpt_account_id = source.chatgpt_account_id
+    target.email = source.email
+    target.plan_type = source.plan_type
+    target.access_token_encrypted = source.access_token_encrypted
+    target.refresh_token_encrypted = source.refresh_token_encrypted
+    target.id_token_encrypted = source.id_token_encrypted
+    target.last_refresh = source.last_refresh
+    target.status = source.status
+    target.deactivation_reason = source.deactivation_reason

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import select
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -28,6 +29,29 @@ def _make_account(account_id: str, email: str) -> Account:
         status=AccountStatus.ACTIVE,
         deactivation_reason=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_accounts_upsert_updates_existing_by_email(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_make_account("acc1", "dup@example.com"))
+
+        updated = _make_account("acc2", "dup@example.com")
+        updated.plan_type = "team"
+        updated.status = AccountStatus.PAUSED
+        updated.deactivation_reason = "reauth"
+        await repo.upsert(updated)
+
+        result = await session.execute(select(Account).where(Account.email == "dup@example.com"))
+        stored = result.scalar_one()
+        assert stored.id == "acc1"
+        assert stored.plan_type == "team"
+        assert stored.status == AccountStatus.PAUSED
+        assert stored.deactivation_reason == "reauth"
+
+        all_accounts = await session.execute(select(Account))
+        assert len(list(all_accounts.scalars().all())) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- update accounts upsert to merge by email when OAuth issues a new account id
- add coverage for duplicate-email upsert behavior

## Testing
- ruff check .
- ty check .
- pytest tests/integration/test_repositories.py -k upsert_updates_existing_by_email