### PR TITLE
feat(proxy): improve token cache affinity for codex and v1/responses endpoints

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -410,6 +410,7 @@ class ResponsesCompactRequest(BaseModel):
     input: JsonValue
     reasoning: ResponsesReasoning | None = None
     store: bool = False
+    prompt_cache_key: str | None = None
 
     @field_validator("input")
     @classmethod

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -123,7 +123,9 @@ async def responses(
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
-    return await _stream_responses(request, payload, context, api_key, codex_session_affinity=True)
+    return await _stream_responses(
+        request, payload, context, api_key, codex_session_affinity=True, openai_cache_affinity=True
+    )
 
 
 @ws_router.websocket("/responses")
@@ -140,7 +142,7 @@ async def responses_websocket(
         websocket,
         websocket.headers,
         codex_session_affinity=True,
-        openai_cache_affinity=False,
+        openai_cache_affinity=True,
         api_key=api_key,
     )
 
@@ -522,7 +524,9 @@ async def responses_compact(
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> JSONResponse:
-    return await _compact_responses(request, payload, context, api_key, codex_session_affinity=True)
+    return await _compact_responses(
+        request, payload, context, api_key, codex_session_affinity=True, openai_cache_affinity=True
+    )
 
 
 @v1_router.post("/responses/compact", response_model=CompactResponseResult)

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -349,16 +349,6 @@ class LoadBalancer:
         if sticky_kind is None:
             raise ValueError("sticky_kind is required when sticky_key is provided")
 
-        if reallocate_sticky:
-            chosen = select_account(
-                states,
-                prefer_earlier_reset=prefer_earlier_reset_accounts,
-                routing_strategy=routing_strategy,
-            )
-            if chosen.account is not None and chosen.account.account_id in account_map:
-                await sticky_repo.upsert(sticky_key, chosen.account.account_id, kind=sticky_kind)
-            return chosen
-
         existing = await sticky_repo.get_account_id(
             sticky_key,
             kind=sticky_kind,
@@ -366,9 +356,7 @@ class LoadBalancer:
         )
         if existing:
             pinned = next((state for state in states if state.account_id == existing), None)
-            if pinned is None:
-                await sticky_repo.delete(sticky_key, kind=sticky_kind)
-            else:
+            if pinned is not None:
                 pinned_result = select_account(
                     [pinned],
                     prefer_earlier_reset=prefer_earlier_reset_accounts,
@@ -376,9 +364,13 @@ class LoadBalancer:
                     allow_backoff_fallback=False,
                 )
                 if pinned_result.account is not None:
-                    if sticky_max_age_seconds is not None:
+                    if not reallocate_sticky and sticky_max_age_seconds is not None:
                         await sticky_repo.upsert(sticky_key, pinned.account_id, kind=sticky_kind)
                     return pinned_result
+                if reallocate_sticky:
+                    await sticky_repo.delete(sticky_key, kind=sticky_kind)
+            else:
+                await sticky_repo.delete(sticky_key, kind=sticky_kind)
 
         chosen = select_account(
             states,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -201,6 +201,7 @@ class ProxyService:
             openai_cache_affinity=openai_cache_affinity,
             openai_cache_affinity_max_age_seconds=settings.openai_cache_affinity_max_age_seconds,
             sticky_threads_enabled=settings.sticky_threads_enabled,
+            api_key=api_key,
         )
         routing_strategy = _routing_strategy(settings)
         try:
@@ -843,6 +844,7 @@ class ProxyService:
                 openai_cache_affinity=openai_cache_affinity,
                 openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
                 sticky_threads_enabled=sticky_threads_enabled,
+                api_key=api_key,
             ),
         )
 
@@ -1826,6 +1828,7 @@ class ProxyService:
             openai_cache_affinity=openai_cache_affinity,
             openai_cache_affinity_max_age_seconds=settings.openai_cache_affinity_max_age_seconds,
             sticky_threads_enabled=settings.sticky_threads_enabled,
+            api_key=api_key,
         )
         routing_strategy = _routing_strategy(settings)
         max_attempts = 3
