### PR TITLE
enhance/fix: Persist cost for request_logs

### DIFF
--- a/app/core/usage/logs.py
+++ b/app/core/usage/logs.py
@@ -8,16 +8,24 @@ from app.core.usage.pricing import UsageTokens, calculate_cost_from_usage, get_p
 class RequestLogLike(Protocol):
     @property
     def model(self) -> str | None: ...
+
     @property
     def service_tier(self) -> str | None: ...
+
     @property
     def input_tokens(self) -> int | None: ...
+
     @property
     def output_tokens(self) -> int | None: ...
+
     @property
     def cached_input_tokens(self) -> int | None: ...
+
     @property
     def reasoning_tokens(self) -> int | None: ...
+
+    @property
+    def cost_usd(self) -> float | None: ...
 
 
 def cached_input_tokens_from_log(log: RequestLogLike) -> int | None:
@@ -46,7 +54,7 @@ def usage_tokens_from_log(log: RequestLogLike) -> UsageTokens | None:
     )
 
 
-def cost_from_log(log: RequestLogLike, *, precision: int | None = None) -> float | None:
+def calculated_cost_from_log(log: RequestLogLike, *, precision: int | None = None) -> float | None:
     if not log.model:
         return None
     usage = usage_tokens_from_log(log)
@@ -62,6 +70,15 @@ def cost_from_log(log: RequestLogLike, *, precision: int | None = None) -> float
     if precision is None:
         return cost
     return round(cost, precision)
+
+
+def cost_from_log(log: RequestLogLike, *, precision: int | None = None) -> float | None:
+    cost = log.cost_usd
+    if cost is None:
+        return None
+    if precision is None:
+        return float(cost)
+    return round(float(cost), precision)
 
 
 def total_tokens_from_log(log: RequestLogLike) -> int | None:

--- a/app/core/usage/types.py
+++ b/app/core/usage/types.py
@@ -118,3 +118,4 @@ class BucketModelAggregate:
     output_tokens: int
     cached_input_tokens: int
     reasoning_tokens: int
+    cost_usd: float = 0.0

