### PR TITLE
fix(proxy): harden admission control and usage refresh

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -190,9 +190,18 @@ class Settings(BaseSettings):
     # Backpressure
     backpressure_max_concurrent_requests: int = 0  # 0 = unlimited
 
-    bulkhead_proxy_limit: int = 200
-    bulkhead_dashboard_limit: int = 50
+    bulkhead_proxy_limit: int = Field(default=200, ge=0)
+    bulkhead_proxy_http_limit: int | None = Field(default=None, ge=0)
+    bulkhead_proxy_websocket_limit: int | None = Field(default=None, ge=0)
+    bulkhead_proxy_compact_limit: int | None = Field(default=None, ge=0)
+    bulkhead_dashboard_limit: int = Field(default=50, ge=0)
     dashboard_bootstrap_token: str | None = None
+    proxy_token_refresh_limit: int = Field(default=32, ge=0)
+    proxy_upstream_websocket_connect_limit: int = Field(default=64, ge=0)
+    proxy_response_create_limit: int = Field(default=64, ge=0)
+    proxy_compact_response_create_limit: int = Field(default=16, ge=0)
+    proxy_refresh_failure_cooldown_seconds: float = Field(default=5.0, ge=0.0)
+    usage_refresh_auth_failure_cooldown_seconds: float = Field(default=300.0, ge=0.0)
 
     memory_warning_threshold_mb: int = 0
     memory_reject_threshold_mb: int = 0
@@ -352,6 +361,17 @@ class Settings(BaseSettings):
                 raise ValueError(
                     "http_responses_session_bridge_advertise_base_url must be replica-specific for bridge routing"
                 )
+        return self
+
+    @model_validator(mode="after")
+    def _normalize_bulkhead_proxy_lane_limits(self) -> "Settings":
+        if self.bulkhead_proxy_http_limit is None:
+            self.bulkhead_proxy_http_limit = self.bulkhead_proxy_limit
+        if self.bulkhead_proxy_websocket_limit is None:
+            self.bulkhead_proxy_websocket_limit = self.bulkhead_proxy_limit
+        if self.bulkhead_proxy_compact_limit is None:
+            http_limit = self.bulkhead_proxy_http_limit
+            self.bulkhead_proxy_compact_limit = 0 if http_limit <= 0 else min(http_limit, 16)
         return self
 
     @model_validator(mode="after")

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -108,6 +108,7 @@ class Settings(BaseSettings):
     proxy_request_budget_seconds: float = Field(default=600.0, gt=0)
     compact_request_budget_seconds: float = Field(default=75.0, gt=0)
     stream_idle_timeout_seconds: float = 300.0
+    proxy_downstream_websocket_idle_timeout_seconds: float = Field(default=120.0, gt=0)
     max_sse_event_bytes: int = Field(default=2 * 1024 * 1024, gt=0)
     auth_base_url: str = "https://auth.openai.com"
     oauth_client_id: str = "app_EMoamEEZ73f0CkXaXp7hrann"

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -365,7 +365,7 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def _normalize_bulkhead_proxy_lane_limits(self) -> "Settings":
+    def _normalize_bulkhead_limits(self) -> "Settings":
         if self.bulkhead_proxy_http_limit is None:
             self.bulkhead_proxy_http_limit = self.bulkhead_proxy_limit
         if self.bulkhead_proxy_websocket_limit is None:

