### PR TITLE
feat(ui): UI adjustments on dashboards

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,13 +10,15 @@ import { AccountsPage } from "@/features/accounts/components/accounts-page";
 import { ApisPage } from "@/features/apis/components/apis-page";
 import { DashboardPage } from "@/features/dashboard/components/dashboard-page";
 import { SettingsPage } from "@/features/settings/components/settings-page";
+import { useTimeFormatStore } from "@/hooks/use-time-format";
 
 function AppLayout() {
   const logout = useAuthStore((state) => state.logout);
   const passwordRequired = useAuthStore((state) => state.passwordRequired);
+  const timeFormat = useTimeFormatStore((state) => state.timeFormat);
 
   return (
-    <div className="flex min-h-screen flex-col bg-background pb-10">
+    <div className="flex min-h-screen flex-col bg-background pb-10" data-time-format={timeFormat}>
       <AppHeader
         onLogout={() => {
           void logout();

--- a/frontend/src/components/donut-chart.test.tsx
+++ b/frontend/src/components/donut-chart.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DonutChart } from "@/components/donut-chart";
 
@@ -8,7 +8,17 @@ const BASE_ITEMS = [
   { label: "Account B", value: 80, color: "#d9a441" },
 ];
 
+let scrollIntoViewMock: ReturnType<typeof vi.fn>;
+
 describe("DonutChart", () => {
+  beforeEach(() => {
+    scrollIntoViewMock = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+  });
+
   it("renders chart title, subtitle, legend, and SVG", () => {
     const { container } = render(
       <DonutChart
@@ -133,6 +143,45 @@ describe("DonutChart", () => {
 
     fireEvent.mouseEnter(sectors[0]!);
     expect(legendRow).toHaveAttribute("data-active", "true");
+  });
+
+  it("limits the legend list to four visible rows before scrolling", () => {
+    render(
+      <DonutChart
+        title="Many Legends"
+        total={1000}
+        items={Array.from({ length: 5 }, (_, index) => ({
+          label: `Account ${index + 1}`,
+          value: 100,
+          color: `#00000${index}`,
+        }))}
+      />,
+    );
+
+    expect(screen.getByTestId("donut-legend-list")).toHaveStyle({
+      maxHeight: "calc(4 * 1.75rem + 1.875rem)",
+    });
+  });
+
+  it("scrolls the hovered pie item into view in the legend list", async () => {
+    const items = Array.from({ length: 5 }, (_, index) => ({
+      label: `Account ${index + 1}`,
+      value: 100,
+      color: `#12345${index}`,
+    }));
+    const { container } = render(
+      <DonutChart title="Scrollable Legends" total={1000} items={items} />,
+    );
+
+    const sectors = container.querySelectorAll(".recharts-pie-sector");
+    const lastLegendRow = screen.getByTestId("donut-legend-4");
+
+    fireEvent.mouseEnter(sectors[4]!);
+
+    await waitFor(() => {
+      expect(lastLegendRow).toHaveAttribute("data-active", "true");
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
+    });
   });
 
   it("renders empty state when total is zero", () => {

--- a/frontend/src/components/donut-chart.test.tsx
+++ b/frontend/src/components/donut-chart.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { DonutChart } from "@/components/donut-chart";
@@ -100,6 +100,39 @@ describe("DonutChart", () => {
 
     expect(screen.getByText(/^Used$/)).toBeInTheDocument();
     expect(screen.getByTestId("donut-used-value")).toHaveTextContent("300");
+  });
+
+  it("highlights the matching legend row when a legend item is hovered", () => {
+    render(
+      <DonutChart
+        title="Legend Hover"
+        total={500}
+        items={BASE_ITEMS}
+      />,
+    );
+
+    const legendRow = screen.getByTestId("donut-legend-0");
+    fireEvent.mouseEnter(legendRow);
+    expect(legendRow).toHaveAttribute("data-active", "true");
+
+    fireEvent.mouseLeave(legendRow);
+    expect(legendRow).toHaveAttribute("data-active", "false");
+  });
+
+  it("highlights the matching legend row when a pie slice is hovered", () => {
+    const { container } = render(
+      <DonutChart
+        title="Slice Hover"
+        total={500}
+        items={BASE_ITEMS}
+      />,
+    );
+
+    const sectors = container.querySelectorAll(".recharts-pie-sector");
+    const legendRow = screen.getByTestId("donut-legend-0");
+
+    fireEvent.mouseEnter(sectors[0]!);
+    expect(legendRow).toHaveAttribute("data-active", "true");
   });
 
   it("renders empty state when total is zero", () => {

--- a/frontend/src/components/donut-chart.test.tsx
+++ b/frontend/src/components/donut-chart.test.tsx
@@ -159,7 +159,7 @@ describe("DonutChart", () => {
     );
 
     expect(screen.getByTestId("donut-legend-list")).toHaveStyle({
-      maxHeight: "calc(4 * 1.75rem + 1.875rem)",
+      maxHeight: "calc(4 * 1.75rem + 0.375rem)",
     });
   });
 

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Cell, Pie, PieChart, Sector, type PieSectorShapeProps } from "recharts";
 
 import { buildDonutPalette } from "@/utils/colors";
@@ -77,6 +77,9 @@ const PIE_CY = 72;
 const INNER_R = 53;
 const OUTER_R = 68;
 const ACTIVE_RADIUS_OFFSET = 4;
+const LEGEND_VISIBLE_COUNT = 4;
+const LEGEND_ROW_HEIGHT_REM = 1.75;
+const LEGEND_ROW_GAP_REM = 0.625;
 
 type DonutDatum = {
   id: string;
@@ -99,6 +102,7 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
   const blurred = usePrivacyStore((s) => s.blurred);
   const reducedMotion = useReducedMotion();
   const [activeLegendId, setActiveLegendId] = useState<string | null>(null);
+  const legendRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const consumedColor = isDark ? "#404040" : "#d3d3d3";
   const palette = buildDonutPalette(items.length, isDark);
   const normalizedItems = items.map((item, index) => ({
@@ -129,6 +133,14 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
     chartData.length = 0;
     chartData.push({ id: "__empty__", name: "__empty__", value: 1, fill: consumedColor });
   }
+
+  useEffect(() => {
+    if (!activeLegendId) {
+      return;
+    }
+
+    legendRefs.current[activeLegendId]?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeLegendId]);
 
   const renderDonutShape = (props: PieSectorShapeProps) => {
     const isHighlighted = props.isActive || (props.payload as DonutDatum | undefined)?.id === activeLegendId;
@@ -209,16 +221,23 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
           </p>
         </div>
 
-        <div className="flex-1 space-y-2.5">
+        <div
+          className="flex-1 space-y-2.5 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          data-testid="donut-legend-list"
+          style={{ maxHeight: `calc(${LEGEND_VISIBLE_COUNT} * ${LEGEND_ROW_HEIGHT_REM}rem + ${(LEGEND_VISIBLE_COUNT - 1) * LEGEND_ROW_GAP_REM}rem)` }}
+        >
           {normalizedItems.map((item, i) => {
             const legendId = item.id ?? item.label;
             const isActive = activeLegendId === legendId;
 
             return (
             <button
+              ref={(node) => {
+                legendRefs.current[legendId] = node;
+              }}
               type="button"
               key={legendId}
-              className="animate-fade-in-up flex w-full items-center justify-between gap-3 rounded-lg border bg-transparent px-2 py-1.5 text-xs transition-all"
+              className="animate-fade-in-up flex h-7 w-full items-center justify-between gap-3 rounded-lg border bg-transparent text-xs transition-all"
               style={{ animationDelay: `${i * 75}ms`, borderColor: isActive ? item.color : "transparent" }}
               onMouseEnter={() => setActiveLegendId(legendId)}
               onMouseLeave={() => setActiveLegendId(null)}
@@ -246,8 +265,11 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
             );
           })}
           <button
+            ref={(node) => {
+              legendRefs.current.__consumed__ = node;
+            }}
             type="button"
-            className="flex w-full items-center justify-between gap-3 rounded-lg border bg-transparent px-2 py-1.5 text-xs transition-all"
+            className="flex h-7 w-full items-center justify-between gap-3 rounded-lg border bg-transparent text-xs transition-all"
             style={{ borderColor: activeLegendId === "__consumed__" ? consumedColor : "transparent" }}
             onMouseEnter={() => setActiveLegendId("__consumed__")}
             onMouseLeave={() => setActiveLegendId(null)}

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -79,7 +79,7 @@ const OUTER_R = 68;
 const ACTIVE_RADIUS_OFFSET = 4;
 const LEGEND_VISIBLE_COUNT = 4;
 const LEGEND_ROW_HEIGHT_REM = 1.75;
-const LEGEND_ROW_GAP_REM = 0.625;
+const LEGEND_ROW_GAP_REM = 0.125;
 
 type DonutDatum = {
   id: string;

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -1,4 +1,5 @@
-import { Cell, Pie, PieChart } from "recharts";
+import { useState } from "react";
+import { Cell, Pie, PieChart, Sector, type PieSectorShapeProps } from "recharts";
 
 import { buildDonutPalette } from "@/utils/colors";
 import { formatCompactNumber } from "@/utils/formatters";
@@ -69,12 +70,20 @@ function SafeLineTick({
   );
 }
 
-const CHART_SIZE = 144;
-const CHART_MARGIN = 1;
-const PIE_CX = 71;
-const PIE_CY = 71;
+const CHART_SIZE = 152;
+const CHART_MARGIN = 4;
+const PIE_CX = 72;
+const PIE_CY = 72;
 const INNER_R = 53;
-const OUTER_R = 71;
+const OUTER_R = 68;
+const ACTIVE_RADIUS_OFFSET = 4;
+
+type DonutDatum = {
+  id: string;
+  name: string;
+  value: number;
+  fill: string;
+};
 
 function formatUsedPercent(percent: number): string {
   if (!Number.isFinite(percent) || percent <= 0) {
@@ -89,6 +98,7 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
   const isDark = useThemeStore((s) => s.theme === "dark");
   const blurred = usePrivacyStore((s) => s.blurred);
   const reducedMotion = useReducedMotion();
+  const [activeLegendId, setActiveLegendId] = useState<string | null>(null);
   const consumedColor = isDark ? "#404040" : "#d3d3d3";
   const palette = buildDonutPalette(items.length, isDark);
   const normalizedItems = items.map((item, index) => ({
@@ -102,22 +112,39 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
   const displayTotal = Math.max(0, centerValue ?? total);
   const usedPercent = safeCapacity > 0 ? (consumed / safeCapacity) * 100 : 0;
 
-  const chartData = [
+  const chartData: DonutDatum[] = [
     ...normalizedItems.map((item) => ({
+      id: item.id ?? item.label,
       name: item.label,
       value: Math.max(0, item.value),
       fill: item.color,
     })),
     ...(consumed > 0
-      ? [{ name: "__consumed__", value: consumed, fill: consumedColor }]
+      ? [{ id: "__consumed__", name: "__consumed__", value: consumed, fill: consumedColor }]
       : []),
   ];
 
   const hasData = chartData.some((d) => d.value > 0);
   if (!hasData) {
     chartData.length = 0;
-    chartData.push({ name: "__empty__", value: 1, fill: consumedColor });
+    chartData.push({ id: "__empty__", name: "__empty__", value: 1, fill: consumedColor });
   }
+
+  const renderDonutShape = (props: PieSectorShapeProps) => {
+    const isHighlighted = props.isActive || (props.payload as DonutDatum | undefined)?.id === activeLegendId;
+    const outerRadius = typeof props.outerRadius === "number"
+      ? props.outerRadius + (isHighlighted ? ACTIVE_RADIUS_OFFSET : 0)
+      : OUTER_R + (isHighlighted ? ACTIVE_RADIUS_OFFSET : 0);
+
+    return (
+      <Sector
+        {...props}
+        outerRadius={outerRadius}
+        stroke={isHighlighted ? "hsl(var(--background))" : "none"}
+        strokeWidth={isHighlighted ? 2 : 0}
+      />
+    );
+  };
 
   return (
     <div className="rounded-xl border bg-card p-5">
@@ -128,29 +155,37 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
 
       <div className="flex items-center gap-6">
         <div className="flex shrink-0 flex-col items-center gap-2">
-          <div className="relative h-36 w-36 overflow-visible">
+          <div className="relative h-[152px] w-[152px] overflow-visible">
             <PieChart width={CHART_SIZE} height={CHART_SIZE} margin={{ top: CHART_MARGIN, right: CHART_MARGIN, bottom: CHART_MARGIN, left: CHART_MARGIN }}>
-            <Pie
-              data={chartData}
-              cx={PIE_CX}
-              cy={PIE_CY}
-              innerRadius={INNER_R}
-              outerRadius={OUTER_R}
-              startAngle={90}
-              endAngle={-270}
-              dataKey="value"
-              stroke="none"
-              isAnimationActive={!reducedMotion}
-              animationDuration={600}
-              animationEasing="ease-out"
-            >
-              {chartData.map((entry, index) => (
-                <Cell key={index} fill={entry.fill} />
-              ))}
-            </Pie>
-          </PieChart>
-          {safeLine && safeLine.riskLevel !== "safe" ? (
-            <svg className="pointer-events-none absolute inset-0" width={CHART_SIZE} height={CHART_SIZE} viewBox={`0 0 ${CHART_SIZE} ${CHART_SIZE}`}>
+             <Pie
+               data={chartData}
+               cx={PIE_CX}
+               cy={PIE_CY}
+               innerRadius={INNER_R}
+                outerRadius={OUTER_R}
+                startAngle={90}
+                endAngle={-270}
+                dataKey="value"
+                stroke="none"
+                shape={renderDonutShape}
+                isAnimationActive={!reducedMotion}
+                animationDuration={600}
+                animationEasing="ease-out"
+                onMouseEnter={(data) => {
+                  if (typeof data?.id === "string") {
+                    setActiveLegendId(data.id);
+                  }
+                }}
+                onMouseLeave={() => setActiveLegendId(null)}
+                onMouseOut={() => setActiveLegendId(null)}
+              >
+                {chartData.map((entry) => (
+                  <Cell key={entry.id} fill={entry.fill} />
+               ))}
+             </Pie>
+           </PieChart>
+           {safeLine && safeLine.riskLevel !== "safe" ? (
+            <svg aria-hidden="true" className="pointer-events-none absolute inset-0" width={CHART_SIZE} height={CHART_SIZE} viewBox={`0 0 ${CHART_SIZE} ${CHART_SIZE}`}>
               <SafeLineTick
                 cx={PIE_CX + CHART_MARGIN}
                 cy={PIE_CY + CHART_MARGIN}
@@ -162,10 +197,10 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
               />
             </svg>
           ) : null}
-          <div className="absolute inset-[18px] flex items-center justify-center rounded-full text-center pointer-events-none">
-            <div>
-              <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Remaining</p>
-              <p className="text-base font-semibold tabular-nums">{formatCompactNumber(displayTotal)}</p>
+          <div className="absolute inset-[22px] flex items-center justify-center rounded-full text-center pointer-events-none">
+             <div>
+               <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Remaining</p>
+               <p className="text-base font-semibold tabular-nums">{formatCompactNumber(displayTotal)}</p>
             </div>
           </div>
           </div>
@@ -175,8 +210,23 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
         </div>
 
         <div className="flex-1 space-y-2.5">
-          {normalizedItems.map((item, i) => (
-            <div key={item.id ?? item.label} className="animate-fade-in-up flex items-center justify-between gap-3 text-xs" style={{ animationDelay: `${i * 75}ms` }}>
+          {normalizedItems.map((item, i) => {
+            const legendId = item.id ?? item.label;
+            const isActive = activeLegendId === legendId;
+
+            return (
+            <button
+              type="button"
+              key={legendId}
+              className="animate-fade-in-up flex w-full items-center justify-between gap-3 rounded-lg border bg-transparent px-2 py-1.5 text-xs transition-all"
+              style={{ animationDelay: `${i * 75}ms`, borderColor: isActive ? item.color : "transparent" }}
+              onMouseEnter={() => setActiveLegendId(legendId)}
+              onMouseLeave={() => setActiveLegendId(null)}
+              onFocus={() => setActiveLegendId(legendId)}
+              onBlur={() => setActiveLegendId(null)}
+              data-active={isActive ? "true" : "false"}
+              data-testid={`donut-legend-${i}`}
+            >
               <div className="flex min-w-0 items-center gap-2">
                 <span
                   aria-hidden
@@ -192,9 +242,20 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
               <span className="tabular-nums text-muted-foreground">
                 {formatCompactNumber(item.value)}
               </span>
-            </div>
-          ))}
-          <div className="flex items-center justify-between gap-3 text-xs" data-testid="donut-used-row">
+            </button>
+            );
+          })}
+          <button
+            type="button"
+            className="flex w-full items-center justify-between gap-3 rounded-lg border bg-transparent px-2 py-1.5 text-xs transition-all"
+            style={{ borderColor: activeLegendId === "__consumed__" ? consumedColor : "transparent" }}
+            onMouseEnter={() => setActiveLegendId("__consumed__")}
+            onMouseLeave={() => setActiveLegendId(null)}
+            onFocus={() => setActiveLegendId("__consumed__")}
+            onBlur={() => setActiveLegendId(null)}
+            data-active={activeLegendId === "__consumed__" ? "true" : "false"}
+            data-testid="donut-used-row"
+          >
             <div className="flex min-w-0 items-center gap-2">
               <span
                 aria-hidden
@@ -206,7 +267,7 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
             <span className="tabular-nums text-muted-foreground" data-testid="donut-used-value">
               {formatCompactNumber(consumed)}
             </span>
-          </div>
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -222,7 +222,7 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
         </div>
 
         <div
-          className="flex-1 space-y-2.5 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          className="flex-1 space-y-0.5 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           data-testid="donut-legend-list"
           style={{ maxHeight: `calc(${LEGEND_VISIBLE_COUNT} * ${LEGEND_ROW_HEIGHT_REM}rem + ${(LEGEND_VISIBLE_COUNT - 1) * LEGEND_ROW_GAP_REM}rem)` }}
         >
@@ -237,7 +237,7 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
               }}
               type="button"
               key={legendId}
-              className="animate-fade-in-up flex h-7 w-full items-center justify-between gap-3 rounded-lg border bg-transparent text-xs transition-all"
+              className="animate-fade-in-up flex h-7 w-full items-center justify-between px-1.5 gap-3 rounded-lg border bg-transparent text-xs transition-all"
               style={{ animationDelay: `${i * 75}ms`, borderColor: isActive ? item.color : "transparent" }}
               onMouseEnter={() => setActiveLegendId(legendId)}
               onMouseLeave={() => setActiveLegendId(null)}
@@ -269,7 +269,7 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
               legendRefs.current.__consumed__ = node;
             }}
             type="button"
-            className="flex h-7 w-full items-center justify-between gap-3 rounded-lg border bg-transparent text-xs transition-all"
+            className="flex h-7 w-full items-center justify-between px-1.5 gap-3 rounded-lg border bg-transparent text-xs transition-all"
             style={{ borderColor: activeLegendId === "__consumed__" ? consumedColor : "transparent" }}
             onMouseEnter={() => setActiveLegendId("__consumed__")}
             onMouseLeave={() => setActiveLegendId(null)}

--- a/frontend/src/features/accounts/components/account-trend-chart.tsx
+++ b/frontend/src/features/accounts/components/account-trend-chart.tsx
@@ -12,6 +12,7 @@ import {
 import { useChartColors } from "@/hooks/use-chart-colors";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import type { UsageTrendPoint } from "@/features/accounts/schemas";
+import { formatChartDateTime } from "@/utils/formatters";
 
 type MergedPoint = {
   t: string;
@@ -63,13 +64,7 @@ type ChartTooltipProps = {
 
 function CustomTooltip({ active, payload, label }: ChartTooltipProps) {
   if (!active || !payload?.length) return null;
-  const d = new Date(label as string);
-  const heading = d.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const heading = formatChartDateTime(label as string);
   return (
     <div className="rounded-lg border bg-popover px-3 py-2 text-popover-foreground shadow-md">
       <p className="mb-1 text-[11px] text-muted-foreground">{heading}</p>

--- a/frontend/src/features/apis/components/api-trend-chart.tsx
+++ b/frontend/src/features/apis/components/api-trend-chart.tsx
@@ -12,7 +12,7 @@ import {
 import { useChartColors } from "@/hooks/use-chart-colors";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import type { ApiKeyTrendPoint } from "@/features/apis/schemas";
-import { formatCompactNumber, formatCurrency } from "@/utils/formatters";
+import { formatChartDateTime, formatCompactNumber, formatCurrency } from "@/utils/formatters";
 
 type MergedPoint = {
   t: string;
@@ -76,13 +76,7 @@ type ChartTooltipProps = {
 
 function CustomTooltip({ active, payload, label }: ChartTooltipProps) {
   if (!active || !payload?.length) return null;
-  const d = new Date(label as string);
-  const heading = d.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const heading = formatChartDateTime(label as string);
   return (
     <div className="rounded-lg border bg-popover px-3 py-2 text-popover-foreground shadow-md">
       <p className="mb-1 text-[11px] text-muted-foreground">{heading}</p>

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -27,6 +27,7 @@ import { PaginationControls } from "@/features/dashboard/components/filters/pagi
 import type { AccountSummary, RequestLog } from "@/features/dashboard/schemas";
 import { REQUEST_STATUS_LABELS } from "@/utils/constants";
 import {
+  formatDateTimeInline,
   formatCompactNumber,
   formatCurrency,
   formatModelLabel,
@@ -262,7 +263,7 @@ export function RecentRequestsTable({
                 <RequestDetailField label="Status" value={selectedRequest ? (REQUEST_STATUS_LABELS[selectedRequest.status] ?? selectedRequest.status) : "—"} />
                 <RequestDetailField label="Model" value={selectedRequest ? formatModelLabel(selectedRequest.model, selectedRequest.reasoningEffort, selectedRequest.actualServiceTier ?? selectedRequest.serviceTier) : "—"} mono />
                 <RequestDetailField label="Transport" value={selectedRequest?.transport ? (TRANSPORT_LABELS[selectedRequest.transport] ?? selectedRequest.transport) : "—"} />
-                <RequestDetailField label="Time" value={selectedRequest ? `${formatTimeLong(selectedRequest.requestedAt).time} ${formatTimeLong(selectedRequest.requestedAt).date}` : "—"} />
+                <RequestDetailField label="Time" value={selectedRequest ? formatDateTimeInline(selectedRequest.requestedAt) : "—"} />
                 <RequestDetailField label="Error Code" value={selectedRequest?.errorCode ?? "—"} mono />
               </div>
             </div>

--- a/frontend/src/features/settings/components/appearance-settings.test.tsx
+++ b/frontend/src/features/settings/components/appearance-settings.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { AppearanceSettings } from "@/features/settings/components/appearance-settings";
+import { useThemeStore } from "@/hooks/use-theme";
+import { useTimeFormatStore } from "@/hooks/use-time-format";
+
+describe("AppearanceSettings", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useThemeStore.setState({ preference: "light", theme: "light", initialized: true });
+    useTimeFormatStore.setState({ timeFormat: "12h" });
+  });
+
+  it("exposes selected state for the time-format toggle", async () => {
+    const user = userEvent.setup();
+
+    render(<AppearanceSettings />);
+
+    const button12h = screen.getByRole("button", { name: /12h/i });
+    const button24h = screen.getByRole("button", { name: /24h/i });
+
+    expect(button12h).toHaveAttribute("aria-pressed", "true");
+    expect(button24h).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(button24h);
+
+    expect(button12h).toHaveAttribute("aria-pressed", "false");
+    expect(button24h).toHaveAttribute("aria-pressed", "true");
+    expect(useTimeFormatStore.getState().timeFormat).toBe("24h");
+  });
+});

--- a/frontend/src/features/settings/components/appearance-settings.tsx
+++ b/frontend/src/features/settings/components/appearance-settings.tsx
@@ -1,6 +1,7 @@
-import { Monitor, Moon, Palette, Sun } from "lucide-react";
+import { Clock3, Monitor, Moon, Palette, Sun } from "lucide-react";
 
 import { useThemeStore, type ThemePreference } from "@/hooks/use-theme";
+import { useTimeFormatStore, type TimeFormatPreference } from "@/hooks/use-time-format";
 import { cn } from "@/lib/utils";
 
 const THEME_OPTIONS: { value: ThemePreference; label: string; icon: typeof Sun }[] = [
@@ -9,9 +10,16 @@ const THEME_OPTIONS: { value: ThemePreference; label: string; icon: typeof Sun }
   { value: "auto", label: "System", icon: Monitor },
 ];
 
+const TIME_FORMAT_OPTIONS: { value: TimeFormatPreference; label: string; preview: string }[] = [
+  { value: "12h", label: "12h", preview: "03:45 PM" },
+  { value: "24h", label: "24h", preview: "15:45" },
+];
+
 export function AppearanceSettings() {
   const preference = useThemeStore((s) => s.preference);
   const setTheme = useThemeStore((s) => s.setTheme);
+  const timeFormat = useTimeFormatStore((s) => s.timeFormat);
+  const setTimeFormat = useTimeFormatStore((s) => s.setTimeFormat);
 
   return (
     <section className="rounded-xl border bg-card p-5">
@@ -21,12 +29,12 @@ export function AppearanceSettings() {
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
               <Palette className="h-4 w-4 text-primary" aria-hidden="true" />
             </div>
-            <div>
-              <h3 className="text-sm font-semibold">Appearance</h3>
-              <p className="text-xs text-muted-foreground">Choose how the interface looks.</p>
-            </div>
-          </div>
-        </div>
+             <div>
+               <h3 className="text-sm font-semibold">Appearance</h3>
+               <p className="text-xs text-muted-foreground">Choose how the interface looks and how time is displayed.</p>
+             </div>
+           </div>
+         </div>
 
         <div className="flex items-center justify-between rounded-lg border p-3">
           <div>
@@ -38,6 +46,7 @@ export function AppearanceSettings() {
               <button
                 key={value}
                 type="button"
+                aria-pressed={preference === value}
                 onClick={() => setTheme(value)}
                 className={cn(
                   "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors duration-200",
@@ -48,6 +57,37 @@ export function AppearanceSettings() {
               >
                 <Icon className="h-3.5 w-3.5" />
                 {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between rounded-lg border p-3">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex h-7 w-7 items-center justify-center rounded-md bg-primary/10">
+              <Clock3 className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-sm font-medium">Time format</p>
+              <p className="text-xs text-muted-foreground">Apply 12h or 24h formatting to datetimes across the dashboard.</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-1 rounded-lg border border-border/50 bg-muted/40 p-0.5">
+            {TIME_FORMAT_OPTIONS.map(({ value, label, preview }) => (
+              <button
+                key={value}
+                type="button"
+                aria-pressed={timeFormat === value}
+                onClick={() => setTimeFormat(value)}
+                className={cn(
+                  "rounded-md px-3 py-1.5 text-left text-xs font-medium transition-colors duration-200",
+                  timeFormat === value
+                    ? "bg-background text-foreground shadow-[var(--shadow-xs)]"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <span className="block">{label}</span>
+                <span className="block text-[10px] font-normal text-muted-foreground">{preview}</span>
               </button>
             ))}
           </div>

--- a/frontend/src/hooks/use-time-format.test.ts
+++ b/frontend/src/hooks/use-time-format.test.ts
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getTimeFormatPreference, useTimeFormatStore } from "@/hooks/use-time-format";
+
+describe("useTimeFormatStore", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useTimeFormatStore.setState({ timeFormat: "12h" });
+  });
+
+  it("defaults to 12h", () => {
+    expect(getTimeFormatPreference()).toBe("12h");
+  });
+
+  it("persists updates to localStorage", () => {
+    useTimeFormatStore.getState().setTimeFormat("24h");
+
+    expect(getTimeFormatPreference()).toBe("24h");
+    expect(window.localStorage.getItem("codex-lb-time-format")).toBe("24h");
+  });
+});

--- a/frontend/src/hooks/use-time-format.ts
+++ b/frontend/src/hooks/use-time-format.ts
@@ -1,0 +1,47 @@
+import { create } from "zustand";
+
+const TIME_FORMAT_STORAGE_KEY = "codex-lb-time-format";
+
+export type TimeFormatPreference = "12h" | "24h";
+
+type TimeFormatState = {
+  timeFormat: TimeFormatPreference;
+  setTimeFormat: (preference: TimeFormatPreference) => void;
+};
+
+function readStoredPreference(): TimeFormatPreference {
+  if (typeof window === "undefined") {
+    return "12h";
+  }
+
+  try {
+    const stored = window.localStorage.getItem(TIME_FORMAT_STORAGE_KEY);
+    return stored === "24h" ? "24h" : "12h";
+  } catch {
+    return "12h";
+  }
+}
+
+function persistPreference(preference: TimeFormatPreference): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(TIME_FORMAT_STORAGE_KEY, preference);
+  } catch {
+    /* Storage blocked - silently ignore. */
+  }
+}
+
+export function getTimeFormatPreference(): TimeFormatPreference {
+  return useTimeFormatStore.getState().timeFormat;
+}
+
+export const useTimeFormatStore = create<TimeFormatState>((set) => ({
+  timeFormat: readStoredPreference(),
+  setTimeFormat: (preference) => {
+    persistPreference(preference);
+    set({ timeFormat: preference });
+  },
+}));

--- a/frontend/src/utils/formatters.test.ts
+++ b/frontend/src/utils/formatters.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RESET_ERROR_LABEL } from "@/utils/constants";
+import { useTimeFormatStore } from "@/hooks/use-time-format";
 import {
+  formatChartDateTime,
+  formatDateTimeInline,
   formatAccessTokenLabel,
   formatCachedTokensMeta,
   formatCompactNumber,
@@ -32,6 +35,7 @@ describe("formatters", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    useTimeFormatStore.setState({ timeFormat: "12h" });
   });
 
   afterEach(() => {
@@ -95,6 +99,20 @@ describe("formatters", () => {
     const formatted = formatTimeLong("2026-01-01T00:00:00.000Z");
     expect(formatted.time).not.toBe("--");
     expect(formatted.date).not.toBe("--");
+  });
+
+  it("respects the configured 12h or 24h time format", () => {
+    const iso = "2026-01-01T00:00:00.000Z";
+
+    const twelveHour = formatTimeLong(iso).time;
+    expect(twelveHour).toMatch(/AM|PM/);
+
+    useTimeFormatStore.getState().setTimeFormat("24h");
+
+    const twentyFourHour = formatTimeLong(iso).time;
+    expect(twentyFourHour).not.toMatch(/AM|PM/);
+    expect(formatDateTimeInline(iso)).toContain(twentyFourHour);
+    expect(formatChartDateTime(iso)).not.toMatch(/AM|PM/);
   });
 
   it("formats relative and countdown values", () => {

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -1,4 +1,5 @@
 import { RESET_ERROR_LABEL } from "@/utils/constants";
+import { getTimeFormatPreference, type TimeFormatPreference } from "@/hooks/use-time-format";
 
 const numberFormatter = new Intl.NumberFormat("en-US");
 const compactFormatter = new Intl.NumberFormat("en-US", {
@@ -11,21 +12,54 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
-const timeFormatter = new Intl.DateTimeFormat("en-US", {
-  hour: "2-digit",
-  minute: "2-digit",
-  second: "2-digit",
-});
 const dateFormatter = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
   month: "2-digit",
   day: "2-digit",
 });
+const timeFormatterMap: Record<TimeFormatPreference, Intl.DateTimeFormat> = {
+  "12h": new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h12",
+  }),
+  "24h": new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }),
+};
+const chartDateTimeFormatterMap: Record<TimeFormatPreference, Intl.DateTimeFormat> = {
+  "12h": new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h12",
+  }),
+  "24h": new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }),
+};
 
 export type FormattedDateTime = {
   time: string;
   date: string;
 };
+
+function getTimeFormatter(): Intl.DateTimeFormat {
+  return timeFormatterMap[getTimeFormatPreference()];
+}
+
+function getChartDateTimeFormatter(): Intl.DateTimeFormat {
+  return chartDateTimeFormatterMap[getTimeFormatPreference()];
+}
 
 type TokenState = {
   state?: string | null;
@@ -182,9 +216,19 @@ export function formatTimeLong(iso: string | null | undefined): FormattedDateTim
     return { time: "--", date: "--" };
   }
   return {
-    time: timeFormatter.format(date),
+    time: getTimeFormatter().format(date),
     date: dateFormatter.format(date),
   };
+}
+
+export function formatDateTimeInline(iso: string | null | undefined): string {
+  const formatted = formatTimeLong(iso);
+  return formatted.time === "--" ? "--" : `${formatted.time} ${formatted.date}`;
+}
+
+export function formatChartDateTime(iso: string | null | undefined): string {
+  const date = parseDate(iso);
+  return date ? getChartDateTimeFormatter().format(date) : "--";
 }
 
 export function formatRelative(ms: number): string {

--- a/openspec/changes/enhance-dashboard-time-format-and-donut-hover/proposal.md
+++ b/openspec/changes/enhance-dashboard-time-format-and-donut-hover/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+Operators currently cannot choose whether dashboard timestamps render in 12-hour or 24-hour format, so the UI always reflects the browser default rather than an explicit dashboard preference. That makes time-heavy views such as request logs, sticky-session tables, and usage tooltips less predictable for teams that standardize on 24-hour time.
+
+The dashboard donut charts also treat the pie and its HTML legend as disconnected surfaces. Hovering a legend item does not emphasize the matching slice, hovering a slice does not visually identify the matching legend row, and enlarging a slice would currently risk clipping against the chart container.
+
+## What Changes
+
+- Add an Appearance setting for `12h` or `24h` time display, defaulting to `12h`, and persist it locally for the dashboard UI.
+- Make dashboard datetime rendering honor that configured time format across shared datetime surfaces and chart tooltips.
+- Add donut-chart hover coordination so hovering either a slice or its legend row enlarges the matching slice and outlines the matching legend row.
+- Slightly increase the donut-chart canvas so the active slice treatment does not clip inside its card.
+
+## Impact
+
+- Specs: `openspec/specs/frontend-architecture/spec.md`
+- Frontend: appearance settings, shared datetime formatting utilities, dashboard donut chart interactions
+- Tests: frontend unit coverage for persisted time-format behavior and donut hover interaction

--- a/openspec/changes/enhance-dashboard-time-format-and-donut-hover/specs/frontend-architecture/spec.md
+++ b/openspec/changes/enhance-dashboard-time-format-and-donut-hover/specs/frontend-architecture/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard page
+
+The Dashboard page SHALL display summary metric cards, primary and secondary usage donut charts with legends, account status cards grid, and a recent requests table with filtering and pagination. Donut charts MUST coordinate hover state between slices and legend rows.
+
+#### Scenario: Donut legend hover highlights the matching slice
+
+- **WHEN** a user hovers a donut legend row, including its color dot or text label
+- **THEN** the matching donut slice enlarges using the chart library's active-slice mechanism
+- **AND** the hovered legend row shows a visible outline tied to the same series color
+
+#### Scenario: Donut slice hover highlights the matching legend row
+
+- **WHEN** a user hovers a donut slice
+- **THEN** the matching legend row shows the same active outline treatment
+- **AND** the chart canvas leaves enough room that the enlarged slice does not clip against the card container
+
+### Requirement: Settings page
+
+The Settings page SHALL include sections for: appearance settings (theme and datetime time format), routing settings (sticky threads, reset priority, prompt-cache affinity TTL), password management (setup/change/remove), TOTP management (setup/disable), API key auth toggle, API key management (table, create, edit, delete, regenerate), and sticky-session administration.
+
+#### Scenario: Appearance time format defaults to 12h
+
+- **WHEN** a user opens the dashboard without a previously saved time-format preference
+- **THEN** the Appearance section shows `12h` as the selected time format
+- **AND** datetime labels across the dashboard render in 12-hour format
+
+#### Scenario: Appearance time format updates datetime rendering
+
+- **WHEN** a user changes the Appearance time format from `12h` to `24h` or from `24h` to `12h`
+- **THEN** the preference is persisted locally for the dashboard UI
+- **AND** datetime labels and chart tooltip timestamps across the application update to use the selected hour format

--- a/openspec/changes/enhance-dashboard-time-format-and-donut-hover/tasks.md
+++ b/openspec/changes/enhance-dashboard-time-format-and-donut-hover/tasks.md
@@ -1,0 +1,15 @@
+## 1. Spec
+
+- [x] 1.1 Specify the Appearance time-format control and its default persistence behavior
+- [x] 1.2 Specify coordinated donut hover behavior between slices and legend rows
+
+## 2. Frontend
+
+- [x] 2.1 Add a persisted `12h`/`24h` appearance setting with `12h` as the default
+- [x] 2.2 Route shared datetime formatting and chart tooltips through the selected time format
+- [x] 2.3 Add active donut hover styling for both slices and legend rows without clipping
+
+## 3. Tests
+
+- [x] 3.1 Add frontend tests for the time-format store and formatter behavior
+- [x] 3.2 Add frontend tests covering donut legend and slice hover highlighting


### PR DESCRIPTION
1. Add a 12h/24h switch in setting so that the UI can show 12h/24h time, which the user chose for
Closes #369   
<img width="93" height="194" alt="螢幕截圖 2026-04-09 22 17 49" src="https://github.com/user-attachments/assets/f8e19b6f-f193-4e30-ac3c-2e1b4b636d8d" />  



2. The pie in the donut will enlarge a slightly little bit when the legend text is hovered. 
The item will also be highlighted as box
Also there is a maximum number of legend items could be shown so that the dashboard will not get overflown
<img width="741" height="288" alt="螢幕截圖 2026-04-09 22 17 25" src="https://github.com/user-attachments/assets/8481b909-e4c1-4526-a4c5-35da576d3c50" />
