### PR TITLE
test(proxy): lock previous_response_id retries to reconnect-only recovery

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3861,6 +3861,10 @@ class ProxyService:
         send_request: bool = True,
     ) -> bool:
         if request_state.previous_response_id is not None and send_request:
+            # After an ambiguous websocket send failure we cannot prove whether
+            # upstream already accepted the continuation. Re-sending the same
+            # previous_response_id request can fork continuity with duplicate
+            # child responses, so only reconnect-without-resend is allowed.
             return False
         if request_state.replay_count >= 1:
             return False
@@ -3901,6 +3905,9 @@ class ProxyService:
                 return False
             request_state = retryable_requests[0]
             if request_state.previous_response_id is not None:
+                # Once a continuation is pending upstream, reconnecting without
+                # replay cannot complete the current request, while replaying it
+                # is unsafe without upstream idempotency guarantees.
                 return False
             if request_state.replay_count >= 1:
                 return False

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -6547,6 +6547,7 @@ async def test_v1_responses_http_bridge_send_failure_returns_upstream_unavailabl
     assert second.status_code == 502
     assert second.json()["error"]["code"] in ("upstream_unavailable", "stream_incomplete", "bridge_owner_unreachable")
     assert "previous_response_not_found" not in second.json()["error"].get("code", "")
+    assert connect_count == 1
 
 
 @pytest.mark.asyncio
@@ -6656,6 +6657,7 @@ async def test_v1_responses_http_bridge_precreated_disconnect_returns_upstream_u
     assert second.status_code == 502
     assert second.json()["error"]["code"] in ("upstream_unavailable", "stream_incomplete", "upstream_request_timeout")
     assert "previous_response_not_found" not in second.json()["error"].get("code", "")
+    assert connect_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1909,6 +1909,110 @@ async def test_maybe_prewarm_http_bridge_session_skips_continuity_turns(
     reconnect.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_retry_http_bridge_request_on_fresh_upstream_reconnects_without_resending_previous_response_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-1",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_prev_1",
+        transport="http",
+    )
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    recovered = await service._retry_http_bridge_request_on_fresh_upstream(
+        session=session,
+        request_state=request_state,
+        text_data='{"type":"response.create","previous_response_id":"resp_prev_1"}',
+        send_request=False,
+    )
+
+    assert recovered is True
+    assert request_state.replay_count == 1
+    reconnect.assert_awaited_once_with(
+        session,
+        request_state=request_state,
+        restart_reader=True,
+    )
+    send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_request_on_fresh_upstream_refuses_to_resend_previous_response_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-1",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_prev_1",
+        transport="http",
+    )
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    recovered = await service._retry_http_bridge_request_on_fresh_upstream(
+        session=session,
+        request_state=request_state,
+        text_data='{"type":"response.create","previous_response_id":"resp_prev_1"}',
+        send_request=True,
+    )
+
+    assert recovered is False
+    assert request_state.replay_count == 0
+    reconnect.assert_not_awaited()
+    send_text.assert_not_awaited()
+
+
 def test_http_bridge_can_recover_during_drain_for_previous_response_anchor() -> None:
     key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_123", None)
 


### PR DESCRIPTION
## Summary
- document why `previous_response_id` continuation requests must never be replayed after ambiguous websocket drops
- add unit coverage for the allowed reconnect-without-resend path and the blocked resend path
- harden integration regressions to assert these failures stay fail-fast instead of reconnecting and replaying

## Testing
- `.venv/bin/python -m pytest tests/unit/test_proxy_http_bridge.py -k 'reconnects_without_resending_previous_response_id or refuses_to_resend_previous_response_id'`
- `.venv/bin/python -m pytest tests/integration/test_http_responses_bridge.py -k 'send_failure_returns_upstream_unavailable or precreated_disconnect_returns_upstream_unavailable'`