### PR TITLE
fix(ci): don't perform ci when just non-code update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,9 @@ on:
   push:
     branches: ["main"]
     paths-ignore:
-      - '**.md'
-      - '.all-contributorsrc'
+      - "**.md"
+      - ".all-contributorsrc"
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '.all-contributorsrc'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
As title said, this fixes when collab-bot / just md file change, the ci stills kicks in even there is no code changes