@@ -3243,6 +3246,58 @@ def _prompt_cache_key_from_request_model(payload: ResponsesRequest | ResponsesCo
     return None
 
 
+def _derive_prompt_cache_key(
+    payload: ResponsesRequest | ResponsesCompactRequest,
+    api_key: ApiKeyData | None,
+) -> str:
+    """Derive a stable, session-scoped prompt_cache_key when the client does not provide one.
+
+    The generated key is scoped to (api-key, instructions-prefix, first-user-input) so that:
+    - Parallel sessions from the same API key get *different* keys (different first input).
+    - Successive turns within one session get the *same* key (first input stays constant).
+    - Different API keys never collide.
+    """
+    parts: list[str] = []
+
+    if api_key is not None:
+        parts.append(api_key.id[:12])
+
+    instructions = getattr(payload, "instructions", None)
+    if isinstance(instructions, str) and instructions:
+        parts.append(sha256(instructions[:512].encode()).hexdigest()[:12])
+
+    first_user_text = _extract_first_user_input(payload)
+    if first_user_text:
+        parts.append(sha256(first_user_text[:512].encode()).hexdigest()[:12])
+
+    return "-".join(parts) if parts else uuid4().hex[:24]
+
+
+def _extract_first_user_input(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
+    """Return a text representation of the first user input item for cache key derivation."""
+    input_value = getattr(payload, "input", None)
+    if isinstance(input_value, str):
+        return input_value[:512]
+    if not isinstance(input_value, list):
+        return None
+    for item in input_value:
+        if not isinstance(item, dict):
+            continue
+        role = item.get("role")
+        if role == "user":
+            content = item.get("content")
+            if isinstance(content, str):
+                return content[:512]
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict):
+                        text = part.get("text")
+                        if isinstance(text, str):
+                            return text[:512]
+            return json.dumps(item, sort_keys=True, ensure_ascii=False)[:512]
+    return None
+
+
 def _sticky_key_from_payload(payload: ResponsesRequest) -> str | None:
     value = _prompt_cache_key_from_request_model(payload)
     if not value:
@@ -3268,6 +3323,7 @@ def _sticky_key_for_responses_request(
     openai_cache_affinity: bool,
     openai_cache_affinity_max_age_seconds: int,
     sticky_threads_enabled: bool,
+    api_key: ApiKeyData | None = None,
 ) -> _AffinityPolicy:
     if codex_session_affinity:
         session_key = _sticky_key_from_session_header(headers)
@@ -3276,15 +3332,19 @@ def _sticky_key_for_responses_request(
                 key=session_key,
                 kind=StickySessionKind.CODEX_SESSION,
             )
+    cache_key = _sticky_key_from_payload(payload)
+    if cache_key is None and openai_cache_affinity:
+        cache_key = _derive_prompt_cache_key(payload, api_key)
+        payload.prompt_cache_key = cache_key
     if openai_cache_affinity:
         return _AffinityPolicy(
-            key=_sticky_key_from_payload(payload),
+            key=cache_key,
             kind=StickySessionKind.PROMPT_CACHE,
             max_age_seconds=openai_cache_affinity_max_age_seconds,
         )
     if sticky_threads_enabled:
         return _AffinityPolicy(
-            key=_sticky_key_from_payload(payload),
+            key=cache_key,
             kind=StickySessionKind.STICKY_THREAD,
             reallocate_sticky=True,
         )
@@ -3307,6 +3367,7 @@ def _sticky_key_for_compact_request(
     openai_cache_affinity: bool,
     openai_cache_affinity_max_age_seconds: int,
     sticky_threads_enabled: bool,
+    api_key: ApiKeyData | None = None,
 ) -> _AffinityPolicy:
     if codex_session_affinity:
         session_key = _sticky_key_from_session_header(headers)
@@ -3315,15 +3376,19 @@ def _sticky_key_for_compact_request(
                 key=session_key,
                 kind=StickySessionKind.CODEX_SESSION,
             )
+    cache_key = _sticky_key_from_compact_payload(payload)
+    if cache_key is None and openai_cache_affinity:
+        cache_key = _derive_prompt_cache_key(payload, api_key)
+        payload.prompt_cache_key = cache_key
     if openai_cache_affinity:
         return _AffinityPolicy(
-            key=_sticky_key_from_compact_payload(payload),
+            key=cache_key,
             kind=StickySessionKind.PROMPT_CACHE,
             max_age_seconds=openai_cache_affinity_max_age_seconds,
         )
     if sticky_threads_enabled:
         return _AffinityPolicy(
-            key=_sticky_key_from_compact_payload(payload),
+            key=cache_key,
             kind=StickySessionKind.STICKY_THREAD,
             reallocate_sticky=True,
         )

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -166,7 +166,7 @@ async def test_proxy_stream_sticky_threads_reallocate_by_prompt_cache_key(async_
     response = await async_client.post("/backend-api/codex/responses", json=payload)
     assert response.status_code == 200
 
-    assert seen == ["acc_a", "acc_b"]
+    assert seen == ["acc_a", "acc_a"]
 
 
 @pytest.mark.asyncio
@@ -327,11 +327,11 @@ async def test_proxy_compact_reallocates_sticky_mapping(async_client, monkeypatc
     }
     response = await async_client.post("/backend-api/codex/responses/compact", json=compact_payload)
     assert response.status_code == 200
-    assert compact_seen == ["acc_c2"]
+    assert compact_seen == ["acc_c1"]
 
     response = await async_client.post("/backend-api/codex/responses", json=stream_payload)
     assert response.status_code == 200
-    assert stream_seen == ["acc_c1", "acc_c2"]
+    assert stream_seen == ["acc_c1", "acc_c1"]
 
 
 @pytest.mark.asyncio
@@ -644,7 +644,7 @@ async def test_v1_session_id_does_not_pin_routing_without_sticky_threads(async_c
     }
     response = await async_client.post("/v1/responses/compact", json=compact_payload, headers=headers)
     assert response.status_code == 200
-    assert compact_seen == ["acc_v1_sid_b"]
+    assert compact_seen == ["acc_v1_sid_a"]
 
 
 @pytest.mark.asyncio
@@ -820,3 +820,220 @@ async def test_v1_prompt_cache_key_rebalances_after_affinity_expires(async_clien
     response = await async_client.post("/v1/responses", json=stream_payload)
     assert response.status_code == 200
     assert stream_seen == ["acc_v1_expire_a", "acc_v1_expire_b"]
+
+
+@pytest.mark.asyncio
+async def test_codex_endpoint_uses_prompt_cache_sticky_kind(async_client, monkeypatch):
+    await _set_routing_settings(async_client, sticky_threads_enabled=True)
+    acc_id = await _import_account(async_client, "acc_kind_a", "kind_a@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    seen: list[str] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        seen.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_k"}}\n\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True, "prompt_cache_key": "pck_abc"}
+    await async_client.post("/backend-api/codex/responses", json=payload)
+    assert seen == ["acc_kind_a"]
+
+    async with SessionLocal() as session:
+        row = (await session.execute(text("SELECT kind FROM sticky_sessions WHERE key = 'pck_abc'"))).fetchone()
+        assert row is not None
+        assert row[0] == "prompt_cache"
+
+
+@pytest.mark.asyncio
+async def test_v1_auto_derived_key_separates_parallel_sessions(async_client, monkeypatch):
+    _install_proxy_settings_cache(monkeypatch, sticky_threads_enabled=False)
+    acc_a_id = await _import_account(async_client, "acc_par_a", "par_a@example.com")
+    acc_b_id = await _import_account(async_client, "acc_par_b", "par_b@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=20.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    seen: list[str] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        seen.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_p"}}\n\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    session_a = {"model": "gpt-5.1", "input": "build a server", "stream": True}
+    session_b = {"model": "gpt-5.1", "input": "write tests", "stream": True}
+
+    await async_client.post("/v1/responses", json=session_a)
+    await async_client.post("/v1/responses", json=session_b)
+
+    assert len(seen) == 2
+    assert seen[0] == "acc_par_a"
+
+
+@pytest.mark.asyncio
+async def test_v1_auto_derived_key_stable_across_turns(async_client, monkeypatch):
+    _install_proxy_settings_cache(monkeypatch, sticky_threads_enabled=False)
+    acc_a_id = await _import_account(async_client, "acc_turn_a", "turn_a@example.com")
+    acc_b_id = await _import_account(async_client, "acc_turn_b", "turn_b@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=20.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    seen: list[str] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        seen.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_t"}}\n\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    turn1 = {
+        "model": "gpt-5.1",
+        "input": [{"role": "user", "content": "build a server"}],
+        "stream": True,
+    }
+    turn2 = {
+        "model": "gpt-5.1",
+        "input": [
+            {"role": "user", "content": "build a server"},
+            {"role": "assistant", "content": "Here is a server..."},
+            {"role": "user", "content": "add logging"},
+        ],
+        "stream": True,
+    }
+
+    await async_client.post("/v1/responses", json=turn1)
+    assert seen == ["acc_turn_a"]
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=90.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=5.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    await async_client.post("/v1/responses", json=turn2)
+
+    assert seen == ["acc_turn_a", "acc_turn_a"]
+
+
+@pytest.mark.asyncio
+async def test_reallocate_sticky_respects_existing_session_then_falls_back(async_client, monkeypatch):
+    await _set_routing_settings(async_client, sticky_threads_enabled=True)
+    acc_a_id = await _import_account(async_client, "acc_realloc_a", "realloc_a@example.com")
+    acc_b_id = await _import_account(async_client, "acc_realloc_b", "realloc_b@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=20.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    seen: list[str] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        seen.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_r"}}\n\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True, "prompt_cache_key": "realloc_key"}
+    await async_client.post("/backend-api/codex/responses", json=payload)
+    assert seen == ["acc_realloc_a"]
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=95.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=5.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    await async_client.post("/backend-api/codex/responses", json=payload)
+    assert seen == ["acc_realloc_a", "acc_realloc_a"]
+
+    async with SessionLocal() as session:
+        await session.execute(text("DELETE FROM accounts WHERE chatgpt_account_id = 'acc_realloc_a'"))
+        await session.commit()
+
+    await async_client.post("/backend-api/codex/responses", json=payload)
+    assert len(seen) == 3
+    assert seen[2] == "acc_realloc_b"

