### PR TITLE
fix(dashboard): cap primary donut remaining by secondary absolute credits

### DIFF
--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -191,6 +191,22 @@ describe("applySecondaryConstraint", () => {
     expect(primary[0].value).toBe(200);
     expect(primary[0].remainingPercent).toBe(90);
   });
+
+  it("caps to zero when secondary items are all zero-valued", () => {
+    const primary = [
+      remainingItem({ accountId: "acc-1", value: 200, remainingPercent: 90 }),
+      remainingItem({ accountId: "acc-2", value: 150, remainingPercent: 60 }),
+    ];
+    const secondary = [
+      remainingItem({ accountId: "acc-1", value: 0, remainingPercent: 0 }),
+      remainingItem({ accountId: "acc-2", value: 0, remainingPercent: 0 }),
+    ];
+
+    const result = applySecondaryConstraint(primary, secondary);
+
+    expect(result[0].value).toBe(0);
+    expect(result[1].value).toBe(0);
+  });
 });
 
 describe("buildRemainingItems", () => {

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -219,7 +219,9 @@ export function buildDashboardView(
 
   return {
     stats,
-    primaryUsageItems: applySecondaryConstraint(rawPrimaryItems, secondaryUsageItems),
+    primaryUsageItems: secondaryWindow
+      ? applySecondaryConstraint(rawPrimaryItems, secondaryUsageItems)
+      : rawPrimaryItems,
     secondaryUsageItems,
     requestLogs,
     safeLinePrimary: buildDepletionView(overview.depletionPrimary),


### PR DESCRIPTION
## Summary

- Primary (5h) donut now reflects the secondary (7d) hard quota constraint — when 7d remaining credits are lower than 5h remaining, the 5h values are capped to the 7d absolute amount
- Compares **absolute credits** (not percentages) because the two windows have vastly different capacities (225 vs 7560 for Plus plans)

## Problem

The dashboard showed two independent donut charts for primary (5h) and secondary (7d) windows. When the 7d quota was depleted, the 5h donut still showed full remaining credits — misleading users into thinking they had available capacity when the account was actually hard-blocked (`QUOTA_EXCEEDED`).

## Solution

Added `applySecondaryConstraint()` in `frontend/src/features/dashboard/utils.ts` that post-processes primary remaining items:

| Scenario | 5h credits | 7d credits | Result |
|---|---|---|---|
| Normal (7d has plenty) | 200 | 3780 | **Unchanged** (3780 ≥ 200) |
| 7d is bottleneck | 200 | 75 | **Capped to 75** |
| 7d depleted | 200 | 0 | **0** |
| 7d % low but absolute is fine | 200 | 3780 (50%) | **Unchanged** — absolute comparison avoids false positive |

## Tests

9 test cases covering: no-op, scaling, zero, null handling, multi-account, immutability.