### PR TITLE
fix(auth): harden dashboard auth modes (Codex review follow-up)

### DIFF
--- a/app/core/auth/dashboard_mode.py
+++ b/app/core/auth/dashboard_mode.py
@@ -14,6 +14,7 @@ _FORBIDDEN_PROXY_AUTH_HEADERS = frozenset(
         "authorization",
         "connection",
         "content-length",
+        "cookie",
         "forwarded",
         "host",
         "keep-alive",

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -75,14 +75,18 @@ def _decorate_session_response(
 ) -> DashboardAuthSessionResponse:
     request_auth = get_dashboard_request_auth(request)
     auth_mode = get_settings().dashboard_auth_mode
+    store = get_dashboard_session_store()
     sid = password_session_id or request.cookies.get(DASHBOARD_SESSION_COOKIE)
-    has_pwd_session = get_dashboard_session_store().is_password_verified(sid) if sid else False
+    session_state = store.get(sid) if sid else None
+    has_pwd = session_state is not None and session_state.password_verified
+    totp_pending = has_pwd and response.totp_required_on_login and not session_state.totp_verified
+    fully_authorized = has_pwd and not totp_pending
 
     if request_auth is None:
         update: dict[str, object] = {
             "auth_mode": auth_mode,
             "password_management_enabled": password_management_enabled(auth_mode),
-            "password_session_active": has_pwd_session,
+            "password_session_active": fully_authorized,
         }
         if (
             auth_mode == DashboardAuthMode.TRUSTED_HEADER
@@ -95,10 +99,10 @@ def _decorate_session_response(
     return response.model_copy(
         update={
             "authenticated": force_authenticated or response.authenticated,
-            "totp_required_on_login": False,
+            "totp_required_on_login": totp_pending,
             "auth_mode": request_auth.mode,
             "password_management_enabled": password_management_enabled(request_auth.mode),
-            "password_session_active": has_pwd_session,
+            "password_session_active": fully_authorized,
         }
     )
 

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -71,13 +71,18 @@ def _decorate_session_response(
     *,
     request: Request,
     force_authenticated: bool = False,
+    password_session_id: str | None = None,
 ) -> DashboardAuthSessionResponse:
     request_auth = get_dashboard_request_auth(request)
     auth_mode = get_settings().dashboard_auth_mode
+    sid = password_session_id or request.cookies.get(DASHBOARD_SESSION_COOKIE)
+    has_pwd_session = get_dashboard_session_store().is_password_verified(sid) if sid else False
+
     if request_auth is None:
-        update = {
+        update: dict[str, object] = {
             "auth_mode": auth_mode,
             "password_management_enabled": password_management_enabled(auth_mode),
+            "password_session_active": has_pwd_session,
         }
         if (
             auth_mode == DashboardAuthMode.TRUSTED_HEADER
@@ -93,6 +98,7 @@ def _decorate_session_response(
             "totp_required_on_login": False,
             "auth_mode": request_auth.mode,
             "password_management_enabled": password_management_enabled(request_auth.mode),
+            "password_session_active": has_pwd_session,
         }
     )
 
@@ -198,7 +204,11 @@ async def setup_password(
 
     await get_settings_cache().invalidate()
     session_id = get_dashboard_session_store().create(password_verified=True, totp_verified=False)
-    response = _decorate_session_response(await context.service.get_session_state(session_id), request=request)
+    response = _decorate_session_response(
+        await context.service.get_session_state(session_id),
+        request=request,
+        password_session_id=session_id,
+    )
     json_response = JSONResponse(status_code=200, content=response.model_dump(by_alias=True))
     _set_session_cookie(json_response, session_id, request)
     return json_response
@@ -244,7 +254,11 @@ async def login_password(
     await limiter.clear_for_key(rate_key, context.session)
 
     session_id = get_dashboard_session_store().create(password_verified=True, totp_verified=False)
-    response = _decorate_session_response(await context.service.get_session_state(session_id), request=request)
+    response = _decorate_session_response(
+        await context.service.get_session_state(session_id),
+        request=request,
+        password_session_id=session_id,
+    )
     json_response = JSONResponse(status_code=200, content=response.model_dump(by_alias=True))
     _set_session_cookie(json_response, session_id, request)
     return json_response
@@ -392,7 +406,11 @@ async def verify_totp(
         raise DashboardBadRequestError(str(exc), code="invalid_totp_code") from exc
 
     await limiter.clear_for_key(rate_key, context.session)
-    response = _decorate_session_response(await context.service.get_session_state(session_id), request=request)
+    response = _decorate_session_response(
+        await context.service.get_session_state(session_id),
+        request=request,
+        password_session_id=session_id,
+    )
     json_response = JSONResponse(status_code=200, content=response.model_dump(by_alias=True))
     _set_session_cookie(json_response, session_id, request)
     return json_response

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -377,6 +377,7 @@ async def verify_totp(
     payload: TotpVerifyRequest = Body(...),
     context: DashboardAuthContext = Depends(get_dashboard_auth_context),
 ) -> DashboardAuthSessionResponse | JSONResponse:
+    _ensure_password_management_enabled(request)
     limiter = get_totp_rate_limiter()
     rate_key = _session_client_key(request, prefix="totp_verify")
     current_session_id = request.cookies.get(DASHBOARD_SESSION_COOKIE)

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -80,7 +80,7 @@ def _decorate_session_response(
     session_state = store.get(sid) if sid else None
     has_pwd = session_state is not None and session_state.password_verified
     totp_pending = has_pwd and response.totp_required_on_login and not session_state.totp_verified
-    fully_authorized = has_pwd and not totp_pending
+    fully_authorized = has_pwd and not totp_pending and response.password_required
 
     if request_auth is None:
         update: dict[str, object] = {

--- a/app/modules/dashboard_auth/schemas.py
+++ b/app/modules/dashboard_auth/schemas.py
@@ -13,6 +13,7 @@ class DashboardAuthSessionResponse(DashboardModel):
     bootstrap_token_configured: bool = False
     auth_mode: DashboardAuthMode = DashboardAuthMode.STANDARD
     password_management_enabled: bool = True
+    password_session_active: bool = False
 
 
 class TotpSetupStartResponse(DashboardModel):

--- a/frontend/src/features/auth/hooks/use-auth.test.ts
+++ b/frontend/src/features/auth/hooks/use-auth.test.ts
@@ -25,6 +25,7 @@ const sessionBase: AuthSession = {
   bootstrapTokenConfigured: false,
   authMode: "standard",
   passwordManagementEnabled: true,
+  passwordSessionActive: false,
 };
 
 function resetAuthStore(): void {

--- a/frontend/src/features/auth/hooks/use-auth.ts
+++ b/frontend/src/features/auth/hooks/use-auth.ts
@@ -18,6 +18,7 @@ type AuthState = {
   bootstrapTokenConfigured: boolean;
   authMode: DashboardAuthMode;
   passwordManagementEnabled: boolean;
+  passwordSessionActive: boolean;
   loading: boolean;
   initialized: boolean;
   error: string | null;
@@ -38,6 +39,7 @@ function applySession(set: (next: Partial<AuthState>) => void, session: AuthSess
     bootstrapTokenConfigured: session.bootstrapTokenConfigured ?? false,
     authMode: session.authMode,
     passwordManagementEnabled: session.passwordManagementEnabled,
+    passwordSessionActive: session.passwordSessionActive,
     initialized: true,
     error: null,
   });
@@ -53,6 +55,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   bootstrapTokenConfigured: false,
   authMode: "standard",
   passwordManagementEnabled: true,
+  passwordSessionActive: false,
   loading: false,
   initialized: false,
   error: null,

--- a/frontend/src/features/auth/schemas.test.ts
+++ b/frontend/src/features/auth/schemas.test.ts
@@ -22,6 +22,7 @@ describe("AuthSessionSchema", () => {
       bootstrapTokenConfigured: false,
       authMode: "trusted_header",
       passwordManagementEnabled: true,
+      passwordSessionActive: false,
     });
   });
 

--- a/frontend/src/features/auth/schemas.ts
+++ b/frontend/src/features/auth/schemas.ts
@@ -11,6 +11,7 @@ export const AuthSessionSchema = z.object({
   bootstrapTokenConfigured: z.boolean().optional().default(false),
   authMode: DashboardAuthModeSchema.default("standard"),
   passwordManagementEnabled: z.boolean().default(true),
+  passwordSessionActive: z.boolean().default(false),
 });
 
 export const LoginRequestSchema = z.object({

--- a/frontend/src/features/settings/components/password-settings.test.tsx
+++ b/frontend/src/features/settings/components/password-settings.test.tsx
@@ -36,7 +36,7 @@ describe("PasswordSettings", () => {
   });
 
   it("shows change/remove buttons when password is configured", () => {
-    useAuthStore.setState({ passwordRequired: true });
+    useAuthStore.setState({ passwordRequired: true, passwordSessionActive: true });
     render(<PasswordSettings />);
     expect(screen.getByRole("button", { name: "Change" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
@@ -78,7 +78,7 @@ describe("PasswordSettings", () => {
 
   it("handles change flow via dialog", async () => {
     const user = userEvent.setup();
-    useAuthStore.setState({ passwordRequired: true });
+    useAuthStore.setState({ passwordRequired: true, passwordSessionActive: true });
     vi.mocked(changePassword).mockResolvedValue({} as never);
 
     render(<PasswordSettings />);
@@ -97,7 +97,7 @@ describe("PasswordSettings", () => {
 
   it("handles remove flow via dialog", async () => {
     const user = userEvent.setup();
-    useAuthStore.setState({ passwordRequired: true });
+    useAuthStore.setState({ passwordRequired: true, passwordSessionActive: true });
     vi.mocked(removePassword).mockResolvedValue({} as never);
 
     render(<PasswordSettings />);
@@ -130,6 +130,21 @@ describe("PasswordSettings", () => {
 
     expect(screen.getByText("No fallback password set.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Set password" })).toBeInTheDocument();
+  });
+
+  it("hides change/remove when proxy-authenticated without password session", () => {
+    useAuthStore.setState({
+      authMode: "trusted_header",
+      passwordRequired: true,
+      passwordManagementEnabled: true,
+      passwordSessionActive: false,
+    });
+    render(<PasswordSettings />);
+
+    expect(screen.getByText("Password is configured as an optional fallback.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Change" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Set password" })).not.toBeInTheDocument();
   });
 
   it("hides password actions when password management is disabled", () => {

--- a/frontend/src/features/settings/components/password-settings.tsx
+++ b/frontend/src/features/settings/components/password-settings.tsx
@@ -37,6 +37,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
   const bootstrapTokenConfigured = useAuthStore((s) => s.bootstrapTokenConfigured);
   const authMode = useAuthStore((s) => s.authMode);
   const passwordManagementEnabled = useAuthStore((s) => s.passwordManagementEnabled);
+  const passwordSessionActive = useAuthStore((s) => s.passwordSessionActive);
   const refreshSession = useAuthStore((s) => s.refreshSession);
 
   const [activeDialog, setActiveDialog] = useState<PasswordDialog>(null);
@@ -134,7 +135,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
         </div>
 
         <div className="flex items-center gap-2">
-          {!passwordManagementEnabled ? null : passwordRequired ? (
+          {!passwordManagementEnabled ? null : passwordRequired && passwordSessionActive ? (
             <>
               <Button
                 type="button"
@@ -157,7 +158,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
                 Remove
               </Button>
             </>
-          ) : (
+          ) : !passwordRequired ? (
             <Button
               type="button"
               size="sm"
@@ -167,7 +168,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
             >
               Set password
             </Button>
-          )}
+          ) : null}
         </div>
         </div>
       </div>

--- a/frontend/src/features/settings/components/password-settings.tsx
+++ b/frontend/src/features/settings/components/password-settings.tsx
@@ -16,12 +16,13 @@ import {
 } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { changePassword, loginPassword, removePassword, setupPassword } from "@/features/auth/api";
+import { changePassword, loginPassword, removePassword, setupPassword, verifyTotp } from "@/features/auth/api";
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
 import {
   PasswordChangeRequestSchema,
   PasswordRemoveRequestSchema,
   PasswordSetupRequestSchema,
+  TotpVerifyRequestSchema,
 } from "@/features/auth/schemas";
 import { getErrorMessage } from "@/utils/errors";
 
@@ -42,6 +43,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
 
   const authenticated = useAuthStore((s) => s.authenticated);
   const [activeDialog, setActiveDialog] = useState<PasswordDialog>(null);
+  const [verifyStep, setVerifyStep] = useState<"password" | "totp">("password");
   const [error, setError] = useState<string | null>(null);
 
   const setupForm = useForm({
@@ -64,11 +66,17 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
     defaultValues: { password: "" },
   });
 
+  const verifyTotpForm = useForm({
+    resolver: zodResolver(TotpVerifyRequestSchema),
+    defaultValues: { code: "" },
+  });
+
   const busy =
     setupForm.formState.isSubmitting ||
     changeForm.formState.isSubmitting ||
     removeForm.formState.isSubmitting ||
-    verifyForm.formState.isSubmitting;
+    verifyForm.formState.isSubmitting ||
+    verifyTotpForm.formState.isSubmitting;
   const lock = busy || disabled || !passwordManagementEnabled;
 
   const closeDialog = () => {
@@ -78,6 +86,8 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
     changeForm.reset();
     removeForm.reset();
     verifyForm.reset();
+    verifyTotpForm.reset();
+    setVerifyStep("password");
   };
 
   const handleSetup = async (values: { password: string; bootstrapToken?: string }) => {
@@ -121,7 +131,23 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
   const handleVerify = async (values: { password: string }) => {
     setError(null);
     try {
-      await loginPassword(values);
+      const session = await loginPassword(values);
+      if (session.totpRequiredOnLogin && !session.passwordSessionActive) {
+        setVerifyStep("totp");
+        return;
+      }
+      await refreshSession();
+      toast.success("Password session established");
+      closeDialog();
+    } catch (caught) {
+      setError(getErrorMessage(caught));
+    }
+  };
+
+  const handleVerifyTotp = async (values: { code: string }) => {
+    setError(null);
+    try {
+      await verifyTotp(values);
       await refreshSession();
       toast.success("Password session established");
       closeDialog();
@@ -351,35 +377,67 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
       <Dialog open={activeDialog === "verify"} onOpenChange={(open) => !open && closeDialog()}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
-            <DialogTitle>Verify password</DialogTitle>
-            <DialogDescription>Enter your password to unlock password and TOTP management.</DialogDescription>
+            <DialogTitle>{verifyStep === "password" ? "Verify password" : "TOTP verification"}</DialogTitle>
+            <DialogDescription>
+              {verifyStep === "password"
+                ? "Enter your password to unlock password and TOTP management."
+                : "Enter your TOTP code to complete verification."}
+            </DialogDescription>
           </DialogHeader>
           {error ? <AlertMessage variant="error">{error}</AlertMessage> : null}
-          <Form {...verifyForm}>
-            <form onSubmit={verifyForm.handleSubmit(handleVerify)} className="space-y-4">
-              <FormField
-                control={verifyForm.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Password</FormLabel>
-                    <FormControl>
-                      <Input {...field} type="password" autoComplete="current-password" placeholder="Enter current password" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <DialogFooter>
-                <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={busy}>
-                  Verify
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
+          {verifyStep === "password" ? (
+            <Form {...verifyForm}>
+              <form onSubmit={verifyForm.handleSubmit(handleVerify)} className="space-y-4">
+                <FormField
+                  control={verifyForm.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Password</FormLabel>
+                      <FormControl>
+                        <Input {...field} type="password" autoComplete="current-password" placeholder="Enter current password" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={busy}>
+                    Verify
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          ) : (
+            <Form {...verifyTotpForm}>
+              <form onSubmit={verifyTotpForm.handleSubmit(handleVerifyTotp)} className="space-y-4">
+                <FormField
+                  control={verifyTotpForm.control}
+                  name="code"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>TOTP code</FormLabel>
+                      <FormControl>
+                        <Input {...field} type="text" inputMode="numeric" autoComplete="one-time-code" placeholder="6-digit code" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={busy}>
+                    Verify
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          )}
         </DialogContent>
       </Dialog>
     </section>

--- a/frontend/src/features/settings/components/password-settings.tsx
+++ b/frontend/src/features/settings/components/password-settings.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { changePassword, removePassword, setupPassword } from "@/features/auth/api";
+import { changePassword, loginPassword, removePassword, setupPassword } from "@/features/auth/api";
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
 import {
   PasswordChangeRequestSchema,
@@ -25,7 +25,7 @@ import {
 } from "@/features/auth/schemas";
 import { getErrorMessage } from "@/utils/errors";
 
-type PasswordDialog = "setup" | "change" | "remove" | null;
+type PasswordDialog = "setup" | "change" | "remove" | "verify" | null;
 
 export type PasswordSettingsProps = {
   disabled?: boolean;
@@ -40,6 +40,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
   const passwordSessionActive = useAuthStore((s) => s.passwordSessionActive);
   const refreshSession = useAuthStore((s) => s.refreshSession);
 
+  const authenticated = useAuthStore((s) => s.authenticated);
   const [activeDialog, setActiveDialog] = useState<PasswordDialog>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -58,10 +59,16 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
     defaultValues: { password: "" },
   });
 
+  const verifyForm = useForm({
+    resolver: zodResolver(PasswordRemoveRequestSchema),
+    defaultValues: { password: "" },
+  });
+
   const busy =
     setupForm.formState.isSubmitting ||
     changeForm.formState.isSubmitting ||
-    removeForm.formState.isSubmitting;
+    removeForm.formState.isSubmitting ||
+    verifyForm.formState.isSubmitting;
   const lock = busy || disabled || !passwordManagementEnabled;
 
   const closeDialog = () => {
@@ -70,6 +77,7 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
     setupForm.reset();
     changeForm.reset();
     removeForm.reset();
+    verifyForm.reset();
   };
 
   const handleSetup = async (values: { password: string; bootstrapToken?: string }) => {
@@ -104,6 +112,18 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
       await removePassword(values);
       await refreshSession();
       toast.success("Password removed");
+      closeDialog();
+    } catch (caught) {
+      setError(getErrorMessage(caught));
+    }
+  };
+
+  const handleVerify = async (values: { password: string }) => {
+    setError(null);
+    try {
+      await loginPassword(values);
+      await refreshSession();
+      toast.success("Password session established");
       closeDialog();
     } catch (caught) {
       setError(getErrorMessage(caught));
@@ -158,6 +178,17 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
                 Remove
               </Button>
             </>
+          ) : passwordRequired && authenticated && !passwordSessionActive ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-8 text-xs"
+              disabled={disabled}
+              onClick={() => setActiveDialog("verify")}
+            >
+              Login to manage
+            </Button>
           ) : !passwordRequired ? (
             <Button
               type="button"
@@ -309,6 +340,42 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
                 </Button>
                 <Button type="submit" variant="destructive" disabled={lock}>
                   Remove password
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
+
+      {/* Verify dialog (re-establish password session for proxy-authenticated users) */}
+      <Dialog open={activeDialog === "verify"} onOpenChange={(open) => !open && closeDialog()}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Verify password</DialogTitle>
+            <DialogDescription>Enter your password to unlock password and TOTP management.</DialogDescription>
+          </DialogHeader>
+          {error ? <AlertMessage variant="error">{error}</AlertMessage> : null}
+          <Form {...verifyForm}>
+            <form onSubmit={verifyForm.handleSubmit(handleVerify)} className="space-y-4">
+              <FormField
+                control={verifyForm.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="password" autoComplete="current-password" placeholder="Enter current password" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={busy}>
+                  Verify
                 </Button>
               </DialogFooter>
             </form>

--- a/frontend/src/features/settings/components/settings-page.tsx
+++ b/frontend/src/features/settings/components/settings-page.tsx
@@ -25,6 +25,7 @@ export function SettingsPage() {
   const { settingsQuery, updateSettingsMutation } = useSettings();
   const authMode = useAuthStore((state) => state.authMode);
   const passwordManagementEnabled = useAuthStore((state) => state.passwordManagementEnabled);
+  const passwordSessionActive = useAuthStore((state) => state.passwordSessionActive);
 
   const settings = settingsQuery.data;
   const busy = updateSettingsMutation.isPending;
@@ -75,7 +76,7 @@ export function SettingsPage() {
             />
             <ImportSettings settings={settings} busy={busy} onSave={handleSave} />
             <PasswordSettings disabled={busy} />
-            {passwordManagementEnabled ? (
+            {passwordManagementEnabled && passwordSessionActive ? (
               <Suspense fallback={null}>
                 <TotpSettings settings={settings} disabled={busy} onSave={handleSave} />
               </Suspense>

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -196,6 +196,7 @@ async def test_trusted_header_mode_requires_proxy_header_for_open_dashboard(asyn
         "bootstrapTokenConfigured": False,
         "authMode": "trusted_header",
         "passwordManagementEnabled": True,
+        "passwordSessionActive": False,
     }
 
     blocked = await async_client.get("/api/settings")
@@ -266,6 +267,7 @@ async def test_disabled_dashboard_auth_mode_bypasses_guard_and_disables_password
         "bootstrapTokenConfigured": False,
         "authMode": "disabled",
         "passwordManagementEnabled": False,
+        "passwordSessionActive": False,
     }
 
     allowed = await async_client.get("/api/settings")
@@ -292,6 +294,46 @@ async def test_disabled_dashboard_auth_mode_bypasses_guard_and_disables_password
     disable_totp = await async_client.post("/api/dashboard-auth/totp/disable", json={"code": "123456"})
     assert disable_totp.status_code == 400
     assert disable_totp.json()["error"]["code"] == "password_management_disabled"
+
+
+@pytest.mark.asyncio
+async def test_trusted_header_proxy_auth_with_fallback_password_reports_no_active_session(async_client, monkeypatch):
+    """Proxy-authenticated user with configured fallback password must see passwordSessionActive=False."""
+    _set_dashboard_auth_env(
+        monkeypatch,
+        mode=DashboardAuthMode.TRUSTED_HEADER,
+        trust_proxy_headers=True,
+    )
+    proxy_headers = {"Remote-User": "admin@example.com"}
+
+    setup = await async_client.post(
+        "/api/dashboard-auth/password/setup",
+        json={"password": "password123"},
+        headers=proxy_headers,
+    )
+    assert setup.status_code == 200
+    assert setup.json()["passwordSessionActive"] is True
+
+    async_client.cookies.clear()
+
+    session = await async_client.get("/api/dashboard-auth/session", headers=proxy_headers)
+    assert session.status_code == 200
+    body = session.json()
+    assert body["authenticated"] is True
+    assert body["authMode"] == "trusted_header"
+    assert body["passwordRequired"] is True
+    assert body["passwordManagementEnabled"] is True
+    assert body["passwordSessionActive"] is False
+
+    fallback_login = await async_client.post(
+        "/api/dashboard-auth/password/login",
+        json={"password": "password123"},
+    )
+    assert fallback_login.status_code == 200
+    assert fallback_login.json()["passwordSessionActive"] is True
+
+    session_after_login = await async_client.get("/api/dashboard-auth/session", headers=proxy_headers)
+    assert session_after_login.json()["passwordSessionActive"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up fixes for #366 (dashboard proxy auth modes) found during adversarial Codex review (5 rounds).

## Changes

1. **`password_session_active` field** — Distinguishes proxy-authenticated users from password-session holders so the SPA doesn't show unusable Change/Remove/TOTP buttons
2. **TOTP verify guard** — Adds `_ensure_password_management_enabled` to `verify_totp` endpoint (was the only auth endpoint missing it)
3. **Verify-password dialog** — Lets proxy-authenticated users re-establish a fallback password session inline, with TOTP step support
4. **Cookie header block** — Adds `cookie` to `_FORBIDDEN_PROXY_AUTH_HEADERS` to prevent misconfigured proxy headers from collapsing the trust model
5. **Fully-authorized semantics** — `password_session_active` now requires both password AND TOTP verification (if enabled), preventing TOTP bypass via partial session
6. **Stale cookie guard** — Gates `password_session_active` on `password_required` so expired cookies from a removed password don't surface management UI

## Known limitation (separate issue)

`_is_trusted_proxy_source` uses post-ProxyHeadersMiddleware `request.client.host` instead of raw socket peer IP. Affects localhost reverse proxy setups (Authelia/Caddy/Nginx). Pre-existing in #366's original design — needs ASGI-level middleware to capture raw peer.

## Testing

- Backend: 26 integration + unit tests passed (including new `test_trusted_header_proxy_auth_with_fallback_password_reports_no_active_session`)
- Frontend: 62 files, 332 tests passed (including new proxy-auth button visibility test)