### PR TITLE
feat(settings): add image generation toggle button for PR #421

### DIFF
--- a/frontend/src/features/settings/components/routing-settings.test.tsx
+++ b/frontend/src/features/settings/components/routing-settings.test.tsx
@@ -97,4 +97,15 @@ describe("RoutingSettings", () => {
     expect(screen.getByText("Upstream stream transport")).toBeInTheDocument();
     expect(screen.getByText("Server default")).toBeInTheDocument();
   });
+
+  it("renders the image generation toggle as disabled", () => {
+    render(<RoutingSettings settings={BASE_SETTINGS} busy={false} onSave={vi.fn().mockResolvedValue(undefined)} />);
+
+    const imageGenerationLabel = screen.getByText("Enable image generation");
+    expect(imageGenerationLabel).toBeInTheDocument();
+
+    const row = imageGenerationLabel.closest("div")?.parentElement;
+    expect(row).not.toBeNull();
+    expect(row ? row.querySelector('[role="switch"]') : null).toBeDisabled();
+  });
 });

--- a/frontend/src/features/settings/components/routing-settings.tsx
+++ b/frontend/src/features/settings/components/routing-settings.tsx
@@ -118,6 +118,16 @@ export function RoutingSettings({ settings, busy, onSave }: RoutingSettingsProps
             />
           </div>
 
+          <div className="flex items-center justify-between p-3">
+            <div>
+              <p className="text-sm font-medium">Enable image generation</p>
+              <p className="text-xs text-muted-foreground">
+                Allow `image_generation` tool calls on incoming OpenAI-compatible requests.
+              </p>
+            </div>
+            <Switch checked={false} disabled />
+          </div>
+
           <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-sm font-medium">Prompt-cache affinity TTL</p>


### PR DESCRIPTION
## Summary
- add the settings toggle button for image generation in the Routing settings UI
- keep this PR limited to the button-only UI addition
- link this button addition to the image-generation compatibility work in #421

## Important dependency
This PR should only be merged **after** https://github.com/Soju06/codex-lb/pull/421 is accepted and merged.

This change is intended as a follow-up UI addition for #421:
- https://github.com/Soju06/codex-lb/pull/421

Without #421, this button does not belong on its own.

## Verification
- `npm run test -- src/features/settings/components/routing-settings.test.tsx`