### PR TITLE
fix(proxy): restore token cache affinity routing

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -75,7 +75,8 @@ class Settings(BaseSettings):
     usage_fetch_max_retries: int = 2
     usage_refresh_enabled: bool = True
     usage_refresh_interval_seconds: int = Field(default=60, gt=0)
-    openai_cache_affinity_max_age_seconds: int = Field(default=300, gt=0)
+    openai_cache_affinity_max_age_seconds: int = Field(default=1800, gt=0)
+    openai_prompt_cache_key_derivation_enabled: bool = True
     sticky_session_cleanup_enabled: bool = True
     sticky_session_cleanup_interval_seconds: int = Field(default=300, gt=0)
     encryption_key_file: Path = DEFAULT_ENCRYPTION_KEY_FILE

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -463,9 +463,45 @@ def _strip_unsupported_fields(payload: dict[str, JsonValue]) -> dict[str, JsonVa
     _normalize_openai_compatible_aliases(payload)
     _normalize_service_tier_aliases(payload)
     _sanitize_interleaved_reasoning_input(payload)
+    _canonicalize_tools(payload)
     for key in _UNSUPPORTED_UPSTREAM_FIELDS:
         payload.pop(key, None)
     return payload
+
+
+def _canonicalize_tools(payload: dict[str, JsonValue]) -> None:
+    tools = payload.get("tools")
+    if not is_json_list(tools):
+        return
+    tool_list = cast(list[JsonValue], tools)
+    if not tool_list:
+        return
+    sorted_tools = sorted(tool_list, key=_tool_sort_key)
+    payload["tools"] = [_sort_keys_recursive(t) for t in sorted_tools]
+
+
+def _tool_sort_key(tool: JsonValue) -> str:
+    if not is_json_mapping(tool):
+        return ""
+    tool_map = cast(Mapping[str, JsonValue], tool)
+    name = tool_map.get("name")
+    if isinstance(name, str):
+        return name
+    func = tool_map.get("function")
+    if is_json_mapping(func):
+        func_name = cast(Mapping[str, JsonValue], func).get("name")
+        if isinstance(func_name, str):
+            return func_name
+    return ""
+
+
+def _sort_keys_recursive(value: JsonValue) -> JsonValue:
+    if is_json_mapping(value):
+        mapping = cast(Mapping[str, JsonValue], value)
+        return {k: _sort_keys_recursive(v) for k, v in sorted(mapping.items())}
+    if is_json_list(value):
+        return [_sort_keys_recursive(item) for item in cast(list[JsonValue], value)]
+    return value
 
 
 def _strip_compact_unsupported_fields(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:

--- a/app/db/alembic/versions/20260319_100937_increase_prompt_cache_ttl_to_1800s.py
+++ b/app/db/alembic/versions/20260319_100937_increase_prompt_cache_ttl_to_1800s.py
@@ -1,0 +1,73 @@
+"""increase prompt cache ttl from 300s to 1800s
+
+Revision ID: 20260319_100937_increase_prompt_cache_ttl_to_1800s
+Revises: 20260313_024500_merge_request_log_transport_heads
+Create Date: 2026-03-19
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+# revision identifiers, used by Alembic.
+revision = "20260319_100937_increase_prompt_cache_ttl_to_1800s"
+down_revision = "20260313_024500_merge_request_log_transport_heads"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(connection: Connection, table_name: str) -> bool:
+    inspector = sa.inspect(connection)
+    return inspector.has_table(table_name)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not _table_exists(bind, "dashboard_settings"):
+        return
+
+    # Update existing rows with value=300 to 1800
+    bind.execute(
+        sa.text(
+            """
+            UPDATE dashboard_settings
+            SET openai_cache_affinity_max_age_seconds = 1800
+            WHERE openai_cache_affinity_max_age_seconds = 300
+            """
+        )
+    )
+
+    # Alter the column default
+    with op.batch_alter_table("dashboard_settings") as batch_op:
+        batch_op.alter_column(
+            "openai_cache_affinity_max_age_seconds",
+            existing_type=sa.Integer(),
+            server_default=sa.text("1800"),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not _table_exists(bind, "dashboard_settings"):
+        return
+
+    # Revert existing rows with value=1800 back to 300
+    bind.execute(
+        sa.text(
+            """
+            UPDATE dashboard_settings
+            SET openai_cache_affinity_max_age_seconds = 300
+            WHERE openai_cache_affinity_max_age_seconds = 1800
+            """
+        )
+    )
+
+    # Alter the column default back to 300
+    with op.batch_alter_table("dashboard_settings") as batch_op:
+        batch_op.alter_column(
+            "openai_cache_affinity_max_age_seconds",
+            existing_type=sa.Integer(),
+            server_default=sa.text("300"),
+        )

--- a/app/db/alembic/versions/20260319_111500_merge_prompt_cache_ttl_and_upstream_transport_heads.py
+++ b/app/db/alembic/versions/20260319_111500_merge_prompt_cache_ttl_and_upstream_transport_heads.py
@@ -1,0 +1,25 @@
+"""merge prompt-cache ttl and upstream transport heads
+
+Revision ID: 20260319_111500_merge_prompt_cache_ttl_and_upstream_transport_heads
+Revises: 20260312_120000_add_dashboard_upstream_stream_transport, 20260319_100937_increase_prompt_cache_ttl_to_1800s
+Create Date: 2026-03-19
+"""
+
+from __future__ import annotations
+
+# revision identifiers, used by Alembic.
+revision = "20260319_111500_merge_prompt_cache_ttl_and_upstream_transport_heads"
+down_revision = (
+    "20260312_120000_add_dashboard_upstream_stream_transport",
+    "20260319_100937_increase_prompt_cache_ttl_to_1800s",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -175,8 +175,8 @@ class DashboardSettings(Base):
     )
     openai_cache_affinity_max_age_seconds: Mapped[int] = mapped_column(
         Integer,
-        default=300,
-        server_default=text("300"),
+        default=1800,
+        server_default=text("1800"),
         nullable=False,
     )
     import_without_overwrite: Mapped[bool] = mapped_column(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -180,6 +180,7 @@ async def v1_responses(
             responses_payload,
             context,
             api_key,
+            codex_session_affinity=False,
             openai_cache_affinity=True,
         )
     return await _collect_responses(
@@ -187,6 +188,7 @@ async def v1_responses(
         responses_payload,
         context,
         api_key,
+        codex_session_affinity=False,
         openai_cache_affinity=True,
     )
 
@@ -364,6 +366,7 @@ async def v1_chat_completions(
     stream = context.service.stream_responses(
         responses_payload,
         request.headers,
+        codex_session_affinity=False,
         propagate_http_errors=True,
         openai_cache_affinity=True,
         api_key=api_key,
@@ -549,6 +552,7 @@ async def v1_responses_compact(
         compact_payload,
         context,
         api_key,
+        codex_session_affinity=False,
         openai_cache_affinity=True,
     )
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -157,7 +157,6 @@ class ProxyService:
         request_transport: str = _REQUEST_TRANSPORT_HTTP,
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream", payload, headers)
-        _maybe_log_proxy_request_shape("stream", payload, headers)
         filtered = filter_inbound_headers(headers)
         return self._stream_with_retry(
             payload,
@@ -182,7 +181,6 @@ class ProxyService:
         api_key_reservation: ApiKeyUsageReservationData | None = None,
     ) -> CompactResponsePayload:
         _maybe_log_proxy_request_payload("compact", payload, headers)
-        _maybe_log_proxy_request_shape("compact", payload, headers)
         filtered = filter_inbound_headers(headers)
         request_id = get_request_id() or ensure_request_id(None)
         start = time.monotonic()
@@ -198,6 +196,7 @@ class ProxyService:
 
         settings = await get_settings_cache().get()
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
+        had_prompt_cache_key = _prompt_cache_key_from_request_model(payload) is not None
         affinity = _sticky_key_for_compact_request(
             payload,
             headers,
@@ -206,6 +205,19 @@ class ProxyService:
             openai_cache_affinity_max_age_seconds=settings.openai_cache_affinity_max_age_seconds,
             sticky_threads_enabled=settings.sticky_threads_enabled,
             api_key=api_key,
+        )
+        sticky_key_source = "none"
+        if affinity.kind == StickySessionKind.CODEX_SESSION:
+            sticky_key_source = "session_header"
+        elif affinity.key:
+            sticky_key_source = "payload" if had_prompt_cache_key else "derived"
+        _maybe_log_proxy_request_shape(
+            "compact",
+            payload,
+            headers,
+            sticky_kind=affinity.kind.value if affinity.kind is not None else None,
+            sticky_key_source=sticky_key_source,
+            prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)
         try:
@@ -882,6 +894,29 @@ class ProxyService:
             request_model=responses_payload.model,
             request_service_tier=forwarded_service_tier,
         )
+        had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
+        affinity_policy = _sticky_key_for_responses_request(
+            responses_payload,
+            headers,
+            codex_session_affinity=codex_session_affinity,
+            openai_cache_affinity=openai_cache_affinity,
+            openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
+            sticky_threads_enabled=sticky_threads_enabled,
+            api_key=api_key,
+        )
+        sticky_key_source = "none"
+        if affinity_policy.kind == StickySessionKind.CODEX_SESSION:
+            sticky_key_source = "session_header"
+        elif affinity_policy.key:
+            sticky_key_source = "payload" if had_prompt_cache_key else "derived"
+        _maybe_log_proxy_request_shape(
+            "websocket",
+            responses_payload,
+            headers,
+            sticky_kind=affinity_policy.kind.value if affinity_policy.kind is not None else None,
+            sticky_key_source=sticky_key_source,
+            prompt_cache_key_set=_prompt_cache_key_from_request_model(responses_payload) is not None,
+        )
 
         return _PreparedWebSocketRequest(
             text_data=json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":")),
@@ -894,15 +929,7 @@ class ProxyService:
                 started_at=time.monotonic(),
                 awaiting_response_created=True,
             ),
-            affinity_policy=_sticky_key_for_responses_request(
-                responses_payload,
-                headers,
-                codex_session_affinity=codex_session_affinity,
-                openai_cache_affinity=openai_cache_affinity,
-                openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
-                sticky_threads_enabled=sticky_threads_enabled,
-                api_key=api_key,
-            ),
+            affinity_policy=affinity_policy,
         )
 
     async def _connect_proxy_websocket(
@@ -1878,6 +1905,7 @@ class ProxyService:
         deadline = start + base_settings.proxy_request_budget_seconds
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
         upstream_stream_transport = _resolve_upstream_stream_transport(settings.upstream_stream_transport)
+        had_prompt_cache_key = _prompt_cache_key_from_request_model(payload) is not None
         affinity = _sticky_key_for_responses_request(
             payload,
             headers,
@@ -1886,6 +1914,19 @@ class ProxyService:
             openai_cache_affinity_max_age_seconds=settings.openai_cache_affinity_max_age_seconds,
             sticky_threads_enabled=settings.sticky_threads_enabled,
             api_key=api_key,
+        )
+        sticky_key_source = "none"
+        if affinity.kind == StickySessionKind.CODEX_SESSION:
+            sticky_key_source = "session_header"
+        elif affinity.key:
+            sticky_key_source = "payload" if had_prompt_cache_key else "derived"
+        _maybe_log_proxy_request_shape(
+            "stream",
+            payload,
+            headers,
+            sticky_kind=affinity.kind.value if affinity.kind is not None else None,
+            sticky_key_source=sticky_key_source,
+            prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)
         max_attempts = 3
@@ -3240,6 +3281,10 @@ def _maybe_log_proxy_request_shape(
     kind: str,
     payload: ResponsesRequest | ResponsesCompactRequest,
     headers: Mapping[str, str],
+    *,
+    sticky_kind: str | None = None,
+    sticky_key_source: str | None = None,
+    prompt_cache_key_set: bool | None = None,
 ) -> None:
     settings = get_settings()
     if not settings.log_proxy_request_shape:
@@ -3258,10 +3303,13 @@ def _maybe_log_proxy_request_shape(
     fields_set = sorted(payload.model_fields_set)
     input_summary = _summarize_input(payload.input)
     header_keys = _interesting_header_keys(headers)
+    session_header_present = _sticky_key_from_session_header(headers) is not None
+    tools_hash = _tools_hash(payload)
 
     logger.warning(
         "proxy_request_shape request_id=%s kind=%s model=%s stream=%s input=%s "
-        "prompt_cache_key=%s prompt_cache_key_raw=%s fields=%s extra=%s headers=%s",
+        "prompt_cache_key=%s prompt_cache_key_raw=%s fields=%s extra=%s headers=%s "
+        "sticky_kind=%s sticky_key_source=%s prompt_cache_key_set=%s session_header_present=%s tools_hash=%s",
         request_id,
         kind,
         payload.model,
@@ -3272,6 +3320,11 @@ def _maybe_log_proxy_request_shape(
         fields_set,
         extra_keys,
         header_keys,
+        sticky_kind,
+        sticky_key_source,
+        prompt_cache_key_set,
+        session_header_present,
+        tools_hash,
     )
 
 
@@ -3346,6 +3399,14 @@ def _truncate_identifier(value: str, *, max_length: int = 96) -> str:
     if len(value) <= max_length:
         return value
     return f"{value[:48]}...{value[-16:]}"
+
+
+def _tools_hash(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
+    payload_tools = payload.to_payload().get("tools")
+    if not isinstance(payload_tools, list) or not payload_tools:
+        return None
+    serialized = json.dumps(payload_tools, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    return _hash_identifier(serialized)
 
 
 def _interesting_header_keys(headers: Mapping[str, str]) -> list[str]:
@@ -3441,12 +3502,38 @@ def _sticky_key_from_payload(payload: ResponsesRequest) -> str | None:
 
 
 def _sticky_key_from_session_header(headers: Mapping[str, str]) -> str | None:
-    for key, value in headers.items():
-        if key.lower() != "session_id":
+    normalized = {key.lower(): value for key, value in headers.items()}
+    for key in ("session_id", "x-codex-session-id", "x-codex-conversation-id"):
+        value = normalized.get(key)
+        if not isinstance(value, str):
             continue
         stripped = value.strip()
-        return stripped or None
+        if stripped:
+            return stripped
     return None
+
+
+def _resolve_prompt_cache_key(
+    payload: ResponsesRequest | ResponsesCompactRequest,
+    *,
+    openai_cache_affinity: bool,
+    api_key: ApiKeyData | None,
+) -> tuple[str | None, str]:
+    cache_key = _prompt_cache_key_from_request_model(payload)
+    if isinstance(cache_key, str):
+        stripped = cache_key.strip()
+        if stripped:
+            if stripped != cache_key:
+                payload.prompt_cache_key = stripped
+            return stripped, "payload"
+    if not openai_cache_affinity:
+        return None, "none"
+    settings = get_settings()
+    if not settings.openai_prompt_cache_key_derivation_enabled:
+        return None, "none"
+    cache_key = _derive_prompt_cache_key(payload, api_key)
+    payload.prompt_cache_key = cache_key
+    return cache_key, "derived"
 
 
 def _sticky_key_for_responses_request(
@@ -3459,6 +3546,11 @@ def _sticky_key_for_responses_request(
     sticky_threads_enabled: bool,
     api_key: ApiKeyData | None = None,
 ) -> _AffinityPolicy:
+    cache_key, _ = _resolve_prompt_cache_key(
+        payload,
+        openai_cache_affinity=openai_cache_affinity,
+        api_key=api_key,
+    )
     if codex_session_affinity:
         session_key = _sticky_key_from_session_header(headers)
         if session_key:
@@ -3466,10 +3558,6 @@ def _sticky_key_for_responses_request(
                 key=session_key,
                 kind=StickySessionKind.CODEX_SESSION,
             )
-    cache_key = _sticky_key_from_payload(payload)
-    if cache_key is None and openai_cache_affinity:
-        cache_key = _derive_prompt_cache_key(payload, api_key)
-        payload.prompt_cache_key = cache_key
     if openai_cache_affinity:
         return _AffinityPolicy(
             key=cache_key,
@@ -3503,6 +3591,11 @@ def _sticky_key_for_compact_request(
     sticky_threads_enabled: bool,
     api_key: ApiKeyData | None = None,
 ) -> _AffinityPolicy:
+    cache_key, _ = _resolve_prompt_cache_key(
+        payload,
+        openai_cache_affinity=openai_cache_affinity,
+        api_key=api_key,
+    )
     if codex_session_affinity:
         session_key = _sticky_key_from_session_header(headers)
         if session_key:
@@ -3510,10 +3603,6 @@ def _sticky_key_for_compact_request(
                 key=session_key,
                 kind=StickySessionKind.CODEX_SESSION,
             )
-    cache_key = _sticky_key_from_compact_payload(payload)
-    if cache_key is None and openai_cache_affinity:
-        cache_key = _derive_prompt_cache_key(payload, api_key)
-        payload.prompt_cache_key = cache_key
     if openai_cache_affinity:
         return _AffinityPolicy(
             key=cache_key,

--- a/openspec/changes/repair-token-cache-affinity-routing/proposal.md
+++ b/openspec/changes/repair-token-cache-affinity-routing/proposal.md
@@ -1,0 +1,16 @@
+# repair-token-cache-affinity-routing
+
+## Why
+OpenAI-style `/v1/*` routes currently enable `codex_session_affinity=True`, which can convert bounded prompt-cache routing into durable `CODEX_SESSION` pinning whenever a `session_id` header is present. Separately, backend Codex routes can early-return on `CODEX_SESSION` before a proxy-derived `prompt_cache_key` is attached, which weakens upstream prompt-cache routing hints when clients omit that field. Operators also lack route-level affinity traces to distinguish session-driven account affinity from prompt-cache routing.
+
+## What Changes
+- Restore OpenAI-style `/v1/*` routes to bounded `prompt_cache_key` affinity by default.
+- Keep backend Codex `session_id` account affinity, but ensure prompt-cache-key derivation happens before `CODEX_SESSION` early return when needed.
+- Harden accepted session header aliases.
+- Add request-shape observability for sticky kind/source and prompt-cache-key injection.
+- Add a feature flag to disable proxy-generated prompt-cache-key derivation for A/B testing.
+
+## Impact
+- `/v1/responses`, `/v1/responses/compact`, `/v1/chat/completions`, and `/v1/responses` websocket return to prompt-cache-bounded routing semantics.
+- Backend Codex keeps durable account affinity but can still send a stable upstream prompt-cache hint.
+- Operators gain safer diagnostics for routing decisions.

--- a/openspec/changes/repair-token-cache-affinity-routing/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/repair-token-cache-affinity-routing/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+
+### Requirement: Optional upstream payload tracing
+When request-shape tracing for proxy routing is enabled, the system MUST log affinity decision metadata without exposing full prompt text or full cache keys. The trace MUST include request id, request kind, sticky kind, sticky-key source, whether a session header was present, whether a prompt-cache key was set/injected, and a stable tools hash when tools are present.
+
+#### Scenario: Affinity request-shape tracing is enabled
+- **WHEN** the proxy resolves routing for a Responses or compact request while request-shape tracing is enabled
+- **THEN** the console shows the chosen sticky kind, sticky-key source, prompt-cache-key presence/injection state, and tools hash
+- **AND** the console does not log raw prompt text or the full prompt-cache key unless the explicit raw-key flag is enabled

--- a/openspec/changes/repair-token-cache-affinity-routing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/repair-token-cache-affinity-routing/specs/responses-api-compat/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Use prompt_cache_key as OpenAI cache affinity
+For OpenAI-style `/v1/responses`, `/v1/responses/compact`, and chat-completions requests mapped onto Responses, the service MUST treat a non-empty `prompt_cache_key` as the bounded upstream account affinity key for prompt-cache correctness even when a `session_id` header is present. OpenAI-style route wiring MUST NOT upgrade those requests to durable `CODEX_SESSION` affinity by default.
+
+#### Scenario: OpenAI-style route ignores session header for durable codex-session pinning
+- **WHEN** a client sends `/v1/responses` or `/v1/responses/compact` with a non-empty `session_id` header and no explicit sticky-thread mode
+- **THEN** the service does not persist a durable `codex_session` mapping solely from that header
+- **AND** bounded prompt-cache affinity behavior remains in effect
+
+### Requirement: Codex backend session_id preserves account affinity
+When a backend Codex Responses or compact request includes a non-empty accepted session header, the service MUST use that value as the routing affinity key for upstream account selection. If the request lacks a client-supplied `prompt_cache_key`, the service MUST derive and attach a stable `prompt_cache_key` before upstream forwarding so account affinity and upstream prompt-cache routing can coexist. Accepted session headers are `session_id`, `x-codex-session-id`, and `x-codex-conversation-id`, in that priority order.
+
+#### Scenario: Backend Codex request derives prompt_cache_key before codex-session routing
+- **WHEN** `/backend-api/codex/responses` is called with `session_id` and without `prompt_cache_key`
+- **THEN** the routing decision still uses durable `codex_session` affinity for account selection
+- **AND** the forwarded upstream payload includes a derived stable `prompt_cache_key`
+
+### Requirement: Proxy-generated prompt cache key derivation is operator-toggleable
+The service MUST provide a runtime flag that disables only proxy-generated prompt-cache-key derivation. When disabled, the service MUST continue forwarding any client-supplied `prompt_cache_key` unchanged and MUST NOT synthesize a new one.
+
+#### Scenario: Derivation disabled preserves client-supplied key
+- **WHEN** the derivation flag is disabled and a client sends `prompt_cache_key`
+- **THEN** the service forwards that key unchanged
+- **AND** it does not generate a replacement key

--- a/openspec/changes/repair-token-cache-affinity-routing/tasks.md
+++ b/openspec/changes/repair-token-cache-affinity-routing/tasks.md
@@ -1,0 +1,5 @@
+- [ ] 1. Add spec deltas for `/v1/*` prompt-cache affinity, backend Codex session+prompt-cache coexistence, derivation flag behavior, and affinity observability fields.
+- [ ] 2. Add failing unit tests for session header alias priority, early prompt-cache-key derivation on backend Codex paths, derivation-flag behavior, and request-shape affinity logging.
+- [ ] 3. Add failing integration tests for `/v1/*` route wiring, backend Codex prompt-cache-key forwarding, and websocket parity.
+- [ ] 4. Implement route wiring, affinity helper changes, header alias support, observability, and derivation flag with minimal diffs.
+- [ ] 5. Run targeted lint/type/test/spec validation and confirm no affected-file diagnostics remain.

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -491,7 +491,7 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
                     text("SELECT openai_cache_affinity_max_age_seconds FROM dashboard_settings WHERE id=1")
                 )
             ).scalar_one()
-            assert affinity_ttl == 300
+            assert affinity_ttl == 1800
             sticky_columns_rows = (await session.execute(text("PRAGMA table_info(sticky_sessions)"))).fetchall()
             sticky_columns = {str(row[1]) for row in sticky_columns_rows if len(row) > 1}
             assert "kind" in sticky_columns

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -589,6 +589,30 @@ async def test_v1_chat_completions_normalizes_tools_and_tool_choice(async_client
 
 
 @pytest.mark.asyncio
+async def test_v1_chat_completions_does_not_enable_codex_session_affinity(async_client, monkeypatch):
+    await _import_account(async_client, "acc_chat_affinity_a", "chat-affinity-a@example.com")
+    await _import_account(async_client, "acc_chat_affinity_b", "chat-affinity-b@example.com")
+
+    seen = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen["account_id"] = account_id
+        seen["prompt_cache_key"] = getattr(payload, "prompt_cache_key", None)
+        yield _completed_event("resp_chat_affinity")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {
+        "model": "gpt-5.2",
+        "messages": [{"role": "user", "content": "Weather?"}],
+    }
+    resp = await async_client.post("/v1/chat/completions", json=payload, headers={"session_id": "chat-session-123"})
+    assert resp.status_code == 200
+    assert isinstance(seen["prompt_cache_key"], str)
+    assert seen["prompt_cache_key"]
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_maps_reasoning_effort(async_client, monkeypatch):
     await _import_account(async_client, "acc_chat_reason", "chat-reason@example.com")
 

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -81,11 +81,13 @@ def _install_proxy_settings_cache(
     sticky_threads_enabled: bool,
     prefer_earlier_reset_accounts: bool = False,
     openai_cache_affinity_max_age_seconds: int = 300,
+    openai_prompt_cache_key_derivation_enabled: bool = True,
 ) -> None:
     settings = SimpleNamespace(
         prefer_earlier_reset_accounts=prefer_earlier_reset_accounts,
         sticky_threads_enabled=sticky_threads_enabled,
         openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
+        openai_prompt_cache_key_derivation_enabled=openai_prompt_cache_key_derivation_enabled,
         routing_strategy="usage_weighted",
         proxy_request_budget_seconds=75.0,
         compact_request_budget_seconds=75.0,
@@ -571,7 +573,7 @@ async def test_proxy_codex_session_id_switches_when_pinned_rate_limited(async_cl
 
 
 @pytest.mark.asyncio
-async def test_v1_session_id_does_not_pin_routing_without_sticky_threads(async_client, monkeypatch):
+async def test_v1_session_id_does_not_create_durable_codex_session_affinity(async_client, monkeypatch):
     await _set_routing_settings(async_client, sticky_threads_enabled=False)
     acc_a_id = await _import_account(async_client, "acc_v1_sid_a", "v1_sid_a@example.com")
     acc_b_id = await _import_account(async_client, "acc_v1_sid_b", "v1_sid_b@example.com")
@@ -645,6 +647,15 @@ async def test_v1_session_id_does_not_pin_routing_without_sticky_threads(async_c
     response = await async_client.post("/v1/responses/compact", json=compact_payload, headers=headers)
     assert response.status_code == 200
     assert compact_seen == ["acc_v1_sid_a"]
+
+    async with SessionLocal() as session:
+        codex_row = (
+            await session.execute(
+                text("SELECT kind FROM sticky_sessions WHERE key = :key"),
+                {"key": "v1-thread-123"},
+            )
+        ).fetchone()
+        assert codex_row is None
 
 
 @pytest.mark.asyncio
@@ -736,6 +747,103 @@ async def test_v1_prompt_cache_key_reuses_recent_responses_and_compact_without_s
     response = await async_client.post("/v1/responses", json=stream_payload)
     assert response.status_code == 200
     assert stream_seen == ["acc_v1_cache_a", "acc_v1_cache_a"]
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_derives_prompt_cache_key_when_absent(async_client, monkeypatch):
+    _install_proxy_settings_cache(
+        monkeypatch,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=60,
+    )
+    acc_a_id = await _import_account(async_client, "acc_v1_derived_a", "v1_derived_a@example.com")
+    acc_b_id = await _import_account(async_client, "acc_v1_derived_b", "v1_derived_b@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=20.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    seen_keys: list[str | None] = []
+    seen_accounts: list[str] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        seen_accounts.append(account_id)
+        seen_keys.append(getattr(payload, "prompt_cache_key", None))
+        yield 'data: {"type":"response.completed","response":{"id":"resp_v1_derived"}}\\n\\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "input": "hello", "stream": True}
+    response = await async_client.post("/v1/responses", json=payload)
+    assert response.status_code == 200
+    assert seen_accounts == ["acc_v1_derived_a"]
+    assert isinstance(seen_keys[0], str)
+    assert seen_keys[0]
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_session_affinity_also_forwards_prompt_cache_key_when_missing(async_client, monkeypatch):
+    _install_proxy_settings_cache(monkeypatch, sticky_threads_enabled=False)
+    acc_id = await _import_account(async_client, "acc_codex_sid_1", "codex_sid_1@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    seen_keys: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        seen_keys.append(getattr(payload, "prompt_cache_key", None))
+        yield 'data: {"type":"response.completed","response":{"id":"resp_backend_codex"}}\\n\\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "stream": True,
+        },
+        headers={"session_id": "backend-thread-123"},
+    )
+    assert response.status_code == 200
+    assert isinstance(seen_keys[0], str)
+    assert seen_keys[0]
+
+    async with SessionLocal() as session:
+        row = (
+            await session.execute(
+                text("SELECT kind FROM sticky_sessions WHERE key = :key"),
+                {"key": "backend-thread-123"},
+            )
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "codex_session"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -83,7 +83,12 @@ def _websocket_settings(**overrides):
         "prefer_earlier_reset_accounts": False,
         "sticky_threads_enabled": False,
         "openai_cache_affinity_max_age_seconds": 300,
+        "openai_prompt_cache_key_derivation_enabled": True,
         "routing_strategy": "usage_weighted",
+        "proxy_request_budget_seconds": 75.0,
+        "stream_idle_timeout_seconds": 300.0,
+        "log_proxy_request_shape": False,
+        "log_proxy_request_shape_raw_cache_key": False,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -577,7 +582,10 @@ def test_backend_responses_websocket_emits_timeout_failure_for_stalled_upstream(
         async def get(self):
             return _websocket_settings()
 
-    runtime_settings = SimpleNamespace(proxy_request_budget_seconds=5.0, stream_idle_timeout_seconds=0.01)
+    runtime_settings = _websocket_settings(
+        proxy_request_budget_seconds=5.0,
+        stream_idle_timeout_seconds=0.01,
+    )
 
     async def allow_firewall(_websocket):
         return None

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -14,7 +14,7 @@ async def test_settings_api_get_and_update(async_client):
     assert payload["upstreamStreamTransport"] == "default"
     assert payload["preferEarlierResetAccounts"] is False
     assert payload["routingStrategy"] == "usage_weighted"
-    assert payload["openaiCacheAffinityMaxAgeSeconds"] == 300
+    assert payload["openaiCacheAffinityMaxAgeSeconds"] == 1800
     assert payload["importWithoutOverwrite"] is False
     assert payload["totpRequiredOnLogin"] is False
     assert payload["totpConfigured"] is False

--- a/tests/integration/test_sticky_sessions_api.py
+++ b/tests/integration/test_sticky_sessions_api.py
@@ -11,6 +11,7 @@ from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, StickySessionKind
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
+from app.modules.settings.repository import SettingsRepository
 from app.modules.sticky_sessions.cleanup_scheduler import StickySessionCleanupScheduler
 
 pytestmark = pytest.mark.integration
@@ -53,16 +54,8 @@ async def _create_accounts() -> list[Account]:
 
 async def _set_affinity_ttl(seconds: int) -> None:
     async with SessionLocal() as session:
-        await session.execute(
-            text(
-                """
-                UPDATE dashboard_settings
-                SET openai_cache_affinity_max_age_seconds = :seconds
-                WHERE id = 1
-                """
-            ),
-            {"seconds": seconds},
-        )
+        settings = await SettingsRepository(session).get_or_create()
+        settings.openai_cache_affinity_max_age_seconds = seconds
         await session.commit()
 
 

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from typing import Mapping, cast
+
 import pytest
 from pydantic import ValidationError
 
 from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
 from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRequest
+from app.core.types import JsonValue
 
 
 def test_responses_requires_instructions():
@@ -155,6 +158,46 @@ def test_openai_prompt_cache_aliases_are_normalized():
     assert "prompt_cache_retention" not in dumped
     assert "promptCacheKey" not in dumped
     assert "promptCacheRetention" not in dumped
+
+
+def test_settings_default_prompt_cache_affinity_ttl_is_1800():
+    from app.core.config.settings import Settings
+
+    settings = Settings()
+
+    assert settings.openai_cache_affinity_max_age_seconds == 1800
+
+
+def test_responses_to_payload_canonicalizes_tool_order_and_object_keys():
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "zeta",
+                    "parameters": {"required": [], "type": "object", "properties": {}},
+                    "description": "later",
+                },
+                {
+                    "description": "first",
+                    "parameters": {"properties": {}, "required": [], "type": "object"},
+                    "type": "function",
+                    "name": "alpha",
+                },
+            ],
+        }
+    )
+
+    dumped = request.to_payload()
+    tools = cast(list[JsonValue], dumped["tools"])
+    first_tool = cast(Mapping[str, JsonValue], tools[0])
+    parameters = cast(Mapping[str, JsonValue], first_tool["parameters"])
+    assert first_tool["name"] == "alpha"
+    assert list(first_tool.keys()) == ["description", "name", "parameters", "type"]
+    assert list(parameters.keys()) == ["properties", "required", "type"]
 
 
 def test_openai_compatible_reasoning_aliases_are_normalized():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -321,6 +321,7 @@ def _make_proxy_settings(*, log_proxy_service_tier_trace: bool) -> object:
         sticky_threads_enabled=False,
         upstream_stream_transport="default",
         openai_cache_affinity_max_age_seconds=300,
+        openai_prompt_cache_key_derivation_enabled=True,
         routing_strategy="usage_weighted",
         proxy_request_budget_seconds=75.0,
         compact_request_budget_seconds=75.0,
@@ -690,6 +691,127 @@ def test_log_proxy_request_payload(monkeypatch, caplog):
 
     assert "proxy_request_payload" in caplog.text
     assert '"model":"gpt-5.1"' in caplog.text
+
+
+def test_log_proxy_request_shape_includes_affinity_metadata(monkeypatch, caplog):
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "tools": [{"type": "function", "name": "b_tool"}, {"type": "function", "name": "a_tool"}],
+        }
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = True
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+
+    token = set_request_id("req_shape_1")
+    try:
+        caplog.set_level(logging.WARNING)
+        proxy_service._maybe_log_proxy_request_shape(
+            "stream",
+            payload,
+            {"session_id": "sid_1"},
+            sticky_kind="codex_session",
+            sticky_key_source="session_header",
+            prompt_cache_key_set=True,
+        )
+    finally:
+        reset_request_id(token)
+
+    assert "proxy_request_shape" in caplog.text
+    assert "sticky_kind=codex_session" in caplog.text
+    assert "sticky_key_source=session_header" in caplog.text
+    assert "prompt_cache_key_set=True" in caplog.text
+    assert "session_header_present=True" in caplog.text
+    assert "tools_hash=sha256:" in caplog.text
+
+
+def test_log_proxy_request_shape_hashes_prompt_cache_key_without_raw_value(monkeypatch, caplog):
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "prompt_cache_key": "thread_secret_123",
+        }
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = True
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+
+    token = set_request_id("req_shape_2")
+    try:
+        caplog.set_level(logging.WARNING)
+        proxy_service._maybe_log_proxy_request_shape(
+            "stream",
+            payload,
+            {},
+            sticky_kind="prompt_cache",
+            sticky_key_source="payload",
+            prompt_cache_key_set=True,
+        )
+    finally:
+        reset_request_id(token)
+
+    assert "prompt_cache_key=sha256:" in caplog.text
+    assert "thread_secret_123" not in caplog.text
+
+
+def test_log_proxy_request_shape_reports_derived_key_after_affinity_resolution(monkeypatch, caplog):
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = True
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "stream": True,
+        }
+    )
+    proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={"session_id": "sid_1"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    token = set_request_id("req_shape_3")
+    try:
+        caplog.set_level(logging.WARNING)
+        proxy_service._maybe_log_proxy_request_shape(
+            "stream",
+            payload,
+            {"session_id": "sid_1"},
+            sticky_kind="codex_session",
+            sticky_key_source="session_header",
+            prompt_cache_key_set=True,
+        )
+    finally:
+        reset_request_id(token)
+
+    assert "prompt_cache_key=sha256:" in caplog.text
+    assert "prompt_cache_key_raw=None" in caplog.text
 
 
 def test_log_proxy_service_tier_trace(monkeypatch, caplog):
@@ -2143,6 +2265,179 @@ def test_sticky_key_for_compact_request_prefers_codex_session_affinity():
     assert policy.max_age_seconds is None
 
 
+def test_sticky_key_from_session_header_accepts_aliases_in_priority_order():
+    assert proxy_service._sticky_key_from_session_header({"session_id": "sid_1"}) == "sid_1"
+    assert proxy_service._sticky_key_from_session_header({"x-codex-session-id": "sid_2"}) == "sid_2"
+    assert proxy_service._sticky_key_from_session_header({"x-codex-conversation-id": "sid_3"}) == "sid_3"
+    assert (
+        proxy_service._sticky_key_from_session_header(
+            {
+                "x-codex-conversation-id": "sid_3",
+                "x-codex-session-id": "sid_2",
+                "session_id": "sid_1",
+            }
+        )
+        == "sid_1"
+    )
+
+
+def test_sticky_key_for_responses_request_derives_prompt_cache_before_codex_session_return():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "stream": True,
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={"session_id": "codex-session-1"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.key == "codex-session-1"
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert isinstance(payload.prompt_cache_key, str)
+    assert payload.prompt_cache_key
+
+
+def test_sticky_key_for_compact_request_derives_prompt_cache_before_codex_session_return():
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_compact_request(
+        payload,
+        headers={"session_id": "codex-session-1"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.key == "codex-session-1"
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert isinstance(payload.prompt_cache_key, str)
+    assert payload.prompt_cache_key
+
+
+def test_sticky_key_for_responses_request_respects_prompt_cache_derivation_flag(monkeypatch):
+    class Settings:
+        openai_prompt_cache_key_derivation_enabled = False
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "stream": True,
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={"session_id": "codex-session-1"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert payload.prompt_cache_key is None
+
+
+def test_sticky_key_for_responses_request_preserves_client_supplied_prompt_cache_key_when_flag_off(monkeypatch):
+    class Settings:
+        openai_prompt_cache_key_derivation_enabled = False
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "stream": True,
+            "prompt_cache_key": "thread_123",
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={"session_id": "codex-session-1"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert payload.prompt_cache_key == "thread_123"
+
+
+def test_sticky_key_for_responses_request_strips_whitespace_before_accepting_payload_key():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "stream": True,
+            "prompt_cache_key": "  thread_123  ",
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={},
+        codex_session_affinity=False,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.kind == proxy_service.StickySessionKind.PROMPT_CACHE
+    assert policy.key == "thread_123"
+    assert payload.prompt_cache_key == "thread_123"
+
+
+def test_sticky_key_for_responses_request_derives_when_payload_key_is_whitespace_only():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            "stream": True,
+            "prompt_cache_key": "   ",
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={},
+        codex_session_affinity=False,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.kind == proxy_service.StickySessionKind.PROMPT_CACHE
+    assert isinstance(policy.key, str)
+    assert policy.key
+    assert payload.prompt_cache_key == policy.key
+
+
 @pytest.mark.asyncio
 async def test_service_compact_budget_does_not_override_unbounded_read_timeout(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
@@ -2866,6 +3161,62 @@ async def test_prepare_websocket_response_create_request_normalizes_payload_and_
     assert normalized_payload["model"] == "gpt-5.2"
     assert normalized_payload["reasoning"] == {"effort": "high"}
     assert normalized_payload["service_tier"] == "priority"
+
+
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_logs_affinity_metadata(monkeypatch, caplog):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_shape",
+        name="shape",
+        key_prefix="sk-shape",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = True
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    token = set_request_id("req_ws_shape_1")
+    try:
+        caplog.set_level(logging.WARNING)
+        prepared = await service._prepare_websocket_response_create_request(
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": "hello",
+            },
+            headers={"session_id": "ws-session-1"},
+            codex_session_affinity=True,
+            openai_cache_affinity=True,
+            sticky_threads_enabled=False,
+            openai_cache_affinity_max_age_seconds=300,
+            api_key=api_key,
+        )
+    finally:
+        reset_request_id(token)
+
+    assert prepared.affinity_policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert "proxy_request_shape" in caplog.text
+    assert "kind=websocket" in caplog.text
+    assert "sticky_kind=codex_session" in caplog.text
+    assert "sticky_key_source=session_header" in caplog.text
+    assert "prompt_cache_key_set=True" in caplog.text
 
 
 def test_websocket_receive_timeout_prefers_idle_timeout_when_budget_allows(monkeypatch):


### PR DESCRIPTION
## Summary
- restore `/v1/*` prompt-cache bounded affinity instead of durable `codex_session` routing
- derive and forward `prompt_cache_key` before backend Codex `CODEX_SESSION` early return
- add session header alias handling, affinity observability, TTL migration coverage, and websocket parity logging

## Testing
- `openspec validate --specs`
- `.venv/bin/ruff check app/core/config/settings.py app/modules/proxy/api.py app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/unit/test_openai_requests.py tests/integration/test_proxy_sticky_sessions.py tests/integration/test_openai_compat_features.py app/db/alembic/versions/20260319_111500_merge_prompt_cache_ttl_and_upstream_transport_heads.py`
- `.venv/bin/pytest -q tests/unit/test_proxy_utils.py tests/unit/test_openai_requests.py tests/unit/test_chat_request_mapping.py tests/integration/test_proxy_sticky_sessions.py tests/integration/test_openai_compat_features.py tests/integration/test_proxy_websocket_responses.py tests/integration/test_migrations.py`
