### PR TITLE
Guard oversized response.create before upstream websocket send

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5849,10 +5849,11 @@ def _openai_error_envelope_from_response_failed_payload(
     param_value = error_payload.get("param")
     if isinstance(param_value, str) and param_value.strip():
         envelope["error"]["param"] = param_value.strip()
+    error_detail = envelope["error"]
     for key in ("plan_type", "resets_at", "resets_in_seconds"):
         value = error_payload.get(key)
         if value is not None:
-            envelope["error"][key] = value  # type: ignore[literal-required]
+            cast(dict[str, object], error_detail)[key] = value
     return envelope
 
 
@@ -5921,7 +5922,7 @@ def _normalize_http_bridge_error_event(
         error_param=error_param_value,
     )
     if rate_limit_metadata:
-        normalized_event["response"]["error"].update(rate_limit_metadata)  # type: ignore[typeddict-item]
+        cast(dict[str, object], normalized_event["response"]["error"]).update(rate_limit_metadata)
     normalized_event_block = format_sse_event(normalized_event)
     normalized_payload = parse_sse_data_json(normalized_event_block)
     parsed_event = parse_sse_event(normalized_event_block)
@@ -6012,7 +6013,6 @@ def _slim_response_create_payload_for_upstream(
 
     tool_outputs_slimmed = 0
     images_slimmed = 0
-    historical_items_dropped = 0
 
     slimmed_historical: list[JsonValue] = []
     for item in historical:
@@ -6028,7 +6028,6 @@ def _slim_response_create_payload_for_upstream(
         return payload, None
 
     return candidate_payload, {
-        "historical_items_dropped": 0,
         "historical_tool_outputs_slimmed": tool_outputs_slimmed,
         "historical_images_slimmed": images_slimmed,
     }

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4195,17 +4195,19 @@ class ProxyService:
             remaining = list(pending_requests)
             pending_requests.clear()
 
-        for request_state in remaining:
+        last_index = len(remaining) - 1
+        for index, request_state in enumerate(remaining):
             request_error_code = request_state.error_code_override or error_code
             request_error_message = request_state.error_message_override or error_message
             request_error_type = request_state.error_type_override or "server_error"
             request_error_param = request_state.error_param_override
-            _maybe_dump_oversized_response_create_request(
-                request_state,
-                account_id_value=account_id_value,
-                error_code=request_error_code,
-                error_message=request_error_message,
-            )
+            if index == last_index:
+                _maybe_dump_oversized_response_create_request(
+                    request_state,
+                    account_id_value=account_id_value,
+                    error_code=request_error_code,
+                    error_message=request_error_message,
+                )
             if response_create_gate is not None:
                 _release_websocket_response_create_gate(request_state, response_create_gate)
             if request_state.event_queue is not None:
@@ -6021,31 +6023,12 @@ def _slim_response_create_payload_for_upstream(
 
     candidate_payload = dict(payload)
     candidate_payload["input"] = slimmed_historical + recent
-    if _json_size_bytes(candidate_payload) <= max_bytes:
-        return candidate_payload, {
-            "historical_items_dropped": historical_items_dropped,
-            "historical_tool_outputs_slimmed": tool_outputs_slimmed,
-            "historical_images_slimmed": images_slimmed,
-        }
 
-    retained_historical = list(slimmed_historical)
-    while retained_historical and _json_size_bytes(candidate_payload) > max_bytes:
-        retained_historical.pop(0)
-        historical_items_dropped += 1
-        candidate_payload["input"] = retained_historical + recent
-
-    if historical_items_dropped > 0:
-        notice_item = _response_create_history_omission_notice_item(historical_items_dropped)
-        noticed_payload = dict(candidate_payload)
-        noticed_payload["input"] = [notice_item, *cast(list[JsonValue], candidate_payload["input"])]
-        if _json_size_bytes(noticed_payload) <= max_bytes:
-            candidate_payload = noticed_payload
-
-    if tool_outputs_slimmed == 0 and images_slimmed == 0 and historical_items_dropped == 0:
+    if tool_outputs_slimmed == 0 and images_slimmed == 0:
         return payload, None
 
     return candidate_payload, {
-        "historical_items_dropped": historical_items_dropped,
+        "historical_items_dropped": 0,
         "historical_tool_outputs_slimmed": tool_outputs_slimmed,
         "historical_images_slimmed": images_slimmed,
     }

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6183,7 +6183,7 @@ def _enforce_response_create_size_limit(request_state: _WebSocketRequestState) -
         request_state,
         account_id_value=None,
         error_code=cast(str, error.get("code") or "payload_too_large"),
-        error_message=cast(str | None, error.get("message")),
+        error_message=error.get("message"),
         log_prefix="guarded",
     )
     raise ProxyResponseError(
@@ -6385,13 +6385,14 @@ def _summarize_response_create_input(input_value: JsonValue) -> dict[str, JsonVa
         largest_items.append(item_summary)
 
     largest_items.sort(key=lambda item: int(item["size_bytes"]), reverse=True)
-    return {
+    summary: dict[str, JsonValue] = {
         "count": len(input_value),
-        "role_counts": role_counts,
-        "item_type_counts": item_type_counts,
-        "content_part_type_counts": content_part_type_counts,
-        "largest_items": largest_items[:_OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS],
+        "role_counts": cast(JsonValue, role_counts),
+        "item_type_counts": cast(JsonValue, item_type_counts),
+        "content_part_type_counts": cast(JsonValue, content_part_type_counts),
+        "largest_items": cast(JsonValue, largest_items[:_OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS]),
     }
+    return summary
 
 
 def _json_size_bytes(value: JsonValue) -> int:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6060,7 +6060,7 @@ def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
             last_user_index = index
     if last_user_index is not None:
         return last_user_index
-    return max(0, len(input_items) - 8)
+    return 0
 
 
 def _slim_historical_response_input_item(item: JsonValue) -> tuple[JsonValue, int, int]:
@@ -6094,6 +6094,8 @@ def _slim_historical_response_input_item(item: JsonValue) -> tuple[JsonValue, in
 
 
 def _slim_historical_response_content(content: JsonValue) -> tuple[JsonValue, int]:
+    if is_json_mapping(content):
+        return _slim_historical_response_content_part(content)
     if not isinstance(content, list):
         return content, 0
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
 import asyncio
+import gzip
 import inspect
 import json
 import logging
+import re
 import time
 from collections import deque
 from collections.abc import Collection, Sequence
+from copy import deepcopy
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from hashlib import sha256
 from ipaddress import ip_address
+from pathlib import Path
 from typing import Any, AsyncIterator, Literal, Mapping, NoReturn, TypeVar, cast, overload
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -145,6 +150,20 @@ from app.modules.usage.additional_quota_keys import get_additional_display_label
 from app.modules.usage.updater import UsageUpdater
 
 logger = logging.getLogger(__name__)
+
+# Stay below the common 16 MiB websocket message ceiling so we can slim or fail
+# early before upstream closes the session with 1009.
+_UPSTREAM_RESPONSE_CREATE_WARN_BYTES = 12 * 1024 * 1024
+_UPSTREAM_RESPONSE_CREATE_MAX_BYTES = 15 * 1024 * 1024
+_OVERSIZED_RESPONSE_CREATE_DUMP_DIR = Path("/var/lib/codex-lb/debug/response-create-dumps")
+_OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS = 10
+_RESPONSE_CREATE_HISTORY_OMISSION_NOTICE = (
+    "[codex-lb omitted {count} historical input items to fit upstream websocket budget]"
+)
+_RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE = (
+    "[codex-lb omitted historical tool output ({bytes} bytes) to fit upstream websocket budget]"
+)
+_RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline image to fit upstream websocket budget]"
 
 _TASK_CANCEL_TIMEOUT_SECONDS = 1.0
 _TaskResultT = TypeVar("_TaskResultT")
@@ -1318,6 +1337,14 @@ class ProxyService:
                             request_state = prepared_request.request_state
                             request_affinity = prepared_request.affinity_policy
                             text_data = prepared_request.text_data
+                        except ProxyResponseError as exc:
+                            async with client_send_lock:
+                                await websocket.send_text(
+                                    _serialize_websocket_error_event(
+                                        _wrapped_websocket_error_event(exc.status_code, exc.payload)
+                                    )
+                                )
+                            continue
                         except AppError as exc:
                             async with client_send_lock:
                                 await websocket.send_text(
@@ -1501,14 +1528,19 @@ class ProxyService:
                 dict(responses_payload.to_payload()).get("service_tier")
             ),
         )
-        request_state, text_data = self._prepare_response_bridge_request_state(
-            responses_payload,
-            api_key=refreshed_api_key,
-            api_key_reservation=reservation,
-            include_type_field=True,
-            attach_event_queue=False,
-            client_metadata=client_metadata,
-        )
+        try:
+            request_state, text_data = self._prepare_response_bridge_request_state(
+                responses_payload,
+                api_key=refreshed_api_key,
+                api_key_reservation=reservation,
+                include_type_field=True,
+                attach_event_queue=False,
+                transport=_REQUEST_TRANSPORT_WEBSOCKET,
+                client_metadata=client_metadata,
+            )
+        except ProxyResponseError:
+            await self._release_websocket_reservation(reservation)
+            raise
         had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
         affinity_policy = _sticky_key_for_responses_request(
             responses_payload,
@@ -1556,6 +1588,7 @@ class ProxyService:
             api_key_reservation=api_key_reservation,
             include_type_field=True,
             attach_event_queue=True,
+            transport=_REQUEST_TRANSPORT_HTTP,
             client_metadata=_response_create_client_metadata(payload.to_payload(), headers=headers),
             request_log_id=request_id or get_request_id() or ensure_request_id(None),
         )
@@ -1568,6 +1601,7 @@ class ProxyService:
         api_key_reservation: ApiKeyUsageReservationData | None,
         include_type_field: bool,
         attach_event_queue: bool,
+        transport: str,
         client_metadata: Mapping[str, JsonValue] | None,
         request_id: str | None = None,
         request_log_id: str | None = None,
@@ -1591,11 +1625,37 @@ class ProxyService:
             requested_service_tier=forwarded_service_tier,
             awaiting_response_created=True,
             event_queue=asyncio.Queue() if attach_event_queue else None,
+            transport=transport,
             api_key=api_key,
             previous_response_id=payload.previous_response_id,
         )
         text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
+        payload_size = len(text_data.encode("utf-8"))
+        if payload_size > _UPSTREAM_RESPONSE_CREATE_MAX_BYTES:
+            slimmed_payload, slim_summary = _slim_response_create_payload_for_upstream(
+                upstream_payload,
+                max_bytes=_UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
+            )
+            if slim_summary is not None:
+                upstream_payload = slimmed_payload
+                text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
+                logger.warning(
+                    (
+                        "Slimmed response.create request_id=%s request_log_id=%s transport=%s "
+                        "original_bytes=%s slimmed_bytes=%s historical_items_dropped=%s "
+                        "historical_tool_outputs_slimmed=%s historical_images_slimmed=%s"
+                    ),
+                    request_state.request_id,
+                    request_state.request_log_id,
+                    transport,
+                    payload_size,
+                    len(text_data.encode("utf-8")),
+                    slim_summary["historical_items_dropped"],
+                    slim_summary["historical_tool_outputs_slimmed"],
+                    slim_summary["historical_images_slimmed"],
+                )
         request_state.request_text = text_data
+        _enforce_response_create_size_limit(request_state)
         return request_state, text_data
 
     async def _connect_proxy_websocket(
@@ -4140,6 +4200,12 @@ class ProxyService:
             request_error_message = request_state.error_message_override or error_message
             request_error_type = request_state.error_type_override or "server_error"
             request_error_param = request_state.error_param_override
+            _maybe_dump_oversized_response_create_request(
+                request_state,
+                account_id_value=account_id_value,
+                error_code=request_error_code,
+                error_message=request_error_message,
+            )
             if response_create_gate is not None:
                 _release_websocket_response_create_gate(request_state, response_create_gate)
             if request_state.event_queue is not None:
@@ -5909,6 +5975,427 @@ def _release_websocket_response_create_gate(
         return
     request_state.awaiting_response_created = False
     response_create_gate.release()
+
+
+def _response_create_too_large_error_envelope(
+    actual_bytes: int,
+    max_bytes: int,
+) -> OpenAIErrorEnvelope:
+    payload = openai_error(
+        "payload_too_large",
+        (
+            "response.create is too large for upstream websocket "
+            f"({actual_bytes} bytes > {max_bytes} bytes). "
+            "Reduce historical images/screenshots or compact the thread."
+        ),
+        error_type="invalid_request_error",
+    )
+    payload["error"]["param"] = "input"
+    return payload
+
+
+def _slim_response_create_payload_for_upstream(
+    payload: dict[str, JsonValue],
+    *,
+    max_bytes: int,
+) -> tuple[dict[str, JsonValue], dict[str, int] | None]:
+    input_value = payload.get("input")
+    if not isinstance(input_value, list) or not input_value:
+        return payload, None
+
+    input_items = cast(list[JsonValue], deepcopy(input_value))
+    preserve_from = _response_create_recent_suffix_start(input_items)
+    historical = input_items[:preserve_from]
+    recent = input_items[preserve_from:]
+
+    tool_outputs_slimmed = 0
+    images_slimmed = 0
+    historical_items_dropped = 0
+
+    slimmed_historical: list[JsonValue] = []
+    for item in historical:
+        slimmed_item, item_tool_outputs_slimmed, item_images_slimmed = _slim_historical_response_input_item(item)
+        tool_outputs_slimmed += item_tool_outputs_slimmed
+        images_slimmed += item_images_slimmed
+        slimmed_historical.append(slimmed_item)
+
+    candidate_payload = dict(payload)
+    candidate_payload["input"] = slimmed_historical + recent
+    if _json_size_bytes(candidate_payload) <= max_bytes:
+        return candidate_payload, {
+            "historical_items_dropped": historical_items_dropped,
+            "historical_tool_outputs_slimmed": tool_outputs_slimmed,
+            "historical_images_slimmed": images_slimmed,
+        }
+
+    retained_historical = list(slimmed_historical)
+    while retained_historical and _json_size_bytes(candidate_payload) > max_bytes:
+        retained_historical.pop(0)
+        historical_items_dropped += 1
+        candidate_payload["input"] = retained_historical + recent
+
+    if historical_items_dropped > 0:
+        notice_item = _response_create_history_omission_notice_item(historical_items_dropped)
+        noticed_payload = dict(candidate_payload)
+        noticed_payload["input"] = [notice_item, *cast(list[JsonValue], candidate_payload["input"])]
+        if _json_size_bytes(noticed_payload) <= max_bytes:
+            candidate_payload = noticed_payload
+
+    if tool_outputs_slimmed == 0 and images_slimmed == 0 and historical_items_dropped == 0:
+        return payload, None
+
+    return candidate_payload, {
+        "historical_items_dropped": historical_items_dropped,
+        "historical_tool_outputs_slimmed": tool_outputs_slimmed,
+        "historical_images_slimmed": images_slimmed,
+    }
+
+
+def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
+    last_user_index: int | None = None
+    for index, item in enumerate(input_items):
+        if not is_json_mapping(item):
+            continue
+        if item.get("role") == "user":
+            last_user_index = index
+    if last_user_index is not None:
+        return last_user_index
+    return max(0, len(input_items) - 8)
+
+
+def _slim_historical_response_input_item(item: JsonValue) -> tuple[JsonValue, int, int]:
+    if not is_json_mapping(item):
+        return item, 0, 0
+
+    item_mapping = dict(cast(dict[str, JsonValue], deepcopy(item)))
+    tool_outputs_slimmed = 0
+    images_slimmed = 0
+
+    item_type = item_mapping.get("type")
+    if item_type == "function_call_output":
+        output = item_mapping.get("output")
+        output_text = output if isinstance(output, str) else None
+        if output_text is not None and _should_slim_historical_tool_output(output_text):
+            item_mapping["output"] = _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
+                bytes=len(output_text.encode("utf-8"))
+            )
+            tool_outputs_slimmed += 1
+
+    content = item_mapping.get("content")
+    slimmed_content, content_images_slimmed = _slim_historical_response_content(content)
+    if content_images_slimmed > 0:
+        item_mapping["content"] = slimmed_content
+        images_slimmed += content_images_slimmed
+
+    if item_mapping.get("type") == "input_image" and _is_inline_image_reference(item_mapping.get("image_url")):
+        return _response_create_inline_image_notice_item(), tool_outputs_slimmed, images_slimmed + 1
+
+    return item_mapping, tool_outputs_slimmed, images_slimmed
+
+
+def _slim_historical_response_content(content: JsonValue) -> tuple[JsonValue, int]:
+    if not isinstance(content, list):
+        return content, 0
+
+    slimmed_parts: list[JsonValue] = []
+    images_slimmed = 0
+    for part in content:
+        slimmed_part, part_images_slimmed = _slim_historical_response_content_part(part)
+        slimmed_parts.append(slimmed_part)
+        images_slimmed += part_images_slimmed
+    return slimmed_parts, images_slimmed
+
+
+def _slim_historical_response_content_part(part: JsonValue) -> tuple[JsonValue, int]:
+    if not is_json_mapping(part):
+        return part, 0
+
+    part_mapping = dict(cast(dict[str, JsonValue], deepcopy(part)))
+    part_type = part_mapping.get("type")
+    if part_type == "input_image" and _is_inline_image_reference(part_mapping.get("image_url")):
+        return _response_create_inline_image_notice_part(), 1
+
+    if part_type == "image_url":
+        image_url_value = part_mapping.get("image_url")
+        if is_json_mapping(image_url_value):
+            image_url = image_url_value.get("url")
+        else:
+            image_url = image_url_value
+        if _is_inline_image_reference(image_url):
+            return _response_create_inline_image_notice_part(), 1
+
+    return part_mapping, 0
+
+
+def _response_create_inline_image_notice_part() -> dict[str, JsonValue]:
+    return {"type": "input_text", "text": _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE}
+
+
+def _response_create_inline_image_notice_item() -> dict[str, JsonValue]:
+    return {"role": "user", "content": [_response_create_inline_image_notice_part()]}
+
+
+def _response_create_history_omission_notice_item(count: int) -> dict[str, JsonValue]:
+    return {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "output_text",
+                "text": _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE.format(count=count),
+            }
+        ],
+    }
+
+
+def _is_inline_image_reference(value: JsonValue) -> bool:
+    return isinstance(value, str) and value.startswith("data:image/")
+
+
+def _should_slim_historical_tool_output(output: str) -> bool:
+    return "data:image/" in output or len(output.encode("utf-8")) > 32 * 1024
+
+
+def _enforce_response_create_size_limit(request_state: _WebSocketRequestState) -> None:
+    request_text = request_state.request_text
+    if not request_text:
+        return
+
+    payload_bytes = request_text.encode("utf-8")
+    payload_size = len(payload_bytes)
+    if payload_size > _UPSTREAM_RESPONSE_CREATE_WARN_BYTES:
+        logger.warning(
+            (
+                "Large response.create prepared request_id=%s request_log_id=%s "
+                "transport=%s bytes=%s previous_response_id=%s"
+            ),
+            request_state.request_id,
+            request_state.request_log_id,
+            request_state.transport,
+            payload_size,
+            request_state.previous_response_id,
+        )
+    if payload_size <= _UPSTREAM_RESPONSE_CREATE_MAX_BYTES:
+        return
+
+    payload = _response_create_too_large_error_envelope(payload_size, _UPSTREAM_RESPONSE_CREATE_MAX_BYTES)
+    error = payload["error"]
+    _write_response_create_dump(
+        request_state,
+        account_id_value=None,
+        error_code=cast(str, error.get("code") or "payload_too_large"),
+        error_message=cast(str | None, error.get("message")),
+        log_prefix="guarded",
+    )
+    raise ProxyResponseError(
+        413,
+        payload,
+        failure_phase="validation",
+        failure_detail=f"response.create_bytes={payload_size}",
+    )
+
+
+def _maybe_dump_oversized_response_create_request(
+    request_state: _WebSocketRequestState,
+    *,
+    account_id_value: str | None,
+    error_code: str,
+    error_message: str | None,
+) -> None:
+    if not _should_dump_oversized_response_create(error_code, error_message):
+        return
+    _write_response_create_dump(
+        request_state,
+        account_id_value=account_id_value,
+        error_code=error_code,
+        error_message=error_message,
+        log_prefix="oversized",
+    )
+
+
+def _write_response_create_dump(
+    request_state: _WebSocketRequestState,
+    *,
+    account_id_value: str | None,
+    error_code: str,
+    error_message: str | None,
+    log_prefix: str,
+) -> bool:
+    request_text = request_state.request_text
+    if not request_text:
+        return False
+
+    payload_bytes = request_text.encode("utf-8")
+    request_sha = sha256(payload_bytes).hexdigest()
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    dump_id = "-".join(
+        (
+            timestamp,
+            _safe_dump_slug(request_state.transport, fallback="transport"),
+            _safe_dump_slug(request_state.model, fallback="model"),
+            _safe_dump_slug(
+                request_state.request_log_id or request_state.response_id or request_state.request_id,
+                fallback="request",
+            ),
+        )
+    )
+    dump_dir = _OVERSIZED_RESPONSE_CREATE_DUMP_DIR
+    dump_path = dump_dir / f"{dump_id}.response-create.json.gz"
+    meta_path = dump_dir / f"{dump_id}.meta.json"
+
+    meta: dict[str, JsonValue] = {
+        "dump_id": dump_id,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "reason": {
+            "error_code": error_code,
+            "error_message": error_message,
+        },
+        "request": {
+            "account_id": account_id_value,
+            "request_id": request_state.request_id,
+            "request_log_id": request_state.request_log_id,
+            "response_id": request_state.response_id,
+            "transport": request_state.transport,
+            "model": request_state.model,
+            "reasoning_effort": request_state.reasoning_effort,
+            "service_tier": request_state.service_tier,
+            "requested_service_tier": request_state.requested_service_tier,
+            "actual_service_tier": request_state.actual_service_tier,
+            "previous_response_id": request_state.previous_response_id,
+            "awaiting_response_created": request_state.awaiting_response_created,
+            "replay_count": request_state.replay_count,
+            "request_text_bytes": len(payload_bytes),
+            "request_text_chars": len(request_text),
+            "request_text_sha256": request_sha,
+        },
+        "paths": {
+            "dump_path": str(dump_path),
+            "meta_path": str(meta_path),
+        },
+    }
+
+    try:
+        parsed_payload = json.loads(request_text)
+    except json.JSONDecodeError as exc:
+        meta["parse_error"] = str(exc)
+    else:
+        if isinstance(parsed_payload, dict):
+            meta["summary"] = _summarize_response_create_payload(parsed_payload)
+        else:
+            meta["summary"] = {"payload_type": type(parsed_payload).__name__}
+
+    try:
+        dump_dir.mkdir(parents=True, exist_ok=True)
+        with gzip.open(dump_path, "wt", encoding="utf-8") as handle:
+            handle.write(request_text)
+        meta_path.write_text(
+            json.dumps(meta, ensure_ascii=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    except Exception:
+        logger.exception(
+            "Failed to dump %s response.create payload request_id=%s request_log_id=%s",
+            log_prefix,
+            request_state.request_id,
+            request_state.request_log_id,
+        )
+        return False
+
+    logger.warning(
+        "Saved %s response.create dump request_id=%s request_log_id=%s dump_path=%s meta_path=%s bytes=%s",
+        log_prefix,
+        request_state.request_id,
+        request_state.request_log_id,
+        dump_path,
+        meta_path,
+        len(payload_bytes),
+    )
+    return True
+
+
+def _should_dump_oversized_response_create(error_code: str, error_message: str | None) -> bool:
+    if error_code != "stream_incomplete" or not error_message:
+        return False
+    normalized = error_message.lower()
+    return "1009" in normalized or "message too big" in normalized
+
+
+def _safe_dump_slug(value: str | None, *, fallback: str) -> str:
+    if not value:
+        return fallback
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-._")
+    if not normalized:
+        return fallback
+    return normalized[:80]
+
+
+def _summarize_response_create_payload(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    field_sizes = sorted(
+        (
+            {
+                "key": key,
+                "size_bytes": _json_size_bytes(value),
+            }
+            for key, value in payload.items()
+        ),
+        key=lambda item: int(item["size_bytes"]),
+        reverse=True,
+    )
+    summary: dict[str, JsonValue] = {
+        "top_level_keys": list(payload.keys()),
+        "top_level_field_sizes": field_sizes,
+    }
+    input_summary = _summarize_response_create_input(payload.get("input"))
+    if input_summary is not None:
+        summary["input"] = input_summary
+    return summary
+
+
+def _summarize_response_create_input(input_value: JsonValue) -> dict[str, JsonValue] | None:
+    if not isinstance(input_value, list):
+        return None
+
+    role_counts: dict[str, int] = {}
+    item_type_counts: dict[str, int] = {}
+    content_part_type_counts: dict[str, int] = {}
+    largest_items: list[dict[str, JsonValue]] = []
+
+    for index, item in enumerate(input_value):
+        item_summary: dict[str, JsonValue] = {
+            "index": index,
+            "size_bytes": _json_size_bytes(item),
+        }
+        if isinstance(item, dict):
+            role = item.get("role")
+            if isinstance(role, str):
+                item_summary["role"] = role
+                role_counts[role] = role_counts.get(role, 0) + 1
+            item_type = item.get("type")
+            if isinstance(item_type, str):
+                item_summary["type"] = item_type
+                item_type_counts[item_type] = item_type_counts.get(item_type, 0) + 1
+            content = item.get("content")
+            if isinstance(content, list):
+                item_summary["content_parts"] = len(content)
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    part_type = part.get("type")
+                    if isinstance(part_type, str):
+                        content_part_type_counts[part_type] = content_part_type_counts.get(part_type, 0) + 1
+        largest_items.append(item_summary)
+
+    largest_items.sort(key=lambda item: int(item["size_bytes"]), reverse=True)
+    return {
+        "count": len(input_value),
+        "role_counts": role_counts,
+        "item_type_counts": item_type_counts,
+        "content_part_type_counts": content_part_type_counts,
+        "largest_items": largest_items[:_OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS],
+    }
+
+
+def _json_size_bytes(value: JsonValue) -> int:
+    return len(json.dumps(value, ensure_ascii=True, separators=(",", ":")).encode("utf-8"))
 
 
 def _pop_terminal_websocket_request_state(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1642,7 +1642,7 @@ class ProxyService:
                 logger.warning(
                     (
                         "Slimmed response.create request_id=%s request_log_id=%s transport=%s "
-                        "original_bytes=%s slimmed_bytes=%s historical_items_dropped=%s "
+                        "original_bytes=%s slimmed_bytes=%s "
                         "historical_tool_outputs_slimmed=%s historical_images_slimmed=%s"
                     ),
                     request_state.request_id,
@@ -1650,7 +1650,6 @@ class ProxyService:
                     transport,
                     payload_size,
                     len(text_data.encode("utf-8")),
-                    slim_summary["historical_items_dropped"],
                     slim_summary["historical_tool_outputs_slimmed"],
                     slim_summary["historical_images_slimmed"],
                 )

--- a/openspec/changes/guard-oversized-response-create/context.md
+++ b/openspec/changes/guard-oversized-response-create/context.md
@@ -1,0 +1,18 @@
+# Context
+
+## Rationale
+
+The observed production failures were constrained by serialized websocket message size, not by the model token window alone. A thread could still appear to have context headroom while the JSON `response.create` payload exceeded the upstream websocket message budget because historical base64 screenshots and image inputs were being replayed inline on every turn.
+
+## Decisions
+
+- Guard the serialized `response.create` before upstream websocket send instead of waiting for upstream `1009`.
+- Preserve the most recent suffix beginning at the final user turn so the current user request and its fresh tool chain are not silently rewritten.
+- Slim only historical inline images and oversized historical tool outputs automatically in v1.
+- If the request still does not fit after slimming, fail locally with a deterministic `payload_too_large` error.
+- Keep oversized payload dumps as an operator diagnostic artifact because size bugs are otherwise hard to root-cause from request logs alone.
+
+## Operational Notes
+
+- The guard leaves headroom below the common 16 MiB websocket message ceiling to avoid last-byte envelope overruns.
+- Dump metadata is intended to answer which top-level fields and which `input` items dominate the payload size without requiring console payload tracing.

--- a/openspec/changes/guard-oversized-response-create/proposal.md
+++ b/openspec/changes/guard-oversized-response-create/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+Responses requests forwarded over the upstream websocket can accumulate historical inline images, Playwright screenshots, and oversized tool outputs into one serialized `response.create` payload. When that payload crosses the upstream websocket message budget, upstream closes the session with `1009 (message too big)`, which surfaces as an opaque `stream_incomplete` failure and can trap clients in reconnect loops.
+
+## What Changes
+
+- Measure serialized outbound `response.create` size before sending it to the upstream websocket.
+- Slim only the historical portion of `input` before the most recent user turn by replacing historical inline images and oversized historical tool outputs with omission notices.
+- Fail deterministically before upstream connect/reuse when the payload still exceeds budget, returning `payload_too_large` on `input`.
+- Persist oversized request dumps and structured metadata for guarded failures and upstream `1009` incidents so operators can inspect what made the payload too large.
+
+## Impact
+
+- Code: `app/modules/proxy/service.py`
+- Tests: `tests/integration/test_http_responses_bridge.py`, `tests/integration/test_proxy_websocket_responses.py`, `tests/unit/test_proxy_utils.py`
+- Specs: `openspec/specs/responses-api-compat/spec.md`

--- a/openspec/changes/guard-oversized-response-create/specs/responses-api-compat/spec.md
+++ b/openspec/changes/guard-oversized-response-create/specs/responses-api-compat/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Oversized upstream response.create payloads are slimmed or rejected before websocket send
+When the service prepares a Responses `response.create` request for an upstream websocket, it MUST measure the serialized outbound request size before sending it upstream. If the payload exceeds the upstream websocket budget, the service MUST first attempt to slim only the historical portion of `input` that precedes the most recent user turn. Historical inline images MUST be replaced with textual omission notices, and oversized historical tool outputs MUST be replaced with textual omission notices that preserve the item in sequence. If the request still exceeds budget after slimming, the service MUST fail locally before opening or reusing the upstream websocket session.
+
+#### Scenario: Historical inline artifacts are slimmed and the latest user turn is preserved
+- **WHEN** a Responses request exceeds the upstream websocket budget because historical inline images or historical oversized tool outputs dominate the serialized `input`
+- **AND** replacing those historical artifacts with omission notices reduces the serialized request below budget
+- **THEN** the service forwards the slimmed `response.create` upstream
+- **AND** it preserves the most recent user turn unchanged
+
+#### Scenario: HTTP Responses route fails locally when the payload still exceeds budget
+- **WHEN** an HTTP `/v1/responses` or `/backend-api/codex/responses` request still exceeds the upstream websocket budget after historical slimming
+- **THEN** the service returns `413`
+- **AND** the error envelope code is `payload_too_large`
+- **AND** the error envelope type is `invalid_request_error`
+- **AND** the error envelope param is `input`
+- **AND** the service MUST NOT allocate or reuse an upstream websocket bridge session for that request
+
+#### Scenario: Websocket Responses route fails locally when the payload still exceeds budget
+- **WHEN** a websocket `/v1/responses` or `/backend-api/codex/responses` request still exceeds the upstream websocket budget after historical slimming
+- **THEN** the service emits a websocket error event with status `413`
+- **AND** the error envelope code is `payload_too_large`
+- **AND** the error envelope type is `invalid_request_error`
+- **AND** the error envelope param is `input`
+- **AND** the service MUST NOT connect the upstream websocket for that request

--- a/openspec/changes/guard-oversized-response-create/tasks.md
+++ b/openspec/changes/guard-oversized-response-create/tasks.md
@@ -1,0 +1,20 @@
+## 1. Spec
+
+- [x] 1.1 Add oversized `response.create` guard requirements for Responses HTTP and websocket flows
+- [x] 1.2 Record change-level context for upstream websocket budget handling
+- [x] 1.3 Validate OpenSpec changes
+
+## 2. Tests
+
+- [x] 2.1 Add HTTP bridge coverage for pre-upstream `payload_too_large`
+- [x] 2.2 Add HTTP bridge coverage for historical inline-artifact slimming
+- [x] 2.3 Add websocket coverage for pre-upstream `payload_too_large`
+- [x] 2.4 Add websocket coverage for historical inline-artifact slimming
+- [x] 2.5 Add unit coverage for reservation cleanup and historical top-level image slimming
+
+## 3. Implementation
+
+- [x] 3.1 Guard serialized upstream `response.create` size before upstream websocket send
+- [x] 3.2 Slim historical inline images and oversized tool outputs before failing
+- [x] 3.3 Emit deterministic local `payload_too_large` errors instead of relying on upstream `1009`
+- [x] 3.4 Persist oversized request dumps for guarded and detected upstream `1009` cases

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -4489,7 +4489,7 @@ async def test_v1_responses_http_bridge_slims_historical_inline_artifacts_and_su
 ):
     _install_bridge_settings(monkeypatch, enabled=True)
     monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64)
-    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 512)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 640)
     account_id = await _import_account(async_client, "acc_http_bridge_slim", "http-bridge-slim@example.com")
     account = await _get_account(account_id)
     fake_upstream = _FakeBridgeUpstreamWebSocket()

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -4437,6 +4437,144 @@ async def test_v1_responses_http_bridge_retries_once_when_upstream_closes_before
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_rejects_oversized_response_create_before_upstream(
+    async_client,
+    monkeypatch,
+    tmp_path,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 128)
+    monkeypatch.setattr(proxy_module, "_OVERSIZED_RESPONSE_CREATE_DUMP_DIR", tmp_path)
+
+    async def fail_get_or_create_http_bridge_session(self, *args, **kwargs):
+        del self, args, kwargs
+        raise AssertionError("oversized response.create must fail before upstream bridge session allocation")
+
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_get_or_create_http_bridge_session",
+        fail_get_or_create_http_bridge_session,
+    )
+
+    response = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "x" * 256}]}],
+            "prompt_cache_key": "oversized-http-bridge",
+        },
+    )
+
+    assert response.status_code == 413
+    payload = response.json()
+    assert payload["error"]["code"] == "payload_too_large"
+    assert payload["error"]["type"] == "invalid_request_error"
+    assert payload["error"]["param"] == "input"
+    assert "response.create is too large for upstream websocket" in payload["error"]["message"]
+
+    meta_files = list(tmp_path.glob("*.meta.json"))
+    assert len(meta_files) == 1
+    meta = json.loads(meta_files[0].read_text(encoding="utf-8"))
+    assert meta["reason"]["error_code"] == "payload_too_large"
+    assert meta["request"]["transport"] == "http"
+    assert meta["request"]["request_text_bytes"] > 128
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_slims_historical_inline_artifacts_and_succeeds(
+    async_client,
+    monkeypatch,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 512)
+    account_id = await _import_account(async_client, "acc_http_bridge_slim", "http-bridge-slim@example.com")
+    account = await _get_account(account_id)
+    fake_upstream = _FakeBridgeUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+    ):
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+            api_key,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return fake_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    response = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "old turn"}]},
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "data:image/png;base64," + ("A" * 1500),
+                },
+                {"role": "assistant", "content": [{"type": "output_text", "text": "done"}]},
+                {"role": "user", "content": [{"type": "input_text", "text": "ping"}]},
+            ],
+            "prompt_cache_key": "slim-http-bridge",
+        },
+    )
+
+    assert response.status_code == 200
+    sent_payload = json.loads(fake_upstream.sent_text[0])
+    assert sent_payload["input"][-1]["content"][0]["text"] == "ping"
+    assert "data:image/" not in json.dumps(sent_payload["input"], ensure_ascii=True)
+    assert "historical tool output" in json.dumps(sent_payload["input"], ensure_ascii=True)
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_does_not_evict_active_session_when_pool_is_full(
     async_client,
     app_instance,

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1271,6 +1271,205 @@ def test_backend_responses_websocket_emits_terminal_failure_when_upstream_send_b
     assert log_calls[0]["status"] == "error"
 
 
+def test_backend_responses_websocket_rejects_oversized_response_create_before_upstream(
+    app_instance,
+    monkeypatch,
+    tmp_path,
+):
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fail_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        raise AssertionError("oversized response.create must fail before upstream websocket connect")
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 128)
+    monkeypatch.setattr(proxy_module, "_OVERSIZED_RESPONSE_CREATE_DUMP_DIR", tmp_path)
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fail_connect_proxy_websocket)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "x" * 256}]}],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            error_event = json.loads(websocket.receive_text())
+
+    assert error_event["type"] == "error"
+    assert error_event["status"] == 413
+    assert error_event["error"]["code"] == "payload_too_large"
+    assert error_event["error"]["type"] == "invalid_request_error"
+    assert error_event["error"]["param"] == "input"
+    assert "response.create is too large for upstream websocket" in error_event["error"]["message"]
+
+    meta_files = list(tmp_path.glob("*.meta.json"))
+    assert len(meta_files) == 1
+    meta = json.loads(meta_files[0].read_text(encoding="utf-8"))
+    assert meta["reason"]["error_code"] == "payload_too_large"
+    assert meta["request"]["transport"] == "websocket"
+    assert meta["request"]["request_text_bytes"] > 128
+
+
+def test_backend_responses_websocket_slims_historical_inline_artifacts_and_succeeds(
+    app_instance,
+    monkeypatch,
+):
+    fake_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_ws_slim", "object": "response", "status": "in_progress"},
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_slim",
+                            "object": "response",
+                            "status": "completed",
+                            "usage": {"input_tokens": 3, "output_tokens": 1, "total_tokens": 4},
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return SimpleNamespace(id="acct_ws_proxy"), fake_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 512)
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "old turn"}]},
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": "data:image/png;base64," + ("A" * 1500),
+            },
+            {"role": "assistant", "content": [{"type": "output_text", "text": "done"}]},
+            {"role": "user", "content": [{"type": "input_text", "text": "ping"}]},
+        ],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            created_event = json.loads(websocket.receive_text())
+            completed_event = json.loads(websocket.receive_text())
+
+    assert created_event["type"] == "response.created"
+    assert completed_event["type"] == "response.completed"
+    sent_payload = json.loads(fake_upstream.sent_text[0])
+    assert sent_payload["input"][-1]["content"][0]["text"] == "ping"
+    assert "data:image/" not in json.dumps(sent_payload["input"], ensure_ascii=True)
+    assert "historical tool output" in json.dumps(sent_payload["input"], ensure_ascii=True)
+
+
 def test_backend_responses_websocket_keeps_downstream_open_after_clean_upstream_close(app_instance, monkeypatch):
     first_upstream = _FakeUpstreamWebSocket(
         [

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4064,6 +4064,49 @@ def test_slim_response_create_payload_rewrites_top_level_historical_input_image(
     assert slimmed_input[-1] == {"role": "user", "content": [{"type": "input_text", "text": "ping"}]}
 
 
+def test_slim_response_create_preserves_all_items_when_no_user_message():
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {"type": "function_call_output", "call_id": "call_1", "output": "A" * 2000},
+            {"type": "function_call_output", "call_id": "call_2", "output": "B" * 2000},
+        ],
+    }
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=256)
+
+    slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
+    assert len(slimmed_input) == 2
+    assert slimmed_input[0]["call_id"] == "call_1"
+    assert slimmed_input[1]["call_id"] == "call_2"
+    assert summary is None
+
+
+def test_slim_response_create_handles_object_valued_content_image():
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {
+                "role": "user",
+                "content": {"type": "input_image", "image_url": "data:image/png;base64," + ("A" * 1500)},
+            },
+            {"role": "user", "content": [{"type": "input_text", "text": "describe this"}]},
+        ],
+    }
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=4096)
+    slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
+
+    assert summary is not None
+    assert summary["historical_images_slimmed"] == 1
+    assert len(slimmed_input) == 2
+    first_content = slimmed_input[0]["content"]
+    assert isinstance(first_content, dict)
+    assert first_content["type"] == "input_text"
+
+
 def test_websocket_receive_timeout_prefers_idle_timeout_when_budget_allows(monkeypatch):
     monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 100.0)
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4053,14 +4053,15 @@ def test_slim_response_create_payload_rewrites_top_level_historical_input_image(
     }
 
     slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=256)
