### PR TITLE
fix(oauth): make manual callback idempotent

### DIFF
--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -232,14 +232,18 @@ class OauthService:
         code = params.get("code", [None])[0]
         state = params.get("state", [None])[0]
 
+        async with self._store.lock:
+            current_status = self._store.state.status
+            expected_state = self._store.state.state_token
+            verifier = self._store.state.code_verifier
+
+        if current_status == "success":
+            return ManualCallbackResponse(status="success")
+
         if error:
             message = f"OAuth error: {error}"
             await self._set_error(message)
             return ManualCallbackResponse(status="error", error_message=message)
-
-        async with self._store.lock:
-            expected_state = self._store.state.state_token
-            verifier = self._store.state.code_verifier
 
         if not code or not state or state != expected_state or not verifier:
             message = "Invalid OAuth callback: state mismatch or missing code."

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -237,7 +237,17 @@ class OauthService:
             expected_state = self._store.state.state_token
             verifier = self._store.state.code_verifier
 
-        if current_status == "success":
+        # Idempotent return only when this manual-callback corresponds to the
+        # same OAuth attempt that already succeeded (state token matches the
+        # current attempt). This avoids reporting success for stale callback
+        # URLs from a different/previous attempt, which would skip state/code
+        # validation and token persistence.
+        if (
+            current_status == "success"
+            and state
+            and expected_state
+            and state == expected_state
+        ):
             return ManualCallbackResponse(status="success")
 
         if error:

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -242,12 +242,7 @@ class OauthService:
         # current attempt). This avoids reporting success for stale callback
         # URLs from a different/previous attempt, which would skip state/code
         # validation and token persistence.
