### PR TITLE
docs(api-keys): clarify local-only behavior when auth is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="http://127.0.0.1:2455/v1",
-    api_key="sk-clb-...",  # from dashboard when auth is enabled; local-only requests may omit it when disabled
+    api_key="sk-clb-...",  # from dashboard, or any non-empty string if auth is disabled
 )
 
 response = client.chat.completions.create(
@@ -321,7 +321,7 @@ Authorization: Bearer sk-clb-...
 
 The protected proxy routes covered by this setting are:
 
-- `/v1/*`
+- `/v1/*` (except `/v1/usage`, which always requires a valid key)
 - `/backend-api/codex/*`
 - `/backend-api/transcribe`
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ opencode
 }
 ```
 
-Set the env var or replace `${CODEX_LB_API_KEY}` with a key from the dashboard. If API key auth is disabled, any value works.
+Set the env var or replace `${CODEX_LB_API_KEY}` with a key from the dashboard. If API key auth is disabled,
+local requests can omit the key, but non-local requests are still rejected until proxy authentication is configured.
 
 </details>
 
@@ -293,7 +294,7 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="http://127.0.0.1:2455/v1",
-    api_key="sk-clb-...",  # from dashboard, or any string if auth is disabled
+    api_key="sk-clb-...",  # from dashboard when auth is enabled; local-only requests may omit it when disabled
 )
 
 response = client.chat.completions.create(
@@ -307,13 +308,22 @@ print(response.choices[0].message.content)
 
 ## API Key Authentication
 
-API key auth is **disabled by default** — the proxy is open to any client. Enable it in **Settings → API Key Auth** on the dashboard.
+API key auth is **disabled by default**. In that mode, only local requests to the protected proxy routes can
+proceed without a key; non-local requests are rejected until proxy authentication is configured. Enable it in
+**Settings → API Key Auth** on the dashboard when clients connect remotely or through Docker, VM, or container
+networking that appears non-local to the service.
 
 When enabled, clients must pass a valid API key as a Bearer token:
 
 ```
 Authorization: Bearer sk-clb-...
 ```
+
+The protected proxy routes covered by this setting are:
+
+- `/v1/*`
+- `/backend-api/codex/*`
+- `/backend-api/transcribe`
 
 **Creating keys**: Dashboard → API Keys → Create. The full key is shown **only once** at creation. Keys support optional expiration, model restrictions, and rate limits (tokens / cost per day / week / month).
 

--- a/frontend/src/features/api-keys/components/api-key-auth-toggle.tsx
+++ b/frontend/src/features/api-keys/components/api-key-auth-toggle.tsx
@@ -12,7 +12,8 @@ export function ApiKeyAuthToggle({ enabled, disabled = false, onChange }: ApiKey
       <div className="space-y-1">
         <p className="text-sm font-medium">API Key Auth</p>
         <p className="text-xs text-muted-foreground">
-          Require API keys for incoming `/v1/*` requests.
+          Require API keys for `/v1/*`, `/backend-api/codex/*`, and `/backend-api/transcribe`. When disabled,
+          only local proxy requests can proceed without a key.
         </p>
       </div>
       <Switch checked={enabled} disabled={disabled} onCheckedChange={onChange} />

--- a/frontend/src/features/api-keys/components/api-key-auth-toggle.tsx
+++ b/frontend/src/features/api-keys/components/api-key-auth-toggle.tsx
@@ -11,10 +11,7 @@ export function ApiKeyAuthToggle({ enabled, disabled = false, onChange }: ApiKey
     <div className="flex items-center justify-between rounded-lg border p-3">
       <div className="space-y-1">
         <p className="text-sm font-medium">API Key Auth</p>
-        <p className="text-xs text-muted-foreground">
-          Require API keys for `/v1/*`, `/backend-api/codex/*`, and `/backend-api/transcribe`. When disabled,
-          only local proxy requests can proceed without a key.
-        </p>
+        <p className="text-xs text-muted-foreground">Require API keys for protected proxy requests.</p>
       </div>
       <Switch checked={enabled} disabled={disabled} onCheckedChange={onChange} />
     </div>

--- a/openspec/changes/clarify-api-key-auth-copy/proposal.md
+++ b/openspec/changes/clarify-api-key-auth-copy/proposal.md
@@ -1,0 +1,14 @@
+## Why
+The current API key auth copy no longer matches runtime behavior after the proxy auth hardening changes in v1.12.0. The dashboard toggle still says it applies to `/v1/*` only, and the README still says disabling API key auth leaves the proxy open to any client.
+
+In reality, the same guard applies to `/v1/*`, `/backend-api/codex/*`, and `/backend-api/transcribe`, and disabling API key auth now only allows unauthenticated local requests. This mismatch is causing operator confusion, especially for Docker deployments where host-to-container requests are often classified as remote.
+
+## What Changes
+- Clarify the dashboard API key auth toggle copy so it reflects the real protected proxy routes and the local-only anonymous behavior.
+- Update the README provider setup and API key auth section to explain that disabled auth only permits local requests.
+- Update the main OpenSpec API key auth requirement to match the implemented fail-closed behavior.
+
+## Impact
+- Affects dashboard copy for API key auth settings.
+- Affects operator-facing README guidance for Codex and OpenAI-compatible clients.
+- Aligns the main `api-keys` spec with the current implementation without changing runtime behavior.

--- a/openspec/changes/clarify-api-key-auth-copy/proposal.md
+++ b/openspec/changes/clarify-api-key-auth-copy/proposal.md
@@ -4,7 +4,7 @@ The current API key auth copy no longer matches runtime behavior after the proxy
 In reality, the same guard applies to `/v1/*`, `/backend-api/codex/*`, and `/backend-api/transcribe`, and disabling API key auth now only allows unauthenticated local requests. This mismatch is causing operator confusion, especially for Docker deployments where host-to-container requests are often classified as remote.
 
 ## What Changes
-- Clarify the dashboard API key auth toggle copy so it reflects the real protected proxy routes and the local-only anonymous behavior.
+- Clarify the dashboard API key auth toggle copy with a short, layout-safe description of protected proxy requests.
 - Update the README provider setup and API key auth section to explain that disabled auth only permits local requests.
 - Update the main OpenSpec API key auth requirement to match the implemented fail-closed behavior.
 

--- a/openspec/changes/clarify-api-key-auth-copy/specs/api-keys/spec.md
+++ b/openspec/changes/clarify-api-key-auth-copy/specs/api-keys/spec.md
@@ -1,0 +1,31 @@
+### MODIFIED Requirement: API Key authentication global switch
+The system SHALL provide an `api_key_auth_enabled` boolean in `DashboardSettings`. When false (default), local requests to protected proxy routes MAY proceed without an API key, but non-local proxy requests MUST be rejected until proxy authentication is configured. When true, protected proxy routes require a valid API key via `Authorization: Bearer <key>`.
+
+#### Scenario: Disable API key auth for a local proxy client
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
+- **AND** a local client calls a protected proxy route
+- **THEN** the request proceeds without API key authentication
+
+#### Scenario: Disable API key auth for a non-local proxy client
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
+- **AND** a non-local client calls a protected proxy route
+- **THEN** the request is rejected with 401 until proxy authentication is configured
+
+### MODIFIED Requirement: API Key Bearer authentication guard
+The system SHALL validate API keys on protected proxy routes (`/v1/*`, `/backend-api/codex/*`, `/backend-api/transcribe`) when `api_key_auth_enabled` is true. Validation MUST be implemented as a router-level `Security` dependency, not ASGI middleware. The dependency MUST compute `sha256` of the Bearer token and look up the hash in the `api_keys` table.
+
+The dependency SHALL return a typed `ApiKeyData` value directly to the route handler. Route handlers MUST NOT access API key data via `request.state`.
+
+`/api/codex/usage` SHALL NOT be covered by the API key auth guard scope.
+
+The dependency SHALL raise a domain exception on validation failure. The exception handler SHALL format the response using the OpenAI error envelope.
+
+#### Scenario: API key auth disabled returns None for local requests
+- **WHEN** `api_key_auth_enabled` is false
+- **AND** the request is classified as local
+- **THEN** the dependency returns `None` and the request proceeds without authentication
+
+#### Scenario: API key auth disabled rejects non-local requests
+- **WHEN** `api_key_auth_enabled` is false
+- **AND** the request is classified as non-local
+- **THEN** the dependency rejects the request with 401

--- a/openspec/changes/clarify-api-key-auth-copy/tasks.md
+++ b/openspec/changes/clarify-api-key-auth-copy/tasks.md
@@ -2,10 +2,10 @@
 - [x] 1.1 Add an `api-keys` delta that describes the local-only behavior when API key auth is disabled.
 
 ## 2. Implementation
-- [x] 2.1 Update the dashboard API key auth toggle copy to reflect the shared proxy route scope and local-only anonymous access.
+- [x] 2.1 Update the dashboard API key auth toggle copy with a short, layout-safe description of protected proxy requests.
 - [x] 2.2 Update the README API key auth guidance and provider notes to match the current behavior.
 - [x] 2.3 Update the main `openspec/specs/api-keys/spec.md` wording so the normative text matches the implementation.
 
 ## 3. Validation
 - [x] 3.1 Review the changed copy for consistency across the dashboard, README, and OpenSpec.
-- [ ] 3.2 Validate specs locally with `openspec validate --specs` if the CLI is available in the environment.
+- [x] 3.2 Validate specs locally with `openspec validate --specs`.

--- a/openspec/changes/clarify-api-key-auth-copy/tasks.md
+++ b/openspec/changes/clarify-api-key-auth-copy/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec
+- [x] 1.1 Add an `api-keys` delta that describes the local-only behavior when API key auth is disabled.
+
+## 2. Implementation
+- [x] 2.1 Update the dashboard API key auth toggle copy to reflect the shared proxy route scope and local-only anonymous access.
+- [x] 2.2 Update the README API key auth guidance and provider notes to match the current behavior.
+- [x] 2.3 Update the main `openspec/specs/api-keys/spec.md` wording so the normative text matches the implementation.
+
+## 3. Validation
+- [x] 3.1 Review the changed copy for consistency across the dashboard, README, and OpenSpec.
+- [ ] 3.2 Validate specs locally with `openspec validate --specs` if the CLI is available in the environment.

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -92,17 +92,24 @@ The system SHALL allow regenerating an API key via `POST /api/api-keys/{id}/rege
 
 ### Requirement: API Key authentication global switch
 
-The system SHALL provide an `api_key_auth_enabled` boolean in `DashboardSettings`. When false (default), all proxy endpoints allow unauthenticated access. When true, all proxy endpoints require a valid API key via `Authorization: Bearer <key>`.
+The system SHALL provide an `api_key_auth_enabled` boolean in `DashboardSettings`. When false (default), local requests to protected proxy routes MAY proceed without an API key, but non-local proxy requests MUST be rejected until proxy authentication is configured. When true, protected proxy routes require a valid API key via `Authorization: Bearer <key>`.
 
 #### Scenario: Enable API key auth
 
 - **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": true }`
 - **THEN** subsequent proxy requests without a valid Bearer token are rejected with 401
 
-#### Scenario: Disable API key auth
+#### Scenario: Disable API key auth for a local request
 
 - **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
-- **THEN** proxy requests are allowed without authentication
+- **AND** a local client calls a protected proxy route
+- **THEN** the request is allowed without API key authentication
+
+#### Scenario: Disable API key auth for a non-local request
+
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
+- **AND** a non-local client calls a protected proxy route
+- **THEN** the request is rejected with 401 until proxy authentication is configured
 
 #### Scenario: Enable without any keys created
 
@@ -111,7 +118,7 @@ The system SHALL provide an `api_key_auth_enabled` boolean in `DashboardSettings
 
 ### Requirement: API Key Bearer authentication guard
 
-The system SHALL validate API keys on proxy routes (`/v1/*`, `/backend-api/codex/*`, `/backend-api/transcribe`) when `api_key_auth_enabled` is true. Validation MUST be implemented as a router-level `Security` dependency, not ASGI middleware. The dependency MUST compute `sha256` of the Bearer token and look up the hash in the `api_keys` table.
+The system SHALL validate API keys on protected proxy routes (`/v1/*`, `/backend-api/codex/*`, `/backend-api/transcribe`) when `api_key_auth_enabled` is true. Validation MUST be implemented as a router-level `Security` dependency, not ASGI middleware. The dependency MUST compute `sha256` of the Bearer token and look up the hash in the `api_keys` table.
 
 The dependency SHALL return a typed `ApiKeyData` value directly to the route handler. Route handlers MUST NOT access API key data via `request.state`.
 
@@ -134,10 +141,17 @@ The dependency SHALL raise a domain exception on validation failure. The excepti
 - **WHEN** `api_key_auth_enabled` is true and a valid Bearer token is provided
 - **THEN** the route handler receives a typed `ApiKeyData` parameter (not `request.state`)
 
-#### Scenario: API key auth disabled returns None
+#### Scenario: API key auth disabled returns None for local requests
 
 - **WHEN** `api_key_auth_enabled` is false
+- **AND** the request is classified as local
 - **THEN** the dependency returns `None` and the request proceeds without authentication
+
+#### Scenario: API key auth disabled rejects non-local requests
+
+- **WHEN** `api_key_auth_enabled` is false
+- **AND** the request is classified as non-local
+- **THEN** the dependency rejects the request with 401
 
 ### Requirement: Model restriction enforcement
 


### PR DESCRIPTION
## Summary
- clarify the API key auth toggle copy to cover protected proxy requests without over-expanding the dashboard UI copy
- update README guidance to explain that disabling API key auth only allows local requests and can still reject Docker/container-networked clients as non-local
- add an OpenSpec change and sync the main `api-keys` spec wording with the implemented fail-closed behavior

## Validation
- reviewed the copy updates across the dashboard, README, and OpenSpec
- `openspec validate --specs`
- `cd frontend && bun run typecheck`

## Context
- aligns user-facing wording with the runtime behavior introduced by PR #339
- related upstream discussion: #365
