### PR TITLE
Fail closed on account_deactivated errors

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -14,6 +14,7 @@ PERMANENT_FAILURE_CODES = {
     "refresh_token_expired": "Refresh token expired - re-login required",
     "refresh_token_reused": "Refresh token was reused - re-login required",
     "refresh_token_invalidated": "Refresh token was revoked - re-login required",
+    "account_deactivated": "Account has been deactivated",
     "account_suspended": "Account has been suspended",
     "account_deleted": "Account has been deleted",
 }

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -140,6 +140,7 @@ _HOP_BY_HOP_HEADER_NAMES = frozenset(
 _AUTO_WEBSOCKET_HANDSHAKE_FALLBACK_STATUSES = frozenset({426})
 _WEBSOCKET_RESPONSE_CREATE_EXCLUDED_FIELDS = frozenset({"background", "stream"})
 _WEBSOCKET_HANDSHAKE_ERROR_HINTS = (
+    ("account_deactivated", "account has been deactivated"),
     ("usage_not_included", "usage not included"),
     ("insufficient_quota", "insufficient quota"),
     ("quota_exceeded", "quota exceeded"),

--- a/app/core/clients/usage.py
+++ b/app/core/clients/usage.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 class UsageErrorDetail(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
+    code: str | None = None
     message: str | None = None
     error_description: str | None = None
 
@@ -36,10 +37,11 @@ class UsageErrorEnvelope(BaseModel):
 
 
 class UsageFetchError(Exception):
-    def __init__(self, status_code: int, message: str) -> None:
+    def __init__(self, status_code: int, message: str, code: str | None = None) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.message = message
+        self.code = code
 
 
 async def fetch_usage(
@@ -70,14 +72,16 @@ async def fetch_usage(
         ) as resp:
             data = await _safe_json(resp)
             if resp.status >= 400:
+                code = _extract_error_code(data)
                 message = _extract_error_message(data) or f"Usage fetch failed ({resp.status})"
                 logger.warning(
-                    "Usage fetch failed request_id=%s status=%s message=%s",
+                    "Usage fetch failed request_id=%s status=%s code=%s message=%s",
                     get_request_id(),
                     resp.status,
+                    code,
                     message,
                 )
-                raise UsageFetchError(resp.status, message)
+                raise UsageFetchError(resp.status, message, code=code)
             try:
                 return UsagePayload.model_validate(data)
             except ValidationError as exc:
@@ -129,6 +133,15 @@ def _extract_error_message(payload: JsonObject) -> str | None:
     if isinstance(error, str):
         return envelope.error_description or error
     return envelope.message
+
+
+def _extract_error_code(payload: JsonObject) -> str | None:
+    envelope = UsageErrorEnvelope.model_validate(payload)
+    error = envelope.error
+    if isinstance(error, UsageErrorDetail) and isinstance(error.code, str):
+        normalized = error.code.strip().lower()
+        return normalized or None
+    return None
 
 
 def _retry_options(attempts: int) -> ExponentialRetry:

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Mapping, Protocol
 
 from app.core.auth.refresh import RefreshError
+from app.core.balancer import PERMANENT_FAILURE_CODES
 from app.core.clients.usage import UsageFetchError, fetch_usage
 from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
@@ -267,7 +268,7 @@ class UsageUpdater:
                 account_id=usage_account_id,
             )
         except UsageFetchError as exc:
-            if _should_deactivate_for_usage_error(exc.status_code):
+            if _should_deactivate_for_usage_error(exc):
                 await self._deactivate_for_client_error(account, exc)
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
             if exc.status_code != 401 or not self._auth_manager:
@@ -283,7 +284,7 @@ class UsageUpdater:
                     account_id=usage_account_id,
                 )
             except UsageFetchError as retry_exc:
-                if _should_deactivate_for_usage_error(retry_exc.status_code):
+                if _should_deactivate_for_usage_error(retry_exc):
                     await self._deactivate_for_client_error(account, retry_exc)
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
 
@@ -674,7 +675,16 @@ def _reset_at(reset_at: int | None, reset_after_seconds: int | None, now_epoch: 
 # for proxy traffic, so treat it as a refresh failure instead of a permanent
 # account-level deactivation signal.
 _DEACTIVATING_USAGE_STATUS_CODES = {402, 404}
+_DEACTIVATING_USAGE_MESSAGE_HINTS = (
+    "your openai account has been deactivated",
+    "account has been deactivated",
+)
 
 
-def _should_deactivate_for_usage_error(status_code: int) -> bool:
-    return status_code in _DEACTIVATING_USAGE_STATUS_CODES
+def _should_deactivate_for_usage_error(exc: UsageFetchError) -> bool:
+    if exc.status_code in _DEACTIVATING_USAGE_STATUS_CODES:
+        return True
+    if exc.code in PERMANENT_FAILURE_CODES:
+        return True
+    lowered = exc.message.lower()
+    return any(hint in lowered for hint in _DEACTIVATING_USAGE_MESSAGE_HINTS)

--- a/openspec/changes/fail-closed-deactivated-accounts/proposal.md
+++ b/openspec/changes/fail-closed-deactivated-accounts/proposal.md
@@ -1,0 +1,15 @@
+## Why
+Upstream deactivated-account failures can currently leak through as routable accounts. In practice this means an account may continue to receive selection attempts after OpenAI has already deactivated it, which can stall traffic until an operator manually pauses or removes that account.
+
+The failure mode is especially visible on the usage refresh path, where `HTTP 401` responses with a deactivation message were not consistently promoted into a terminal account status.
+
+## What Changes
+- Treat `account_deactivated` as a permanent failure code across account selection and recovery logic.
+- Preserve upstream usage error codes so the usage refresh path can distinguish permanent deactivation from generic unauthorized responses.
+- Fail closed on usage refresh errors that explicitly identify a deactivated account, including message-only fallbacks.
+- Preserve the deactivated status in the dashboard/runtime model so the account leaves the routing pool automatically.
+
+## Impact
+- Deactivated upstream accounts stop receiving new traffic without requiring manual operator intervention.
+- Generic `401 Unauthorized` responses that do not indicate account deactivation continue to follow the existing non-terminal flow.
+- Dashboard and account APIs surface a first-class `deactivated` status with a deactivation reason for affected accounts.

--- a/openspec/changes/fail-closed-deactivated-accounts/specs/query-caching/spec.md
+++ b/openspec/changes/fail-closed-deactivated-accounts/specs/query-caching/spec.md
@@ -1,0 +1,26 @@
+### ADDED Requirement: Deactivated upstream accounts fail closed
+When the system receives a permanent upstream deactivation signal for an account, it MUST mark that account as `deactivated`, persist a deactivation reason, and remove the account from future routing eligibility until an operator explicitly reactivates it.
+
+#### Scenario: Request-path account_deactivated error removes the account from the pool
+- **WHEN** the proxy request path receives an upstream error with `error.code = "account_deactivated"`
+- **THEN** the account is marked `deactivated`
+- **AND** the deactivation reason is persisted
+- **AND** future account selection excludes that account from the routing pool
+
+#### Scenario: Usage-path deactivation code removes the account from the pool
+- **WHEN** the usage refresh path receives `HTTP 401` with `error.code = "account_deactivated"`
+- **THEN** the account is marked `deactivated`
+- **AND** the deactivation reason is persisted
+- **AND** future account selection excludes that account from the routing pool
+
+#### Scenario: Usage-path deactivation message removes the account from the pool
+- **WHEN** the usage refresh path receives `HTTP 401` whose error message states that the OpenAI account has been deactivated
+- **AND** no structured error code is available
+- **THEN** the account is marked `deactivated`
+- **AND** the deactivation reason is persisted
+- **AND** future account selection excludes that account from the routing pool
+
+#### Scenario: Generic unauthorized usage errors stay non-terminal
+- **WHEN** the usage refresh path receives `HTTP 401` without a permanent deactivation code or deactivation message
+- **THEN** the system does not mark the account `deactivated`
+- **AND** the existing retry or refresh-token recovery behavior remains in effect

--- a/openspec/changes/fail-closed-deactivated-accounts/tasks.md
+++ b/openspec/changes/fail-closed-deactivated-accounts/tasks.md
@@ -1,0 +1,5 @@
+- [x] Treat `account_deactivated` as a permanent failure classification in the balancer/runtime logic.
+- [x] Preserve usage API `error.code` values in the usage client.
+- [x] Deactivate accounts on usage-path deactivation signals instead of treating them as generic 401s.
+- [x] Add regression coverage for request-path, websocket-handshake, and usage-path deactivation handling.
+- [x] Update the OpenSpec requirements to document fail-closed behavior for deactivated upstream accounts.

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -22,6 +22,7 @@ def test_should_refresh_within_interval():
 
 def test_classify_refresh_error_permanent():
     assert classify_refresh_error("refresh_token_expired") is True
+    assert classify_refresh_error("account_deactivated") is True
 
 
 def test_classify_refresh_error_temporary():

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -274,6 +274,13 @@ def test_handle_permanent_failure_sets_reason():
     assert state.deactivation_reason is not None
 
 
+def test_handle_permanent_failure_sets_reason_for_account_deactivated():
+    state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
+    handle_permanent_failure(state, "account_deactivated")
+    assert state.status == AccountStatus.DEACTIVATED
+    assert state.deactivation_reason == "Account has been deactivated"
+
+
 def test_apply_usage_quota_respects_runtime_reset_for_quota_exceeded(monkeypatch):
     now = 1_700_000_000.0
     future = now + 3600.0

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -314,6 +314,24 @@ def test_has_native_codex_transport_headers_still_accepts_explicit_native_stream
     assert proxy_module._has_native_codex_transport_headers({"x-codex-beta-features": "repl"}) is True
 
 
+def test_infer_websocket_handshake_error_code_detects_account_deactivated_message():
+    code = proxy_module._infer_websocket_handshake_error_code(
+        401,
+        "Your OpenAI account has been deactivated, please check your email for more information.",
+    )
+
+    assert code == "account_deactivated"
+
+
+def test_infer_websocket_handshake_error_code_keeps_generic_401_when_no_deactivation_hint():
+    code = proxy_module._infer_websocket_handshake_error_code(
+        401,
+        "Unauthorized",
+    )
+
+    assert code == "invalid_api_key"
+
+
 def test_parse_sse_event_reads_json_payload():
     payload = {"type": "response.completed", "response": {"id": "resp_1"}}
     line = f"data: {json.dumps(payload)}\n"

--- a/tests/unit/test_usage_client.py
+++ b/tests/unit/test_usage_client.py
@@ -146,3 +146,36 @@ async def test_fetch_usage_raises_after_retries(failing_usage_server):
     exc = excinfo.value
     assert isinstance(exc, UsageFetchError)
     assert exc.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_fetch_usage_preserves_error_code():
+    state = UsageClientState()
+    responses = [
+        StubResponse(
+            401,
+            {
+                "error": {
+                    "code": "account_deactivated",
+                    "message": "Your OpenAI account has been deactivated.",
+                }
+            },
+            "",
+        )
+    ]
+    client = StubRetryClient(responses, state)
+
+    with pytest.raises(UsageFetchError) as excinfo:
+        await fetch_usage(
+            access_token="access-token",
+            account_id=None,
+            base_url="http://usage.test/backend-api",
+            max_retries=0,
+            timeout_seconds=1.0,
+            client=client,
+        )
+
+    exc = excinfo.value
+    assert exc.status_code == 401
+    assert exc.code == "account_deactivated"
+    assert "deactivated" in exc.message.lower()

--- a/tests/unit/test_usage_client.py
+++ b/tests/unit/test_usage_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, cast
 
 import pytest
 
@@ -123,7 +124,7 @@ async def test_fetch_usage_retries_and_returns_payload(usage_server):
         base_url=base_url,
         max_retries=1,
         timeout_seconds=2.0,
-        client=client,
+        client=cast(Any, client),
     )
     assert data.plan_type == "plus"
     assert state.calls == 2
@@ -141,7 +142,7 @@ async def test_fetch_usage_raises_after_retries(failing_usage_server):
             base_url=base_url,
             max_retries=0,
             timeout_seconds=1.0,
-            client=client,
+            client=cast(Any, client),
         )
     exc = excinfo.value
     assert isinstance(exc, UsageFetchError)
@@ -172,7 +173,7 @@ async def test_fetch_usage_preserves_error_code():
             base_url="http://usage.test/backend-api",
             max_retries=0,
             timeout_seconds=1.0,
-            client=client,
+            client=cast(Any, client),
         )
 
     exc = excinfo.value

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -452,6 +452,68 @@ async def test_usage_updater_does_not_deactivate_on_401(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_usage_updater_deactivates_on_401_account_deactivated_code(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.clients.usage import UsageFetchError
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage_401_deactivated(**_: Any) -> UsagePayload:
+        raise UsageFetchError(
+            401,
+            "Your OpenAI account has been deactivated, please check your email for more information.",
+            code="account_deactivated",
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_401_deactivated)
+
+    usage_repo = StubUsageRepository()
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+
+    acc = _make_account("acc_401_deactivated", "workspace_401_deactivated", email="dead@example.com")
+    accounts_repo.accounts_by_id[acc.id] = acc
+
+    await updater.refresh_accounts([acc], latest_usage={})
+
+    assert len(accounts_repo.status_updates) == 1
+    update = accounts_repo.status_updates[0]
+    assert update["status"] == AccountStatus.DEACTIVATED
+    assert "401" in update["deactivation_reason"]
+    assert "deactivated" in update["deactivation_reason"].lower()
+
+
+@pytest.mark.asyncio
+async def test_usage_updater_deactivates_on_401_deactivated_message_without_code(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.clients.usage import UsageFetchError
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage_401_deactivated_message(**_: Any) -> UsagePayload:
+        raise UsageFetchError(
+            401,
+            "Your OpenAI account has been deactivated, please check your email for more information.",
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_401_deactivated_message)
+
+    usage_repo = StubUsageRepository()
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+
+    acc = _make_account("acc_401_message", "workspace_401_message", email="message@example.com")
+    accounts_repo.accounts_by_id[acc.id] = acc
+
+    await updater.refresh_accounts([acc], latest_usage={})
+
+    assert len(accounts_repo.status_updates) == 1
+    assert accounts_repo.status_updates[0]["status"] == AccountStatus.DEACTIVATED
+
+
+@pytest.mark.asyncio
 async def test_usage_updater_does_not_deactivate_on_5xx(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.clients.usage import UsageFetchError


### PR DESCRIPTION
## Summary
- treat `account_deactivated` as a permanent failure so affected accounts become `deactivated` and leave the routing pool automatically
- preserve usage API `error.code` values and fail closed on usage-path deactivation signals, including message-only 401 fallbacks
- add regression coverage for balancer handling, usage refresh handling, and websocket handshake deactivation classification
- document the behavior change in OpenSpec

Closes #353.

## Testing
- frontend: `docker run --rm -v /home/renat/apps/codex-lb:/workspace -w /workspace/frontend oven/bun:1.3.10 sh -lc 'bun install --frozen-lockfile && bun run lint && bun run typecheck && bun run build'`
- backend: `docker run --rm -v /home/renat/apps/codex-lb:/workspace -w /workspace python:3.13-slim bash -lc 'pip install -q uv && uv sync --dev --frozen && uv run ruff check . && uv run ruff format --check . && uv run ty check'`
- targeted tests: `docker run --rm -v /home/renat/apps/codex-lb:/workspace -w /workspace python:3.13-slim bash -lc 'pip install -q uv && uv sync --dev --frozen && uv run pytest -q tests/unit/test_auth_refresh.py tests/unit/test_load_balancer.py tests/unit/test_usage_client.py tests/unit/test_usage_updater.py tests/unit/test_proxy_utils.py tests/unit/test_select_with_stickiness.py'`
