### PR TITLE
chore(models): add gpt-5.3 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Open [localhost:2455](http://localhost:2455) → Add account → Done.
 Add to `~/.codex/config.toml`:
 
 ```toml
-model = "gpt-5.2-codex"
+model = "gpt-5.3-codex"
 model_reasoning_effort = "xhigh"
 model_provider = "codex-lb"
 

--- a/app/core/openai/models_catalog.py
+++ b/app/core/openai/models_catalog.py
@@ -35,6 +35,29 @@ class ModelEntry(BaseModel):
 
 
 MODEL_CATALOG: dict[str, ModelEntry] = {
+    "gpt-5.3": ModelEntry(
+        name="GPT 5.3",
+        limit=ModelLimits(context=272000, output=128000),
+        modalities=ModelModalities(input=["text", "image"], output=["text"]),
+        variants={
+            "none": ModelVariant(reasoningEffort="none", reasoningSummary="auto", textVerbosity="medium"),
+            "low": ModelVariant(reasoningEffort="low", reasoningSummary="auto", textVerbosity="medium"),
+            "medium": ModelVariant(reasoningEffort="medium", reasoningSummary="auto", textVerbosity="medium"),
+            "high": ModelVariant(reasoningEffort="high", reasoningSummary="detailed", textVerbosity="medium"),
+            "xhigh": ModelVariant(reasoningEffort="xhigh", reasoningSummary="detailed", textVerbosity="medium"),
+        },
+    ),
+    "gpt-5.3-codex": ModelEntry(
+        name="GPT 5.3 Codex",
+        limit=ModelLimits(context=272000, output=128000),
+        modalities=ModelModalities(input=["text", "image"], output=["text"]),
+        variants={
+            "low": ModelVariant(reasoningEffort="low", reasoningSummary="auto", textVerbosity="medium"),
+            "medium": ModelVariant(reasoningEffort="medium", reasoningSummary="auto", textVerbosity="medium"),
+            "high": ModelVariant(reasoningEffort="high", reasoningSummary="detailed", textVerbosity="medium"),
+            "xhigh": ModelVariant(reasoningEffort="xhigh", reasoningSummary="detailed", textVerbosity="medium"),
+        },
+    ),
     "gpt-5.2": ModelEntry(
         name="GPT 5.2",
         limit=ModelLimits(context=272000, output=128000),

--- a/app/core/usage/pricing.py
+++ b/app/core/usage/pricing.py
@@ -58,6 +58,7 @@ def _normalize_usage(usage: UsageTokens | ResponseUsage | None) -> UsageTokens |
 
 
 DEFAULT_PRICING_MODELS: dict[str, ModelPrice] = {
+    "gpt-5.3": ModelPrice(input_per_1m=1.75, cached_input_per_1m=0.175, output_per_1m=14.0),
     "gpt-5.2": ModelPrice(input_per_1m=1.75, cached_input_per_1m=0.175, output_per_1m=14.0),
     "gpt-5.1": ModelPrice(input_per_1m=1.25, cached_input_per_1m=0.125, output_per_1m=10.0),
     "gpt-5": ModelPrice(input_per_1m=1.25, cached_input_per_1m=0.125, output_per_1m=10.0),
@@ -76,6 +77,7 @@ DEFAULT_PRICING_MODELS: dict[str, ModelPrice] = {
 }
 
 DEFAULT_MODEL_ALIASES: dict[str, str] = {
+    "gpt-5.3*": "gpt-5.3",
     "gpt-5.2*": "gpt-5.2",
     "gpt-5.1*": "gpt-5.1",
     "gpt-5*": "gpt-5",

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -15,6 +15,7 @@ async def test_v1_models_list(async_client):
     assert isinstance(data, list)
     ids = {item["id"] for item in data}
     assert "gpt-5.2" in ids
+    assert "gpt-5.3-codex" in ids
     for item in data:
         assert item["object"] == "model"
         assert item["owned_by"] == "codex-lb"

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -35,6 +35,13 @@ def test_get_pricing_for_model_alias():
     assert price.output_per_1m == 2.0
 
 
+def test_get_pricing_for_model_gpt_5_3_alias():
+    result = get_pricing_for_model("gpt-5.3-codex-2026", DEFAULT_PRICING_MODELS, DEFAULT_MODEL_ALIASES)
+    assert result is not None
+    model, _ = result
+    assert model == "gpt-5.3"
+
+
 def test_calculate_cost_from_usage_cached_tokens():
     usage = ResponseUsage(
         input_tokens=1000,


### PR DESCRIPTION
Adds gpt-5.3 and gpt-5.3-codex to /v1/models metadata.

- Update model catalog and pricing aliases for gpt-5.3
- Update README default model example to gpt-5.3-codex
- Add tests for models list + pricing alias
