### PR TITLE
fix(oauth-ui): start device polling right after device flow start

### DIFF
--- a/frontend/src/features/accounts/hooks/use-oauth.test.ts
+++ b/frontend/src/features/accounts/hooks/use-oauth.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useOauth } from "@/features/accounts/hooks/use-oauth";
+
+const startOauthMock = vi.fn();
+const completeOauthMock = vi.fn();
+
+vi.mock("@/features/accounts/api", () => ({
+  startOauth: (...args: unknown[]) => startOauthMock(...args),
+  completeOauth: (...args: unknown[]) => completeOauthMock(...args),
+  getOauthStatus: vi.fn().mockResolvedValue({ status: "pending", errorMessage: null }),
+}));
+
+describe("useOauth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts device polling immediately after device OAuth start", async () => {
+    startOauthMock.mockResolvedValue({
+      method: "device",
+      authorizationUrl: null,
+      callbackUrl: null,
+      verificationUrl: "https://auth.example.com/device",
+      userCode: "ABCD-1234",
+      deviceAuthId: "device-auth-id",
+      intervalSeconds: 5,
+      expiresInSeconds: 600,
+    });
+    completeOauthMock.mockResolvedValue({ status: "pending" });
+
+    const { result } = renderHook(() => useOauth());
+
+    await act(async () => {
+      await result.current.start("device");
+    });
+
+    expect(completeOauthMock).toHaveBeenCalledTimes(1);
+    expect(completeOauthMock).toHaveBeenCalledWith({
+      deviceAuthId: "device-auth-id",
+      userCode: "ABCD-1234",
+    });
+  });
+
+  it("does not trigger device completion for browser OAuth start", async () => {
+    startOauthMock.mockResolvedValue({
+      method: "browser",
+      authorizationUrl: "https://auth.example.com/authorize",
+      callbackUrl: "http://127.0.0.1:1455/auth/callback",
+      verificationUrl: null,
+      userCode: null,
+      deviceAuthId: null,
+      intervalSeconds: null,
+      expiresInSeconds: null,
+    });
+
+    const { result } = renderHook(() => useOauth());
+
+    await act(async () => {
+      await result.current.start("browser");
+    });
+
+    expect(completeOauthMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/accounts/hooks/use-oauth.ts
+++ b/frontend/src/features/accounts/hooks/use-oauth.ts
@@ -87,6 +87,18 @@ export function useOauth() {
         errorMessage: null,
       });
       setState(nextState);
+
+      if (
+        nextState.method === "device"
+        && nextState.deviceAuthId
+        && nextState.userCode
+      ) {
+        await completeOauth({
+          deviceAuthId: nextState.deviceAuthId,
+          userCode: nextState.userCode,
+        });
+      }
+
       return nextState;
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start OAuth";


### PR DESCRIPTION
## What this fixes
Device OAuth login could appear stuck in the dashboard because polling was not started at the right moment.

## Root cause
For device flow, backend polling only begins after `POST /api/oauth/complete`.
The frontend called `complete()` only after success state, which cannot happen before polling starts.

## Change
- After `startOauth(..., forceMethod=device)` succeeds, the frontend now immediately calls `completeOauth({ deviceAuthId, userCode })`.
- Browser flow behavior stays unchanged.

## Tests
- Added `frontend/src/features/accounts/hooks/use-oauth.test.ts`:
  - verifies device flow auto-starts completion/polling
  - verifies browser flow does not auto-complete
- `bun run test src/features/accounts/hooks/use-oauth.test.ts`
- `bun run typecheck`