### PR TITLE
fix(proxy): websocket connect-phase failover + deterministic failover integration tests

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -214,6 +214,8 @@ _ACCOUNT_RECOVERY_RETRY_CODES = frozenset(
 _TRANSIENT_RETRY_CODES = frozenset({"server_error"})
 _MAX_TRANSIENT_SAME_ACCOUNT_RETRIES = 3
 _COMPACT_MAX_ACCOUNT_ATTEMPTS = 2
+_STREAM_MAX_ACCOUNT_ATTEMPTS = 3
+_WEBSOCKET_MAX_ACCOUNT_ATTEMPTS = 3
 
 
 @dataclass(frozen=True, slots=True)
@@ -1807,6 +1809,88 @@ class ProxyService:
         sticky_max_age_seconds: int | None = None,
     ) -> tuple[Account | None, UpstreamResponsesWebSocket | None]:
         deadline = _websocket_connect_deadline(request_state, get_settings().proxy_request_budget_seconds)
+        base_settings = get_settings()
+        max_attempts = _WEBSOCKET_MAX_ACCOUNT_ATTEMPTS
+        excluded_account_ids: set[str] = set()
+        for attempt in range(max_attempts):
+            account = await self._select_websocket_connect_account(
+                deadline,
+                sticky_key=sticky_key,
+                sticky_kind=sticky_kind,
+                prefer_earlier_reset=prefer_earlier_reset,
+                routing_strategy=routing_strategy,
+                model=model,
+                request_state=request_state,
+                api_key=api_key,
+                client_send_lock=client_send_lock,
+                websocket=websocket,
+                reallocate_sticky=reallocate_sticky,
+                sticky_max_age_seconds=sticky_max_age_seconds,
+                exclude_account_ids=excluded_account_ids,
+            )
+            if account is None:
+                return None, None
+
+            try:
+                connect_result = await self._try_open_websocket_connect_attempt(
+                    account,
+                    headers,
+                    deadline=deadline,
+                    api_key=api_key,
+                    request_state=request_state,
+                    client_send_lock=client_send_lock,
+                    websocket=websocket,
+                )
+            except ProxyResponseError as exc:
+                action = await self._decide_websocket_failover_action(
+                    account=account,
+                    exc=exc,
+                    request_state=request_state,
+                    attempt=attempt + 1,
+                    max_attempts=max_attempts,
+                    deterministic_failover_enabled=getattr(base_settings, "deterministic_failover_enabled", True),
+                )
+                if action == "failover_next":
+                    excluded_account_ids.add(account.id)
+                    continue
+                error = _parse_openai_error(exc.payload)
+                error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
+                error_message = error.message if error else None
+                await self._emit_websocket_connect_failure(
+                    websocket,
+                    client_send_lock=client_send_lock,
+                    account_id=account.id,
+                    api_key=api_key,
+                    request_state=request_state,
+                    status_code=exc.status_code,
+                    payload=exc.payload,
+                    error_code=error_code or "upstream_error",
+                    error_message=error_message or "Upstream error",
+                )
+                return None, None
+
+            if connect_result is None:
+                return None, None
+            return connect_result
+        return None, None
+
+    async def _select_websocket_connect_account(
+        self,
+        deadline: float,
+        *,
+        sticky_key: str | None,
+        sticky_kind: StickySessionKind | None,
+        prefer_earlier_reset: bool,
+        routing_strategy: RoutingStrategy,
+        model: str | None,
+        request_state: _WebSocketRequestState,
+        api_key: ApiKeyData | None,
+        client_send_lock: anyio.Lock,
+        websocket: WebSocket,
+        reallocate_sticky: bool,
+        sticky_max_age_seconds: int | None,
+        exclude_account_ids: set[str],
+    ) -> Account | None:
         try:
             selection = await self._select_account_with_budget_compatible(
                 deadline,
@@ -1820,63 +1904,76 @@ class ProxyService:
                 prefer_earlier_reset_accounts=prefer_earlier_reset,
                 routing_strategy=routing_strategy,
                 model=model,
+                exclude_account_ids=exclude_account_ids,
             )
         except ProxyResponseError as exc:
             if _is_proxy_budget_exhausted_error(exc):