--- a/app/db/alembic/versions/20260325_000000_add_request_log_cost.py
+++ b/app/db/alembic/versions/20260325_000000_add_request_log_cost.py
@@ -1,0 +1,193 @@
+"""add persisted cost to request_logs
+
+Revision ID: 20260325_000000_add_request_log_cost
+Revises: 20260321_210000_merge_request_log_tiers_and_dashboard_index_heads
+Create Date: 2026-03-25
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+from app.core.usage.pricing import UsageTokens, calculate_cost_from_usage, get_pricing_for_model
+
+# revision identifiers, used by Alembic.
+revision = "20260325_000000_add_request_log_cost"
+down_revision = "20260321_210000_merge_request_log_tiers_and_dashboard_index_heads"
+branch_labels = None
+depends_on = None
+
+_BACKFILL_BATCH_SIZE = 1000
+_TEMP_COST_TABLE_NAME = "request_log_cost_backfill"
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return set()
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def _calculate_cost(
+    *,
+    model: str | None,
+    service_tier: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    cached_input_tokens: int | None,
+    reasoning_tokens: int | None,
+) -> float | None:
+    if not model or input_tokens is None:
+        return None
+    resolved_output_tokens = output_tokens if output_tokens is not None else reasoning_tokens
+    if resolved_output_tokens is None:
+        return None
+    resolved = get_pricing_for_model(model, None, None)
+    if resolved is None:
+        return None
+    _, price = resolved
+    normalized_cached_tokens = max(0, min(int(cached_input_tokens or 0), int(input_tokens)))
+    return calculate_cost_from_usage(
+        UsageTokens(
+            input_tokens=float(input_tokens),
+            output_tokens=float(resolved_output_tokens),
+            cached_input_tokens=float(normalized_cached_tokens),
+        ),
+        price,
+        service_tier=service_tier,
+    )
+
+
+def _create_backfill_temp_table(bind: Connection) -> None:
+    bind.execute(sa.text(f"DROP TABLE IF EXISTS {_TEMP_COST_TABLE_NAME}"))
+    bind.execute(
+        sa.text(
+            f"""
+            CREATE TEMPORARY TABLE {_TEMP_COST_TABLE_NAME} (
+                id INTEGER PRIMARY KEY,
+                cost_usd FLOAT NULL
+            )
+            """
+        )
+    )
+
+
+def _apply_cost_backfill_batch(
+    bind: Connection,
+    batch: Sequence[dict[str, int | float | None]],
+) -> None:
+    if not batch:
+        return
+
+    bind.execute(sa.text(f"DELETE FROM {_TEMP_COST_TABLE_NAME}"))
+    bind.execute(
+        sa.text(f"INSERT INTO {_TEMP_COST_TABLE_NAME} (id, cost_usd) VALUES (:id, :cost_usd)"),
+        list(batch),
+    )
+    if bind.dialect.name == "sqlite":
+        bind.execute(
+            sa.text(
+                f"""
+                UPDATE request_logs
+                SET cost_usd = (
+                    SELECT tmp.cost_usd
+                    FROM {_TEMP_COST_TABLE_NAME} AS tmp
+                    WHERE tmp.id = request_logs.id
+                )
+                WHERE id IN (SELECT id FROM {_TEMP_COST_TABLE_NAME})
+                """
+            )
+        )
+        return
+
+    bind.execute(
+        sa.text(
+            f"""
+            UPDATE request_logs
+            SET cost_usd = tmp.cost_usd
+            FROM {_TEMP_COST_TABLE_NAME} AS tmp
+            WHERE request_logs.id = tmp.id
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind, "request_logs")
+    if not columns:
+        return
+
+    if "cost_usd" not in columns:
+        with op.batch_alter_table("request_logs") as batch_op:
+            batch_op.add_column(sa.Column("cost_usd", sa.Float(), nullable=True))
+
+    request_logs = sa.table(
+        "request_logs",
+        sa.column("id", sa.Integer()),
+        sa.column("model", sa.String()),
+        sa.column("service_tier", sa.String()),
+        sa.column("input_tokens", sa.Integer()),
+        sa.column("output_tokens", sa.Integer()),
+        sa.column("cached_input_tokens", sa.Integer()),
+        sa.column("reasoning_tokens", sa.Integer()),
+        sa.column("cost_usd", sa.Float()),
+    )
+
+    last_seen_id = 0
+    _create_backfill_temp_table(bind)
+    try:
+        while True:
+            rows = (
+                bind.execute(
+                    sa.select(
+                        request_logs.c.id,
+                        request_logs.c.model,
+                        request_logs.c.service_tier,
+                        request_logs.c.input_tokens,
+                        request_logs.c.output_tokens,
+                        request_logs.c.cached_input_tokens,
+                        request_logs.c.reasoning_tokens,
+                    )
+                    .where(request_logs.c.id > last_seen_id)
+                    .order_by(request_logs.c.id)
+                    .limit(_BACKFILL_BATCH_SIZE)
+                )
+                .mappings()
+                .all()
+            )
+            if not rows:
+                break
+
+            batch = [
+                {
+                    "id": row["id"],
+                    "cost_usd": _calculate_cost(
+                        model=row["model"],
+                        service_tier=row["service_tier"],
+                        input_tokens=row["input_tokens"],
+                        output_tokens=row["output_tokens"],
+                        cached_input_tokens=row["cached_input_tokens"],
+                        reasoning_tokens=row["reasoning_tokens"],
+                    ),
+                }
+                for row in rows
+            ]
+            _apply_cost_backfill_batch(bind, batch)
+            last_seen_id = int(rows[-1]["id"])
+    finally:
+        bind.execute(sa.text(f"DROP TABLE IF EXISTS {_TEMP_COST_TABLE_NAME}"))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind, "request_logs")
+    if not columns or "cost_usd" not in columns:
+        return
+
+    with op.batch_alter_table("request_logs") as batch_op:
+        batch_op.drop_column("cost_usd")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -124,6 +124,7 @@ class RequestLog(Base):
     output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
     cached_input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
     reasoning_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_usd: Mapped[float | None] = mapped_column(Float, nullable=True)
     reasoning_effort: Mapped[str | None] = mapped_column(String, nullable=True)
     latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     status: Mapped[str] = mapped_column(String, nullable=False)

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -8,7 +8,6 @@ from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.usage.pricing import UsageTokens, calculate_cost_from_usage, get_pricing_for_model
 from app.db.models import Account, AccountStatus, DashboardSettings, RequestLog, StickySession, UsageHistory
 
 _SETTINGS_ROW_ID = 1
