### PR TITLE
fix(proxy): close stream immediately after terminal SSE events

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -951,7 +951,14 @@ async def _stream_websocket_events(
         if not isinstance(payload, dict):
             continue
         normalized = _normalize_stream_event_payload(payload)
+        event_type = payload.get("type")
         yield format_sse_event(normalized)
+        if isinstance(event_type, str) and event_type in (
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+        ):
+            break
 
 
 async def _stream_responses_via_websocket(
@@ -1390,6 +1397,8 @@ async def stream_responses(
                     if event_type in ("response.completed", "response.failed", "response.incomplete"):
                         seen_terminal = True
                 yield event_block
+                if seen_terminal:
+                    break
 
     _maybe_log_upstream_request_start(
         kind="responses",
@@ -1423,6 +1432,8 @@ async def stream_responses(
                         if event_type in ("response.completed", "response.failed", "response.incomplete"):
                             seen_terminal = True
                     yield event_block
+                    if seen_terminal:
+                        break
             except aiohttp.WSServerHandshakeError as exc:
                 if not _should_fallback_to_http_after_websocket_handshake_error(transport_mode, exc):
                     error_payload = _error_payload_from_websocket_handshake_error(exc)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2971,17 +2971,10 @@ def _websocket_receive_timeout_for_pending_requests(
             error_message="Upstream stream idle timeout",
             fail_all_pending=True,
         )
-    if remaining_budget <= idle_timeout_seconds:
-        return _WebSocketReceiveTimeout(
-            timeout_seconds=remaining_budget,
-            error_code="upstream_request_timeout",
-            error_message="Proxy request budget exhausted",
-        )
     return _WebSocketReceiveTimeout(
-        timeout_seconds=idle_timeout_seconds,
-        error_code="stream_idle_timeout",
-        error_message="Upstream stream idle timeout",
-        fail_all_pending=True,
+        timeout_seconds=remaining_budget,
+        error_code="upstream_request_timeout",
+        error_message="Proxy request budget exhausted",
     )
 
 


### PR DESCRIPTION
## Summary

- **Fix SSE/WebSocket streams hanging for ~5 minutes** after receiving terminal events (`response.completed`, `response.failed`, `response.incomplete`). The proxy kept the reading loop open until `stream_idle_timeout_seconds` (default 300s) fired, causing every streaming request through the LB to take ~5 min regardless of actual upstream response time.
- **Break out of all three reading loops** immediately after yielding terminal events: `_stream_via_http`, `_stream_responses_via_websocket` consumer loop, and `_stream_websocket_events`.
- **Remove unreachable dead code** in `_websocket_receive_timeout_for_pending_requests` — redundant conditional branch and unreachable return after exhaustive conditions.

## Root Cause

In `stream_responses` (proxy.py), after detecting a terminal SSE event type, the code set `seen_terminal = True` but never broke out of `async for event_block in _iter_sse_events(...)`. Since `_iter_sse_events` waits up to `stream_idle_timeout_seconds` for the next chunk, every stream hung for exactly 300 seconds after the real response completed.

Same pattern existed in the WebSocket transport path and in `_stream_websocket_events`.

## Changes

| File | Change |
|------|--------|
| `app/core/clients/proxy.py` | Add `if seen_terminal: break` after yield in `_stream_via_http` loop (~L1399) |
| `app/core/clients/proxy.py` | Add `if seen_terminal: break` after yield in WebSocket consumer loop (~L1434) |
| `app/core/clients/proxy.py` | Add terminal event type detection + `break` in `_stream_websocket_events` (~L954-960) |
| `app/modules/proxy/service.py` | Remove unreachable dead code in `_websocket_receive_timeout_for_pending_requests` |

## Testing

- All 886 tests pass (4 skipped — PostgreSQL-only)
- Pre-commit hooks (ruff, ruff-format, ty) all pass