-                await self._emit_websocket_proxy_request_timeout(
-                    websocket,
+                await self._emit_websocket_connect_timeout(
+                    websocket=websocket,
                     client_send_lock=client_send_lock,
                     account_id=None,
                     api_key=api_key,
                     request_state=request_state,
                 )
-                return None, None
+                return None
             raise
 
         account = selection.account
-        if not account:
-            error_code = selection.error_code or "no_accounts"
-            error_message = selection.error_message or "No active accounts available"
-            await self._emit_websocket_connect_failure(
-                websocket,
-                client_send_lock=client_send_lock,
-                account_id=None,
-                api_key=api_key,
-                request_state=request_state,
-                status_code=503,
-                payload=openai_error(
-                    error_code,
-                    error_message,
-                    error_type="server_error",
-                ),
-                error_code=error_code,
-                error_message=error_message,
-            )
-            return None, None
+        if account:
+            return account
+        error_code = selection.error_code or "no_accounts"
+        error_message = selection.error_message or "No active accounts available"
+        await self._emit_websocket_connect_failure(
+            websocket,
+            client_send_lock=client_send_lock,
+            account_id=None,
+            api_key=api_key,
+            request_state=request_state,
+            status_code=503,
+            payload=openai_error(
+                error_code,
+                error_message,
+                error_type="server_error",
+            ),
+            error_code=error_code,
+            error_message=error_message,
+        )
+        return None
 
+    async def _try_open_websocket_connect_attempt(
+        self,
+        account: Account,
+        headers: dict[str, str],
+        *,
+        deadline: float,
+        api_key: ApiKeyData | None,
+        request_state: _WebSocketRequestState,
+        client_send_lock: anyio.Lock,
+        websocket: WebSocket,
+    ) -> tuple[Account, UpstreamResponsesWebSocket] | None:
         try:
             remaining_budget = _remaining_budget_seconds(deadline)
             if remaining_budget <= 0:
-                await self._emit_websocket_proxy_request_timeout(
-                    websocket,
+                await self._emit_websocket_connect_timeout(
+                    websocket=websocket,
                     client_send_lock=client_send_lock,
                     account_id=account.id,
                     api_key=api_key,
                     request_state=request_state,
                 )
-                return None, None
+                return None
             account = await self._ensure_fresh_with_budget(account, timeout_seconds=remaining_budget)
 
             remaining_budget = _remaining_budget_seconds(deadline)
             if remaining_budget <= 0:
-                await self._emit_websocket_proxy_request_timeout(
-                    websocket,
+                await self._emit_websocket_connect_timeout(
+                    websocket=websocket,
                     client_send_lock=client_send_lock,
                     account_id=account.id,
                     api_key=api_key,
                     request_state=request_state,
                 )
-                return None, None
+                return None
             return account, await self._open_upstream_websocket_with_budget(
                 account,
                 headers,
@@ -1884,111 +1981,25 @@ class ProxyService:
             )
         except ProxyResponseError as exc:
             if _is_proxy_budget_exhausted_error(exc):
-                await self._emit_websocket_proxy_request_timeout(
-                    websocket,
+                await self._emit_websocket_connect_timeout(
+                    websocket=websocket,
                     client_send_lock=client_send_lock,
                     account_id=account.id,
                     api_key=api_key,
                     request_state=request_state,
                 )
-                return None, None
-            if exc.status_code == 401:
-                try:
-                    remaining_budget = _remaining_budget_seconds(deadline)
-                    if remaining_budget <= 0:
-                        await self._emit_websocket_proxy_request_timeout(
-                            websocket,
-                            client_send_lock=client_send_lock,
-                            account_id=account.id,
-                            api_key=api_key,
-                            request_state=request_state,
-                        )
-                        return None, None
-                    account = await self._ensure_fresh_with_budget(
-                        account,
-                        force=True,
-                        timeout_seconds=remaining_budget,
-                    )
-                except RefreshError as refresh_exc:
-                    if refresh_exc.is_permanent:
-                        await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
-                    await self._emit_websocket_connect_failure(
-                        websocket,
-                        client_send_lock=client_send_lock,
-                        account_id=account.id,
-                        api_key=api_key,
-                        request_state=request_state,
-                        status_code=401,
-                        payload=openai_error(
-                            "invalid_api_key",
-                            refresh_exc.message,
-                            error_type="authentication_error",
-                        ),
-                        error_code="invalid_api_key",
-                        error_message=refresh_exc.message,
-                    )
-                    return None, None
-                except (aiohttp.ClientError, asyncio.TimeoutError) as refresh_transport_exc:
-                    message = str(refresh_transport_exc) or "Request to upstream timed out"
-                    await self._emit_websocket_connect_failure(
-                        websocket,
-                        client_send_lock=client_send_lock,
-                        account_id=account.id,
-                        api_key=api_key,
-                        request_state=request_state,
-                        status_code=502,
-                        payload=openai_error(
-                            "upstream_unavailable",
-                            message,
-                            error_type="server_error",
-                        ),
-                        error_code="upstream_unavailable",
-                        error_message=message,
-                    )
-                    return None, None
-                try:
-                    remaining_budget = _remaining_budget_seconds(deadline)
-                    if remaining_budget <= 0:
-                        await self._emit_websocket_proxy_request_timeout(
-                            websocket,
-                            client_send_lock=client_send_lock,
-                            account_id=account.id,
-                            api_key=api_key,
-                            request_state=request_state,
-                        )
-                        return None, None
-                    return account, await self._open_upstream_websocket_with_budget(
-                        account,
-                        headers,
-                        timeout_seconds=remaining_budget,
-                    )
-                except ProxyResponseError as retry_exc:
-                    exc = retry_exc
-                    if _is_proxy_budget_exhausted_error(exc):
-                        await self._emit_websocket_proxy_request_timeout(
-                            websocket,
-                            client_send_lock=client_send_lock,
-                            account_id=account.id,
-                            api_key=api_key,
-                            request_state=request_state,
-                        )
-                        return None, None
-            await self._handle_websocket_connect_error(account, exc)
-            error = _parse_openai_error(exc.payload)
-            error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
-            error_message = error.message if error else None
-            await self._emit_websocket_connect_failure(
-                websocket,
-                client_send_lock=client_send_lock,
-                account_id=account.id,
+                return None
+            if exc.status_code != 401:
+                raise
+            return await self._retry_websocket_connect_after_401(
+                account,
+                headers,
+                deadline=deadline,
                 api_key=api_key,
                 request_state=request_state,
-                status_code=exc.status_code,
-                payload=exc.payload,
-                error_code=error_code or "upstream_error",
-                error_message=error_message or "Upstream error",
+                client_send_lock=client_send_lock,
+                websocket=websocket,
             )
-            return None, None
         except RefreshError as exc:
             if exc.is_permanent:
                 await self._load_balancer.mark_permanent_failure(account, exc.code)
@@ -2007,7 +2018,7 @@ class ProxyService:
                 error_code="invalid_api_key",
                 error_message=exc.message,
             )
-            return None, None
+            return None
         except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
             message = str(exc) or "Request to upstream timed out"
             await self._emit_websocket_connect_failure(
@@ -2025,7 +2036,148 @@ class ProxyService:
                 error_code="upstream_unavailable",
                 error_message=message,
             )
-            return None, None
+            return None
+
+    async def _retry_websocket_connect_after_401(
+        self,
+        account: Account,
+        headers: dict[str, str],
+        *,
+        deadline: float,
+        api_key: ApiKeyData | None,
+        request_state: _WebSocketRequestState,
+        client_send_lock: anyio.Lock,
+        websocket: WebSocket,
+    ) -> tuple[Account, UpstreamResponsesWebSocket] | None:
+        try:
+            remaining_budget = _remaining_budget_seconds(deadline)
+            if remaining_budget <= 0:
+                await self._emit_websocket_connect_timeout(
+                    websocket=websocket,
+                    client_send_lock=client_send_lock,
+                    account_id=account.id,
+                    api_key=api_key,
+                    request_state=request_state,
+                )
+                return None
+            account = await self._ensure_fresh_with_budget(
+                account,
+                force=True,
+                timeout_seconds=remaining_budget,
+            )
+        except RefreshError as refresh_exc:
+            if refresh_exc.is_permanent:
+                await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+            await self._emit_websocket_connect_failure(
+                websocket,
+                client_send_lock=client_send_lock,
+                account_id=account.id,
+                api_key=api_key,
+                request_state=request_state,
+                status_code=401,
+                payload=openai_error(
+                    "invalid_api_key",
+                    refresh_exc.message,
+                    error_type="authentication_error",
+                ),
+                error_code="invalid_api_key",
+                error_message=refresh_exc.message,
+            )
+            return None
+        except (aiohttp.ClientError, asyncio.TimeoutError) as refresh_transport_exc:
+            message = str(refresh_transport_exc) or "Request to upstream timed out"
+            await self._emit_websocket_connect_failure(
+                websocket,
+                client_send_lock=client_send_lock,
+                account_id=account.id,
+                api_key=api_key,
+                request_state=request_state,
+                status_code=502,
+                payload=openai_error(
+                    "upstream_unavailable",
+                    message,
+                    error_type="server_error",
+                ),
+                error_code="upstream_unavailable",
+                error_message=message,
+            )
+            return None
+
+        try:
+            remaining_budget = _remaining_budget_seconds(deadline)
+            if remaining_budget <= 0:
+                await self._emit_websocket_connect_timeout(
+                    websocket=websocket,
+                    client_send_lock=client_send_lock,
+                    account_id=account.id,
+                    api_key=api_key,
+                    request_state=request_state,
+                )
+                return None
+            return account, await self._open_upstream_websocket_with_budget(
+                account,
+                headers,
+                timeout_seconds=remaining_budget,
+            )
+        except ProxyResponseError as exc:
+            if _is_proxy_budget_exhausted_error(exc):
+                await self._emit_websocket_connect_timeout(
+                    websocket=websocket,
+                    client_send_lock=client_send_lock,
+                    account_id=account.id,
+                    api_key=api_key,
+                    request_state=request_state,
+                )
+                return None
+            raise
+
+    async def _decide_websocket_failover_action(
+        self,
+        *,
+        account: Account,
+        exc: ProxyResponseError,
+        request_state: _WebSocketRequestState,
+        attempt: int,
+        max_attempts: int,
+        deterministic_failover_enabled: bool,
+    ) -> str:
+        classified = await self._handle_websocket_connect_error(account, exc)
+        failure_class = classified["failure_class"] if isinstance(classified, dict) else "non_retryable"
+        if deterministic_failover_enabled:
+            action = failover_decision(
+                failure_class=failure_class,
+                downstream_visible=False,
+                candidates_remaining=max_attempts - attempt,
+            )
+        else:
+            action = "surface"
+        logger.info(
+            "Failover decision request_id=%s transport=websocket account_id=%s "
+            "attempt=%d failure_class=%s action=%s",
+            request_state.request_log_id or request_state.request_id,
+            account.id,
+            attempt,
+            failure_class,
+            action,
+        )
+        return action
+
+    async def _emit_websocket_connect_timeout(
+        self,
+        *,
+        websocket: WebSocket,
+        client_send_lock: anyio.Lock,
+        account_id: str | None,
+        api_key: ApiKeyData | None,
+        request_state: _WebSocketRequestState,
+    ) -> None:
+        await self._emit_websocket_proxy_request_timeout(
+            websocket,
+            client_send_lock=client_send_lock,
+            account_id=account_id,
+            api_key=api_key,
+            request_state=request_state,
+        )
 
     async def _open_upstream_websocket_with_budget(
         self,
@@ -3909,15 +4061,14 @@ class ProxyService:
                 except ApiKeyInvalidError as exc:
                     raise ProxyAuthError(str(exc)) from exc
 
-    async def _handle_websocket_connect_error(self, account: Account, exc: ProxyResponseError) -> None:
+    async def _handle_websocket_connect_error(self, account: Account, exc: ProxyResponseError) -> ClassifiedFailure:
         error = _parse_openai_error(exc.payload)
         error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
-        if _is_account_neutral_error_code(error_code):
-            return
-        await self._handle_stream_error(
+        return await self._handle_stream_error(
             account,
             _upstream_error_from_openai(error),
             error_code,
+            http_status=exc.status_code,
         )
 
     async def _relay_upstream_websocket_messages(
@@ -4752,7 +4903,7 @@ class ProxyService:
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)
-        max_attempts = 3
+        max_attempts = _STREAM_MAX_ACCOUNT_ATTEMPTS
         settled = False
         any_attempt_logged = False
         settlement = _StreamSettlement()

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1818,8 +1818,8 @@ class ProxyService:
             is_retry = attempt > 0
             account = await self._select_websocket_connect_account(
                 deadline,
-                sticky_key=None if is_retry else sticky_key,
-                sticky_kind=None if is_retry else sticky_kind,
+                sticky_key=sticky_key,
+                sticky_kind=sticky_kind,
                 prefer_earlier_reset=prefer_earlier_reset,
                 routing_strategy=routing_strategy,
                 model=model,
@@ -1827,26 +1827,11 @@ class ProxyService:
                 api_key=api_key,
                 client_send_lock=client_send_lock,
                 websocket=websocket,
-                reallocate_sticky=False if is_retry else reallocate_sticky,
+                reallocate_sticky=True if is_retry else reallocate_sticky,
                 sticky_max_age_seconds=sticky_max_age_seconds,
                 exclude_account_ids=excluded_account_ids,
             )
             if account is None:
-                if last_failover_exc is not None and last_failover_account is not None:
-                    error = _parse_openai_error(last_failover_exc.payload)
-                    error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
-                    error_message = error.message if error else None
-                    await self._emit_websocket_connect_failure(
-                        websocket,
-                        client_send_lock=client_send_lock,
-                        account_id=last_failover_account.id,
-                        api_key=api_key,
-                        request_state=request_state,
-                        status_code=last_failover_exc.status_code,
-                        payload=last_failover_exc.payload,
-                        error_code=error_code or "upstream_error",
-                        error_message=error_message or "Upstream error",
-                    )
                 return None, None
 
             try:
@@ -1892,6 +1877,22 @@ class ProxyService:
             if connect_result is None:
                 return None, None
             return connect_result
+
+        if last_failover_exc is not None and last_failover_account is not None:
+            error = _parse_openai_error(last_failover_exc.payload)
+            error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
+            error_message = error.message if error else None
+            await self._emit_websocket_connect_failure(
+                websocket,
+                client_send_lock=client_send_lock,
+                account_id=last_failover_account.id,
+                api_key=api_key,
+                request_state=request_state,
+                status_code=last_failover_exc.status_code,
+                payload=last_failover_exc.payload,
+                error_code=error_code or "upstream_error",
+                error_message=error_message or "Upstream error",
+            )
         return None, None
 
     async def _select_websocket_connect_account(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1812,11 +1812,14 @@ class ProxyService:
         base_settings = get_settings()
         max_attempts = _WEBSOCKET_MAX_ACCOUNT_ATTEMPTS
         excluded_account_ids: set[str] = set()
+        last_failover_exc: ProxyResponseError | None = None
+        last_failover_account: Account | None = None
         for attempt in range(max_attempts):
+            is_retry = attempt > 0
             account = await self._select_websocket_connect_account(
                 deadline,
-                sticky_key=sticky_key,
-                sticky_kind=sticky_kind,
+                sticky_key=None if is_retry else sticky_key,
+                sticky_kind=None if is_retry else sticky_kind,
                 prefer_earlier_reset=prefer_earlier_reset,
                 routing_strategy=routing_strategy,
                 model=model,
@@ -1824,11 +1827,26 @@ class ProxyService:
                 api_key=api_key,
                 client_send_lock=client_send_lock,
                 websocket=websocket,
-                reallocate_sticky=reallocate_sticky,
+                reallocate_sticky=False if is_retry else reallocate_sticky,
                 sticky_max_age_seconds=sticky_max_age_seconds,
                 exclude_account_ids=excluded_account_ids,
             )
             if account is None:
+                if last_failover_exc is not None and last_failover_account is not None:
+                    error = _parse_openai_error(last_failover_exc.payload)
+                    error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
+                    error_message = error.message if error else None
+                    await self._emit_websocket_connect_failure(
+                        websocket,
+                        client_send_lock=client_send_lock,
+                        account_id=last_failover_account.id,
+                        api_key=api_key,
+                        request_state=request_state,
+                        status_code=last_failover_exc.status_code,
+                        payload=last_failover_exc.payload,
+                        error_code=error_code or "upstream_error",
+                        error_message=error_message or "Upstream error",
+                    )
                 return None, None
 
             try:
@@ -1851,6 +1869,8 @@ class ProxyService:
                     deterministic_failover_enabled=getattr(base_settings, "deterministic_failover_enabled", True),
                 )
                 if action == "failover_next":
+                    last_failover_exc = exc
+                    last_failover_account = account
                     excluded_account_ids.add(account.id)
                     continue
                 error = _parse_openai_error(exc.payload)
@@ -2152,8 +2172,7 @@ class ProxyService:
         else:
             action = "surface"
         logger.info(
-            "Failover decision request_id=%s transport=websocket account_id=%s "
-            "attempt=%d failure_class=%s action=%s",
+            "Failover decision request_id=%s transport=websocket account_id=%s attempt=%d failure_class=%s action=%s",
             request_state.request_log_id or request_state.request_id,
             account.id,
             attempt,

--- a/openspec/changes/deterministic-failover-soft-drain/tasks.md
+++ b/openspec/changes/deterministic-failover-soft-drain/tasks.md
@@ -26,12 +26,12 @@
 
 - [x] T17: Modify `_stream_with_retry` in `service.py`: catch connect-phase `ProxyResponseError(429/quota)` → `classify_upstream_failure` → `failover_decision` → break to next account if `failover_next`
 - [x] T18: Modify `compact_responses` in `service.py`: catch 429/quota `ProxyResponseError` → `classify_upstream_failure` → `failover_decision` → continue to next account if `failover_next`
-- [ ] T19: Add WebSocket handshake-phase failover: on upstream connect 429/quota before first downstream frame, select next account and retry
+- [x] T19: Add WebSocket handshake-phase failover: on upstream connect 429/quota before first downstream frame, select next account and retry
 - [x] T20: Adjust `_select_with_stickiness()` in `load_balancer.py`: skip new sticky creation for DRAINING accounts (codex_session exempt)
-- [ ] T21: Add integration tests: streaming connect-phase 429 → transparent failover to account B
-- [ ] T22: Add integration tests: compact quota_exceeded → transparent failover to account B
-- [ ] T23: Add integration tests: mid-stream error → surface (no failover)
-- [ ] T24: Add integration tests: all accounts DRAINING → still selects best DRAINING (no hard block)
+- [x] T21: Add integration tests: streaming connect-phase 429 → transparent failover to account B
+- [x] T22: Add integration tests: compact quota_exceeded → transparent failover to account B
+- [x] T23: Add integration tests: mid-stream error → surface (no failover)
+- [x] T24: Add integration tests: all accounts DRAINING → still selects best DRAINING (no hard block)
 
 ## Wave 4 — Feature flags, observability, cleanup (depends on Wave 3)
 

--- a/tests/integration/test_load_balancer_integration.py
+++ b/tests/integration/test_load_balancer_integration.py
@@ -6,6 +6,7 @@ from datetime import timedelta, timezone
 
 import pytest
 
+from app.core.balancer import HEALTH_TIER_DRAINING
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
@@ -427,3 +428,82 @@ async def test_load_balancer_filters_accounts_by_persisted_additional_usage(db_s
 
     assert selection.account is not None
     assert selection.account.id == eligible_account.id
+
+
+@pytest.mark.asyncio
+async def test_load_balancer_selects_best_draining_account_when_all_are_draining(db_setup):
+    encryptor = TokenEncryptor()
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    primary_reset = now_epoch + 3600
+    secondary_reset = now_epoch + 7200
+
+    account_a = Account(
+        id="acc_all_draining_a",
+        email="all_draining_a@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-drain-a"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-drain-a"),
+        id_token_encrypted=encryptor.encrypt("id-drain-a"),
+        last_refresh=now,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    account_b = Account(
+        id="acc_all_draining_b",
+        email="all_draining_b@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-drain-b"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-drain-b"),
+        id_token_encrypted=encryptor.encrypt("id-drain-b"),
+        last_refresh=now,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        await accounts_repo.upsert(account_a)
+        await accounts_repo.upsert(account_b)
+
+        await usage_repo.add_entry(
+            account_id=account_a.id,
+            used_percent=94.0,
+            window="primary",
+            reset_at=primary_reset,
+            window_minutes=300,
+            recorded_at=now,
+        )
+        await usage_repo.add_entry(
+            account_id=account_a.id,
+            used_percent=96.0,
+            window="secondary",
+            reset_at=secondary_reset,
+            window_minutes=10080,
+            recorded_at=now,
+        )
+        await usage_repo.add_entry(
+            account_id=account_b.id,
+            used_percent=88.0,
+            window="primary",
+            reset_at=primary_reset,
+            window_minutes=300,
+            recorded_at=now,
+        )
+        await usage_repo.add_entry(
+            account_id=account_b.id,
+            used_percent=93.0,
+            window="secondary",
+            reset_at=secondary_reset,
+            window_minutes=10080,
+            recorded_at=now,
+        )
+
+    balancer = LoadBalancer(_repo_factory)
+    selection = await balancer.select_account(routing_strategy="usage_weighted")
+
+    assert selection.account is not None
+    assert selection.account.id == account_b.id
+    assert balancer._runtime[account_a.id].health_tier == HEALTH_TIER_DRAINING
+    assert balancer._runtime[account_b.id].health_tier == HEALTH_TIER_DRAINING

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -20,6 +20,8 @@ from app.core.auth import generate_unique_account_id
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
 from app.core.openai.models import CompactResponsePayload
+from app.db.models import Account, AccountStatus
+from app.db.session import SessionLocal
 
 pytestmark = pytest.mark.integration
 
@@ -308,6 +310,39 @@ async def test_stream_http_500_exhausts_then_failover(async_client, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_stream_connect_phase_429_usage_limit_transparent_failover(async_client, monkeypatch):
+    """Connect-phase 429/usage_limit_reached on A should fail over to B before any downstream event."""
+    await _import_account(async_client, "acc_stream_429_a", "stream429a@example.com")
+    await _import_account(async_client, "acc_stream_429_b", "stream429b@example.com")
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen_account_ids.append(account_id)
+        if account_id == "acc_stream_429_a":
+            raise ProxyResponseError(
+                429,
+                openai_error("usage_limit_reached", "usage limit reached"),
+                failure_phase="status",
+            )
+        yield _success_sse_event("resp_stream_429_ok")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    completed = [e for e in events if e.get("type") == "response.completed"]
+    failed = [e for e in events if e.get("type") == "response.failed"]
+    assert len(completed) == 1
+    assert len(failed) == 0
+    assert seen_account_ids[:2] == ["acc_stream_429_a", "acc_stream_429_b"]
+
+
+@pytest.mark.asyncio
 async def test_stream_http_502_unknown_code_fails_over_to_second_account(async_client, monkeypatch):
     await _import_account(async_client, "acc_h502_a", "h502_a@example.com")
     await _import_account(async_client, "acc_h502_b", "h502_b@example.com")
@@ -419,6 +454,43 @@ async def test_stream_rate_limit_on_last_attempt_returns_actual_error(async_clie
     last_event = events[-1] if events else {}
     error = last_event.get("response", {}).get("error", {})
     assert error.get("code") != "no_accounts", "Client received generic no_accounts instead of actual error"
+
+
+@pytest.mark.asyncio
+async def test_stream_mid_stream_error_is_surfaced_without_failover(async_client, monkeypatch):
+    """Once bytes/events are emitted downstream, failover is forbidden; surface the mid-stream error."""
+    await _import_account(async_client, "acc_midstream_a", "midstreama@example.com")
+    await _import_account(async_client, "acc_midstream_b", "midstreamb@example.com")
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen_account_ids.append(account_id)
+        if account_id == "acc_midstream_a":
+            yield _sse_event({"type": "response.in_progress", "response": {"id": "resp_midstream"}})
+            yield _sse_event(
+                {
+                    "type": "response.failed",
+                    "response": {"error": {"code": "rate_limit_exceeded", "message": "mid-stream limit"}},
+                }
+            )
+            return
+        yield _success_sse_event("resp_should_not_happen")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    failed = [e for e in events if e.get("type") == "response.failed"]
+    completed = [e for e in events if e.get("type") == "response.completed"]
+    assert len(failed) == 1
+    assert failed[0].get("response", {}).get("error", {}).get("code") == "rate_limit_exceeded"
+    assert len(completed) == 0
+    assert seen_account_ids == ["acc_midstream_a"]
 
 
 @pytest.mark.asyncio
@@ -548,6 +620,40 @@ async def test_compact_500_exhausts_retries_then_failover(async_client, monkeypa
     b_calls = [aid for aid in seen_account_ids if aid == "acc_cfo_b"]
     assert len(a_calls) == 3
     assert len(b_calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_compact_quota_exceeded_transparent_failover(async_client, monkeypatch):
+    """quota_exceeded on A should fail over to B before response write."""
+    await _import_account(async_client, "acc_compact_quota_a", "compactquotaa@example.com")
+    await _import_account(async_client, "acc_compact_quota_b", "compactquotab@example.com")
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        seen_account_ids.append(account_id)
+        if account_id == "acc_compact_quota_a":
+            raise ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": []}
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+    assert response.status_code == 200
+    assert response.json()["object"] == "response.compaction"
+    assert seen_account_ids[:2] == ["acc_compact_quota_a", "acc_compact_quota_b"]
+
+    async with SessionLocal() as session:
+        account_id = generate_unique_account_id("acc_compact_quota_a", "compactquotaa@example.com")
+        account_a = await session.get(Account, account_id)
+        assert account_a is not None
+        await session.refresh(account_a)
+        assert account_a.status == AccountStatus.QUOTA_EXCEEDED
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3685,6 +3685,71 @@ async def test_connect_proxy_websocket_surfaces_retry_handshake_error(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_connect_proxy_websocket_fails_over_on_handshake_usage_limit_reached(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_ws_failover_a")
+    account_b = _make_account("acc_ws_failover_b")
+    upstream = SimpleNamespace()
+
+    select_account = AsyncMock(
+        side_effect=[
+            AccountSelection(account=account_a, error_message=None),
+            AccountSelection(account=account_b, error_message=None),
+        ]
+    )
+    mark_rate_limit = AsyncMock()
+    first_handshake_error = proxy_module.ProxyResponseError(
+        429,
+        openai_error("usage_limit_reached", "usage limit reached"),
+    )
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "mark_rate_limit", mark_rate_limit)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_open_upstream_websocket", AsyncMock(side_effect=[first_handshake_error, upstream]))
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_failover_handshake_429",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+
+    websocket_send = AsyncMock()
+    websocket = cast(WebSocket, SimpleNamespace(send_text=websocket_send))
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=websocket,
+    )
+
+    assert selected_account == account_b
+    assert selected_upstream is upstream
+    assert select_account.await_count == 2
+    first_call, second_call = select_account.await_args_list
+    assert first_call.kwargs["exclude_account_ids"] == set()
+    assert second_call.kwargs["exclude_account_ids"] == {account_a.id}
+    mark_rate_limit.assert_awaited_once()
+    mark_call = mark_rate_limit.await_args
+    assert mark_call is not None
+    assert mark_call.args[0] == account_a
+    assert mark_call.args[1]["message"] == "usage limit reached"
+    websocket_send.assert_not_awaited()
+    assert request_logs.calls == []
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_surfaces_local_connect_overload_without_penalizing_account(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.proxy_upstream_websocket_connect_limit = 1


### PR DESCRIPTION
Closes #385

  ## Summary
  This PR implements and hardens deterministic failover behavior across transports, with a focus on websocket connect-phase handling and missing integration coverage.

  ## What changed
  - Added websocket connect-phase failover logic (before first downstream frame) in `ProxyService`.
  - Refactored `_connect_proxy_websocket` into smaller internal helpers to reduce complexity while preserving behavior.
  - Replaced hardcoded retry attempt values with named constants:
    - `_WEBSOCKET_MAX_ACCOUNT_ATTEMPTS`
    - `_STREAM_MAX_ACCOUNT_ATTEMPTS`
  - Added unit coverage for websocket handshake failover on `429 usage_limit_reached`.
  - Added integration coverage for:
    - streaming connect-phase `429` -> transparent failover to account B (T21)
    - compact `quota_exceeded` -> transparent failover to account B (T22)
    - mid-stream error -> surfaced to client, no failover (T23)
    - all accounts `DRAINING` -> best `DRAINING` account still selected (T24)
  - Updated OpenSpec task checklist for completed items (T19, T21–T24).

  ## Notes
  - No behavioral changes were introduced for post-first-frame websocket errors (they are still surfaced, not failed over).

  ## Validation
  - `ruff check` on modified files
  - `py_compile` on modified files
  - `pytest tests/unit/test_proxy_utils.py -k "connect_proxy_websocket or stream_with_retry" -q --timeout=120`