--- a/app/core/rate_limiter/db_rate_limiter.py
+++ b/app/core/rate_limiter/db_rate_limiter.py
@@ -76,7 +76,8 @@ class DatabaseRateLimiter:
         attempted_at_column = RateLimitAttempt.__table__.c.attempted_at
 
         raw_result = await session.execute(
-            insert(RateLimitAttempt).from_select(
+            insert(RateLimitAttempt)
+            .from_select(
                 [key_column.name, type_column.name, attempted_at_column.name],
                 select(
                     literal(key, type_=key_column.type),
@@ -94,8 +95,9 @@ class DatabaseRateLimiter:
                     < self.max_attempts
                 ),
             )
+            .returning(attempted_at_column)
         )
-        inserted = raw_result.rowcount > 0  # type: ignore[union-attr]
+        inserted = raw_result.scalar_one_or_none() is not None
         await session.commit()
 
         if not inserted:

--- a/app/core/resilience/backpressure.py
+++ b/app/core/resilience/backpressure.py
@@ -4,15 +4,13 @@ import asyncio
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-
-async def _reject_websocket(receive: Receive, send: Send, *, reason: str) -> None:
-    try:
-        event = await receive()
-        if event.get("type") != "websocket.connect":
-            return
-    except Exception:
-        return
-    await send({"type": "websocket.close", "code": 1013, "reason": reason})
+from app.core.resilience.overload import (
+    deny_websocket_with_http_response,
+    is_proxy_path,
+    local_overload_error,
+    merge_retry_after_headers,
+    send_json_http_response,
+)
 
 
 class BackpressureMiddleware:
@@ -30,18 +28,23 @@ class BackpressureMiddleware:
             await self.app(scope, receive, send)
             return
 
-        if self._semaphore._value <= 0:
+        if self._semaphore.locked():
+            message = "codex-lb is temporarily overloaded by local backpressure"
             if scope["type"] == "websocket":
-                await _reject_websocket(receive, send, reason="Too Many Requests")
+                await deny_websocket_with_http_response(
+                    receive,
+                    send,
+                    status_code=429,
+                    payload=local_overload_error(message) if is_proxy_path(path) else {"detail": message},
+                    headers=merge_retry_after_headers(),
+                )
                 return
-            await send(
-                {
-                    "type": "http.response.start",
-                    "status": 429,
-                    "headers": [(b"retry-after", b"5"), (b"content-type", b"application/json")],
-                }
+            await send_json_http_response(
+                send,
+                status_code=429,
+                payload=local_overload_error(message) if is_proxy_path(path) else {"detail": message},
+                headers=merge_retry_after_headers(),
             )
-            await send({"type": "http.response.body", "body": b'{"detail":"Too Many Requests"}'})
             return
 
         await self._semaphore.acquire()
@@ -49,6 +52,5 @@ class BackpressureMiddleware:
             await self.app(scope, receive, send)
         finally:
             self._semaphore.release()
-
 
 __all__ = ["BackpressureMiddleware"]

--- a/app/core/resilience/backpressure.py
+++ b/app/core/resilience/backpressure.py
@@ -53,4 +53,5 @@ class BackpressureMiddleware:
         finally:
             self._semaphore.release()
 
+
 __all__ = ["BackpressureMiddleware"]

--- a/app/core/resilience/bulkhead.py
+++ b/app/core/resilience/bulkhead.py
@@ -7,6 +7,15 @@ from asyncio import Semaphore
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.core.resilience.memory_monitor import is_memory_pressure, is_memory_warning
+from app.core.resilience.overload import (
+    deny_websocket_with_http_response,
+    is_proxy_path,
+    local_overload_error,
+    local_unavailable_error,
+    merge_retry_after_headers,
+    send_json_http_response,
+)
+from app.core.utils.request_id import get_request_id
 
 logger = logging.getLogger(__name__)
 
@@ -14,26 +23,46 @@ _MEMORY_WARNING_LOG_INTERVAL = 30.0
 _last_memory_warning_log: float = 0.0
 
 
-async def _reject_websocket(receive: Receive, send: Send, *, reason: str) -> None:
-    try:
-        event = await receive()
-        if event.get("type") != "websocket.connect":
-            return
-    except Exception:
-        return
-    await send({"type": "websocket.close", "code": 1013, "reason": reason})
-
-
 class BulkheadSemaphore:
-    def __init__(self, proxy_limit: int = 200, dashboard_limit: int = 50, background_limit: int = 10) -> None:
-        self._proxy = Semaphore(proxy_limit) if proxy_limit > 0 else None
+    def __init__(
+        self,
+        proxy_limit: int | None = None,
+        dashboard_limit: int = 50,
+        background_limit: int = 10,
+        *,
+        proxy_http_limit: int | None = None,
+        proxy_websocket_limit: int | None = None,
+        proxy_compact_limit: int | None = None,
+    ) -> None:
+        resolved_proxy_limit = 200 if proxy_limit is None else proxy_limit
+        resolved_proxy_http_limit = (
+            resolved_proxy_limit if proxy_http_limit is None else proxy_http_limit
+        )
+        resolved_proxy_websocket_limit = (
+            resolved_proxy_limit if proxy_websocket_limit is None else proxy_websocket_limit
+        )
+        if proxy_compact_limit is None:
+            resolved_proxy_compact_limit = 0 if resolved_proxy_http_limit <= 0 else min(resolved_proxy_http_limit, 16)
+        else:
+            resolved_proxy_compact_limit = proxy_compact_limit
+        self._proxy_http = Semaphore(resolved_proxy_http_limit) if resolved_proxy_http_limit > 0 else None
+        self._proxy_websocket = (
+            Semaphore(resolved_proxy_websocket_limit) if resolved_proxy_websocket_limit > 0 else None
+        )
+        self._proxy_compact = (
+            Semaphore(resolved_proxy_compact_limit) if resolved_proxy_compact_limit > 0 else None
+        )
         self._dashboard = Semaphore(dashboard_limit) if dashboard_limit > 0 else None
         self._background = Semaphore(background_limit) if background_limit > 0 else None
 
-    def get_semaphore(self, path: str) -> Semaphore | None:
-        if path.startswith("/v1/") or path.startswith("/backend-api/"):
-            return self._proxy
-        return self._dashboard
+    def get_semaphore(self, scope_type: str, path: str) -> tuple[str, Semaphore | None]:
+        if scope_type == "websocket" and is_proxy_path(path):
+            return "proxy_websocket", self._proxy_websocket
+        if scope_type == "http" and _is_compact_path(path):
+            return "proxy_compact", self._proxy_compact
+        if scope_type == "http" and is_proxy_path(path):
+            return "proxy_http", self._proxy_http
+        return "dashboard", self._dashboard
 
 
 class BulkheadMiddleware:
@@ -60,38 +89,62 @@ class BulkheadMiddleware:
                 logger.warning("Memory warning threshold exceeded")
 
         if is_memory_pressure():
-            if scope["type"] == "websocket":
-                await _reject_websocket(receive, send, reason="Service temporarily unavailable (memory pressure)")
-                return
-            body = b'{"detail":"Service temporarily unavailable (memory pressure)"}'
-            await send(
-                {
-                    "type": "http.response.start",
-                    "status": 503,
-                    "headers": [(b"retry-after", b"5"), (b"content-type", b"application/json")],
-                }
+            message = "codex-lb is temporarily unavailable due to local memory pressure"
+            await self._log_rejection(
+                path=path,
+                scope_type=scope["type"],
+                lane="memory",
+                status_code=503,
+                message=message,
+                available=None,
             )
-            await send({"type": "http.response.body", "body": body})
+            if scope["type"] == "websocket":
+                await deny_websocket_with_http_response(
+                    receive,
+                    send,
+                    status_code=503,
+                    payload=local_unavailable_error(message) if is_proxy_path(path) else {"detail": message},
+                    headers=merge_retry_after_headers(),
+                )
+                return
+            await send_json_http_response(
+                send,
+                status_code=503,
+                payload=local_unavailable_error(message) if is_proxy_path(path) else {"detail": message},
+                headers=merge_retry_after_headers(),
+            )
             return
 
-        sem = self._bulkhead.get_semaphore(path)
+        lane, sem = self._bulkhead.get_semaphore(scope["type"], path)
         if sem is None:
             await self.app(scope, receive, send)
             return
 
-        if sem._value <= 0:
-            if scope["type"] == "websocket":
-                await _reject_websocket(receive, send, reason="Service temporarily unavailable (bulkhead full)")
-                return
-            body = b'{"detail":"Service temporarily unavailable (bulkhead full)"}'
-            await send(
-                {
-                    "type": "http.response.start",
-                    "status": 503,
-                    "headers": [(b"retry-after", b"5"), (b"content-type", b"application/json")],
-                }
+        if sem.locked():
+            message = f"codex-lb is temporarily overloaded in the {lane} lane"
+            await self._log_rejection(
+                path=path,
+                scope_type=scope["type"],
+                lane=lane,
+                status_code=429,
+                message=message,
+                available=0,
             )
-            await send({"type": "http.response.body", "body": body})
+            if scope["type"] == "websocket":
+                await deny_websocket_with_http_response(
+                    receive,
+                    send,
+                    status_code=429,
+                    payload=local_overload_error(message) if is_proxy_path(path) else {"detail": message},
+                    headers=merge_retry_after_headers(),
+                )
+                return
+            await send_json_http_response(
+                send,
+                status_code=429,
+                payload=local_overload_error(message) if is_proxy_path(path) else {"detail": message},
+                headers=merge_retry_after_headers(),
+            )
             return
 
         await sem.acquire()
@@ -101,14 +154,49 @@ class BulkheadMiddleware:
         finally:
             sem.release()
 
+    async def _log_rejection(
+        self,
+        *,
+        path: str,
+        scope_type: str,
+        lane: str,
+        status_code: int,
+        message: str,
+        available: int | None,
+    ) -> None:
+        logger.warning(
+            "proxy_admission_rejected request_id=%s scope=%s path=%s lane=%s status=%s available=%s message=%s",
+            get_request_id(),
+            scope_type,
+            path,
+            lane,
+            status_code,
+            available,
+            message,
+        )
+
 
 _bulkhead: BulkheadSemaphore | None = None
 
+def _is_compact_path(path: str) -> bool:
+    return path.endswith("/responses/compact")
 
-def get_bulkhead(proxy_limit: int = 200, dashboard_limit: int = 50) -> BulkheadSemaphore:
+
+def get_bulkhead(
+    *,
+    proxy_http_limit: int = 200,
+    proxy_websocket_limit: int = 200,
+    proxy_compact_limit: int = 16,
+    dashboard_limit: int = 50,
+) -> BulkheadSemaphore:
     global _bulkhead
     if _bulkhead is None:
-        _bulkhead = BulkheadSemaphore(proxy_limit=proxy_limit, dashboard_limit=dashboard_limit)
+        _bulkhead = BulkheadSemaphore(
+            proxy_http_limit=proxy_http_limit,
+            proxy_websocket_limit=proxy_websocket_limit,
+            proxy_compact_limit=proxy_compact_limit,
+            dashboard_limit=dashboard_limit,
+        )
     return _bulkhead
 
 

--- a/app/core/resilience/bulkhead.py
+++ b/app/core/resilience/bulkhead.py
@@ -35,9 +35,7 @@ class BulkheadSemaphore:
         proxy_compact_limit: int | None = None,
     ) -> None:
         resolved_proxy_limit = 200 if proxy_limit is None else proxy_limit
-        resolved_proxy_http_limit = (
-            resolved_proxy_limit if proxy_http_limit is None else proxy_http_limit
-        )
+        resolved_proxy_http_limit = resolved_proxy_limit if proxy_http_limit is None else proxy_http_limit
         resolved_proxy_websocket_limit = (
             resolved_proxy_limit if proxy_websocket_limit is None else proxy_websocket_limit
         )
@@ -49,9 +47,7 @@ class BulkheadSemaphore:
         self._proxy_websocket = (
             Semaphore(resolved_proxy_websocket_limit) if resolved_proxy_websocket_limit > 0 else None
         )
-        self._proxy_compact = (
-            Semaphore(resolved_proxy_compact_limit) if resolved_proxy_compact_limit > 0 else None
-        )
+        self._proxy_compact = Semaphore(resolved_proxy_compact_limit) if resolved_proxy_compact_limit > 0 else None
         self._dashboard = Semaphore(dashboard_limit) if dashboard_limit > 0 else None
         self._background = Semaphore(background_limit) if background_limit > 0 else None
 
@@ -177,6 +173,7 @@ class BulkheadMiddleware:
 
 
 _bulkhead: BulkheadSemaphore | None = None
+
 
 def _is_compact_path(path: str) -> bool:
     return path.endswith("/responses/compact")

--- a/app/core/resilience/bulkhead.py
+++ b/app/core/resilience/bulkhead.py
@@ -183,7 +183,7 @@ def get_bulkhead(
     *,
     proxy_http_limit: int = 200,
     proxy_websocket_limit: int = 200,
-    proxy_compact_limit: int = 16,
+    proxy_compact_limit: int | None = None,
     dashboard_limit: int = 50,
 ) -> BulkheadSemaphore:
     global _bulkhead

--- a/app/core/resilience/overload.py
+++ b/app/core/resilience/overload.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+from starlette.types import Receive, Send
+
+from app.core.errors import OpenAIErrorEnvelope, openai_error
+
+LOCAL_OVERLOAD_CODE = "proxy_overloaded"
+LOCAL_OVERLOAD_RETRY_AFTER_SECONDS = "5"
+
+
+def local_overload_error(message: str) -> OpenAIErrorEnvelope:
+    return openai_error(LOCAL_OVERLOAD_CODE, message, error_type="rate_limit_error")
+
+
+def local_unavailable_error(message: str) -> OpenAIErrorEnvelope:
+    return openai_error("proxy_unavailable", message, error_type="server_error")
+
+
+def is_local_overload_error_code(code: str | None) -> bool:
+    return code == LOCAL_OVERLOAD_CODE
+
+
+def merge_retry_after_headers(
+    headers: Mapping[str, str] | None = None,
+    *,
+    retry_after: str = LOCAL_OVERLOAD_RETRY_AFTER_SECONDS,
+) -> dict[str, str]:
+    merged = dict(headers or {})
+    merged.setdefault("Retry-After", retry_after)
+    return merged
+
+
+def is_proxy_path(path: str) -> bool:
+    return path.startswith("/v1/") or path.startswith("/backend-api/")
+
+
+async def send_json_http_response(
+    send: Send,
+    *,
+    status_code: int,
+    payload: object,
+    headers: Mapping[str, str] | None = None,
+) -> None:
+    body = json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+    encoded_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        encoded_headers.append((key.lower().encode("ascii"), value.encode("utf-8")))
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status_code,
+            "headers": encoded_headers,
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+async def deny_websocket_with_http_response(
+    receive: Receive,
+    send: Send,
+    *,
+    status_code: int,
+    payload: object,
+    headers: Mapping[str, str] | None = None,
+) -> None:
+    try:
+        event = await receive()
+        if event.get("type") != "websocket.connect":
+            return
+    except Exception:
+        return
+    body = json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+    encoded_headers = [(b"content-type", b"application/json")]
+    for key, value in (headers or {}).items():
+        encoded_headers.append((key.lower().encode("ascii"), value.encode("utf-8")))
+    await send(
+        {
+            "type": "websocket.http.response.start",
+            "status": status_code,
+            "headers": encoded_headers,
+        }
+    )
+    await send({"type": "websocket.http.response.body", "body": body})

--- a/app/main.py
+++ b/app/main.py
@@ -329,7 +329,9 @@ def create_app() -> FastAPI:
     app.add_middleware(
         cast(Any, BulkheadMiddleware),
         bulkhead=get_bulkhead(
-            proxy_limit=settings.bulkhead_proxy_limit,
+            proxy_http_limit=settings.bulkhead_proxy_http_limit,
+            proxy_websocket_limit=settings.bulkhead_proxy_websocket_limit,
+            proxy_compact_limit=settings.bulkhead_proxy_compact_limit,
             dashboard_limit=settings.bulkhead_dashboard_limit,
         ),
     )

--- a/app/main.py
+++ b/app/main.py
@@ -326,12 +326,18 @@ def create_app() -> FastAPI:
             cast(Any, BackpressureMiddleware),
             max_concurrent=settings.backpressure_max_concurrent_requests,
         )
+    proxy_http_limit = settings.bulkhead_proxy_http_limit
+    proxy_websocket_limit = settings.bulkhead_proxy_websocket_limit
+    proxy_compact_limit = settings.bulkhead_proxy_compact_limit
+    assert proxy_http_limit is not None
+    assert proxy_websocket_limit is not None
+    assert proxy_compact_limit is not None
     app.add_middleware(
         cast(Any, BulkheadMiddleware),
         bulkhead=get_bulkhead(
-            proxy_http_limit=settings.bulkhead_proxy_http_limit,
-            proxy_websocket_limit=settings.bulkhead_proxy_websocket_limit,
-            proxy_compact_limit=settings.bulkhead_proxy_compact_limit,
+            proxy_http_limit=proxy_http_limit,
+            proxy_websocket_limit=proxy_websocket_limit,
+            proxy_compact_limit=proxy_compact_limit,
             dashboard_limit=settings.bulkhead_dashboard_limit,
         ),
     )

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -78,29 +78,36 @@ class _RefreshSingleflight:
             if task is None or task.done():
                 task = asyncio.create_task(factory())
                 self._inflight[key] = task
-                task.add_done_callback(lambda done, *, cache_key=key: self._complete(cache_key, done))
+                task.add_done_callback(lambda done, *, cache_key=key: self._schedule_complete(cache_key, done))
         return await asyncio.shield(task)
 
-    def _complete(self, key: _RefreshSingleflightKey, task: asyncio.Task[Account]) -> None:
-        current = self._inflight.get(key)
-        if current is task:
-            self._inflight.pop(key, None)
-        if task.cancelled():
-            self._recent_failures.pop(key, None)
-            return
+    def _schedule_complete(self, key: _RefreshSingleflightKey, task: asyncio.Task[Account]) -> None:
+        asyncio.create_task(self._complete(key, task))
+
+    async def _complete(self, key: _RefreshSingleflightKey, task: asyncio.Task[Account]) -> None:
         try:
-            task.result()
-        except RefreshError as exc:
-            ttl = max(0.0, float(get_settings().proxy_refresh_failure_cooldown_seconds))
-            if ttl > 0:
-                self._recent_failures[key] = (
-                    time.monotonic() + ttl,
-                    (exc.code, exc.message, exc.is_permanent),
-                )
+            async with self._lock:
+                current = self._inflight.get(key)
+                if current is task:
+                    self._inflight.pop(key, None)
+                if task.cancelled():
+                    self._recent_failures.pop(key, None)
+                    return
+                try:
+                    task.result()
+                except RefreshError as exc:
+                    ttl = max(0.0, float(get_settings().proxy_refresh_failure_cooldown_seconds))
+                    if ttl > 0:
+                        self._recent_failures[key] = (
+                            time.monotonic() + ttl,
+                            (exc.code, exc.message, exc.is_permanent),
+                        )
+                except BaseException:
+                    self._recent_failures.pop(key, None)
+                else:
+                    self._recent_failures.pop(key, None)
         except BaseException:
-            self._recent_failures.pop(key, None)
-        else:
-            self._recent_failures.pop(key, None)
+            logger.exception("Refresh singleflight completion cleanup failed key=%s", key)
 
     def _purge_stale_versions(self, account_id: str, *, keep_key: _RefreshSingleflightKey) -> None:
         stale_failures = [key for key in self._recent_failures if key[0] == account_id and key != keep_key]
@@ -146,7 +153,11 @@ class AuthManager:
         except RefreshError as exc:
             if exc.is_permanent:
                 latest = await self._repo.get_by_id(account.id)
-                if latest is not None and latest.refresh_token_encrypted != account.refresh_token_encrypted:
+                if latest is not None and _refresh_token_material_changed(
+                    self._encryptor,
+                    latest.refresh_token_encrypted,
+                    account.refresh_token_encrypted,
+                ):
                     raise RefreshError(exc.code, exc.message, False) from exc
                 reason = PERMANENT_FAILURE_CODES.get(exc.code, exc.message)
                 await self._repo.update_status(account.id, AccountStatus.DEACTIVATED, reason)
@@ -227,12 +238,29 @@ def _chatgpt_account_id_from_id_token(id_token: str) -> str | None:
 
 
 def _refresh_singleflight_key(encryptor: TokenEncryptor, account: Account) -> _RefreshSingleflightKey:
+    return (account.id, _refresh_token_material_fingerprint(encryptor, account.refresh_token_encrypted))
+
+
+def _refresh_token_material_changed(
+    encryptor: TokenEncryptor,
+    latest_refresh_token_encrypted: bytes,
+    current_refresh_token_encrypted: bytes,
+) -> bool:
+    return _refresh_token_material_fingerprint(
+        encryptor,
+        latest_refresh_token_encrypted,
+    ) != _refresh_token_material_fingerprint(
+        encryptor,
+        current_refresh_token_encrypted,
+    )
+
+
+def _refresh_token_material_fingerprint(encryptor: TokenEncryptor, refresh_token_encrypted: bytes) -> str:
     try:
-        refresh_token = encryptor.decrypt(account.refresh_token_encrypted)
-        material = refresh_token.encode("utf-8")
+        material = encryptor.decrypt(refresh_token_encrypted).encode("utf-8")
     except Exception:
-        material = account.refresh_token_encrypted
-    return (account.id, sha256(material).hexdigest())
+        material = refresh_token_encrypted
+    return sha256(material).hexdigest()
 
 
 def _clear_refresh_singleflight_state() -> None:

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -81,6 +81,7 @@ class _RefreshSingleflight:
                 task = asyncio.create_task(factory())
                 self._inflight[key] = task
                 task.add_done_callback(lambda done, *, cache_key=key: self._schedule_complete(cache_key, done))
+        assert task is not None
         return await asyncio.shield(task)
 
     def _schedule_complete(self, key: _RefreshSingleflightKey, task: asyncio.Task[Account]) -> None:

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from datetime import datetime
 from hashlib import sha256
 from typing import Protocol, TypeAlias
@@ -62,7 +62,7 @@ class _RefreshSingleflight:
     async def run(
         self,
         key: _RefreshSingleflightKey,
-        factory: Callable[[], Awaitable[Account]],
+        factory: Callable[[], Coroutine[object, object, Account]],
     ) -> Account:
         account_id = key[0]
         async with self._lock:
@@ -103,9 +103,7 @@ class _RefreshSingleflight:
             self._recent_failures.pop(key, None)
 
     def _purge_stale_versions(self, account_id: str, *, keep_key: _RefreshSingleflightKey) -> None:
-        stale_failures = [
-            key for key in self._recent_failures if key[0] == account_id and key != keep_key
-        ]
+        stale_failures = [key for key in self._recent_failures if key[0] == account_id and key != keep_key]
         for key in stale_failures:
             self._recent_failures.pop(key, None)
         stale_inflight = [

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import time
+from collections.abc import Awaitable, Callable
 from datetime import datetime
-from typing import Protocol
+from hashlib import sha256
+from typing import Protocol, TypeAlias
 
 from app.core.auth import DEFAULT_PLAN, OpenAIAuthClaims, extract_id_token_claims
-from app.core.auth.refresh import RefreshError, refresh_access_token, should_refresh
+from app.core.auth.refresh import RefreshError, TokenRefreshResult, refresh_access_token, should_refresh
 from app.core.balancer import PERMANENT_FAILURE_CODES
+from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.utils.time import utcnow
@@ -38,25 +43,113 @@ class AccountsRepositoryPort(Protocol):
     ) -> bool: ...
 
 
+class RefreshAdmissionLeasePort(Protocol):
+    def release(self) -> None: ...
+
+
 logger = logging.getLogger(__name__)
 
 
+_RefreshSingleflightKey: TypeAlias = tuple[str, str]
+
+
+class _RefreshSingleflight:
+    def __init__(self) -> None:
+        self._inflight: dict[_RefreshSingleflightKey, asyncio.Task[Account]] = {}
+        self._recent_failures: dict[_RefreshSingleflightKey, tuple[float, tuple[str, str, bool]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def run(
+        self,
+        key: _RefreshSingleflightKey,
+        factory: Callable[[], Awaitable[Account]],
+    ) -> Account:
+        account_id = key[0]
+        async with self._lock:
+            self._purge_stale_versions(account_id, keep_key=key)
+            cached_failure = self._recent_failures.get(key)
+            if cached_failure is not None:
+                expires_at, failure = cached_failure
+                if expires_at > time.monotonic():
+                    code, message, is_permanent = failure
+                    raise RefreshError(code, message, is_permanent)
+                self._recent_failures.pop(key, None)
+            task = self._inflight.get(key)
+            if task is None or task.done():
+                task = asyncio.create_task(factory())
+                self._inflight[key] = task
+                task.add_done_callback(lambda done, *, cache_key=key: self._complete(cache_key, done))
+        return await asyncio.shield(task)
+
+    def _complete(self, key: _RefreshSingleflightKey, task: asyncio.Task[Account]) -> None:
+        current = self._inflight.get(key)
+        if current is task:
+            self._inflight.pop(key, None)
+        if task.cancelled():
+            self._recent_failures.pop(key, None)
+            return
+        try:
+            task.result()
+        except RefreshError as exc:
+            ttl = max(0.0, float(get_settings().proxy_refresh_failure_cooldown_seconds))
+            if ttl > 0:
+                self._recent_failures[key] = (
+                    time.monotonic() + ttl,
+                    (exc.code, exc.message, exc.is_permanent),
+                )
+        except BaseException:
+            self._recent_failures.pop(key, None)
+        else:
+            self._recent_failures.pop(key, None)
+
+    def _purge_stale_versions(self, account_id: str, *, keep_key: _RefreshSingleflightKey) -> None:
+        stale_failures = [
+            key for key in self._recent_failures if key[0] == account_id and key != keep_key
+        ]
+        for key in stale_failures:
+            self._recent_failures.pop(key, None)
+        stale_inflight = [
+            key for key, task in self._inflight.items() if key[0] == account_id and key != keep_key and task.done()
+        ]
+        for key in stale_inflight:
+            self._inflight.pop(key, None)
+
+    def clear(self) -> None:
+        self._inflight.clear()
+        self._recent_failures.clear()
+
+
+_REFRESH_SINGLEFLIGHT = _RefreshSingleflight()
+
+
 class AuthManager:
-    def __init__(self, repo: AccountsRepositoryPort) -> None:
+    def __init__(
+        self,
+        repo: AccountsRepositoryPort,
+        *,
+        acquire_refresh_admission: Callable[[], Awaitable[RefreshAdmissionLeasePort]] | None = None,
+    ) -> None:
         self._repo = repo
         self._encryptor = TokenEncryptor()
+        self._acquire_refresh_admission = acquire_refresh_admission
 
     async def ensure_fresh(self, account: Account, *, force: bool = False) -> Account:
         if force or should_refresh(account.last_refresh):
-            account = await self.refresh_account(account)
+            account = await _REFRESH_SINGLEFLIGHT.run(
+                _refresh_singleflight_key(self._encryptor, account),
+                lambda: self.refresh_account(account),
+            )
         return await self._ensure_chatgpt_account_id(account)
 
     async def refresh_account(self, account: Account) -> Account:
         refresh_token = self._encryptor.decrypt(account.refresh_token_encrypted)
         try:
-            result = await refresh_access_token(refresh_token)
+            result = await self._refresh_tokens(refresh_token)
         except RefreshError as exc:
             if exc.is_permanent:
+                latest = await self._repo.get_by_id(account.id)
+                if latest is not None and latest.refresh_token_encrypted != account.refresh_token_encrypted:
+                    raise RefreshError(exc.code, exc.message, False) from exc
                 reason = PERMANENT_FAILURE_CODES.get(exc.code, exc.message)
                 await self._repo.update_status(account.id, AccountStatus.DEACTIVATED, reason)
                 account.status = AccountStatus.DEACTIVATED
@@ -91,6 +184,16 @@ class AuthManager:
         )
         return account
 
+    async def _refresh_tokens(self, refresh_token: str) -> TokenRefreshResult:
+        refresh_lease: RefreshAdmissionLeasePort | None = None
+        if self._acquire_refresh_admission is not None:
+            refresh_lease = await self._acquire_refresh_admission()
+        try:
+            return await refresh_access_token(refresh_token)
+        finally:
+            if refresh_lease is not None:
+                refresh_lease.release()
+
     async def _ensure_chatgpt_account_id(self, account: Account) -> Account:
         if account.chatgpt_account_id:
             return account
@@ -123,3 +226,16 @@ def _chatgpt_account_id_from_id_token(id_token: str) -> str | None:
     claims = extract_id_token_claims(id_token)
     auth_claims = claims.auth or OpenAIAuthClaims()
     return auth_claims.chatgpt_account_id or claims.chatgpt_account_id
+
+
+def _refresh_singleflight_key(encryptor: TokenEncryptor, account: Account) -> _RefreshSingleflightKey:
+    try:
+        refresh_token = encryptor.decrypt(account.refresh_token_encrypted)
+        material = refresh_token.encode("utf-8")
+    except Exception:
+        material = account.refresh_token_encrypted
+    return (account.id, sha256(material).hexdigest())
+
+
+def _clear_refresh_singleflight_state() -> None:
+    _REFRESH_SINGLEFLIGHT.clear()

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -75,7 +75,7 @@ class _RefreshSingleflight:
                     raise RefreshError(code, message, is_permanent)
                 self._recent_failures.pop(key, None)
             task = self._inflight.get(key)
-            if task is None or task.done():
+            if task is None or (task.done() and (task.cancelled() or task.exception() is not None)):
                 task = asyncio.create_task(factory())
                 self._inflight[key] = task
                 task.add_done_callback(lambda done, *, cache_key=key: self._schedule_complete(cache_key, done))

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -75,7 +75,9 @@ class _RefreshSingleflight:
                     raise RefreshError(code, message, is_permanent)
                 self._recent_failures.pop(key, None)
             task = self._inflight.get(key)
-            if task is None or (task.done() and (task.cancelled() or task.exception() is not None)):
+            if task is not None and task.done() and not task.cancelled() and task.exception() is None:
+                pass
+            elif task is None or task.done():
                 task = asyncio.create_task(factory())
                 self._inflight[key] = task
                 task.add_done_callback(lambda done, *, cache_key=key: self._schedule_complete(cache_key, done))
@@ -158,7 +160,7 @@ class AuthManager:
                     latest.refresh_token_encrypted,
                     account.refresh_token_encrypted,
                 ):
-                    raise RefreshError(exc.code, exc.message, False) from exc
+                    return latest
                 reason = PERMANENT_FAILURE_CODES.get(exc.code, exc.message)
                 await self._repo.update_status(account.id, AccountStatus.DEACTIVATED, reason)
                 account.status = AccountStatus.DEACTIVATED

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -79,7 +79,9 @@ def _decorate_session_response(
     sid = password_session_id or request.cookies.get(DASHBOARD_SESSION_COOKIE)
     session_state = store.get(sid) if sid else None
     has_pwd = session_state is not None and session_state.password_verified
-    totp_pending = has_pwd and response.totp_required_on_login and not session_state.totp_verified
+    totp_pending = (
+        has_pwd and session_state is not None and response.totp_required_on_login and not session_state.totp_verified
+    )
     fully_authorized = has_pwd and not totp_pending and response.password_required
 
     if request_auth is None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -44,6 +44,7 @@ from app.core.openai.models import (
 from app.core.openai.parsing import parse_response_payload
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
 from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRequest
+from app.core.resilience.overload import is_local_overload_error_code, merge_retry_after_headers
 from app.core.runtime_logging import log_error_response
 from app.core.types import JsonValue
 from app.core.usage.types import UsageWindowRow
@@ -1104,6 +1105,9 @@ def _logged_error_json_response(
     headers: Mapping[str, str] | None = None,
 ) -> JSONResponse:
     code, message = _error_details_from_content(content)
+    effective_headers = dict(headers or {})
+    if status_code == 429 and is_local_overload_error_code(code):
+        effective_headers = merge_retry_after_headers(effective_headers)
     log_error_response(
         logger,
         request,
@@ -1112,7 +1116,7 @@ def _logged_error_json_response(
         message,
         category="proxy_error_response",
     )
-    return JSONResponse(status_code=status_code, content=content, headers=headers)
+    return JSONResponse(status_code=status_code, content=content, headers=effective_headers or None)
 
 
 def _error_details_from_content(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -77,6 +77,7 @@ from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.models import CompactResponsePayload, OpenAIEvent, OpenAIResponsePayload
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+from app.core.resilience.overload import is_local_overload_error_code
 from app.core.types import JsonValue
 from app.core.usage.types import UsageWindowRow
 from app.core.utils.json_guards import is_json_mapping
@@ -146,6 +147,7 @@ from app.modules.proxy.types import (
     RateLimitStatusPayloadData,
     RateLimitWindowSnapshotData,
 )
+from app.modules.proxy.work_admission import AdmissionLease, WorkAdmissionController
 from app.modules.usage.additional_quota_keys import get_additional_display_label_for_quota_key
 from app.modules.usage.updater import UsageUpdater
 
@@ -244,6 +246,18 @@ class ProxyService:
         self._http_bridge_turn_state_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
         self._http_bridge_previous_response_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
         self._http_bridge_lock = anyio.Lock()
+        self._work_admission: WorkAdmissionController | None = None
+
+    def _get_work_admission(self) -> WorkAdmissionController:
+        if self._work_admission is None:
+            settings = get_settings()
+            self._work_admission = WorkAdmissionController(
+                token_refresh_limit=settings.proxy_token_refresh_limit,
+                websocket_connect_limit=settings.proxy_upstream_websocket_connect_limit,
+                response_create_limit=settings.proxy_response_create_limit,
+                compact_response_create_limit=settings.proxy_compact_response_create_limit,
+            )
+        return self._work_admission
 
     def stream_responses(
         self,
@@ -851,9 +865,11 @@ class ProxyService:
                         connect_timeout_seconds=remaining_budget,
                         total_timeout_seconds=remaining_budget,
                     )
+                create_lease = await self._get_work_admission().acquire_response_create(compact=True)
                 try:
                     return await core_compact_responses(payload, filtered, access_token, account_id)
                 finally:
+                    create_lease.release()
                     pop_compact_timeout_overrides(timeout_tokens)
 
             last_exc: ProxyResponseError | None = None
@@ -1011,6 +1027,14 @@ class ProxyService:
                             error.code if error else None,
                             error.type if error else None,
                         )
+                        if _is_account_neutral_error_code(code):
+                            await self._settle_compact_api_key_usage(
+                                api_key=api_key,
+                                api_key_reservation=api_key_reservation,
+                                response=None,
+                                request_service_tier=request_service_tier,
+                            )
+                            raise
                         classified = await self._handle_stream_error(
                             account,
                             _upstream_error_from_openai(error),
@@ -1386,10 +1410,55 @@ class ProxyService:
                     account = None
 
                 if request_state is not None:
-                    await response_create_gate.acquire()
-                    async with pending_lock:
-                        pending_requests.append(request_state)
-                    request_state_registered = True
+                    try:
+                        await self._acquire_request_state_response_create_admission(
+                            request_state,
+                            response_create_gate=response_create_gate,
+                        )
+                        async with pending_lock:
+                            pending_requests.append(request_state)
+                        request_state_registered = True
+                    except ProxyResponseError as exc:
+                        error = _parse_openai_error(exc.payload)
+                        error_code = _normalize_error_code(
+                            error.code if error else None,
+                            error.type if error else None,
+                        )
+                        error_message = error.message if error else "Upstream error"
+                        await self._release_websocket_reservation(request_state.api_key_reservation)
+                        await self._write_websocket_connect_failure(
+                            account_id=account.id if account else None,
+                            api_key=api_key,
+                            request_state=request_state,
+                            error_code=error_code or "upstream_error",
+                            error_message=error_message,
+                        )
+                        await self._emit_websocket_terminal_error(
+                            websocket,
+                            client_send_lock=client_send_lock,
+                            request_state=request_state,
+                            error_code=error_code or "upstream_error",
+                            error_message=error_message,
+                            error_type=error.type if error else "server_error",
+                        )
+                        _release_websocket_response_create_gate(request_state, response_create_gate)
+                        continue
+                    except asyncio.CancelledError:
+                        await self._release_websocket_reservation(request_state.api_key_reservation)
+                        if request_state_registered:
+                            async with pending_lock:
+                                if request_state in pending_requests:
+                                    pending_requests.remove(request_state)
+                        _release_websocket_response_create_gate(request_state, response_create_gate)
+                        raise
+                    except Exception:
+                        await self._release_websocket_reservation(request_state.api_key_reservation)
+                        if request_state_registered:
+                            async with pending_lock:
+                                if request_state in pending_requests:
+                                    pending_requests.remove(request_state)
+                        _release_websocket_response_create_gate(request_state, response_create_gate)
+                        raise
 
                 if upstream is None:
                     if text_data is not None and payload is None:
@@ -1657,6 +1726,24 @@ class ProxyService:
         _enforce_response_create_size_limit(request_state)
         return request_state, text_data
 
+    async def _acquire_request_state_response_create_admission(
+        self,
+        request_state: _WebSocketRequestState,
+        *,
+        response_create_gate: asyncio.Semaphore,
+        compact: bool = False,
+    ) -> None:
+        await response_create_gate.acquire()
+        request_state.response_create_gate_acquired = True
+        request_state.awaiting_response_created = True
+        try:
+            request_state.response_create_admission = await self._get_work_admission().acquire_response_create(
+                compact=compact
+            )
+        except BaseException:
+            _release_websocket_response_create_gate(request_state, response_create_gate)
+            raise
+
     async def _connect_proxy_websocket(
         self,
         headers: dict[str, str],
@@ -1914,7 +2001,11 @@ class ProxyService:
     ) -> UpstreamResponsesWebSocket:
         access_token = self._encryptor.decrypt(account.access_token_encrypted)
         account_id = _header_account_id(account.chatgpt_account_id)
-        return await connect_responses_websocket(headers, access_token, account_id)
+        connect_lease = await self._get_work_admission().acquire_websocket_connect()
+        try:
+            return await connect_responses_websocket(headers, access_token, account_id)
+        finally:
+            connect_lease.release()
 
     async def _http_bridge_pending_count(self, session: "_HTTPBridgeSession") -> int:
         async with session.pending_lock:
@@ -3158,13 +3249,24 @@ class ProxyService:
                 )
             session.queued_request_count += 1
         try:
-            await session.response_create_gate.acquire()
+            await self._acquire_request_state_response_create_admission(
+                request_state,
+                response_create_gate=session.response_create_gate,
+            )
             gate_acquired = True
             async with session.pending_lock:
                 session.pending_requests.append(request_state)
             request_enqueued = True
             await session.upstream.send_text(text_data)
             session.last_used_at = time.monotonic()
+        except ProxyResponseError:
+            await self._cleanup_http_bridge_submit_interruption(
+                session,
+                request_state=request_state,
+                gate_acquired=gate_acquired,
+                request_enqueued=request_enqueued,
+            )
+            raise
         except asyncio.CancelledError:
             await self._cleanup_http_bridge_submit_interruption(
                 session,
@@ -3275,7 +3377,10 @@ class ProxyService:
             try:
                 event_queue = warmup_state.event_queue
                 assert event_queue is not None
-                await session.response_create_gate.acquire()
+                await self._acquire_request_state_response_create_admission(
+                    warmup_state,
+                    response_create_gate=session.response_create_gate,
+                )
                 gate_acquired = True
                 async with session.pending_lock:
                     session.pending_requests.append(warmup_state)
@@ -3297,6 +3402,20 @@ class ProxyService:
                             ),
                         )
                 session.last_used_at = time.monotonic()
+            except ProxyResponseError as exc:
+                error = _parse_openai_error(exc.payload)
+                code = _normalize_error_code(error.code if error else None, error.type if error else None)
+                await self._cleanup_http_bridge_submit_interruption(
+                    session,
+                    request_state=warmup_state,
+                    gate_acquired=gate_acquired,
+                    request_enqueued=request_enqueued,
+                )
+                if is_local_overload_error_code(code):
+                    session.prewarmed = False
+                    return
+                session.prewarmed = False
+                raise
             except Exception:
                 session.prewarmed = False
                 await self._cleanup_http_bridge_submit_interruption(
@@ -3747,6 +3866,8 @@ class ProxyService:
     async def _handle_websocket_connect_error(self, account: Account, exc: ProxyResponseError) -> None:
         error = _parse_openai_error(exc.payload)
         error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
+        if _is_account_neutral_error_code(error_code):
+            return
         await self._handle_stream_error(
             account,
             _upstream_error_from_openai(error),
@@ -4734,6 +4855,8 @@ class ProxyService:
                                     error.code if error else None,
                                     error.type if error else None,
                                 )
+                                if _is_account_neutral_error_code(code):
+                                    raise
                                 classified = await self._handle_stream_error(
                                     account,
                                     _upstream_error_from_openai(error),
@@ -5064,8 +5187,10 @@ class ProxyService:
         usage = None
         saw_text_delta = False
         latency_first_token_ms: int | None = None
+        response_create_lease = AdmissionLease(None)
 
         try:
+            response_create_lease = await self._get_work_admission().acquire_response_create()
             if upstream_stream_transport is not None:
                 stream = core_stream_responses(
                     payload,
@@ -5087,7 +5212,9 @@ class ProxyService:
             try:
                 first = await iterator.__anext__()
             except StopAsyncIteration:
+                response_create_lease.release()
                 return
+            response_create_lease.release()
             first_payload = parse_sse_data_json(first)
             event = parse_sse_event(first)
             event_type = _event_type_from_payload(event, first_payload)
@@ -5188,6 +5315,7 @@ class ProxyService:
                     latency_first_token_ms = int((time.monotonic() - request_started_at) * 1000)
                 yield line
         except ProxyResponseError as exc:
+            response_create_lease.release()
             error = _parse_openai_error(exc.payload)
             status = "error"
             error_code = _normalize_error_code(
@@ -5199,6 +5327,7 @@ class ProxyService:
             settlement.account_health_error = _should_penalize_stream_error(error_code)
             raise
         finally:
+            response_create_lease.release()
             input_tokens = usage.input_tokens if usage else None
             output_tokens = usage.output_tokens if usage else None
             cached_input_tokens = (
@@ -5492,13 +5621,16 @@ class ProxyService:
         force: bool = False,
         timeout_seconds: float | None = None,
     ) -> Account:
-        async with self._repo_factory() as repos:
-            auth_manager = AuthManager(repos.accounts)
-            token = push_token_refresh_timeout_override(timeout_seconds)
-            try:
+        token = push_token_refresh_timeout_override(timeout_seconds)
+        try:
+            async with self._repo_factory() as repos:
+                auth_manager = AuthManager(
+                    repos.accounts,
+                    acquire_refresh_admission=self._get_work_admission().acquire_token_refresh,
+                )
                 return await auth_manager.ensure_fresh(account, force=force)
-            finally:
-                pop_token_refresh_timeout_override(token)
+        finally:
+            pop_token_refresh_timeout_override(token)
 
     async def _ensure_fresh_with_budget(
         self,
@@ -5602,6 +5734,8 @@ class ProxyService:
             error.code if error else None,
             error.type if error else None,
         )
+        if _is_account_neutral_error_code(code):
+            return
         await self._handle_stream_error(
             account,
             _upstream_error_from_openai(error),
@@ -5622,6 +5756,8 @@ class ProxyService:
             http_status=http_status,
             phase="first_event",
         )
+        if _is_account_neutral_error_code(code):
+            return classified
         if classified["failure_class"] == "rate_limit":
             await self._load_balancer.mark_rate_limit(account, error)
         elif classified["failure_class"] == "quota":
@@ -5696,6 +5832,10 @@ def _should_penalize_stream_error(code: str | None) -> bool:
     return code in _ACCOUNT_RECOVERY_RETRY_CODES
 
 
+def _is_account_neutral_error_code(code: str | None) -> bool:
+    return code in {"proxy_overloaded", "proxy_unavailable"}
+
+
 @dataclass
 class _WebSocketRequestState:
     request_id: str
@@ -5724,6 +5864,8 @@ class _WebSocketRequestState:
     error_type_override: str | None = None
     error_param_override: str | None = None
     error_http_status_override: int | None = None
+    response_create_gate_acquired: bool = False
+    response_create_admission: AdmissionLease | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -5973,9 +6115,13 @@ def _release_websocket_response_create_gate(
     request_state: _WebSocketRequestState,
     response_create_gate: asyncio.Semaphore,
 ) -> None:
-    if not request_state.awaiting_response_created:
-        return
+    if request_state.response_create_admission is not None:
+        request_state.response_create_admission.release()
+        request_state.response_create_admission = None
     request_state.awaiting_response_created = False
+    if not request_state.response_create_gate_acquired:
+        return
+    request_state.response_create_gate_acquired = False
     response_create_gate.release()
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1332,19 +1332,24 @@ class ProxyService:
                         idle_timeout_seconds=downstream_idle_timeout_seconds,
                     ):
                         continue
+                    idle_close = False
                     async with client_send_lock:
-                        if not await self._downstream_websocket_is_idle(
+                        if await self._downstream_websocket_is_idle(
                             pending_requests,
                             pending_lock=pending_lock,
                             downstream_activity=downstream_activity,
                             idle_timeout_seconds=downstream_idle_timeout_seconds,
                         ):
-                            continue
-                        try:
-                            await websocket.close(code=1001, reason=_DOWNSTREAM_WEBSOCKET_IDLE_CLOSE_REASON)
-                        except Exception:
-                            logger.debug("Failed to close idle downstream websocket", exc_info=True)
-                    break
+                            try:
+                                message = await asyncio.wait_for(websocket.receive(), timeout=0.05)
+                            except asyncio.TimeoutError:
+                                try:
+                                    await websocket.close(code=1001, reason=_DOWNSTREAM_WEBSOCKET_IDLE_CLOSE_REASON)
+                                except Exception:
+                                    logger.debug("Failed to close idle downstream websocket", exc_info=True)
+                                idle_close = True
+                    if idle_close:
+                        break
                 downstream_activity.mark()
                 message_type = message["type"]
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -169,6 +169,8 @@ _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline im
 
 _TASK_CANCEL_TIMEOUT_SECONDS = 1.0
 _TaskResultT = TypeVar("_TaskResultT")
+_DOWNSTREAM_WEBSOCKET_IDLE_CLOSE_REASON = "Idle downstream websocket timeout"
+_DOWNSTREAM_WEBSOCKET_RECEIVE_POLL_SECONDS = 1.0
 
 
 async def _await_cancelled_task(
@@ -1312,10 +1314,32 @@ class ProxyService:
         upstream_control: _WebSocketUpstreamControl | None = None
         account: Account | None = None
         upstream_turn_state: str | None = _sticky_key_from_turn_state_header(headers)
+        downstream_idle_started_at: float | None = time.monotonic()
 
         try:
             while True:
-                message = await websocket.receive()
+                downstream_idle_timeout_seconds = runtime_settings.proxy_downstream_websocket_idle_timeout_seconds
+                try:
+                    message = await asyncio.wait_for(
+                        websocket.receive(),
+                        timeout=min(downstream_idle_timeout_seconds, _DOWNSTREAM_WEBSOCKET_RECEIVE_POLL_SECONDS),
+                    )
+                except asyncio.TimeoutError:
+                    downstream_idle_started_at = await self._refresh_downstream_websocket_idle_started_at(
+                        pending_requests,
+                        pending_lock=pending_lock,
+                        idle_started_at=downstream_idle_started_at,
+                    )
+                    if downstream_idle_started_at is None:
+                        continue
+                    if time.monotonic() - downstream_idle_started_at < downstream_idle_timeout_seconds:
+                        continue
+                    try:
+                        await websocket.close(code=1001, reason=_DOWNSTREAM_WEBSOCKET_IDLE_CLOSE_REASON)
+                    except Exception:
+                        logger.debug("Failed to close idle downstream websocket", exc_info=True)
+                    break
+                downstream_idle_started_at = time.monotonic()
                 message_type = message["type"]
 
                 if message_type == "websocket.disconnect":
@@ -1417,6 +1441,7 @@ class ProxyService:
                         )
                         async with pending_lock:
                             pending_requests.append(request_state)
+                        downstream_idle_started_at = None
                         request_state_registered = True
                     except ProxyResponseError as exc:
                         error = _parse_openai_error(exc.payload)
@@ -4074,6 +4099,20 @@ class ProxyService:
             proxy_request_budget_seconds=proxy_request_budget_seconds,
             stream_idle_timeout_seconds=stream_idle_timeout_seconds,
         )
+
+    async def _refresh_downstream_websocket_idle_started_at(
+        self,
+        pending_requests: deque[_WebSocketRequestState],
+        *,
+        pending_lock: anyio.Lock,
+        idle_started_at: float | None,
+    ) -> float | None:
+        async with pending_lock:
+            if pending_requests:
+                return None
+        if idle_started_at is not None:
+            return idle_started_at
+        return time.monotonic()
 
     async def _fail_expired_pending_websocket_requests(
         self,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1424,7 +1424,8 @@ class ProxyService:
                             error.code if error else None,
                             error.type if error else None,
                         )
-                        error_message = error.message if error else "Upstream error"
+                        error_message = error.message if error and error.message else "Upstream error"
+                        error_type = error.type if error and error.type else "server_error"
                         await self._release_websocket_reservation(request_state.api_key_reservation)
                         await self._write_websocket_connect_failure(
                             account_id=account.id if account else None,
@@ -1439,7 +1440,7 @@ class ProxyService:
                             request_state=request_state,
                             error_code=error_code or "upstream_error",
                             error_message=error_message,
-                            error_type=error.type if error else "server_error",
+                            error_type=error_type,
                         )
                         _release_websocket_response_create_gate(request_state, response_create_gate)
                         continue

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1314,7 +1314,7 @@ class ProxyService:
         upstream_control: _WebSocketUpstreamControl | None = None
         account: Account | None = None
         upstream_turn_state: str | None = _sticky_key_from_turn_state_header(headers)
-        downstream_idle_started_at: float | None = time.monotonic()
+        downstream_activity = _DownstreamWebSocketActivity()
 
         try:
             while True:
@@ -1325,21 +1325,27 @@ class ProxyService:
                         timeout=min(downstream_idle_timeout_seconds, _DOWNSTREAM_WEBSOCKET_RECEIVE_POLL_SECONDS),
                     )
                 except asyncio.TimeoutError:
-                    downstream_idle_started_at = await self._refresh_downstream_websocket_idle_started_at(
+                    if not await self._downstream_websocket_is_idle(
                         pending_requests,
                         pending_lock=pending_lock,
-                        idle_started_at=downstream_idle_started_at,
-                    )
-                    if downstream_idle_started_at is None:
+                        downstream_activity=downstream_activity,
+                        idle_timeout_seconds=downstream_idle_timeout_seconds,
+                    ):
                         continue
-                    if time.monotonic() - downstream_idle_started_at < downstream_idle_timeout_seconds:
-                        continue
-                    try:
-                        await websocket.close(code=1001, reason=_DOWNSTREAM_WEBSOCKET_IDLE_CLOSE_REASON)
-                    except Exception:
-                        logger.debug("Failed to close idle downstream websocket", exc_info=True)
+                    async with client_send_lock:
+                        if not await self._downstream_websocket_is_idle(
+                            pending_requests,
+                            pending_lock=pending_lock,
+                            downstream_activity=downstream_activity,
+                            idle_timeout_seconds=downstream_idle_timeout_seconds,
+                        ):
+                            continue
+                        try:
+                            await websocket.close(code=1001, reason=_DOWNSTREAM_WEBSOCKET_IDLE_CLOSE_REASON)
+                        except Exception:
+                            logger.debug("Failed to close idle downstream websocket", exc_info=True)
                     break
-                downstream_idle_started_at = time.monotonic()
+                downstream_activity.mark()
                 message_type = message["type"]
 
                 if message_type == "websocket.disconnect":
@@ -1441,7 +1447,6 @@ class ProxyService:
                         )
                         async with pending_lock:
                             pending_requests.append(request_state)
-                        downstream_idle_started_at = None
                         request_state_registered = True
                     except ProxyResponseError as exc:
                         error = _parse_openai_error(exc.payload)
@@ -1466,6 +1471,7 @@ class ProxyService:
                             error_code=error_code or "upstream_error",
                             error_message=error_message,
                             error_type=error_type,
+                            downstream_activity=downstream_activity,
                         )
                         _release_websocket_response_create_gate(request_state, response_create_gate)
                         continue
@@ -1548,6 +1554,7 @@ class ProxyService:
                             response_create_gate=response_create_gate,
                             proxy_request_budget_seconds=runtime_settings.proxy_request_budget_seconds,
                             stream_idle_timeout_seconds=runtime_settings.stream_idle_timeout_seconds,
+                            downstream_activity=downstream_activity,
                         )
                     )
 
@@ -1567,6 +1574,7 @@ class ProxyService:
                         websocket=websocket,
                         client_send_lock=client_send_lock,
                         response_create_gate=response_create_gate,
+                        downstream_activity=downstream_activity,
                     )
                     if upstream_reader is not None:
                         await _await_cancelled_task(upstream_reader, label="proxy websocket upstream reader")
@@ -1598,6 +1606,7 @@ class ProxyService:
                 websocket=websocket,
                 client_send_lock=client_send_lock,
                 response_create_gate=response_create_gate,
+                downstream_activity=downstream_activity,
             )
 
     async def _prepare_websocket_response_create_request(
@@ -3915,6 +3924,7 @@ class ProxyService:
         response_create_gate: asyncio.Semaphore,
         proxy_request_budget_seconds: float,
         stream_idle_timeout_seconds: float,
+        downstream_activity: _DownstreamWebSocketActivity,
     ) -> None:
         try:
             while True:
