### PR TITLE
fix(http-bridge): propagate bridged Spark model errors as HTTP 400

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -371,6 +371,7 @@ class ProxyService:
         try:
             event_queue = request_state.event_queue
             assert event_queue is not None
+            yielded_any = False
             while True:
                 event_block = await event_queue.get()
                 if event_block is None:
@@ -380,7 +381,8 @@ class ProxyService:
                 if request_state.latency_first_token_ms is None and block_event_type in _TEXT_DELTA_EVENT_TYPES:
                     request_state.latency_first_token_ms = int((time.monotonic() - request_state.started_at) * 1000)
                 if (
-                    propagate_http_errors
+                    not yielded_any
+                    and propagate_http_errors
                     and block_event_type == "response.failed"
                     and request_state.error_http_status_override is not None
                     and request_state.error_http_status_override >= 400
@@ -390,6 +392,7 @@ class ProxyService:
                         _openai_error_envelope_from_response_failed_payload(block_payload),
                     )
                 yield event_block
+                yielded_any = True
         finally:
             with anyio.CancelScope(shield=True):
                 await self._detach_http_bridge_request(session, request_state=request_state)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -371,7 +371,6 @@ class ProxyService:
         try:
             event_queue = request_state.event_queue
             assert event_queue is not None
-            yielded_any = False
             while True:
                 event_block = await event_queue.get()
                 if event_block is None:
@@ -381,8 +380,7 @@ class ProxyService:
                 if request_state.latency_first_token_ms is None and block_event_type in _TEXT_DELTA_EVENT_TYPES:
                     request_state.latency_first_token_ms = int((time.monotonic() - request_state.started_at) * 1000)
                 if (
-                    not yielded_any
-                    and propagate_http_errors
+                    propagate_http_errors
                     and block_event_type == "response.failed"
                     and request_state.error_http_status_override is not None
                     and request_state.error_http_status_override >= 400
@@ -392,7 +390,6 @@ class ProxyService:
                         _openai_error_envelope_from_response_failed_payload(block_payload),
                     )
                 yield event_block
-                yielded_any = True
         finally:
             with anyio.CancelScope(shield=True):
                 await self._detach_http_bridge_request(session, request_state=request_state)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2551,6 +2551,18 @@ class ProxyService:
                 if terminal_request_state is not None:
                     session.queued_request_count = max(0, session.queued_request_count - 1)
 
+        if event_type == "error":
+            (
+                event_block,
+                payload,
+                event,
+                event_type,
+            ) = _normalize_http_bridge_error_event(
+                event=event,
+                payload=payload,
+                request_state=terminal_request_state or matched_request_state,
+            )
+
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
             _release_websocket_response_create_gate(created_request_state, session.response_create_gate)
 
@@ -4618,6 +4630,67 @@ def _event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonV
     if isinstance(payload_type, str):
         return payload_type
     return None
+
+
+def _normalize_http_bridge_error_event(
+    *,
+    event: OpenAIEvent | None,
+    payload: dict[str, JsonValue] | None,
+    request_state: _WebSocketRequestState | None,
+) -> tuple[str, dict[str, JsonValue] | None, OpenAIEvent | None, str]:
+    error_code_value: str | None = None
+    error_type_value: str | None = None
+    error_message_value: str | None = None
+    error_param_value: str | None = None
+
+    if event is not None and event.error is not None:
+        error_code_value = event.error.code
+        error_type_value = event.error.type
+        error_message_value = event.error.message
+        error_param_value = event.error.param
+    elif isinstance(payload, dict):
+        payload_error = payload.get("error")
+        if isinstance(payload_error, dict):
+            code_value = payload_error.get("code")
+            if isinstance(code_value, str):
+                stripped = code_value.strip()
+                if stripped:
+                    error_code_value = stripped
+            type_value = payload_error.get("type")
+            if isinstance(type_value, str):
+                stripped = type_value.strip()
+                if stripped:
+                    error_type_value = stripped
+            message_value = payload_error.get("message")
+            if isinstance(message_value, str):
+                stripped = message_value.strip()
+                if stripped:
+                    error_message_value = stripped
+            param_value = payload_error.get("param")
+            if isinstance(param_value, str):
+                stripped = param_value.strip()
+                if stripped:
+                    error_param_value = stripped
+
+    normalized_error_code = _normalize_error_code(error_code_value, error_type_value) or "upstream_error"
+    normalized_error_type = error_type_value or "server_error"
+    normalized_error_message = error_message_value or "Upstream error"
+
+    normalized_response_id = None
+    if request_state is not None:
+        normalized_response_id = request_state.response_id or request_state.request_id
+
+    normalized_event = response_failed_event(
+        normalized_error_code,
+        normalized_error_message,
+        error_type=normalized_error_type,
+        response_id=normalized_response_id,
+        error_param=error_param_value,
+    )
+    normalized_event_block = format_sse_event(normalized_event)
+    normalized_payload = parse_sse_data_json(normalized_event_block)
+    parsed_event = parse_sse_event(normalized_event_block)
+    return normalized_event_block, normalized_payload, parsed_event, "response.failed"
 
 
 def _websocket_response_id(event: OpenAIEvent | None, payload: dict[str, JsonValue] | None) -> str | None:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -299,7 +299,7 @@ class ProxyService:
         prompt_cache_idle_ttl_seconds: float | None = None,
         downstream_turn_state: str | None = None,
     ) -> AsyncIterator[str]:
