### PR TITLE
fix(dashboard): restore capacity-based usage donut totals

### DIFF
--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -165,8 +165,8 @@ export function DashboardPage() {
             <UsageDonuts
               primaryItems={view.primaryUsageItems}
               secondaryItems={view.secondaryUsageItems}
-              primaryTotal={view.primaryUsageTotal}
-              secondaryTotal={view.secondaryUsageTotal}
+              primaryTotal={overview?.summary.primaryWindow.capacityCredits ?? 0}
+              secondaryTotal={overview?.summary.secondaryWindow?.capacityCredits ?? 0}
               safeLinePrimary={view.safeLinePrimary}
               safeLineSecondary={view.safeLineSecondary}
             />

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -262,7 +262,7 @@ describe("buildRemainingItems", () => {
 });
 
 describe("buildDashboardView", () => {
-  it("derives the primary donut total from the constrained displayed slices", () => {
+  it("keeps donut totals anchored to window capacity even when displayed slices are constrained", () => {
     const overview = createDashboardOverview({
       accounts: [
         account({
@@ -325,9 +325,9 @@ describe("buildDashboardView", () => {
     expect(view.primaryUsageItems).toHaveLength(2);
     expect(view.primaryUsageItems[0]?.value).toBeCloseTo(75.6);
     expect(view.primaryUsageItems[1]?.value).toBeCloseTo(135);
-    expect(view.primaryUsageTotal).toBeCloseTo(210.6);
-    expect(view.primaryUsageTotal).toBeCloseTo(view.primaryUsageItems.reduce((total, item) => total + item.value, 0));
-    expect(view.secondaryUsageTotal).toBe(5370);
+    expect(overview.summary.primaryWindow.capacityCredits).toBe(450);
+    expect(overview.summary.secondaryWindow?.capacityCredits).toBe(15120);
+    expect(view.primaryUsageItems.reduce((total, item) => total + item.value, 0)).toBeCloseTo(210.6);
   });
 
   it("keeps primary totals intact for accounts without secondary usage data", () => {
@@ -407,6 +407,6 @@ describe("buildDashboardView", () => {
     expect(view.primaryUsageItems).toHaveLength(1);
     expect(view.primaryUsageItems[0]?.value).toBeCloseTo(202.5);
     expect(view.primaryUsageItems[0]?.remainingPercent).toBe(90);
-    expect(view.primaryUsageTotal).toBeCloseTo(202.5);
+    expect(overview.summary.primaryWindow.capacityCredits).toBe(225);
   });
 });

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -48,8 +48,6 @@ export type DashboardView = {
   stats: DashboardStat[];
   primaryUsageItems: RemainingItem[];
   secondaryUsageItems: RemainingItem[];
-  primaryUsageTotal: number;
-  secondaryUsageTotal: number;
   requestLogs: RequestLog[];
   safeLinePrimary: SafeLineView | null;
   safeLineSecondary: SafeLineView | null;
@@ -166,10 +164,6 @@ function trendPointsToValues(points: TrendPoint[]): { value: number }[] {
   return points.map((p) => ({ value: p.v }));
 }
 
-function sumRemainingItems(items: RemainingItem[]): number {
-  return items.reduce((total, item) => total + item.value, 0);
-}
-
 export function buildDashboardView(
   overview: DashboardOverview,
   requestLogs: RequestLog[],
@@ -242,8 +236,6 @@ export function buildDashboardView(
     stats,
     primaryUsageItems,
     secondaryUsageItems,
-    primaryUsageTotal: sumRemainingItems(primaryUsageItems),
-    secondaryUsageTotal: overview.summary.secondaryWindow?.remainingCredits ?? 0,
     requestLogs,
     safeLinePrimary: buildDepletionView(overview.depletionPrimary),
     safeLineSecondary: buildDepletionView(overview.depletionSecondary),


### PR DESCRIPTION
## Summary
- restore dashboard donut totals to use window capacity so the consumed gap is visible again
- remove the view-model totals that turned remaining-slice sums into the donut total
- update dashboard tests to lock the reverted capacity-based behavior

## Verification
- bun run test -- src/features/dashboard/utils.test.ts src/__integration__/dashboard-flow.test.tsx
- bun run lint -- src/features/dashboard/components/dashboard-page.tsx src/features/dashboard/utils.ts src/features/dashboard/utils.test.ts
- bun run typecheck
- bun run build