@@ -3969,6 +3979,7 @@ class ProxyService:
                     )
                     continue
                 if message.kind == "text" and message.text is not None:
+                    downstream_activity.mark()
                     await self._process_upstream_websocket_text(
                         message.text,
                         account=account,
@@ -3979,8 +3990,12 @@ class ProxyService:
                         upstream_control=upstream_control,
                         response_create_gate=response_create_gate,
                     )
-                    async with client_send_lock:
-                        await websocket.send_text(message.text)
+                    await self._send_downstream_websocket_text(
+                        websocket,
+                        client_send_lock=client_send_lock,
+                        text=message.text,
+                        downstream_activity=downstream_activity,
+                    )
                     if upstream_control.reconnect_requested:
                         async with pending_lock:
                             should_reconnect = not pending_requests
@@ -3992,8 +4007,13 @@ class ProxyService:
                             break
                     continue
                 if message.kind == "binary" and message.data is not None:
-                    async with client_send_lock:
-                        await websocket.send_bytes(message.data)
+                    downstream_activity.mark()
+                    await self._send_downstream_websocket_bytes(
+                        websocket,
+                        client_send_lock=client_send_lock,
+                        data=message.data,
+                        downstream_activity=downstream_activity,
+                    )
                     continue
                 await self._fail_pending_websocket_requests(
                     account_id_value=account_id_value,
@@ -4005,6 +4025,7 @@ class ProxyService:
                     websocket=websocket,
                     client_send_lock=client_send_lock,
                     response_create_gate=response_create_gate,
+                    downstream_activity=downstream_activity,
                 )
                 break
         finally:
