### PR TITLE
fix(usage): avoid deactivating accounts on usage 403

### DIFF
--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -251,7 +251,10 @@ def _reset_at(reset_at: int | None, reset_after_seconds: int | None, now_epoch: 
     return now_epoch + max(0, int(reset_after_seconds))
 
 
-_DEACTIVATING_USAGE_STATUS_CODES = {402, 403, 404}
+# The usage endpoint can return 403 for accounts that are still otherwise usable
+# for proxy traffic, so treat it as a refresh failure instead of a permanent
+# account-level deactivation signal.
+_DEACTIVATING_USAGE_STATUS_CODES = {402, 404}
 
 
 def _should_deactivate_for_usage_error(status_code: int) -> bool:

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -201,6 +201,30 @@ async def test_usage_updater_deactivates_on_account_invalid_4xx(monkeypatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_usage_updater_does_not_deactivate_on_403(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.clients.usage import UsageFetchError
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage_403(**_: Any) -> UsagePayload:
+        raise UsageFetchError(403, "Forbidden")
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_403)
+
+    usage_repo = StubUsageRepository()
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+
+    acc = _make_account("acc_403", "workspace_403", email="forbidden@example.com")
+
+    await updater.refresh_accounts([acc], latest_usage={})
+
+    assert len(accounts_repo.status_updates) == 0
+
+
+@pytest.mark.asyncio
 async def test_usage_updater_does_not_deactivate_on_transient_4xx(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.clients.usage import UsageFetchError


### PR DESCRIPTION
## Summary
- stop treating usage API 403 responses as permanent account failures
- add a unit regression test to keep usage refresh from deactivating accounts on 403
- keep 402/404 permanent deactivation behavior unchanged

## Testing
- uv run pytest tests/unit/test_usage_updater.py -k "deactivate_on_account_invalid_4xx or does_not_deactivate_on_403 or does_not_deactivate_on_transient_4xx or does_not_deactivate_on_401 or does_not_deactivate_on_5xx"