### PR TITLE
docs: clarify ServiceMonitor and PrometheusRule defaults and alternatives

### DIFF
--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -295,6 +295,13 @@ metrics:
   port: 9090
   serviceMonitor:
     # @param metrics.serviceMonitor.enabled Create a ServiceMonitor for Prometheus Operator
+    # Defaults to false because it requires the Prometheus Operator CRDs to be installed.
+    # Enable this when running kube-prometheus-stack or standalone Prometheus Operator.
+    # Without ServiceMonitor, configure prometheus.io annotations for scraping:
+    #   commonAnnotations:
+    #     prometheus.io/scrape: "true"
+    #     prometheus.io/port: "9090"
+    #     prometheus.io/path: "/metrics"
     enabled: false
     # @param metrics.serviceMonitor.interval Metrics scrape interval
     interval: 30s
@@ -306,6 +313,8 @@ metrics:
     relabelings: []
   prometheusRule:
     # @param metrics.prometheusRule.enabled Create PrometheusRule for alerting
+    # Requires Prometheus Operator. Includes alerts for: high error rate, circuit breaker open,
+    # all accounts exhausted, high request latency. See templates/prometheusrule.yaml for details.
     enabled: false
     # @param metrics.prometheusRule.additionalLabels Additional labels for PrometheusRule
     additionalLabels: {}
@@ -354,6 +363,28 @@ externalDatabase:
   user: codexlb
   # @param externalDatabase.existingSecret Secret containing external DB credentials
   existingSecret: ""
+
+# @section Database initialization parameters
+dbInit:
+  # @param dbInit.enabled Enable pre-install Job to create databases/users on external PostgreSQL
+  enabled: false
+  # @param dbInit.host External PostgreSQL host
+  host: ""
+  # @param dbInit.port External PostgreSQL port
+  port: "5432"
+  # @param dbInit.adminUser Admin username for creating databases/users
+  adminUser: "adminuser"
+  # @param dbInit.adminPassword Admin password (use adminPasswordSecret for production)
+  adminPassword: ""
+  # @param dbInit.adminPasswordSecret Reference to existing Secret for admin password
+  adminPasswordSecret: {}
+  #   name: pg-admin-secret
+  #   key: password
+  # @param dbInit.databases List of databases and users to create
+  databases:
+    - name: codexlb
+      user: codexlb
+      password: changeme
 
 # @section Migration parameters
 migration:


### PR DESCRIPTION
## Summary
- Explain why ServiceMonitor defaults to false (requires Prometheus Operator CRDs)
- Document prometheus.io annotation alternative for basic Prometheus scraping
- Describe what PrometheusRule alerts are included

## Motivation
Users deploying with Prometheus (but not Prometheus Operator) don't know how to scrape codex-lb metrics. Users with Prometheus Operator don't know what alerts are available.