@@ -4100,19 +4121,18 @@ class ProxyService:
             stream_idle_timeout_seconds=stream_idle_timeout_seconds,
         )
 
-    async def _refresh_downstream_websocket_idle_started_at(
+    async def _downstream_websocket_is_idle(
         self,
         pending_requests: deque[_WebSocketRequestState],
         *,
         pending_lock: anyio.Lock,
-        idle_started_at: float | None,
-    ) -> float | None:
+        downstream_activity: _DownstreamWebSocketActivity,
+        idle_timeout_seconds: float,
+    ) -> bool:
         async with pending_lock:
             if pending_requests:
-                return None
-        if idle_started_at is not None:
-            return idle_started_at
-        return time.monotonic()
+                return False
+        return (time.monotonic() - downstream_activity.last_activity_at) >= idle_timeout_seconds
 
     async def _fail_expired_pending_websocket_requests(
         self,
@@ -4350,6 +4370,7 @@ class ProxyService:
         websocket: WebSocket | None = None,
         client_send_lock: anyio.Lock | None = None,
         response_create_gate: asyncio.Semaphore | None = None,
+        downstream_activity: _DownstreamWebSocketActivity | None = None,
     ) -> None:
         async with pending_lock:
             remaining = list(pending_requests)
@@ -4392,6 +4413,7 @@ class ProxyService:
                     error_message=request_error_message,
                     error_type=request_error_type,
                     error_param=request_error_param,
+                    downstream_activity=downstream_activity,
                 )
             await self._release_websocket_reservation(request_state.api_key_reservation)
             if account_id_value is None or request_state.skip_request_log:
@@ -4424,6 +4446,7 @@ class ProxyService:
         error_message: str,
         error_type: str = "server_error",
         error_param: str | None = None,
+        downstream_activity: _DownstreamWebSocketActivity | None = None,
     ) -> None:
         event = response_failed_event(
             error_code,
@@ -4433,10 +4456,48 @@ class ProxyService:
             error_param=error_param,
         )
         try:
-            async with client_send_lock:
-                await websocket.send_text(json.dumps(event, ensure_ascii=True, separators=(",", ":")))
+            await self._send_downstream_websocket_text(
+                websocket,
+                client_send_lock=client_send_lock,
+                text=json.dumps(event, ensure_ascii=True, separators=(",", ":")),
+                downstream_activity=downstream_activity,
+            )
         except Exception:
             logger.debug("Failed to emit websocket terminal error", exc_info=True)
+
+    async def _send_downstream_websocket_text(
+        self,
+        websocket: WebSocket,
+        *,
+        client_send_lock: anyio.Lock,
+        text: str,
+        downstream_activity: _DownstreamWebSocketActivity | None = None,
+    ) -> None:
+        if downstream_activity is not None:
+            downstream_activity.mark()
+        async with client_send_lock:
+            if downstream_activity is not None:
+                downstream_activity.mark()
+            await websocket.send_text(text)
+            if downstream_activity is not None:
+                downstream_activity.mark()
+
+    async def _send_downstream_websocket_bytes(
+        self,
+        websocket: WebSocket,
+        *,
+        client_send_lock: anyio.Lock,
+        data: bytes,
+        downstream_activity: _DownstreamWebSocketActivity | None = None,
+    ) -> None:
+        if downstream_activity is not None:
+            downstream_activity.mark()
+        async with client_send_lock:
+            if downstream_activity is not None:
+                downstream_activity.mark()
+            await websocket.send_bytes(data)
+            if downstream_activity is not None:
+                downstream_activity.mark()
 
     async def _reserve_websocket_api_key_usage(
         self,
@@ -5964,6 +6025,14 @@ class _HTTPBridgeSession:
 @dataclass(slots=True)
 class _WebSocketUpstreamControl:
     reconnect_requested: bool = False
+
+
+@dataclass(slots=True)
+class _DownstreamWebSocketActivity:
+    last_activity_at: float = field(default_factory=time.monotonic)
+
+    def mark(self) -> None:
+        self.last_activity_at = time.monotonic()
 
 
 @dataclass(slots=True)

--- a/app/modules/proxy/work_admission.py
+++ b/app/modules/proxy/work_admission.py
@@ -58,7 +58,7 @@ class WorkAdmissionController:
         if gate is None:
             return AdmissionLease(None)
         async with gate.lock:
-            if gate.semaphore._value <= 0:
+            if gate.semaphore.locked():
                 message = f"codex-lb is temporarily overloaded during {stage}"
                 logger.warning(
                     "proxy_admission_rejected request_id=%s stage=%s status=429 available=%s message=%s",
@@ -68,7 +68,7 @@ class WorkAdmissionController:
                     message,
                 )
                 raise ProxyResponseError(429, local_overload_error(message))
-            gate.semaphore._value -= 1
+            await gate.semaphore.acquire()
         return AdmissionLease(gate.semaphore)
 
 

--- a/app/modules/proxy/work_admission.py
+++ b/app/modules/proxy/work_admission.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+from asyncio import Semaphore
+from dataclasses import dataclass
+
+from app.core.clients.proxy import ProxyResponseError
+from app.core.resilience.overload import local_overload_error
+from app.core.utils.request_id import get_request_id
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class AdmissionLease:
+    _semaphore: Semaphore | None
+    _released: bool = False
+
+    def release(self) -> None:
+        if self._released or self._semaphore is None:
+            return
+        self._released = True
+        self._semaphore.release()
+
+
+class WorkAdmissionController:
+    def __init__(
+        self,
+        *,
+        token_refresh_limit: int,
+        websocket_connect_limit: int,
+        response_create_limit: int,
+        compact_response_create_limit: int,
+    ) -> None:
+        self._token_refresh = Semaphore(token_refresh_limit) if token_refresh_limit > 0 else None
+        self._websocket_connect = Semaphore(websocket_connect_limit) if websocket_connect_limit > 0 else None
+        self._response_create = Semaphore(response_create_limit) if response_create_limit > 0 else None
+        self._compact_response_create = (
+            Semaphore(compact_response_create_limit) if compact_response_create_limit > 0 else None
+        )
+
+    async def acquire_token_refresh(self) -> AdmissionLease:
+        return await self._acquire(self._token_refresh, stage="token_refresh")
+
+    async def acquire_websocket_connect(self) -> AdmissionLease:
+        return await self._acquire(self._websocket_connect, stage="upstream_websocket_connect")
+
+    async def acquire_response_create(self, *, compact: bool = False) -> AdmissionLease:
+        semaphore = self._compact_response_create if compact else self._response_create
+        stage = "compact_response_create" if compact else "response_create"
+        return await self._acquire(semaphore, stage=stage)
+
+    async def _acquire(self, semaphore: Semaphore | None, *, stage: str) -> AdmissionLease:
+        if semaphore is None:
+            return AdmissionLease(None)
+        if semaphore.locked():
+            message = f"codex-lb is temporarily overloaded during {stage}"
+            logger.warning(
+                "proxy_admission_rejected request_id=%s stage=%s status=429 available=%s message=%s",
+                get_request_id(),
+                stage,
+                0,
+                message,
+            )
+            raise ProxyResponseError(429, local_overload_error(message))
+        await semaphore.acquire()
+        return AdmissionLease(semaphore)

--- a/app/modules/proxy/work_admission.py
+++ b/app/modules/proxy/work_admission.py
@@ -41,9 +41,7 @@ class WorkAdmissionController:
         self._token_refresh = _make_gate(token_refresh_limit)
         self._websocket_connect = _make_gate(websocket_connect_limit)
         self._response_create = _make_gate(response_create_limit)
-        self._compact_response_create = (
-            _make_gate(compact_response_create_limit)
-        )
+        self._compact_response_create = _make_gate(compact_response_create_limit)
 
     async def acquire_token_refresh(self) -> AdmissionLease:
         return await self._acquire(self._token_refresh, stage="token_refresh")

--- a/app/modules/proxy/work_admission.py
+++ b/app/modules/proxy/work_admission.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import asyncio
 import logging
-from asyncio import Semaphore
 from dataclasses import dataclass
 
 from app.core.clients.proxy import ProxyResponseError
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class AdmissionLease:
-    _semaphore: Semaphore | None
+    _semaphore: asyncio.Semaphore | None
     _released: bool = False
 
     def release(self) -> None:
@@ -21,6 +21,12 @@ class AdmissionLease:
             return
         self._released = True
         self._semaphore.release()
+
+
+@dataclass(slots=True)
+class _AdmissionGate:
+    semaphore: asyncio.Semaphore
+    lock: asyncio.Lock
 
 
 class WorkAdmissionController:
@@ -32,11 +38,11 @@ class WorkAdmissionController:
         response_create_limit: int,
         compact_response_create_limit: int,
     ) -> None:
-        self._token_refresh = Semaphore(token_refresh_limit) if token_refresh_limit > 0 else None
-        self._websocket_connect = Semaphore(websocket_connect_limit) if websocket_connect_limit > 0 else None
-        self._response_create = Semaphore(response_create_limit) if response_create_limit > 0 else None
+        self._token_refresh = _make_gate(token_refresh_limit)
+        self._websocket_connect = _make_gate(websocket_connect_limit)
+        self._response_create = _make_gate(response_create_limit)
         self._compact_response_create = (
-            Semaphore(compact_response_create_limit) if compact_response_create_limit > 0 else None
+            _make_gate(compact_response_create_limit)
         )
 
     async def acquire_token_refresh(self) -> AdmissionLease:
@@ -50,18 +56,25 @@ class WorkAdmissionController:
         stage = "compact_response_create" if compact else "response_create"
         return await self._acquire(semaphore, stage=stage)
 
-    async def _acquire(self, semaphore: Semaphore | None, *, stage: str) -> AdmissionLease:
-        if semaphore is None:
+    async def _acquire(self, gate: _AdmissionGate | None, *, stage: str) -> AdmissionLease:
+        if gate is None:
             return AdmissionLease(None)
-        if semaphore.locked():
-            message = f"codex-lb is temporarily overloaded during {stage}"
-            logger.warning(
-                "proxy_admission_rejected request_id=%s stage=%s status=429 available=%s message=%s",
-                get_request_id(),
-                stage,
-                0,
-                message,
-            )
-            raise ProxyResponseError(429, local_overload_error(message))
-        await semaphore.acquire()
-        return AdmissionLease(semaphore)
+        async with gate.lock:
+            if gate.semaphore._value <= 0:
+                message = f"codex-lb is temporarily overloaded during {stage}"
+                logger.warning(
+                    "proxy_admission_rejected request_id=%s stage=%s status=429 available=%s message=%s",
+                    get_request_id(),
+                    stage,
+                    0,
+                    message,
+                )
+                raise ProxyResponseError(429, local_overload_error(message))
+            gate.semaphore._value -= 1
+        return AdmissionLease(gate.semaphore)
+
+
+def _make_gate(limit: int) -> _AdmissionGate | None:
+    if limit <= 0:
+        return None
+    return _AdmissionGate(semaphore=asyncio.Semaphore(limit), lock=asyncio.Lock())

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import logging
 import math
+import time
 from collections.abc import Awaitable, Callable, Collection
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -120,6 +121,7 @@ class _MergedAdditionalWindow:
 # entry). Used as a fast path to avoid DB queries on every pass within the same
 # process. Updated only after a successful refresh that wrote data.
 _last_successful_refresh: dict[str, datetime] = {}
+_usage_refresh_auth_cooldowns: dict[str, float] = {}
 
 
 class _UsageRefreshSingleflight:
@@ -184,8 +186,11 @@ class UsageUpdater:
         refreshed = False
         now = utcnow()
         interval = settings.usage_refresh_interval_seconds
+        _prune_usage_refresh_auth_cooldowns()
         for account in accounts:
             if account.status == AccountStatus.DEACTIVATED:
+                continue
+            if _is_usage_refresh_in_cooldown(account.id):
                 continue
             latest = latest_usage.get(account.id)
             if _latest_usage_is_fresh(latest, now=now, interval_seconds=interval):
@@ -227,6 +232,7 @@ class UsageUpdater:
                 # suppress retries within the interval.
                 if result.fetch_succeeded:
                     _last_successful_refresh[account.id] = now
