### PR TITLE
fix(auth): allow explicit unauthenticated proxy client CIDRs

### DIFF
--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from ipaddress import ip_address, ip_network
 from typing import cast
 
 from fastapi import Request, Security
@@ -11,6 +12,7 @@ from starlette.requests import HTTPConnection
 from app.core.auth.api_key_cache import get_api_key_cache
 from app.core.auth.dashboard_mode import DashboardAuthMode, get_dashboard_request_auth
 from app.core.clients.usage import UsageFetchError, fetch_usage
+from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.exceptions import DashboardAuthError, ProxyAuthError, ProxyUpstreamError
 from app.core.request_locality import is_local_request
@@ -56,7 +58,8 @@ async def validate_proxy_api_key_authorization(
     settings = await get_settings_cache().get()
     if not settings.api_key_auth_enabled:
         if request is not None and not is_local_request(request):
-            raise ProxyAuthError("Proxy authentication must be configured before remote access is allowed")
+            if not _is_proxy_unauthenticated_socket_peer_allowed(request):
+                raise ProxyAuthError("Proxy authentication must be configured before remote access is allowed")
         return None
 
     token = _extract_bearer_token(authorization)
@@ -150,6 +153,20 @@ def get_dashboard_request_auth_mode() -> DashboardAuthMode:
     from app.core.config.settings import get_settings
 
     return get_settings().dashboard_auth_mode
+
+
+def _is_proxy_unauthenticated_socket_peer_allowed(request: HTTPConnection) -> bool:
+    socket_host = request.client.host if request.client else None
+    if socket_host is None:
+        return False
+
+    try:
+        socket_ip = ip_address(socket_host)
+    except ValueError:
+        return False
+
+    configured_cidrs = get_settings().proxy_unauthenticated_client_cidrs
+    return any(socket_ip in ip_network(cidr, strict=False) for cidr in configured_cidrs)
 
 
 # --- Codex usage caller identity auth ---

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -84,6 +84,31 @@ def _configured_http_port() -> int:
     return 2455
 
 
+def _normalize_cidr_list(value: StringListInput, *, field_name: str, invalid_label: str) -> list[str]:
+    if value is None:
+        return []
+
+    cidrs: list[str] = []
+    if isinstance(value, str):
+        entries = [entry.strip() for entry in value.split(",")]
+        cidrs = [entry for entry in entries if entry]
+    elif isinstance(value, list):
+        for entry in value:
+            if isinstance(entry, str):
+                cidr = entry.strip()
+                if cidr:
+                    cidrs.append(cidr)
+    else:
+        raise TypeError(f"{field_name} must be a list or comma-separated string")
+
+    for cidr in cidrs:
+        try:
+            ip_network(cidr, strict=False)
+        except ValueError as exc:
+            raise ValueError(f"Invalid {invalid_label}: {cidr}") from exc
+    return cidrs
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="CODEX_LB_",
@@ -155,6 +180,7 @@ class Settings(BaseSettings):
     model_registry_refresh_interval_seconds: int = Field(default=300, gt=0)
     model_registry_client_version: str = "0.101.0"
     model_context_window_overrides: Annotated[dict[str, int], NoDecode] = Field(default_factory=dict)
+    proxy_unauthenticated_client_cidrs: Annotated[list[str], NoDecode] = Field(default_factory=list)
     firewall_trust_proxy_headers: bool = False
     firewall_trusted_proxy_cidrs: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["127.0.0.1/32", "::1/128"]
@@ -259,27 +285,20 @@ class Settings(BaseSettings):
     @field_validator("firewall_trusted_proxy_cidrs", mode="before")
     @classmethod
     def _normalize_firewall_trusted_proxy_cidrs(cls, value: StringListInput) -> list[str]:
-        if value is None:
-            return []
-        cidrs: list[str] = []
-        if isinstance(value, str):
-            entries = [entry.strip() for entry in value.split(",")]
-            cidrs = [entry for entry in entries if entry]
-        elif isinstance(value, list):
-            for entry in value:
-                if isinstance(entry, str):
-                    cidr = entry.strip()
-                    if cidr:
-                        cidrs.append(cidr)
-        else:
-            raise TypeError("firewall_trusted_proxy_cidrs must be a list or comma-separated string")
+        return _normalize_cidr_list(
+            value,
+            field_name="firewall_trusted_proxy_cidrs",
+            invalid_label="firewall trusted proxy CIDR",
+        )
 
-        for cidr in cidrs:
-            try:
-                ip_network(cidr, strict=False)
-            except ValueError as exc:
-                raise ValueError(f"Invalid firewall trusted proxy CIDR: {cidr}") from exc
-        return cidrs
+    @field_validator("proxy_unauthenticated_client_cidrs", mode="before")
+    @classmethod
+    def _normalize_proxy_unauthenticated_client_cidrs(cls, value: StringListInput) -> list[str]:
+        return _normalize_cidr_list(
+            value,
+            field_name="proxy_unauthenticated_client_cidrs",
+            invalid_label="proxy unauthenticated client CIDR",
+        )
 
     @field_validator("dashboard_auth_proxy_header", mode="before")
     @classmethod

--- a/openspec/changes/allow-proxy-unauthenticated-client-cidrs/proposal.md
+++ b/openspec/changes/allow-proxy-unauthenticated-client-cidrs/proposal.md
@@ -1,0 +1,15 @@
+## Why
+The v1.12.0 proxy-auth hardening intentionally stopped treating non-local proxy requests as implicitly trusted when API key auth is disabled. That closed a security gap, but it also broke a common Docker Desktop for Mac workflow where host-to-container traffic appears non-local to the container even when the operator is only using localhost on the host machine.
+
+There is currently no narrow way to restore that local development path without either turning API key auth on everywhere or relaxing the shared locality rules that also gate dashboard bootstrap and authentication.
+
+## What Changes
+- Add an explicit proxy-only CIDR allowlist for unauthenticated proxy requests when API key auth is disabled.
+- Apply the allowlist only to the direct socket peer IP for protected proxy routes.
+- Leave `is_local_request()` and dashboard bootstrap/auth behavior unchanged.
+- Add regression coverage for HTTP and websocket proxy requests plus dashboard isolation.
+
+## Impact
+- Affects `/v1/*`, `/backend-api/codex/*`, and `/backend-api/transcribe` only when API key auth is disabled.
+- Restores opt-in Docker Desktop for Mac host-to-container access without reopening general remote access.
+- Adds a new environment-backed configuration knob for operators who intentionally want this exception.

--- a/openspec/changes/allow-proxy-unauthenticated-client-cidrs/specs/api-keys/spec.md
+++ b/openspec/changes/allow-proxy-unauthenticated-client-cidrs/specs/api-keys/spec.md
@@ -1,0 +1,29 @@
+### MODIFIED Requirement: API Key authentication global switch
+The system SHALL provide an `api_key_auth_enabled` boolean in `DashboardSettings`. When false (default), local requests to protected proxy routes MAY proceed without an API key. Operators MAY additionally opt specific non-local proxy clients into unauthenticated access by configuring `proxy_unauthenticated_client_cidrs`. Requests that are neither local nor explicitly allowlisted MUST be rejected until proxy authentication is configured. When true, protected proxy routes require a valid API key via `Authorization: Bearer <key>`.
+
+#### Scenario: Disable API key auth for an explicitly allowlisted proxy client
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
+- **AND** the request socket peer IP belongs to configured `proxy_unauthenticated_client_cidrs`
+- **THEN** the protected proxy route proceeds without API key authentication
+
+#### Scenario: Disable API key auth for a non-local request outside the explicit allowlist
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
+- **AND** a non-local client calls a protected proxy route
+- **AND** the request socket peer IP is outside configured `proxy_unauthenticated_client_cidrs`
+- **THEN** the request is rejected with 401 until proxy authentication is configured
+
+### MODIFIED Requirement: API Key Bearer authentication guard
+The system SHALL validate API keys on protected proxy routes (`/v1/*`, `/backend-api/codex/*`, `/backend-api/transcribe`) when `api_key_auth_enabled` is true. Validation MUST be implemented as a router-level `Security` dependency, not ASGI middleware. The dependency MUST compute `sha256` of the Bearer token and look up the hash in the `api_keys` table.
+
+The dependency SHALL return a typed `ApiKeyData` value directly to the route handler. Route handlers MUST NOT access API key data via `request.state`.
+
+`/api/codex/usage` SHALL NOT be covered by the API key auth guard scope.
+
+The dependency SHALL raise a domain exception on validation failure. The exception handler SHALL format the response using the OpenAI error envelope.
+
+#### Scenario: Disabled auth allowlist uses raw socket peer only
+- **WHEN** `api_key_auth_enabled` is false
+- **AND** forwarded headers claim a different client IP
+- **AND** the request socket peer IP is outside configured `proxy_unauthenticated_client_cidrs`
+- **THEN** the dependency rejects the request with 401
+- **AND** forwarded headers do not satisfy the explicit allowlist

--- a/openspec/changes/allow-proxy-unauthenticated-client-cidrs/tasks.md
+++ b/openspec/changes/allow-proxy-unauthenticated-client-cidrs/tasks.md
@@ -1,0 +1,12 @@
+## 1. Spec
+- [x] 1.1 Add an `api-keys` delta for the explicit proxy unauthenticated client CIDR allowlist.
+- [x] 1.2 Update the main `api-keys` spec so the normative proxy-auth behavior matches the implementation.
+
+## 2. Implementation
+- [x] 2.1 Add a validated environment-backed proxy unauthenticated client CIDR setting.
+- [x] 2.2 Allow only raw socket peers in that CIDR list to bypass proxy API key auth when dashboard API key auth is disabled.
+- [x] 2.3 Keep dashboard bootstrap/auth behavior and global locality classification unchanged.
+
+## 3. Validation
+- [x] 3.1 Add regression tests for settings parsing, HTTP proxy auth, websocket proxy auth, and dashboard isolation.
+- [x] 3.2 Run targeted pytest coverage for the new proxy auth path.

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -21,3 +21,440 @@ The system SHALL allow updating key properties via `PATCH /api/api-keys/{id}`. U
 - **WHEN** admin submits `PATCH /api/api-keys/{id}` with `{ "expiresAt": "2025-12-31T00:00:00Z" }`
 - **THEN** the system persists the expiration successfully without PostgreSQL datetime binding errors
 - **AND** the response returns `expiresAt` representing the same UTC instant
+
+#### Scenario: Update non-existent key
+
+- **WHEN** admin submits `PATCH /api/api-keys/{id}` with an unknown ID
+- **THEN** the system returns 404
+
+### Requirement: API Key deletion
+
+The system SHALL allow deleting an API key via `DELETE /api/api-keys/{id}`. Deletion MUST be permanent and the key MUST immediately stop authenticating.
+
+#### Scenario: Delete existing key
+
+- **WHEN** admin calls `DELETE /api/api-keys/{id}` for an existing key
+- **THEN** the key is permanently removed from the database and returns 204
+
+#### Scenario: Delete non-existent key
+
+- **WHEN** admin calls `DELETE /api/api-keys/{id}` with an unknown ID
+- **THEN** the system returns 404
+
+### Requirement: API Key regeneration
+
+The system SHALL allow regenerating an API key via `POST /api/api-keys/{id}/regenerate`. This MUST generate a new key value (new hash, new prefix) while preserving all other properties (name, models, limits, expiration). The new plain key MUST be returned exactly once.
+
+#### Scenario: Regenerate key
+
+- **WHEN** admin calls `POST /api/api-keys/{id}/regenerate`
+- **THEN** the system returns the updated key object with a new `key` and `keyPrefix`; the old key immediately stops authenticating
+
+### Requirement: API Key authentication global switch
+
+The system SHALL provide an `api_key_auth_enabled` boolean in `DashboardSettings`. When false (default), local requests to protected proxy routes MAY proceed without an API key. Operators MAY additionally opt specific non-local proxy clients into unauthenticated access by configuring `proxy_unauthenticated_client_cidrs`. Requests that are neither local nor explicitly allowlisted MUST be rejected until proxy authentication is configured. When true, protected proxy routes require a valid API key via `Authorization: Bearer <key>`.
+
+#### Scenario: Enable API key auth
+
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": true }`
+- **THEN** subsequent proxy requests without a valid Bearer token are rejected with 401
+
+#### Scenario: Disable API key auth for a local request
+
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
+- **AND** a local client calls a protected proxy route
+- **THEN** the request is allowed without API key authentication
+
+#### Scenario: Disable API key auth for a non-local request
+
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
+- **AND** a non-local client calls a protected proxy route
+- **THEN** the request is rejected with 401 until proxy authentication is configured
+
+#### Scenario: Disable API key auth for an explicitly allowlisted proxy client
+
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": false }`
+- **AND** the request socket peer IP belongs to configured `proxy_unauthenticated_client_cidrs`
+- **THEN** the protected proxy route proceeds without API key authentication
+
+#### Scenario: Enable without any keys created
+
+- **WHEN** admin enables API key auth but no keys exist
+- **THEN** all proxy requests are rejected with 401 (the system SHALL NOT prevent enabling even if no keys exist)
+
+### Requirement: API Key Bearer authentication guard
+
+The system SHALL validate API keys on protected proxy routes (`/v1/*`, `/backend-api/codex/*`, `/backend-api/transcribe`) when `api_key_auth_enabled` is true. Validation MUST be implemented as a router-level `Security` dependency, not ASGI middleware. The dependency MUST compute `sha256` of the Bearer token and look up the hash in the `api_keys` table.
+
+The dependency SHALL return a typed `ApiKeyData` value directly to the route handler. Route handlers MUST NOT access API key data via `request.state`.
+
+`/api/codex/usage` SHALL NOT be covered by the API key auth guard scope.
+
+The dependency SHALL raise a domain exception on validation failure. The exception handler SHALL format the response using the OpenAI error envelope.
+
+#### Scenario: API key guard route scope
+
+- **WHEN** `api_key_auth_enabled` is true and a request is made to `/v1/responses`, `/backend-api/codex/responses`, `/v1/audio/transcriptions`, or `/backend-api/transcribe`
+- **THEN** the API key guard validation is applied
+
+#### Scenario: Codex usage excluded from API key guard scope
+
+- **WHEN** `api_key_auth_enabled` is true and a request is made to `/api/codex/usage`
+- **THEN** API key guard validation is not applied
+
+#### Scenario: Valid API key injected into handler
+
+- **WHEN** `api_key_auth_enabled` is true and a valid Bearer token is provided
+- **THEN** the route handler receives a typed `ApiKeyData` parameter (not `request.state`)
+
+#### Scenario: API key auth disabled returns None for local requests
+
+- **WHEN** `api_key_auth_enabled` is false
+- **AND** the request is classified as local
+- **THEN** the dependency returns `None` and the request proceeds without authentication
+
+#### Scenario: API key auth disabled rejects non-local requests
+
+- **WHEN** `api_key_auth_enabled` is false
+- **AND** the request is classified as non-local
+- **AND** the request socket peer IP is outside configured `proxy_unauthenticated_client_cidrs`
+- **THEN** the dependency rejects the request with 401
+
+#### Scenario: Disabled auth allowlist uses raw socket peer only
+
+- **WHEN** `api_key_auth_enabled` is false
+- **AND** forwarded headers claim a different client IP
+- **AND** the request socket peer IP is outside configured `proxy_unauthenticated_client_cidrs`
+- **THEN** the dependency rejects the request with 401
+- **AND** forwarded headers do not satisfy the explicit allowlist
+
+### Requirement: Model restriction enforcement
+
+The system SHALL enforce per-key model restrictions in the proxy service layer (not middleware). When `allowed_models` is set (non-null, non-empty) and the requested model is not in the list, the system MUST reject the request. The `/v1/models` endpoint MUST filter the model list based on the authenticated key's `allowed_models`.
+
+For fixed-model endpoints such as `/v1/audio/transcriptions` and `/backend-api/transcribe`, the service MUST evaluate restrictions against fixed effective model `gpt-4o-transcribe`.
+
+#### Scenario: Requested model not allowed
+
+- **WHEN** a key has `allowed_models: ["o3-pro"]` and a request is made for model `gpt-4.1`
+- **THEN** the proxy returns 403 with OpenAI-format error `{ "error": { "code": "model_not_allowed", "message": "This API key does not have access to model 'gpt-4.1'" } }`
+
+#### Scenario: All models allowed
+
+- **WHEN** a key has `allowed_models: null`
+- **THEN** any model is permitted
+
+#### Scenario: Model list filtered
+
+- **WHEN** a key with `allowed_models: ["o3-pro"]` calls `GET /v1/models`
+- **THEN** the response contains only models matching the allowed list
+
+#### Scenario: No API key auth (disabled)
+
+- **WHEN** `api_key_auth_enabled` is false and a request is made to `/v1/models`
+- **THEN** the full model catalog is returned
+
+#### Scenario: Fixed transcription model not allowed
+
+- **WHEN** a key has `allowed_models: ["gpt-5.1"]` and a request is made to `/v1/audio/transcriptions` or `/backend-api/transcribe`
+- **THEN** the proxy returns 403 with OpenAI-format error code `model_not_allowed` for model `gpt-4o-transcribe`
+
+### Requirement: Weekly token usage tracking
+
+The system SHALL atomically increment `weekly_tokens_used` on the API key record when a proxy request completes with token usage data. The token count MUST be `input_tokens + output_tokens`. If token usage is unavailable (error response), the counter MUST NOT be incremented.
+
+#### Scenario: Successful request with usage
+
+- **WHEN** a proxy request completes with `input_tokens: 100, output_tokens: 50` for an authenticated key
+- **THEN** `weekly_tokens_used` is atomically incremented by 150
+
+#### Scenario: Request with no usage data
+
+- **WHEN** a proxy request fails with an error and no usage data is returned
+- **THEN** `weekly_tokens_used` is not incremented
+
+#### Scenario: Request without API key auth
+
+- **WHEN** `api_key_auth_enabled` is false and a proxy request completes
+- **THEN** no API key usage tracking occurs
+
+### Requirement: Weekly token usage reset
+
+The system SHALL reset `weekly_tokens_used` to 0 using a lazy on-read strategy. When validating an API key, if `weekly_reset_at < now()`, the system MUST reset the counter and advance `weekly_reset_at` by 7-day intervals until it is in the future.
+
+#### Scenario: Weekly reset triggered on validation
+
+- **WHEN** an API key is validated and `weekly_reset_at` is 2 weeks in the past
+- **THEN** `weekly_tokens_used` is set to 0 and `weekly_reset_at` is advanced by 14 days (2 × 7 days) to a future date
+
+#### Scenario: No reset needed
+
+- **WHEN** an API key is validated and `weekly_reset_at` is in the future
+- **THEN** no reset occurs; `weekly_tokens_used` retains its current value
+
+### Requirement: RequestLog API key reference
+
+The system SHALL record the `api_key_id` in the `request_logs` table for proxy requests authenticated with an API key. The field MUST be NULL when API key auth is disabled or the request is unauthenticated.
+
+#### Scenario: Authenticated request logged
+
+- **WHEN** a proxy request is authenticated with API key `key-123` and completes
+- **THEN** the `request_logs` entry has `api_key_id = "key-123"`
+
+#### Scenario: Unauthenticated request logged
+
+- **WHEN** API key auth is disabled and a proxy request completes
+- **THEN** the `request_logs` entry has `api_key_id = NULL`
+
+### Requirement: Frontend API Key management
+
+The SPA settings page SHALL include an API Key management section with: a toggle for `apiKeyAuthEnabled`, a key list table showing prefix/name/models/limit/usage/expiry/status, a create dialog (name, model selection, weekly limit, expiry date), and key actions (edit, delete, regenerate). On key creation, the SPA MUST display the plain key in a copy-able dialog with a warning that it will not be shown again.
+
+#### Scenario: Create key and show plain key
+
+- **WHEN** admin creates a key via the UI
+- **THEN** a dialog shows the full plain key with a copy button and a warning message
+
+#### Scenario: Toggle API key auth
+
+- **WHEN** admin toggles `apiKeyAuthEnabled` in settings
+- **THEN** the system calls `PUT /api/settings` and reflects the new state
+
+### Requirement: Cost accounting uses model and service-tier pricing
+When computing API key `cost_usd` usage, the system MUST price requests using the resolved model pricing and the authoritative `service_tier` reported by the upstream response when available, falling back to the forwarded request `service_tier` only when the response omits it. Requests sent with non-standard service tiers MUST use the published pricing for the tier actually used instead of falling back to standard-tier pricing.
+
+#### Scenario: Priority-tier request increments cost limit
+- **WHEN** an authenticated request for a priced model is finalized with `service_tier: "priority"`
+- **THEN** the system computes `cost_usd` using the priority-tier rate for that model
+
+#### Scenario: Flex-tier request increments cost limit
+- **WHEN** an authenticated request for a priced model is finalized with `service_tier: "flex"`
+- **THEN** the system computes `cost_usd` using the flex-tier rate for that model
+
+#### Scenario: Standard-tier request keeps standard pricing
+- **WHEN** an authenticated request for the same model is finalized without `service_tier`
+- **THEN** the system computes `cost_usd` using the standard-tier rate
+
+### Requirement: gpt-5.4 pricing is recognized
+The system MUST recognize `gpt-5.4` pricing when computing request costs. For standard-tier requests with more than 272K input tokens, the system MUST apply the published higher long-context rates.
+
+#### Scenario: gpt-5.4 request priced at standard tier
+- **WHEN** a request for `gpt-5.4` completes with standard service tier
+- **THEN** the system computes non-zero cost using the configured `gpt-5.4` standard rates
+
+#### Scenario: gpt-5.4 long-context request priced at long-context rates
+- **WHEN** a standard-tier `gpt-5.4` request completes with more than 272K input tokens
+- **THEN** the system computes cost using the configured long-context `gpt-5.4` rates
+
+### Requirement: Model-scoped limit enforcement
+
+The system SHALL separate authentication validation from quota enforcement. `validate_key()` in the auth guard SHALL only verify key validity (existence, active status, expiry, basic reset). Quota enforcement SHALL occur at a point where the request model is known.
+
+Limit applicability rules:
+- `limit.model_filter is None` → always applies (global limit)
+- `limit.model_filter == request_model` → applies (model-scoped limit)
+- otherwise → does not apply for this request
+
+For model-less requests (e.g., `/v1/models`), only global limits SHALL be evaluated.
+
+The service contract SHALL be typed explicitly: `enforce_limits_for_request(key_id: str, *, request_model: str | None, request_service_tier: str | None = None) -> None`.
+
+#### Scenario: Model-scoped limit does not block other models
+
+- **WHEN** `model_filter="gpt-5.1"` limit is exhausted
+- **AND** request model is `gpt-4o-mini`
+- **THEN** the request is allowed
+
+#### Scenario: Model-scoped limit blocks matching model
+
+- **WHEN** `model_filter="gpt-5.1"` limit is exhausted
+- **AND** request model is `gpt-5.1`
+- **THEN** the request returns 429
+
+#### Scenario: Model-scoped limit does not block model-less endpoints
+
+- **WHEN** `model_filter="gpt-5.1"` limit is exhausted
+- **AND** request is to `/v1/models` (no model context)
+- **THEN** the request is allowed
+
+#### Scenario: Global limit blocks all proxy requests
+
+- **WHEN** a global limit (no `model_filter`) is exhausted
+- **THEN** all proxy requests return 429
+
+### Requirement: Limit update with usage state preservation
+
+When updating API key limits, the system SHALL preserve existing usage state (`current_value`, `reset_at`) for unchanged limit rules. Limit comparison key is `(limit_type, limit_window, model_filter)`.
+
+- Matching existing rule: `current_value` and `reset_at` SHALL be preserved; only `max_value` is updated
+- New rule (no match): `current_value=0` and fresh `reset_at`
+- Removed rule (in existing but not in update): row is deleted
+
+Usage reset SHALL only occur via an explicit action (`reset_usage` field or dedicated endpoint), never as a side-effect of metadata or policy edits.
+
+#### Scenario: Metadata-only edit preserves usage state
+
+- **WHEN** an API key PATCH updates only name or is_active
+- **AND** `limits` field is not included in the payload
+- **THEN** existing `current_value` and `reset_at` are unchanged
+
+#### Scenario: Same policy re-submission preserves usage state
+
+- **WHEN** an API key PATCH includes `limits` with identical rules (same type/window/filter/max_value)
+- **THEN** existing `current_value` and `reset_at` are unchanged
+
+#### Scenario: max_value adjustment preserves counters
+
+- **WHEN** an API key PATCH includes `limits` with a changed `max_value` for an existing rule
+- **THEN** `current_value` and `reset_at` are preserved; only the threshold changes
+
+#### Scenario: Explicit reset action resets usage
+
+- **WHEN** an explicit usage reset action is invoked
+- **THEN** `current_value` is set to 0 and `reset_at` is refreshed
+
+### Requirement: API key edit payload — conditional limits transmission
+
+The frontend API key edit dialog SHALL transmit `limits` in the PATCH payload only when limit values have actually changed. The system SHALL normalize and compare initial and current limit values to detect changes.
+
+- Metadata-only changes (name, is_active): `limits` field MUST be omitted from the payload
+- Identical rule sets with different ordering: MUST be treated as unchanged (`limits` omitted)
+
+Backend contract:
+- `limits` absent in payload: limit policy unchanged (usage/reset state preserved)
+- `limits` present in payload: policy replacement (state-preserving upsert applied)
+
+#### Scenario: Name-only edit omits limits from payload
+
+- **WHEN** only the API key name is modified in the edit dialog
+- **THEN** the PATCH payload does not include the `limits` field
+
+#### Scenario: Reordered identical rules treated as unchanged
+
+- **WHEN** the same limit rules are submitted in a different order
+- **THEN** the system treats this as unchanged and omits `limits` from the payload
+
+### Requirement: Public model list filtering
+
+All model list endpoints SHALL filter models using a single predicate that requires both conditions:
+1. `model.supported_in_api` is true
+2. If `allowed_models` is configured, the model is in the allowed set
+
+This predicate SHALL be applied consistently across `/api/models`, `/v1/models`, and `/backend-api/codex/models`.
+
+#### Scenario: Unsupported model excluded from /v1/models
+
+- **WHEN** a model snapshot contains a model with `supported_in_api=false`
+- **THEN** that model is not included in the `/v1/models` response
+
+#### Scenario: Unsupported model excluded from /backend-api/codex/models
+
+- **WHEN** a model snapshot contains a model with `supported_in_api=false`
+- **THEN** that model is not included in the `/backend-api/codex/models` response
+
+#### Scenario: Allowed but unsupported model excluded
+
+- **WHEN** a model is in the `allowed_models` set but has `supported_in_api=false`
+- **THEN** that model is not exposed in any model list endpoint
+
+#### Scenario: Consistent model set across endpoints
+
+- **GIVEN** any model registry state
+- **THEN** `/api/models`, `/v1/models`, and `/backend-api/codex/models` expose the same set of models
+
+### Requirement: Reservation 정산 exactly-once 보장
+
+Usage reservation의 최종 정산(finalize 또는 release)은 요청 단위에서 정확히 1회 수행되어야 한다. 재시도 가능한 중간 attempt에서는 정산을 defer하고, 요청 종료 시점에서 단일 지점이 정산 책임을 갖는다. 시스템은 이 동작을 SHALL 보장해야 한다.
+
+#### Scenario: 스트림 401 → refresh retry 성공 시 finalize 1회
+
+- **WHEN** 첫 `_stream_once()` attempt에서 401을 수신하고 계정 refresh 후 재시도가 성공하면
+- **THEN** 첫 attempt에서는 reservation 정산이 수행되지 않아야 한다 (SHALL)
+- **AND** 최종 성공 시점에서 `finalize_usage_reservation()`이 정확히 1회 호출되어야 한다 (SHALL)
+- **AND** 실제 token 사용량이 quota에 반영되어야 한다 (SHALL)
+
+#### Scenario: 스트림 401 → retry 소진 실패 시 release 1회
+
+- **WHEN** 401 후 재시도를 모두 소진하여 요청이 최종 실패하면
+- **THEN** `release_usage_reservation()`이 정확히 1회 호출되어야 한다 (SHALL)
+- **AND** 예약된 quota가 원복되어야 한다 (SHALL)
+
+#### Scenario: 스트림 성공 시 finalize 1회
+
+- **WHEN** `_stream_once()`가 retry 없이 첫 attempt에서 성공하면
+- **THEN** `finalize_usage_reservation()`이 정확히 1회 호출되어야 한다 (SHALL)
+
+### Requirement: 조기 종료 경로에서 reservation release 보장
+
+Reservation 생성 후 upstream API 호출에 진입하지 않고 종료되는 모든 경로에서 reservation이 release되어야 한다. `reserved` 상태로 남는 reservation이 존재하면 안 된다. 시스템은 이 동작을 SHALL 보장해야 한다.
+
+#### Scenario: no_accounts 즉시 종료 시 release
+
+- **WHEN** reservation 생성 후 `_stream_with_retry()`가 사용 가능한 계정 없음(`no_accounts`)으로 즉시 종료되면
+- **THEN** `release_usage_reservation()`이 호출되어 reservation이 `released` 상태로 전이되어야 한다 (SHALL)
+- **AND** pre-reserved quota가 원복되어야 한다 (SHALL)
+
+#### Scenario: 재시도 소진 후 no_accounts 종료 시 release
+
+- **WHEN** 재시도 루프가 모든 attempt를 소진한 후 `no_accounts`로 종료되면
+- **THEN** `release_usage_reservation()`이 호출되어야 한다 (SHALL)
+
+#### Scenario: reservation 미생성 시 정산 스킵
+
+- **WHEN** API key auth가 비활성이거나 reservation이 생성되지 않은 상태에서 요청이 종료되면
+- **THEN** 정산 로직이 안전하게 스킵되어야 하며 에러가 발생하지 않아야 한다 (SHALL)
+
+### Requirement: Compact 경로 예외 무관 reservation cleanup
+
+`_compact_responses()` 경로에서 reservation이 존재할 때, 어떤 예외 타입이 발생하더라도 reservation이 정리되어야 한다. 특정 예외 타입에만 의존하는 cleanup은 허용되지 않는다. 시스템은 이 동작을 SHALL 보장해야 한다.
+
+#### Scenario: ProxyResponseError 발생 시 release
+
+- **WHEN** `compact_responses()`에서 `ProxyResponseError`가 발생하면
+- **THEN** reservation이 release되어야 한다 (SHALL)
+
+#### Scenario: 예상 외 런타임 예외 발생 시 release
+
+- **WHEN** `compact_responses()`에서 `ProxyResponseError` 외의 예외(`Exception`)가 발생하면
+- **THEN** reservation이 동일하게 release되어야 한다 (SHALL)
+
+#### Scenario: compact 성공 시 finalize
+
+- **WHEN** `compact_responses()`가 정상 완료되면
+- **THEN** `finalize_usage_reservation()`이 호출되어야 한다 (SHALL)
+
+### Requirement: Finalize / Release 멱등성
+
+`finalize_usage_reservation()`과 `release_usage_reservation()`은 이미 정산된(finalized 또는 released) reservation에 대해 안전하게 no-op 처리되어야 한다. 이중 호출이 quota를 이중 반영하거나 에러를 발생시키면 안 된다. 시스템은 이 동작을 SHALL 보장해야 한다.
+
+#### Scenario: finalize 후 release 호출 시 no-op
+
+- **WHEN** reservation이 이미 `finalized` 상태에서 `release_usage_reservation()`이 호출되면
+- **THEN** 아무 동작 없이 반환되어야 한다 (SHALL)
+- **AND** quota 값이 변경되지 않아야 한다 (SHALL)
+
+#### Scenario: release 후 finalize 호출 시 no-op
+
+- **WHEN** reservation이 이미 `released` 상태에서 `finalize_usage_reservation()`이 호출되면
+- **THEN** 아무 동작 없이 반환되어야 한다 (SHALL)
+- **AND** quota 값이 변경되지 않아야 한다 (SHALL)
+
+#### Scenario: 동일 finalize 이중 호출 시 1회만 반영
+
+- **WHEN** 동일 `reservation_id`로 `finalize_usage_reservation()`이 2회 호출되면
+- **THEN** 사용량은 정확히 1회만 반영되어야 한다 (SHALL)
+
+### Requirement: gpt-5.4-mini pricing is recognized
+
+The system MUST recognize `gpt-5.4-mini` pricing when computing request costs. Snapshot aliases for the same model family MUST resolve to the canonical `gpt-5.4-mini` price table entry.
+
+#### Scenario: gpt-5.4-mini request priced at standard tier
+
+- **WHEN** a request for `gpt-5.4-mini` completes with standard service tier
+- **THEN** the system computes non-zero cost using the configured `gpt-5.4-mini` standard rates
+
+#### Scenario: gpt-5.4-mini snapshot request priced at canonical rates
+
+- **WHEN** a request for `gpt-5.4-mini-2026-03-17` completes
+- **THEN** the system resolves the snapshot alias to `gpt-5.4-mini`
+- **AND** the system applies the same standard rates

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -77,6 +77,15 @@ def _set_dashboard_auth_env(
     get_settings.cache_clear()
 
 
+def _set_proxy_unauthenticated_client_cidrs_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cidrs: str,
+) -> None:
+    monkeypatch.setenv("CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS", cidrs)
+    get_settings.cache_clear()
+
+
 @pytest.mark.asyncio
 async def test_session_branch_allows_without_password_and_blocks_without_session(async_client):
     public_mode = await async_client.get("/api/settings")
@@ -106,6 +115,43 @@ async def test_session_branch_allows_without_password_and_blocks_without_session
 async def test_remote_proxy_denied_before_auth_is_configured(app_instance):
     async with app_instance.router.lifespan_context(app_instance):
         transport = ASGITransport(app=app_instance, client=("203.0.113.11", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
+            response = await remote_client.get("/v1/models")
+            assert response.status_code == 401
+            assert response.json()["error"]["code"] == "invalid_api_key"
+
+            spoofed = await remote_client.get("/v1/models", headers={"Host": "localhost"})
+            assert spoofed.status_code == 401
+            assert spoofed.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_proxy_unauthenticated_client_cidr_allows_explicit_remote_proxy_peer(app_instance, monkeypatch):
+    _set_proxy_unauthenticated_client_cidrs_env(
+        monkeypatch,
+        cidrs="192.168.65.1/32",
+    )
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("192.168.65.1", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as allowlisted_client:
+            proxy_response = await allowlisted_client.get("/v1/models")
+            assert proxy_response.status_code == 200
+
+            dashboard_response = await allowlisted_client.get("/api/settings")
+            assert dashboard_response.status_code == 401
+            assert dashboard_response.json()["error"]["code"] == "bootstrap_required"
+
+
+@pytest.mark.asyncio
+async def test_proxy_unauthenticated_client_cidr_does_not_allow_other_remote_peers(app_instance, monkeypatch):
+    _set_proxy_unauthenticated_client_cidrs_env(
+        monkeypatch,
+        cidrs="192.168.65.1/32",
+    )
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("192.168.65.2", 50001))
         async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
             response = await remote_client.get("/v1/models")
             assert response.status_code == 401

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -109,6 +109,7 @@ def _websocket_settings(**overrides):
         "proxy_request_budget_seconds": 75.0,
         "stream_idle_timeout_seconds": 300.0,
         "proxy_downstream_websocket_idle_timeout_seconds": 120.0,
+        "http_responses_session_bridge_instance_id": "test-instance",
         "log_proxy_request_shape": False,
         "log_proxy_request_shape_raw_cache_key": False,
         "proxy_token_refresh_limit": 32,
@@ -1761,7 +1762,7 @@ def test_backend_responses_websocket_does_not_expire_downstream_while_request_pe
                 ),
             ),
         ],
