### PR TITLE
fix(acc): define trend as secondary instead of primary for free acc

### DIFF
--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -350,6 +350,13 @@ class UsageUpdater:
         if primary is None and secondary is None:
             additional_synced = self._additional_usage_repo is not None and payload.additional_rate_limits is not None
             return AccountRefreshResult(usage_written=additional_synced)
+        # This is a special case that if the account type is free (or probably go)
+        # The 7d stat is in primary window instead of secondary window 
+        # (that is widely defined as 7d in the ui)
+        # This will cause the account usage trend is "primary" instead of "secondary"
+        if primary and primary.limit_window_seconds == 604800:
+            secondary = rate_limit.primary_window
+            primary = None
         credits_has, credits_unlimited, credits_balance = _credits_snapshot(payload)
         usage_written = False
 


### PR DESCRIPTION
For free account (at least), the window returned by the api is primary instead of secondary (free tier have 7d quota only, no 5h), in which secondary is widely defined as 7d window.
<img width="296" height="228" alt="螢幕截圖 2026-03-12 18 16 10" src="https://github.com/user-attachments/assets/8b049724-0f34-4f11-a0a0-d421e64029c4" />

The UI before the fix, you can see the actual usage in free account is "primary"
And it is back to "secondary" after the fix
<img width="755" height="434" alt="螢幕截圖 2026-03-12 20 46 39" src="https://github.com/user-attachments/assets/0d7245ac-58e7-4d34-a3bc-65919b5caead" />

Note that the primary data display will be a bit wired during the 7-day period after the upgrade. 
