### PR TITLE
fix: trend graph do not render when primary = [], even secondary have data

### DIFF
--- a/frontend/src/features/accounts/components/account-trend-chart.tsx
+++ b/frontend/src/features/accounts/components/account-trend-chart.tsx
@@ -24,9 +24,17 @@ function mergePoints(
   secondary: UsageTrendPoint[],
 ): MergedPoint[] {
   const secondaryMap = new Map(secondary.map((p) => [p.t, p.v]));
-  return primary.map((p) => ({
+  const primaryMap = new Map(primary.map((p) => [p.t, p.v]));
+  
+  if (primary.length === 0 && secondary.length === 0) {
+    return [];
+  }
+  
+  const basePoints = primary.length > 0 ? primary : secondary;
+  
+  return basePoints.map((p) => ({
     t: p.t,
-    primary: p.v,
+    primary: primaryMap.get(p.t) ?? 0,
     secondary: secondaryMap.get(p.t) ?? 0,
   }));
 }
@@ -140,29 +148,33 @@ export function AccountTrendChart({ primary, secondary }: AccountTrendChartProps
           content={<CustomTooltip />}
           cursor={{ stroke: "hsl(var(--border))", strokeWidth: 1 }}
         />
-        <Area
-          type="monotone"
-          dataKey="primary"
-          stroke={c1}
-          strokeWidth={1.5}
-          fill="url(#trend-primary)"
-          dot={false}
-          activeDot={{ r: 3, strokeWidth: 1.5, fill: "hsl(var(--popover))" }}
-          isAnimationActive={!reducedMotion}
-          animationDuration={500}
-        />
-        <Area
-          type="monotone"
-          dataKey="secondary"
-          stroke={c2}
-          strokeWidth={1.5}
-          fill="url(#trend-secondary)"
-          dot={false}
-          activeDot={{ r: 3, strokeWidth: 1.5, fill: "hsl(var(--popover))" }}
-          isAnimationActive={!reducedMotion}
-          animationDuration={500}
-          animationBegin={100}
-        />
+        {primary.length > 0 && (
+          <Area
+            type="monotone"
+            dataKey="primary"
+            stroke={c1}
+            strokeWidth={1.5}
+            fill="url(#trend-primary)"
+            dot={false}
+            activeDot={{ r: 3, strokeWidth: 1.5, fill: "hsl(var(--popover))" }}
+            isAnimationActive={!reducedMotion}
+            animationDuration={500}
+          />
+        )}
+        {secondary.length > 0 && (
+          <Area
+            type="monotone"
+            dataKey="secondary"
+            stroke={c2}
+            strokeWidth={1.5}
+            fill="url(#trend-secondary)"
+            dot={false}
+            activeDot={{ r: 3, strokeWidth: 1.5, fill: "hsl(var(--popover))" }}
+            isAnimationActive={!reducedMotion}
+            animationDuration={500}
+            animationBegin={100}
+          />
+        )}
       </AreaChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
It is a follow up case for #190 

It fixes the graph does not render when it is a free acc (only have secondary data)

This is the graph after the fix for the free acc
<img width="865" height="258" alt="螢幕截圖 2026-03-23 21 01 53" src="https://github.com/user-attachments/assets/a43ea71d-5d1f-4218-a33a-3f526e2a1ffd" />