-        delays=[0.05, 0.05],
+        delays=[0.12, 0.12],
     )
     log_calls: list[dict[str, object]] = []
 
@@ -1770,7 +1771,7 @@ def test_backend_responses_websocket_does_not_expire_downstream_while_request_pe
             return _websocket_settings()
 
     runtime_settings = _websocket_settings(
-        proxy_downstream_websocket_idle_timeout_seconds=0.02,
+        proxy_downstream_websocket_idle_timeout_seconds=0.1,
         stream_idle_timeout_seconds=0.2,
     )
 

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -11,6 +11,7 @@ from fastapi import WebSocket
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
+import app.core.auth.dependencies as auth_dependencies
 import app.modules.proxy.api as proxy_api_module
 from app.core.errors import openai_error
 from app.core.exceptions import ProxyAuthError
@@ -99,6 +100,66 @@ async def test_validate_proxy_websocket_request_returns_validated_api_key(monkey
 
     assert response is None
     assert resolved_api_key == api_key
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_websocket_request_allows_explicit_socket_peer_when_auth_disabled(monkeypatch):
+    async def fake_denial(_websocket):
+        return None
+
+    async def fake_dashboard_settings() -> SimpleNamespace:
+        return SimpleNamespace(api_key_auth_enabled=False)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
+    monkeypatch.setattr(auth_dependencies, "get_settings_cache", lambda: SimpleNamespace(get=fake_dashboard_settings))
+    monkeypatch.setattr(
+        auth_dependencies,
+        "get_settings",
+        lambda: SimpleNamespace(proxy_unauthenticated_client_cidrs=["192.168.65.1/32"]),
+    )
+    monkeypatch.setattr(auth_dependencies, "is_local_request", lambda _request: False)
+
+    resolved_api_key, response = await proxy_api_module._validate_proxy_websocket_request(
+        cast(
+            WebSocket,
+            SimpleNamespace(headers={}, client=SimpleNamespace(host="192.168.65.1")),
+        )
+    )
+
+    assert response is None
+    assert resolved_api_key is None
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_websocket_request_rejects_remote_socket_peer_outside_allowlist(monkeypatch):
+    async def fake_denial(_websocket):
+        return None
+
+    async def fake_dashboard_settings() -> SimpleNamespace:
+        return SimpleNamespace(api_key_auth_enabled=False)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
+    monkeypatch.setattr(auth_dependencies, "get_settings_cache", lambda: SimpleNamespace(get=fake_dashboard_settings))
+    monkeypatch.setattr(
+        auth_dependencies,
+        "get_settings",
+        lambda: SimpleNamespace(proxy_unauthenticated_client_cidrs=["192.168.65.1/32"]),
+    )
+    monkeypatch.setattr(auth_dependencies, "is_local_request", lambda _request: False)
+
+    resolved_api_key, response = await proxy_api_module._validate_proxy_websocket_request(
+        cast(
+            WebSocket,
+            SimpleNamespace(headers={}, client=SimpleNamespace(host="192.168.65.2")),
+        )
+    )
+
+    assert resolved_api_key is None
+    assert response is not None
+    assert response.status_code == 401
+    payload = json.loads(cast(bytes, response.body).decode("utf-8"))
+    assert payload["error"]["code"] == "invalid_api_key"
+    assert payload["error"]["message"] == "Proxy authentication must be configured before remote access is allowed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_settings_firewall.py
+++ b/tests/unit/test_settings_firewall.py
@@ -21,6 +21,21 @@ def test_settings_rejects_invalid_firewall_trusted_proxy_cidr(monkeypatch):
         Settings()
 
 
+def test_settings_parses_proxy_unauthenticated_client_cidrs_from_csv(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS", "192.168.65.1/32, 172.17.0.0/16")
+
+    settings = Settings()
+
+    assert settings.proxy_unauthenticated_client_cidrs == ["192.168.65.1/32", "172.17.0.0/16"]
+
+
+def test_settings_rejects_invalid_proxy_unauthenticated_client_cidr(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS", "not-a-cidr")
+
+    with pytest.raises(ValidationError):
+        Settings()
+
+
 def test_settings_parses_http_bridge_instance_ring_from_csv(monkeypatch):
     monkeypatch.setenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_ID", "instance-b")
     monkeypatch.setenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_RING", "instance-a, instance-b")


### PR DESCRIPTION
## Summary

- add an explicit `CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS` escape hatch for protected proxy routes when API key auth is disabled
- apply that allowlist only to the raw socket peer IP seen by the container
- keep the fix intentionally narrow and proxy-only
- leave global `is_local_request()` behavior unchanged
- keep dashboard/bootstrap auth protected
- add regression coverage for settings parsing, HTTP proxy access, websocket proxy access, and dashboard isolation

## Why

This was prompted by a real regression I hit after updating `codex-lb` from `1.11.0` to `1.12.0`.

My Codex desktop app workflow on macOS stopped working through Docker Desktop after that update: `/backend-api/codex/responses` started failing with `401 invalid_api_key`, while the same setup still worked on `1.11.0`.

That regression is why I investigated this path and contributed this fix.

## What This Changes

When API key auth is disabled, `codex-lb` still keeps the default fail-closed behavior for non-local proxy requests.

This change only adds a narrow opt-in allowlist for specific raw socket peer IPs via `CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS`, so operators can restore local Docker Desktop-style workflows without broadly weakening security.

Forwarded headers are not used for this exception. The match is based only on the observed raw socket peer IP.

Dashboard/bootstrap auth remains protected and does not use this new allowlist.

## Validation

- added targeted regression tests for:
  - settings parsing and CIDR validation
  - HTTP proxy access with API key auth disabled
  - websocket proxy access with API key auth disabled
  - dashboard isolation, to confirm dashboard/bootstrap auth is still protected
- manually validated on Docker Desktop for Mac and with the Codex desktop app

One important detail from manual validation: on my machine, the actual socket peer IP seen by the container was `172.64.155.209`, so the working value for `CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS` during validation was `172.64.155.209/32`, not `192.168.65.1/32`.

The exact CIDR is environment-specific. The key point is that the configured CIDR must match the observed raw socket peer IP that the container actually sees.

## Result

This restores the Codex desktop app workflow for the Docker Desktop case I observed, without changing the shared locality rules and without bypassing dashboard/bootstrap auth.