-        del propagate_http_errors, suppress_text_done_events
+        del suppress_text_done_events
         request_id = ensure_request_id()
         settings = await get_settings_cache().get()
         had_prompt_cache_key = _prompt_cache_key_from_request_model(payload) is not None
@@ -371,16 +371,28 @@ class ProxyService:
         try:
             event_queue = request_state.event_queue
             assert event_queue is not None
+            yielded_any = False
             while True:
                 event_block = await event_queue.get()
                 if event_block is None:
                     break
-                if request_state.latency_first_token_ms is None:
-                    block_payload = parse_sse_data_json(event_block)
-                    block_event_type = _event_type_from_payload(None, block_payload)
-                    if block_event_type in _TEXT_DELTA_EVENT_TYPES:
-                        request_state.latency_first_token_ms = int((time.monotonic() - request_state.started_at) * 1000)
+                block_payload = parse_sse_data_json(event_block)
+                block_event_type = _event_type_from_payload(None, block_payload)
+                if request_state.latency_first_token_ms is None and block_event_type in _TEXT_DELTA_EVENT_TYPES:
+                    request_state.latency_first_token_ms = int((time.monotonic() - request_state.started_at) * 1000)
+                if (
+                    not yielded_any
+                    and propagate_http_errors
+                    and block_event_type == "response.failed"
+                    and request_state.error_http_status_override is not None
+                    and request_state.error_http_status_override >= 400
+                ):
+                    raise ProxyResponseError(
+                        request_state.error_http_status_override,
+                        _openai_error_envelope_from_response_failed_payload(block_payload),
+                    )
                 yield event_block
+                yielded_any = True
         finally:
             with anyio.CancelScope(shield=True):
                 await self._detach_http_bridge_request(session, request_state=request_state)
@@ -2552,6 +2564,10 @@ class ProxyService:
                     session.queued_request_count = max(0, session.queued_request_count - 1)
 
         if event_type == "error":
