### PR TITLE
fix(proxy): strip forwarded identity headers before upstream

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -21,7 +21,15 @@ from app.core.types import JsonObject, JsonValue
 from app.core.utils.request_id import get_request_id
 from app.core.utils.sse import format_sse_event
 
-IGNORE_INBOUND_HEADERS = {"authorization", "chatgpt-account-id", "content-length", "host"}
+IGNORE_INBOUND_HEADERS = {
+    "authorization",
+    "chatgpt-account-id",
+    "content-length",
+    "host",
+    "forwarded",
+    "x-real-ip",
+    "true-client-ip",
+}
 
 _ERROR_TYPE_CODE_MAP = {
     "rate_limit_exceeded": "rate_limit_exceeded",
@@ -93,8 +101,19 @@ class ProxyResponseError(Exception):
         self.payload = payload
 
 
+def _should_drop_inbound_header(name: str) -> bool:
+    normalized = name.lower()
+    if normalized in IGNORE_INBOUND_HEADERS:
+        return True
+    if normalized.startswith("x-forwarded-"):
+        return True
+    if normalized.startswith("cf-"):
+        return True
+    return False
+
+
 def filter_inbound_headers(headers: Mapping[str, str]) -> dict[str, str]:
-    return {key: value for key, value in headers.items() if key.lower() not in IGNORE_INBOUND_HEADERS}
+    return {key: value for key, value in headers.items() if not _should_drop_inbound_header(key)}
 
 
 def _build_upstream_headers(

--- a/openspec/changes/sanitize-upstream-forwarded-headers/.openspec.yaml
+++ b/openspec/changes/sanitize-upstream-forwarded-headers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-18

--- a/openspec/changes/sanitize-upstream-forwarded-headers/design.md
+++ b/openspec/changes/sanitize-upstream-forwarded-headers/design.md
@@ -1,0 +1,42 @@
+## Context
+
+현재 proxy 경로는 `request.headers`를 서비스 계층으로 전달하고, `filter_inbound_headers()`에서 일부 헤더만 제거한 뒤 upstream request 헤더의 base로 사용한다. 제거 대상이 제한적이라 reverse proxy/Cloudflare가 추가한 프록시 식별 헤더가 upstream(ChatGPT)까지 전달된다.
+
+## Goal / Non-Goal
+
+**Goal**
+- upstream 요청에서 프록시 체인 식별 헤더를 일관되게 제거한다.
+- stream/compact 경로 모두 동일 정책을 적용한다.
+- 동작을 테스트로 고정해 회귀를 방지한다.
+
+**Non-Goal**
+- API 응답 포맷 변경
+- nginx/cloudflare 설정 자동 수정
+- upstream 차단 정책 자체 우회 로직 추가
+
+## Decision
+
+### 1) 중앙 필터 규칙 확장
+
+`app/core/clients/proxy.py`에서 inbound 헤더 필터 함수를 확장한다.
+
+- 제거할 단일 헤더:
+  - `forwarded`
+  - `x-real-ip`
+  - `true-client-ip`
+  - 기존 제거 대상(`authorization`, `chatgpt-account-id`, `content-length`, `host`)
+- 제거할 접두사:
+  - `x-forwarded-`
+  - `cf-`
+
+이 정책은 stream/compact 공통 경로에서 동일하게 적용된다.
+
+### 2) 회귀 테스트
+
+- unit: 필터 함수가 proxy identity 헤더를 제거하고 일반 헤더는 유지하는지 검증
+- integration: `/backend-api/codex/responses` 호출 시 monkeypatch된 upstream 함수에 전달된 헤더에서 proxy identity 헤더가 제외되는지 검증
+
+## Trade-offs
+
+- `cf-*` 전부 제거는 보수적 정책이다. 일부 비식별 헤더도 함께 제거될 수 있지만 upstream 호환성/안정성 측면에서 안전한 기본값이다.
+- 네트워크 환경이 다양해도 애플리케이션 레벨에서 동일한 최소 헤더 정책을 강제할 수 있다.

--- a/openspec/changes/sanitize-upstream-forwarded-headers/proposal.md
+++ b/openspec/changes/sanitize-upstream-forwarded-headers/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+홈서버 환경(`docker -> nginx reverse proxy -> cloudflare -> user`)에서 codex-lb를 원격 사용하면 upstream(ChatGPT)에서 Cloudflare 차단 페이지가 반환되는 문제가 발생했다. 원인 분석 결과, codex-lb가 inbound 헤더를 그대로 upstream으로 전달하면서 프록시 체인에서 추가된 `Forwarded`, `X-Forwarded-*`, `CF-*` 계열 헤더까지 전파되고 있었다.
+
+로컬 직결 환경에서는 재현되지 않고, reverse proxy + Cloudflare 환경에서만 재현된 점과 헤더 제거(`clean`) 경로에서 즉시 정상화된 점을 기준으로, upstream 호출 전에 프록시 식별 헤더를 명시적으로 제거해야 한다.
+
+## What Changes
+
+- Upstream 호출 전 inbound 헤더 필터링 규칙 강화
+  - 기존 제거 대상(`Authorization`, `chatgpt-account-id`, `Content-Length`, `Host`) 유지
+  - `Forwarded`, `X-Forwarded-*`, `X-Real-IP`, `True-Client-IP`, `CF-*` 제거 추가
+- 필터링 회귀 테스트 추가
+  - unit: 헤더 필터 함수에서 프록시 식별 헤더가 제거되는지 검증
+  - integration: `/backend-api/codex/responses` 경로에서 upstream 호출 mock에 전달되는 헤더 검증
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: upstream 전달 시 네트워크/프록시 식별 헤더를 제거하는 계약 추가
+
+## Impact
+
+- **코드**: `app/core/clients/proxy.py`
+- **테스트**: `tests/unit/test_proxy_utils.py`, `tests/integration/test_proxy_api_extended.py`
+- **API 계약**: 응답 스키마/필드 변화 없음, upstream 전달 헤더 정책만 강화

--- a/openspec/changes/sanitize-upstream-forwarded-headers/specs/responses-api-compat/spec.md
+++ b/openspec/changes/sanitize-upstream-forwarded-headers/specs/responses-api-compat/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Strip proxy identity headers before upstream forwarding
+Before forwarding requests to the upstream Responses endpoint, the service MUST strip network/proxy identity headers derived from downstream edges. The service MUST remove `Forwarded`, `X-Forwarded-*`, `X-Real-IP`, `True-Client-IP`, and `CF-*` headers, and MUST continue to set upstream auth/account headers from internal account state.
+
+#### Scenario: Request contains reverse-proxy forwarding headers
+- **WHEN** the inbound request includes headers such as `X-Forwarded-For`, `X-Forwarded-Proto`, `Forwarded`, or `X-Real-IP`
+- **THEN** those headers are not forwarded to upstream
+
+#### Scenario: Request contains Cloudflare identity headers
+- **WHEN** the inbound request includes headers such as `CF-Connecting-IP` or `CF-Ray`
+- **THEN** those headers are not forwarded to upstream

--- a/openspec/changes/sanitize-upstream-forwarded-headers/tasks.md
+++ b/openspec/changes/sanitize-upstream-forwarded-headers/tasks.md
@@ -1,0 +1,14 @@
+## 1. Header Sanitization
+
+- [x] 1.1 `app/core/clients/proxy.py`에 inbound header drop 규칙 확장 (`Forwarded`, `X-Forwarded-*`, `X-Real-IP`, `True-Client-IP`, `CF-*`)
+- [x] 1.2 stream/compact 공통 경로에서 기존 필터 함수만 사용해도 정책이 적용되는지 확인
+
+## 2. Tests
+
+- [x] 2.1 unit 테스트 추가: proxy identity 헤더 제거 + 일반 헤더 유지 검증
+- [x] 2.2 integration 테스트 추가: `/backend-api/codex/responses`에서 upstream mock으로 전달된 헤더 검증
+
+## 3. Spec Delta
+
+- [x] 3.1 `openspec/changes/sanitize-upstream-forwarded-headers/specs/responses-api-compat/spec.md`에 requirements delta 추가
+- [x] 3.2 `openspec validate --specs` 실행

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -185,6 +185,52 @@ async def test_proxy_stream_retries_rate_limit_then_success(async_client, monkey
 
 
 @pytest.mark.asyncio
+async def test_proxy_stream_drops_forwarded_headers(async_client, monkeypatch):
+    await _import_account(async_client, "acc_headers", "headers@example.com")
+    captured_headers: dict[str, str] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        captured_headers.update(headers)
+        event = {
+            "type": "response.completed",
+            "response": {"id": "resp_headers", "usage": {"input_tokens": 1, "output_tokens": 1}},
+        }
+        yield _sse_event(event)
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    request_headers = {
+        "x-forwarded-for": "1.2.3.4",
+        "x-forwarded-proto": "https",
+        "x-real-ip": "1.2.3.4",
+        "forwarded": "for=1.2.3.4;proto=https",
+        "cf-connecting-ip": "1.2.3.4",
+        "cf-ray": "ray123",
+        "true-client-ip": "1.2.3.4",
+        "user-agent": "codex-test",
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers=request_headers,
+    ) as resp:
+        assert resp.status_code == 200
+        _ = [line async for line in resp.aiter_lines() if line]
+
+    normalized = {key.lower() for key in captured_headers}
+    assert "x-forwarded-for" not in normalized
+    assert "x-forwarded-proto" not in normalized
+    assert "x-real-ip" not in normalized
+    assert "forwarded" not in normalized
+    assert "cf-connecting-ip" not in normalized
+    assert "cf-ray" not in normalized
+    assert "true-client-ip" not in normalized
+    assert "user-agent" in normalized
+
+
+@pytest.mark.asyncio
 async def test_proxy_stream_usage_limit_returns_http_error(async_client, monkeypatch):
     expected_account_id = await _import_account(async_client, "acc_limit", "limit@example.com")
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -31,6 +31,32 @@ def test_filter_inbound_headers_strips_auth_and_account():
     assert filtered["X-Request-Id"] == "req_1"
 
 
+def test_filter_inbound_headers_strips_proxy_identity_headers():
+    headers = {
+        "X-Forwarded-For": "1.2.3.4",
+        "X-Forwarded-Proto": "https",
+        "X-Real-IP": "1.2.3.4",
+        "Forwarded": "for=1.2.3.4;proto=https",
+        "CF-Connecting-IP": "1.2.3.4",
+        "CF-Ray": "ray123",
+        "True-Client-IP": "1.2.3.4",
+        "User-Agent": "codex-test",
+        "Accept": "text/event-stream",
+    }
+
+    filtered = filter_inbound_headers(headers)
+
+    assert "X-Forwarded-For" not in filtered
+    assert "X-Forwarded-Proto" not in filtered
+    assert "X-Real-IP" not in filtered
+    assert "Forwarded" not in filtered
+    assert "CF-Connecting-IP" not in filtered
+    assert "CF-Ray" not in filtered
+    assert "True-Client-IP" not in filtered
+    assert filtered["User-Agent"] == "codex-test"
+    assert filtered["Accept"] == "text/event-stream"
+
+
 def test_build_upstream_headers_overrides_auth():
     inbound = {"X-Request-Id": "req_1"}
     headers = _build_upstream_headers(inbound, "token", "acc_2")


### PR DESCRIPTION
## Summary
- strip proxy identity headers before forwarding upstream (`Forwarded`, `X-Forwarded-*`, `X-Real-IP`, `True-Client-IP`, `CF-*`)
- keep upstream auth/account headers injected internally as before
- add unit/integration coverage for header sanitization on proxy request paths
- add OpenSpec change: `sanitize-upstream-forwarded-headers`

## Validation
- `pytest -q tests/unit/test_proxy_utils.py tests/integration/test_proxy_api_extended.py`
- `openspec validate --specs`
