### PR TITLE
[codex] add request id utility coverage

### DIFF
--- a/app/core/utils/request_id.py
+++ b/app/core/utils/request_id.py
@@ -19,6 +19,7 @@ def reset_request_id(token: Token[str | None]) -> None:
 
 
 def ensure_request_id(value: str | None = None) -> str:
+    """Return the active request ID, storing an explicit or generated value when needed."""
     if value:
         _REQUEST_ID.set(value)
         return value

--- a/tests/unit/test_request_id.py
+++ b/tests/unit/test_request_id.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.utils.request_id import ensure_request_id, get_request_id, reset_request_id, set_request_id
+
+pytestmark = pytest.mark.unit
+
+
+def test_ensure_request_id_uses_explicit_value() -> None:
+    token = set_request_id(None)
+    try:
+        assert ensure_request_id("req-explicit") == "req-explicit"
+        assert get_request_id() == "req-explicit"
+    finally:
+        reset_request_id(token)
+
+
+def test_ensure_request_id_generates_and_reuses_request_id() -> None:
+    token = set_request_id(None)
+    try:
+        request_id = ensure_request_id()
+        assert request_id == ensure_request_id()
+        assert get_request_id() == request_id
+        assert request_id
+    finally:
+        reset_request_id(token)


### PR DESCRIPTION
## Summary

This PR adds focused coverage for `ensure_request_id` and documents its behavior with a short docstring. The utility is shared infrastructure for request-scoped logging, so having a small direct unit test makes future refactors safer without changing runtime behavior.

## What changed

- added a concise docstring to `app/core/utils/request_id.py::ensure_request_id`
- added `tests/unit/test_request_id.py`
- covered the two behavior paths that matter here:
  - an explicit request ID is stored and returned as-is
  - a generated request ID is reused for the current context once created

## Why this is low risk

This change does not alter request ID generation logic, branching, or state handling. It only documents the existing contract and adds isolated unit coverage around the current implementation.

## Validation

- ran `.codex-pr-venv/bin/pytest tests/unit/test_request_id.py`
- result: `2 passed`
