### PR TITLE
fix(bootstrap): log first-run token at WARNING, not INFO (#458)

### DIFF
--- a/app/core/bootstrap.py
+++ b/app/core/bootstrap.py
@@ -32,7 +32,11 @@ def _get_encryptor() -> TokenEncryptor:
 
 
 def log_bootstrap_token(logger: logging.Logger, token: str, *, reason: str = "first-run") -> None:
-    logger.info(
+    # Emit at WARNING so the one-time token is surfaced regardless of the
+    # container/root logger level (which defaults to WARNING in most docker
+    # setups, silently dropping an INFO log and leaving operators unable to
+    # find the token). See #458.
+    logger.warning(
         "\n"
         "============================================\n"
         "  Dashboard bootstrap token (%s):\n"

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -166,3 +166,31 @@ async def test_ensure_auto_bootstrap_token_reuses_existing_encrypted_token(monke
 
     assert await bootstrap_module.ensure_auto_bootstrap_token() == "shared-auto-token"
     repository.store_bootstrap_token_if_absent.assert_not_called()
+
+
+def test_log_bootstrap_token_emits_at_warning_level_so_docker_default_surfaces_it() -> None:
+    """Regression guard for #458.
+
+    The token must be logged at a level that survives docker's default
+    root-logger WARNING threshold. If it downgrades to INFO, operators
+    following the README quickstart cannot find their first-run token.
+    """
+    import io
+    import logging
+
+    handler_stream = io.StringIO()
+    handler = logging.StreamHandler(handler_stream)
+    handler.setLevel(logging.WARNING)
+    test_logger = logging.getLogger("app.core.bootstrap.test_458_regression")
+    test_logger.setLevel(logging.WARNING)
+    test_logger.addHandler(handler)
+    test_logger.propagate = False
+
+    try:
+        bootstrap_module.log_bootstrap_token(test_logger, "tok-regression-458")
+    finally:
+        test_logger.removeHandler(handler)
+
+    output = handler_stream.getvalue()
+    assert "Dashboard bootstrap token" in output
+    assert "tok-regression-458" in output


### PR DESCRIPTION
Closes #458.

## Problem

Operators following the README quickstart report that `docker logs codex-lb` does not print the first-run bootstrap token, leaving them stuck on the bootstrap screen with no way to recover the token short of reading the encrypted DB.

Confirmed reproduction on v1.14.0 + a fresh docker volume, exact quickstart command from the README:

```
$ docker logs codex-lb
current_revision=20260417_000000_add_request_log_plan_type
... uvicorn startup lines ...
(no token line)
```

The token **is** generated and persisted:

```json
GET /api/dashboard-auth/session
{ "bootstrapRequired": true, "bootstrapTokenConfigured": true, ... }
```

## Root cause

`log_bootstrap_token` in `app/core/bootstrap.py` emits at **INFO**, but the `app.core.bootstrap` logger resolves to effective level **WARNING** (30) in the default docker container — root logger is WARNING with no explicit level set on the module's own logger. Verified in-container:

```
$ docker exec codex-lb python3 -c 'from app.core.bootstrap import logger; print(logger.getEffectiveLevel())'
30    # WARNING
```

The INFO token message is silently dropped.

## Fix

Promote the token message to **WARNING**. It's a one-time startup artifact the operator genuinely needs to see regardless of log level. The message body is unchanged — just the log level.

## Test

Added `test_log_bootstrap_token_emits_at_warning_level_so_docker_default_surfaces_it` in `tests/unit/test_bootstrap.py`:

- Attaches a `WARNING`-level handler to a namespaced logger
- Calls `log_bootstrap_token`
- Asserts the token line reaches the handler

Any future downgrade back to INFO fails CI loudly.

## Verification

- `uvx ruff check .` ✅
- `uvx ruff format --check .` ✅
- `uvx ty check app/core/bootstrap.py` ✅
- `uv run pytest tests/unit/test_bootstrap.py -q` → **11 passed**

## Rollout note

This also retroactively unblocks users stuck on #458-style symptom after pulling any `codex-lb` release so far — the token in their DB is valid, they just couldn't see it. After this fix ships, a container restart will re-log the existing token (`ensure_auto_bootstrap_token` returns the decrypted stored token on every startup when no password is set).

cc @MPiland who reported it.