--- a/tests/unit/test_prompt_cache_key_derivation.py
+++ b/tests/unit/test_prompt_cache_key_derivation.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+from app.modules.api_keys.service import ApiKeyData
+from app.modules.proxy.service import (
+    _derive_prompt_cache_key,
+    _extract_first_user_input,
+)
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
+def _make_api_key(id: str = "ak_test_001122334455") -> ApiKeyData:
+    return ApiKeyData(
+        id=id,
+        name="test-key",
+        key_prefix="sk-test",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        expires_at=None,
+        is_active=True,
+        created_at=_NOW,
+        last_used_at=None,
+    )
+
+
+class TestExtractFirstUserInput:
+    def test_string_input(self):
+        payload = ResponsesRequest(model="gpt-5.4", instructions="sys", input="hello world")
+        assert _extract_first_user_input(payload) == "hello world"
+
+    def test_string_input_truncated_to_512(self):
+        long_text = "x" * 1000
+        payload = ResponsesRequest(model="gpt-5.4", instructions="sys", input=long_text)
+        assert _extract_first_user_input(payload) == long_text[:512]
+
+    def test_user_message_with_text_content(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="sys",
+            input=[
+                {"role": "user", "content": "first question"},
+                {"role": "assistant", "content": "response"},
+                {"role": "user", "content": "second question"},
+            ],
+        )
+        assert _extract_first_user_input(payload) == "first question"
+
+    def test_user_message_with_structured_content(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="sys",
+            input=[
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "structured msg"}],
+                },
+            ],
+        )
+        assert _extract_first_user_input(payload) == "structured msg"
+
+    def test_message_type_item_with_user_role(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="sys",
+            input=[
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "typed item"}],
+                },
+            ],
+        )
+        assert _extract_first_user_input(payload) == "typed item"
+
+    def test_skips_assistant_and_system_items(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="sys",
+            input=[
+                {"role": "assistant", "content": "I am assistant"},
+                {"type": "function_call", "name": "shell", "arguments": "{}"},
+                {"role": "user", "content": "the real first input"},
+            ],
+        )
+        assert _extract_first_user_input(payload) == "the real first input"
+
+    def test_empty_input_array(self):
+        payload = ResponsesRequest(model="gpt-5.4", instructions="sys", input=[])
+        assert _extract_first_user_input(payload) is None
+
+    def test_no_user_items(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="sys",
+            input=[
+                {"role": "assistant", "content": "only assistant"},
+            ],
+        )
+        assert _extract_first_user_input(payload) is None
+
+    def test_compact_request_string_input(self):
+        payload = ResponsesCompactRequest(model="gpt-5.4", instructions="sys", input="compact hello")
+        assert _extract_first_user_input(payload) == "compact hello"
+
+
+class TestDerivePromptCacheKey:
+    def test_same_session_across_turns_produces_same_key(self):
+        turn1 = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="You are a helpful assistant",
+            input=[{"role": "user", "content": "build a server"}],
+        )
+        turn2 = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="You are a helpful assistant",
+            input=[
+                {"role": "user", "content": "build a server"},
+                {"role": "assistant", "content": "Sure, here is..."},
+                {"role": "user", "content": "add logging"},
+            ],
+        )
+        api_key = _make_api_key()
+        key1 = _derive_prompt_cache_key(turn1, api_key)
+        key2 = _derive_prompt_cache_key(turn2, api_key)
+        assert key1 == key2
+
+    def test_parallel_sessions_produce_different_keys(self):
+        session_a = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="You are a helpful assistant",
+            input=[{"role": "user", "content": "build a server"}],
+        )
+        session_b = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="You are a helpful assistant",
+            input=[{"role": "user", "content": "write tests"}],
+        )
+        api_key = _make_api_key()
+        key_a = _derive_prompt_cache_key(session_a, api_key)
+        key_b = _derive_prompt_cache_key(session_b, api_key)
+        assert key_a != key_b
+
+    def test_different_api_keys_produce_different_keys(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="same instructions",
+            input=[{"role": "user", "content": "same input"}],
+        )
+        key_a = _derive_prompt_cache_key(payload, _make_api_key(id="key_AAAAAA"))
+        key_b = _derive_prompt_cache_key(payload, _make_api_key(id="key_BBBBBB"))
+        assert key_a != key_b
+
+    def test_different_instructions_produce_different_keys(self):
+        api_key = _make_api_key()
+        p1 = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="You are Codex",
+            input=[{"role": "user", "content": "hello"}],
+        )
+        p2 = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="You are a reviewer",
+            input=[{"role": "user", "content": "hello"}],
+        )
+        assert _derive_prompt_cache_key(p1, api_key) != _derive_prompt_cache_key(p2, api_key)
+
+    def test_no_api_key_still_produces_key(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="sys",
+            input=[{"role": "user", "content": "hi"}],
+        )
+        key = _derive_prompt_cache_key(payload, None)
+        assert isinstance(key, str)
+        assert len(key) > 0
+
+    def test_empty_instructions_and_empty_input(self):
+        payload = ResponsesRequest(model="gpt-5.4", instructions="", input=[])
+        key = _derive_prompt_cache_key(payload, None)
+        assert isinstance(key, str)
+        assert len(key) > 0
+
+    def test_key_is_deterministic(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="sys",
+            input=[{"role": "user", "content": "hello"}],
+        )
+        api_key = _make_api_key()
+        keys = {_derive_prompt_cache_key(payload, api_key) for _ in range(10)}
+        assert len(keys) == 1
+
+    def test_compact_request_produces_key(self):
+        payload = ResponsesCompactRequest(model="gpt-5.4", instructions="sys", input="compact input")
+        key = _derive_prompt_cache_key(payload, _make_api_key())
+        assert isinstance(key, str)
+        assert len(key) > 0
+
+    def test_key_parts_structure(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="instructions here",
+            input=[{"role": "user", "content": "hello"}],
+        )
+        key = _derive_prompt_cache_key(payload, _make_api_key(id="ak_12345678ABCD"))
+        parts = key.split("-")
+        assert len(parts) == 3
+        assert parts[0] == "ak_12345678ABCD"[:12]
+        assert len(parts[1]) == 12
+        assert len(parts[2]) == 12


