### PR TITLE
fix(proxy): match Codex CLI compact timeout defaults

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -904,10 +904,11 @@ async def compact_responses(
         account_id,
         accept="application/json",
     )
+    compact_timeout_seconds = settings.upstream_compact_timeout_seconds
     timeout = aiohttp.ClientTimeout(
-        total=settings.upstream_compact_timeout_seconds,
+        total=compact_timeout_seconds,
         sock_connect=settings.upstream_connect_timeout_seconds,
-        sock_read=settings.upstream_compact_timeout_seconds,
+        sock_read=compact_timeout_seconds,
     )
 
     client_session = session or get_http_client().session

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -54,7 +54,7 @@ class Settings(BaseSettings):
     database_alembic_auto_remap_enabled: bool = True
     upstream_base_url: str = "https://chatgpt.com/backend-api"
     upstream_connect_timeout_seconds: float = 30.0
-    upstream_compact_timeout_seconds: float = 300.0
+    upstream_compact_timeout_seconds: float | None = None
     stream_idle_timeout_seconds: float = 300.0
     max_sse_event_bytes: int = Field(default=2 * 1024 * 1024, gt=0)
     auth_base_url: str = "https://auth.openai.com"
@@ -149,6 +149,15 @@ class Settings(BaseSettings):
             except ValueError as exc:
                 raise ValueError(f"Invalid firewall trusted proxy CIDR: {cidr}") from exc
         return cidrs
