### PR TITLE
chore: add stale bot for needs-info issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Stale issues
 
 on:
   schedule:
-    # 매일 05:00 UTC (Asia/Seoul 14:00)
+    # Daily at 05:00 UTC
     - cron: "0 5 * * *"
   workflow_dispatch:
 
@@ -17,12 +17,12 @@ jobs:
       - name: Mark needs-info issues stale and close after timeout
         uses: actions/stale@v9
         with:
-          # needs-info 라벨 붙고 7일 무응답 → stale 마킹
+          # 7 days with no activity after needs-info is applied -> mark stale
           days-before-issue-stale: 7
-          # stale 마킹 후 7일 더 무응답 → close (총 14일)
+          # 7 more days after stale -> close (14 days total)
           days-before-issue-close: 7
 
-          only-issue-labels: "needs-info"
+          only-labels: "needs-info"
           stale-issue-label: "stale"
           close-issue-reason: "not_planned"
 
@@ -42,14 +42,14 @@ jobs:
 
             Please feel free to reopen with the requested details. 🙏
 
-          # PRs 는 건드리지 않음
+          # Do not touch pull requests
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
-          # 오퍼레이터 보호 라벨
+          # Operator-protected labels
           exempt-issue-labels: "pinned,security,in-progress"
 
-          # 무한 스크롤 방지
+          # Safety cap per run
           operations-per-run: 100
           remove-stale-when-updated: true
           ascending: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,11 +8,11 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Mark needs-info issues stale and close after timeout
         uses: actions/stale@v9

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,55 @@
+name: Stale issues
+
+on:
+  schedule:
+    # 매일 05:00 UTC (Asia/Seoul 14:00)
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark needs-info issues stale and close after timeout
+        uses: actions/stale@v9
+        with:
+          # needs-info 라벨 붙고 7일 무응답 → stale 마킹
+          days-before-issue-stale: 7
+          # stale 마킹 후 7일 더 무응답 → close (총 14일)
+          days-before-issue-close: 7
+
+          only-issue-labels: "needs-info"
+          stale-issue-label: "stale"
+          close-issue-reason: "not_planned"
+
+          stale-issue-message: |
+            This issue has been automatically marked as **stale** because it has been open for 7 days with no reporter activity since `needs-info` was applied.
+
+            It will be closed in 7 more days unless additional information is provided.
+
+            If this is still relevant, please:
+            - Reply with the requested details, or
+            - Remove the `stale` label to keep it open
+
+            Thanks for the report 🙏
+
+          close-issue-message: |
+            Closing as **insufficient information** — no response from reporter within the 14-day `needs-info` window.
+
+            Please feel free to reopen with the requested details. 🙏
+
+          # PRs 는 건드리지 않음
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          # 오퍼레이터 보호 라벨
+          exempt-issue-labels: "pinned,security,in-progress"
+
+          # 무한 스크롤 방지
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          ascending: true


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that auto-closes issues labeled `needs-info` after a 14-day silence window.

## Flow

1. Maintainer (or triage bot) adds `needs-info` label + comment requesting details
2. **+7 days** no reporter activity → workflow adds `stale` label + warning comment
3. **+7 more days** still no activity → workflow closes as `not_planned` with a polite message
4. Reporter replies or removes `stale` → timer resets, issue stays open

## Guards

- Only touches issues with `needs-info` label (won't grim-reap random stuff)
- PRs are excluded (`days-before-pr-* = -1`)
- Exempt labels: `pinned`, `security`, `in-progress`
- `operations-per-run: 100` to stay well under API limits
- Scheduled daily at 05:00 UTC (14:00 KST)
- Manual trigger via `workflow_dispatch` for testing

## Context

Part of the triage cleanup today — 62 unlabeled issues classified, 3 duplicates closed, 11 underspecified issues received `needs-info` requests. This automates the cleanup tail so we don't have to revisit them manually.