### PR TITLE
fix(api-limit): Add fallback for api limit reset

### DIFF
--- a/app/db/alembic/versions/20260423_120000_add_api_key_limit_reset_at_index.py
+++ b/app/db/alembic/versions/20260423_120000_add_api_key_limit_reset_at_index.py
@@ -1,0 +1,43 @@
+"""add api_key_limits reset_at index
+
+Revision ID: 20260423_120000_add_api_key_limit_reset_at_index
+Revises: 20260421_120000_merge_request_log_lookup_and_plan_type_heads
+Create Date: 2026-04-23
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260423_120000_add_api_key_limit_reset_at_index"
+down_revision = "20260421_120000_merge_request_log_lookup_and_plan_type_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("api_key_limits"):
+        return
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes("api_key_limits")}
+    if "idx_api_key_limits_reset_at" not in existing_indexes:
+        op.create_index(
+            "idx_api_key_limits_reset_at",
+            "api_key_limits",
+            ["reset_at"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("api_key_limits"):
+        return
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes("api_key_limits")}
+    if "idx_api_key_limits_reset_at" in existing_indexes:
+        op.drop_index("idx_api_key_limits_reset_at", table_name="api_key_limits")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -654,6 +654,7 @@ Index("idx_sticky_kind_updated_at", StickySession.kind, StickySession.updated_at
 Index("idx_api_keys_hash", ApiKey.key_hash)
 Index("idx_api_key_accounts_account_id", ApiKeyAccountAssignment.account_id)
 Index("idx_api_key_limits_key_id", ApiKeyLimit.api_key_id)
+Index("idx_api_key_limits_reset_at", ApiKeyLimit.reset_at)
 Index("idx_api_key_usage_reservations_key_id", ApiKeyUsageReservation.api_key_id)
 Index("idx_api_key_usage_reservations_status", ApiKeyUsageReservation.status)
 Index("idx_api_key_usage_res_items_reservation_id", ApiKeyUsageReservationItem.reservation_id)

--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ from app.core.usage.refresh_scheduler import build_usage_refresh_scheduler
 from app.db.session import SessionLocal, close_db, init_background_db, init_db
 from app.modules.accounts import api as accounts_api
 from app.modules.api_keys import api as api_keys_api
+from app.modules.api_keys.reset_scheduler import build_api_key_limit_reset_scheduler
 from app.modules.audit import api as audit_api
 from app.modules.dashboard import api as dashboard_api
 from app.modules.dashboard_auth import api as dashboard_auth_api
@@ -124,9 +125,11 @@ async def lifespan(app: FastAPI):
     if bridge_durable_schema_ready:
         startup_module.mark_bridge_durable_schema_ready()
     usage_scheduler = build_usage_refresh_scheduler()
+    api_key_limit_reset_scheduler = build_api_key_limit_reset_scheduler()
     model_scheduler = build_model_refresh_scheduler()
     sticky_session_cleanup_scheduler = build_sticky_session_cleanup_scheduler()
     await usage_scheduler.start()
+    await api_key_limit_reset_scheduler.start()
     await model_scheduler.start()
     await sticky_session_cleanup_scheduler.start()
     if settings.metrics_enabled and PROMETHEUS_AVAILABLE:
@@ -285,6 +288,7 @@ async def lifespan(app: FastAPI):
         await cache_poller.stop()
         await sticky_session_cleanup_scheduler.stop()
         await model_scheduler.stop()
+        await api_key_limit_reset_scheduler.stop()
         await usage_scheduler.stop()
         try:
             await close_http_client()

--- a/app/modules/api_keys/limit_windows.py
+++ b/app/modules/api_keys/limit_windows.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from app.db.models import LimitWindow
+
+
+def next_limit_reset(now: datetime, window: LimitWindow) -> datetime:
+    if window == LimitWindow.FIVE_HOURS:
+        return now + timedelta(hours=5)
+    if window == LimitWindow.SEVEN_DAYS:
+        return now + timedelta(days=7)
+    if window == LimitWindow.DAILY:
+        return now + timedelta(days=1)
+    if window == LimitWindow.WEEKLY:
+        return now + timedelta(days=7)
+    if window == LimitWindow.MONTHLY:
+        return now + timedelta(days=30)
+    return now + timedelta(days=7)
+
+
+def advance_limit_reset(reset_at: datetime, now: datetime, window: LimitWindow) -> datetime:
+    delta = limit_window_delta(window)
+    next_reset = reset_at
+    while next_reset <= now:
+        next_reset += delta
+    return next_reset
+
+
+def limit_window_delta(window: LimitWindow) -> timedelta:
+    if window == LimitWindow.FIVE_HOURS:
+        return timedelta(hours=5)
+    if window == LimitWindow.SEVEN_DAYS:
+        return timedelta(days=7)
+    if window == LimitWindow.DAILY:
+        return timedelta(days=1)
+    if window == LimitWindow.WEEKLY:
+        return timedelta(days=7)
+    if window == LimitWindow.MONTHLY:
+        return timedelta(days=30)
+    return timedelta(days=7)

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -20,6 +20,7 @@ from app.db.models import (
     LimitWindow,
     RequestLog,
 )
+from app.modules.api_keys.limit_windows import advance_limit_reset
 
 
 @dataclass(frozen=True, slots=True)
@@ -344,6 +345,31 @@ class ApiKeysRepository:
         )
         await self._session.commit()
         return result.scalar_one_or_none() is not None
+
+    async def reset_expired_limits(self, *, now: datetime) -> int:
+        result = await self._session.execute(select(ApiKeyLimit).where(ApiKeyLimit.reset_at < now))
+        expired_limits = list(result.scalars().all())
+        if not expired_limits:
+            return 0
+
+        reset_count = 0
+        for limit in expired_limits:
+            update_result = await self._session.execute(
+                update(ApiKeyLimit)
+                .where(ApiKeyLimit.id == limit.id)
+                .where(ApiKeyLimit.reset_at == limit.reset_at)
+                .values(
+                    current_value=0,
+                    reset_at=advance_limit_reset(limit.reset_at, now, limit.limit_window),
+                )
+                .returning(ApiKeyLimit.id)
+            )
+            if update_result.scalar_one_or_none() is not None:
+                reset_count += 1
+
+        if reset_count > 0:
+            await self._session.commit()
+        return reset_count
 
     async def try_reserve_usage(
         self,

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -78,6 +78,7 @@ class _Unset(Enum):
 
 
 _UNSET = _Unset.UNSET
+_EXPIRED_LIMIT_RESET_BATCH_SIZE = 500
 
 
 class ApiKeysRepository:
@@ -347,29 +348,36 @@ class ApiKeysRepository:
         return result.scalar_one_or_none() is not None
 
     async def reset_expired_limits(self, *, now: datetime) -> int:
-        result = await self._session.execute(select(ApiKeyLimit).where(ApiKeyLimit.reset_at < now))
-        expired_limits = list(result.scalars().all())
-        if not expired_limits:
-            return 0
-
         reset_count = 0
-        for limit in expired_limits:
-            update_result = await self._session.execute(
-                update(ApiKeyLimit)
-                .where(ApiKeyLimit.id == limit.id)
-                .where(ApiKeyLimit.reset_at == limit.reset_at)
-                .values(
-                    current_value=0,
-                    reset_at=advance_limit_reset(limit.reset_at, now, limit.limit_window),
+        while True:
+            result = await self._session.execute(
+                select(
+                    ApiKeyLimit.id,
+                    ApiKeyLimit.reset_at,
+                    ApiKeyLimit.limit_window,
                 )
-                .returning(ApiKeyLimit.id)
+                .where(ApiKeyLimit.reset_at < now)
+                .order_by(ApiKeyLimit.reset_at.asc(), ApiKeyLimit.id.asc())
+                .limit(_EXPIRED_LIMIT_RESET_BATCH_SIZE)
             )
-            if update_result.scalar_one_or_none() is not None:
-                reset_count += 1
+            expired_limits = result.all()
+            if not expired_limits:
+                return reset_count
 
-        if reset_count > 0:
+            for limit in expired_limits:
+                update_result = await self._session.execute(
+                    update(ApiKeyLimit)
+                    .where(ApiKeyLimit.id == limit.id)
+                    .where(ApiKeyLimit.reset_at == limit.reset_at)
+                    .values(
+                        current_value=0,
+                        reset_at=advance_limit_reset(limit.reset_at, now, limit.limit_window),
+                    )
+                    .returning(ApiKeyLimit.id)
+                )
+                if update_result.scalar_one_or_none() is not None:
+                    reset_count += 1
             await self._session.commit()
-        return reset_count
 
     async def try_reserve_usage(
         self,

--- a/app/modules/api_keys/reset_scheduler.py
+++ b/app/modules/api_keys/reset_scheduler.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import logging
+from dataclasses import dataclass, field
+from typing import Protocol, cast
+
+from app.core.utils.time import utcnow
+from app.db.session import get_background_session
+from app.modules.api_keys.repository import ApiKeysRepository
+
+logger = logging.getLogger(__name__)
+
+_API_KEY_LIMIT_RESET_INTERVAL_SECONDS = 3600
+
+
+class _LeaderElectionLike(Protocol):
+    async def try_acquire(self) -> bool: ...
+
+
+def _get_leader_election() -> _LeaderElectionLike:
+    module = importlib.import_module("app.core.scheduling.leader_election")
+    return cast(_LeaderElectionLike, module.get_leader_election())
+
+
+@dataclass(slots=True)
+class ApiKeyLimitResetScheduler:
+    interval_seconds: int
+    enabled: bool
+    _task: asyncio.Task[None] | None = None
+    _stop: asyncio.Event = field(default_factory=asyncio.Event)
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def start(self) -> None:
+        if not self.enabled:
+            return
+        if self._task and not self._task.done():
+            return
+        self._stop.clear()
+        self._task = asyncio.create_task(self._run_loop())
+
+    async def stop(self) -> None:
+        if not self._task:
+            return
+        self._stop.set()
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    async def _run_loop(self) -> None:
+        while not self._stop.is_set():
+            await self._reset_once()
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self.interval_seconds)
+            except asyncio.TimeoutError:
+                continue
+
+    async def _reset_once(self) -> None:
+        if not await _get_leader_election().try_acquire():
+            return
+        async with self._lock:
+            try:
+                async with get_background_session() as session:
+                    repo = ApiKeysRepository(session)
+                    reset_count = await repo.reset_expired_limits(now=utcnow())
+                    if reset_count > 0:
+                        logger.info("Reset expired API key limits reset_count=%s", reset_count)
+            except Exception:
+                logger.exception("API key limit reset loop failed")
+
+
+def build_api_key_limit_reset_scheduler() -> ApiKeyLimitResetScheduler:
+    return ApiKeyLimitResetScheduler(
+        interval_seconds=_API_KEY_LIMIT_RESET_INTERVAL_SECONDS,
+        enabled=True,
+    )

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -17,6 +17,7 @@ from app.core.usage.pricing import (
 )
 from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import Account, ApiKey, ApiKeyLimit, LimitType, LimitWindow
+from app.modules.api_keys.limit_windows import advance_limit_reset, next_limit_reset
 from app.modules.api_keys.repository import (
     _UNSET,
     ApiKeyTrendBucket,
@@ -990,7 +991,7 @@ async def _lazy_reset_expired_limits(
     for limit in limits:
         if limit.reset_at >= now:
             continue
-        new_reset_at = _advance_reset(limit.reset_at, now, limit.limit_window)
+        new_reset_at = advance_limit_reset(limit.reset_at, now, limit.limit_window)
         await repository.reset_limit(
             limit.id,
             expected_reset_at=limit.reset_at,
@@ -1161,7 +1162,7 @@ def _limit_input_to_row(
         max_value=li.max_value,
         current_value=current_value,
         model_filter=li.model_filter,
-        reset_at=reset_at if reset_at is not None else _next_reset(now, window),
+        reset_at=reset_at if reset_at is not None else next_limit_reset(now, window),
     )
 
 
@@ -1213,7 +1214,7 @@ def _build_reset_limit_rows(
                 max_value=existing.max_value,
                 current_value=0,
                 model_filter=existing.model_filter,
-                reset_at=_next_reset(now, existing.limit_window),
+                reset_at=next_limit_reset(now, existing.limit_window),
             )
         )
     return rows
@@ -1225,42 +1226,6 @@ def _limit_identity_from_input(limit: LimitRuleInput) -> tuple[str, str, str | N
 
 def _limit_identity_from_row(limit: ApiKeyLimit) -> tuple[str, str, str | None]:
     return (limit.limit_type.value, limit.limit_window.value, limit.model_filter)
-
-
-def _next_reset(now: datetime, window: LimitWindow) -> datetime:
-    if window == LimitWindow.FIVE_HOURS:
-        return now + timedelta(hours=5)
-    if window == LimitWindow.SEVEN_DAYS:
-        return now + timedelta(days=7)
-    if window == LimitWindow.DAILY:
-        return now + timedelta(days=1)
-    if window == LimitWindow.WEEKLY:
-        return now + timedelta(days=7)
-    if window == LimitWindow.MONTHLY:
-        return now + timedelta(days=30)
-    return now + timedelta(days=7)
-
-
-def _advance_reset(reset_at: datetime, now: datetime, window: LimitWindow) -> datetime:
-    delta = _window_delta(window)
-    next_reset = reset_at
-    while next_reset <= now:
-        next_reset += delta
-    return next_reset
-
-
-def _window_delta(window: LimitWindow) -> timedelta:
-    if window == LimitWindow.FIVE_HOURS:
-        return timedelta(hours=5)
-    if window == LimitWindow.SEVEN_DAYS:
-        return timedelta(days=7)
-    if window == LimitWindow.DAILY:
-        return timedelta(days=1)
-    if window == LimitWindow.WEEKLY:
-        return timedelta(days=7)
-    if window == LimitWindow.MONTHLY:
-        return timedelta(days=30)
-    return timedelta(days=7)
 
 
 def _calculate_cost_microdollars(

--- a/frontend/src/features/settings/components/appearance-settings.tsx
+++ b/frontend/src/features/settings/components/appearance-settings.tsx
@@ -36,54 +36,56 @@ export function AppearanceSettings() {
           </div>
         </div>
 
-        <div className="flex items-center justify-between rounded-lg border p-3">
-          <div>
-            <p className="text-sm font-medium">Theme</p>
-            <p className="text-xs text-muted-foreground">Select your preferred color scheme.</p>
+        <div className="divide-y rounded-lg border">
+          <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-medium">Theme</p>
+              <p className="text-xs text-muted-foreground">Select your preferred color scheme.</p>
+            </div>
+            <div className="flex items-center gap-1 rounded-lg border border-border/50 bg-muted/40 p-0.5">
+              {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+                <button
+                  key={value}
+                  type="button"
+                  aria-pressed={preference === value}
+                  onClick={() => setTheme(value)}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors duration-200",
+                    preference === value
+                      ? "bg-background text-foreground shadow-[var(--shadow-xs)]"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" />
+                  {label}
+                </button>
+              ))}
+            </div>
           </div>
-          <div className="flex items-center gap-1 rounded-lg border border-border/50 bg-muted/40 p-0.5">
-            {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
-              <button
-                key={value}
-                type="button"
-                aria-pressed={preference === value}
-                onClick={() => setTheme(value)}
-                className={cn(
-                  "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors duration-200",
-                  preference === value
-                    ? "bg-background text-foreground shadow-[var(--shadow-xs)]"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-              >
-                <Icon className="h-3.5 w-3.5" />
-                {label}
-              </button>
-            ))}
-          </div>
-        </div>
 
-        <div className="flex items-center justify-between rounded-lg border p-3">
-          <div>
-            <p className="text-sm font-medium">Time format</p>
-            <p className="text-xs text-muted-foreground">Apply 12h or 24h formatting to datetimes across the dashboard.</p>
-          </div>
-          <div className="flex items-center gap-1 rounded-lg border border-border/50 bg-muted/40 p-0.5">
-            {TIME_FORMAT_OPTIONS.map(({ value, label }) => (
-              <button
-                key={value}
-                type="button"
-                aria-pressed={timeFormat === value}
-                onClick={() => setTimeFormat(value)}
-                className={cn(
-                  "rounded-md px-3 py-1.5 text-left text-xs font-medium transition-colors duration-200",
-                  timeFormat === value
-                    ? "bg-background text-foreground shadow-[var(--shadow-xs)]"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-              >
-                <span className="block">{label}</span>
-              </button>
-            ))}
+          <div className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-medium">Time format</p>
+              <p className="text-xs text-muted-foreground">Apply 12h or 24h formatting to datetimes across the dashboard.</p>
+            </div>
+            <div className="flex items-center gap-1 rounded-lg border border-border/50 bg-muted/40 p-0.5">
+              {TIME_FORMAT_OPTIONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  type="button"
+                  aria-pressed={timeFormat === value}
+                  onClick={() => setTimeFormat(value)}
+                  className={cn(
+                    "rounded-md px-3 py-1.5 text-left text-xs font-medium transition-colors duration-200",
+                    timeFormat === value
+                      ? "bg-background text-foreground shadow-[var(--shadow-xs)]"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <span className="block">{label}</span>
+                </button>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/features/settings/components/appearance-settings.tsx
+++ b/frontend/src/features/settings/components/appearance-settings.tsx
@@ -1,4 +1,4 @@
-import { Clock3, Monitor, Moon, Palette, Sun } from "lucide-react";
+import { Monitor, Moon, Palette, Sun } from "lucide-react";
 
 import { useThemeStore, type ThemePreference } from "@/hooks/use-theme";
 import { useTimeFormatStore, type TimeFormatPreference } from "@/hooks/use-time-format";
@@ -10,9 +10,9 @@ const THEME_OPTIONS: { value: ThemePreference; label: string; icon: typeof Sun }
   { value: "auto", label: "System", icon: Monitor },
 ];
 
-const TIME_FORMAT_OPTIONS: { value: TimeFormatPreference; label: string; preview: string }[] = [
-  { value: "12h", label: "12h", preview: "03:45 PM" },
-  { value: "24h", label: "24h", preview: "15:45" },
+const TIME_FORMAT_OPTIONS: { value: TimeFormatPreference; label: string }[] = [
+  { value: "12h", label: "12h" },
+  { value: "24h", label: "24h" },
 ];
 
 export function AppearanceSettings() {
@@ -29,12 +29,12 @@ export function AppearanceSettings() {
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
               <Palette className="h-4 w-4 text-primary" aria-hidden="true" />
             </div>
-             <div>
-               <h3 className="text-sm font-semibold">Appearance</h3>
-               <p className="text-xs text-muted-foreground">Choose how the interface looks and how time is displayed.</p>
-             </div>
-           </div>
-         </div>
+            <div>
+              <h3 className="text-sm font-semibold">Appearance</h3>
+              <p className="text-xs text-muted-foreground">Choose how the interface looks and how time is displayed.</p>
+            </div>
+          </div>
+        </div>
 
         <div className="flex items-center justify-between rounded-lg border p-3">
           <div>
@@ -63,17 +63,12 @@ export function AppearanceSettings() {
         </div>
 
         <div className="flex items-center justify-between rounded-lg border p-3">
-          <div className="flex items-start gap-3">
-            <div className="mt-0.5 flex h-7 w-7 items-center justify-center rounded-md bg-primary/10">
-              <Clock3 className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
-            </div>
-            <div>
-              <p className="text-sm font-medium">Time format</p>
-              <p className="text-xs text-muted-foreground">Apply 12h or 24h formatting to datetimes across the dashboard.</p>
-            </div>
+          <div>
+            <p className="text-sm font-medium">Time format</p>
+            <p className="text-xs text-muted-foreground">Apply 12h or 24h formatting to datetimes across the dashboard.</p>
           </div>
           <div className="flex items-center gap-1 rounded-lg border border-border/50 bg-muted/40 p-0.5">
-            {TIME_FORMAT_OPTIONS.map(({ value, label, preview }) => (
+            {TIME_FORMAT_OPTIONS.map(({ value, label }) => (
               <button
                 key={value}
                 type="button"
@@ -87,7 +82,6 @@ export function AppearanceSettings() {
                 )}
               >
                 <span className="block">{label}</span>
-                <span className="block text-[10px] font-normal text-muted-foreground">{preview}</span>
               </button>
             ))}
           </div>

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -180,7 +180,7 @@ The system SHALL atomically increment `weekly_tokens_used` on the API key record
 
 ### Requirement: Weekly token usage reset
 
-The system SHALL reset `weekly_tokens_used` to 0 using a lazy on-read strategy. When validating an API key, if `weekly_reset_at < now()`, the system MUST reset the counter and advance `weekly_reset_at` by 7-day intervals until it is in the future.
+The system SHALL keep the existing lazy on-read reset strategy for API key usage limits. When validating an API key, if a limit `reset_at < now()`, the system MUST reset the counter and advance `reset_at` by whole window intervals until it is in the future. The system MUST also run an hourly background fallback sweep that repairs expired API key limit usage even when no validation request arrives.
 
 #### Scenario: Weekly reset triggered on validation
 
@@ -191,6 +191,11 @@ The system SHALL reset `weekly_tokens_used` to 0 using a lazy on-read strategy. 
 
 - **WHEN** an API key is validated and `weekly_reset_at` is in the future
 - **THEN** no reset occurs; `weekly_tokens_used` retains its current value
+
+#### Scenario: Hourly fallback resets expired usage without a read
+
+- **WHEN** an API key usage limit is expired and no validation request occurs
+- **THEN** the hourly background fallback resets `current_value` to 0 and advances `reset_at` into the future
 
 ### Requirement: RequestLog API key reference
 

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 import pytest
 from sqlalchemy import select, update
 
+import app.modules.api_keys.repository as api_keys_repository_module
 import app.modules.proxy.load_balancer as load_balancer_module
 import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
@@ -2058,6 +2059,57 @@ async def test_reset_expired_limits_background_fallback_advances_windows(async_c
         assert daily_limit.reset_at == now + timedelta(days=1)
         assert weekly_limit.current_value == 0
         assert weekly_limit.reset_at == now + timedelta(days=7)
+
+
+@pytest.mark.asyncio
+async def test_reset_expired_limits_background_fallback_processes_batches(async_client, monkeypatch):
+    monkeypatch.setattr(api_keys_repository_module, "_EXPIRED_LIMIT_RESET_BATCH_SIZE", 2)
+
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "batched-reset",
+            "allowedModels": [],
+            "limits": [
+                {"limitType": "total_tokens", "limitWindow": "daily", "maxValue": 1000},
+                {"limitType": "input_tokens", "limitWindow": "weekly", "maxValue": 1000},
+                {"limitType": "output_tokens", "limitWindow": "monthly", "maxValue": 1000},
+            ],
+        },
+    )
+    assert created.status_code == 200
+    key_id = created.json()["id"]
+
+    now = utcnow()
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        limits = await repo.get_limits_by_key(key_id)
+        assert len(limits) == 3
+        for limit in limits:
+            limit.current_value = 42
+            if limit.limit_window == LimitWindow.DAILY:
+                limit.reset_at = now - timedelta(days=2)
+            elif limit.limit_window == LimitWindow.WEEKLY:
+                limit.reset_at = now - timedelta(days=14)
+            else:
+                limit.reset_at = now - timedelta(days=60)
+        await session.commit()
+
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        reset_count = await repo.reset_expired_limits(now=now)
+        assert reset_count == 3
+
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        limits = await repo.get_limits_by_key(key_id)
+        by_window = {limit.limit_window: limit for limit in limits}
+        assert by_window[LimitWindow.DAILY].current_value == 0
+        assert by_window[LimitWindow.DAILY].reset_at == now + timedelta(days=1)
+        assert by_window[LimitWindow.WEEKLY].current_value == 0
+        assert by_window[LimitWindow.WEEKLY].reset_at == now + timedelta(days=7)
+        assert by_window[LimitWindow.MONTHLY].current_value == 0
+        assert by_window[LimitWindow.MONTHLY].reset_at == now + timedelta(days=30)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -15,7 +15,7 @@ from app.core.clients.proxy import ProxyResponseError
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
 from app.core.openai.models import OpenAIResponsePayload
 from app.core.utils.time import utcnow
-from app.db.models import RequestLog
+from app.db.models import LimitWindow, RequestLog
 from app.db.session import SessionLocal
 from app.modules.api_keys.repository import ApiKeysRepository
 
@@ -2014,6 +2014,50 @@ async def test_update_key_reset_usage_requires_explicit_action(async_client):
         assert len(limits) == 1
         assert limits[0].current_value == 0
         assert limits[0].reset_at > original_reset_at
+
+
+@pytest.mark.asyncio
+async def test_reset_expired_limits_background_fallback_advances_windows(async_client):
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "hourly-reset-fallback",
+            "limits": [
+                {"limitType": "total_tokens", "limitWindow": "daily", "maxValue": 1000},
+                {"limitType": "cost_usd", "limitWindow": "weekly", "maxValue": 1000},
+            ],
+        },
+    )
+    assert created.status_code == 200
+    key_id = created.json()["id"]
+
+    now = utcnow()
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        limits = await repo.get_limits_by_key(key_id)
+        assert len(limits) == 2
+        daily_limit = next(limit for limit in limits if limit.limit_window == LimitWindow.DAILY)
+        weekly_limit = next(limit for limit in limits if limit.limit_window == LimitWindow.WEEKLY)
+        daily_limit.current_value = 123
+        daily_limit.reset_at = now - timedelta(days=2)
+        weekly_limit.current_value = 456
+        weekly_limit.reset_at = now - timedelta(days=14)
+        await session.commit()
+
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        reset_count = await repo.reset_expired_limits(now=now)
+        assert reset_count == 2
+
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        limits = await repo.get_limits_by_key(key_id)
+        daily_limit = next(limit for limit in limits if limit.limit_window == LimitWindow.DAILY)
+        weekly_limit = next(limit for limit in limits if limit.limit_window == LimitWindow.WEEKLY)
+        assert daily_limit.current_value == 0
+        assert daily_limit.reset_at == now + timedelta(days=1)
+        assert weekly_limit.current_value == 0
+        assert weekly_limit.reset_at == now + timedelta(days=7)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_api_key_limit_reset_scheduler.py
+++ b/tests/unit/test_api_key_limit_reset_scheduler.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.modules.api_keys.reset_scheduler as reset_scheduler
+
+pytestmark = pytest.mark.unit
+
+
+def test_build_api_key_limit_reset_scheduler_uses_fixed_hourly_interval() -> None:
+    scheduler = reset_scheduler.build_api_key_limit_reset_scheduler()
+
+    assert scheduler.interval_seconds == 3600
+    assert scheduler.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_reset_once_resets_expired_limits(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = AsyncMock()
+    repo.reset_expired_limits = AsyncMock(return_value=3)
+
+    class FakeSession:
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *args):
+            pass
+
+    scheduler = reset_scheduler.ApiKeyLimitResetScheduler(interval_seconds=3600, enabled=True)
+    leader = SimpleNamespace(try_acquire=AsyncMock(return_value=True))
+
+    monkeypatch.setattr(reset_scheduler, "_get_leader_election", lambda: leader)
+
+    with (
+        patch.object(reset_scheduler, "get_background_session", FakeSession),
+        patch.object(reset_scheduler, "ApiKeysRepository", return_value=repo),
+    ):
+        await scheduler._reset_once()
+
+    leader.try_acquire.assert_awaited_once()
+    repo.reset_expired_limits.assert_awaited_once()

--- a/tests/unit/test_api_keys_repository.py
+++ b/tests/unit/test_api_keys_repository.py
@@ -9,7 +9,6 @@ import pytest
 from app.db.models import LimitWindow
 from app.modules.api_keys.repository import ApiKeysRepository
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/unit/test_api_keys_repository.py
+++ b/tests/unit/test_api_keys_repository.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.db.models import LimitWindow
+from app.modules.api_keys.repository import ApiKeysRepository
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_reset_expired_limits_counts_successful_updates_without_rowcount() -> None:
+    session = AsyncMock()
+    repo = ApiKeysRepository(session)
+    now = datetime(2026, 4, 23, 12, 0, 0)
+    expired_limits = [
+        SimpleNamespace(id=101, reset_at=now - timedelta(days=2), limit_window=LimitWindow.DAILY),
+        SimpleNamespace(id=102, reset_at=now - timedelta(days=14), limit_window=LimitWindow.WEEKLY),
+    ]
+
+    executed_sql: list[str] = []
+
+    async def _execute(statement):
+        executed_sql.append(str(statement))
+        call_index = len(executed_sql)
+        if call_index == 1:
+            return SimpleNamespace(all=lambda: expired_limits)
+        if call_index == 2:
+            return SimpleNamespace(rowcount=-1, scalar_one_or_none=lambda: 101)
+        if call_index == 3:
+            return SimpleNamespace(rowcount=-1, scalar_one_or_none=lambda: None)
+        if call_index == 4:
+            return SimpleNamespace(all=lambda: [])
+        raise AssertionError(f"unexpected execute call {call_index}")
+
+    session.execute.side_effect = _execute
+
+    reset_count = await repo.reset_expired_limits(now=now)
+
+    assert reset_count == 1
+    assert len(executed_sql) == 4
+    assert "RETURNING api_key_limits.id" in executed_sql[1]
+    assert "RETURNING api_key_limits.id" in executed_sql[2]
+    session.commit.assert_awaited_once()

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -261,6 +261,7 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     )
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
     usage_scheduler = _DummyScheduler()
+    api_key_limit_reset_scheduler = _DummyScheduler()
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
     ring_service = SimpleNamespace(
@@ -296,6 +297,7 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     monkeypatch.setattr(main, "close_http_client", close_http_client)
     monkeypatch.setattr(main, "close_db", close_db)
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
+    monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(main, "RingMembershipService", lambda session_factory: ring_service)
@@ -304,6 +306,7 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
         await asyncio.sleep(0)
         assert startup_module._startup_complete is True
         assert usage_scheduler.started is True
+        assert api_key_limit_reset_scheduler.started is True
         assert model_scheduler.started is True
         assert sticky_scheduler.started is True
 
@@ -316,6 +319,7 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     rate_limit_cache.invalidate.assert_awaited_once()
     assert call_order[:2] == ["init_db", "init_background_db"]
     assert usage_scheduler.stopped is True
+    assert api_key_limit_reset_scheduler.stopped is True
     assert model_scheduler.stopped is True
     assert sticky_scheduler.stopped is True
 
@@ -338,6 +342,7 @@ async def test_lifespan_marks_bridge_membership_stale_on_shutdown(monkeypatch: p
     )
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
     usage_scheduler = _DummyScheduler()
+    api_key_limit_reset_scheduler = _DummyScheduler()
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
     close_http_client = AsyncMock()
@@ -372,6 +377,7 @@ async def test_lifespan_marks_bridge_membership_stale_on_shutdown(monkeypatch: p
     monkeypatch.setattr(main, "close_http_client", close_http_client)
     monkeypatch.setattr(main, "close_db", close_db)
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
+    monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(main, "RingMembershipService", lambda session_factory: ring_service)
@@ -427,6 +433,7 @@ async def test_lifespan_shutdown_fails_bridge_capacity_waiter_and_cancels_usage_
     )
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
     usage_scheduler = _NoopStartUsageScheduler(interval_seconds=60, enabled=True)
+    api_key_limit_reset_scheduler = _DummyScheduler()
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
     close_http_client = AsyncMock()
@@ -455,6 +462,7 @@ async def test_lifespan_shutdown_fails_bridge_capacity_waiter_and_cancels_usage_
     monkeypatch.setattr(main, "close_http_client", close_http_client)
     monkeypatch.setattr(main, "close_db", close_db)
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
+    monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(main, "RingMembershipService", lambda session_factory: ring_service)
@@ -590,6 +598,7 @@ async def test_lifespan_marks_bridge_membership_stale_for_hostname_shared_ids(
     )
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
     usage_scheduler = _DummyScheduler()
+    api_key_limit_reset_scheduler = _DummyScheduler()
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
     close_http_client = AsyncMock()
@@ -624,6 +633,7 @@ async def test_lifespan_marks_bridge_membership_stale_for_hostname_shared_ids(
     monkeypatch.setattr(main, "close_http_client", close_http_client)
     monkeypatch.setattr(main, "close_db", close_db)
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
+    monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(main, "RingMembershipService", lambda session_factory: ring_service)
@@ -664,6 +674,7 @@ async def test_lifespan_registers_bridge_without_waiting_for_advertise_self_prob
     settings_cache = SimpleNamespace(invalidate=AsyncMock())
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
     usage_scheduler = _DummyScheduler()
+    api_key_limit_reset_scheduler = _DummyScheduler()
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
     close_http_client = AsyncMock()
@@ -694,6 +705,7 @@ async def test_lifespan_registers_bridge_without_waiting_for_advertise_self_prob
     monkeypatch.setattr(main, "close_http_client", close_http_client)
     monkeypatch.setattr(main, "close_db", close_db)
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
+    monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(main, "RingMembershipService", lambda session_factory: ring_service)
@@ -749,6 +761,7 @@ async def test_lifespan_fails_fast_when_bridge_durable_schema_is_missing(monkeyp
     settings_cache = SimpleNamespace(invalidate=AsyncMock())
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
     usage_scheduler = _DummyScheduler()
+    api_key_limit_reset_scheduler = _DummyScheduler()
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
 
@@ -763,6 +776,7 @@ async def test_lifespan_fails_fast_when_bridge_durable_schema_is_missing(monkeyp
     monkeypatch.setattr(main, "close_http_client", AsyncMock())
     monkeypatch.setattr(main, "close_db", AsyncMock())
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
+    monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(
@@ -791,6 +805,7 @@ async def test_lifespan_allows_missing_bridge_schema_when_fail_fast_disabled(mon
     )
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
     usage_scheduler = _DummyScheduler()
+    api_key_limit_reset_scheduler = _DummyScheduler()
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
     ring_service = SimpleNamespace(
@@ -809,6 +824,7 @@ async def test_lifespan_allows_missing_bridge_schema_when_fail_fast_disabled(mon
     monkeypatch.setattr(main, "close_http_client", AsyncMock())
     monkeypatch.setattr(main, "close_db", AsyncMock())
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
+    monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(main, "RingMembershipService", lambda session_factory: ring_service)


### PR DESCRIPTION
<img width="1056" height="645" alt="螢幕截圖 2026-04-23 21 00 08" src="https://github.com/user-attachments/assets/11128fac-3aa2-42c0-95e0-02bb46785e09" />

Added a fallback to reset expired api limit per hour as the old logic relies on lazy reset, which will make stale UI limit still "visually exist" before shooting the request (the lazy reset)
But still preserve the lazy reset for accurate timing

And also a very minor UI adjustment for cleaner time setting, removed the icon and the example
<img width="857" height="187" alt="螢幕截圖 2026-04-24 02 07 12" src="https://github.com/user-attachments/assets/46e991fa-65de-4373-81fe-38b2470cf5a5" />


