### PR TITLE
fix(ui): some append fix for #379

### DIFF
--- a/frontend/src/components/donut-chart.test.tsx
+++ b/frontend/src/components/donut-chart.test.tsx
@@ -159,7 +159,7 @@ describe("DonutChart", () => {
     );
 
     expect(screen.getByTestId("donut-legend-list")).toHaveStyle({
-      maxHeight: "calc(5 * 1.75rem + 0.5rem)",
+      maxHeight: "calc(5 * 1.75rem)",
     });
   });
 

--- a/frontend/src/components/donut-chart.test.tsx
+++ b/frontend/src/components/donut-chart.test.tsx
@@ -145,7 +145,7 @@ describe("DonutChart", () => {
     expect(legendRow).toHaveAttribute("data-active", "true");
   });
 
-  it("limits the legend list to four visible rows before scrolling", () => {
+  it("limits the legend list to five visible rows before scrolling", () => {
     render(
       <DonutChart
         title="Many Legends"
@@ -159,7 +159,7 @@ describe("DonutChart", () => {
     );
 
     expect(screen.getByTestId("donut-legend-list")).toHaveStyle({
-      maxHeight: "calc(4 * 1.75rem + 0.375rem)",
+      maxHeight: "calc(5 * 1.75rem + 0.5rem)",
     });
   });
 

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -79,7 +79,7 @@ const OUTER_R = 68;
 const ACTIVE_RADIUS_OFFSET = 4;
 const LEGEND_VISIBLE_COUNT = 5;
 const LEGEND_ROW_HEIGHT_REM = 1.75;
-const LEGEND_ROW_GAP_REM = 0.125;
+const LEGEND_ROW_GAP_REM = 0;
 
 type DonutDatum = {
   id: string;

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -222,7 +222,7 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
         </div>
 
         <div
-          className="flex-1 space-y-0.5 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          className="flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           data-testid="donut-legend-list"
           style={{ maxHeight: `calc(${LEGEND_VISIBLE_COUNT} * ${LEGEND_ROW_HEIGHT_REM}rem + ${(LEGEND_VISIBLE_COUNT - 1) * LEGEND_ROW_GAP_REM}rem)` }}
         >

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -77,7 +77,7 @@ const PIE_CY = 72;
 const INNER_R = 53;
 const OUTER_R = 68;
 const ACTIVE_RADIUS_OFFSET = 4;
-const LEGEND_VISIBLE_COUNT = 4;
+const LEGEND_VISIBLE_COUNT = 5;
 const LEGEND_ROW_HEIGHT_REM = 1.75;
 const LEGEND_ROW_GAP_REM = 0.125;
 

--- a/frontend/src/features/dashboard/components/account-cards.test.tsx
+++ b/frontend/src/features/dashboard/components/account-cards.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AccountCards } from "@/features/dashboard/components/account-cards";
+import { createAccountSummary } from "@/test/mocks/factories";
+
+describe("AccountCards", () => {
+  it("caps the dashboard account grid at two visible rows without clipping taller cards", () => {
+    render(
+      <AccountCards
+        accounts={Array.from({ length: 7 }, (_, index) =>
+          createAccountSummary({
+            accountId: `acc-${index + 1}`,
+            email: `account-${index + 1}@example.com`,
+            displayName: `Account ${index + 1}`,
+          }),
+        )}
+        onAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("dashboard-account-cards")).toHaveStyle({
+      maxHeight: "calc(2 * 12.5rem + 1rem)",
+    });
+  });
+
+  it("keeps the scrollbar hidden on the dashboard account grid", () => {
+    render(
+      <AccountCards
+        accounts={[createAccountSummary(), createAccountSummary({ accountId: "acc-2", email: "two@example.com" })]}
+        onAction={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("dashboard-account-cards")).toHaveClass(
+      "overflow-y-auto",
+      "[scrollbar-width:none]",
+      "[&::-webkit-scrollbar]:hidden",
+    );
+  });
+});

--- a/frontend/src/features/dashboard/components/account-cards.tsx
+++ b/frontend/src/features/dashboard/components/account-cards.tsx
@@ -6,6 +6,11 @@ import { AccountCard, type AccountCardProps } from "@/features/dashboard/compone
 import type { AccountSummary } from "@/features/dashboard/schemas";
 import { buildDuplicateAccountIdSet } from "@/utils/account-identifiers";
 
+const ACCOUNT_CARD_VISIBLE_ROWS = 2;
+// Account cards can grow when the optional email row is rendered.
+const ACCOUNT_CARD_ROW_HEIGHT_REM = 12.5;
+const ACCOUNT_CARD_ROW_GAP_REM = 1;
+
 export type AccountCardsProps = {
   accounts: AccountSummary[];
   onAction?: AccountCardProps["onAction"];
@@ -25,10 +30,20 @@ export function AccountCards({ accounts, onAction }: AccountCardsProps) {
   }
 
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div
+      data-testid="dashboard-account-cards"
+      className="grid gap-4 overflow-y-auto pr-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:grid-cols-2 lg:grid-cols-3"
+      style={{
+        maxHeight: `calc(${ACCOUNT_CARD_VISIBLE_ROWS} * ${ACCOUNT_CARD_ROW_HEIGHT_REM}rem + ${(ACCOUNT_CARD_VISIBLE_ROWS - 1) * ACCOUNT_CARD_ROW_GAP_REM}rem)`,
+      }}
+    >
       {accounts.map((account, index) => (
         <div key={account.accountId} className="animate-fade-in-up" style={{ animationDelay: `${index * 75}ms` }}>
-          <AccountCard account={account} showAccountId={duplicateAccountIds.has(account.accountId)} onAction={onAction} />
+          <AccountCard
+            account={account}
+            showAccountId={duplicateAccountIds.has(account.accountId)}
+            onAction={onAction}
+          />
         </div>
       ))}
     </div>

--- a/openspec/changes/tweak-dashboard-legend-and-account-viewport/proposal.md
+++ b/openspec/changes/tweak-dashboard-legend-and-account-viewport/proposal.md
@@ -1,0 +1,9 @@
+# Change Proposal
+
+The dashboard density currently caps donut legends at four visible rows and leaves the account cards grid fully expanded. This can waste vertical space on smaller dashboard viewports and makes longer account lists harder to scan.
+
+## Changes
+
+- Increase the donut legend viewport from 4 to 5 visible rows before scrolling.
+- Make the dashboard account cards grid vertically scrollable with hidden scrollbars and cap the visible content at 2 rows.
+

--- a/openspec/changes/tweak-dashboard-legend-and-account-viewport/specs/frontend-architecture/spec.md
+++ b/openspec/changes/tweak-dashboard-legend-and-account-viewport/specs/frontend-architecture/spec.md
@@ -1,0 +1,16 @@
+### ADDED Requirement: Dashboard density limits
+
+The Dashboard page SHALL render donut legends in a vertically scrollable list that shows up to 5 legend rows before scrolling. The Dashboard page SHALL render the account cards grid inside a vertically scrollable container with hidden scrollbars and a viewport that shows no more than 2 rows of accounts.
+
+#### Scenario: Donut legend viewport shows five rows
+
+- **WHEN** a donut chart has more than 5 legend items
+- **THEN** the legend list shows 5 rows before scrolling
+
+#### Scenario: Account cards viewport shows two rows
+
+- **WHEN** the Dashboard page renders more than 2 rows of account cards
+- **THEN** the account cards container scrolls vertically
+- **AND** the scrollbar remains visually hidden
+- **AND** only 2 rows are visible without scrolling
+

--- a/openspec/changes/tweak-dashboard-legend-and-account-viewport/tasks.md
+++ b/openspec/changes/tweak-dashboard-legend-and-account-viewport/tasks.md
@@ -1,0 +1,3 @@
+- [x] 1. Update the dashboard donut legend viewport to allow five visible rows.
+- [x] 2. Make the dashboard account cards grid scrollable with hidden scrollbars and a two-row viewport.
+- [x] 3. Add or update frontend tests for the new dashboard density limits.


### PR DESCRIPTION
Append #379 
1. Just found that the behavior of showing 5 legends max is not aligned with the #379 described, adjusted accordingly.
2. For the accounts, this is also scrollable now, to prevent producing overflown page

<img width="799" height="769" alt="螢幕截圖 2026-04-10 20 46 49" src="https://github.com/user-attachments/assets/030fbc5d-755f-435a-80a9-b822d84a4e82" />