@@ -47,29 +46,27 @@ class AccountsRepository:
         self,
         account_ids: list[str] | None = None,
     ) -> dict[str, AccountRequestUsageSummary]:
+        summaries: dict[str, AccountRequestUsageSummary] = {}
         output_tokens_expr = func.coalesce(RequestLog.output_tokens, RequestLog.reasoning_tokens, 0)
         stmt = select(
             RequestLog.account_id,
-            RequestLog.model,
-            RequestLog.service_tier,
             func.count(RequestLog.id).label("request_count"),
             func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
             func.coalesce(func.sum(output_tokens_expr), 0).label("output_tokens"),
             func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
-        ).group_by(RequestLog.account_id, RequestLog.model, RequestLog.service_tier)
+            func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
+        ).group_by(RequestLog.account_id)
         if account_ids:
             stmt = stmt.where(RequestLog.account_id.in_(account_ids))
 
         result = await self._session.execute(stmt)
-        rollup: dict[str, dict[str, float | int]] = {}
         for (
             account_id,
-            model,
-            service_tier,
             request_count,
             input_tokens,
             output_tokens,
             cached_input_tokens,
+            total_cost_usd,
         ) in result.all():
             if not account_id:
                 continue
@@ -77,46 +74,15 @@ class AccountsRepository:
             output_sum = int(output_tokens or 0)
             cached_sum = int(cached_input_tokens or 0)
             cached_sum = max(0, min(cached_sum, input_sum))
