### PR TITLE
helm: make service type, port, and annotations configurable

### DIFF
--- a/deploy/helm/codex-lb/templates/service.yaml
+++ b/deploy/helm/codex-lb/templates/service.yaml
@@ -5,16 +5,26 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "codex-lb.labels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
+  {{- with mustMerge (.Values.service.annotations | default dict) (.Values.commonAnnotations | default dict) }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
   selector:
     {{- include "codex-lb.selectorLabels" . | nindent 4 }}
   ports:
     - name: http
-      port: 2455
+      port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -231,6 +231,21 @@ tolerations: []
 # @param priorityClassName Pod priority class name
 priorityClassName: ""
 
+# @section Service parameters
+service:
+  # @param service.type Kubernetes Service type (ClusterIP, NodePort, LoadBalancer)
+  type: ClusterIP
+  # @param service.port Service port
+  port: 2455
+  # @param service.nodePort NodePort number (only when type is NodePort)
+  nodePort: ""
+  # @param service.loadBalancerIP Static IP for LoadBalancer type
+  loadBalancerIP: ""
+  # @param service.loadBalancerSourceRanges Allowed source ranges for LoadBalancer
+  loadBalancerSourceRanges: []
+  # @param service.annotations Additional annotations for the Service
+  annotations: {}
+
 # @section Network parameters
 networkPolicy:
   # @param networkPolicy.enabled Enable NetworkPolicy with default-deny + whitelist


### PR DESCRIPTION
## Summary
- Templatize service type (was hardcoded to ClusterIP), port, annotations, loadBalancerIP, loadBalancerSourceRanges, and nodePort
- Maintain backward compatibility: defaults to ClusterIP:2455 (same as before)

## Motivation
Deploying on cloud providers (OCI, AWS, GCP) often requires LoadBalancer or NodePort services with provider-specific annotations. Currently users must create a separate Service manifest to expose codex-lb externally.

## Changes
- `templates/service.yaml`: Templatize type, port, annotations, loadBalancer/nodePort settings
- `values.yaml`: Add `service` section with all configurable parameters