+
+    @field_validator("upstream_compact_timeout_seconds")
+    @classmethod
+    def _validate_upstream_compact_timeout_seconds(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        if value <= 0:
+            raise ValueError("upstream_compact_timeout_seconds must be greater than zero")
+        return value
 
 
 @lru_cache(maxsize=1)

--- a/openspec/changes/increase-compact-upstream-timeout/proposal.md
+++ b/openspec/changes/increase-compact-upstream-timeout/proposal.md
@@ -1,17 +1,17 @@
-# Change Proposal: Increase compact upstream timeout
+# Change Proposal: Match Codex CLI compact timeout behavior
 
 ## Why
 
-`/backend-api/codex/responses/compact` currently uses a hard-coded 60 second upstream read timeout. Real compact requests can legitimately take longer than that, which makes the proxy return `502 upstream_unavailable` even when the provider would have succeeded if given more time.
+`/backend-api/codex/responses/compact` currently imposes a proxy-side timeout that the original Codex CLI does not use. That makes the proxy fail compact requests with `502 upstream_unavailable` even though the original client would continue waiting for the provider.
 
 ## What Changes
 
 - add a dedicated `CODEX_LB_UPSTREAM_COMPACT_TIMEOUT_SECONDS` setting
-- raise the default compact upstream timeout from 60 seconds to 300 seconds
-- use that setting for both total and read timeout on upstream compact calls
+- default that setting to disabled so compact behaves like the original Codex CLI
+- use the setting only when an operator explicitly configures a compact timeout override
 - add regression coverage for compact read timeouts and timeout wiring
 
 ## Impact
 
-- fewer false `502 upstream_unavailable` failures on slow but valid compact requests
-- operators can tune compact latency tolerance independently from SSE stream idle timeout
+- eliminates proxy-only false `502 upstream_unavailable` failures on slow but valid compact requests
+- keeps an operator escape hatch for explicit compact request time limits when needed

--- a/openspec/changes/increase-compact-upstream-timeout/tasks.md
+++ b/openspec/changes/increase-compact-upstream-timeout/tasks.md
@@ -1,4 +1,4 @@
-- [x] Add a dedicated compact upstream timeout setting with a higher default
+- [x] Add a dedicated compact upstream timeout setting that defaults to disabled
 - [x] Update compact upstream calls to use the configurable timeout
-- [x] Add regression coverage for configured timeout wiring and read-timeout mapping
+- [x] Add regression coverage for default no-timeout wiring, configured timeout wiring, and read-timeout mapping
 - [x] Update the responses compatibility spec with the compact timeout contract

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -236,9 +236,13 @@ When a backend Codex Responses or compact request includes a non-empty `session_
 - **WHEN** a pinned backend Codex compact request gets a `401` from upstream, refreshes the selected account, and retries
 - **THEN** the retry forwards the refreshed account's `chatgpt-account-id` header instead of reusing the pre-refresh account header
 
-### Requirement: Compact upstream timeout is configurable and longer-lived
-The service MUST use a dedicated compact upstream timeout setting for `/responses/compact` requests. The default compact upstream timeout MUST be 300 seconds, and upstream read timeouts on compact MUST surface as `502` OpenAI-format errors with code `upstream_unavailable`.
+### Requirement: Compact upstream timeout matches Codex CLI by default
+The service MUST not impose a compact request timeout by default for `/responses/compact` requests. The service MAY allow operators to configure an explicit compact timeout override, and upstream read timeouts on compact MUST surface as `502` OpenAI-format errors with code `upstream_unavailable`.
 
 #### Scenario: Compact request exceeds read timeout
 - **WHEN** an upstream compact request does not produce a complete JSON response before the configured compact timeout elapses
 - **THEN** the service returns `502` with error code `upstream_unavailable`
+
+#### Scenario: Compact request uses no timeout by default
+- **WHEN** `/responses/compact` is called and no compact timeout override is configured
+- **THEN** the service forwards the request without setting an upstream total or read timeout

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -408,7 +408,7 @@ async def test_compact_responses_starts_upstream_timer_after_image_inlining(monk
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 1.0
-        upstream_compact_timeout_seconds = 60.0
+        upstream_compact_timeout_seconds = None
         image_inline_fetch_enabled = True
         log_upstream_request_payload = False
 
@@ -496,6 +496,40 @@ async def test_compact_responses_uses_configured_timeout_and_maps_read_timeout(m
     assert exc_info.value.status_code == 502
     assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
     assert exc_info.value.payload["error"]["message"] == "Timeout on reading data from socket"
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_defaults_to_no_request_timeout(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 2.0
+        upstream_compact_timeout_seconds = None
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+    session = _CompactSession(_JsonCompactResponse({"output": []}))
+
+    result = await proxy_module.compact_responses(
+        payload,
+        headers={},
+        access_token="token",
+        account_id="acc_1",
+        session=cast(proxy_module.aiohttp.ClientSession, session),
+    )
+
+    timeout = session.calls[0]["timeout"]
+    assert isinstance(timeout, proxy_module.aiohttp.ClientTimeout)
+    assert timeout.total is None
+    assert timeout.sock_connect == 2.0
+    assert timeout.sock_read is None
+    assert result.model_extra == {"output": []}
 
 
 def test_logged_error_json_response_emits_proxy_error_log(caplog):


### PR DESCRIPTION
## Summary
- remove the proxy-imposed compact request timeout by default so `/responses/compact` matches Codex CLI behavior
- keep `CODEX_LB_UPSTREAM_COMPACT_TIMEOUT_SECONDS` as an optional override instead of a default limit
- preserve `upstream_unavailable` mapping for configured compact read timeouts and add regression coverage

## Why
We were still seeing compact fail with proxy-generated `502 upstream_unavailable` errors after the earlier routing fixes. The root cause here was different: codex-lb was imposing a compact request timeout, while the original Codex CLI compact path does not set one by default.

That meant slow but valid compact requests could fail in the proxy even though the original client would have continued waiting for the provider.

## Verification
- `uv run ruff check app/core/config/settings.py app/core/clients/proxy.py tests/unit/test_proxy_utils.py`
- `uv run ty check app/core/config/settings.py app/core/clients/proxy.py tests/unit/test_proxy_utils.py`
- `pytest tests/unit/test_proxy_utils.py tests/integration/test_proxy_compact.py tests/integration/test_proxy_sticky_sessions.py -q`
