### PR TITLE
fix: strip unsupported safety_identifier before upstream forwarding

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -393,6 +393,7 @@ class ResponsesCompactRequest(BaseModel):
 _UNSUPPORTED_UPSTREAM_FIELDS = {
     "max_output_tokens",
     "prompt_cache_retention",
+    "safety_identifier",
     "temperature",
 }
 

--- a/openspec/changes/strip-unsupported-safety-identifier/.openspec.yaml
+++ b/openspec/changes/strip-unsupported-safety-identifier/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-03

--- a/openspec/changes/strip-unsupported-safety-identifier/design.md
+++ b/openspec/changes/strip-unsupported-safety-identifier/design.md
@@ -1,0 +1,15 @@
+## Overview
+
+Reuse the existing Responses payload sanitization hook and add one additional unsupported upstream parameter.
+
+## Design
+
+1. Add `safety_identifier` to `_UNSUPPORTED_UPSTREAM_FIELDS` in `app/core/openai/requests.py`.
+2. Keep stripping centralized in `to_payload()` for both `ResponsesRequest` and `ResponsesCompactRequest`.
+3. Keep non-listed extra fields untouched.
+
+## Testing Strategy
+
+- Verify `ResponsesRequest.to_payload()` strips `safety_identifier`.
+- Verify `ResponsesCompactRequest.to_payload()` strips `safety_identifier`.
+- Verify Chat->Responses mapped payload also drops `safety_identifier`.

--- a/openspec/changes/strip-unsupported-safety-identifier/proposal.md
+++ b/openspec/changes/strip-unsupported-safety-identifier/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Some clients now send `safety_identifier`, but ChatGPT upstream rejects it on Responses endpoints with `Unsupported parameter: safety_identifier`. This causes avoidable request failures for otherwise valid prompts.
+
+## What Changes
+
+- Strip `safety_identifier` from normalized Responses payloads before upstream forwarding.
+- Add regression tests for standard Responses, compact Responses, and Chat-mapped payloads.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: extend unsupported advisory-parameter stripping to include `safety_identifier`.
+
+## Impact
+
+- **Code**: `app/core/openai/requests.py`
+- **Tests**: `tests/unit/test_openai_requests.py`, `tests/unit/test_chat_request_mapping.py`

--- a/openspec/changes/strip-unsupported-safety-identifier/specs/responses-api-compat/spec.md
+++ b/openspec/changes/strip-unsupported-safety-identifier/specs/responses-api-compat/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Strip safety_identifier before upstream forwarding
+Before forwarding Responses payloads upstream, the service MUST remove `safety_identifier` from normalized payloads for both standard and compact Responses endpoints.
+
+#### Scenario: safety_identifier provided in Responses request
+- **WHEN** a client sends a valid Responses request including `safety_identifier`
+- **THEN** the service accepts the request and forwards payload without `safety_identifier`
+
+#### Scenario: safety_identifier provided in Chat-mapped request
+- **WHEN** a client sends a Chat Completions request including `safety_identifier`
+- **THEN** the mapped Responses payload forwarded upstream excludes `safety_identifier`

--- a/openspec/changes/strip-unsupported-safety-identifier/tasks.md
+++ b/openspec/changes/strip-unsupported-safety-identifier/tasks.md
@@ -1,0 +1,15 @@
+## 1. Payload Sanitization
+
+- [x] 1.1 Add `safety_identifier` to Responses unsupported-upstream field stripping list
+- [x] 1.2 Ensure stripping applies to both standard and compact Responses payload builders
+
+## 2. Tests
+
+- [x] 2.1 Extend Responses payload unit test to assert `safety_identifier` is removed
+- [x] 2.2 Extend compact Responses payload unit test to assert `safety_identifier` is removed
+- [x] 2.3 Add chat-mapping regression assertion for `safety_identifier`
+
+## 3. Specs
+
+- [x] 3.1 Add `responses-api-compat` spec delta for `safety_identifier` stripping
+- [x] 3.2 Run `openspec validate --specs`

--- a/tests/unit/test_chat_request_mapping.py
+++ b/tests/unit/test_chat_request_mapping.py
@@ -83,11 +83,13 @@ def test_chat_temperature_is_stripped_for_upstream_compat():
         "model": "gpt-5.2",
         "messages": [{"role": "user", "content": "hi"}],
         "temperature": 0.2,
+        "safety_identifier": "safe_123",
     }
     req = ChatCompletionsRequest.model_validate(payload)
     responses = req.to_responses_request()
     dumped = responses.to_payload()
     assert "temperature" not in dumped
+    assert "safety_identifier" not in dumped
 
 
 def test_chat_reasoning_effort_maps_to_responses_reasoning():

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -46,6 +46,7 @@ def test_known_unsupported_upstream_fields_are_stripped():
         "input": [],
         "max_output_tokens": 32000,
         "prompt_cache_retention": "4h",
+        "safety_identifier": "safe_123",
         "temperature": 0.2,
         "custom_field": "kept",
     }
@@ -54,6 +55,7 @@ def test_known_unsupported_upstream_fields_are_stripped():
     dumped = request.to_payload()
     assert "max_output_tokens" not in dumped
     assert "prompt_cache_retention" not in dumped
+    assert "safety_identifier" not in dumped
     assert "temperature" not in dumped
     assert dumped["custom_field"] == "kept"
 
@@ -64,12 +66,14 @@ def test_compact_known_unsupported_upstream_fields_are_stripped():
         "instructions": "hi",
         "input": [],
         "prompt_cache_retention": "4h",
+        "safety_identifier": "safe_123",
         "temperature": 0.2,
     }
     request = ResponsesCompactRequest.model_validate(payload)
 
     dumped = request.to_payload()
     assert "prompt_cache_retention" not in dumped
+    assert "safety_identifier" not in dumped
     assert "temperature" not in dumped
 
 


### PR DESCRIPTION
## Summary
- strip `safety_identifier` from normalized Responses payloads before upstream forwarding
- keep existing behavior for other fields
- add OpenSpec change artifacts for this behavior update
- extend unit tests for Responses, compact Responses, and Chat->Responses mapping paths

## Validation
- `uv run pytest tests/unit/test_openai_requests.py tests/unit/test_chat_request_mapping.py`
- `openspec validate --specs`