+    slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
 
     assert summary is not None
     assert summary["historical_images_slimmed"] == 1
-    assert slimmed_payload["input"][0] == {
+    assert slimmed_input[0] == {
         "role": "user",
         "content": [{"type": "input_text", "text": proxy_service._RESPONSE_CREATE_IMAGE_OMISSION_NOTICE}],
     }
-    assert slimmed_payload["input"][-1] == {"role": "user", "content": [{"type": "input_text", "text": "ping"}]}
+    assert slimmed_input[-1] == {"role": "user", "content": [{"type": "input_text", "text": "ping"}]}
 
 
 def test_websocket_receive_timeout_prefers_idle_timeout_when_budget_allows(monkeypatch):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4078,8 +4078,10 @@ def test_slim_response_create_preserves_all_items_when_no_user_message():
 
     slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
     assert len(slimmed_input) == 2
-    assert slimmed_input[0]["call_id"] == "call_1"
-    assert slimmed_input[1]["call_id"] == "call_2"
+    first = slimmed_input[0]
+    second = slimmed_input[1]
+    assert isinstance(first, dict) and first["call_id"] == "call_1"
+    assert isinstance(second, dict) and second["call_id"] == "call_2"
     assert summary is None
 
 
@@ -4099,10 +4101,12 @@ def test_slim_response_create_handles_object_valued_content_image():
     slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=4096)
     slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
 