+                    _clear_usage_refresh_auth_cooldown(account.id)
             except Exception as exc:
                 logger.warning(
                     "Usage refresh failed account_id=%s request_id=%s error=%s",
@@ -272,10 +278,12 @@ class UsageUpdater:
                 await self._deactivate_for_client_error(account, exc)
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
             if exc.status_code != 401 or not self._auth_manager:
+                _mark_usage_refresh_auth_cooldown(account.id, exc.status_code)
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
             try:
                 account = await self._auth_manager.ensure_fresh(account, force=True)
             except RefreshError:
+                _mark_usage_refresh_auth_cooldown(account.id, exc.status_code)
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
             access_token = self._encryptor.decrypt(account.access_token_encrypted)
             try:
@@ -286,6 +294,8 @@ class UsageUpdater:
             except UsageFetchError as retry_exc:
                 if _should_deactivate_for_usage_error(retry_exc):
                     await self._deactivate_for_client_error(account, retry_exc)
+                else:
+                    _mark_usage_refresh_auth_cooldown(account.id, retry_exc.status_code)
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
 
         if payload is None:
@@ -688,3 +698,37 @@ def _should_deactivate_for_usage_error(exc: UsageFetchError) -> bool:
         return True
     lowered = exc.message.lower()
     return any(hint in lowered for hint in _DEACTIVATING_USAGE_MESSAGE_HINTS)
+
+def _mark_usage_refresh_auth_cooldown(account_id: str, status_code: int) -> None:
+    if status_code not in {401, 403}:
+        return
+    cooldown_seconds = max(0.0, float(get_settings().usage_refresh_auth_failure_cooldown_seconds))
+    if cooldown_seconds <= 0:
+        return
+    _usage_refresh_auth_cooldowns[account_id] = time.monotonic() + cooldown_seconds
+
+
+def _is_usage_refresh_in_cooldown(account_id: str) -> bool:
+    expires_at = _usage_refresh_auth_cooldowns.get(account_id)
+    if expires_at is None:
+        return False
+    if expires_at > time.monotonic():
+        return True
+    _usage_refresh_auth_cooldowns.pop(account_id, None)
+    return False
+
+
+def _clear_usage_refresh_auth_cooldown(account_id: str) -> None:
+    _usage_refresh_auth_cooldowns.pop(account_id, None)
+
+
+def _prune_usage_refresh_auth_cooldowns() -> None:
+    now = time.monotonic()
+    stale = [account_id for account_id, expires_at in _usage_refresh_auth_cooldowns.items() if expires_at <= now]
+    for account_id in stale:
+        _usage_refresh_auth_cooldowns.pop(account_id, None)
+
+
+def _clear_usage_refresh_state() -> None:
+    _usage_refresh_auth_cooldowns.clear()
+    _last_successful_refresh.clear()

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -155,6 +155,9 @@ class _UsageRefreshSingleflight:
         if current is task:
             self._inflight.pop(account_id, None)
 
+    def clear(self) -> None:
+        self._inflight.clear()
+
 
 _USAGE_REFRESH_SINGLEFLIGHT = _UsageRefreshSingleflight()
 
@@ -732,3 +735,4 @@ def _prune_usage_refresh_auth_cooldowns() -> None:
 def _clear_usage_refresh_state() -> None:
     _usage_refresh_auth_cooldowns.clear()
     _last_successful_refresh.clear()
+    _USAGE_REFRESH_SINGLEFLIGHT.clear()

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -702,6 +702,7 @@ def _should_deactivate_for_usage_error(exc: UsageFetchError) -> bool:
     lowered = exc.message.lower()
     return any(hint in lowered for hint in _DEACTIVATING_USAGE_MESSAGE_HINTS)
 
+
 def _mark_usage_refresh_auth_cooldown(account_id: str, status_code: int) -> None:
     if status_code not in {401, 403}:
         return

--- a/openspec/changes/expire-idle-downstream-websockets/.openspec.yaml
+++ b/openspec/changes/expire-idle-downstream-websockets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-08

--- a/openspec/changes/expire-idle-downstream-websockets/proposal.md
+++ b/openspec/changes/expire-idle-downstream-websockets/proposal.md
@@ -1,0 +1,25 @@
+# Expire Idle Downstream Websockets
+
+## Why
+
+The Responses websocket proxy currently holds a `proxy_websocket` bulkhead slot for the entire downstream websocket lifetime. If a client leaks idle downstream websocket sessions or reconnects aggressively without cleaning up older sockets, those abandoned sessions can monopolize the websocket lane and cause repeated local `429` handshake rejections even when the upstream is healthy.
+
+The proxy already times out stalled upstream response streams, but it does not reclaim downstream websocket sessions that have no pending requests and no client traffic. That leaves the proxy vulnerable to long-lived idle sockets from one client process saturating the lane for everyone else.
+
+## What Changes
+
+- Add a configurable downstream websocket idle timeout for Responses websocket routes.
+- Close downstream websocket sessions after that timeout only when they have no pending requests.
+- Reclaim the associated upstream websocket session and downstream admission slot when an idle downstream websocket expires.
+- Add regression coverage for the idle-expiry behavior and the new runtime setting.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: define idle expiry behavior for downstream Responses websocket sessions so abandoned client sockets do not hold capacity indefinitely.
+
+## Impact
+
+- Code: `app/core/config/settings.py`, `app/modules/proxy/service.py`
+- Tests: `tests/integration/test_proxy_websocket_responses.py`, `tests/unit/test_settings_multi_replica.py`

--- a/openspec/changes/expire-idle-downstream-websockets/specs/responses-api-compat/spec.md
+++ b/openspec/changes/expire-idle-downstream-websockets/specs/responses-api-compat/spec.md
@@ -1,0 +1,11 @@
+### MODIFIED Requirements
+
+### Requirement: Websocket responses advertise and honor Codex turn-state affinity
+When serving websocket Responses endpoints, the service MUST advertise an `x-codex-turn-state` header during websocket accept. If the client reconnects and presents that same `x-codex-turn-state`, the service MUST treat it as the highest-priority Codex-affinity key for upstream routing on that websocket turn. On `/v1/responses`, a proxy-generated turn-state MUST NOT override the first request's prompt-cache routing unless the client explicitly sends the turn-state back. When a downstream websocket session has no pending requests and receives no client traffic for the configured downstream idle timeout, the service MUST close that downstream websocket session and release any associated upstream session state.
+
+#### Scenario: idle downstream websocket session is reclaimed
+- **WHEN** a client opens a websocket Responses route
+- **AND** the session has no pending requests
+- **AND** no client traffic arrives before the configured downstream idle timeout elapses
+- **THEN** the service closes the downstream websocket session
+- **AND** it releases the associated upstream websocket session instead of holding proxy websocket capacity indefinitely

--- a/openspec/changes/expire-idle-downstream-websockets/tasks.md
+++ b/openspec/changes/expire-idle-downstream-websockets/tasks.md
@@ -1,0 +1,14 @@
+## 1. Specs
+
+- [x] 1.1 Add `responses-api-compat` requirements for downstream websocket idle expiry.
+- [x] 1.2 Validate OpenSpec changes.
+
+## 2. Tests
+
+- [x] 2.1 Add websocket integration coverage for idle downstream-session expiry.
+- [x] 2.2 Add settings coverage for the downstream websocket idle-timeout default and env override.
+
+## 3. Implementation
+
+- [x] 3.1 Add a configurable downstream websocket idle-timeout setting.
+- [x] 3.2 Expire idle downstream Responses websockets only when no requests are pending, and ensure normal cleanup releases the upstream socket and lane capacity.

--- a/openspec/changes/stabilize-proxy-admission-and-usage-refresh/.openspec.yaml
+++ b/openspec/changes/stabilize-proxy-admission-and-usage-refresh/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/stabilize-proxy-admission-and-usage-refresh/design.md
+++ b/openspec/changes/stabilize-proxy-admission-and-usage-refresh/design.md
@@ -1,0 +1,86 @@
+## Context
+
+This incident exposed two different problems:
+
+1. Downstream admission fairness: one shared proxy semaphore treats long-lived websockets and short HTTP requests the same, so websocket occupancy can starve compact and HTTP request paths.
+2. Upstream expensive-work amplification: even after a request clears downstream admission, it can still pile up on token refresh, upstream websocket connect, or first-turn creation.
+
+The usage scheduler has a related resilience gap: repeated usage `401` or `403` failures keep retrying without either deactivating clearly dead accounts or backing off ambiguous failures.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent websocket sessions from starving HTTP proxy traffic.
+- Preserve a compact lane under heavy mixed traffic.
+- Surface local overload clearly in both HTTP and websocket handshake flows.
+- Bound concurrency for token refresh, websocket connect, and response-create admission.
+- Reduce refresh retry storms with per-account singleflight and short failure caching.
+- Deactivate accounts on clear usage deactivation signals and cool down repeated ambiguous auth failures.
+
+**Non-Goals:**
+- Introduce a distributed admission controller across replicas.
+- Redesign account-selection strategy or upstream failover policy.
+- Persist usage-refresh cooldown state in the database.
+
+## Decisions
+
+### Split downstream proxy admission by traffic class
+
+The middleware bulkhead will expose separate semaphores for:
+
+- proxy HTTP requests
+- proxy websocket sessions
+- compact HTTP requests
+- dashboard/API traffic
+
+Compact requests get their own lane instead of sharing the general HTTP pool so short bootstrap requests remain available during websocket-heavy traffic.
+
+### Deny websocket handshakes with HTTP responses, not close frames
+
+When local admission rejects a websocket handshake, the middleware will return an HTTP denial response with the real overload status and OpenAI-style error payload. This removes the current ambiguous `403` access-log signal caused by pre-accept websocket closes.
+
+### Add a second-stage work admission controller
+
+`ProxyService` will own an in-process controller that separately limits:
+
+- token refresh work
+- upstream websocket connect work
+- first-turn response creation
+
+The controller is global to the process, not per account. This is a deliberate first step: it bounds the most expensive shared work without introducing cross-replica coordination or account-sharing bugs.
+
+### Reuse existing first-turn lifecycle hooks for response-create admission
+
+The websocket and HTTP bridge flows already track `awaiting_response_created` and release a per-session gate when `response.created` arrives or the request fails. The new response-create admission slot will piggyback on that lifecycle so permits release on the same terminal paths.
+
+### Singleflight forced refreshes with a short failure TTL
+
+Per-account refresh attempts will share one in-flight refresh task. If that refresh fails, subsequent callers within a short cooldown window will reuse the failure instead of immediately reissuing another refresh request upstream.
+
+### Cool down ambiguous usage auth failures, but deactivate clear deactivation signals
+
+Background usage refresh will:
+
+- deactivate on `402` and `404` as before
+- deactivate on `401` when the upstream message clearly indicates the OpenAI account has been deactivated
+- apply an in-memory cooldown for repeated `401` and `403` usage failures that are not clear deactivation signals
+
+This avoids repeated scheduler noise without deactivating accounts on generic auth glitches.
+
+## Risks / Trade-offs
+
+- Separate downstream lanes can increase total in-flight work if operators keep all limits high. Mitigation: default websocket and compact lanes remain bounded and independently configurable.
+- In-process work admission does not coordinate across replicas. Mitigation: this still protects a single pod from self-induced overload and is a clean foundation for later distributed coordination if needed.
+- Usage cooldown is memory-only, so a restart forgets the backoff state. Mitigation: that is acceptable for scheduler hygiene and avoids a schema change.
+
+## Migration Plan
+
+1. Add new settings with backward-compatible defaults derived from the existing proxy bulkhead limit.
+2. Deploy downstream lane splitting and explicit overload responses first.
+3. Deploy second-stage work admission and refresh singleflight/failure TTL.
+4. Deploy usage-refresh cooldown and deactivation-signal handling.
+5. Verify with targeted middleware, proxy, and usage tests plus `openspec validate --specs`.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/stabilize-proxy-admission-and-usage-refresh/proposal.md
+++ b/openspec/changes/stabilize-proxy-admission-and-usage-refresh/proposal.md
@@ -1,0 +1,35 @@
+# Stabilize Proxy Admission And Usage Refresh
+
+## Why
+
+The proxy currently mixes short-lived HTTP requests and long-lived websocket sessions into one downstream bulkhead, so active websocket sessions can starve `/backend-api/codex/responses` and `/backend-api/codex/responses/compact` before those requests ever reach the proxy handlers. Those local rejections are hard to distinguish from upstream failures because they return generic overload responses and websocket handshake denials appear as `403` in the access log.
+
+The proxy also lacks a second-stage admission controller around the most expensive upstream work. Concurrent token refreshes, upstream websocket connects, and first-turn response creation can amplify overload and retry storms even after downstream admission succeeds.
+
+On the usage side, background refresh keeps retrying some accounts that return usage `401` or `403` indefinitely. When upstream explicitly says the account has been deactivated, the account should be deactivated locally. When the error is transient or ambiguous, the scheduler should back off instead of hammering the same account every cycle.
+
+## What Changes
+
+- Split downstream proxy admission into separate HTTP, websocket-session, and compact-request lanes.
+- Return explicit local-overload error payloads and `Retry-After` headers for admission rejections, including websocket handshake denials.
+- Add second-stage admission controls around token refresh, upstream websocket connect, and first-turn response creation.
+- Reserve a compact lane so `/responses/compact` stays available during heavy chat traffic.
+- Reduce retry amplification by singleflighting token refreshes and short-circuiting rapid repeat failures.
+- Add usage-refresh cooldown for repeated auth-like failures and treat deactivation-signaling `401` messages as permanent account deactivation.
+- Emit operator-visible logs for local admission rejections with the rejection stage and capacity lane.
+
+## Capabilities
+
+### New Capabilities
+
+- `proxy-admission-control`: define downstream and expensive-work admission policies, overload responses, and compact protection.
+- `usage-refresh-policy`: define cooldown and deactivation behavior for background usage refresh failures.
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: log local admission rejections with explicit rejection metadata.
+
+## Impact
+
+- Code: `app/core/config/settings.py`, `app/core/resilience/bulkhead.py`, `app/main.py`, `app/modules/accounts/auth_manager.py`, `app/modules/proxy/service.py`, `app/modules/usage/updater.py`
+- Tests: bulkhead middleware tests, proxy service unit tests, auth manager tests, usage updater tests, settings tests

--- a/openspec/changes/stabilize-proxy-admission-and-usage-refresh/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/stabilize-proxy-admission-and-usage-refresh/specs/proxy-admission-control/spec.md
@@ -1,0 +1,47 @@
+# proxy-admission-control Specification
+
+## Purpose
+Define how the proxy protects itself under load while preserving short request paths and surfacing local overload clearly.
+
+## Requirements
+### Requirement: Downstream proxy admission is split by traffic class
+
+The system MUST enforce independent downstream admission limits for proxy HTTP requests, proxy websocket sessions, compact HTTP requests, and dashboard traffic. Exhausting one proxy lane MUST NOT consume capacity from the others.
+
+#### Scenario: Websocket session load does not starve HTTP responses
+- **WHEN** the proxy websocket admission lane is full
+- **THEN** new websocket sessions are rejected locally
+- **AND** eligible proxy HTTP requests may still proceed if their own lane has capacity
+
+#### Scenario: Compact lane survives general proxy load
+- **WHEN** the general proxy HTTP lane is saturated
+- **AND** the compact lane still has capacity
+- **THEN** `/backend-api/codex/responses/compact` and `/v1/responses/compact` requests continue to be admitted
+
+### Requirement: Local overload responses are explicit
+
+When the proxy rejects a request locally because an admission lane or expensive-work stage is full, it MUST return a local-overload response with a `Retry-After` header. HTTP requests MUST use an OpenAI-style error envelope and websocket handshake denials MUST use an HTTP denial response instead of a pre-accept close frame.
+
+#### Scenario: HTTP admission rejection returns explicit overload envelope
+- **WHEN** a proxy HTTP request is rejected locally for overload
+- **THEN** the response status is `429`
+- **AND** the response includes `Retry-After`
+- **AND** the error payload identifies the failure as local proxy overload instead of upstream unavailability
+
+#### Scenario: Websocket handshake rejection returns explicit overload status
+- **WHEN** a websocket handshake is rejected locally for overload
+- **THEN** the client receives an HTTP denial response with the real overload status
+- **AND** the server access log reflects that overload status instead of `403 Forbidden`
+
+### Requirement: Expensive upstream work is admission controlled
+
+The proxy MUST enforce separate in-process admission limits for token refresh, upstream websocket connect, and first-turn response creation.
+
+#### Scenario: Token refresh admission rejects excess work
+- **WHEN** concurrent forced token refresh work reaches the configured refresh limit
+- **THEN** additional refresh attempts are rejected locally with an explicit overload response
+
+#### Scenario: Response creation admission releases after first upstream acceptance
+- **WHEN** the proxy is waiting for an upstream response to be created
+- **THEN** that request holds a response-create admission slot
+- **AND** the slot is released when the request receives `response.created` or fails before creation completes

--- a/openspec/changes/stabilize-proxy-admission-and-usage-refresh/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/stabilize-proxy-admission-and-usage-refresh/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,8 @@
+## MODIFIED Requirements
+### Requirement: Proxy 4xx/5xx responses are logged with error detail
+When the proxy returns a 4xx or 5xx response for a proxied request, the system MUST log the request id, method, path, status code, error code, and error message to the console. For local admission rejections, the log MUST also include the rejection stage or lane.
+
+#### Scenario: Local admission rejection is logged
+- **WHEN** the proxy rejects a request locally because a downstream or expensive-work admission lane is full
+- **THEN** the console log includes the local response status, normalized error code and message
+- **AND** it includes which admission lane or stage rejected the request

--- a/openspec/changes/stabilize-proxy-admission-and-usage-refresh/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/stabilize-proxy-admission-and-usage-refresh/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,29 @@
+# usage-refresh-policy Specification
+
+## Purpose
+Define how background usage refresh reacts to auth-like failures without permanently hammering bad accounts.
+
+## Requirements
+### Requirement: Usage refresh cools down repeated auth-like failures
+
+Background usage refresh MUST apply a cooldown to accounts that repeatedly fail usage refresh with ambiguous `401` or `403` responses. Accounts in that cooldown window MUST be skipped until the cooldown expires or a later successful refresh clears it.
+
+#### Scenario: Ambiguous usage 401 enters cooldown
+- **WHEN** usage refresh receives a `401` that does not match a permanent deactivation signal
+- **THEN** the account is not deactivated immediately
+- **AND** subsequent refresh cycles skip the account until the cooldown window expires
+
+#### Scenario: Successful refresh clears cooldown
+- **WHEN** a later usage refresh succeeds for an account that had been cooled down
+- **THEN** the cooldown is cleared
+- **AND** normal refresh cadence resumes
+
+### Requirement: Usage refresh deactivates on clear deactivation signals
+
+The system MUST deactivate accounts when usage refresh receives a permanent deactivation signal. At minimum, `402`, `404`, and `401` responses whose message explicitly indicates that the OpenAI account has been deactivated MUST be treated as deactivation signals.
+
+#### Scenario: Usage 401 deactivation message deactivates the account
+- **WHEN** usage refresh receives HTTP `401`
+- **AND** the upstream message states that the OpenAI account has been deactivated
+- **THEN** the account is marked `deactivated`
+- **AND** later usage refresh cycles skip that account

--- a/openspec/changes/stabilize-proxy-admission-and-usage-refresh/tasks.md
+++ b/openspec/changes/stabilize-proxy-admission-and-usage-refresh/tasks.md
@@ -1,0 +1,23 @@
+## 1. Specs
+
+- [x] 1.1 Add `proxy-admission-control` requirements for split downstream lanes, compact protection, and explicit overload responses.
+- [x] 1.2 Add `usage-refresh-policy` requirements for cooldown and `401` deactivation-signal handling.
+- [x] 1.3 Extend `proxy-runtime-observability` with local admission rejection logging requirements.
+- [x] 1.4 Validate OpenSpec changes.
+
+## 2. Tests
+
+- [x] 2.1 Add bulkhead middleware regression coverage for split lanes and websocket HTTP denial responses.
+- [x] 2.2 Add proxy service unit coverage for response-create admission and local-overload surfacing.
+- [x] 2.3 Add auth manager regression coverage for refresh singleflight and short failure caching.
+- [x] 2.4 Add usage updater regression coverage for cooldown and `401` deactivation-signal handling.
+- [x] 2.5 Add settings coverage for the new admission-control defaults and env overrides.
+
+## 3. Implementation
+
+- [x] 3.1 Add configurable downstream admission lanes for proxy HTTP, proxy websocket, compact HTTP, and dashboard traffic.
+- [x] 3.2 Return explicit local-overload envelopes and `Retry-After` on HTTP and websocket-handshake admission rejections.
+- [x] 3.3 Add second-stage admission controls around token refresh, upstream websocket connect, and first-turn response creation.
+- [x] 3.4 Singleflight forced refreshes and short-circuit rapid repeat failures.
+- [x] 3.5 Add usage-refresh cooldown for repeated `401`/`403` failures and deactivate on deactivation-signaling `401` messages.
+- [x] 3.6 Emit structured logs for local admission rejections.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -116,6 +116,22 @@ async def _wait_for_event(event: asyncio.Event, *, timeout: float = _TEST_SYNC_T
     await asyncio.wait_for(event.wait(), timeout=timeout)
 
 
+async def _replace_http_bridge_upstream_reader(
+    service: proxy_module.ProxyService,
+    session: proxy_module._HTTPBridgeSession,
+    upstream: proxy_module.UpstreamResponsesWebSocket,
+) -> None:
+    reader = session.upstream_reader
+    if reader is not None:
+        reader.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reader
+    session.upstream = upstream
+    session.closed = False
+    session.upstream_control = proxy_module._WebSocketUpstreamControl()
+    session.upstream_reader = asyncio.create_task(service._relay_http_bridge_upstream_messages(session))
+
+
 class _SettingsCache:
     def __init__(self, settings: DashboardSettings) -> None:
         self._settings = settings
@@ -6629,7 +6645,11 @@ async def test_v1_responses_http_bridge_precreated_disconnect_returns_previous_r
     service = get_proxy_service_for_app(app_instance)
     async with service._http_bridge_lock:
         session = next(iter(service._http_bridge_sessions.values()))
-        session.upstream = cast(proxy_module.UpstreamResponsesWebSocket, precreated_close_upstream)
+        await _replace_http_bridge_upstream_reader(
+            service,
+            session,
+            cast(proxy_module.UpstreamResponsesWebSocket, precreated_close_upstream),
+        )
 
     second = await async_client.post(
         "/v1/responses",

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -2098,6 +2098,7 @@ async def test_v1_responses_http_bridge_reconnect_uses_last_upstream_turn_state(
         api_key_reservation=None,
         started_at=time.monotonic(),
         awaiting_response_created=True,
+        response_create_gate_acquired=True,
         request_text=json.dumps({"type": "response.create", "model": "gpt-5.4", "input": []}),
     )
     await service._reconnect_http_bridge_session(bridge_session, request_state=request_state)
@@ -2221,6 +2222,7 @@ async def test_v1_responses_http_bridge_session_id_reconnect_keeps_upstream_turn
         api_key_reservation=None,
         started_at=time.monotonic(),
         awaiting_response_created=True,
+        response_create_gate_acquired=True,
         request_text=json.dumps({"type": "response.create", "model": "gpt-5.4", "input": []}),
     )
     await service._reconnect_http_bridge_session(bridge_session, request_state=request_state)
@@ -2491,6 +2493,7 @@ async def test_v1_responses_http_bridge_reconnect_fails_when_reader_cancel_times
         api_key_reservation=None,
         started_at=time.monotonic(),
         awaiting_response_created=True,
+        response_create_gate_acquired=True,
         request_text=json.dumps({"type": "response.create", "model": "gpt-5.4", "input": []}),
     )
 
@@ -4679,6 +4682,7 @@ async def test_v1_responses_http_bridge_does_not_evict_active_session_when_pool_
                 api_key_reservation=None,
                 started_at=time.monotonic(),
                 awaiting_response_created=True,
+                response_create_gate_acquired=True,
                 event_queue=asyncio.Queue(),
                 transport="http",
             )
