### PR TITLE
fix: prevent sticky session thrashing when all accounts exceed budget threshold

### DIFF
--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -561,6 +561,39 @@ class LoadBalancer:
                             await sticky_repo.upsert(sticky_key, pinned.account_id, kind=sticky_kind)
                         return pinned_result
                 else:
+                    # Before reallocating, check whether the pool has a
+                    # meaningfully better candidate.  When every account
+                    # is above the budget threshold, reallocating just
+                    # wastes DB writes and destroys prompt-cache locality
+                    # (thrashing).
+                    if budget_exhausted:
+                        pool_best = select_account(
+                            states,
+                            prefer_earlier_reset=prefer_earlier_reset_accounts,
+                            routing_strategy=routing_strategy,
+                        )
+                        pool_also_exhausted = pool_best.account is not None and (
+                            pool_best.account.account_id == pinned.account_id
+                            or (
+                                pool_best.account.used_percent is not None
+                                and pool_best.account.used_percent > budget_threshold_pct
+                            )
+                        )
+                        if pool_also_exhausted:
+                            pinned_result = select_account(
+                                [pinned],
+                                prefer_earlier_reset=prefer_earlier_reset_accounts,
+                                routing_strategy=routing_strategy,
+                                allow_backoff_fallback=False,
+                            )
+                            if pinned_result.account is not None:
+                                if sticky_max_age_seconds is not None:
+                                    await sticky_repo.upsert(
+                                        sticky_key,
+                                        pinned.account_id,
+                                        kind=sticky_kind,
+                                    )
+                                return pinned_result
                     reallocate_sticky = True
                 # Grace period: if the pinned account is rate-limited with a
                 # known reset time within a short window, retry selection

--- a/tests/unit/test_select_with_stickiness.py
+++ b/tests/unit/test_select_with_stickiness.py
@@ -210,7 +210,109 @@ async def test_sticky_deleted_when_pinned_account_removed_from_pool():
 
     assert result.account is not None
     assert result.account.account_id == "b"
-    repo.delete.assert_called_once()
+    repo.delete.assert_called_once_with("key1", kind=StickySessionKind.PROMPT_CACHE)
+    repo.upsert.assert_called_once_with("key1", "b", kind=StickySessionKind.PROMPT_CACHE)
+
+
+# ---------------------------------------------------------------------------
+# Pool exhaustion guard — prevent thrashing when all accounts are depleted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_accounts_exhausted_keeps_pinned_no_thrashing():
+    acc_a = _active("a", used_percent=96.0)
+    acc_b = _active("b", used_percent=97.0)
+    acc_c = _active("c", used_percent=98.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b, acc_c],
+        "key1",
+        repo,
+        reallocate_sticky=False,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    repo.delete.assert_not_called()
+    repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_pool_exhausted_but_better_candidate_exists_reallocates():
+    acc_a = _active("a", used_percent=96.0)
+    acc_b = _active("b", used_percent=50.0)
+    acc_c = _active("c", used_percent=97.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b, acc_c],
+        "key1",
+        repo,
+        reallocate_sticky=False,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "b"
+    repo.delete.assert_called_once_with("key1", kind=StickySessionKind.PROMPT_CACHE)
+    repo.upsert.assert_called_once_with("key1", "b", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_pool_exhausted_single_account_keeps_pinned():
+    acc_a = _active("a", used_percent=96.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a],
+        "key1",
+        repo,
+        reallocate_sticky=False,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    repo.delete.assert_not_called()
+    repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_pool_exhausted_with_custom_threshold():
+    acc_a = _active("a", used_percent=85.0)
+    acc_b = _active("b", used_percent=88.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b],
+        "key1",
+        repo,
+        reallocate_sticky=False,
+        budget_threshold_pct=80.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    repo.delete.assert_not_called()
+    repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_pool_exhausted_candidate_with_none_usage_triggers_reallocation():
+    acc_a = _active("a", used_percent=96.0)
+    acc_b = AccountState("b", AccountStatus.ACTIVE, used_percent=None)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b],
+        "key1",
+        repo,
+        reallocate_sticky=False,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "b"
+    repo.delete.assert_called_once_with("key1", kind=StickySessionKind.PROMPT_CACHE)
     repo.upsert.assert_called_once_with("key1", "b", kind=StickySessionKind.PROMPT_CACHE)
 
 


### PR DESCRIPTION
## Summary

- When every account in the pool exceeds the budget threshold (default 95%), the prompt-cache sticky reallocation would delete and re-create the DB mapping on **every single request** — a thrashing loop that wastes writes and destroys cache locality.
- Added a pre-check: before reallocating, `select_account` is called on the full pool. If the best candidate is also above the threshold (or is the same account), the pinned account is kept to preserve prompt-cache affinity.
- Reallocation still proceeds normally when a viable (below-threshold or unknown-usage) candidate exists.

## Changes

**`app/modules/proxy/load_balancer.py`** — pool exhaustion guard in `_select_with_stickiness`
**`tests/unit/test_select_with_stickiness.py`** — 5 new test cases covering:
- All accounts exhausted → keeps pinned (no thrashing)
- Better candidate exists → reallocates normally
- Single exhausted account → stays pinned
- Custom threshold respected
- `None` usage account treated as viable target