-            tokens_sum = input_sum + output_sum
-
-            entry = rollup.setdefault(
-                account_id,
-                {
-                    "request_count": 0,
-                    "total_tokens": 0,
-                    "cached_input_tokens": 0,
-                    "total_cost_usd": 0.0,
-                },
+            return_row = AccountRequestUsageSummary(
+                request_count=int(request_count or 0),
+                total_tokens=input_sum + output_sum,
+                cached_input_tokens=cached_sum,
+                total_cost_usd=round(float(total_cost_usd or 0.0), 6),
             )
-            entry["request_count"] += int(request_count or 0)
-            entry["total_tokens"] += tokens_sum
-            entry["cached_input_tokens"] += cached_sum
+            summaries[account_id] = return_row
 
-            resolved = get_pricing_for_model(model or "", None, None)
-            if resolved is None:
-                continue
-            _, price = resolved
-            cost_usd = calculate_cost_from_usage(
-                UsageTokens(
-                    input_tokens=float(input_sum),
-                    output_tokens=float(output_sum),
-                    cached_input_tokens=float(cached_sum),
-                ),
-                price,
-                service_tier=service_tier,
-            )
-            if cost_usd is not None:
-                entry["total_cost_usd"] += cost_usd
-
-        return {
-            account_id: AccountRequestUsageSummary(
-                request_count=int(values["request_count"]),
-                total_tokens=int(values["total_tokens"]),
-                cached_input_tokens=int(values["cached_input_tokens"]),
-                total_cost_usd=round(float(values["total_cost_usd"]), 6),
-            )
-            for account_id, values in rollup.items()
-        }
+        return summaries
 
     async def exists_active_chatgpt_account_id(self, chatgpt_account_id: str) -> bool:
         result = await self._session.execute(

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -8,7 +8,6 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.core.usage.pricing import UsageTokens, calculate_cost_from_usage, get_pricing_for_model
 from app.core.utils.time import utcnow
 from app.db.models import (
     ApiKey,
@@ -90,8 +89,6 @@ class ApiKeysRepository:
         stmt = (
             select(
                 RequestLog.api_key_id,
-                RequestLog.model,
-                RequestLog.service_tier,
                 func.count(RequestLog.id).label("request_count"),
                 func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
                 func.coalesce(
@@ -99,20 +96,20 @@ class ApiKeysRepository:
                     0,
                 ).label("output_tokens"),
                 func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
+                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
             )
             .where(RequestLog.api_key_id.is_not(None))
-            .group_by(RequestLog.api_key_id, RequestLog.model, RequestLog.service_tier)
+            .group_by(RequestLog.api_key_id)
         )
         result = await self._session.execute(stmt)
-        rollup: dict[str, dict[str, float | int]] = {}
+        summaries: dict[str, ApiKeyUsageSummary] = {}
         for (
             api_key_id,
-            model,
-            service_tier,
             request_count,
             input_tokens,
             output_tokens,
             cached_input_tokens,
+            total_cost_usd,
         ) in result.all():
             if not api_key_id:
                 continue
@@ -120,46 +117,14 @@ class ApiKeysRepository:
             output_sum = int(output_tokens or 0)
             cached_sum = int(cached_input_tokens or 0)
             cached_sum = max(0, min(cached_sum, input_sum))
-            tokens_sum = input_sum + output_sum
-
-            entry = rollup.setdefault(
-                api_key_id,
-                {
-                    "request_count": 0,
-                    "total_tokens": 0,
-                    "cached_input_tokens": 0,
-                    "total_cost_usd": 0.0,
-                },
+            summaries[api_key_id] = ApiKeyUsageSummary(
+                request_count=int(request_count or 0),
+                total_tokens=input_sum + output_sum,
+                cached_input_tokens=cached_sum,
+                total_cost_usd=round(float(total_cost_usd or 0.0), 6),
             )
-            entry["request_count"] += int(request_count or 0)
-            entry["total_tokens"] += tokens_sum
-            entry["cached_input_tokens"] += cached_sum
 
-            resolved = get_pricing_for_model(model or "", None, None)
-            if resolved is None:
-                continue
-            _, price = resolved
-            cost_usd = calculate_cost_from_usage(
-                UsageTokens(
-                    input_tokens=float(input_sum),
-                    output_tokens=float(output_sum),
-                    cached_input_tokens=float(cached_sum),
-                ),
-                price,
-                service_tier=service_tier,
-            )
-            if cost_usd is not None:
-                entry["total_cost_usd"] += cost_usd
-
-        return {
-            api_key_id: ApiKeyUsageSummary(
-                request_count=int(values["request_count"]),
-                total_tokens=int(values["total_tokens"]),
-                cached_input_tokens=int(values["cached_input_tokens"]),
-                total_cost_usd=round(float(values["total_cost_usd"]), 6),
-            )
-            for api_key_id, values in rollup.items()
-        }
+        return summaries
 
     async def update(
         self,

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -8,6 +8,7 @@ from sqlalchemy import Integer, String, and_, cast, func, literal_column, or_, s
 from sqlalchemy import exc as sa_exc
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.usage.logs import calculated_cost_from_log
 from app.core.usage.types import BucketModelAggregate
 from app.core.utils.request_id import ensure_request_id
 from app.core.utils.time import utcnow
@@ -54,6 +55,7 @@ class RequestLogsRepository:
                 func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
                 func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
                 func.coalesce(func.sum(RequestLog.reasoning_tokens), 0).label("reasoning_tokens"),
+                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
             )
             .where(RequestLog.requested_at >= since)
             .group_by(bucket_col, RequestLog.model, RequestLog.service_tier)
@@ -71,6 +73,7 @@ class RequestLogsRepository:
                 output_tokens=int(row.output_tokens),
                 cached_input_tokens=int(row.cached_input_tokens),
                 reasoning_tokens=int(row.reasoning_tokens),
+                cost_usd=float(row.cost_usd or 0.0),
             )
             for row in result.all()
         ]
@@ -110,6 +113,7 @@ class RequestLogsRepository:
             output_tokens=output_tokens,
             cached_input_tokens=cached_input_tokens,
             reasoning_tokens=reasoning_tokens,
+            cost_usd=None,
             reasoning_effort=reasoning_effort,
             latency_ms=latency_ms,
             status=status,
@@ -117,6 +121,7 @@ class RequestLogsRepository:
             error_message=error_message,
             requested_at=requested_at or utcnow(),
         )
+        log.cost_usd = calculated_cost_from_log(log)
         self._session.add(log)
         try:
             await self._session.commit()

--- a/app/modules/usage/builders.py
+++ b/app/modules/usage/builders.py
@@ -5,14 +5,10 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from app.core import usage as usage_core
-from app.core.usage.logs import (
-    cached_input_tokens_from_log,
-    total_tokens_from_log,
-    usage_tokens_from_log,
-)
-from app.core.usage.pricing import CostItem, UsageTokens, calculate_costs
+from app.core.usage.logs import cached_input_tokens_from_log, cost_from_log, total_tokens_from_log
 from app.core.usage.types import (
     BucketModelAggregate,
+    UsageCostByModel,
     UsageCostSummary,
     UsageMetricsSummary,
     UsageSummaryPayload,
@@ -57,12 +53,14 @@ def build_trends_from_buckets(
     bucket_requests: dict[int, int] = defaultdict(int)
     bucket_errors: dict[int, int] = defaultdict(int)
     bucket_tokens: dict[int, int] = defaultdict(int)
-    bucket_cost_items: dict[int, list[CostItem]] = defaultdict(list)
+    bucket_costs: dict[int, float] = defaultdict(float)
+    total_costs_by_model: dict[str, float] = defaultdict(float)
 
     total_requests = 0
     total_errors = 0
     total_tokens = 0
     total_cached_tokens = 0
+    total_cost_usd = 0.0
 
     for row in rows:
         epoch = row.bucket_epoch
@@ -71,22 +69,14 @@ def build_trends_from_buckets(
         bucket_requests[epoch] += row.request_count
         bucket_errors[epoch] += row.error_count
         bucket_tokens[epoch] += row.input_tokens + row.output_tokens
-        bucket_cost_items[epoch].append(
-            CostItem(
-                model=row.model,
-                service_tier=row.service_tier,
-                usage=UsageTokens(
-                    input_tokens=float(row.input_tokens),
-                    output_tokens=float(row.output_tokens),
-                    cached_input_tokens=float(row.cached_input_tokens),
-                ),
-            )
-        )
+        bucket_costs[epoch] += float(row.cost_usd)
+        total_costs_by_model[row.model] += float(row.cost_usd)
 
         total_requests += row.request_count
         total_errors += row.error_count
         total_tokens += row.input_tokens + row.output_tokens
         total_cached_tokens += row.cached_input_tokens
+        total_cost_usd += float(row.cost_usd)
 
     requests_points: list[TrendPoint] = []
     tokens_points: list[TrendPoint] = []
@@ -98,11 +88,7 @@ def build_trends_from_buckets(
         req = bucket_requests.get(epoch, 0)
         err = bucket_errors.get(epoch, 0)
         tok = bucket_tokens.get(epoch, 0)
-
-        cost_value = 0.0
-        if epoch in bucket_cost_items:
-            cost_summary = calculate_costs(bucket_cost_items[epoch])
-            cost_value = cost_summary.total_usd_7d
+        cost_value = bucket_costs.get(epoch, 0.0)
 
         err_rate = (err / req) if req > 0 else 0.0
 
@@ -130,21 +116,13 @@ def build_trends_from_buckets(
         top_error=None,
     )
 
-    # Compute total cost from all rows
-    all_cost_items = [
-        CostItem(
-            model=row.model,
-            service_tier=row.service_tier,
-            usage=UsageTokens(
-                input_tokens=float(row.input_tokens),
-                output_tokens=float(row.output_tokens),
-                cached_input_tokens=float(row.cached_input_tokens),
-            ),
-        )
-        for row in rows
-        if row.bucket_epoch in slot_set
-    ]
-    total_cost = calculate_costs(all_cost_items)
+    total_cost = UsageCostSummary(
+        currency="USD",
+        total_usd_7d=round(total_cost_usd, 6),
+        by_model=[
+            UsageCostByModel(model=model, usd=round(cost, 6)) for model, cost in sorted(total_costs_by_model.items())
+        ],
+    )
 
     return trends, metrics, total_cost
 
@@ -165,8 +143,7 @@ def build_usage_summary_response(
     if cost_override is not None:
         cost = cost_override
     else:
-        cost_items = [item for item in (_log_to_cost_item(log) for log in logs_secondary) if item]
-        cost = calculate_costs(cost_items)
+        cost = _cost_summary_from_logs(logs_secondary)
 
     metrics = metrics_override if metrics_override is not None else _usage_metrics(logs_secondary)
 
@@ -244,12 +221,20 @@ def _build_account_history(
     return results
 
 
-def _log_to_cost_item(log: RequestLog) -> CostItem | None:
-    model = log.model
-    usage = usage_tokens_from_log(log)
-    if not model or not usage:
-        return None
-    return CostItem(model=model, usage=usage, service_tier=log.service_tier)
+def _cost_summary_from_logs(logs: list[RequestLog]) -> UsageCostSummary:
+    total = 0.0
+    by_model: dict[str, float] = defaultdict(float)
+    for log in logs:
+        cost = cost_from_log(log)
+        if cost is None:
+            continue
+        total += cost
+        by_model[log.model] += cost
+    return UsageCostSummary(
+        currency="USD",
+        total_usd_7d=round(total, 6),
+        by_model=[UsageCostByModel(model=model, usd=round(cost, 6)) for model, cost in sorted(by_model.items())],
+    )
 
 
 def _usage_metrics(logs_secondary: list[RequestLog]) -> UsageMetricsSummary:

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -5,6 +5,7 @@ import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from sqlalchemy import update
 
 from app.core.auth import fallback_account_id, generate_unique_account_id
 from app.core.crypto import TokenEncryptor
@@ -432,6 +433,37 @@ async def test_accounts_list_request_usage_cost_rollup_respects_service_tier(asy
     assert request_usage["totalTokens"] == 2_000_000
     assert request_usage["cachedInputTokens"] == 0
     assert request_usage["totalCostUsd"] == pytest.approx(35.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_accounts_list_request_usage_uses_persisted_cost(async_client, db_setup):
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_persisted_cost", "persisted-cost@example.com"))
+
+        log = await logs_repo.add_log(
+            account_id="acc_persisted_cost",
+            request_id="req_persisted_cost_1",
+            model="gpt-5.1",
+            input_tokens=10,
+            output_tokens=5,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+        )
+        await session.execute(update(log.__class__).where(log.__class__.id == log.id).values(cost_usd=12.345678))
+        await session.commit()
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    request_usage = accounts["acc_persisted_cost"]["requestUsage"]
+    assert request_usage is not None
+    assert request_usage["totalCostUsd"] == pytest.approx(12.345678, abs=1e-6)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -6,7 +6,7 @@ import json
 from datetime import timedelta
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
@@ -542,6 +542,81 @@ async def test_api_key_usage_summary_cost_respects_service_tier(async_client, mo
     assert usage_key_row is not None
     assert usage_key_row["usageSummary"] is not None
     assert usage_key_row["usageSummary"]["totalCostUsd"] == pytest.approx(35.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_api_key_usage_summary_uses_persisted_request_log_cost(async_client, monkeypatch):
+    enable = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert enable.status_code == 200
+
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "persisted-usage-summary",
+            "limits": [
+                {"limitType": "cost_usd", "limitWindow": "weekly", "maxValue": 100_000_000},
+            ],
+        },
+    )
+    assert created.status_code == 200
+    payload = created.json()
+    key = payload["key"]
+    key_id = payload["id"]
+
+    await _import_account(async_client, "acc_persisted_usage_summary", "persisted-usage-summary@example.com")
+
+    async def fake_stream(_payload, _headers, _access_token, _account_id, base_url=None, raise_for_status=False):
+        event = {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_persisted_usage_summary",
+                "status": "completed",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "total_tokens": 15,
+                },
+            },
+        }
+        yield f"data: {json.dumps(event)}\n\n"
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        headers={"Authorization": f"Bearer {key}"},
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+        },
+    ) as response:
+        assert response.status_code == 200
+        _ = [line async for line in response.aiter_lines() if line]
+
+    async with SessionLocal() as session:
+        result = await session.execute(select(RequestLog).where(RequestLog.api_key_id == key_id))
+        log = result.scalar_one()
+        await session.execute(update(RequestLog).where(RequestLog.id == log.id).values(cost_usd=7.654321))
+        await session.commit()
+
+    listed = await async_client.get("/api/api-keys/")
+    assert listed.status_code == 200
+    listed_rows = listed.json()
+    usage_key_row = next((row for row in listed_rows if row["id"] == key_id), None)
+    assert usage_key_row is not None
+    assert usage_key_row["usageSummary"] is not None
+    assert usage_key_row["usageSummary"]["totalCostUsd"] == pytest.approx(7.654321, abs=1e-6)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_request_logs_filters.py
+++ b/tests/integration/test_request_logs_filters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import update
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -492,6 +493,35 @@ async def test_request_logs_cost_uses_flex_service_tier(async_client, db_setup):
     assert entry["serviceTier"] == "flex"
     expected = round(_cost(300_000, 100_000, 50_000, input_rate=2.5, cached_rate=0.25, output_rate=11.25), 6)
     assert entry["costUsd"] == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
+async def test_request_logs_cost_uses_persisted_cost_field(async_client, db_setup):
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_persisted_log_cost", "persisted-log-cost@example.com"))
+
+        log = await logs_repo.add_log(
+            account_id="acc_persisted_log_cost",
+            request_id="req_persisted_log_cost_1",
+            model="gpt-5.1",
+            input_tokens=1000,
+            output_tokens=500,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=now,
+        )
+        await session.execute(update(log.__class__).where(log.__class__.id == log.id).values(cost_usd=4.321234))
+        await session.commit()
+
+    response = await async_client.get("/api/request-logs?accountId=acc_persisted_log_cost&limit=1")
+    assert response.status_code == 200
+    payload = response.json()["requests"]
+    assert len(payload) == 1
+    assert payload[0]["costUsd"] == pytest.approx(4.321234)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_usage_summary.py
+++ b/tests/integration/test_usage_summary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import update
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -105,3 +106,35 @@ async def test_usage_summary_metrics(db_setup):
         assert metrics.tokens_secondary_window == 35
         assert metrics.error_rate_7d == pytest.approx(0.5)
         assert metrics.top_error == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_usage_summary_uses_persisted_request_log_cost(db_setup):
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        usage_repo = UsageRepository(session)
+        service = UsageService(usage_repo, logs_repo, accounts_repo)
+
+        await accounts_repo.upsert(_make_account("acc3", "persisted-cost@example.com"))
+
+        now = utcnow()
+        log = await logs_repo.add_log(
+            account_id="acc3",
+            request_id="req_summary_persisted_cost",
+            model="gpt-5.1",
+            input_tokens=1000,
+            output_tokens=500,
+            cached_input_tokens=200,
+            reasoning_tokens=None,
+            latency_ms=100,
+            status="success",
+            error_code=None,
+            requested_at=now - timedelta(minutes=5),
+        )
+        await session.execute(update(log.__class__).where(log.__class__.id == log.id).values(cost_usd=9.876543))
+        await session.commit()
+
+        summary = await service.get_usage_summary()
+
+        assert summary.cost.total_usd_7d == pytest.approx(9.876543)

--- a/tests/unit/test_dashboard_trends.py
+++ b/tests/unit/test_dashboard_trends.py
@@ -24,6 +24,7 @@ def _make_row(
     output_tokens: int = 200,
     cached_input_tokens: int = 50,
     reasoning_tokens: int = 0,
+    cost_usd: float = 0.123,
 ) -> BucketModelAggregate:
     return BucketModelAggregate(
         bucket_epoch=FIRST_SLOT_EPOCH + slot_index * BUCKET_SECONDS,
@@ -35,6 +36,7 @@ def _make_row(
         output_tokens=output_tokens,
         cached_input_tokens=cached_input_tokens,
         reasoning_tokens=reasoning_tokens,
+        cost_usd=cost_usd,
     )
 
 
@@ -115,11 +117,11 @@ class TestBuildTrendsFromBuckets:
                 input_tokens=1_000_000,
                 output_tokens=1_000_000,
                 cached_input_tokens=0,
+                cost_usd=11.25,
             ),
         ]
         _, _, cost = build_trends_from_buckets(rows, SINCE)
 
-        # gpt-5.1: $1.25/1M input + $10.0/1M output = $11.25
         assert cost.total_usd_7d == pytest.approx(11.25)
 
     def test_out_of_range_buckets_are_ignored(self):
@@ -134,6 +136,7 @@ class TestBuildTrendsFromBuckets:
                 output_tokens=0,
                 cached_input_tokens=0,
                 reasoning_tokens=0,
+                cost_usd=123.0,
             ),
         ]
         trends, metrics, _ = build_trends_from_buckets(rows, SINCE)
@@ -165,6 +168,7 @@ class TestBuildTrendsFromBuckets:
                 input_tokens=1_000_000,
                 output_tokens=1_000_000,
                 cached_input_tokens=0,
+                cost_usd=35.0,
             ),
         ]
         _, _, cost = build_trends_from_buckets(rows, SINCE)
