### PR TITLE
fix(proxy): align compact retry account header after refresh

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -125,11 +125,11 @@ class ProxyService:
                 openai_error("no_accounts", selection.error_message or "No active accounts available"),
             )
         account = await self._ensure_fresh(account)
-        account_id = _header_account_id(account.chatgpt_account_id)
         request_service_tier = _service_tier_from_compact_payload(payload)
 
         async def _call_compact(target: Account) -> OpenAIResponsePayload:
             access_token = self._encryptor.decrypt(target.access_token_encrypted)
+            account_id = _header_account_id(target.chatgpt_account_id)
             return await core_compact_responses(payload, filtered, access_token, account_id)
 
         try:

--- a/openspec/changes/pin-codex-session-routing/proposal.md
+++ b/openspec/changes/pin-codex-session-routing/proposal.md
@@ -2,12 +2,13 @@
 
 Codex CLI sends a stable thread `session_id` header on backend Responses and compact requests. `codex-lb` currently ignores that header for routing unless the dashboard-level sticky thread setting is enabled, which allows a compact request to hop to a different upstream account than the one already serving the thread.
 
-That breaks Codex remote compaction semantics for multi-account setups because thread-scoped history can contain upstream-owned encrypted items that must stay on the same account path.
+That breaks Codex remote compaction semantics for multi-account setups because thread-scoped history can contain upstream-owned encrypted items that must stay on the same account path. The compact retry path also has to keep the provider account header aligned with the refreshed account record, otherwise a correctly pinned thread can still fail upstream after token refresh.
 
 ## What Changes
 
 - Treat inbound Codex `session_id` as a routing affinity key for backend Responses and compact requests.
 - Preserve that affinity even when `sticky_threads_enabled` is disabled, while keeping existing prompt-cache stickiness for other clients unchanged.
+- Ensure compact retries derive the upstream `chatgpt-account-id` header from the refreshed target account instead of the pre-refresh snapshot.
 - Add regression coverage for the response-to-compact handoff.
 
 ## Impact

--- a/openspec/changes/pin-codex-session-routing/tasks.md
+++ b/openspec/changes/pin-codex-session-routing/tasks.md
@@ -2,11 +2,14 @@
 
 - [x] 1.1 Use inbound `session_id` as the sticky routing key for Codex backend Responses requests
 - [x] 1.2 Use inbound `session_id` as the sticky routing key for Codex compact requests
+- [x] 1.3 Derive the compact upstream account header from the current refreshed account on every compact attempt
 
 ## 2. Regression coverage
 
 - [x] 2.1 Add an integration test that proves a Codex thread stays pinned across response and compact requests when dashboard sticky threads are disabled
+- [x] 2.2 Add an integration test that proves compact retry uses the refreshed provider account header after a 401 refresh
 
 ## 3. Spec updates
 
 - [x] 3.1 Document Codex `session_id` routing affinity for backend Responses and compact requests
+- [x] 3.2 Document that compact retries use the refreshed upstream account identity

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -213,3 +213,7 @@ When a backend Codex Responses or compact request includes a non-empty `session_
 #### Scenario: Compact request reuses pinned Codex session account
 - **WHEN** `/backend-api/codex/responses/compact` is called with the same non-empty `session_id` header after routing preferences change
 - **THEN** the service reuses the previously pinned upstream account for that thread instead of reallocating to a different account
+
+#### Scenario: Compact retry uses refreshed provider account identity
+- **WHEN** a pinned backend Codex compact request gets a `401` from upstream, refreshes the selected account, and retries
+- **THEN** the retry forwards the refreshed account's `chatgpt-account-id` header instead of reusing the pre-refresh account header

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -9,6 +9,7 @@ import pytest
 import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
 from app.core.clients.proxy import ProxyResponseError
+from app.core.errors import openai_error
 from app.core.openai.models import OpenAIResponsePayload
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
@@ -179,3 +180,38 @@ async def test_proxy_compact_usage_limit_marks_account(async_client, monkeypatch
         account = await session.get(Account, expected_account_id)
         assert account is not None
         assert account.status == AccountStatus.RATE_LIMITED
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_retry_uses_refreshed_account_id(async_client, monkeypatch):
+    email = "compact-retry@example.com"
+    raw_account_id = "acc_compact_retry_old"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    captured_account_ids: list[str | None] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        captured_account_ids.append(account_id)
+        if len(captured_account_ids) == 1:
+            raise ProxyResponseError(
+                401,
+                openai_error("invalid_api_key", "token expired"),
+            )
+        return OpenAIResponsePayload.model_validate({"output": []})
+
+    async def fake_ensure_fresh(self, account, force: bool = False):
+        if force:
+            account.chatgpt_account_id = "acc_compact_retry_new"
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh", fake_ensure_fresh)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": []}
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+    assert response.status_code == 200
+    assert response.json()["output"] == []
+    assert captured_account_ids == ["acc_compact_retry_old", "acc_compact_retry_new"]


### PR DESCRIPTION
## Summary
- fix compact retry to forward the refreshed provider account header on retry
- add regression coverage for a 401 refresh plus compact retry
- update the existing Codex session-routing OpenSpec change to document the retry contract

## Why
The earlier compact routing fix stopped mid-thread account hopping and was merged upstream in #143. There was still one remaining compact 502 path: if the selected account refreshed after a 401, the retry reused the pre-refresh `chatgpt-account-id` header instead of the refreshed account identity. That can still produce provider-side mismatch failures during compaction in multi-account setups.

## Testing
- /mnt/scratch/home/aaiyer/codex-lb/.venv/bin/pytest tests/integration/test_proxy_compact.py tests/integration/test_proxy_sticky_sessions.py -q
- /mnt/scratch/home/aaiyer/codex-lb/.venv/bin/ruff check app/modules/proxy/service.py tests/integration/test_proxy_compact.py
- git diff --check
