### PR TITLE
fix(codex): allow backend responses image_generation tools

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from typing import cast
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from app.core.types import JsonObject, JsonValue
 from app.core.utils.json_guards import is_json_list, is_json_mapping
@@ -33,6 +33,8 @@ _TOOL_TYPE_ALIASES = {
     "web_search_preview": "web_search",
 }
 
+_TOOL_VALIDATION_CONTEXT_KEY = "allowed_builtin_tool_types"
+
 _INTERLEAVED_REASONING_KEYS = frozenset({"reasoning_content", "reasoning_details", "tool_calls", "function_call"})
 _INTERLEAVED_REASONING_PART_TYPES = frozenset({"reasoning", "reasoning_content", "reasoning_details"})
 _ASSISTANT_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
@@ -55,6 +57,29 @@ def normalize_tool_type(tool_type: str) -> str:
     return _TOOL_TYPE_ALIASES.get(tool_type, tool_type)
 
 
+def tool_validation_context(*, allowed_builtin_tool_types: Collection[str] = ()) -> dict[str, object] | None:
+    normalized_allowed_builtin_tool_types = tuple(
+        normalize_tool_type(tool_type) for tool_type in allowed_builtin_tool_types
+    )
+    if not normalized_allowed_builtin_tool_types:
+        return None
+    return {_TOOL_VALIDATION_CONTEXT_KEY: normalized_allowed_builtin_tool_types}
+
+
+def allowed_builtin_tool_types_from_context(info: ValidationInfo) -> frozenset[str]:
+    context = info.context
+    if not isinstance(context, dict):
+        return frozenset()
+    allowed_builtin_tool_types = context.get(_TOOL_VALIDATION_CONTEXT_KEY)
+    if not isinstance(allowed_builtin_tool_types, tuple):
+        return frozenset()
+    return frozenset(
+        normalize_tool_type(tool_type)
+        for tool_type in allowed_builtin_tool_types
+        if isinstance(tool_type, str) and tool_type
+    )
+
+
 def normalize_tool_choice(choice: JsonValue | None) -> JsonValue | None:
     if not is_json_mapping(choice):
         return choice
@@ -69,7 +94,14 @@ def normalize_tool_choice(choice: JsonValue | None) -> JsonValue | None:
     return choice
 
 
-def validate_tool_types(tools: list[JsonValue]) -> list[JsonValue]:
+def validate_tool_types(
+    tools: list[JsonValue],
+    *,
+    allowed_builtin_tool_types: Collection[str] = (),
+) -> list[JsonValue]:
+    unsupported_tool_types = UNSUPPORTED_TOOL_TYPES.difference(
+        normalize_tool_type(tool_type) for tool_type in allowed_builtin_tool_types
+    )
     normalized_tools: list[JsonValue] = []
     for tool in tools:
         if not is_json_mapping(tool):
@@ -83,7 +115,7 @@ def validate_tool_types(tools: list[JsonValue]) -> list[JsonValue]:
                 tool = dict(tool_mapping)
                 tool["type"] = normalized_type
                 tool_type = normalized_type
-            if tool_type in UNSUPPORTED_TOOL_TYPES:
+            if tool_type in unsupported_tool_types:
                 raise ValueError(f"Unsupported tool type: {tool_type}")
         normalized_tools.append(tool)
     return normalized_tools
@@ -378,8 +410,8 @@ class ResponsesRequest(BaseModel):
 
     @field_validator("tools")
     @classmethod
-    def _validate_tools(cls, value: list[JsonValue]) -> list[JsonValue]:
-        return validate_tool_types(value)
+    def _validate_tools(cls, value: list[JsonValue], info: ValidationInfo) -> list[JsonValue]:
+        return validate_tool_types(value, allowed_builtin_tool_types=allowed_builtin_tool_types_from_context(info))
 
     @field_validator("tool_choice")
     @classmethod

--- a/app/core/openai/v1_requests.py
+++ b/app/core/openai/v1_requests.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.message_coercion import coerce_messages
@@ -9,6 +9,8 @@ from app.core.openai.requests import (
     ResponsesReasoning,
     ResponsesRequest,
     ResponsesTextControls,
+    allowed_builtin_tool_types_from_context,
+    tool_validation_context,
     validate_tool_types,
 )
 from app.core.types import JsonValue
@@ -53,8 +55,8 @@ class V1ResponsesRequest(BaseModel):
 
     @field_validator("tools")
     @classmethod
