### PR TITLE
fix(api-keys): reuse shared copy button for created keys

### DIFF
--- a/frontend/src/features/api-keys/components/api-key-created-dialog.test.tsx
+++ b/frontend/src/features/api-keys/components/api-key-created-dialog.test.tsx
@@ -1,0 +1,52 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/test/utils";
+
+import { ApiKeyCreatedDialog } from "./api-key-created-dialog";
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccess,
+    error: toastError,
+  },
+}));
+
+describe("ApiKeyCreatedDialog", () => {
+  beforeEach(() => {
+    toastSuccess.mockReset();
+    toastError.mockReset();
+  });
+
+  it("copies the created API key with the shared copy button", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    renderWithProviders(
+      <ApiKeyCreatedDialog
+        open
+        apiKey="sk-demo-secret"
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("sk-demo-secret");
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith("Copied to clipboard");
+    expect(screen.getByRole("button", { name: "Copy Copied" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/api-keys/components/api-key-created-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-created-dialog.tsx
@@ -1,6 +1,4 @@
-import { useCallback, useState } from "react";
-import { Check, Copy } from "lucide-react";
-
+import { CopyButton } from "@/components/copy-button";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -33,7 +31,7 @@ export function ApiKeyCreatedDialog({ open, apiKey, onOpenChange }: ApiKeyCreate
             <p className="text-xs font-medium text-muted-foreground">API Key</p>
             <div className="flex min-w-0 items-center gap-2 overflow-hidden rounded-lg border bg-muted/20 px-3 py-2">
               <p className="min-w-0 flex-1 truncate font-mono text-xs">{apiKey}</p>
-              <InlineCopyButton text={apiKey} />
+              <CopyButton value={apiKey} />
             </div>
           </div>
         ) : null}
@@ -45,37 +43,5 @@ export function ApiKeyCreatedDialog({ open, apiKey, onOpenChange }: ApiKeyCreate
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function InlineCopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }, [text]);
-
-  return (
-    <Button
-      type="button"
-      size="sm"
-      variant="ghost"
-      className="h-7 shrink-0 gap-1 px-2 text-xs"
-      onClick={() => void handleCopy()}
-    >
-      {copied ? (
-        <>
-          <Check className="h-3 w-3" />
-          Copied!
-        </>
-      ) : (
-        <>
-          <Copy className="h-3 w-3" />
-          Copy
-        </>
-      )}
-    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- replace the custom inline copy logic in the API key created dialog with the shared `CopyButton`
- reuse the existing clipboard success/error handling instead of calling `navigator.clipboard.writeText(...)` directly
- add focused component coverage for copying a newly created API key

## Why
The API key created dialog had its own minimal clipboard implementation with no error handling or user feedback on failure. Reusing the shared copy control makes the behavior consistent across browsers and aligns this dialog with the rest of the frontend.

## Testing
- cd frontend && npx -y node@20 ./node_modules/vitest/vitest.mjs run src/components/copy-button.test.tsx src/features/api-keys/components/api-key-created-dialog.test.tsx

## Notes
- fixes #389
- related to #127
