### PR TITLE
fix(auth): accept API keys on /api/codex/usage

### DIFF
--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -172,7 +172,7 @@ def _is_proxy_unauthenticated_socket_peer_allowed(request: HTTPConnection) -> bo
 # --- Codex usage caller identity auth ---
 
 
-async def validate_codex_usage_identity(request: Request) -> None:
+async def validate_codex_usage_identity(request: Request) -> ApiKeyData | None:
     token = _extract_bearer_token(request.headers.get("Authorization"))
     if not token:
         raise ProxyAuthError("Missing ChatGPT token in Authorization header")
@@ -180,6 +180,8 @@ async def validate_codex_usage_identity(request: Request) -> None:
     raw_account_id = request.headers.get("chatgpt-account-id")
     account_id = raw_account_id.strip() if raw_account_id else ""
     if not account_id:
+        if token.startswith("sk-clb-"):
+            return await _validate_api_key_token(token)
         raise ProxyAuthError("Missing chatgpt-account-id header")
 
     async with get_background_session() as session:
@@ -198,6 +200,7 @@ async def validate_codex_usage_identity(request: Request) -> None:
         if exc.status_code in (401, 403):
             raise ProxyAuthError("Invalid ChatGPT token or chatgpt-account-id") from exc
         raise ProxyUpstreamError("Unable to validate ChatGPT credentials at this time") from exc
+    return None
 
 
 def _extract_bearer_token(authorization: str | None) -> str | None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -478,7 +478,7 @@ def _codex_usage_credit_snapshot(
     primary_limit: V1UsageLimitResponse | None,
     secondary_limit: V1UsageLimitResponse | None,
 ) -> CreditStatusDetailsData | None:
-    preferred = primary_limit or secondary_limit
+    preferred = secondary_limit or primary_limit
     if preferred is None or preferred.limit_type != "credits":
         return None
     return CreditStatusDetailsData(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -67,6 +67,7 @@ from app.modules.firewall.repository import FirewallRepository
 from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
 from app.modules.proxy import service as proxy_service_module
 from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
+from app.modules.proxy.helpers import _rate_limit_details
 from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     openai_invalid_payload_error,
@@ -84,6 +85,7 @@ from app.modules.proxy.schemas import (
     V1UsageLimitResponse,
     V1UsageResponse,
 )
+from app.modules.proxy.types import CreditStatusDetailsData, RateLimitStatusPayloadData, RateLimitWindowSnapshotData
 from app.modules.usage.repository import UsageRepository
 
 logger = logging.getLogger(__name__)
@@ -125,7 +127,7 @@ v1_ws_router = APIRouter(
 )
 usage_router = APIRouter(
     tags=["proxy"],
-    dependencies=[Depends(validate_codex_usage_identity), Depends(set_openai_error_format)],
+    dependencies=[Depends(set_openai_error_format)],
 )
 transcribe_router = APIRouter(
     prefix="/backend-api",
@@ -409,6 +411,74 @@ def _apply_credit_override(
         model_filter=None,
         reset_at=aggregate_limit.reset_at,
         source="api_key_override",
+    )
+
+
+async def _build_codex_usage_payload_for_api_key(api_key: ApiKeyData) -> RateLimitStatusPayloadData:
+    async with get_background_session() as session:
+        service = ApiKeysService(ApiKeysRepository(session))
+        usage = await service.get_key_usage_summary_for_self(api_key.id)
+        aggregate_limits = await _build_aggregate_credit_limits(session)
+
+    if usage is None:
+        raise ProxyAuthError("Invalid API key")
+
+    merged_limits = _build_v1_usage_limits(usage, aggregate_limits)
+    primary_credit_limit = _select_codex_usage_limit(merged_limits, "5h")
+    secondary_credit_limit = _select_codex_usage_limit(merged_limits, "7d")
+
+    return RateLimitStatusPayloadData(
+        plan_type="api_key",
+        rate_limit=_rate_limit_details(
+            _codex_usage_window_snapshot(primary_credit_limit),
+            _codex_usage_window_snapshot(secondary_credit_limit),
+        ),
+        credits=_codex_usage_credit_snapshot(primary_credit_limit, secondary_credit_limit),
+    )
+
+
+def _select_codex_usage_limit(
+    limits: list[V1UsageLimitResponse],
+    window: str,
+) -> V1UsageLimitResponse | None:
+    candidates = [limit for limit in limits if limit.limit_window == window and limit.model_filter is None]
+    if not candidates:
+        return None
+    for limit in candidates:
+        if limit.limit_type == "credits":
+            return limit
+    return candidates[0]
+
+
+def _codex_usage_window_snapshot(limit: V1UsageLimitResponse | None) -> RateLimitWindowSnapshotData | None:
+    if limit is None or limit.max_value <= 0:
+        return None
+    reset_at = datetime.fromisoformat(limit.reset_at.replace("Z", "+00:00"))
+    reset_epoch = int(reset_at.timestamp())
+    now_epoch = int(time.time())
+    used_percent = int(max(0, min(100, round((limit.current_value / limit.max_value) * 100))))
+    window_seconds = 18000 if limit.limit_window == "5h" else 604800 if limit.limit_window == "7d" else None
+    return RateLimitWindowSnapshotData(
+        used_percent=used_percent,
+        limit_window_seconds=window_seconds,
+        reset_after_seconds=max(0, reset_epoch - now_epoch),
+        reset_at=reset_epoch,
+    )
+
+
+def _codex_usage_credit_snapshot(
+    primary_limit: V1UsageLimitResponse | None,
+    secondary_limit: V1UsageLimitResponse | None,
+) -> CreditStatusDetailsData | None:
+    preferred = secondary_limit or primary_limit
+    if preferred is None or preferred.limit_type != "credits":
+        return None
+    return CreditStatusDetailsData(
+        has_credits=True,
+        unlimited=False,
+        balance=str(preferred.remaining_value),
+        approx_local_messages=None,
+        approx_cloud_messages=None,
     )
 
 
@@ -1081,8 +1151,13 @@ async def _transcribe_request(
 @usage_router.get("/api/codex/usage/", response_model=RateLimitStatusPayload, include_in_schema=False)
 async def codex_usage(
     context: ProxyContext = Depends(get_proxy_context),
+    api_key: ApiKeyData | None = Depends(validate_codex_usage_identity),
 ) -> RateLimitStatusPayload:
-    payload = await context.service.get_rate_limit_payload()
+    payload = (
+        await _build_codex_usage_payload_for_api_key(api_key)
+        if api_key is not None
+        else await context.service.get_rate_limit_payload()
+    )
     return RateLimitStatusPayload.from_data(payload)
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -427,8 +427,10 @@ async def _build_codex_usage_payload_for_api_key(api_key: ApiKeyData) -> RateLim
         raise ProxyAuthError("Invalid API key")
 
     key_limits = [_to_v1_usage_limit_response(limit) for limit in usage.limits]
-    primary_credit_limit = _select_codex_usage_limit(key_limits, "5h")
-    secondary_credit_limit = _select_codex_usage_limit(key_limits, "7d")
+    primary_credit_limit = _select_codex_usage_limit(key_limits, "5h") or _select_codex_usage_limit(key_limits, "daily")
+    secondary_credit_limit = _select_codex_usage_limit(key_limits, "7d") or _select_codex_usage_limit(
+        key_limits, "weekly"
+    )
 
     return RateLimitStatusPayloadData(
         plan_type="api_key",
@@ -459,7 +461,9 @@ def _codex_usage_window_snapshot(limit: V1UsageLimitResponse | None) -> RateLimi
     reset_epoch = int(reset_at.timestamp())
     now_epoch = int(time.time())
     used_percent = max(0, min(100, int((limit.current_value / limit.max_value) * 100)))
-    window_seconds = 18000 if limit.limit_window == "5h" else 604800 if limit.limit_window == "7d" else None
+    window_seconds = {"5h": 18000, "daily": 86400, "7d": 604800, "weekly": 604800, "monthly": 2592000}.get(
+        limit.limit_window
+    )
     return RateLimitWindowSnapshotData(
         used_percent=used_percent,
         limit_window_seconds=window_seconds,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -66,8 +66,8 @@ from app.modules.api_keys.service import (
 from app.modules.firewall.repository import FirewallRepository
 from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
 from app.modules.proxy import service as proxy_service_module
-from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
 from app.modules.proxy.helpers import _rate_limit_details
+from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
 from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     openai_invalid_payload_error,
@@ -85,7 +85,11 @@ from app.modules.proxy.schemas import (
     V1UsageLimitResponse,
     V1UsageResponse,
 )
-from app.modules.proxy.types import CreditStatusDetailsData, RateLimitStatusPayloadData, RateLimitWindowSnapshotData
+from app.modules.proxy.types import (
+    CreditStatusDetailsData,
+    RateLimitStatusPayloadData,
+    RateLimitWindowSnapshotData,
+)
 from app.modules.usage.repository import UsageRepository
 
 logger = logging.getLogger(__name__)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -444,13 +444,12 @@ def _select_codex_usage_limit(
     limits: list[V1UsageLimitResponse],
     window: str,
 ) -> V1UsageLimitResponse | None:
-    candidates = [limit for limit in limits if limit.limit_window == window and limit.model_filter is None]
-    if not candidates:
-        return None
-    for limit in candidates:
-        if limit.limit_type == "credits":
-            return limit
-    return candidates[0]
+    candidates = [
+        limit
+        for limit in limits
+        if limit.limit_window == window and limit.model_filter is None and limit.limit_type == "credits"
+    ]
+    return candidates[0] if candidates else None
 
 
 def _codex_usage_window_snapshot(limit: V1UsageLimitResponse | None) -> RateLimitWindowSnapshotData | None:
@@ -459,7 +458,7 @@ def _codex_usage_window_snapshot(limit: V1UsageLimitResponse | None) -> RateLimi
     reset_at = datetime.fromisoformat(limit.reset_at.replace("Z", "+00:00"))
     reset_epoch = int(reset_at.timestamp())
     now_epoch = int(time.time())
-    used_percent = int(max(0, min(100, round((limit.current_value / limit.max_value) * 100))))
+    used_percent = max(0, min(100, int((limit.current_value / limit.max_value) * 100)))
     window_seconds = 18000 if limit.limit_window == "5h" else 604800 if limit.limit_window == "7d" else None
     return RateLimitWindowSnapshotData(
         used_percent=used_percent,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -428,8 +428,10 @@ async def _build_codex_usage_payload_for_api_key(api_key: ApiKeyData) -> RateLim
 
     key_limits = [_to_v1_usage_limit_response(limit) for limit in usage.limits]
     primary_credit_limit = _select_codex_usage_limit(key_limits, "5h") or _select_codex_usage_limit(key_limits, "daily")
-    secondary_credit_limit = _select_codex_usage_limit(key_limits, "7d") or _select_codex_usage_limit(
-        key_limits, "weekly"
+    secondary_credit_limit = (
+        _select_codex_usage_limit(key_limits, "7d")
+        or _select_codex_usage_limit(key_limits, "weekly")
+        or _select_codex_usage_limit(key_limits, "monthly")
     )
 
     return RateLimitStatusPayloadData(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -434,14 +434,6 @@ async def _build_codex_usage_payload_for_api_key(api_key: ApiKeyData) -> RateLim
         or _select_codex_usage_limit(key_limits, "monthly")
     )
 
-    if primary_credit_limit is None and secondary_credit_limit is None:
-        async with get_background_session() as session:
-            aggregate_limits = await _build_aggregate_credit_limits(session)
-        if aggregate_limits:
-            agg_limits = list(aggregate_limits.values())
-            primary_credit_limit = _select_codex_usage_limit(agg_limits, "5h")
-            secondary_credit_limit = _select_codex_usage_limit(agg_limits, "7d")
-
     return RateLimitStatusPayloadData(
         plan_type="api_key",
         rate_limit=_rate_limit_details(
@@ -486,11 +478,11 @@ def _codex_usage_credit_snapshot(
     primary_limit: V1UsageLimitResponse | None,
     secondary_limit: V1UsageLimitResponse | None,
 ) -> CreditStatusDetailsData | None:
-    preferred = secondary_limit or primary_limit
+    preferred = primary_limit or secondary_limit
     if preferred is None or preferred.limit_type != "credits":
         return None
     return CreditStatusDetailsData(
-        has_credits=True,
+        has_credits=preferred.remaining_value > 0,
         unlimited=False,
         balance=str(preferred.remaining_value),
         approx_local_messages=None,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -422,14 +422,13 @@ async def _build_codex_usage_payload_for_api_key(api_key: ApiKeyData) -> RateLim
     async with get_background_session() as session:
         service = ApiKeysService(ApiKeysRepository(session))
         usage = await service.get_key_usage_summary_for_self(api_key.id)
-        aggregate_limits = await _build_aggregate_credit_limits(session)
 
     if usage is None:
         raise ProxyAuthError("Invalid API key")
 
-    merged_limits = _build_v1_usage_limits(usage, aggregate_limits)
-    primary_credit_limit = _select_codex_usage_limit(merged_limits, "5h")
-    secondary_credit_limit = _select_codex_usage_limit(merged_limits, "7d")
+    key_limits = [_to_v1_usage_limit_response(limit) for limit in usage.limits]
+    primary_credit_limit = _select_codex_usage_limit(key_limits, "5h")
+    secondary_credit_limit = _select_codex_usage_limit(key_limits, "7d")
 
     return RateLimitStatusPayloadData(
         plan_type="api_key",

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -434,6 +434,14 @@ async def _build_codex_usage_payload_for_api_key(api_key: ApiKeyData) -> RateLim
         or _select_codex_usage_limit(key_limits, "monthly")
     )
 
+    if primary_credit_limit is None and secondary_credit_limit is None:
+        async with get_background_session() as session:
+            aggregate_limits = await _build_aggregate_credit_limits(session)
+        if aggregate_limits:
+            agg_limits = list(aggregate_limits.values())
+            primary_credit_limit = _select_codex_usage_limit(agg_limits, "5h")
+            secondary_credit_limit = _select_codex_usage_limit(agg_limits, "7d")
+
     return RateLimitStatusPayloadData(
         plan_type="api_key",
         rate_limit=_rate_limit_details(

--- a/openspec/changes/add-codex-usage-api-key-compat/proposal.md
+++ b/openspec/changes/add-codex-usage-api-key-compat/proposal.md
@@ -1,0 +1,13 @@
+# add-codex-usage-api-key-compat
+
+## Why
+OpenCodeBar calls `/api/codex/usage` with the same LB API key it uses for `/v1/*` proxy calls. In 1.13.x that route only accepts ChatGPT caller identity (`chatgpt-account-id` + ChatGPT token), so API-key clients fail with `Missing chatgpt-account-id header` even though codex-lb already has self-service usage data for API keys.
+
+## What Changes
+- Allow `/api/codex/usage` to authenticate LB API-key callers in addition to ChatGPT callers.
+- Keep existing ChatGPT identity validation unchanged when `chatgpt-account-id` is present.
+- Return a `RateLimitStatusPayload` compatibility response for API-key callers using the existing self-usage and credit-limit data.
+
+## Impact
+- OpenCodeBar and similar API-key-based codex clients can call `/api/codex/usage` without sending `chatgpt-account-id`.
+- Existing browser/ChatGPT-style callers continue to use the current identity validation path.

--- a/openspec/changes/add-codex-usage-api-key-compat/specs/api-keys/spec.md
+++ b/openspec/changes/add-codex-usage-api-key-compat/specs/api-keys/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: API Key Bearer authentication guard
+The system SHALL validate API keys on protected proxy routes (`/v1/*`, `/backend-api/codex/*`, `/backend-api/transcribe`) when `api_key_auth_enabled` is true. Validation MUST be implemented as a router-level `Security` dependency, not ASGI middleware. The dependency MUST compute `sha256` of the Bearer token and look up the hash in the `api_keys` table.
+
+The dependency SHALL return a typed `ApiKeyData` value directly to the route handler. Route handlers MUST NOT access API key data via `request.state`.
+
+`/api/codex/usage` SHALL NOT be covered by the router-level API key auth guard scope, but the route SHALL accept valid LB API keys through a dedicated compatibility dependency.
+
+The dependency SHALL raise a domain exception on validation failure. The exception handler SHALL format the response using the OpenAI error envelope.
+
+#### Scenario: Codex usage accepts API key compatibility auth
+- **WHEN** a request is made to `/api/codex/usage` with `Authorization: Bearer sk-clb-...`
+- **AND** no `chatgpt-account-id` header is present
+- **THEN** the route authenticates the request as an API-key caller
+- **AND** returns a `RateLimitStatusPayload` compatibility response instead of `Missing chatgpt-account-id header`
+
+#### Scenario: Codex usage preserves ChatGPT identity validation
+- **WHEN** a request is made to `/api/codex/usage` with a ChatGPT bearer token and `chatgpt-account-id`
+- **THEN** the route keeps using the ChatGPT identity validation path
+- **AND** existing usage validation and error semantics remain unchanged

--- a/openspec/changes/add-codex-usage-api-key-compat/tasks.md
+++ b/openspec/changes/add-codex-usage-api-key-compat/tasks.md
@@ -1,0 +1,4 @@
+- [ ] 1. Update `/api/codex/usage` auth to accept API-key callers without `chatgpt-account-id`.
+- [ ] 2. Map API-key self-usage data into the existing `RateLimitStatusPayload` schema.
+- [ ] 3. Add integration coverage for API-key callers while preserving existing ChatGPT identity tests.
+- [ ] 4. Validate targeted tests and prepare a separate PR.

--- a/tests/integration/test_codex_usage_api.py
+++ b/tests/integration/test_codex_usage_api.py
@@ -7,7 +7,7 @@ import pytest
 from app.core.crypto import TokenEncryptor
 from app.core.usage.models import UsagePayload
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus, ApiKeyLimit, LimitType, LimitWindow
+from app.db.models import Account, AccountStatus, ApiKeyLimit, LimitType, LimitWindow, UsageHistory
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -382,3 +382,95 @@ async def test_codex_usage_accepts_api_key_callers(async_client, db_setup):
         "approx_local_messages": None,
         "approx_cloud_messages": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_api_key_ignores_aggregate_workspace_limits(async_client, db_setup):
+    now = utcnow()
+    suffix = str(int(now.timestamp() * 1_000_000))
+
+    async with SessionLocal() as session:
+        session.add_all(
+            [
+                _make_account(f"acc-agg-a-{suffix}", f"agg-a-{suffix}@test.com"),
+                _make_account(f"acc-agg-b-{suffix}", f"agg-b-{suffix}@test.com"),
+                UsageHistory(
+                    account_id=f"acc-agg-a-{suffix}",
+                    recorded_at=now,
+                    window="primary",
+                    used_percent=80.0,
+                    reset_at=int((now + timedelta(hours=4)).timestamp()),
+                    window_minutes=300,
+                ),
+                UsageHistory(
+                    account_id=f"acc-agg-b-{suffix}",
+                    recorded_at=now,
+                    window="primary",
+                    used_percent=90.0,
+                    reset_at=int((now + timedelta(hours=4)).timestamp()),
+                    window_minutes=300,
+                ),
+                UsageHistory(
+                    account_id=f"acc-agg-a-{suffix}",
+                    recorded_at=now,
+                    window="secondary",
+                    used_percent=70.0,
+                    reset_at=int((now + timedelta(days=6)).timestamp()),
+                    window_minutes=10080,
+                ),
+                UsageHistory(
+                    account_id=f"acc-agg-b-{suffix}",
+                    recorded_at=now,
+                    window="secondary",
+                    used_percent=60.0,
+                    reset_at=int((now + timedelta(days=6)).timestamp()),
+                    window_minutes=10080,
+                ),
+            ]
+        )
+        await session.commit()
+
+    key_id, plain_key = await _create_api_key(
+        name="codex-usage-agg-test",
+        limits=[
+            LimitRuleInput(limit_type="credits", limit_window="5h", max_value=100),
+            LimitRuleInput(limit_type="credits", limit_window="7d", max_value=500),
+        ],
+    )
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        await repo.replace_limits(
+            key_id,
+            [
+                ApiKeyLimit(
+                    api_key_id=key_id,
+                    limit_type=LimitType.CREDITS,
+                    limit_window=LimitWindow.FIVE_HOURS,
+                    max_value=100,
+                    current_value=5,
+                    model_filter=None,
+                    reset_at=now + timedelta(hours=5),
+                ),
+                ApiKeyLimit(
+                    api_key_id=key_id,
+                    limit_type=LimitType.CREDITS,
+                    limit_window=LimitWindow.SEVEN_DAYS,
+                    max_value=500,
+                    current_value=50,
+                    model_filter=None,
+                    reset_at=now + timedelta(days=7),
+                ),
+            ],
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/codex/usage",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["rate_limit"]["primary_window"]["used_percent"] == 5
+    assert payload["rate_limit"]["secondary_window"]["used_percent"] == 10
+    assert payload["credits"]["balance"] == "450"

--- a/tests/integration/test_codex_usage_api.py
+++ b/tests/integration/test_codex_usage_api.py
@@ -7,9 +7,11 @@ import pytest
 from app.core.crypto import TokenEncryptor
 from app.core.usage.models import UsagePayload
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountStatus, ApiKeyLimit, LimitType, LimitWindow
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
+from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService, LimitRuleInput
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
 pytestmark = pytest.mark.integration
@@ -35,6 +37,19 @@ def _make_account(
         status=AccountStatus.ACTIVE,
         deactivation_reason=None,
     )
+
+
+async def _create_api_key(*, name: str, limits: list[LimitRuleInput] | None = None) -> tuple[str, str]:
+    async with SessionLocal() as session:
+        service = ApiKeysService(ApiKeysRepository(session))
+        created = await service.create_key(
+            ApiKeyCreateData(
+                name=name,
+                allowed_models=None,
+                limits=limits or [],
+            )
+        )
+    return created.id, created.key
 
 
 @pytest.fixture(autouse=True)
@@ -308,3 +323,62 @@ async def test_codex_usage_additional_limit_supports_secondary_only(async_client
     assert additional_limit["rate_limit"]["primary_window"] is None
     assert additional_limit["rate_limit"]["secondary_window"]["used_percent"] == 65
     assert additional_limit["rate_limit"]["secondary_window"]["reset_at"] == 1735862400
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_accepts_api_key_callers(async_client, db_setup):
+    key_id, plain_key = await _create_api_key(
+        name="codex-usage-api-key",
+        limits=[
+            LimitRuleInput(limit_type="credits", limit_window="5h", max_value=60),
+            LimitRuleInput(limit_type="credits", limit_window="7d", max_value=1000),
+        ],
+    )
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        await repo.replace_limits(
+            key_id,
+            [
+                ApiKeyLimit(
+                    api_key_id=key_id,
+                    limit_type=LimitType.CREDITS,
+                    limit_window=LimitWindow.FIVE_HOURS,
+                    max_value=60,
+                    current_value=12,
+                    model_filter=None,
+                    reset_at=now + timedelta(hours=5),
+                ),
+                ApiKeyLimit(
+                    api_key_id=key_id,
+                    limit_type=LimitType.CREDITS,
+                    limit_window=LimitWindow.SEVEN_DAYS,
+                    max_value=1000,
+                    current_value=250,
+                    model_filter=None,
+                    reset_at=now + timedelta(days=7),
+                ),
+            ],
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/codex/usage",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["plan_type"] == "api_key"
+    assert payload["rate_limit"]["allowed"] is True
+    assert payload["rate_limit"]["limit_reached"] is False
+    assert payload["rate_limit"]["primary_window"]["used_percent"] == 20
+    assert payload["rate_limit"]["secondary_window"]["used_percent"] == 25
+    assert payload["credits"] == {
+        "has_credits": True,
+        "unlimited": False,
+        "balance": "750",
+        "approx_local_messages": None,
+        "approx_cloud_messages": None,
+    }


### PR DESCRIPTION
## Summary
- allow `/api/codex/usage` to accept LB API-key callers when they do not send `chatgpt-account-id`
- return a `RateLimitStatusPayload` compatibility response for API-key callers using existing self-usage and credit-limit data
- preserve the existing ChatGPT identity validation path for callers that do send `chatgpt-account-id`

## Testing
- `./.venv/bin/python -m pytest tests/integration/test_codex_usage_api.py`
- `./.venv/bin/python -m pytest tests/integration/test_v1_usage.py -k 'v1_usage_returns_aggregate_credit_limits_when_upstream_usage_exists or v1_usage_overrides_aggregate_credit_windows_with_api_key_credit_limits'`