-    def _validate_tools(cls, value: list[JsonValue]) -> list[JsonValue]:
-        return validate_tool_types(value)
+    def _validate_tools(cls, value: list[JsonValue], info: ValidationInfo) -> list[JsonValue]:
+        return validate_tool_types(value, allowed_builtin_tool_types=allowed_builtin_tool_types_from_context(info))
 
     @model_validator(mode="after")
     def _validate_input(self) -> "V1ResponsesRequest":
@@ -66,7 +68,7 @@ class V1ResponsesRequest(BaseModel):
             raise ValueError("Provide either 'conversation' or 'previous_response_id', not both.")
         return self
 
-    def to_responses_request(self) -> ResponsesRequest:
+    def to_responses_request(self, *, validation_context: dict[str, object] | None = None) -> ResponsesRequest:
         data = self.model_dump(mode="json", exclude_none=True)
         messages = data.pop("messages", None)
         instructions = data.get("instructions")
@@ -88,7 +90,8 @@ class V1ResponsesRequest(BaseModel):
             data["input"] = input_text
         else:
             data["input"] = input_items
-        return ResponsesRequest.model_validate(data)
+        effective_validation_context = validation_context or tool_validation_context()
+        return ResponsesRequest.model_validate(data, context=effective_validation_context)
 
 
 class V1ResponsesCompactRequest(BaseModel):

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -69,7 +69,9 @@ from app.modules.proxy import service as proxy_service_module
 from app.modules.proxy.helpers import _rate_limit_details
 from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
 from app.modules.proxy.request_policy import (
+    BACKEND_CODEX_ALLOWED_BUILTIN_TOOL_TYPES,
     apply_api_key_enforcement,
+    normalize_responses_request_payload,
     openai_invalid_payload_error,
     openai_validation_error,
     validate_model_access,
@@ -153,6 +155,14 @@ _UNAVAILABLE_SELECTION_ERROR_CODES = {
 }
 
 
+def _normalize_backend_codex_responses_payload(payload: dict[str, JsonValue]) -> ResponsesRequest:
+    return normalize_responses_request_payload(
+        payload,
+        openai_compat=False,
+        allowed_builtin_tool_types=BACKEND_CODEX_ALLOWED_BUILTIN_TOOL_TYPES,
+    )
+
+
 @router.post(
     "/responses",
     responses={
@@ -167,13 +177,18 @@ _UNAVAILABLE_SELECTION_ERROR_CODES = {
 )
 async def responses(
     request: Request,
-    payload: ResponsesRequest = Body(...),
+    payload: dict[str, JsonValue] = Body(...),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
+    try:
+        responses_payload = _normalize_backend_codex_responses_payload(payload)
+    except ValidationError as exc:
+        error = openai_validation_error(exc)
+        return _logged_error_json_response(request, 400, error)
     return await _stream_responses(
         request,
-        payload,
+        responses_payload,
         context,
         api_key,
         codex_session_affinity=True,
@@ -201,6 +216,7 @@ async def responses_websocket(
         codex_session_affinity=True,
         openai_cache_affinity=True,
         api_key=api_key,
+        allowed_builtin_tool_types=BACKEND_CODEX_ALLOWED_BUILTIN_TOOL_TYPES,
     )
 
 
@@ -267,12 +283,17 @@ async def v1_responses(
 )
 async def internal_bridge_responses(
     request: Request,
-    payload: ResponsesRequest = Body(...),
+    payload: dict[str, JsonValue] = Body(...),
     context: ProxyContext = Depends(get_proxy_context),
 ) -> Response:
+    try:
+        responses_payload = _normalize_backend_codex_responses_payload(payload)
+    except ValidationError as exc:
+        error = openai_validation_error(exc)
+        return _logged_error_json_response(request, 400, error)
     forwarded_request_context, internal_error = parse_forwarded_request(
         request.headers,
-        payload=payload,
+        payload=responses_payload,
         current_instance=get_settings().http_responses_session_bridge_instance_id,
     )
     if internal_error is not None or forwarded_request_context is None:
@@ -285,7 +306,7 @@ async def internal_bridge_responses(
     forwarded_headers = _strip_internal_bridge_headers(request.headers)
     return await _stream_responses(
         request,
-        payload,
+        responses_payload,
         context,
         api_key,
         codex_session_affinity=forwarded_request_context.context.codex_session_affinity,

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -6,13 +6,20 @@ from pydantic import ValidationError
 
 from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.exceptions import ProxyModelNotAllowed
-from app.core.openai.requests import ResponsesCompactRequest, ResponsesReasoning, ResponsesRequest
+from app.core.openai.requests import (
+    ResponsesCompactRequest,
+    ResponsesReasoning,
+    ResponsesRequest,
+    tool_validation_context,
+)
 from app.core.openai.v1_requests import V1ResponsesRequest
 from app.core.types import JsonValue
 from app.core.utils.request_id import get_request_id
 from app.modules.api_keys.service import ApiKeyData
 
 logger = logging.getLogger(__name__)
+
+BACKEND_CODEX_ALLOWED_BUILTIN_TOOL_TYPES = frozenset({"image_generation"})
 
 
 def validate_model_access(api_key: ApiKeyData | None, model: str | None) -> None:
@@ -95,7 +102,11 @@ def normalize_responses_request_payload(
     payload: dict[str, JsonValue],
     *,
     openai_compat: bool,
+    allowed_builtin_tool_types: frozenset[str] = frozenset(),
 ) -> ResponsesRequest:
+    validation_context = tool_validation_context(allowed_builtin_tool_types=allowed_builtin_tool_types)
     if openai_compat:
-        return V1ResponsesRequest.model_validate(payload).to_responses_request()
-    return ResponsesRequest.model_validate(payload)
+        return V1ResponsesRequest.model_validate(payload, context=validation_context).to_responses_request(
+            validation_context=validation_context
+        )
+    return ResponsesRequest.model_validate(payload, context=validation_context)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -137,7 +137,6 @@ from app.modules.proxy.load_balancer import AccountSelection, LoadBalancer
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.proxy.repo_bundle import ProxyRepoFactory, ProxyRepositories
 from app.modules.proxy.request_policy import (
-    BACKEND_CODEX_ALLOWED_BUILTIN_TOOL_TYPES,
     apply_api_key_enforcement,
     normalize_responses_request_payload,
     openai_invalid_payload_error,
@@ -1640,7 +1639,7 @@ class ProxyService:
         sticky_threads_enabled: bool,
         openai_cache_affinity_max_age_seconds: int,
         api_key: ApiKeyData | None,
-        allowed_builtin_tool_types: frozenset[str],
+        allowed_builtin_tool_types: frozenset[str] = frozenset(),
     ) -> _PreparedWebSocketRequest:
         refreshed_api_key = await self._refresh_websocket_api_key_policy(api_key)
         client_metadata = _response_create_client_metadata(payload, headers=headers)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -137,6 +137,7 @@ from app.modules.proxy.load_balancer import AccountSelection, LoadBalancer
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.proxy.repo_bundle import ProxyRepoFactory, ProxyRepositories
 from app.modules.proxy.request_policy import (
+    BACKEND_CODEX_ALLOWED_BUILTIN_TOOL_TYPES,
     apply_api_key_enforcement,
     normalize_responses_request_payload,
     openai_invalid_payload_error,
@@ -1310,6 +1311,7 @@ class ProxyService:
         codex_session_affinity: bool,
         openai_cache_affinity: bool,
         api_key: ApiKeyData | None,
+        allowed_builtin_tool_types: frozenset[str] = frozenset(),
     ) -> None:
         filtered_headers = filter_inbound_websocket_headers(dict(headers))
         runtime_settings = get_settings()
@@ -1405,6 +1407,7 @@ class ProxyService:
                                 sticky_threads_enabled=sticky_threads_enabled,
                                 openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
                                 api_key=api_key,
+                                allowed_builtin_tool_types=allowed_builtin_tool_types,
                             )
                             request_state = prepared_request.request_state
                             request_affinity = prepared_request.affinity_policy
@@ -1637,10 +1640,15 @@ class ProxyService:
         sticky_threads_enabled: bool,
         openai_cache_affinity_max_age_seconds: int,
         api_key: ApiKeyData | None,
+        allowed_builtin_tool_types: frozenset[str],
     ) -> _PreparedWebSocketRequest:
         refreshed_api_key = await self._refresh_websocket_api_key_policy(api_key)
         client_metadata = _response_create_client_metadata(payload, headers=headers)
-        responses_payload = normalize_responses_request_payload(payload, openai_compat=openai_cache_affinity)
+        responses_payload = normalize_responses_request_payload(
+            payload,
+            openai_compat=openai_cache_affinity,
+            allowed_builtin_tool_types=allowed_builtin_tool_types,
+        )
         apply_api_key_enforcement(responses_payload, refreshed_api_key)
         validate_model_access(refreshed_api_key, responses_payload.model)
         reservation = await self._reserve_websocket_api_key_usage(

--- a/openspec/changes/support-codex-image-generation-tool/design.md
+++ b/openspec/changes/support-codex-image-generation-tool/design.md
@@ -1,0 +1,44 @@
+## Context
+
+`ResponsesRequest` and `V1ResponsesRequest` currently share one built-in tool validator. That shared path rejects `image_generation`, which is still correct for `/v1/responses` and chat-completions compatibility, but it is too strict for backend Codex traffic. `/backend-api/codex/responses` uses the shared validator in three places: the HTTP route body model, websocket `response.create` normalization, and the internal bridge HTTP owner-handoff route.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Accept `image_generation` for backend Codex Responses HTTP and websocket requests.
+- Preserve the same backend-only acceptance when HTTP bridge owner handoff revalidates the forwarded request on `/internal/bridge/responses`.
+- Keep `/v1/responses` and `/v1/chat/completions` rejecting `image_generation`.
+- Keep the shared normalization behavior for aliases like `web_search_preview`.
+
+**Non-Goals:**
+
+- Allow additional built-in tool types such as `file_search`, `code_interpreter`, or `computer_use`.
+- Change upstream tool rewriting beyond the backend-specific validation allowance.
+- Broaden OpenAI-style `/v1/*` compatibility contracts.
+
+## Decisions
+
+### Route-scoped tool validation context
+
+The shared tool validator will accept an explicit allowlist of built-in tool types instead of mutating the global unsupported set. Backend Codex call paths will opt into `image_generation`; OpenAI-style `/v1` and chat paths will continue using the default strict behavior.
+
+This keeps one normalization function and avoids duplicating the tool canonicalization logic in multiple models.
+
+### Manual backend HTTP parsing
+
+The backend HTTP route and internal bridge route will validate raw JSON payloads through the shared normalization helper instead of relying on FastAPI body parsing straight into `ResponsesRequest`. That allows the backend routes to pass their route-specific tool policy while preserving the existing OpenAI error envelope behavior on validation failures.
+
+This is preferred over weakening the `ResponsesRequest` model globally, which would unintentionally broaden `/v1` behavior through shared helpers.
+
+### Explicit websocket policy plumbing
+
+`ProxyService.proxy_responses_websocket()` and its request preparation path will receive an explicit backend tool allowlist parameter. The backend websocket route will pass `image_generation`; the `/v1/responses` websocket route will pass no extra allowances.
+
+This keeps websocket policy separate from unrelated flags such as Codex session affinity and avoids coupling tool policy to transport behavior.
+
+## Risks / Trade-offs
+
+- [Risk] Backend-only policy could drift across HTTP, websocket, and internal bridge call paths. → Mitigation: route all three through the same shared validation helper and add regression coverage for HTTP and websocket acceptance.
+- [Risk] Manual backend HTTP parsing could change validation envelopes. → Mitigation: reuse the existing `openai_validation_error()` wrapper so backend failures still return the same `invalid_request_error` shape.
+- [Risk] Future Codex-only built-in tools may require more route-specific exceptions. → Mitigation: represent the backend allowance as an explicit allowlist so the policy can be extended intentionally instead of relaxing the global unsupported set.

--- a/openspec/changes/support-codex-image-generation-tool/proposal.md
+++ b/openspec/changes/support-codex-image-generation-tool/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Recent Codex CLI builds include `image_generation` in the default tool inventory they send to `/backend-api/codex/responses`. `codex-lb` currently rejects that built-in tool in the shared Responses validator, so backend Codex requests fail locally with `invalid_request_error` before they ever reach the upstream service.
+
+## What Changes
+
+- Add a backend Codex Responses-specific tool validation path that accepts `image_generation` on `/backend-api/codex/responses`.
+- Apply the same backend-only tool policy to HTTP requests, websocket `response.create` requests, and internal bridge revalidation so owner handoff does not reintroduce the same failure.
+- Keep `/v1/responses` and `/v1/chat/completions` tool validation behavior unchanged.
+- Add regression coverage for backend HTTP and websocket acceptance plus continued OpenAI-style rejection on `/v1/*`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: backend Codex Responses routes accept `image_generation` tool definitions while preserving the stricter `/v1` contract.
+
+## Impact
+
+- Affected code: `app/core/openai/requests.py`, `app/modules/proxy/request_policy.py`, `app/modules/proxy/api.py`, `app/modules/proxy/service.py`
+- Affected tests: backend HTTP/websocket Responses compatibility coverage and tool validation regression tests
+- External behavior: `/backend-api/codex/responses` becomes compatible with Codex CLI tool inventories that include `image_generation`; `/v1/*` and chat remain unchanged

--- a/openspec/changes/support-codex-image-generation-tool/specs/responses-api-compat/spec.md
+++ b/openspec/changes/support-codex-image-generation-tool/specs/responses-api-compat/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Backend Codex Responses accepts image_generation tools
+When handling backend Codex Responses traffic on `/backend-api/codex/responses`, the service MUST accept tool definitions with type `image_generation` and forward them upstream unchanged. This backend-only allowance MUST apply to direct HTTP requests, websocket `response.create` requests, and internal bridge owner-handoff revalidation for forwarded backend requests. `/v1/responses` MUST continue rejecting `image_generation` with an OpenAI `invalid_request_error`.
+
+#### Scenario: backend HTTP request includes image_generation
+- **WHEN** a client sends `POST /backend-api/codex/responses` with `tools=[{"type":"image_generation"}]`
+- **THEN** the service accepts the request instead of returning a local validation error
+- **AND** the forwarded upstream Responses payload still includes `{"type":"image_generation"}`
+
+#### Scenario: backend websocket request includes image_generation
+- **WHEN** a client sends a websocket `response.create` event on `/backend-api/codex/responses` with `tools=[{"type":"image_generation"}]`
+- **THEN** the service accepts the event instead of returning a local validation error
+- **AND** the forwarded upstream `response.create` payload still includes `{"type":"image_generation"}`
+
+#### Scenario: backend bridge owner handoff preserves image_generation allowance
+- **WHEN** an internal `/internal/bridge/responses` forward revalidates a backend Codex Responses payload that includes `tools=[{"type":"image_generation"}]`
+- **THEN** the owner instance accepts the forwarded payload instead of failing local tool validation
+
+#### Scenario: v1 responses remains strict
+- **WHEN** a client sends `POST /v1/responses` with `tools=[{"type":"image_generation"}]`
+- **THEN** the service returns a 4xx OpenAI `invalid_request_error`

--- a/openspec/changes/support-codex-image-generation-tool/tasks.md
+++ b/openspec/changes/support-codex-image-generation-tool/tasks.md
@@ -1,0 +1,14 @@
+## 1. Validation plumbing
+
+- [x] 1.1 Add route-scoped built-in tool validation support to shared Responses normalization helpers.
+- [x] 1.2 Validate backend HTTP and internal bridge Responses payloads with the backend Codex `image_generation` allowance while keeping `/v1` parsing unchanged.
+
+## 2. Transport handling
+
+- [x] 2.1 Pass the backend Codex `image_generation` allowance through websocket `response.create` preparation for `/backend-api/codex/responses`.
+- [x] 2.2 Keep `/v1/responses` websocket validation strict and preserve backend upstream forwarding unchanged.
+
+## 3. Verification
+
+- [x] 3.1 Add regression tests for backend HTTP and websocket `image_generation` acceptance plus continued `/v1` rejection.
+- [x] 3.2 Run targeted pytest coverage for backend responses and websocket tool validation paths.

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -532,8 +532,11 @@ async def test_proxy_responses_forces_stream(async_client, monkeypatch):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tool_type", ["web_search", "web_search_preview"])
-async def test_proxy_responses_accepts_builtin_tools(async_client, monkeypatch, tool_type):
+@pytest.mark.parametrize(
+    ("tool_type", "expected_tool_type"),
+    [("web_search", "web_search"), ("web_search_preview", "web_search"), ("image_generation", "image_generation")],
+)
+async def test_proxy_responses_accepts_builtin_tools(async_client, monkeypatch, tool_type, expected_tool_type):
     email = "tools@example.com"
     raw_account_id = "acc_tools"
     auth_json = _make_auth_json(raw_account_id, email)
@@ -566,7 +569,7 @@ async def test_proxy_responses_accepts_builtin_tools(async_client, monkeypatch, 
 
     event = _extract_first_event(lines)
     assert event["type"] == "response.completed"
-    assert getattr(seen.get("payload"), "tools", None) == [{"type": "web_search"}]
+    assert getattr(seen.get("payload"), "tools", None) == [{"type": expected_tool_type}]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -208,6 +208,7 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
         "service_tier": "fast",
         "reasoning": {"effort": "high"},
         "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "tools": [{"type": "image_generation"}],
         "stream": True,
     }
 
@@ -240,7 +241,7 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
             "model": "gpt-5.4",
             "instructions": "",
             "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
-            "tools": [],
+            "tools": [{"type": "image_generation"}],
             "reasoning": {"effort": "high"},
             "client_metadata": {"x-codex-turn-metadata": '{"turn_id":"turn_123","sandbox":"workspace-write"}'},
             "service_tier": "priority",
@@ -844,7 +845,25 @@ def test_v1_responses_websocket_normalizes_payload_before_forwarding(app_instanc
     ]
 
 
-def test_v1_responses_websocket_rejects_invalid_payload_before_connect(app_instance, monkeypatch):
+@pytest.mark.parametrize(
+    "request_payload",
+    [
+        {
+            "type": "response.create",
+            "model": "gpt-5.4",
+            "input": "hi",
+            "store": True,
+        },
+        {
+            "type": "response.create",
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": "hi",
+            "tools": [{"type": "image_generation"}],
+        },
+    ],
+)
+def test_v1_responses_websocket_rejects_invalid_payload_before_connect(app_instance, monkeypatch, request_payload):
     called = {"connect": False}
 
     class _FakeSettingsCache:
@@ -869,16 +888,7 @@ def test_v1_responses_websocket_rejects_invalid_payload_before_connect(app_insta
 
     with TestClient(app_instance) as client:
         with client.websocket_connect("/v1/responses") as websocket:
-            websocket.send_text(
-                json.dumps(
-                    {
-                        "type": "response.create",
-                        "model": "gpt-5.4",
-                        "input": "hi",
-                        "store": True,
-                    }
-                )
-            )
+            websocket.send_text(json.dumps(request_payload))
             json.loads(websocket.receive_text())
 
     assert called["connect"] is False

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from app.core.openai.exceptions import ClientPayloadError
-from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest, tool_validation_context
 from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRequest
 from app.core.types import JsonValue
 
@@ -368,6 +368,21 @@ def test_responses_accepts_builtin_tools(tool_type, expected):
     request = ResponsesRequest.model_validate(payload)
 
     assert request.tools == [{"type": expected}]
+
+
+def test_responses_accepts_image_generation_with_validation_context():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [],
+        "tools": [{"type": "image_generation"}],
+    }
+    request = ResponsesRequest.model_validate(
+        payload,
+        context=tool_validation_context(allowed_builtin_tool_types=("image_generation",)),
+    )
+
+    assert request.tools == [{"type": "image_generation"}]
 
 
 @pytest.mark.parametrize("tool_choice", [{"type": "web_search"}, {"type": "web_search_preview"}])


### PR DESCRIPTION
## Summary

Recent Codex clients advertise a top-level `image_generation` tool on `/backend-api/codex/responses`. `codex-lb` still routes backend Codex Responses payloads through shared request validation, so those requests fail locally with `invalid_request_error` before they reach the upstream service.

This change keeps the fix backend-Codex-specific by introducing route-scoped built-in tool validation. Backend Codex Responses requests can advertise `image_generation`, while `/v1/responses` and `/v1/chat/completions` remain strict.

## What Changed

- added validation-context plumbing to shared Responses request normalization so routes can explicitly allow selected built-in tool types
- updated backend HTTP `/backend-api/codex/responses` and `/internal/bridge/responses` handling to normalize raw payloads with the backend-only `image_generation` allowance
- passed the same backend-only allowance through websocket `response.create` preparation for `/backend-api/codex/responses`
- kept `/v1/responses` validation strict and preserved existing tool alias normalization such as `web_search_preview`
- added regression coverage for backend HTTP/websocket acceptance and continued `/v1` rejection
- added the matching OpenSpec change under `openspec/changes/support-codex-image-generation-tool`

## Impact

- `/backend-api/codex/responses` now accepts and forwards `{"type":"image_generation"}` unchanged
- internal bridge owner handoff no longer reintroduces the same validation failure for backend Codex traffic
- `/v1/*` behavior is unchanged

## Validation

- `openspec validate --specs`
- `.venv/bin/python -m pytest tests/unit/test_openai_requests.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_websocket_responses.py -q`