@@ -6332,6 +6336,7 @@ async def test_retry_http_bridge_precreated_request_releases_pending_lock_before
         api_key_reservation=None,
         started_at=time.monotonic(),
         awaiting_response_created=True,
+        response_create_gate_acquired=True,
         request_text=json.dumps({"type": "response.create", "model": "gpt-5.1", "input": []}),
     )
     session.pending_requests.append(request_state)

--- a/tests/integration/test_multi_replica.py
+++ b/tests/integration/test_multi_replica.py
@@ -40,6 +40,18 @@ async def test_cross_instance_rate_limiting(db_session):
 
 
 @pytest.mark.asyncio
+async def test_check_and_increment_records_first_password_attempt(db_session):
+    from app.core.rate_limiter.db_rate_limiter import DatabaseRateLimiter
+
+    limiter = DatabaseRateLimiter(max_attempts=8, window_seconds=300, type="password")
+    key = "test-password-login"
+
+    await limiter.check_and_increment(key, db_session)
+    await limiter.clear_for_key(key, db_session)
+    await limiter.check_and_increment(key, db_session)
+
+
+@pytest.mark.asyncio
 async def test_settings_cache_consistency(db_session):
     from app.core.config.settings_cache import get_settings_cache
 

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -59,6 +59,10 @@ def _disable_http_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
         log_proxy_request_shape_raw_cache_key=False,
         log_proxy_service_tier_trace=False,
         stream_idle_timeout_seconds=300.0,
+        proxy_token_refresh_limit=32,
+        proxy_upstream_websocket_connect_limit=64,
+        proxy_response_create_limit=64,
+        proxy_compact_response_create_limit=16,
     )
     dashboard_settings = DashboardSettings(
         id=1,

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -109,6 +109,10 @@ def _install_proxy_settings_cache(
         http_responses_session_bridge_queue_limit=8,
         http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
         http_responses_session_bridge_gateway_safe_mode=False,
+        proxy_token_refresh_limit=32,
+        proxy_upstream_websocket_connect_limit=64,
+        proxy_response_create_limit=64,
+        proxy_compact_response_create_limit=16,
     )
     monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_module, "get_settings", lambda: settings)

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1761,7 +1761,7 @@ def test_backend_responses_websocket_does_not_expire_downstream_while_request_pe
                 ),
             ),
         ],
-        delays=[0.05, 0.0],
+        delays=[0.05, 0.05],
     )
     log_calls: list[dict[str, object]] = []
 
@@ -1770,7 +1770,7 @@ def test_backend_responses_websocket_does_not_expire_downstream_while_request_pe
             return _websocket_settings()
 
     runtime_settings = _websocket_settings(
-        proxy_downstream_websocket_idle_timeout_seconds=0.01,
+        proxy_downstream_websocket_idle_timeout_seconds=0.02,
         stream_idle_timeout_seconds=0.2,
     )
 

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1654,7 +1654,7 @@ def test_backend_responses_websocket_reclaims_idle_downstream_session_and_upstre
         async def get(self):
             return _websocket_settings()
 
-    runtime_settings = _websocket_settings(proxy_downstream_websocket_idle_timeout_seconds=0.01)
+    runtime_settings = _websocket_settings(proxy_downstream_websocket_idle_timeout_seconds=0.1)
 
     async def allow_firewall(_websocket):
         return None

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -98,6 +98,10 @@ def _websocket_settings(**overrides):
         "stream_idle_timeout_seconds": 300.0,
         "log_proxy_request_shape": False,
         "log_proxy_request_shape_raw_cache_key": False,
+        "proxy_token_refresh_limit": 32,
+        "proxy_upstream_websocket_connect_limit": 64,
+        "proxy_response_create_limit": 64,
+        "proxy_compact_response_create_limit": 16,
     }
     values.update(overrides)
     return SimpleNamespace(**values)

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
@@ -87,6 +88,17 @@ class _FailingSendUpstreamWebSocket(_FakeUpstreamWebSocket):
         raise RuntimeError("socket closed during send")
 
 
+class _DelayedUpstreamWebSocket(_FakeUpstreamWebSocket):
+    def __init__(self, messages: list[_FakeUpstreamMessage], *, delays: list[float]) -> None:
+        super().__init__(messages)
+        self._delays = deque(delays)
+
+    async def receive(self) -> _FakeUpstreamMessage:
+        if self._delays:
+            await asyncio.sleep(self._delays.popleft())
+        return await super().receive()
+
+
 def _websocket_settings(**overrides):
     values = {
         "prefer_earlier_reset_accounts": False,
@@ -96,6 +108,7 @@ def _websocket_settings(**overrides):
         "routing_strategy": "usage_weighted",
         "proxy_request_budget_seconds": 75.0,
         "stream_idle_timeout_seconds": 300.0,
+        "proxy_downstream_websocket_idle_timeout_seconds": 120.0,
         "log_proxy_request_shape": False,
         "log_proxy_request_shape_raw_cache_key": False,
         "proxy_token_refresh_limit": 32,
@@ -1607,6 +1620,230 @@ def test_backend_responses_websocket_keeps_downstream_open_after_clean_upstream_
     assert [event["type"] for event in first_events] == ["response.created", "response.completed"]
     assert [event["type"] for event in second_events] == ["response.created", "response.completed"]
     assert connect_models == ["gpt-5.4", "gpt-5.5"]
+
+
+def test_backend_responses_websocket_reclaims_idle_downstream_session_and_upstream(app_instance, monkeypatch):
+    fake_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": "resp_ws_idle_client", "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_idle_client",
+                            "status": "completed",
+                            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+    log_calls: list[dict[str, object]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    runtime_settings = _websocket_settings(proxy_downstream_websocket_idle_timeout_seconds=0.01)
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return SimpleNamespace(id="acct_ws_proxy"), fake_upstream
+
+    async def fake_write_request_log(self, **kwargs):
+        del self
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: runtime_settings)
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            created_event = json.loads(websocket.receive_text())
+            completed_event = json.loads(websocket.receive_text())
+
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                websocket.receive_text()
+
+    assert created_event["type"] == "response.created"
+    assert completed_event["type"] == "response.completed"
+    assert exc_info.value.code == 1001
+    assert exc_info.value.reason == "Idle downstream websocket timeout"
+    assert fake_upstream.closed is True
+    assert len(log_calls) == 1
+    assert log_calls[0]["request_id"] == "resp_ws_idle_client"
+    assert log_calls[0]["status"] == "success"
+
+
+def test_backend_responses_websocket_does_not_expire_downstream_while_request_pending(app_instance, monkeypatch):
+    fake_upstream = _DelayedUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_ws_pending", "status": "in_progress"},
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_pending",
+                            "status": "completed",
+                            "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5},
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ],
+        delays=[0.05, 0.0],
+    )
+    log_calls: list[dict[str, object]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    runtime_settings = _websocket_settings(
+        proxy_downstream_websocket_idle_timeout_seconds=0.01,
+        stream_idle_timeout_seconds=0.2,
+    )
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return SimpleNamespace(id="acct_ws_proxy"), fake_upstream
+
+    async def fake_write_request_log(self, **kwargs):
+        del self
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: runtime_settings)
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            created_event = json.loads(websocket.receive_text())
+            completed_event = json.loads(websocket.receive_text())
+
+    assert created_event["type"] == "response.created"
+    assert completed_event["type"] == "response.completed"
+    assert fake_upstream.closed is True
+    assert len(log_calls) == 1
+    assert log_calls[0]["request_id"] == "resp_ws_pending"
+    assert log_calls[0]["status"] == "success"
 
 
 def test_backend_responses_websocket_reconnects_after_account_health_failure(app_instance, monkeypatch):

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -336,3 +336,39 @@ async def test_refresh_account_does_not_deactivate_when_repo_has_newer_refresh_t
     assert exc_info.value.is_permanent is False
     assert repo.status_payload is None
     assert stale_account.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_refresh_account_deactivates_when_repo_only_reencrypted_same_refresh_token(monkeypatch):
