### PR TITLE
fix(proxy): use short-lived sessions for streaming

### DIFF
--- a/app/modules/proxy/repo_bundle.py
+++ b/app/modules/proxy/repo_bundle.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import AsyncContextManager
+
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.proxy.sticky_repository import StickySessionsRepository
+from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.settings.repository import SettingsRepository
+from app.modules.usage.repository import UsageRepository
+
+
+@dataclass(slots=True)
+class ProxyRepositories:
+    accounts: AccountsRepository
+    usage: UsageRepository
+    request_logs: RequestLogsRepository
+    sticky_sessions: StickySessionsRepository
+    settings: SettingsRepository
+
+
+ProxyRepoFactory = Callable[[], AsyncContextManager[ProxyRepositories]]


### PR DESCRIPTION
## Summary
- introduce proxy repo factory for short-lived sessions
- refactor proxy service/load balancer to avoid detached session usage
- update load balancer integration tests for cross-session refresh

## Testing
- python -m pytest
- ruff check .
- ty check