### PR TITLE
feat(proxy): make response.create payload limit configurable

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -89,8 +89,8 @@ _IMAGE_INLINE_MAX_BYTES = 8 * 1024 * 1024
 _IMAGE_INLINE_CHUNK_SIZE = 64 * 1024
 _IMAGE_INLINE_TIMEOUT_SECONDS = 8.0
 _BLOCKED_LITERAL_HOSTS = {"localhost", "localhost.localdomain"}
-_UPSTREAM_RESPONSE_CREATE_WARN_BYTES = 12 * 1024 * 1024
-_UPSTREAM_RESPONSE_CREATE_MAX_BYTES = 15 * 1024 * 1024
+_UPSTREAM_RESPONSE_CREATE_MAX_BYTES = get_settings().upstream_response_create_max_bytes
+_UPSTREAM_RESPONSE_CREATE_WARN_BYTES = int(_UPSTREAM_RESPONSE_CREATE_MAX_BYTES * 0.8)
 _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE = (
     "[codex-lb omitted historical tool output ({bytes} bytes) to fit upstream websocket budget]"
 )

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -140,6 +140,7 @@ class Settings(BaseSettings):
     # large built-in tool payloads (for example image_generation outputs) do not
     # fail locally with a 1009 before upstream completion.
     max_sse_event_bytes: int = Field(default=16 * 1024 * 1024, gt=0)
+    upstream_response_create_max_bytes: int = Field(default=15 * 1024 * 1024, gt=0)
     auth_base_url: str = "https://auth.openai.com"
     oauth_client_id: str = "app_EMoamEEZ73f0CkXaXp7hrann"
     oauth_originator: str = "codex_chatgpt_desktop"

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -161,10 +161,8 @@ from app.modules.usage.updater import UsageUpdater
 
 logger = logging.getLogger(__name__)
 
-# Stay below the common 16 MiB websocket message ceiling so we can slim or fail
-# early before upstream closes the session with 1009.
-_UPSTREAM_RESPONSE_CREATE_WARN_BYTES = 12 * 1024 * 1024
-_UPSTREAM_RESPONSE_CREATE_MAX_BYTES = 15 * 1024 * 1024
+_UPSTREAM_RESPONSE_CREATE_MAX_BYTES = get_settings().upstream_response_create_max_bytes
+_UPSTREAM_RESPONSE_CREATE_WARN_BYTES = int(_UPSTREAM_RESPONSE_CREATE_MAX_BYTES * 0.8)
 _OVERSIZED_RESPONSE_CREATE_DUMP_DIR = Path("/var/lib/codex-lb/debug/response-create-dumps")
 _OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS = 10
 _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE = (


### PR DESCRIPTION
## Summary

The 15 MiB `response.create` websocket payload limit is hardcoded in both `app/modules/proxy/service.py` and `app/core/clients/proxy.py`. This makes it impossible to raise the ceiling without patching source and restarting.

This adds `CODEX_LB_UPSTREAM_RESPONSE_CREATE_MAX_BYTES` to `Settings` so operators can tune the limit via env var or `.env` file. The warn threshold stays proportional at 80% of max. Default is unchanged (15 MiB).

## Changes

- Add `upstream_response_create_max_bytes` field to `Settings` (pydantic, `gt=0`, default `15 * 1024 * 1024`)
- Both modules read the value from settings at import time instead of hardcoding
- Warn threshold derived as `int(max * 0.8)` — no separate config needed
- Existing tests unaffected (they monkeypatch the module-level constant directly)

## Test plan

- [x] Verified default value matches original (15728640 bytes)
- [x] Verified env var override: `CODEX_LB_UPSTREAM_RESPONSE_CREATE_MAX_BYTES=33554432` → 32 MiB
- [x] Ran `test_proxy_utils.py` — all 207 tests pass