### PR TITLE
docs: mention Helm chart install option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ docker run -d --name codex-lb \
 
 # or uvx
 uvx codex-lb
+
+# or Helm (Kubernetes)
+helm repo add icoretech https://icoretech.github.io/helm
+helm repo update
+helm upgrade --install codex-lb icoretech/codex-lb
 ```
 
 Open [localhost:2455](http://localhost:2455) → Add account → Done.


### PR DESCRIPTION
## summary
- add the published Helm chart as a third install option in Quick Start
- keep the change limited to the existing install snippet
- point readers at the `icoretech` Helm repo for Kubernetes installs
