### PR TITLE
fix(proxy): preserve v1 response reasoning output

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 
 from fastapi import APIRouter, Body, Depends, File, Form, Request, Response, Security, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -563,11 +563,13 @@ def _validate_model_access(api_key: ApiKeyData | None, model: str | None) -> Non
 
 
 async def _collect_responses_payload(stream: AsyncIterator[str]) -> OpenAIResponseResult:
+    output_items: dict[int, dict[str, JsonValue]] = {}
     async for line in stream:
         payload = _parse_sse_payload(line)
         if not payload:
             continue
         event_type = payload.get("type")
+        _collect_output_item_event(payload, output_items)
         if event_type == "error":
             return _parse_event_error_envelope(payload)
         if event_type == "response.failed":
@@ -586,11 +588,41 @@ async def _collect_responses_payload(stream: AsyncIterator[str]) -> OpenAIRespon
         if event_type in ("response.completed", "response.incomplete"):
             response = payload.get("response")
             if isinstance(response, dict):
-                parsed = parse_response_payload(response)
+                parsed = parse_response_payload(_merge_collected_output_items(response, output_items))
                 if parsed is not None:
                     return parsed
             return _default_error_envelope()
     return _default_error_envelope()
+
+
+def _collect_output_item_event(
+    payload: dict[str, JsonValue],
+    output_items: dict[int, dict[str, JsonValue]],
+) -> None:
+    event_type = payload.get("type")
+    if event_type not in ("response.output_item.added", "response.output_item.done"):
+        return
+    output_index = payload.get("output_index")
+    item = payload.get("item")
+    if not isinstance(output_index, int) or not isinstance(item, dict):
+        return
+    output_items[output_index] = dict(item)
+
+
+def _merge_collected_output_items(
+    response: Mapping[str, JsonValue],
+    output_items: dict[int, dict[str, JsonValue]],
+) -> dict[str, JsonValue]:
+    merged = dict(response)
+    if not output_items:
+        return merged
+
+    existing_output = response.get("output")
+    if isinstance(existing_output, list) and existing_output:
+        return merged
+
+    merged["output"] = [item for _, item in sorted(output_items.items())]
+    return merged
 
 
 def _parse_event_error_envelope(payload: dict[str, JsonValue]) -> OpenAIErrorEnvelopeModel:

--- a/openspec/changes/preserve-v1-response-reasoning-details/.openspec.yaml
+++ b/openspec/changes/preserve-v1-response-reasoning-details/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-07

--- a/openspec/changes/preserve-v1-response-reasoning-details/design.md
+++ b/openspec/changes/preserve-v1-response-reasoning-details/design.md
@@ -1,0 +1,17 @@
+## Overview
+
+Keep the existing transport strategy for `/v1/responses` non-streaming requests: call upstream with `stream=true`, consume the SSE stream, and return a single JSON response to the client. Fix the data loss by collecting completed output items during stream consumption and merging them into the terminal response payload when the terminal payload does not already contain output items.
+
+## Decisions
+
+### Collect output items from SSE
+
+Track `response.output_item.added` and `response.output_item.done` events by `output_index`. `done` events overwrite earlier `added` snapshots for the same index.
+
+### Prefer terminal output when present
+
+If the terminal `response.completed.response` or `response.incomplete.response` already includes a non-empty `output` array, return it unchanged. Otherwise, synthesize `output` from the collected SSE item events in `output_index` order.
+
+### Preserve raw payloads
+
+Do not validate or reshape collected output items beyond the top-level response parsing already used by `OpenAIResponsePayload`. This preserves reasoning-specific and vendor-specific fields that clients may rely on.

