### PR TITLE
feat(auth): add a flag CODEX_LB_DISABLE_BOOTSTRAP_TOKEN to disable remote auth requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,4 +74,7 @@ CODEX_LB_SHUTDOWN_DRAIN_TIMEOUT_SECONDS=30
 CODEX_LB_HTTP_CONNECTOR_LIMIT=100
 CODEX_LB_HTTP_CONNECTOR_LIMIT_PER_HOST=50
 
+# Remote bootstrap token gate (optional)
+# CODEX_LB_DISABLE_BOOTSTRAP_TOKEN=false
+
 # Dashboard authentication is configured in the settings UI

--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -9,6 +9,7 @@ from starlette.requests import HTTPConnection
 
 from app.core.auth.api_key_cache import get_api_key_cache
 from app.core.clients.usage import UsageFetchError, fetch_usage
+from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.exceptions import DashboardAuthError, ProxyAuthError, ProxyUpstreamError
 from app.core.request_locality import is_local_request
@@ -111,10 +112,13 @@ async def validate_usage_api_key(
 
 
 async def validate_dashboard_session(request: Request) -> None:
-    settings = await get_settings_cache().get()
-    password_required = bool(settings.password_hash)
-    requires_auth = password_required or settings.totp_required_on_login
+    dashboard_settings = await get_settings_cache().get()
+    app_settings = get_settings()
+    password_required = bool(dashboard_settings.password_hash)
+    requires_auth = password_required or dashboard_settings.totp_required_on_login
     if not requires_auth:
+        if app_settings.disable_bootstrap_token:
+            return
         if not is_local_request(request):
             raise DashboardAuthError(
                 "Remote bootstrap is required before dashboard access is allowed",
@@ -122,7 +126,7 @@ async def validate_dashboard_session(request: Request) -> None:
             )
         return
 
-    if not password_required and settings.totp_required_on_login:
+    if not password_required and dashboard_settings.totp_required_on_login:
         logger.warning(
             "dashboard_auth_migration_inconsistency password_hash is NULL"
             " while totp_required_on_login=true metric=dashboard_auth_migration_inconsistency"
@@ -134,7 +138,7 @@ async def validate_dashboard_session(request: Request) -> None:
         raise DashboardAuthError("Authentication is required")
     if password_required and not state.password_verified:
         raise DashboardAuthError("Authentication is required")
-    if settings.totp_required_on_login and not state.totp_verified:
+    if dashboard_settings.totp_required_on_login and not state.totp_verified:
         raise DashboardAuthError("TOTP verification is required for dashboard access", code="totp_required")
 
 

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -163,6 +163,7 @@ class Settings(BaseSettings):
 
     bulkhead_proxy_limit: int = 200
     bulkhead_dashboard_limit: int = 50
+    disable_bootstrap_token: bool = False
     dashboard_bootstrap_token: str | None = None
 
     memory_warning_threshold_mb: int = 0

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -80,9 +80,10 @@ async def get_dashboard_auth_session(
 ) -> DashboardAuthSessionResponse:
     session_id = request.cookies.get(DASHBOARD_SESSION_COOKIE)
     response = await context.service.get_session_state(session_id)
-    if response.password_required or is_local_request(request):
+    settings = get_settings()
+    if response.password_required or is_local_request(request) or settings.disable_bootstrap_token:
         return response
-    bootstrap_token_configured = bool((get_settings().dashboard_bootstrap_token or "").strip())
+    bootstrap_token_configured = bool((settings.dashboard_bootstrap_token or "").strip())
     return response.model_copy(
         update={
             "authenticated": False,
@@ -100,15 +101,17 @@ async def setup_password(
 ) -> DashboardAuthSessionResponse | JSONResponse:
     current_settings = await context.repository.get_settings()
     if current_settings.password_hash is None and not is_local_request(request):
-        configured_bootstrap_token = (get_settings().dashboard_bootstrap_token or "").strip()
-        if not configured_bootstrap_token:
-            raise DashboardAuthError(
-                "Remote bootstrap is disabled until CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN is configured.",
-                code="bootstrap_unavailable",
-            )
-        submitted_bootstrap_token = (payload.bootstrap_token or "").strip()
-        if submitted_bootstrap_token != configured_bootstrap_token:
-            raise DashboardAuthError("Invalid dashboard bootstrap token.", code="invalid_bootstrap_token")
+        app_settings = get_settings()
+        if not app_settings.disable_bootstrap_token:
+            configured_bootstrap_token = (app_settings.dashboard_bootstrap_token or "").strip()
+            if not configured_bootstrap_token:
+                raise DashboardAuthError(
+                    "Remote bootstrap is disabled until CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN is configured.",
+                    code="bootstrap_unavailable",
+                )
+            submitted_bootstrap_token = (payload.bootstrap_token or "").strip()
+            if submitted_bootstrap_token != configured_bootstrap_token:
+                raise DashboardAuthError("Invalid dashboard bootstrap token.", code="invalid_bootstrap_token")
     password = payload.password.strip()
     if len(password) < 8:
         raise DashboardValidationError("Password must be at least 8 characters")

--- a/deploy/helm/codex-lb/templates/configmap.yaml
+++ b/deploy/helm/codex-lb/templates/configmap.yaml
@@ -34,6 +34,7 @@ data:
   CODEX_LB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS: {{ .Values.config.circuitBreakerRecoveryTimeoutSeconds | toString | quote }}
   # Backpressure
   CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS: {{ .Values.config.backpressureMaxConcurrentRequests | toString | quote }}
+  CODEX_LB_DISABLE_BOOTSTRAP_TOKEN: {{ .Values.config.disableBootstrapToken | toString | quote }}
   # Shutdown
   CODEX_LB_SHUTDOWN_DRAIN_TIMEOUT_SECONDS: {{ .Values.config.shutdownDrainTimeoutSeconds | toString | quote }}
   # HTTP connector

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -136,6 +136,8 @@ config:
   circuitBreakerRecoveryTimeoutSeconds: 60
   # @param config.backpressureMaxConcurrentRequests Max concurrent in-flight requests
   backpressureMaxConcurrentRequests: 200
+  # @param config.disableBootstrapToken Disable remote bootstrap-token enforcement
+  disableBootstrapToken: false
   # @param config.shutdownDrainTimeoutSeconds Graceful shutdown drain timeout
   shutdownDrainTimeoutSeconds: 30
   # @param config.httpConnectorLimit Global HTTP connection pool limit

--- a/openspec/changes/disable-dashboard-bootstrap-token/.openspec.yaml
+++ b/openspec/changes/disable-dashboard-bootstrap-token/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/disable-dashboard-bootstrap-token/proposal.md
+++ b/openspec/changes/disable-dashboard-bootstrap-token/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Remote first-run dashboard access currently requires `CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN` before an admin can set the initial password. Some deployments need to disable that remote bootstrap gate entirely and allow the dashboard to behave like local access during first-run setup.
+
+## What Changes
+
+- Add `CODEX_LB_DISABLE_BOOTSTRAP_TOKEN` as a boolean environment flag.
+- When disabled, remote dashboard session checks and password setup bypass the bootstrap-token requirement.
+- Keep the existing bootstrap-token flow unchanged when the flag is not enabled.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `admin-auth`
+
+## Impact
+
+- Code: `app/core/config/settings.py`, `app/core/auth/dependencies.py`, `app/modules/dashboard_auth/api.py`
+- Deployment: `.env.example`, `deploy/helm/codex-lb/templates/configmap.yaml`, `deploy/helm/codex-lb/values.yaml`
+- Tests: dashboard auth middleware coverage, settings env parsing

--- a/openspec/changes/disable-dashboard-bootstrap-token/specs/admin-auth/spec.md
+++ b/openspec/changes/disable-dashboard-bootstrap-token/specs/admin-auth/spec.md
@@ -1,0 +1,15 @@
+### Requirement: Remote bootstrap gate can be disabled
+
+The system SHALL treat `CODEX_LB_DISABLE_BOOTSTRAP_TOKEN=true` as disabling the remote bootstrap-token gate for dashboard access and initial password setup. When this flag is enabled and no password is configured, remote requests SHALL follow the same dashboard bootstrap behavior as local requests without requiring `CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN`.
+
+#### Scenario: Remote first-run session bypasses bootstrap gate when disabled
+
+- **WHEN** `password_hash` is NULL, `totp_required_on_login` is false, `CODEX_LB_DISABLE_BOOTSTRAP_TOKEN` is true, and the session request comes from a non-local client
+- **THEN** `GET /api/dashboard-auth/session` does not report `bootstrapRequired: true`
+- **AND** the response remains usable for dashboard bootstrap without a bootstrap token
+
+#### Scenario: Remote password setup works without bootstrap token when disabled
+
+- **WHEN** `password_hash` is NULL, `CODEX_LB_DISABLE_BOOTSTRAP_TOKEN` is true, and a non-local client calls `POST /api/dashboard-auth/password/setup` with a valid password and no bootstrap token
+- **THEN** the system accepts the request and configures the password
+- **AND** the configured `CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN` value is ignored

--- a/openspec/changes/disable-dashboard-bootstrap-token/tasks.md
+++ b/openspec/changes/disable-dashboard-bootstrap-token/tasks.md
@@ -1,0 +1,13 @@
+## 1. Specs
+
+- [x] 1.1 Add admin-auth requirements for disabling the remote bootstrap-token gate with `CODEX_LB_DISABLE_BOOTSTRAP_TOKEN`.
+
+## 2. Implementation
+
+- [x] 2.1 Add the new settings flag and wire it into the dashboard auth session and password setup paths.
+- [x] 2.2 Wire the new env var through the example env file and Helm configmap.
+
+## 3. Tests
+
+- [x] 3.1 Add integration coverage for remote first-run access with the bootstrap gate disabled.
+- [x] 3.2 Add settings coverage for the new boolean env flag.

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -159,6 +159,34 @@ async def test_remote_first_run_requires_bootstrap_token(app_instance, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_remote_first_run_can_skip_bootstrap_token_when_disabled(app_instance, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_DISABLE_BOOTSTRAP_TOKEN", "true")
+    monkeypatch.setenv("CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN", "bootstrap-secret")
+    from app.core.config.settings import get_settings
+    from app.core.config.settings_cache import get_settings_cache
+
+    get_settings.cache_clear()
+    await get_settings_cache().invalidate()
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("203.0.113.12", 50002))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
+            session = await remote_client.get("/api/dashboard-auth/session")
+            assert session.status_code == 200
+            assert session.json()["authenticated"] is True
+            assert session.json()["bootstrapRequired"] is False
+
+            protected_settings = await remote_client.get("/api/settings")
+            assert protected_settings.status_code == 200
+
+            allowed = await remote_client.post(
+                "/api/dashboard-auth/password/setup",
+                json={"password": "password123"},
+            )
+            assert allowed.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_totp_only_mode_requires_session_even_when_password_hash_is_null(async_client, caplog):
     await _set_migration_inconsistent_totp_only_mode()
 

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -19,6 +19,7 @@ def test_settings_multi_replica_defaults():
     assert settings.circuit_breaker_failure_threshold == 5
     assert settings.circuit_breaker_recovery_timeout_seconds == 60
     assert settings.backpressure_max_concurrent_requests == 0
+    assert settings.disable_bootstrap_token is False
     assert settings.otel_enabled is False
     assert settings.otel_exporter_endpoint == ""
     assert settings.shutdown_drain_timeout_seconds == 30
@@ -85,6 +86,12 @@ def test_settings_backpressure_max_concurrent_requests_from_env(monkeypatch):
     monkeypatch.setenv("CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS", "50")
     settings = Settings()
     assert settings.backpressure_max_concurrent_requests == 50
+
+
+def test_settings_disable_bootstrap_token_from_env(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_DISABLE_BOOTSTRAP_TOKEN", "true")
+    settings = Settings()
+    assert settings.disable_bootstrap_token is True
 
 
 def test_settings_otel_enabled_from_env(monkeypatch):


### PR DESCRIPTION
Just observed that the remote needs authentication, which in some case is not necessary for remote deployment 
In my case, I have put the `codex-lb` behind a `pangolin` reverse proxy, which already handles authentication for me

So I have added `CODEX_LB_DISABLE_BOOTSTRAP_TOKEN` (default to `false`, to preserve the current behavior, needs to set password on first auth)

When `CODEX_LB_DISABLE_BOOTSTRAP_TOKEN` is set to true, there will be no authentication required, just like before. 