@@ -179,9 +183,26 @@ class TestBuildTrendsFromBuckets:
                 input_tokens=1_000_000,
                 output_tokens=1_000_000,
                 cached_input_tokens=100_000,
+                cost_usd=5.2575,
             ),
         ]
         _, _, cost = build_trends_from_buckets(rows, SINCE)
 
-        expected = (900_000 / 1_000_000) * 0.75 + (100_000 / 1_000_000) * 0.075 + (1_000_000 / 1_000_000) * 4.5
-        assert cost.total_usd_7d == pytest.approx(expected)
+        assert cost.total_usd_7d == pytest.approx(5.2575)
+
+    def test_cost_uses_persisted_bucket_value(self):
+        rows = [
+            _make_row(
+                slot_index=0,
+                model="gpt-5.1",
+                input_tokens=1,
+                output_tokens=1,
+                cached_input_tokens=0,
+                cost_usd=42.5,
+            ),
+        ]
+
+        trends, _, cost = build_trends_from_buckets(rows, SINCE)
+
+        assert trends.cost[0].v == pytest.approx(42.5)
+        assert cost.total_usd_7d == pytest.approx(42.5)

--- a/tests/unit/test_request_logs_repository.py
+++ b/tests/unit/test_request_logs_repository.py
@@ -25,11 +25,12 @@ async def test_add_log_ignores_closed_transaction(monkeypatch) -> None:
             account_id="acc",
             request_id="req",
             model="gpt-5.2",
-            input_tokens=None,
-            output_tokens=None,
+            input_tokens=1000,
+            output_tokens=500,
             latency_ms=1,
             status="success",
             error_code=None,
         )
 
         assert log.request_id == "req"
+        assert log.cost_usd is not None


### PR DESCRIPTION
The cause:

When `long_context` is introduced in `gpt-5.4`, which will cause the input size > 272K having doubled cost.
The problem is the 6h bucket aggregation will group the separate requests into one big request, which the total input token could easily exceed the 272K context, finally caused the cost in the dashboard nearly doubled, but actually it is not.

The `GET /api/usage/summary` does the API cost correctly because the cost is calculated row by row.

The solution:
Persist the cost in the `request_log` table and calculate the cost when the request is done.
So that there is no room for the bucket aggregation to make it wrong by checking aggregated input token.