--- a/openspec/changes/preserve-v1-response-reasoning-details/proposal.md
+++ b/openspec/changes/preserve-v1-response-reasoning-details/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+`/v1/responses` non-streaming requests are currently executed as upstream SSE streams and then collapsed into a single JSON response by reading only the terminal `response.completed` or `response.incomplete` event. When the upstream emits reasoning or other rich output items in intermediate events such as `response.output_item.done`, those items are dropped from the final JSON response if the terminal event omits `response.output`.
+
+This makes `codex-lb` lose reasoning-related payloads that clients expect from the v1 Responses API surface.
+
+## What Changes
+
+- Reconstruct non-streaming `/v1/responses` output items from upstream SSE item events before returning the final JSON response.
+- Preserve raw output item payloads, including reasoning-related fields, when the terminal response omits or leaves `output` empty.
+- Add regression coverage for reasoning-style output item preservation in non-streaming `/v1/responses`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: preserve output items from streamed upstream Responses events when serving non-streaming `/v1/responses`.
+
+## Impact
+
+- **Code**: `app/modules/proxy/api.py`
+- **Tests**: `tests/integration/test_proxy_responses.py`

--- a/openspec/changes/preserve-v1-response-reasoning-details/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-v1-response-reasoning-details/specs/responses-api-compat/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Reconstruct non-streaming Responses output from streamed item events
+When serving non-streaming `/v1/responses`, the service MUST preserve output items emitted on upstream SSE item events even when the terminal `response.completed` or `response.incomplete` payload omits `response.output` or returns it as an empty list.
+
+#### Scenario: Reasoning item emitted before terminal response
+- **WHEN** upstream emits a reasoning or other output item on `response.output_item.done` and the terminal response omits `output`
+- **THEN** the final non-streaming JSON response includes that output item in `output`
+
+#### Scenario: Terminal response already includes output
+- **WHEN** the terminal response already includes a non-empty `output` array
+- **THEN** the service returns the terminal `output` array unchanged

--- a/openspec/changes/preserve-v1-response-reasoning-details/tasks.md
+++ b/openspec/changes/preserve-v1-response-reasoning-details/tasks.md
@@ -1,0 +1,12 @@
+## 1. Implementation
+
+- [x] 1.1 Update `/v1/responses` non-streaming SSE collection to retain `response.output_item.*` payloads and merge them into the terminal response when `output` is missing or empty
+
+## 2. Tests
+
+- [x] 2.1 Add an integration regression test covering reasoning-style output item preservation for non-streaming `/v1/responses`
+
+## 3. Spec Delta
+
+- [x] 3.1 Add a `responses-api-compat` spec delta for non-streaming output reconstruction
+- [x] 3.2 Validate specs locally with `openspec validate --specs`

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -555,6 +555,44 @@ async def test_v1_responses_non_streaming_returns_response(async_client, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_non_streaming_reconstructs_reasoning_output(async_client, monkeypatch):
+    email = "responses-reasoning-output@example.com"
+    raw_account_id = "acc_responses_reasoning_output"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        yield (
+            'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1",'
+            '"type":"reasoning","summary":[{"type":"summary_text","text":"Need more steps"}],'
+            '"reasoning_details":{"tokens":4}}}\n\n'
+        )
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_reasoning_1","object":"response",'
+            '"status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "input": [{"role": "user", "content": "hi"}], "stream": False}
+    resp = await async_client.post("/v1/responses", json=payload)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == "resp_reasoning_1"
+    assert body["output"] == [
+        {
+            "id": "rs_1",
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "Need more steps"}],
+            "reasoning_details": {"tokens": 4},
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_non_streaming_preserves_sse_error_payload(async_client, monkeypatch):
     email = "responses-error-event@example.com"
     raw_account_id = "acc_responses_error_event"


### PR DESCRIPTION
## Summary
- preserve output items from upstream SSE when `/v1/responses` non-streaming collapses a stream into JSON
- merge collected `response.output_item.*` events into the terminal response when `output` is missing or empty
- add OpenSpec change artifacts and a regression test for reasoning-style output preservation

## Verification
- uv run pytest tests/integration/test_proxy_responses.py -q
- openspec validate --specs