### PR TITLE
docs: fix codex defaults / add migration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ model_reasoning_effort = "xhigh"
 model_provider = "codex-lb"
 
 [model_providers.codex-lb]
-name = "OpenAI"                                      # required — enables remote /responses/compact
+name = "OpenAI"  # required — enables remote /responses/compact
 base_url = "http://127.0.0.1:2455/backend-api/codex"
 wire_api = "responses"
 ```


### PR DESCRIPTION
## Fix codex defaults


- Remove `requires_openai_auth = true` from default example (triggers OpenAI OAuth, wrong for a load balancer)
- Clarify why `name = "OpenAI"` is required (remote `/responses/compact routing`)
- De-duplicate API key auth example


## Add migration note

`codex resume` filters by `model_provider`, so old sessions need re-tagging in both JSONL files (all versions) and SQLite state DB (>= v0.105.0)

Rationale to add it here: though not an issue of `codex-lb` per-se, configuring it implies `model_provider` change, therefore exposing `codex-lb` user to the problem.


