### PR TITLE
fix(proxy): finalize v1 responses non-stream reservations

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -651,34 +651,46 @@ def _compact_request_service_tier(payload: ResponsesCompactRequest) -> str | Non
 
 async def _collect_responses_payload(stream: AsyncIterator[str]) -> OpenAIResponseResult:
     output_items: dict[int, dict[str, JsonValue]] = {}
+    terminal_result: OpenAIResponseResult | None = None
     async for line in stream:
         payload = _parse_sse_payload(line)
         if not payload:
             continue
         event_type = payload.get("type")
         _collect_output_item_event(payload, output_items)
+        if terminal_result is not None:
+            continue
         if event_type == "error":
-            return _parse_event_error_envelope(payload)
+            terminal_result = _parse_event_error_envelope(payload)
+            continue
         if event_type == "response.failed":
             response = payload.get("response")
             if isinstance(response, dict):
                 error_value = response.get("error")
                 if isinstance(error_value, dict):
                     try:
-                        return OpenAIErrorEnvelopeModel.model_validate({"error": error_value})
+                        terminal_result = OpenAIErrorEnvelopeModel.model_validate({"error": error_value})
+                        continue
                     except ValidationError:
-                        return _default_error_envelope()
+                        terminal_result = _default_error_envelope()
+                        continue
                 parsed = parse_response_payload(response)
                 if parsed is not None and parsed.error is not None:
-                    return _error_envelope_from_response(parsed.error)
-            return _default_error_envelope()
+                    terminal_result = _error_envelope_from_response(parsed.error)
+                    continue
+            terminal_result = _default_error_envelope()
+            continue
         if event_type in ("response.completed", "response.incomplete"):
             response = payload.get("response")
             if isinstance(response, dict):
                 parsed = parse_response_payload(_merge_collected_output_items(response, output_items))
                 if parsed is not None:
-                    return parsed
-            return _default_error_envelope()
+                    terminal_result = parsed
+                    continue
+            terminal_result = _default_error_envelope()
+
+    if terminal_result is not None:
+        return terminal_result
     return _default_error_envelope()
 
 

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -971,6 +971,77 @@ async def test_compact_cost_limit_prefers_response_service_tier_over_request(
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_non_stream_finalizes_cost_limit(async_client, monkeypatch):
+    enable = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert enable.status_code == 200
+
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "v1-responses-cost-limit",
+            "limits": [
+                {"limitType": "cost_usd", "limitWindow": "weekly", "maxValue": 30_000_000},
+            ],
+        },
+    )
+    assert created.status_code == 200
+    payload = created.json()
+    key = payload["key"]
+    key_id = payload["id"]
+
+    await _import_account(async_client, "acc_v1_responses_cost", "v1-responses-cost@example.com")
+
+    seen = {"calls": 0}
+
+    async def fake_stream(_payload, _headers, _access_token, _account_id, base_url=None, raise_for_status=False):
+        seen["calls"] += 1
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_v1_cost_limit","model":"gpt-5.4",'
+            '"status":"completed","service_tier":"default","usage":{"input_tokens":1000000,"output_tokens":1000000,'
+            '"total_tokens":2000000}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    response = await async_client.post(
+        "/v1/responses",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gpt-5.4", "input": "hi"},
+    )
+    assert response.status_code == 200
+
+    second = await async_client.post(
+        "/v1/responses",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gpt-5.4", "input": "hi"},
+    )
+    assert second.status_code == 200
+
+    blocked = await async_client.post(
+        "/v1/responses",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gpt-5.4", "input": "hi"},
+    )
+    assert blocked.status_code == 429
+    assert blocked.json()["error"]["code"] == "rate_limit_exceeded"
+    assert seen["calls"] == 2
+
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        limits = await repo.get_limits_by_key(key_id)
+        assert len(limits) == 1
+        assert limits[0].current_value == 55_000_000
+
+
+@pytest.mark.asyncio
 async def test_api_key_reservation_released_on_compact_upstream_failure(async_client, monkeypatch):
     enable = await async_client.put(
         "/api/settings",


### PR DESCRIPTION
## Summary
- keep non-stream `/v1/responses` collection draining the upstream SSE after the terminal event so the proxy can finalize API key reservations
- add a regression test covering cost-limit settlement for non-stream `/v1/responses`
- preserve existing output-item reconstruction while fixing the reservation lifecycle

## Testing
- uv run pytest tests/integration/test_api_keys_api.py