-    assert summary is not None
+    assert isinstance(summary, dict)
     assert summary["historical_images_slimmed"] == 1
     assert len(slimmed_input) == 2
-    first_content = slimmed_input[0]["content"]
+    first_item = slimmed_input[0]
+    assert isinstance(first_item, dict)
+    first_content = first_item["content"]
     assert isinstance(first_content, dict)
     assert first_content["type"] == "input_text"
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3988,6 +3988,81 @@ async def test_prepare_websocket_response_create_request_logs_affinity_metadata(
     assert "prompt_cache_key_set=True" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_releases_reservation_on_payload_too_large(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reservation = SimpleNamespace(reservation_id="res_large_ws", model="gpt-5.1")
+    reserve_usage = AsyncMock(return_value=reservation)
+    release_usage = AsyncMock()
+    api_key = ApiKeyData(
+        id="key_ws_large",
+        name="large",
+        key_prefix="sk-large",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_service, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64)
+    monkeypatch.setattr(proxy_service, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 128)
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_release_websocket_reservation", release_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+        await service._prepare_websocket_response_create_request(
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": "x" * 256}]}],
+            },
+            headers={},
+            codex_session_affinity=False,
+            openai_cache_affinity=True,
+            sticky_threads_enabled=False,
+            openai_cache_affinity_max_age_seconds=300,
+            api_key=api_key,
+        )
+
+    assert exc_info.value.status_code == 413
+    release_usage.assert_awaited_once_with(reservation)
+
+
+def test_slim_response_create_payload_rewrites_top_level_historical_input_image():
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {"type": "input_image", "image_url": "data:image/png;base64," + ("A" * 1500)},
+            {"role": "user", "content": [{"type": "input_text", "text": "ping"}]},
+        ],
+    }
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=256)
+
+    assert summary is not None
+    assert summary["historical_images_slimmed"] == 1
+    assert slimmed_payload["input"][0] == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": proxy_service._RESPONSE_CREATE_IMAGE_OMISSION_NOTICE}],
+    }
+    assert slimmed_payload["input"][-1] == {"role": "user", "content": [{"type": "input_text", "text": "ping"}]}
+
+
 def test_websocket_receive_timeout_prefers_idle_timeout_when_budget_allows(monkeypatch):
     monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 100.0)
 


