### PR TITLE
fix: strip unsupported prompt params before upstream forwarding

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -390,7 +390,11 @@ class ResponsesCompactRequest(BaseModel):
         return _strip_unsupported_fields(payload)
 
 
-_UNSUPPORTED_UPSTREAM_FIELDS = {"max_output_tokens"}
+_UNSUPPORTED_UPSTREAM_FIELDS = {
+    "max_output_tokens",
+    "prompt_cache_retention",
+    "temperature",
+}
 
 
 def _strip_unsupported_fields(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:

--- a/openspec/changes/strip-unsupported-request-params/.openspec.yaml
+++ b/openspec/changes/strip-unsupported-request-params/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-01

--- a/openspec/changes/strip-unsupported-request-params/design.md
+++ b/openspec/changes/strip-unsupported-request-params/design.md
@@ -1,0 +1,22 @@
+## Overview
+
+Apply parameter sanitization at the shared Responses payload normalization layer so all call paths (`/backend-api/codex/responses`, `/v1/responses`, `/responses/compact`, and Chat->Responses mapping) inherit the same behavior.
+
+## Design
+
+1. Extend `_UNSUPPORTED_UPSTREAM_FIELDS` in `app/core/openai/requests.py` to include:
+   - `prompt_cache_retention`
+   - `temperature`
+2. Keep sanitization in `ResponsesRequest.to_payload()` and `ResponsesCompactRequest.to_payload()` as the single source of truth.
+3. Preserve unknown extra fields that are not explicitly listed as unsupported.
+
+## Testing Strategy
+
+- Unit: verify `ResponsesRequest.to_payload()` drops `prompt_cache_retention` and `temperature` while preserving unrelated extra fields.
+- Unit: verify `ResponsesCompactRequest.to_payload()` also drops these fields.
+- Unit: verify Chat request mapping path no longer forwards `temperature` once converted to Responses payload.
+
+## Risks and Mitigations
+
+- Risk: accidentally dropping too many fields and breaking forward compatibility.
+  - Mitigation: keep a narrow allow-to-drop list and assert non-listed fields remain in payload.

--- a/openspec/changes/strip-unsupported-request-params/proposal.md
+++ b/openspec/changes/strip-unsupported-request-params/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+ChatGPT upstream currently rejects `prompt_cache_retention` and `temperature` on Responses endpoints with `unknown_parameter`, which turns otherwise valid requests into hard failures. We need codex-lb to preserve compatibility by dropping these known unsupported fields before forwarding upstream.
+
+## What Changes
+
+- Strip `prompt_cache_retention` and `temperature` from Responses payloads before upstream forwarding.
+- Keep existing pass-through behavior for unrelated extra fields.
+- Add regression tests for `/responses`, `/responses/compact`, and Chat->Responses mapping paths.
+- Update compatibility support matrix notes for request parameters that are intentionally ignored for upstream compatibility.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: define that known unsupported advisory parameters are removed before upstream forwarding instead of surfacing upstream `unknown_parameter`.
+
+## Impact
+
+- **Code**: `app/core/openai/requests.py`
+- **Tests**: `tests/unit/test_openai_requests.py`, `tests/unit/test_chat_request_mapping.py`
+- **Docs/Refs**: `refs/openai-compat-test-plan.md`

--- a/openspec/changes/strip-unsupported-request-params/specs/responses-api-compat/spec.md
+++ b/openspec/changes/strip-unsupported-request-params/specs/responses-api-compat/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Strip known unsupported advisory parameters before upstream forwarding
+Before forwarding Responses payloads upstream, the service MUST remove known unsupported advisory parameters that upstream rejects with `unknown_parameter`. At minimum, the service MUST strip `prompt_cache_retention` and `temperature` from normalized payloads for both standard and compact Responses endpoints.
+
+#### Scenario: prompt_cache_retention provided
+- **WHEN** a client sends a valid Responses request that includes `prompt_cache_retention`
+- **THEN** the service accepts the request and forwards payload without `prompt_cache_retention`
+
+#### Scenario: temperature provided
+- **WHEN** a client sends a valid Responses or Chat-mapped request that includes `temperature`
+- **THEN** the service accepts the request and forwards payload without `temperature`
+
+#### Scenario: unrelated extra field provided
+- **WHEN** a client sends a valid request with an unrelated extra field not in the unsupported list
+- **THEN** the service preserves that field in forwarded payload

--- a/openspec/changes/strip-unsupported-request-params/tasks.md
+++ b/openspec/changes/strip-unsupported-request-params/tasks.md
@@ -1,0 +1,17 @@
+## 1. Payload Sanitization
+
+- [x] 1.1 Add `prompt_cache_retention` to Responses unsupported-upstream field stripping
+- [x] 1.2 Add `temperature` to Responses unsupported-upstream field stripping
+- [x] 1.3 Ensure stripping applies to both `ResponsesRequest` and `ResponsesCompactRequest`
+
+## 2. Tests
+
+- [x] 2.1 Add unit regression test for `ResponsesRequest.to_payload()` stripping behavior
+- [x] 2.2 Add unit regression test for `ResponsesCompactRequest.to_payload()` stripping behavior
+- [x] 2.3 Add chat-mapping regression test to verify `temperature` is not forwarded upstream
+
+## 3. Specs and Compatibility Docs
+
+- [x] 3.1 Add `responses-api-compat` spec delta for stripping known unsupported advisory parameters
+- [x] 3.2 Update `refs/openai-compat-test-plan.md` support matrix with parameter compatibility note
+- [x] 3.3 Run `openspec validate --specs`

--- a/tests/unit/test_chat_request_mapping.py
+++ b/tests/unit/test_chat_request_mapping.py
@@ -78,6 +78,18 @@ def test_chat_max_tokens_are_stripped():
     assert "max_completion_tokens" not in dumped
 
 
+def test_chat_temperature_is_stripped_for_upstream_compat():
+    payload = {
+        "model": "gpt-5.2",
+        "messages": [{"role": "user", "content": "hi"}],
+        "temperature": 0.2,
+    }
+    req = ChatCompletionsRequest.model_validate(payload)
+    responses = req.to_responses_request()
+    dumped = responses.to_payload()
+    assert "temperature" not in dumped
+
+
 def test_chat_reasoning_effort_maps_to_responses_reasoning():
     payload = {
         "model": "gpt-5.2",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -39,12 +39,38 @@ def test_store_false_is_preserved():
     assert request.to_payload()["store"] is False
 
 
-def test_extra_fields_are_preserved():
-    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "max_output_tokens": 32000}
+def test_known_unsupported_upstream_fields_are_stripped():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [],
+        "max_output_tokens": 32000,
+        "prompt_cache_retention": "4h",
+        "temperature": 0.2,
+        "custom_field": "kept",
+    }
     request = ResponsesRequest.model_validate(payload)
 
     dumped = request.to_payload()
     assert "max_output_tokens" not in dumped
+    assert "prompt_cache_retention" not in dumped
+    assert "temperature" not in dumped
+    assert dumped["custom_field"] == "kept"
+
+
+def test_compact_known_unsupported_upstream_fields_are_stripped():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [],
+        "prompt_cache_retention": "4h",
+        "temperature": 0.2,
+    }
+    request = ResponsesCompactRequest.model_validate(payload)
+
+    dumped = request.to_payload()
+    assert "prompt_cache_retention" not in dumped
+    assert "temperature" not in dumped
 
 
 def test_openai_compatible_reasoning_aliases_are_normalized():


### PR DESCRIPTION
## Summary
- strip `prompt_cache_retention` and `temperature` from normalized Responses payloads before upstream forwarding
- keep non-listed extra fields unchanged
- add OpenSpec change artifacts for this behavior update
- add unit tests for Responses, compact Responses, and Chat->Responses mapping paths

## Validation
- `uv run pytest tests/unit/test_openai_requests.py tests/unit/test_chat_request_mapping.py`
- `openspec validate --specs`
- manual runtime check in docker container: `/backend-api/codex/responses/compact` with `prompt_cache_retention` + `temperature` now returns 200