+            http_status = _http_error_status_from_payload(payload)
+            status_request_state = terminal_request_state or matched_request_state
+            if status_request_state is not None:
+                status_request_state.error_http_status_override = http_status
             (
                 event_block,
                 payload,
@@ -4563,6 +4579,7 @@ class _WebSocketRequestState:
     error_message_override: str | None = None
     error_type_override: str | None = None
     error_param_override: str | None = None
+    error_http_status_override: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -4630,6 +4647,47 @@ def _event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonV
     if isinstance(payload_type, str):
         return payload_type
     return None
+
+
+def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    status = payload.get("status")
+    if isinstance(status, int):
+        return status
+    return None
+
+
+def _openai_error_envelope_from_response_failed_payload(
+    payload: dict[str, JsonValue] | None,
+) -> OpenAIErrorEnvelope:
+    default_envelope = openai_error("upstream_error", "Upstream error")
+    if not isinstance(payload, dict):
+        return default_envelope
+    response_payload = payload.get("response")
+    if not isinstance(response_payload, dict):
+        return default_envelope
+    error_payload = response_payload.get("error")
+    if not isinstance(error_payload, dict):
+        return default_envelope
+
+    message_value = error_payload.get("message")
+    if isinstance(message_value, str) and message_value.strip():
+        message = message_value.strip()
+    else:
+        message = "Upstream error"
+
+    code_value = error_payload.get("code")
+    code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else "upstream_error"
+
+    type_value = error_payload.get("type")
+    error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else "server_error"
+
+    envelope = openai_error(code, message, error_type)
+    param_value = error_payload.get("param")
+    if isinstance(param_value, str) and param_value.strip():
+        envelope["error"]["param"] = param_value.strip()
+    return envelope
 
 
 def _normalize_http_bridge_error_event(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4687,6 +4687,10 @@ def _openai_error_envelope_from_response_failed_payload(
     param_value = error_payload.get("param")
     if isinstance(param_value, str) and param_value.strip():
         envelope["error"]["param"] = param_value.strip()
+    for key in ("plan_type", "resets_at", "resets_in_seconds"):
+        value = error_payload.get(key)
+        if value is not None:
+            envelope["error"][key] = value  # type: ignore[literal-required]
     return envelope
 
 
@@ -4700,6 +4704,7 @@ def _normalize_http_bridge_error_event(
     error_type_value: str | None = None
     error_message_value: str | None = None
     error_param_value: str | None = None
+    rate_limit_metadata: dict[str, object] = {}
 
     if event is not None and event.error is not None:
         error_code_value = event.error.code
@@ -4730,6 +4735,14 @@ def _normalize_http_bridge_error_event(
                 if stripped:
                     error_param_value = stripped
 
+    if isinstance(payload, dict):
+        raw_error = payload.get("error")
+        if isinstance(raw_error, dict):
+            for key in ("plan_type", "resets_at", "resets_in_seconds"):
+                value = raw_error.get(key)
+                if value is not None:
+                    rate_limit_metadata[key] = value
+
     normalized_error_code = _normalize_error_code(error_code_value, error_type_value) or "upstream_error"
     normalized_error_type = error_type_value or "server_error"
     normalized_error_message = error_message_value or "Upstream error"
@@ -4745,6 +4758,8 @@ def _normalize_http_bridge_error_event(
         response_id=normalized_response_id,
         error_param=error_param_value,
     )
+    if rate_limit_metadata:
+        normalized_event["response"]["error"].update(rate_limit_metadata)  # type: ignore[typeddict-item]
     normalized_event_block = format_sse_event(normalized_event)
     normalized_payload = parse_sse_data_json(normalized_event_block)
     parsed_event = parse_sse_event(normalized_event_block)

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5671,7 +5671,7 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
 
 
 @pytest.mark.asyncio
-async def test_v1_responses_http_bridge_normalizes_upstream_error_event(async_client, monkeypatch):
+async def test_v1_responses_http_bridge_surfaces_upstream_error_event_as_http_400(async_client, monkeypatch):
     _install_bridge_settings(monkeypatch, enabled=True)
     account_id = await _import_account(
         async_client,
@@ -5734,10 +5734,9 @@ async def test_v1_responses_http_bridge_normalizes_upstream_error_event(async_cl
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
     monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
 
-    events = await _collect_sse_events(
-        async_client,
+    response = await async_client.post(
         "/v1/responses",
-        json_body={
+        json={
             "model": "gpt-5.3-codex-spark",
             "instructions": "Return exactly OK.",
             "input": "hello",
@@ -5746,12 +5745,14 @@ async def test_v1_responses_http_bridge_normalizes_upstream_error_event(async_cl
         },
     )
 
-    assert [event["type"] for event in events] == ["response.failed"]
-    assert events[0]["response"]["error"]["code"] == "invalid_request_error"
-    assert (
-        events[0]["response"]["error"]["message"]
-        == "The 'gpt-5.3-codex-spark' model is not supported when using Codex with a ChatGPT account."
-    )
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "message": "The 'gpt-5.3-codex-spark' model is not supported when using Codex with a ChatGPT account.",
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+        }
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -332,6 +332,31 @@ class _ErrorOnlyUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
         )
 
 
+class _RateLimitErrorUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
+    async def send_text(self, text: str) -> None:
+        self.sent_text.append(text)
+        await self._messages.put(
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "error",
+                        "status": 429,
+                        "error": {
+                            "type": "rate_limit_error",
+                            "code": "rate_limit_exceeded",
+                            "message": "Rate limit reached for gpt-4o on tokens per day",
+                            "plan_type": "team",
+                            "resets_at": 1700000000,
+                            "resets_in_seconds": 3600,
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        )
+
+
 class _FailingSendThenCloseUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
     async def send_text(self, text: str) -> None:
         self.sent_text.append(text)
@@ -5753,6 +5778,72 @@ async def test_v1_responses_http_bridge_surfaces_upstream_error_event_as_http_40
             "code": "invalid_request_error",
         }
     }
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_preserves_rate_limit_metadata_in_429(async_client, monkeypatch):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_ratelimit",
+        "http-bridge-ratelimit@example.com",
+    )
+    account = await _get_account(account_id)
+    fake_upstream = _RateLimitErrorUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+    ):
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        return fake_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    response = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-4o",
+            "instructions": "Return exactly OK.",
+            "input": "hello",
+            "prompt_cache_key": "http-bridge-ratelimit-key",
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 429
+    body = response.json()
+    assert body["error"]["code"] == "rate_limit_exceeded"
+    assert body["error"]["plan_type"] == "team"
+    assert body["error"]["resets_at"] == 1700000000
+    assert body["error"]["resets_in_seconds"] == 3600
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -307,6 +307,31 @@ class _CreatedThenCloseUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
         await self._messages.put(_FakeUpstreamMessage("close", close_code=1011))
 
 
+class _ErrorOnlyUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
+    async def send_text(self, text: str) -> None:
+        self.sent_text.append(text)
+        await self._messages.put(
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "error",
+                        "status": 400,
+                        "error": {
+                            "type": "invalid_request_error",
+                            "code": "invalid_request_error",
+                            "message": (
+                                "The 'gpt-5.3-codex-spark' model is not supported when using Codex "
+                                "with a ChatGPT account."
+                            ),
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        )
+
+
 class _FailingSendThenCloseUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
     async def send_text(self, text: str) -> None:
         self.sent_text.append(text)
@@ -5643,6 +5668,90 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
     events = [json.loads(line[6:]) for line in lines]
     assert [event["type"] for event in events] == ["response.created", "response.failed"]
     assert events[-1]["response"]["error"]["code"] == "stream_incomplete"
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_normalizes_upstream_error_event(async_client, monkeypatch):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_error_norm",
+        "http-bridge-error-norm@example.com",
+    )
+    account = await _get_account(account_id)
+    fake_upstream = _ErrorOnlyUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+    ):
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return fake_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    events = await _collect_sse_events(
+        async_client,
+        "/v1/responses",
+        json_body={
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "Return exactly OK.",
+            "input": "hello",
+            "prompt_cache_key": "http-bridge-error-norm-key",
+            "stream": True,
+        },
+    )
+
+    assert [event["type"] for event in events] == ["response.failed"]
+    assert events[0]["response"]["error"]["code"] == "invalid_request_error"
+    assert (
+        events[0]["response"]["error"]["message"]
+        == "The 'gpt-5.3-codex-spark' model is not supported when using Codex with a ChatGPT account."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reproduced an OpenCode UX mismatch for unsupported `gpt-5.3-codex-spark` on Team accounts: direct ChatGPT path surfaced the error, but the codex-lb bridge path did not.
- Compared `mitmproxy` captures and confirmed behavior difference: direct backend (to ChatGPT API) returned `HTTP 400` JSON, while codex-lb returned `HTTP 200` SSE terminal error. This causes OpenCode to not display the error correctly.
- Updated HTTP bridge error handling to preserve normalized SSE events and also propagate first terminal bridged errors as `ProxyResponseError` when `propagate_http_errors=True`, so `/v1/responses` returns `HTTP 4xx` JSON.
- Added integration coverage for the bridged upstream `type:error` payload and asserted `POST /v1/responses` returns `400` with the expected OpenAI error envelope.

## Root Cause
- In `_stream_via_http_bridge`, `propagate_http_errors` was discarded, so terminal bridged errors were always emitted as stream events under a `200` response.

Fixed and ran tests. I used red-green testing approach to fix this issue. I then ran a local build of codex-lb to make sure that OpenCode surfaces the error correctly.