### PR DESCRIPTION
﻿## Summary
- guard serialized upstream `response.create` payloads before attempting the upstream websocket send
- slim historical inline images and oversized historical tool outputs before the most recent user turn when that is enough to fit under budget
- return deterministic local `payload_too_large` errors for HTTP and websocket Responses routes when the request still does not fit
- persist oversized payload dumps and add OpenSpec + regression coverage for the guarded/slimmed paths

## Why
Threads with accumulated screenshots, inline images, and large tool outputs could build a `response.create` payload large enough to trigger upstream websocket `1009 (message too big)`. That surfaced as opaque `stream_incomplete` failures and reconnect loops. This change turns that into a local preflight guard and recovery path.

## Failure mode
Large threads could accumulate historical inline images, Playwright screenshots, and oversized tool outputs inside the serialized `response.create` payload. Even a small follow-up message could then fail because the proxy still had to resend that historical payload upstream.

In production this surfaced as:

`Upstream websocket closed before response.completed: received 1009 (message too big); then sent 1009 (message too big)`

This is a websocket message-size problem in bytes, not just a token-window overflow.

## OpenSpec
- added `openspec/changes/guard-oversized-response-create`

## Testing
- `ruff check app/modules/proxy/service.py tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_websocket_responses.py tests/unit/test_proxy_utils.py`
- `python -m py_compile app/modules/proxy/service.py`
- `pytest -q tests/unit/test_proxy_utils.py -k "payload_too_large or slim_response_create or prepare_websocket_response_create_request"`
- `pytest -q tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_websocket_responses.py`
- `npx -y @fission-ai/openspec validate --specs`
