### PR TITLE
chore: resolve static analysis warnings and clean up unused imports in app/modules/settings/service.py

### DIFF
--- a/app/modules/settings/service.py
+++ b/app/modules/settings/service.py
@@ -48,7 +48,9 @@ class SettingsService:
             prefer_earlier_reset_accounts=row.prefer_earlier_reset_accounts,
             routing_strategy=row.routing_strategy,
             openai_cache_affinity_max_age_seconds=row.openai_cache_affinity_max_age_seconds,
-            http_responses_session_bridge_prompt_cache_idle_ttl_seconds=row.http_responses_session_bridge_prompt_cache_idle_ttl_seconds,
+            http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
+                row.http_responses_session_bridge_prompt_cache_idle_ttl_seconds
+            ),
             http_responses_session_bridge_gateway_safe_mode=row.http_responses_session_bridge_gateway_safe_mode,
             sticky_reallocation_budget_threshold_pct=row.sticky_reallocation_budget_threshold_pct,
             import_without_overwrite=row.import_without_overwrite,
@@ -67,7 +69,9 @@ class SettingsService:
             prefer_earlier_reset_accounts=payload.prefer_earlier_reset_accounts,
             routing_strategy=payload.routing_strategy,
             openai_cache_affinity_max_age_seconds=payload.openai_cache_affinity_max_age_seconds,
-            http_responses_session_bridge_prompt_cache_idle_ttl_seconds=payload.http_responses_session_bridge_prompt_cache_idle_ttl_seconds,
+            http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
+                payload.http_responses_session_bridge_prompt_cache_idle_ttl_seconds
+            ),
             http_responses_session_bridge_gateway_safe_mode=payload.http_responses_session_bridge_gateway_safe_mode,
             sticky_reallocation_budget_threshold_pct=payload.sticky_reallocation_budget_threshold_pct,
             import_without_overwrite=payload.import_without_overwrite,
@@ -80,7 +84,9 @@ class SettingsService:
             prefer_earlier_reset_accounts=row.prefer_earlier_reset_accounts,
             routing_strategy=row.routing_strategy,
             openai_cache_affinity_max_age_seconds=row.openai_cache_affinity_max_age_seconds,
-            http_responses_session_bridge_prompt_cache_idle_ttl_seconds=row.http_responses_session_bridge_prompt_cache_idle_ttl_seconds,
+            http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
+                row.http_responses_session_bridge_prompt_cache_idle_ttl_seconds
+            ),
             http_responses_session_bridge_gateway_safe_mode=row.http_responses_session_bridge_gateway_safe_mode,
             sticky_reallocation_budget_threshold_pct=row.sticky_reallocation_budget_threshold_pct,
             import_without_overwrite=row.import_without_overwrite,


### PR DESCRIPTION
## Summary
This is a minor cleanup to resolve static linter warnings, improving overall code hygiene.

## Changes
- wrapped three overlong assignment lines in app/modules/settings/service.py
- preserved existing behavior (formatting-only change)

## Notes
- zero logic change; this PR is strictly cosmetic/lint-related