### PR TITLE
fix(proxy): expose models regardless of supported_in_api

### DIFF
--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -116,8 +116,6 @@ def get_model_registry() -> ModelRegistry:
 
 
 def is_public_model(model: UpstreamModel, allowed_models: set[str] | None) -> bool:
-    if not model.supported_in_api:
-        return False
     if allowed_models is None:
         return True
     return model.slug in allowed_models

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -850,7 +850,7 @@ async def test_update_key_reset_usage_requires_explicit_action(async_client):
 
 
 @pytest.mark.asyncio
-async def test_allowed_but_unsupported_model_is_not_exposed(async_client):
+async def test_allowed_but_unsupported_model_is_exposed(async_client):
     registry = get_model_registry()
     models = [
         _make_upstream_model(_TEST_MODELS[0], supported_in_api=True),
@@ -883,7 +883,7 @@ async def test_allowed_but_unsupported_model_is_not_exposed(async_client):
     assert listed.status_code == 200
     ids = {item["id"] for item in listed.json()["data"]}
     assert _TEST_MODELS[0] in ids
-    assert _HIDDEN_MODEL not in ids
+    assert _HIDDEN_MODEL in ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -68,7 +68,7 @@ async def test_v1_models_empty_when_registry_not_populated(async_client):
 
 
 @pytest.mark.asyncio
-async def test_v1_models_excludes_unsupported_models(async_client):
+async def test_v1_models_includes_supported_in_api_false_models(async_client):
     registry = get_model_registry()
     models = [
         _make_upstream_model("gpt-5.2"),
@@ -80,12 +80,11 @@ async def test_v1_models_excludes_unsupported_models(async_client):
     resp = await async_client.get("/v1/models")
     assert resp.status_code == 200
     ids = {item["id"] for item in resp.json()["data"]}
-    assert "gpt-hidden" not in ids
-    assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(ids)
+    assert {"gpt-5.2", "gpt-5.3-codex", "gpt-hidden"}.issubset(ids)
 
 
 @pytest.mark.asyncio
-async def test_backend_codex_models_excludes_unsupported_models(async_client):
+async def test_backend_codex_models_include_supported_in_api_false_models(async_client):
     registry = get_model_registry()
     models = [
         _make_upstream_model("gpt-5.2"),
@@ -97,8 +96,7 @@ async def test_backend_codex_models_excludes_unsupported_models(async_client):
     resp = await async_client.get("/backend-api/codex/models")
     assert resp.status_code == 200
     ids = {item["id"] for item in resp.json()["data"]}
-    assert "gpt-hidden" not in ids
-    assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(ids)
+    assert {"gpt-5.2", "gpt-5.3-codex", "gpt-hidden"}.issubset(ids)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stop filtering model listings by `supported_in_api` in `is_public_model`
- keep API key `allowed_models` filtering as the only visibility gate
- update integration tests to verify `supported_in_api=false` models are listed when allowed

## Test
- `.venv/bin/python -m pytest tests/integration/test_v1_models.py tests/integration/test_api_keys_api.py -k "supported_in_api_false or unsupported_model_is_exposed"`
