### PR TITLE
fix(proxy): preserve Codex session affinity for compact to stop 502s

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -95,7 +95,7 @@ async def responses(
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
-    return await _stream_responses(request, payload, context, api_key)
+    return await _stream_responses(request, payload, context, api_key, codex_session_affinity=True)
 
 
 @v1_router.post(
@@ -328,6 +328,7 @@ async def _stream_responses(
     context: ProxyContext,
     api_key: ApiKeyData | None,
     *,
+    codex_session_affinity: bool = False,
     suppress_text_done_events: bool = False,
 ) -> Response:
     _apply_api_key_enforcement(payload, api_key)
@@ -343,6 +344,7 @@ async def _stream_responses(
     stream = context.service.stream_responses(
         payload,
         request.headers,
+        codex_session_affinity=codex_session_affinity,
         propagate_http_errors=True,
         api_key=api_key,
         api_key_reservation=reservation,
@@ -372,6 +374,7 @@ async def _collect_responses(
     context: ProxyContext,
     api_key: ApiKeyData | None,
     *,
+    codex_session_affinity: bool = False,
     suppress_text_done_events: bool = False,
 ) -> Response:
     _apply_api_key_enforcement(payload, api_key)
@@ -387,6 +390,7 @@ async def _collect_responses(
     stream = context.service.stream_responses(
         payload,
         request.headers,
+        codex_session_affinity=codex_session_affinity,
         propagate_http_errors=True,
         api_key=api_key,
         api_key_reservation=reservation,
@@ -430,7 +434,7 @@ async def responses_compact(
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> JSONResponse:
-    return await _compact_responses(request, payload, context, api_key)
+    return await _compact_responses(request, payload, context, api_key, codex_session_affinity=True)
 
 
 @v1_router.post("/responses/compact", response_model=OpenAIResponseResult)
@@ -456,6 +460,7 @@ async def _compact_responses(
     payload: ResponsesCompactRequest,
     context: ProxyContext,
     api_key: ApiKeyData | None,
+    codex_session_affinity: bool = False,
 ) -> JSONResponse:
     _apply_api_key_enforcement(payload, api_key)
     _validate_model_access(api_key, payload.model)
@@ -470,6 +475,7 @@ async def _compact_responses(
         result = await context.service.compact_responses(
             payload,
             request.headers,
+            codex_session_affinity=codex_session_affinity,
             api_key=api_key,
             api_key_reservation=reservation,
         )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -70,6 +70,7 @@ class ProxyService:
         payload: ResponsesRequest,
         headers: Mapping[str, str],
         *,
+        codex_session_affinity: bool = False,
         propagate_http_errors: bool = False,
         api_key: ApiKeyData | None = None,
         api_key_reservation: ApiKeyUsageReservationData | None = None,
@@ -81,6 +82,7 @@ class ProxyService:
         return self._stream_with_retry(
             payload,
             filtered,
+            codex_session_affinity=codex_session_affinity,
             propagate_http_errors=propagate_http_errors,
             api_key=api_key,
             api_key_reservation=api_key_reservation,
@@ -92,6 +94,7 @@ class ProxyService:
         payload: ResponsesCompactRequest,
         headers: Mapping[str, str],
         *,
+        codex_session_affinity: bool = False,
         api_key: ApiKeyData | None = None,
         api_key_reservation: ApiKeyUsageReservationData | None = None,
     ) -> OpenAIResponsePayload:
@@ -102,10 +105,15 @@ class ProxyService:
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
         sticky_threads_enabled = settings.sticky_threads_enabled
         routing_strategy = getattr(settings, "routing_strategy", "usage_weighted")
-        sticky_key = _sticky_key_from_compact_payload(payload) if sticky_threads_enabled else None
+        sticky_key, reallocate_sticky = _sticky_key_for_compact_request(
+            payload,
+            headers,
+            codex_session_affinity=codex_session_affinity,
+            sticky_threads_enabled=sticky_threads_enabled,
+        )
         selection = await self._load_balancer.select_account(
             sticky_key=sticky_key,
-            reallocate_sticky=sticky_key is not None,
+            reallocate_sticky=reallocate_sticky,
             prefer_earlier_reset_accounts=prefer_earlier_reset,
             routing_strategy=routing_strategy,
             model=payload.model,
@@ -401,6 +409,7 @@ class ProxyService:
         payload: ResponsesRequest,
         headers: Mapping[str, str],
         *,
+        codex_session_affinity: bool,
         propagate_http_errors: bool,
         api_key: ApiKeyData | None,
         api_key_reservation: ApiKeyUsageReservationData | None,
@@ -411,7 +420,12 @@ class ProxyService:
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
         sticky_threads_enabled = settings.sticky_threads_enabled
         routing_strategy = getattr(settings, "routing_strategy", "usage_weighted")
-        sticky_key = _sticky_key_from_payload(payload) if sticky_threads_enabled else None
+        sticky_key = _sticky_key_for_responses_request(
+            payload,
+            headers,
+            codex_session_affinity=codex_session_affinity,
+            sticky_threads_enabled=sticky_threads_enabled,
+        )
         max_attempts = 3
         settled = False
         settlement = _StreamSettlement()
@@ -934,6 +948,7 @@ def _interesting_header_keys(headers: Mapping[str, str]) -> list[str]:
         "user-agent",
         "x-request-id",
         "request-id",
+        "session_id",
         "x-openai-client-id",
         "x-openai-client-version",
         "x-openai-client-arch",
@@ -953,6 +968,31 @@ def _sticky_key_from_payload(payload: ResponsesRequest) -> str | None:
     return stripped or None
 
 
+def _sticky_key_from_session_header(headers: Mapping[str, str]) -> str | None:
+    for key, value in headers.items():
+        if key.lower() != "session_id":
+            continue
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _sticky_key_for_responses_request(
+    payload: ResponsesRequest,
+    headers: Mapping[str, str],
+    *,
+    codex_session_affinity: bool,
+    sticky_threads_enabled: bool,
+) -> str | None:
+    if codex_session_affinity:
+        session_key = _sticky_key_from_session_header(headers)
+        if session_key:
+            return session_key
+    if sticky_threads_enabled:
+        return _sticky_key_from_payload(payload)
+    return None
+
+
 def _sticky_key_from_compact_payload(payload: ResponsesCompactRequest) -> str | None:
     if not payload.model_extra:
         return None
@@ -961,6 +1001,22 @@ def _sticky_key_from_compact_payload(payload: ResponsesCompactRequest) -> str | 
         return None
     stripped = value.strip()
     return stripped or None
+
+
+def _sticky_key_for_compact_request(
+    payload: ResponsesCompactRequest,
+    headers: Mapping[str, str],
+    *,
+    codex_session_affinity: bool,
+    sticky_threads_enabled: bool,
+) -> tuple[str | None, bool]:
+    if codex_session_affinity:
+        session_key = _sticky_key_from_session_header(headers)
+        if session_key:
+            return session_key, False
+    if sticky_threads_enabled:
+        return _sticky_key_from_compact_payload(payload), True
+    return None, False
 
 
 def _service_tier_from_compact_payload(payload: ResponsesCompactRequest) -> str | None:

--- a/openspec/changes/pin-codex-session-routing/proposal.md
+++ b/openspec/changes/pin-codex-session-routing/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+Codex CLI sends a stable thread `session_id` header on backend Responses and compact requests. `codex-lb` currently ignores that header for routing unless the dashboard-level sticky thread setting is enabled, which allows a compact request to hop to a different upstream account than the one already serving the thread.
+
+That breaks Codex remote compaction semantics for multi-account setups because thread-scoped history can contain upstream-owned encrypted items that must stay on the same account path.
+
+## What Changes
+
+- Treat inbound Codex `session_id` as a routing affinity key for backend Responses and compact requests.
+- Preserve that affinity even when `sticky_threads_enabled` is disabled, while keeping existing prompt-cache stickiness for other clients unchanged.
+- Add regression coverage for the response-to-compact handoff.
+
+## Impact
+
+- Code: `app/modules/proxy/service.py`
+- Tests: `tests/integration/test_proxy_sticky_sessions.py`
+- Specs: `openspec/specs/responses-api-compat/spec.md`

--- a/openspec/changes/pin-codex-session-routing/tasks.md
+++ b/openspec/changes/pin-codex-session-routing/tasks.md
@@ -1,0 +1,12 @@
+## 1. Routing behavior
+
+- [x] 1.1 Use inbound `session_id` as the sticky routing key for Codex backend Responses requests
+- [x] 1.2 Use inbound `session_id` as the sticky routing key for Codex compact requests
+
+## 2. Regression coverage
+
+- [x] 2.1 Add an integration test that proves a Codex thread stays pinned across response and compact requests when dashboard sticky threads are disabled
+
+## 3. Spec updates
+
+- [x] 3.1 Document Codex `session_id` routing affinity for backend Responses and compact requests

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -203,3 +203,13 @@ Before forwarding requests to the upstream Responses endpoint, the service MUST 
 - **WHEN** the inbound request includes headers such as `CF-Connecting-IP` or `CF-Ray`
 - **THEN** those headers are not forwarded to upstream
 
+### Requirement: Codex backend session_id preserves account affinity
+When a backend Codex Responses or compact request includes a non-empty `session_id` header, the service MUST use that value as the routing affinity key for upstream account selection. This affinity MUST apply even when dashboard `sticky_threads_enabled` is disabled.
+
+#### Scenario: Codex Responses request with session_id and sticky threads disabled
+- **WHEN** `/backend-api/codex/responses` is called with a non-empty `session_id` header and `sticky_threads_enabled=false`
+- **THEN** the selected upstream account is pinned to that `session_id` for later backend Codex requests on the same thread
+
+#### Scenario: Compact request reuses pinned Codex session account
+- **WHEN** `/backend-api/codex/responses/compact` is called with the same non-empty `session_id` header after routing preferences change
+- **THEN** the service reuses the previously pinned upstream account for that thread instead of reallocating to a different account

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -296,3 +296,167 @@ async def test_proxy_compact_reallocates_sticky_mapping(async_client, monkeypatc
     response = await async_client.post("/backend-api/codex/responses", json=stream_payload)
     assert response.status_code == 200
     assert stream_seen == ["acc_c1", "acc_c2"]
+
+
+@pytest.mark.asyncio
+async def test_proxy_codex_session_id_pins_responses_and_compact_without_sticky_threads(async_client, monkeypatch):
+    await _set_routing_settings(async_client, sticky_threads_enabled=False)
+    acc_a_id = await _import_account(async_client, "acc_sid_a", "sid_a@example.com")
+    acc_b_id = await _import_account(async_client, "acc_sid_b", "sid_b@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=20.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    stream_seen: list[str] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        stream_seen.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_session"}}\n\n'
+
+    compact_seen: list[str] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        compact_seen.append(account_id)
+        return OpenAIResponsePayload.model_validate({"output": []})
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    headers = {"session_id": "codex-thread-123"}
+    stream_payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [],
+        "stream": True,
+    }
+    response = await async_client.post("/backend-api/codex/responses", json=stream_payload, headers=headers)
+    assert response.status_code == 200
+    assert stream_seen == ["acc_sid_a"]
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=95.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=5.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    compact_payload = {
+        "model": "gpt-5.1",
+        "instructions": "summarize",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+    }
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json=compact_payload,
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert compact_seen == ["acc_sid_a"]
+
+    response = await async_client.post("/backend-api/codex/responses", json=stream_payload, headers=headers)
+    assert response.status_code == 200
+    assert stream_seen == ["acc_sid_a", "acc_sid_a"]
+
+
+@pytest.mark.asyncio
+async def test_v1_session_id_does_not_pin_routing_without_sticky_threads(async_client, monkeypatch):
+    await _set_routing_settings(async_client, sticky_threads_enabled=False)
+    acc_a_id = await _import_account(async_client, "acc_v1_sid_a", "v1_sid_a@example.com")
+    acc_b_id = await _import_account(async_client, "acc_v1_sid_b", "v1_sid_b@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=20.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    stream_seen: list[str] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        stream_seen.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_v1_session"}}\n\n'
+
+    compact_seen: list[str] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        compact_seen.append(account_id)
+        return OpenAIResponsePayload.model_validate({"output": []})
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    headers = {"session_id": "v1-thread-123"}
+    stream_payload = {
+        "model": "gpt-5.1",
+        "input": "hello",
+        "stream": True,
+    }
+    response = await async_client.post("/v1/responses", json=stream_payload, headers=headers)
+    assert response.status_code == 200
+    assert stream_seen == ["acc_v1_sid_a"]
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=95.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=5.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    compact_payload = {
+        "model": "gpt-5.1",
+        "input": "hello",
+    }
+    response = await async_client.post("/v1/responses/compact", json=compact_payload, headers=headers)
+    assert response.status_code == 200
+    assert compact_seen == ["acc_v1_sid_b"]


### PR DESCRIPTION
## Summary
- pin backend Codex routing to the inbound `session_id` contract so compact stays on the same account as the owning thread
- scope `session_id` affinity to `/backend-api/codex/*` instead of treating it as a proxy-wide routing signal
- add regression coverage for backend Codex stickiness and the negative `/v1/*` case

## Why
We were seeing `502` failures from compact when load balancing moved `/backend-api/codex/responses/compact` to a different upstream account than the account that owned the existing Codex thread. The original Codex client already sends the stable session/thread identifier, so the proxy needs to preserve that account affinity for backend Codex requests.

## Testing
- `.venv/bin/pytest tests/integration/test_proxy_sticky_sessions.py -q`
- `git diff --check`
