### PR TITLE
enhance(ui+ci): Fixes on CI, and dashboard ui changes

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -10,6 +10,11 @@
           "type": "toml",
           "path": "uv.lock",
           "jsonpath": "$.package[?(@.name=='codex-lb')].version"
+        },
+        {
+          "type": "json",
+          "path": "frontend/package.json",
+          "jsonpath": "$.version"
         }
       ]
     }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
               tag_name: tag,
               previous_tag_name: prev,
             });
-            fs.writeFileSync("release_notes.md", `${data.body.trimEnd()}\\n`);
+            fs.writeFileSync("release_notes.md", `${data.body.trimEnd()}\n`);
             core.setOutput("tag_name", tag);
 
       - name: Append install and contributors

--- a/frontend/src/components/layout/status-bar.tsx
+++ b/frontend/src/components/layout/status-bar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Activity, ArrowRightLeft } from "lucide-react";
+import { Activity, ArrowRightLeft, Tag } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getDashboardOverview } from "@/features/dashboard/api";
@@ -49,7 +49,7 @@ export function StatusBar() {
       <div className="mx-auto flex w-full max-w-[1500px] flex-wrap items-center gap-x-5 gap-y-1 text-xs text-muted-foreground">
         <span className="inline-flex items-center gap-1.5">
           {isLive ? (
-            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-label="Live" />
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" title="Live" />
           ) : (
             <Activity className="h-3 w-3" aria-hidden="true" />
           )}
@@ -58,6 +58,10 @@ export function StatusBar() {
         <span className="inline-flex items-center gap-1.5">
           <ArrowRightLeft className="h-3 w-3" aria-hidden="true" />
           <span className="font-medium">Routing:</span> {routingLabel}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <Tag className="h-3 w-3" aria-hidden="true" />
+          <span className="font-medium">Version:</span> {__APP_VERSION__}
         </span>
       </div>
     </footer>

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -132,16 +132,14 @@ export function DashboardPage() {
         <>
           <StatsGrid stats={view.stats} />
 
-          <UsageDonuts
-            primaryItems={view.primaryUsageItems}
-            secondaryItems={view.secondaryUsageItems}
-            primaryTotal={overview?.summary.primaryWindow.capacityCredits ?? 0}
-            secondaryTotal={overview?.summary.secondaryWindow?.capacityCredits ?? 0}
-            primaryWindowMinutes={overview?.windows.primary.windowMinutes ?? null}
-            secondaryWindowMinutes={overview?.windows.secondary?.windowMinutes ?? null}
-            safeLinePrimary={view.safeLinePrimary}
-            safeLineSecondary={view.safeLineSecondary}
-          />
+            <UsageDonuts
+              primaryItems={view.primaryUsageItems}
+              secondaryItems={view.secondaryUsageItems}
+              primaryTotal={overview?.summary.primaryWindow.capacityCredits ?? 0}
+              secondaryTotal={overview?.summary.secondaryWindow?.capacityCredits ?? 0}
+              safeLinePrimary={view.safeLinePrimary}
+              safeLineSecondary={view.safeLineSecondary}
+            />
 
           <section className="space-y-4">
             <div className="flex items-center gap-3">

--- a/frontend/src/features/dashboard/components/usage-donuts.test.tsx
+++ b/frontend/src/features/dashboard/components/usage-donuts.test.tsx
@@ -16,13 +16,11 @@ describe("UsageDonuts", () => {
         secondaryItems={[item({ accountId: "acc-2", label: "secondary@example.com", value: 80, remainingPercent: 40, color: "#d9a441" })]}
         primaryTotal={200}
         secondaryTotal={200}
-        primaryWindowMinutes={300}
-        secondaryWindowMinutes={10080}
       />,
     );
 
-    expect(screen.getByText("Primary Remaining")).toBeInTheDocument();
-    expect(screen.getByText("Secondary Remaining")).toBeInTheDocument();
+    expect(screen.getByText("5h Remaining")).toBeInTheDocument();
+    expect(screen.getByText("Weekly Remaining")).toBeInTheDocument();
     expect(screen.getByText("primary@example.com")).toBeInTheDocument();
     expect(screen.getByText("secondary@example.com")).toBeInTheDocument();
   });
@@ -34,13 +32,11 @@ describe("UsageDonuts", () => {
         secondaryItems={[]}
         primaryTotal={0}
         secondaryTotal={0}
-        primaryWindowMinutes={null}
-        secondaryWindowMinutes={null}
       />,
     );
 
-    expect(screen.getByText("Primary Remaining")).toBeInTheDocument();
-    expect(screen.getByText("Secondary Remaining")).toBeInTheDocument();
+    expect(screen.getByText("5h Remaining")).toBeInTheDocument();
+    expect(screen.getByText("Weekly Remaining")).toBeInTheDocument();
     expect(screen.getAllByText("Remaining").length).toBeGreaterThanOrEqual(2);
   });
 
@@ -51,8 +47,6 @@ describe("UsageDonuts", () => {
         secondaryItems={[item({ accountId: "acc-2", label: "secondary@example.com", value: 80, remainingPercent: 40, color: "#d9a441" })]}
         primaryTotal={200}
         secondaryTotal={200}
-        primaryWindowMinutes={300}
-        secondaryWindowMinutes={10080}
         safeLinePrimary={{ safePercent: 60, riskLevel: "warning" }}
       />,
     );
@@ -67,8 +61,6 @@ describe("UsageDonuts", () => {
         secondaryItems={[item({ accountId: "acc-2", label: "secondary@example.com", value: 80, remainingPercent: 40, color: "#d9a441" })]}
         primaryTotal={200}
         secondaryTotal={200}
-        primaryWindowMinutes={300}
-        secondaryWindowMinutes={10080}
         safeLinePrimary={{ safePercent: 60, riskLevel: "warning" }}
         safeLineSecondary={{ safePercent: 40, riskLevel: "danger" }}
       />,
@@ -84,8 +76,6 @@ describe("UsageDonuts", () => {
         secondaryItems={[item({ accountId: "acc-1", label: "weekly@example.com", value: 80, remainingPercent: 40, color: "#d9a441" })]}
         primaryTotal={0}
         secondaryTotal={200}
-        primaryWindowMinutes={null}
-        secondaryWindowMinutes={10080}
         safeLineSecondary={{ safePercent: 60, riskLevel: "warning" }}
       />,
     );

--- a/frontend/src/features/dashboard/components/usage-donuts.tsx
+++ b/frontend/src/features/dashboard/components/usage-donuts.tsx
@@ -2,15 +2,12 @@ import { useMemo } from "react";
 
 import { DonutChart } from "@/components/donut-chart";
 import type { RemainingItem, SafeLineView } from "@/features/dashboard/utils";
-import { formatWindowLabel } from "@/utils/formatters";
 
 export type UsageDonutsProps = {
 	primaryItems: RemainingItem[];
 	secondaryItems: RemainingItem[];
 	primaryTotal: number;
 	secondaryTotal: number;
-	primaryWindowMinutes: number | null;
-	secondaryWindowMinutes: number | null;
 	safeLinePrimary?: SafeLineView | null;
 	safeLineSecondary?: SafeLineView | null;
 };
@@ -20,8 +17,6 @@ export function UsageDonuts({
 	secondaryItems,
 	primaryTotal,
 	secondaryTotal,
-	primaryWindowMinutes,
-	secondaryWindowMinutes,
 	safeLinePrimary,
 	safeLineSecondary,
 }: UsageDonutsProps) {
@@ -53,15 +48,13 @@ export function UsageDonuts({
 	return (
 		<div className="grid gap-4 lg:grid-cols-2">
 			<DonutChart
-				title="Primary Remaining"
-				subtitle={`Window ${formatWindowLabel("primary", primaryWindowMinutes)}`}
+				title="5h Remaining"
 				items={primaryChartItems}
 				total={primaryTotal}
 				safeLine={safeLinePrimary}
 			/>
 			<DonutChart
-				title="Secondary Remaining"
-				subtitle={`Window ${formatWindowLabel("secondary", secondaryWindowMinutes)}`}
+				title="Weekly Remaining"
 				items={secondaryChartItems}
 				total={secondaryTotal}
 				safeLine={safeLineSecondary}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import react from "@vitejs/plugin-react-swc";
@@ -6,9 +7,14 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vitest/config";
 
 const proxyTarget = process.env.API_PROXY_TARGET || "http://localhost:2455";
+const packageJson = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")) as { version?: string };
+const appVersion = packageJson.version ?? "0.0.0";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   resolve: {
     alias: {
       "@": path.resolve(path.dirname(fileURLToPath(import.meta.url)), "./src"),


### PR DESCRIPTION
1. The dashboard align with the changes on the account page, showing 5h and weekly
<img width="1460" height="231" alt="螢幕截圖 2026-03-19 15 03 49" src="https://github.com/user-attachments/assets/ccf4c679-1bd4-43b0-bb14-9ff506cc7734" />

2. Add version at the bottom for better understanding on what version currently is
<img width="408" height="47" alt="螢幕截圖 2026-03-19 15 03 55" src="https://github.com/user-attachments/assets/d8662d32-88e5-40e9-90f9-5c54fa1384e1" />

3.  In addition of point 2, `package.json` version needed to be updated for each `release-please` iteration

4. Probably fix the `\n` in the release changelog
<img width="548" height="169" alt="螢幕截圖 2026-03-19 15 08 38" src="https://github.com/user-attachments/assets/93d17a16-a270-421a-8520-7d05a2b68284" />

