### PR TITLE
fix(core): support gzip/deflate request decompression

### DIFF
--- a/tests/unit/test_request_decompression_middleware.py
+++ b/tests/unit/test_request_decompression_middleware.py
@@ -100,6 +100,27 @@ async def test_request_decompression_supports_deflate():
 
 
 @pytest.mark.asyncio
+async def test_request_decompression_allows_identity():
+    app = _build_echo_app()
+
+    payload = {"hello": "identity"}
+    body = json.dumps(payload).encode("utf-8")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/echo",
+            content=body,
+            headers={"Content-Encoding": "identity", "Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 200
+    response_data = resp.json()
+    assert response_data["content_encoding"] is None
+    assert response_data["data"] == payload
+
+
+@pytest.mark.asyncio
 async def test_request_decompression_supports_multiple_encodings():
     app = _build_echo_app()
 


### PR DESCRIPTION
## Summary

  - Add gzip/deflate support alongside zstd for request body decompression.
  - Handle chained Content-Encoding values with size limits and clear 400/413 errors.
  - Add unit tests covering gzip/deflate, multiple encodings, and unsupported encoding.
  
   ## Changes

  - app/core/middleware/request_decompression.py: support gzip/deflate and chained encodings with improved error handling.
  - tests/unit/test_request_decompression_middleware.py: add gzip/deflate/multi-encoding/unsupported encoding tests.

  ## Testing

  - ruff (via pre-commit)
  - ruff format (via pre-commit)
  - ty (via pre-commit)
  - pytest -m unit