-        if (
-            current_status == "success"
-            and state
-            and expected_state
-            and state == expected_state
-        ):
+        if current_status == "success" and state and expected_state and state == expected_state:
             return ManualCallbackResponse(status="success")
 
         if error:

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -451,9 +451,7 @@ async def test_manual_callback_is_idempotent_for_same_attempt(async_client, monk
     async with oauth_module._OAUTH_STORE.lock:
         state_token = oauth_module._OAUTH_STORE.state.state_token
 
-    callback_url = (
-        f"http://localhost:1455/auth/callback?code=manual-code&state={state_token}"
-    )
+    callback_url = f"http://localhost:1455/auth/callback?code=manual-code&state={state_token}"
 
     first = await async_client.post(
         "/api/oauth/manual-callback",
@@ -508,9 +506,7 @@ async def test_manual_callback_after_success_rejects_stale_callback(async_client
     first = await async_client.post(
         "/api/oauth/manual-callback",
         json={
-            "callbackUrl": (
-                f"http://localhost:1455/auth/callback?code=manual-code&state={state_token}"
-            ),
+            "callbackUrl": (f"http://localhost:1455/auth/callback?code=manual-code&state={state_token}"),
         },
     )
     assert first.status_code == 200

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -414,3 +414,119 @@ async def test_manual_callback_returns_error_message_for_invalid_state(async_cli
         "status": "error",
         "errorMessage": "Invalid OAuth callback: state mismatch or missing code.",
     }
+
+
+@pytest.mark.asyncio
+async def test_manual_callback_is_idempotent_for_same_attempt(async_client, monkeypatch):
+    await oauth_module._OAUTH_STORE.reset()
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    email = "manual-idem@example.com"
+    raw_account_id = "acc_manual_idem"
+
+    exchange_calls = 0
+
+    async def fake_exchange_authorization_code(**_):
+        nonlocal exchange_calls
+        exchange_calls += 1
+        payload = {
+            "email": email,
+            "chatgpt_account_id": raw_account_id,
+            "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+        }
+        return OAuthTokens(
+            access_token="manual-idem-access-token",
+            refresh_token="manual-idem-refresh-token",
+            id_token=_encode_jwt(payload),
+        )
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+    monkeypatch.setattr(oauth_module, "exchange_authorization_code", fake_exchange_authorization_code)
+
+    start = await async_client.post("/api/oauth/start", json={"forceMethod": "browser"})
+    assert start.status_code == 200
+
+    async with oauth_module._OAUTH_STORE.lock:
+        state_token = oauth_module._OAUTH_STORE.state.state_token
+
+    callback_url = (
+        f"http://localhost:1455/auth/callback?code=manual-code&state={state_token}"
+    )
+
+    first = await async_client.post(
+        "/api/oauth/manual-callback",
+        json={"callbackUrl": callback_url},
+    )
+    assert first.status_code == 200
+    assert first.json() == {"status": "success", "errorMessage": None}
+    assert exchange_calls == 1
+
+    # Re-submitting the same callback URL for the same attempt must be a
+    # no-op success (idempotent), not a re-exchange of the consumed code.
+    second = await async_client.post(
+        "/api/oauth/manual-callback",
+        json={"callbackUrl": callback_url},
+    )
+    assert second.status_code == 200
+    assert second.json() == {"status": "success", "errorMessage": None}
+    assert exchange_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_manual_callback_after_success_rejects_stale_callback(async_client, monkeypatch):
+    await oauth_module._OAUTH_STORE.reset()
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    email = "manual-stale@example.com"
+    raw_account_id = "acc_manual_stale"
+
+    async def fake_exchange_authorization_code(**_):
+        payload = {
+            "email": email,
+            "chatgpt_account_id": raw_account_id,
+            "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+        }
+        return OAuthTokens(
+            access_token="manual-stale-access-token",
+            refresh_token="manual-stale-refresh-token",
+            id_token=_encode_jwt(payload),
+        )
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+    monkeypatch.setattr(oauth_module, "exchange_authorization_code", fake_exchange_authorization_code)
+
+    start = await async_client.post("/api/oauth/start", json={"forceMethod": "browser"})
+    assert start.status_code == 200
+
+    async with oauth_module._OAUTH_STORE.lock:
+        state_token = oauth_module._OAUTH_STORE.state.state_token
+
+    first = await async_client.post(
+        "/api/oauth/manual-callback",
+        json={
+            "callbackUrl": (
+                f"http://localhost:1455/auth/callback?code=manual-code&state={state_token}"
+            ),
+        },
+    )
+    assert first.status_code == 200
+    assert first.json() == {"status": "success", "errorMessage": None}
+
+    # A stale callback URL from a previous/different attempt arrives after
+    # success. Idempotent return must NOT mask state-mismatch validation: the
+    # request must still be rejected as an invalid callback.
+    stale = await async_client.post(
+        "/api/oauth/manual-callback",
+        json={
+            "callbackUrl": "http://localhost:1455/auth/callback?code=stale-code&state=stale-state",
+        },
+    )
+    assert stale.status_code == 200
+    assert stale.json() == {
+        "status": "error",
+        "errorMessage": "Invalid OAuth callback: state mismatch or missing code.",
+    }


### PR DESCRIPTION
## Summary
- Make `/api/oauth/manual-callback` idempotent after the current OAuth attempt has already reached `success`.
- Avoid re-exchanging an already-consumed authorization code when the automatic localhost callback persisted the account first.
- Preserve the successful OAuth/account-add state instead of overwriting it with a later manual-callback token exchange error.

## Observed Bug Evidence
I hit this in a real local Docker dashboard OAuth flow, not only from code inspection.

Environment:
- Dashboard: `http://localhost:2455`
- OAuth callback port exposed as `1455:1455`
- Redirect URI: `http://localhost:1455/auth/callback`

Actual behavior observed:
- The account was added successfully by the automatic callback path.(But I didn't know that.)
- So I pasted the same callback URL into the manual callback field, the dashboard showed an OAuth/account-add failure message.
- The account list still showed the newly added account, so the final UI state contradicted the persisted account state.

Most important evidence is the timing: the account existed before the manual callback request that reported the token error.

```text
account created_at: 2026-04-24 05:30:33 UTC
manual callback:    2026-04-24 05:30:40 UTC
```

Relevant logs from the same flow:

```text
2026-04-24T05:30:17Z POST /api/oauth/start HTTP/1.1 200 OK
2026-04-24T05:30:40Z OAuth token request failed request_id=60915954-d78a-4953-92e3-cf0a0b6316d8 status=400
2026-04-24T05:30:40Z POST /api/oauth/manual-callback HTTP/1.1 200 OK
```

So the account was created about 7 seconds before the manual callback tried to exchange the same already-consumed authorization code.

## Root Cause
The browser OAuth flow has two completion paths: the local callback server at `localhost:1455` and the dashboard manual callback endpoint. In local Docker setups where `1455:1455` is exposed, the automatic callback can complete first and create the account. If the user then submits the same callback URL manually, the previous implementation tried to exchange the same authorization code again. Upstream rejects the consumed code with HTTP 400, and `manual_callback()` converted that into `_set_error()`, causing the dashboard to show an authorization failure even though the account was already added.

## Fix
`manual_callback()` now checks the current OAuth state before exchanging the authorization code. If the OAuth attempt is already `success`, the manual callback returns success without calling `exchange_authorization_code()` again.

## Test Plan
- [x] `uv run --frozen --python $env:APPDATA\uv\python\cpython-3.13.12-windows-x86_64-none\python.exe python -m pytest tests\integration\test_oauth_flow.py -q`