+    async def _fake_refresh(_: str) -> TokenRefreshResult:
+        raise RefreshError("invalid_grant", "refresh failed", True)
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    stale_account = Account(
+        id="acc_same_token_reencrypted",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-same"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    repo = _DummyRepo()
+    latest_account = Account(
+        **{column.name: getattr(stale_account, column.name) for column in Account.__table__.columns}
+    )
+    latest_account.refresh_token_encrypted = encryptor.encrypt("refresh-same")
+    repo.accounts_by_id[stale_account.id] = latest_account
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    with pytest.raises(RefreshError) as exc_info:
+        await manager.refresh_account(stale_account)
+
+    assert exc_info.value.is_permanent is True
+    assert repo.status_payload is not None
+    assert repo.status_payload["status"] == AccountStatus.DEACTIVATED

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
 
-from app.core.auth.refresh import TokenRefreshResult
+from app.core.auth.refresh import RefreshError, TokenRefreshResult
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
@@ -15,9 +17,19 @@ from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManage
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture(autouse=True)
+def _clear_refresh_state() -> None:
+    auth_manager_module._clear_refresh_singleflight_state()
+
+
 class _DummyRepo:
     def __init__(self) -> None:
         self.tokens_payload: dict[str, object] | None = None
+        self.status_payload: dict[str, object] | None = None
+        self.accounts_by_id: dict[str, Account] = {}
+
+    async def get_by_id(self, account_id: str) -> Account | None:
+        return self.accounts_by_id.get(account_id)
 
     async def update_status(
         self,
@@ -27,6 +39,11 @@ class _DummyRepo:
         reset_at: int | None = None,
         blocked_at: int | None = None,
     ) -> bool:
+        self.status_payload = {
+            "account_id": account_id,
+            "status": status,
+            "deactivation_reason": deactivation_reason,
+        }
         return True
 
     async def update_tokens(
@@ -87,3 +104,235 @@ async def test_refresh_account_preserves_plan_type_when_missing(monkeypatch):
     assert updated.plan_type == "pro"
     assert repo.tokens_payload is not None
     assert repo.tokens_payload["plan_type"] == "pro"
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_singleflights_concurrent_refreshes(monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    refresh_calls = 0
+
+    async def _fake_refresh(_: str) -> TokenRefreshResult:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        started.set()
+        await release.wait()
+        return TokenRefreshResult(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            id_token="new-id",
+            account_id="acc_sf",
+            plan_type="plus",
+            email=None,
+        )
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    account_a = Account(
+        id="acc_sf",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    account_b = Account(**{column.name: getattr(account_a, column.name) for column in Account.__table__.columns})
+    repo = _DummyRepo()
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    first = asyncio.create_task(manager.ensure_fresh(account_a, force=True))
+    await started.wait()
+    second = asyncio.create_task(manager.ensure_fresh(account_b, force=True))
+    await asyncio.sleep(0.01)
+    assert not second.done()
+
+    release.set()
+    await asyncio.gather(first, second)
+
+    assert refresh_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_singleflights_refresh_admission_for_same_account(monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    refresh_calls = 0
+    admission_calls = 0
+
+    async def _fake_refresh(_: str) -> TokenRefreshResult:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        started.set()
+        await release.wait()
+        return TokenRefreshResult(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            id_token="new-id",
+            account_id="acc_sf_admission",
+            plan_type="plus",
+            email=None,
+        )
+
+    async def _acquire_refresh_admission():
+        nonlocal admission_calls
+        admission_calls += 1
+        return SimpleNamespace(release=lambda: None)
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    account_a = Account(
+        id="acc_sf_admission",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    account_b = Account(**{column.name: getattr(account_a, column.name) for column in Account.__table__.columns})
+    repo = _DummyRepo()
+    manager = AuthManager(
+        cast(AccountsRepositoryPort, repo),
+        acquire_refresh_admission=_acquire_refresh_admission,
+    )
+
+    first = asyncio.create_task(manager.ensure_fresh(account_a, force=True))
+    await started.wait()
+    second = asyncio.create_task(manager.ensure_fresh(account_b, force=True))
+    await asyncio.sleep(0.01)
+    assert not second.done()
+
+    release.set()
+    await asyncio.gather(first, second)
+
+    assert refresh_calls == 1
+    assert admission_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_reuses_recent_failure_without_reissuing_refresh(monkeypatch):
+    refresh_calls = 0
+
+    async def _fake_refresh(_: str) -> TokenRefreshResult:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        raise RefreshError("invalid_grant", "refresh failed", False)
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+    monkeypatch.setattr(
+        auth_manager_module,
+        "get_settings",
+        lambda: SimpleNamespace(proxy_refresh_failure_cooldown_seconds=30.0),
+    )
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    account = Account(
+        id="acc_fail_cache",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    repo = _DummyRepo()
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    with pytest.raises(RefreshError):
+        await manager.ensure_fresh(account, force=True)
+    with pytest.raises(RefreshError):
+        await manager.ensure_fresh(account, force=True)
+
+    assert refresh_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_does_not_reuse_failure_after_refresh_token_changes(monkeypatch):
+    refresh_calls = 0
+
+    async def _fake_refresh(refresh_token: str) -> TokenRefreshResult:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        raise RefreshError("invalid_grant", f"refresh failed for {refresh_token}", False)
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+    monkeypatch.setattr(
+        auth_manager_module,
+        "get_settings",
+        lambda: SimpleNamespace(proxy_refresh_failure_cooldown_seconds=30.0),
+    )
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    account = Account(
+        id="acc_fail_cache_versioned",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    repo = _DummyRepo()
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    with pytest.raises(RefreshError):
+        await manager.ensure_fresh(account, force=True)
+
+    account.refresh_token_encrypted = encryptor.encrypt("refresh-new")
+
+    with pytest.raises(RefreshError) as exc_info:
+        await manager.ensure_fresh(account, force=True)
+
+    assert exc_info.value.message == "refresh failed for refresh-new"
+    assert refresh_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_account_does_not_deactivate_when_repo_has_newer_refresh_token(monkeypatch):
+    async def _fake_refresh(_: str) -> TokenRefreshResult:
+        raise RefreshError("invalid_grant", "refresh failed", True)
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    stale_account = Account(
+        id="acc_stale_snapshot",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    repo = _DummyRepo()
+    latest_account = Account(
+        **{column.name: getattr(stale_account, column.name) for column in Account.__table__.columns}
+    )
+    latest_account.refresh_token_encrypted = encryptor.encrypt("refresh-new")
+    repo.accounts_by_id[stale_account.id] = latest_account
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    with pytest.raises(RefreshError) as exc_info:
+        await manager.refresh_account(stale_account)
+
+    assert exc_info.value.is_permanent is False
+    assert repo.status_payload is None
+    assert stale_account.status == AccountStatus.ACTIVE

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -330,10 +330,9 @@ async def test_refresh_account_does_not_deactivate_when_repo_has_newer_refresh_t
     repo.accounts_by_id[stale_account.id] = latest_account
     manager = AuthManager(cast(AccountsRepositoryPort, repo))
 
-    with pytest.raises(RefreshError) as exc_info:
-        await manager.refresh_account(stale_account)
+    result = await manager.refresh_account(stale_account)
 
-    assert exc_info.value.is_permanent is False
+    assert result is latest_account
     assert repo.status_payload is None
     assert stale_account.status == AccountStatus.ACTIVE
 

--- a/tests/unit/test_backpressure.py
+++ b/tests/unit/test_backpressure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any, cast
 
 import pytest
@@ -52,7 +53,7 @@ async def test_backpressure_returns_429_when_at_capacity():
         first_response = await first_request
 
     assert overloaded.status_code == 429
-    assert overloaded.json() == {"detail": "Too Many Requests"}
+    assert overloaded.json() == {"detail": "codex-lb is temporarily overloaded by local backpressure"}
     assert overloaded.headers["retry-after"] == "5"
     assert first_response.status_code == 200
 
@@ -88,7 +89,7 @@ async def test_backpressure_exempts_health_live_even_at_capacity():
 
 
 @pytest.mark.asyncio
-async def test_backpressure_websocket_rejects_with_close_when_at_capacity():
+async def test_backpressure_websocket_rejects_with_http_response_when_at_capacity():
     app_called = False
 
     async def inner_app(scope, receive, send):
@@ -121,10 +122,46 @@ async def test_backpressure_websocket_rejects_with_close_when_at_capacity():
         middleware._semaphore.release()
 
     assert app_called is False
-    assert sent_events == [
-        {
-            "type": "websocket.close",
-            "code": 1013,
-            "reason": "Too Many Requests",
-        }
-    ]
+    assert sent_events[0]["type"] == "websocket.http.response.start"
+    assert sent_events[0]["status"] == 429
+    assert sent_events[1]["type"] == "websocket.http.response.body"
+    payload = json.loads(cast(bytes, sent_events[1]["body"]).decode("utf-8"))
+    assert payload["error"]["code"] == "proxy_overloaded"
+
+
+@pytest.mark.asyncio
+async def test_backpressure_dashboard_websocket_uses_detail_payload_when_at_capacity():
+    app_called = False
+
+    async def inner_app(scope, receive, send):
+        nonlocal app_called
+        app_called = True
+        del scope, receive, send
+
+    middleware = BackpressureMiddleware(cast(Any, inner_app), max_concurrent=1)
+    await middleware._semaphore.acquire()
+    sent_events: list[dict[str, object]] = []
+    connect_delivered = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal connect_delivered
+        if not connect_delivered:
+            connect_delivered = True
+            return {"type": "websocket.connect"}
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: dict[str, object]) -> None:
+        sent_events.append(message)
+
+    try:
+        await middleware(
+            {"type": "websocket", "path": "/api/status/socket"},
+            cast(Any, receive),
+            cast(Any, send),
+        )
+    finally:
+        middleware._semaphore.release()
+
+    assert app_called is False
+    payload = json.loads(cast(bytes, sent_events[1]["body"]).decode("utf-8"))
+    assert payload == {"detail": "codex-lb is temporarily overloaded by local backpressure"}

--- a/tests/unit/test_bulkhead.py
+++ b/tests/unit/test_bulkhead.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any, cast
 
 import pytest
@@ -12,13 +13,19 @@ from app.core.resilience.bulkhead import BulkheadMiddleware, BulkheadSemaphore
 pytestmark = pytest.mark.unit
 
 
+def _bulkhead(**kwargs: int) -> BulkheadSemaphore:
+    return BulkheadSemaphore(
+        proxy_http_limit=kwargs.get("proxy_http_limit", 1),
+        proxy_websocket_limit=kwargs.get("proxy_websocket_limit", 1),
+        proxy_compact_limit=kwargs.get("proxy_compact_limit", 1),
+        dashboard_limit=kwargs.get("dashboard_limit", 1),
+    )
+
+
 @pytest.mark.asyncio
 async def test_bulkhead_allows_requests_under_limit():
     app = FastAPI()
-    app.add_middleware(
-        cast(Any, BulkheadMiddleware),
-        bulkhead=BulkheadSemaphore(proxy_limit=2, dashboard_limit=2),
-    )
+    app.add_middleware(cast(Any, BulkheadMiddleware), bulkhead=_bulkhead(proxy_http_limit=2, dashboard_limit=2))
 
     @app.get("/v1/work")
     async def work():
@@ -33,12 +40,9 @@ async def test_bulkhead_allows_requests_under_limit():
 
 
 @pytest.mark.asyncio
-async def test_bulkhead_returns_503_when_proxy_bucket_full():
+async def test_bulkhead_returns_429_when_proxy_http_lane_full():
     app = FastAPI()
-    app.add_middleware(
-        cast(Any, BulkheadMiddleware),
-        bulkhead=BulkheadSemaphore(proxy_limit=1, dashboard_limit=1),
-    )
+    app.add_middleware(cast(Any, BulkheadMiddleware), bulkhead=_bulkhead())
     entered = asyncio.Event()
     release = asyncio.Event()
 
@@ -57,19 +61,46 @@ async def test_bulkhead_returns_503_when_proxy_bucket_full():
         release.set()
         first_response = await first_request
 
-    assert overloaded.status_code == 503
-    assert overloaded.json() == {"detail": "Service temporarily unavailable (bulkhead full)"}
+    assert overloaded.status_code == 429
+    assert overloaded.json()["error"]["code"] == "proxy_overloaded"
     assert overloaded.headers["retry-after"] == "5"
     assert first_response.status_code == 200
 
 
 @pytest.mark.asyncio
+async def test_bulkhead_compact_lane_isolated_from_general_proxy_http():
+    app = FastAPI()
+    app.add_middleware(cast(Any, BulkheadMiddleware), bulkhead=_bulkhead())
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    @app.get("/v1/work")
+    async def proxy_work():
+        entered.set()
+        await release.wait()
+        return {"ok": True}
+
+    @app.post("/v1/responses/compact")
+    async def compact_work():
+        return {"ok": "compact"}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        first_request = asyncio.create_task(client.get("/v1/work"))
+        await entered.wait()
+
+        compact_response = await client.post("/v1/responses/compact")
+        release.set()
+        await first_request
+
+    assert compact_response.status_code == 200
+    assert compact_response.json() == {"ok": "compact"}
+
+
+@pytest.mark.asyncio
 async def test_bulkhead_isolates_dashboard_when_proxy_full():
     app = FastAPI()
-    app.add_middleware(
-        cast(Any, BulkheadMiddleware),
-        bulkhead=BulkheadSemaphore(proxy_limit=1, dashboard_limit=1),
-    )
+    app.add_middleware(cast(Any, BulkheadMiddleware), bulkhead=_bulkhead())
     entered = asyncio.Event()
     release = asyncio.Event()
 
@@ -99,10 +130,7 @@ async def test_bulkhead_isolates_dashboard_when_proxy_full():
 @pytest.mark.asyncio
 async def test_bulkhead_health_probes_bypass_limits():
     app = FastAPI()
-    app.add_middleware(
-        cast(Any, BulkheadMiddleware),
-        bulkhead=BulkheadSemaphore(proxy_limit=1, dashboard_limit=1),
-    )
+    app.add_middleware(cast(Any, BulkheadMiddleware), bulkhead=_bulkhead())
     entered = asyncio.Event()
     release = asyncio.Event()
 
@@ -130,9 +158,10 @@ async def test_bulkhead_health_probes_bypass_limits():
 
 
 @pytest.mark.asyncio
-async def test_bulkhead_websocket_rejects_with_close_when_proxy_bucket_full():
-    bulkhead = BulkheadSemaphore(proxy_limit=1, dashboard_limit=1)
-    sem = bulkhead.get_semaphore("/v1/responses")
+async def test_bulkhead_websocket_denies_with_http_response_when_lane_full():
+    bulkhead = _bulkhead()
+    lane_name, sem = bulkhead.get_semaphore("websocket", "/v1/responses")
+    assert lane_name == "proxy_websocket"
     assert sem is not None
     await sem.acquire()
 
@@ -167,10 +196,51 @@ async def test_bulkhead_websocket_rejects_with_close_when_proxy_bucket_full():
         sem.release()
 
     assert app_called is False
-    assert sent_events == [
-        {
-            "type": "websocket.close",
-            "code": 1013,
-            "reason": "Service temporarily unavailable (bulkhead full)",
-        }
-    ]
+    assert sent_events[0]["type"] == "websocket.http.response.start"
+    assert sent_events[0]["status"] == 429
+    assert sent_events[1]["type"] == "websocket.http.response.body"
+    payload = json.loads(cast(bytes, sent_events[1]["body"]).decode("utf-8"))
+    assert payload["error"]["code"] == "proxy_overloaded"
+
+
+@pytest.mark.asyncio
+async def test_bulkhead_dashboard_websocket_uses_detail_payload_when_lane_full():
+    bulkhead = _bulkhead(dashboard_limit=1)
+    lane_name, sem = bulkhead.get_semaphore("websocket", "/api/status/socket")
+    assert lane_name == "dashboard"
+    assert sem is not None
+    await sem.acquire()
+
+    app_called = False
+
+    async def inner_app(scope, receive, send):
+        nonlocal app_called
+        app_called = True
+        del scope, receive, send
+
+    middleware = BulkheadMiddleware(cast(Any, inner_app), bulkhead=bulkhead)
+    sent_events: list[dict[str, object]] = []
+    connect_delivered = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal connect_delivered
+        if not connect_delivered:
+            connect_delivered = True
+            return {"type": "websocket.connect"}
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message: dict[str, object]) -> None:
+        sent_events.append(message)
+
+    try:
+        await middleware(
+            {"type": "websocket", "path": "/api/status/socket"},
+            cast(Any, receive),
+            cast(Any, send),
+        )
+    finally:
+        sem.release()
+
+    assert app_called is False
+    payload = json.loads(cast(bytes, sent_events[1]["body"]).decode("utf-8"))
+    assert payload == {"detail": "codex-lb is temporarily overloaded in the dashboard lane"}

--- a/tests/unit/test_bulkhead.py
+++ b/tests/unit/test_bulkhead.py
@@ -244,3 +244,82 @@ async def test_bulkhead_dashboard_websocket_uses_detail_payload_when_lane_full()
     assert app_called is False
     payload = json.loads(cast(bytes, sent_events[1]["body"]).decode("utf-8"))
     assert payload == {"detail": "codex-lb is temporarily overloaded in the dashboard lane"}
+
+
+@pytest.mark.asyncio
+async def test_bulkhead_websocket_lane_recovers_after_active_session_exits():
+    bulkhead = _bulkhead(proxy_websocket_limit=1)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    app_calls = 0
+
+    async def inner_app(scope, receive, send):
+        nonlocal app_calls
+        del scope, receive
+        app_calls += 1
+        await send({"type": "websocket.accept"})
+        if app_calls == 1:
+            entered.set()
+            await release.wait()
+        await send({"type": "websocket.close", "code": 1000})
+
+    middleware = BulkheadMiddleware(cast(Any, inner_app), bulkhead=bulkhead)
+
+    async def dormant_receive() -> dict[str, object]:
+        await asyncio.sleep(3600)
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    first_sent_events: list[dict[str, object]] = []
+
+    async def first_send(message: dict[str, object]) -> None:
+        first_sent_events.append(message)
+
+    first_scope = {"type": "websocket", "path": "/backend-api/codex/responses"}
+    first_call = asyncio.create_task(
+        middleware(
+            cast(Any, first_scope),
+            cast(Any, dormant_receive),
+            cast(Any, first_send),
+        )
+    )
+    await entered.wait()
+
+    denied_events: list[dict[str, object]] = []
+    connect_delivered = False
+
+    async def denial_receive() -> dict[str, object]:
+        nonlocal connect_delivered
+        if not connect_delivered:
+            connect_delivered = True
+            return {"type": "websocket.connect"}
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def denial_send(message: dict[str, object]) -> None:
+        denied_events.append(message)
+
+    await middleware(
+        cast(Any, first_scope),
+        cast(Any, denial_receive),
+        cast(Any, denial_send),
+    )
+
+    release.set()
+    await first_call
+
+    recovered_events: list[dict[str, object]] = []
+
+    async def recovered_send(message: dict[str, object]) -> None:
+        recovered_events.append(message)
+
+    await middleware(
+        cast(Any, first_scope),
+        cast(Any, denial_receive),
+        cast(Any, recovered_send),
+    )
+
+    assert first_sent_events[0]["type"] == "websocket.accept"
+    assert denied_events[0]["type"] == "websocket.http.response.start"
+    assert denied_events[0]["status"] == 429
+    assert recovered_events[0]["type"] == "websocket.accept"
+    assert recovered_events[1]["type"] == "websocket.close"
+    assert app_calls == 2

--- a/tests/unit/test_bulkhead.py
+++ b/tests/unit/test_bulkhead.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+import app.core.resilience.bulkhead as bulkhead_module
 from app.core.resilience.bulkhead import BulkheadMiddleware, BulkheadSemaphore
 
 pytestmark = pytest.mark.unit
@@ -244,6 +245,14 @@ async def test_bulkhead_dashboard_websocket_uses_detail_payload_when_lane_full()
     assert app_called is False
     payload = json.loads(cast(bytes, sent_events[1]["body"]).decode("utf-8"))
     assert payload == {"detail": "codex-lb is temporarily overloaded in the dashboard lane"}
+
+
+def test_get_bulkhead_derives_compact_limit_from_http_limit(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(bulkhead_module, "_bulkhead", None)
+    bulkhead = bulkhead_module.get_bulkhead(proxy_http_limit=0, proxy_websocket_limit=1, dashboard_limit=1)
+    lane_name, sem = bulkhead.get_semaphore("http", "/v1/responses/compact")
+    assert lane_name == "proxy_compact"
+    assert sem is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -29,6 +29,7 @@ from app.core.utils.request_id import get_request_id, reset_request_id, set_requ
 from app.core.utils.sse import parse_sse_data_json
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
+from app.modules.accounts import auth_manager as auth_manager_module
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyData
@@ -535,6 +536,10 @@ def _make_proxy_settings(*, log_proxy_service_tier_trace: bool) -> object:
         log_proxy_request_shape=False,
         log_proxy_request_shape_raw_cache_key=False,
         log_proxy_service_tier_trace=log_proxy_service_tier_trace,
+        proxy_token_refresh_limit=32,
+        proxy_upstream_websocket_connect_limit=64,
+        proxy_response_create_limit=64,
+        proxy_compact_response_create_limit=16,
     )
 
 
@@ -3680,6 +3685,68 @@ async def test_connect_proxy_websocket_surfaces_retry_handshake_error(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_connect_proxy_websocket_surfaces_local_connect_overload_without_penalizing_account(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_upstream_websocket_connect_limit = 1
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_connect_overload")
+    record_error = AsyncMock()
+    release_reservation = AsyncMock()
+    connect_upstream = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service, "_release_websocket_reservation", release_reservation)
+    monkeypatch.setattr(proxy_service, "connect_responses_websocket", connect_upstream)
+
+    lease = await service._get_work_admission().acquire_websocket_connect()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_connect_overload",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+
+    websocket_send = AsyncMock()
+    websocket = cast(WebSocket, SimpleNamespace(send_text=websocket_send))
+    try:
+        selected_account, selected_upstream = await service._connect_proxy_websocket(
+            {},
+            sticky_key=None,
+            sticky_kind=None,
+            prefer_earlier_reset=False,
+            routing_strategy="usage_weighted",
+            model="gpt-5.1",
+            request_state=request_state,
+            api_key=None,
+            client_send_lock=anyio.Lock(),
+            websocket=websocket,
+        )
+    finally:
+        lease.release()
+
+    assert selected_account is None
+    assert selected_upstream is None
+    record_error.assert_not_awaited()
+    connect_upstream.assert_not_awaited()
+    release_reservation.assert_awaited_once_with(None)
+    sent_payload = json.loads(websocket_send.await_args.args[0])
+    assert sent_payload["status"] == 429
+    assert sent_payload["error"]["code"] == "proxy_overloaded"
+    assert request_logs.calls[0]["error_code"] == "proxy_overloaded"
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_surfaces_refresh_transport_error(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -4815,6 +4882,239 @@ async def test_compact_responses_records_transient_error_for_generic_upstream_fa
     assert _proxy_error_code(exc) == "upstream_unavailable"
     record_error.assert_awaited_once_with(account)
     record_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_surfaces_local_create_overload_without_penalizing_account(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_compact_response_create_limit = 1
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_local_overload")
+    record_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    failing_upstream = AsyncMock()
+    monkeypatch.setattr(proxy_service, "core_compact_responses", failing_upstream)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+
+    lease = await service._get_work_admission().acquire_response_create(compact=True)
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    try:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            await service.compact_responses(payload, {"session_id": "sid-compact"})
+    finally:
+        lease.release()
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 429
+    assert _proxy_error_code(exc) == "proxy_overloaded"
+    failing_upstream.assert_not_awaited()
+    record_error.assert_not_awaited()
+    assert request_logs.calls[0]["error_code"] == "proxy_overloaded"
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_skips_token_refresh_admission_for_fresh_account(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_token_refresh_limit = 1
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_fresh_no_refresh")
+
+    async def fake_ensure_fresh(self, target, *, force: bool = False):
+        assert force is False
+        return target
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.AuthManager, "ensure_fresh", fake_ensure_fresh)
+
+    lease = await service._get_work_admission().acquire_token_refresh()
+    try:
+        refreshed = await service._ensure_fresh(account, force=False)
+    finally:
+        lease.release()
+
+    assert refreshed is account
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_same_stale_account_joins_singleflight_before_refresh_admission(monkeypatch):
+    auth_manager_module._clear_refresh_singleflight_state()
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_token_refresh_limit = 1
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    account_a = Account(
+        id="acc_refresh_singleflight",
+        chatgpt_account_id="acc_refresh_singleflight",
+        email="singleflight@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    account_b = Account(**{column.name: getattr(account_a, column.name) for column in Account.__table__.columns})
+    started = asyncio.Event()
+    release = asyncio.Event()
+    refresh_calls = 0
+
+    async def fake_refresh_access_token(_: str):
+        nonlocal refresh_calls
+        refresh_calls += 1
+        started.set()
+        await release.wait()
+        return auth_manager_module.TokenRefreshResult(
+            access_token="access-new",
+            refresh_token="refresh-new",
+            id_token="id-new",
+            account_id="acc_refresh_singleflight",
+            plan_type="plus",
+            email="singleflight@example.com",
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", fake_refresh_access_token)
+
+    first = asyncio.create_task(service._ensure_fresh(account_a, force=True))
+    await started.wait()
+    second = asyncio.create_task(service._ensure_fresh(account_b, force=True))
+    await asyncio.sleep(0.01)
+    assert not second.done()
+
+    release.set()
+    refreshed_a, refreshed_b = await asyncio.gather(first, second)
+
+    assert refresh_calls == 1
+    assert refreshed_a.chatgpt_account_id == "acc_refresh_singleflight"
+    assert refreshed_b.chatgpt_account_id == "acc_refresh_singleflight"
+    auth_manager_module._clear_refresh_singleflight_state()
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_releases_token_refresh_admission_when_repo_factory_enter_fails(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_token_refresh_limit = 1
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_refresh_repo_failure")
+    account.last_refresh = utcnow().replace(year=utcnow().year - 1)
+
+    class _FailingRepos:
+        async def __aenter__(self):
+            raise RuntimeError("repo enter failed")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    service._repo_factory = lambda: _FailingRepos()
+
+    with pytest.raises(RuntimeError, match="repo enter failed"):
+        await service._ensure_fresh(account, force=True)
+
+    lease = await service._get_work_admission().acquire_token_refresh()
+    lease.release()
+
+
+@pytest.mark.asyncio
+async def test_response_create_admission_failure_releases_session_gate(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_response_create_limit = 1
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_gate_release",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+    )
+    response_create_gate = asyncio.Semaphore(1)
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    lease = await service._get_work_admission().acquire_response_create()
+    try:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            await service._acquire_request_state_response_create_admission(
+                request_state,
+                response_create_gate=response_create_gate,
+            )
+    finally:
+        lease.release()
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 429
+    assert _proxy_error_code(exc) == "proxy_overloaded"
+    assert response_create_gate.locked() is False
+    assert request_state.awaiting_response_created is False
+    assert request_state.response_create_gate_acquired is False
+    assert request_state.response_create_admission is None
+
+
+@pytest.mark.asyncio
+async def test_response_create_admission_waits_on_session_gate_before_shared_capacity(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_response_create_limit = 2
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    first_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_first",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    second_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_second",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    response_create_gate = asyncio.Semaphore(1)
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    await service._acquire_request_state_response_create_admission(
+        first_request,
+        response_create_gate=response_create_gate,
+    )
+
+    waiting_for_gate = asyncio.Event()
+
+    async def acquire_second_request() -> None:
+        waiting_for_gate.set()
+        await service._acquire_request_state_response_create_admission(
+            second_request,
+            response_create_gate=response_create_gate,
+        )
+
+    second_task = asyncio.create_task(acquire_second_request())
+    await waiting_for_gate.wait()
+    await asyncio.sleep(0)
+
+    shared_lease = await service._get_work_admission().acquire_response_create()
+    shared_lease.release()
+
+    proxy_service._release_websocket_response_create_gate(first_request, response_create_gate)
+    await second_task
+    proxy_service._release_websocket_response_create_gate(second_request, response_create_gate)
+
+    assert second_request.response_create_gate_acquired is False
+    assert second_request.response_create_admission is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -518,7 +518,7 @@ def _repo_factory(request_logs: _RequestLogsRecorder) -> proxy_service.ProxyRepo
     return factory
 
 
-def _make_proxy_settings(*, log_proxy_service_tier_trace: bool) -> object:
+def _make_proxy_settings(*, log_proxy_service_tier_trace: bool) -> SimpleNamespace:
     return SimpleNamespace(
         prefer_earlier_reset_accounts=False,
         sticky_threads_enabled=False,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3740,6 +3740,7 @@ async def test_connect_proxy_websocket_surfaces_local_connect_overload_without_p
     record_error.assert_not_awaited()
     connect_upstream.assert_not_awaited()
     release_reservation.assert_awaited_once_with(None)
+    assert websocket_send.await_args is not None
     sent_payload = json.loads(websocket_send.await_args.args[0])
     assert sent_payload["status"] == 429
     assert sent_payload["error"]["code"] == "proxy_overloaded"

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -19,6 +19,15 @@ def test_settings_multi_replica_defaults():
     assert settings.circuit_breaker_failure_threshold == 5
     assert settings.circuit_breaker_recovery_timeout_seconds == 60
     assert settings.backpressure_max_concurrent_requests == 0
+    assert settings.bulkhead_proxy_http_limit == settings.bulkhead_proxy_limit
+    assert settings.bulkhead_proxy_websocket_limit == settings.bulkhead_proxy_limit
+    assert settings.bulkhead_proxy_compact_limit == 16
+    assert settings.proxy_token_refresh_limit == 32
+    assert settings.proxy_upstream_websocket_connect_limit == 64
+    assert settings.proxy_response_create_limit == 64
+    assert settings.proxy_compact_response_create_limit == 16
+    assert settings.proxy_refresh_failure_cooldown_seconds == 5.0
+    assert settings.usage_refresh_auth_failure_cooldown_seconds == 300.0
     assert settings.otel_enabled is False
     assert settings.otel_exporter_endpoint == ""
     assert settings.shutdown_drain_timeout_seconds == 30
@@ -85,6 +94,38 @@ def test_settings_backpressure_max_concurrent_requests_from_env(monkeypatch):
     monkeypatch.setenv("CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS", "50")
     settings = Settings()
     assert settings.backpressure_max_concurrent_requests == 50
+
+
+def test_settings_split_bulkhead_limits_from_env(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_BULKHEAD_PROXY_HTTP_LIMIT", "40")
+    monkeypatch.setenv("CODEX_LB_BULKHEAD_PROXY_WEBSOCKET_LIMIT", "25")
+    monkeypatch.setenv("CODEX_LB_BULKHEAD_PROXY_COMPACT_LIMIT", "8")
+    settings = Settings()
+    assert settings.bulkhead_proxy_http_limit == 40
+    assert settings.bulkhead_proxy_websocket_limit == 25
+    assert settings.bulkhead_proxy_compact_limit == 8
+
+
+def test_settings_split_bulkhead_limits_allow_explicit_zero(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_BULKHEAD_PROXY_HTTP_LIMIT", "0")
+    monkeypatch.setenv("CODEX_LB_BULKHEAD_PROXY_WEBSOCKET_LIMIT", "0")
+    monkeypatch.setenv("CODEX_LB_BULKHEAD_PROXY_COMPACT_LIMIT", "0")
+    settings = Settings()
+    assert settings.bulkhead_proxy_http_limit == 0
+    assert settings.bulkhead_proxy_websocket_limit == 0
+    assert settings.bulkhead_proxy_compact_limit == 0
+
+
+def test_settings_work_admission_limits_from_env(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_PROXY_TOKEN_REFRESH_LIMIT", "7")
+    monkeypatch.setenv("CODEX_LB_PROXY_UPSTREAM_WEBSOCKET_CONNECT_LIMIT", "9")
+    monkeypatch.setenv("CODEX_LB_PROXY_RESPONSE_CREATE_LIMIT", "11")
+    monkeypatch.setenv("CODEX_LB_PROXY_COMPACT_RESPONSE_CREATE_LIMIT", "3")
+    settings = Settings()
+    assert settings.proxy_token_refresh_limit == 7
+    assert settings.proxy_upstream_websocket_connect_limit == 9
+    assert settings.proxy_response_create_limit == 11
+    assert settings.proxy_compact_response_create_limit == 3
 
 
 def test_settings_otel_enabled_from_env(monkeypatch):

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -26,6 +26,7 @@ def test_settings_multi_replica_defaults():
     assert settings.proxy_upstream_websocket_connect_limit == 64
     assert settings.proxy_response_create_limit == 64
     assert settings.proxy_compact_response_create_limit == 16
+    assert settings.proxy_downstream_websocket_idle_timeout_seconds == 120.0
     assert settings.proxy_refresh_failure_cooldown_seconds == 5.0
     assert settings.usage_refresh_auth_failure_cooldown_seconds == 300.0
     assert settings.otel_enabled is False
@@ -126,6 +127,12 @@ def test_settings_work_admission_limits_from_env(monkeypatch):
     assert settings.proxy_upstream_websocket_connect_limit == 9
     assert settings.proxy_response_create_limit == 11
     assert settings.proxy_compact_response_create_limit == 3
+
+
+def test_settings_proxy_downstream_websocket_idle_timeout_from_env(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_PROXY_DOWNSTREAM_WEBSOCKET_IDLE_TIMEOUT_SECONDS", "45")
+    settings = Settings()
+    assert settings.proxy_downstream_websocket_idle_timeout_seconds == 45.0
 
 
 def test_settings_otel_enabled_from_env(monkeypatch):

--- a/tests/unit/test_ttft_optimization.py
+++ b/tests/unit/test_ttft_optimization.py
@@ -72,6 +72,10 @@ def _make_proxy_settings() -> object:
         log_proxy_request_shape_raw_cache_key=False,
         log_proxy_service_tier_trace=False,
         sticky_reallocation_budget_threshold_pct=95.0,
+        proxy_token_refresh_limit=32,
+        proxy_upstream_websocket_connect_limit=64,
+        proxy_response_create_limit=64,
+        proxy_compact_response_create_limit=16,
     )
 
 

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -12,8 +12,9 @@ from app.core.auth.refresh import RefreshError
 from app.core.crypto import TokenEncryptor
 from app.core.usage.models import UsagePayload
 from app.db.models import Account, AccountStatus, UsageHistory
+from app.modules.usage import updater as usage_updater_module
 from app.modules.usage.additional_quota_keys import canonicalize_additional_quota_key
-from app.modules.usage.updater import UsageUpdater, _last_successful_refresh
+from app.modules.usage.updater import UsageUpdater
 
 pytestmark = pytest.mark.unit
 
@@ -21,9 +22,9 @@ pytestmark = pytest.mark.unit
 @pytest.fixture(autouse=True)
 def _clear_refresh_cache():
     """Clear the module-level freshness cache between tests."""
-    _last_successful_refresh.clear()
+    usage_updater_module._clear_usage_refresh_state()
     yield
-    _last_successful_refresh.clear()
+    usage_updater_module._clear_usage_refresh_state()
 
 
 @dataclass(frozen=True, slots=True)
@@ -515,6 +516,86 @@ async def test_usage_updater_deactivates_on_401_deactivated_message_without_code
 
     assert len(accounts_repo.status_updates) == 1
     assert accounts_repo.status_updates[0]["status"] == AccountStatus.DEACTIVATED
+
+
+@pytest.mark.asyncio
+async def test_usage_updater_cools_down_repeated_403_failures(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_AUTH_FAILURE_COOLDOWN_SECONDS", "300")
+    from app.core.clients.usage import UsageFetchError
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    fetch_calls = 0
+
+    async def stub_fetch_usage_403(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        raise UsageFetchError(403, "Forbidden")
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage_403)
+
+    usage_repo = StubUsageRepository()
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+
+    acc = _make_account("acc_403_cooldown", "workspace_403_cooldown", email="forbidden@example.com")
+    accounts_repo.accounts_by_id[acc.id] = acc
+
+    await updater.refresh_accounts([acc], latest_usage={})
+    await updater.refresh_accounts([acc], latest_usage={})
+
+    assert fetch_calls == 1
+    assert len(accounts_repo.status_updates) == 0
+
+
+@pytest.mark.asyncio
+async def test_usage_updater_subset_refresh_does_not_clear_other_account_cooldowns(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_AUTH_FAILURE_COOLDOWN_SECONDS", "300")
+    from app.core.clients.usage import UsageFetchError
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    fetch_calls = 0
+
+    async def stub_fetch_usage(*, account_id: str | None, **_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        if account_id == "workspace_cooled":
+            raise UsageFetchError(403, "Forbidden")
+        return UsagePayload.model_validate({})
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository()
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+
+    cooled = _make_account("acc_cooldown_kept", "workspace_cooled", email="cooled@example.com")
+    imported = _make_account("acc_imported", "workspace_imported", email="imported@example.com")
+    accounts_repo.accounts_by_id[cooled.id] = cooled
+    accounts_repo.accounts_by_id[imported.id] = imported
+
+    await updater.refresh_accounts([cooled], latest_usage={})
+    await updater.refresh_accounts([imported], latest_usage={})
+    await updater.refresh_accounts([cooled], latest_usage={})
+
+    assert fetch_calls == 2
+
+
+def test_mark_usage_refresh_auth_cooldown_ignores_non_auth_status(monkeypatch) -> None:
+    monkeypatch.setattr(
+        usage_updater_module,
+        "get_settings",
+        lambda: type("Settings", (), {"usage_refresh_auth_failure_cooldown_seconds": 300.0})(),
+    )
+
+    usage_updater_module._mark_usage_refresh_auth_cooldown("acc_non_auth", 500)
+
+    assert usage_updater_module._is_usage_refresh_in_cooldown("acc_non_auth") is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -27,6 +27,26 @@ def _clear_refresh_cache():
     usage_updater_module._clear_usage_refresh_state()
 
 
+@pytest.mark.asyncio
+async def test_clear_usage_refresh_state_clears_singleflight_cache() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def factory():
+        started.set()
+        await release.wait()
+        return usage_updater_module.AccountRefreshResult(usage_written=False)
+
+    first = asyncio.create_task(
+        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run("acc_singleflight_clear", factory)
+    )
+    await started.wait()
+    usage_updater_module._clear_usage_refresh_state()
+    assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight == {}
+    release.set()
+    await first
+
+
 @dataclass(frozen=True, slots=True)
 class UsageEntry:
     account_id: str

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -37,9 +37,7 @@ async def test_clear_usage_refresh_state_clears_singleflight_cache() -> None:
         await release.wait()
         return usage_updater_module.AccountRefreshResult(usage_written=False)
 
-    first = asyncio.create_task(
-        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run("acc_singleflight_clear", factory)
-    )
+    first = asyncio.create_task(usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run("acc_singleflight_clear", factory))
     await started.wait()
     usage_updater_module._clear_usage_refresh_state()
     assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight == {}

--- a/tests/unit/test_work_admission.py
+++ b/tests/unit/test_work_admission.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.core.clients.proxy import ProxyResponseError
+from app.modules.proxy.work_admission import WorkAdmissionController
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_work_admission_rejects_concurrent_race_without_waiting() -> None:
+    controller = WorkAdmissionController(
+        token_refresh_limit=1,
+        websocket_connect_limit=0,
+        response_create_limit=0,
+        compact_response_create_limit=0,
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder() -> None:
+        lease = await controller.acquire_token_refresh()
+        started.set()
+        try:
+            await release.wait()
+        finally:
+            lease.release()
+
+    first = asyncio.create_task(holder())
+    await started.wait()
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await asyncio.wait_for(controller.acquire_token_refresh(), timeout=0.1)
+
+    release.set()
+    await first
+
+    assert exc_info.value.status_code == 429


### PR DESCRIPTION
## Problem observed
- repeated `503 Service Unavailable` responses from `/backend-api/codex/responses` and `/backend-api/codex/responses/compact`
- repeated websocket handshake failures around `/backend-api/codex/responses` that made it unclear whether failures were coming from OpenAI or from local proxy admission / overload behavior
- usage refresh kept emitting repeated `401` failures even after account cleanup, and deactivation-signaling usage failures were not being handled clearly enough
- abandoned downstream websocket sessions could keep holding `proxy_websocket` capacity, causing recurring local `429` admission failures until the client or container restarted

## What this changes
- split downstream admission handling into explicit HTTP, websocket, compact, and dashboard lanes with clearer local overload responses and retry hints
- harden response-create and refresh admission so same-account refreshes singleflight correctly, work-admission stays fail-fast under contention, and response-create cleanup does not leak or over-release gates
- improve usage-refresh handling for repeated auth failures, including clearing module-level singleflight state between resets and deactivating accounts when the usage `401` clearly signals upstream deactivation
- reclaim idle downstream websocket sessions so abandoned clients release `proxy_websocket` capacity instead of monopolizing the lane
- add OpenSpec change artifacts and regression coverage around the affected concurrency, bridge, and websocket recovery paths

## Validation
- `openspec validate --specs`
- `uv run pytest tests/unit/test_auth_manager.py tests/unit/test_usage_updater.py tests/unit/test_settings_multi_replica.py tests/unit/test_bulkhead.py tests/unit/test_backpressure.py tests/unit/test_proxy_utils.py -q`
- `uv run pytest tests/integration/test_http_responses_bridge.py -q -k "codex_session_prewarms_first_request or reconnect_uses_last_upstream_turn_state or session_id_reconnect_keeps_upstream_turn_state or does_not_evict_active_session_when_pool_is_full or retry_http_bridge_precreated_request_releases_pending_lock_before_reconnect"`
- `uv run pytest tests/integration/test_proxy_websocket_responses.py -q -k "reclaims_idle_downstream_session_and_upstream or does_not_expire_downstream_while_request_pending or keeps_downstream_open_after_clean_upstream_close or emits_timeout_failure_for_stalled_upstream"`
- `uv run pytest tests/unit/test_bulkhead.py -q -k "websocket_lane_recovers_after_active_session_exits or websocket_denies_with_http_response_when_lane_full"`
- `uv run pytest tests/unit/test_work_admission.py tests/unit/test_usage_updater.py tests/unit/test_settings_multi_replica.py -q`
- `uvx ruff check app/core/config/settings.py app/core/resilience/backpressure.py app/core/resilience/bulkhead.py app/core/resilience/overload.py app/main.py app/modules/accounts/auth_manager.py app/modules/proxy/service.py app/modules/proxy/work_admission.py app/modules/usage/updater.py tests/unit/test_auth_manager.py tests/unit/test_backpressure.py tests/unit/test_bulkhead.py tests/unit/test_proxy_utils.py tests/unit/test_settings_multi_replica.py tests/unit/test_usage_updater.py tests/unit/test_work_admission.py tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_websocket_responses.py`

## Local soak test
- built and ran the branch locally in Docker and exercised it continuously for 2 days without reproducing the original `503` / repeated usage-refresh error pattern
- rebuilt `codex-lb-local` with the idle-websocket follow-up and verified the local websocket lane recovered without fresh `429` admissions after restart
