### PR TITLE
feat(proxy): add GPT-5.5 and GPT-5.5 Pro model support

### DIFF
--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -48,7 +48,7 @@ class ModelRegistrySnapshot:
     fetched_at: float
 
 
-_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = ("gpt-5.4", "gpt-5.4-*")
+_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = ("gpt-5.5", "gpt-5.5-*", "gpt-5.4", "gpt-5.4-*")
 
 
 class ModelRegistry:

--- a/app/core/usage/pricing.py
+++ b/app/core/usage/pricing.py
@@ -70,6 +70,23 @@ def _normalize_usage(usage: UsageTokens | ResponseUsage | None) -> UsageTokens |
 
 
 DEFAULT_PRICING_MODELS: dict[str, ModelPrice] = {
+    "gpt-5.5": ModelPrice(
+        input_per_1m=5.0,
+        cached_input_per_1m=0.5,
+        output_per_1m=30.0,
+        flex_input_per_1m=2.5,
+        flex_cached_input_per_1m=0.25,
+        flex_output_per_1m=15.0,
+        priority_input_per_1m=12.5,
+        priority_cached_input_per_1m=1.25,
+        priority_output_per_1m=75.0,
+    ),
+    "gpt-5.5-pro": ModelPrice(
+        input_per_1m=30.0,
+        output_per_1m=180.0,
+        flex_input_per_1m=15.0,
+        flex_output_per_1m=90.0,
+    ),
     "gpt-5.4": ModelPrice(
         input_per_1m=2.5,
         cached_input_per_1m=0.25,
@@ -210,6 +227,8 @@ DEFAULT_PRICING_MODELS: dict[str, ModelPrice] = {
 }
 
 DEFAULT_MODEL_ALIASES: dict[str, str] = {
+    "gpt-5.5-pro*": "gpt-5.5-pro",
+    "gpt-5.5*": "gpt-5.5",
     "gpt-5.4-pro*": "gpt-5.4-pro",
     "gpt-5.4-mini*": "gpt-5.4-mini",
     "gpt-5.4-nano*": "gpt-5.4-nano",


### PR DESCRIPTION
## Summary

Adds GPT-5.5 and GPT-5.5 Pro to the pricing registry, alias mappings, and websocket bootstrap preferences so the proxy can route, price, and track usage for the new model family out of the box.

## Changes

- **Pricing** (`app/core/usage/pricing.py`): Added `gpt-5.5` ($5/$30 per 1M tokens, with flex at half rate and priority at 2.5x) and `gpt-5.5-pro` ($30/$180, flex at half rate) based on the official pricing page
- **Aliases** (`app/core/usage/pricing.py`): Added `gpt-5.5*` and `gpt-5.5-pro*` glob patterns so dated model slugs (e.g. `gpt-5.5-2026-07-01`) resolve correctly
- **Websocket preference** (`app/core/openai/model_registry.py`): Extended `_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS` to include `gpt-5.5` and `gpt-5.5-*`

Model discovery is dynamic via the upstream registry refresh, so no bootstrap model entries are needed — this just ensures pricing/alias/ws-preference are ready when the model shows up.

## Test plan

- [x] All 24 pricing unit tests pass
- [x] Verified alias resolution: `gpt-5.5-2026-07-01` → `gpt-5.5`, `gpt-5.5-pro-2026-07-01` → `gpt-5.5-pro`
- [x] Verified pricing values match official announcement ($5/$30 standard, $30/$180 pro)