### PR DESCRIPTION
## Summary

Addresses token cache rate degradation observed in production (95% → 12-26% over Feb–Mar). Root causes: `responses_path` traffic surged to ~65% with inherent 2-5% cache rate, codex endpoints used `openai_cache_affinity=False`, and `reallocate_sticky=True` re-routed every request without checking existing sessions.

## Changes

### P0-A: Auto-derive `prompt_cache_key` for v1/responses
- New `_derive_prompt_cache_key()` generates stable session-scoped keys from `hash(api_key_id + instructions[:512] + first_user_input[:512])`
- Parallel sessions get different keys; successive turns get the same key
- Added `prompt_cache_key` field to `ResponsesCompactRequest` for upstream cache hint parity

### P0-B: Enable `openai_cache_affinity` on codex endpoints
- 3 endpoints changed: HTTP POST, WebSocket, compact (`openai_cache_affinity=True`)
- Codex requests now use `PROMPT_CACHE` sticky kind instead of `STICKY_THREAD`

### P1: Refactor `reallocate_sticky` behavior
- Unified `_select_with_stickiness` flow: always checks existing session first
- Only falls back to re-routing when pinned account is removed from pool or in backoff
- TTL refresh scoped to non-reallocate paths only

## Testing

- 18 unit tests for `_derive_prompt_cache_key` and `_extract_first_user_input`
- 4 integration tests: sticky kind verification, parallel session separation, cross-turn stability, reallocation fallback
- 3 existing test assertions updated to match new `reallocate_sticky` behavior
- Full suite: **908 passed, 0 failed, 4 skipped**
- Pre-commit: ruff ✅, ruff format ✅, ty ✅