### PR TITLE
chore(pyproject): add maintainer metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [{ name = "Soju06", email = "qlskssk@gmail.com" }]
 maintainers = [
     { name = "Soju06", email = "qlskssk@gmail.com" },
     { name = "choi138", email = "kidjustinchoi@gmail.com" },
+    { name = "aaiyer", email = "aaiyer0@proton.me" },
 ]
 keywords = [
     "codex",


### PR DESCRIPTION
## Summary
- keep the existing maintainer entry in `pyproject.toml`
- add `choi138 <kidjustinchoi@gmail.com>` as an additional maintainer

## Testing
- not run (metadata-only change)