### PR TITLE
perf(usage): replace DISTINCT ON with lateral join in latest_by_account

### DIFF
--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from collections.abc import Collection
 from datetime import datetime
 
-from sqlalchemy import Integer, cast, delete, func, literal_column, or_, select
+from sqlalchemy import Integer, cast, delete, func, literal_column, or_, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.usage.types import UsageAggregateRow, UsageTrendBucket
 from app.core.utils.time import utcnow
-from app.db.models import AdditionalUsageHistory, UsageHistory
+from app.db.models import Account, AdditionalUsageHistory, UsageHistory
 from app.modules.usage.additional_quota_keys import (
     AdditionalQuotaQueryScope,
     canonicalize_additional_quota_key,
@@ -163,12 +163,22 @@ class UsageRepository:
         bind = self._session.get_bind()
         dialect = bind.dialect.name if bind else "sqlite"
         if dialect == "postgresql":
-            stmt = (
-                select(UsageHistory)
-                .distinct(UsageHistory.account_id)
-                .where(conditions)
-                .order_by(UsageHistory.account_id.asc(), UsageHistory.recorded_at.desc(), UsageHistory.id.desc())
+            acct_subq = select(Account.id).subquery("accts")
+            lateral = (
+                select(UsageHistory.id)
+                .where(
+                    conditions,
+                    UsageHistory.account_id == acct_subq.c.id,
+                )
+                .order_by(UsageHistory.recorded_at.desc(), UsageHistory.id.desc())
+                .limit(1)
+                .correlate(acct_subq)
+                .lateral("latest")
             )
+            id_query = (
+                select(lateral.c.id).select_from(acct_subq.outerjoin(lateral, true())).where(lateral.c.id.is_not(None))
+            )
+            stmt = select(UsageHistory).where(UsageHistory.id.in_(id_query))
             result = await self._session.execute(stmt)
             return {entry.account_id: entry for entry in result.scalars().all()}
         subq = (


### PR DESCRIPTION
## Summary

- Replace `DISTINCT ON` full-table scan with PostgreSQL `LATERAL` join in `UsageRepository.latest_by_account()`
- The old query scanned 530K+ rows and sorted on disk to find the latest row per account (only 17 accounts)
- The lateral join performs 17 indexed lookups instead, one per account with `LIMIT 1`

## Benchmark (EXPLAIN ANALYZE on production)

| Window | Before | After | Speedup |
|--------|--------|-------|---------|
| `primary` | 1,529ms (Parallel Seq Scan + disk sort) | **1.1ms** (17 Index Scans) | **1,390x** |
| `secondary` | 1,188ms (Parallel Seq Scan + in-memory sort) | **48ms** (17 Index Scans) | **24x** |

The `overview` endpoint calls this query twice (primary + secondary), so this saves **~2.6s per dashboard page load**.

## Changes

- `app/modules/usage/repository.py`: PostgreSQL path now uses `Account` table → `CROSS JOIN LATERAL` → `LIMIT 1` per account
- SQLite path unchanged (uses existing `row_number()` window function)
- All existing tests pass (20 passed, 0 failed)