### PR TITLE
fix(proxy): inject session-level previous_response_id to enable input trimming for all clients

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -579,10 +579,15 @@ class ProxyService:
         if proxy_injected_previous_response_id:
             request_state.proxy_injected_previous_response_id = True
             request_state.fresh_upstream_request_text = fresh_upstream_request_text or text_data
-            # Durable-anchor injection only fires for trim-safe full-resend
-            # payloads, so the unanchored request text is a valid fresh-turn
-            # replay target.
-            request_state.fresh_upstream_request_is_retry_safe = True
+            # Durable-anchor injection actually runs when the incoming
+            # payload is *not* a full resend (see the
+            # ``not _http_bridge_payload_looks_like_full_resend(payload)``
+            # guard above), so the captured unanchored text is typically
+            # just a short follow-up. Replaying it as a fresh turn would
+            # drop the conversational context the anchor was pointing at.
+            # Only the trim branch below (which verifies the stored prefix
+            # fingerprint) is allowed to flip this flag to ``True``.
+            request_state.fresh_upstream_request_is_retry_safe = False
         session_or_forward = await self._get_or_create_http_bridge_session(
             bridge_session_key,
             headers=dict(headers),

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -734,16 +734,15 @@ class ProxyService:
         session = session_or_forward
         # --- Session-level previous_response_id injection ---
         # If the client didn't send previous_response_id and the durable
-        # lookup didn't inject one, but this bridge session has already
-        # completed a request on the *same* WebSocket connection, inject the
-        # session's last completed response ID.  This is reliable because the
-        # upstream conversation state is guaranteed to contain this response
-        # — it was produced on the very connection we are about to use.
-        # Without this, clients like Codex CLI that never send
-        # previous_response_id would bypass the trimming logic below and
-        # cause input tokens to grow monotonically for the whole session.
+        # lookup didn't inject one, but this bridge session is carrying
+        # Codex-style conversational continuity and has already completed a
+        # request on this logical conversation, inject the session's last
+        # completed response ID. Soft affinity reuse (for example prompt
+        # cache / sticky-thread sharing) must stay self-contained, so it
+        # must never inherit a previous_response_id from another request.
         if (
-            not proxy_injected_previous_response_id
+            session.codex_session
+            and not proxy_injected_previous_response_id
             and effective_payload.previous_response_id is None
             and session.last_completed_response_id is not None
         ):

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -579,6 +579,10 @@ class ProxyService:
         if proxy_injected_previous_response_id:
             request_state.proxy_injected_previous_response_id = True
             request_state.fresh_upstream_request_text = fresh_upstream_request_text or text_data
+            # Durable-anchor injection only fires for trim-safe full-resend
+            # payloads, so the unanchored request text is a valid fresh-turn
+            # replay target.
+            request_state.fresh_upstream_request_is_retry_safe = True
         session_or_forward = await self._get_or_create_http_bridge_session(
             bridge_session_key,
             headers=dict(headers),
@@ -801,6 +805,14 @@ class ProxyService:
             request_state.preferred_account_id = durable_lookup.account_id if durable_lookup is not None else None
             request_state.proxy_injected_previous_response_id = True
             request_state.fresh_upstream_request_text = fresh_upstream_request_text
+            # Session-level anchor injection may be attached to a payload
+            # that relied on the anchor for context (for example a
+            # single-item follow-up turn whose prior history is only
+            # represented by ``previous_response_id``). Replaying without
+            # the anchor would silently turn it into a fresh turn and drop
+            # conversational context, so opt this path out of fresh-upstream
+            # fresh-turn replay.
+            request_state.fresh_upstream_request_is_retry_safe = False
             logger.info(
                 "session_anchor_injected request_id=%s response_id=%s",
                 request_id,
@@ -848,6 +860,13 @@ class ProxyService:
                 if proxy_injected_previous_response_id:
                     request_state.proxy_injected_previous_response_id = True
                     request_state.fresh_upstream_request_text = fresh_upstream_request_text
+                    # The trim branch only fires when the untrimmed payload
+                    # is a true full resend whose prefix exactly matches the
+                    # already-stored context, so the unanchored request text
+                    # is a safe fresh-turn replay target regardless of
+                    # whether the anchor came from the durable or
+                    # session-level injection path.
+                    request_state.fresh_upstream_request_is_retry_safe = True
                 logger.info(
                     "store_context_input_trimmed request_id=%s original_items=%s trimmed_to=%s previous_response_id=%s",
                     request_id,
@@ -4738,7 +4757,16 @@ class ProxyService:
             # upstream already accepted the continuation. Re-sending the same
             # previous_response_id request can fork continuity with duplicate
             # child responses, so only reconnect-without-resend is allowed.
-            if not request_state.proxy_injected_previous_response_id or not request_state.fresh_upstream_request_text:
+            # The single exception is proxy-injected anchors on trim-safe
+            # full-resend payloads: dropping the anchor and replaying the
+            # original unanchored request is equivalent to the client's own
+            # retry. Session-level injections do not opt in because their
+            # payload may depend on the anchor for context preservation.
+            if (
+                not request_state.proxy_injected_previous_response_id
+                or not request_state.fresh_upstream_request_text
+                or not request_state.fresh_upstream_request_is_retry_safe
+            ):
                 return False
             retry_text_data = request_state.fresh_upstream_request_text
         if request_state.replay_count >= 1:
@@ -7749,6 +7777,16 @@ class _WebSocketRequestState:
     session_id: str | None = None
     proxy_injected_previous_response_id: bool = False
     fresh_upstream_request_text: str | None = None
+    # True only when ``fresh_upstream_request_text`` contains a *safe* pre-
+    # injection form of this request that can be replayed as a fresh turn.
+    # Durable-anchor injection captures the original unanchored full-resend
+    # payload, so dropping the anchor and replaying is equivalent to the
+    # client's own retry. Session-level anchor injection does **not** set
+    # this: the original payload may have omitted history the conversation
+    # depended on (for example a single-item follow-up whose context came
+    # entirely from the injected anchor), and dropping the anchor there
+    # would silently turn a continuation into a context-free fresh turn.
+    fresh_upstream_request_is_retry_safe: bool = False
     request_stage: str = "first_turn"
     preferred_account_id: str | None = None
     error_code_override: str | None = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -489,6 +489,7 @@ class ProxyService:
             durable_lookup = None
         effective_payload = payload
         proxy_injected_previous_response_id = False
+        fresh_upstream_request_text: str | None = None
         if durable_lookup is not None:
             bridge_session_key = _HTTPBridgeSessionKey(
                 durable_lookup.canonical_kind,
@@ -513,6 +514,14 @@ class ProxyService:
                     update={"previous_response_id": durable_lookup.latest_response_id}
                 )
                 proxy_injected_previous_response_id = True
+                _fresh_request_state, fresh_upstream_request_text = self._prepare_http_bridge_request(
+                    payload,
+                    headers,
+                    api_key=api_key,
+                    api_key_reservation=api_key_reservation,
+                    request_id=request_id,
+                )
+                del _fresh_request_state
                 _log_http_bridge_event(
                     "fresh_reattach_anchor_injected",
                     bridge_session_key,
@@ -567,6 +576,9 @@ class ProxyService:
                 session_id=request_state.session_id,
                 surface="http_bridge",
             )
+        if proxy_injected_previous_response_id:
+            request_state.proxy_injected_previous_response_id = True
+            request_state.fresh_upstream_request_text = fresh_upstream_request_text or text_data
         session_or_forward = await self._get_or_create_http_bridge_session(
             bridge_session_key,
             headers=dict(headers),
@@ -746,6 +758,7 @@ class ProxyService:
             and effective_payload.previous_response_id is None
             and session.last_completed_response_id is not None
         ):
+            fresh_upstream_request_text = text_data
             effective_payload = effective_payload.model_copy(
                 update={"previous_response_id": session.last_completed_response_id}
             )
@@ -764,6 +777,8 @@ class ProxyService:
                 durable_lookup=durable_lookup,
             )
             request_state.preferred_account_id = durable_lookup.account_id if durable_lookup is not None else None
+            request_state.proxy_injected_previous_response_id = True
+            request_state.fresh_upstream_request_text = fresh_upstream_request_text
             logger.info(
                 "session_anchor_injected request_id=%s response_id=%s",
                 request_id,
@@ -808,6 +823,9 @@ class ProxyService:
                 request_state.preferred_account_id = previous_preferred_account_id
                 request_state.input_item_count = original_count
                 request_state.input_full_fingerprint = _fingerprint_input_items(incoming_input_list)
+                if proxy_injected_previous_response_id:
+                    request_state.proxy_injected_previous_response_id = True
+                    request_state.fresh_upstream_request_text = fresh_upstream_request_text
                 logger.info(
                     "store_context_input_trimmed request_id=%s original_items=%s trimmed_to=%s previous_response_id=%s",
                     request_id,
@@ -4692,12 +4710,15 @@ class ProxyService:
         text_data: str,
         send_request: bool = True,
     ) -> bool:
+        retry_text_data = text_data
         if request_state.previous_response_id is not None and send_request:
             # After an ambiguous websocket send failure we cannot prove whether
             # upstream already accepted the continuation. Re-sending the same
             # previous_response_id request can fork continuity with duplicate
             # child responses, so only reconnect-without-resend is allowed.
-            return False
+            if not request_state.proxy_injected_previous_response_id or not request_state.fresh_upstream_request_text:
+                return False
+            retry_text_data = request_state.fresh_upstream_request_text
         if request_state.replay_count >= 1:
             return False
         request_state.replay_count += 1
@@ -4717,7 +4738,11 @@ class ProxyService:
                 restart_reader=True,
             )
             if send_request:
-                await session.upstream.send_text(text_data)
+                if retry_text_data != text_data:
+                    request_state.previous_response_id = None
+                    request_state.proxy_injected_previous_response_id = False
+                    request_state.request_text = retry_text_data
+                await session.upstream.send_text(retry_text_data)
             session.last_used_at = time.monotonic()
             return True
         except Exception:
@@ -7697,6 +7722,8 @@ class _WebSocketRequestState:
     skip_request_log: bool = False
     previous_response_id: str | None = None
     session_id: str | None = None
+    proxy_injected_previous_response_id: bool = False
+    fresh_upstream_request_text: str | None = None
     request_stage: str = "first_turn"
     preferred_account_id: str | None = None
     error_code_override: str | None = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -732,6 +732,44 @@ class ProxyService:
                             session.last_used_at = time.monotonic()
                 return
         session = session_or_forward
+        # --- Session-level previous_response_id injection ---
+        # If the client didn't send previous_response_id and the durable
+        # lookup didn't inject one, but this bridge session has already
+        # completed a request on the *same* WebSocket connection, inject the
+        # session's last completed response ID.  This is reliable because the
+        # upstream conversation state is guaranteed to contain this response
+        # — it was produced on the very connection we are about to use.
+        # Without this, clients like Codex CLI that never send
+        # previous_response_id would bypass the trimming logic below and
+        # cause input tokens to grow monotonically for the whole session.
+        if (
+            not proxy_injected_previous_response_id
+            and effective_payload.previous_response_id is None
+            and session.last_completed_response_id is not None
+        ):
+            effective_payload = effective_payload.model_copy(
+                update={"previous_response_id": session.last_completed_response_id}
+            )
+            proxy_injected_previous_response_id = True
+            request_state, text_data = self._prepare_http_bridge_request(
+                effective_payload,
+                headers,
+                api_key=api_key,
+                api_key_reservation=api_key_reservation,
+                request_id=request_id,
+            )
+            request_state.transport = _REQUEST_TRANSPORT_HTTP
+            request_state.request_stage = _http_bridge_request_stage(
+                headers=headers,
+                payload=effective_payload,
+                durable_lookup=durable_lookup,
+            )
+            request_state.preferred_account_id = durable_lookup.account_id if durable_lookup is not None else None
+            logger.info(
+                "session_anchor_injected request_id=%s response_id=%s",
+                request_id,
+                session.last_completed_response_id,
+            )
         # Trim already-stored prefix when previous_response_id anchors context.
         has_previous_response_id = (
             proxy_injected_previous_response_id or effective_payload.previous_response_id is not None
@@ -4999,6 +5037,8 @@ class ProxyService:
         ):
             session.last_completed_input_count = terminal_request_state.input_item_count
             session.last_completed_input_prefix_fingerprint = terminal_request_state.input_full_fingerprint
+            if response_id is not None:
+                session.last_completed_response_id = response_id
 
         if event_type == "error":
             http_status = _http_error_status_from_payload(payload)
@@ -7721,6 +7761,7 @@ class _HTTPBridgeSession:
     downstream_turn_state_aliases: set[str] = field(default_factory=set)
     previous_response_ids: set[str] = field(default_factory=set)
     last_completed_input_count: int = 0
+    last_completed_response_id: str | None = None
     last_completed_input_prefix_fingerprint: str | None = None
     durable_session_id: str | None = None
     durable_owner_epoch: int | None = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -749,14 +749,36 @@ class ProxyService:
         # lookup didn't inject one, but this bridge session is carrying
         # Codex-style conversational continuity and has already completed a
         # request on this logical conversation, inject the session's last
-        # completed response ID. Soft affinity reuse (for example prompt
-        # cache / sticky-thread sharing) must stay self-contained, so it
-        # must never inherit a previous_response_id from another request.
+        # completed response ID so the trim branch below can strip the
+        # already-stored prefix.
+        #
+        # Correctness guards:
+        # - Soft affinity reuse (for example prompt cache / sticky-thread
+        #   sharing) must stay self-contained, so only true Codex
+        #   continuity sessions opt in.
+        # - Injecting an anchor when the incoming payload is a full-resend
+        #   whose prefix cannot be safely trimmed (non-list input, prefix
+        #   mismatch, or shorter-than-stored history) would send both the
+        #   full history *and* the anchor upstream, which duplicates
+        #   context and distorts output/cost. Gate injection so it only
+        #   fires when the trim branch below would actually succeed.
+        incoming_input_preview = effective_payload.input
+        stored_count_preview = session.last_completed_input_count
+        stored_fingerprint_preview = session.last_completed_input_prefix_fingerprint
+        session_anchor_trimmable = (
+            stored_count_preview > 0
+            and stored_fingerprint_preview is not None
+            and isinstance(incoming_input_preview, list)
+            and len(incoming_input_preview) > stored_count_preview
+            and _fingerprint_input_items(cast(list[JsonValue], incoming_input_preview)[:stored_count_preview])
+            == stored_fingerprint_preview
+        )
         if (
             session.codex_session
             and not proxy_injected_previous_response_id
             and effective_payload.previous_response_id is None
             and session.last_completed_response_id is not None
+            and session_anchor_trimmable
         ):
             fresh_upstream_request_text = text_data
             effective_payload = effective_payload.model_copy(
@@ -5054,15 +5076,18 @@ class ProxyService:
             )
             event_block = f"data: {rewritten_text}\n\n"
 
-        if (
-            event_type == "response.completed"
-            and terminal_request_state is not None
-            and terminal_request_state.input_item_count > 0
-        ):
-            session.last_completed_input_count = terminal_request_state.input_item_count
-            session.last_completed_input_prefix_fingerprint = terminal_request_state.input_full_fingerprint
+        if event_type == "response.completed" and terminal_request_state is not None:
+            # Record the completed response id regardless of input shape so
+            # subsequent turns (including ones that never populated
+            # input_item_count, e.g. string inputs) can still reuse this
+            # anchor for continuity lookups.
             if response_id is not None:
                 session.last_completed_response_id = response_id
+            # Prefix trimming is only meaningful for list-shaped inputs, so
+            # keep the input-count / fingerprint update scoped to that path.
+            if terminal_request_state.input_item_count > 0:
+                session.last_completed_input_count = terminal_request_state.input_item_count
+                session.last_completed_input_prefix_fingerprint = terminal_request_state.input_full_fingerprint
 
         if event_type == "error":
             http_status = _http_error_status_from_payload(payload)

--- a/tests/unit/test_bridge_context_blowup.py
+++ b/tests/unit/test_bridge_context_blowup.py
@@ -267,6 +267,37 @@ class TestRetryHelperPreservesPreviousResponseId:
         reconnect_mock.assert_awaited_once()
         send_text.assert_not_awaited()
 
+    async def test_retry_with_proxy_injected_previous_response_replays_full_request(self, monkeypatch):
+        """Proxy-injected anchors can fall back to the original full request.
+
+        If the proxy injected previous_response_id for trimming, a websocket
+        send failure should still be able to reconnect and replay the original
+        unanchored request text on a fresh upstream connection.
+        """
+        service = proxy_service.ProxyService(cast(Any, nullcontext()))
+        session = _make_session(closed=False)
+        request_state = _make_request_state(previous_response_id="resp_xyz789")
+        request_state.proxy_injected_previous_response_id = True
+        request_state.fresh_upstream_request_text = '{"type":"response.create","input":"hello"}'
+        request_state.request_text = '{"type":"response.create","previous_response_id":"resp_xyz789","input":"delta"}'
+
+        send_text = AsyncMock()
+        session.upstream = cast(Any, SimpleNamespace(send_text=send_text, close=AsyncMock()))
+        monkeypatch.setattr(service, "_reconnect_http_bridge_session", AsyncMock())
+
+        result = await service._retry_http_bridge_request_on_fresh_upstream(
+            session=session,
+            request_state=request_state,
+            text_data='{"type":"response.create","previous_response_id":"resp_xyz789","input":"delta"}',
+            send_request=True,
+        )
+
+        assert result is True
+        send_text.assert_awaited_once_with('{"type":"response.create","input":"hello"}')
+        assert request_state.previous_response_id is None
+        assert request_state.proxy_injected_previous_response_id is False
+        assert request_state.request_text == '{"type":"response.create","input":"hello"}'
+
 
 class TestContextGrowthScenarios:
     """Scenario tests modelling real Codex session data.

--- a/tests/unit/test_bridge_context_blowup.py
+++ b/tests/unit/test_bridge_context_blowup.py
@@ -279,6 +279,10 @@ class TestRetryHelperPreservesPreviousResponseId:
         request_state = _make_request_state(previous_response_id="resp_xyz789")
         request_state.proxy_injected_previous_response_id = True
         request_state.fresh_upstream_request_text = '{"type":"response.create","input":"hello"}'
+        # Durable-anchor injection captures the full-resend original
+        # payload and opts into fresh-turn replay. Session-level
+        # injections keep this False.
+        request_state.fresh_upstream_request_is_retry_safe = True
         request_state.request_text = '{"type":"response.create","previous_response_id":"resp_xyz789","input":"delta"}'
 
         send_text = AsyncMock()

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -4986,6 +4986,133 @@ async def test_retry_http_bridge_request_on_fresh_upstream_refuses_to_resend_pre
     send_text.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_retry_http_bridge_request_on_fresh_upstream_replays_retry_safe_injection_without_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Durable-anchor injections opt in to fresh-turn replay on send failure.
+
+    The proxy captures the original unanchored full-resend payload before
+    injecting ``previous_response_id`` on durable reattach. That text is a
+    safe fresh-turn replay target because it already contains the full
+    history; dropping the anchor and replaying is equivalent to the
+    client's own retry.
+    """
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-safe", None),
+        headers={"x-codex-session-id": "sid-safe"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-safe",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-retry-safe",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_prev_safe",
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_text='{"type":"response.create","input":"full-history-fallback"}',
+        fresh_upstream_request_is_retry_safe=True,
+        transport="http",
+    )
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    recovered = await service._retry_http_bridge_request_on_fresh_upstream(
+        session=session,
+        request_state=request_state,
+        text_data='{"type":"response.create","previous_response_id":"resp_prev_safe","input":"full-history-fallback"}',
+        send_request=True,
+    )
+
+    assert recovered is True
+    assert request_state.replay_count == 1
+    # Replaying should have dropped the anchor metadata so the request
+    # executes as a fresh turn using the captured unanchored payload.
+    assert request_state.previous_response_id is None
+    assert request_state.proxy_injected_previous_response_id is False
+    send_text.assert_awaited_once_with('{"type":"response.create","input":"full-history-fallback"}')
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_request_on_fresh_upstream_refuses_session_level_injection_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Session-level injections must not be replayed as fresh turns.
+
+    When the proxy injects ``previous_response_id`` from a bridge session's
+    last completed response, the original payload may have relied on the
+    anchor for context (for example a single-item follow-up whose prior
+    turns live only in the stored conversation). Dropping the anchor and
+    replaying would silently turn the continuation into a context-free
+    fresh turn and return wrong-but-successful output instead of surfacing
+    the retriable send failure.
+    """
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-unsafe", None),
+        headers={"x-codex-session-id": "sid-unsafe"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-unsafe",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-retry-unsafe",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_prev_unsafe",
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_text='{"type":"response.create","input":"single-item-followup"}',
+        fresh_upstream_request_is_retry_safe=False,
+        transport="http",
+    )
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    recovered = await service._retry_http_bridge_request_on_fresh_upstream(
+        session=session,
+        request_state=request_state,
+        text_data='{"type":"response.create","previous_response_id":"resp_prev_unsafe","input":"single-item-followup"}',
+        send_request=True,
+    )
+
+    assert recovered is False
+    assert request_state.replay_count == 0
+    reconnect.assert_not_awaited()
+    send_text.assert_not_awaited()
+
+
 def test_http_bridge_can_recover_during_drain_for_previous_response_anchor() -> None:
     key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_123", None)
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -890,6 +890,7 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
     assert event_queue is not None
     await event_queue.put(None)
     captured: dict[str, object] = {}
+    prepared_input_lengths: list[int] = []
 
     def fake_prepare(
         prepared_payload: proxy_service.ResponsesRequest,
@@ -901,6 +902,8 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
     ) -> tuple[proxy_service._WebSocketRequestState, str]:
         del api_key, api_key_reservation, request_id
         captured["previous_response_id"] = prepared_payload.previous_response_id
+        inp = prepared_payload.input
+        prepared_input_lengths.append(len(inp) if isinstance(inp, list) else 1)
         return request_state, '{"type":"response.create"}'
 
     session = proxy_service._HTTPBridgeSession(
@@ -984,6 +987,23 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
 
     assert chunks == []
     assert captured["previous_response_id"] is None
+    # Durable anchor injection now preserves the original unanchored request
+    # text for fresh-upstream retries before re-preparing the anchored request
+    # and then the trimmed suffix.
+    assert prepared_input_lengths == [3, 3, 1]
+    assert request_state.input_item_count == 3
+    # After trimming, input_full_fingerprint must reflect the ORIGINAL
+    # full input (all 3 items), not the trimmed suffix. Otherwise the
+    # session would later promote a suffix hash as its prefix fingerprint
+    # and break trimming on every subsequent turn.
+    expected_full_fingerprint = proxy_service._fingerprint_input_items(
+        [
+            {"role": "user", "content": [{"type": "input_text", "text": "first"}]},
+            {"role": "assistant", "content": [{"type": "output_text", "text": "second"}]},
+            {"role": "user", "content": [{"type": "input_text", "text": "third"}]},
+        ]
+    )
+    assert request_state.input_full_fingerprint == expected_full_fingerprint
 
 
 @pytest.mark.asyncio
@@ -2072,6 +2092,8 @@ async def test_stream_via_http_bridge_uses_generated_downstream_turn_state_for_o
         idle_ttl_seconds=120.0,
     )
 
+    prepared_input_lengths: list[int] = []
+
     def fake_prepare(
         _prepared_payload: proxy_service.ResponsesRequest,
         _headers: dict[str, str] | Any,
@@ -2081,6 +2103,8 @@ async def test_stream_via_http_bridge_uses_generated_downstream_turn_state_for_o
         request_id: str,
     ) -> tuple[proxy_service._WebSocketRequestState, str]:
         del api_key, api_key_reservation, request_id
+        inp = _prepared_payload.input
+        prepared_input_lengths.append(len(inp) if isinstance(inp, list) else 1)
         return request_state, '{"type":"response.create"}'
 
     async def fake_stream_http_bridge_session_events(
@@ -2149,6 +2173,11 @@ async def test_stream_via_http_bridge_uses_generated_downstream_turn_state_for_o
     )
     assert request_state.session_id == "http_turn_generated"
     assert request_state.preferred_account_id == "acc-owner-from-turn-state"
+    # Durable anchor injection preserves the original unanchored full-input
+    # request for fresh-upstream retries, then prepares the anchored request.
+    # The trim branch itself must still not fire a third prepare with a
+    # 1-item suffix when the prefix fingerprint does not match.
+    assert prepared_input_lengths == [3, 3]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -759,6 +759,108 @@ async def test_stream_via_http_bridge_injects_durable_previous_response_anchor(
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_does_not_inject_session_anchor_for_soft_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": "hello"},
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-soft",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    await event_queue.put(None)
+    prepared_previous_response_ids: list[str | None] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id
+        prepared_previous_response_ids.append(prepared_payload.previous_response_id)
+        return request_state, '{"type":"response.create"}'
+
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "cache-123", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(
+            key="cache-123",
+            kind=proxy_service.StickySessionKind.PROMPT_CACHE,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+        last_completed_response_id="resp_soft_latest",
+    )
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_enabled=True,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=session))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == []
+    assert prepared_previous_response_ids == [None]
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_anchor_for_full_resend_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -987,23 +987,12 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
 
     assert chunks == []
     assert captured["previous_response_id"] is None
-    # Durable anchor injection now preserves the original unanchored request
-    # text for fresh-upstream retries before re-preparing the anchored request
-    # and then the trimmed suffix.
-    assert prepared_input_lengths == [3, 3, 1]
-    assert request_state.input_item_count == 3
-    # After trimming, input_full_fingerprint must reflect the ORIGINAL
-    # full input (all 3 items), not the trimmed suffix. Otherwise the
-    # session would later promote a suffix hash as its prefix fingerprint
-    # and break trimming on every subsequent turn.
-    expected_full_fingerprint = proxy_service._fingerprint_input_items(
-        [
-            {"role": "user", "content": [{"type": "input_text", "text": "first"}]},
-            {"role": "assistant", "content": [{"type": "output_text", "text": "second"}]},
-            {"role": "user", "content": [{"type": "input_text", "text": "third"}]},
-        ]
-    )
-    assert request_state.input_full_fingerprint == expected_full_fingerprint
+    # Full-resend payloads are explicitly excluded from durable anchor
+    # injection, so the bridge prepares the original request exactly once.
+    assert prepared_input_lengths == [3]
+    # This path never reaches the trim branch, so the fake request_state
+    # returned by fake_prepare keeps its default metadata.
+    assert request_state.input_full_fingerprint is None
 
 
 @pytest.mark.asyncio
@@ -2173,11 +2162,10 @@ async def test_stream_via_http_bridge_uses_generated_downstream_turn_state_for_o
     )
     assert request_state.session_id == "http_turn_generated"
     assert request_state.preferred_account_id == "acc-owner-from-turn-state"
-    # Durable anchor injection preserves the original unanchored full-input
-    # request for fresh-upstream retries, then prepares the anchored request.
-    # The trim branch itself must still not fire a third prepare with a
-    # 1-item suffix when the prefix fingerprint does not match.
-    assert prepared_input_lengths == [3, 3]
+    # No durable anchor is injected in this path; the request is prepared
+    # once with the original single-item input while owner lookup uses the
+    # generated downstream turn state for scoping.
+    assert prepared_input_lengths == [1]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -861,6 +861,131 @@ async def test_stream_via_http_bridge_does_not_inject_session_anchor_for_soft_re
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_skips_session_anchor_injection_when_trim_would_not_apply(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard session-level previous_response_id injection.
+
+    The session anchor must only be injected when the trim branch would
+    actually strip the already-stored prefix. If the incoming payload is
+    a full resend whose prefix cannot be trimmed (non-list input, shorter
+    history, or a prefix fingerprint mismatch), injecting an anchor would
+    send both the full history and a previous_response_id upstream, which
+    duplicates context and distorts output/cost.
+    """
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    # Non-list input: trim cannot possibly apply, so no anchor should be
+    # injected even though the session has a completed response.
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": "fresh turn text"},
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-session-anchor-guard",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    await event_queue.put(None)
+    prepared_previous_response_ids: list[str | None] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id
+        prepared_previous_response_ids.append(prepared_payload.previous_response_id)
+        return request_state, '{"type":"response.create"}'
+
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-anchor-guard", None),
+        headers={"x-codex-session-id": "sid-anchor-guard"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-anchor-guard",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+        last_completed_response_id="resp_session_latest",
+        last_completed_input_count=3,
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(
+            [
+                {"role": "user", "content": [{"type": "input_text", "text": "a"}]},
+                {"role": "assistant", "content": [{"type": "output_text", "text": "b"}]},
+                {"role": "user", "content": [{"type": "input_text", "text": "c"}]},
+            ]
+        ),
+    )
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_enabled=True,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=session))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"x-codex-session-id": "sid-anchor-guard"},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == []
+    # No anchor should have been injected because the non-list input
+    # would have left the trim branch inert, which would have duplicated
+    # context upstream.
+    assert prepared_previous_response_ids == [None]
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_anchor_for_full_resend_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem

Codex CLI and other clients that don't send `previous_response_id` in their request payload bypass the input trimming logic entirely, causing input tokens to grow monotonically within a bridge session.

**Observed:** 31K → 201K input tokens across 15 requests in a single session, with zero trimming despite the upstream caching 99% of the input (same WebSocket connection).

The existing trimming (from #448) only fires when `has_previous_response_id` is true — i.e., when the client sends `previous_response_id` or the durable lookup injects one. But:
1. **Codex CLI never sends `previous_response_id`** in its request payload
2. **Durable lookup injection** only fires when a canonical session key exists from a prior lookup, which doesn't always happen (e.g., session key transitions from `session_header` to `turn_state_header` after idle timeout)

This means the common case of a Codex CLI session staying on the same bridge WebSocket never gets trimming.

## Fix

After a `response.completed` event, record the response ID on the bridge session (`last_completed_response_id`). On the next request through the same session, if no `previous_response_id` is available from the client or durable lookup, inject the session's last completed response ID.

### Why this is reliable

- **Same WebSocket connection** → the upstream conversation state is guaranteed to contain this response (it was produced on the very connection we're about to use)
- **WebSocket reconnects** → new session is created → `last_completed_response_id = None` → no stale injection
- **Upstream lost the response** → existing error recovery at the `_HTTPBridgeOwnerForward` failure path handles the "unknown previous_response_id" error

### Changes

1. `_HTTPBridgeSession.last_completed_response_id` — new field to track the most recent successful response ID on this session
2. `_process_http_bridge_upstream_text` — on `response.completed`, store the response ID alongside the existing `last_completed_input_count` and fingerprint
3. `_stream_via_http_bridge` — before the trimming block, inject `session.last_completed_response_id` as `previous_response_id` when neither the client nor durable lookup provided one

### Expected behavior

| Request # | Before (no fix) | After (with fix) |
|-----------|----------------|-----------------|
| 1 | 31K tokens (full) | 31K tokens (full) |
| 2 | 71K tokens (full) | ~1K tokens (trimmed) |
| 3 | 99K tokens (full) | ~1K tokens (trimmed) |
| ... | grows monotonically | stays flat |
| 15 | 201K tokens | ~1K tokens |
