### PR TITLE
fix(proxy): load balancer filter

### DIFF
--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -411,7 +411,7 @@ class LoadBalancer:
         async with self._repo_factory() as repos:
             all_accounts = await repos.accounts.list_accounts()
             effective_limit_name = additional_limit_name or _gated_limit_name_for_model(model)
-            accounts = all_accounts
+            accounts = _selectable_accounts(all_accounts)
             if account_ids is not None:
                 allowed_account_ids = set(account_ids)
                 accounts = [account for account in accounts if account.id in allowed_account_ids]
@@ -1165,6 +1165,10 @@ def _filter_accounts_for_model(accounts: list[Account], model: str) -> list[Acco
     if allowed_plans is None:
         return accounts
     return [a for a in accounts if a.plan_type in allowed_plans]
+
+
+def _selectable_accounts(accounts: list[Account]) -> list[Account]:
+    return [account for account in accounts if account.status not in (AccountStatus.DEACTIVATED, AccountStatus.PAUSED)]
 
 
 def _gated_limit_name_for_model(model: str | None) -> str | None:

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -146,7 +146,8 @@ class StubUsageRepository(UsageRepository):
 
 class StubStickySessionsRepository(StickySessionsRepository):
     def __init__(self) -> None:
-        pass
+        self.upserts: list[StickySession] = []
+        self.deletes: list[tuple[str, StickySessionKind | None]] = []
 
     async def get_account_id(
         self,
@@ -158,9 +159,12 @@ class StubStickySessionsRepository(StickySessionsRepository):
         return None
 
     async def upsert(self, key: str, account_id: str, *, kind: StickySessionKind) -> StickySession:
-        return self._build_row(key, account_id, kind)
+        row = self._build_row(key, account_id, kind)
+        self.upserts.append(row)
+        return row
 
     async def delete(self, key: str, *, kind: StickySessionKind | None = None) -> bool:
+        self.deletes.append((key, kind))
         return False
 
     @staticmethod
@@ -1756,6 +1760,90 @@ async def test_select_account_sticky_does_not_return_stale_selection_at_retry_ca
 
     assert load_calls >= 2
     assert selection.account is None
+
+
+@pytest.mark.asyncio
+async def test_load_selection_inputs_excludes_paused_accounts_from_sticky_pool(monkeypatch) -> None:
+    paused_team = _make_account("acc-team-paused", "shared@example.com")
+    paused_team.plan_type = "team"
+    paused_team.status = AccountStatus.PAUSED
+    active_free = _make_account("acc-free-active", "shared@example.com")
+    active_free.plan_type = "free"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    primary = {
+        paused_team.id: UsageHistory(
+            id=1,
+            account_id=paused_team.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=10.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+        active_free.id: UsageHistory(
+            id=2,
+            account_id=active_free.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=15.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+    }
+    secondary = {
+        paused_team.id: UsageHistory(
+            id=3,
+            account_id=paused_team.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=10.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+        active_free.id: UsageHistory(
+            id=4,
+            account_id=active_free.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=15.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+    }
+
+    accounts_repo = StubAccountsRepository([paused_team, active_free])
+    usage_repo = StubUsageRepository(primary=primary, secondary=secondary)
+    sticky_repo = StubStickySessionsRepository()
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+
+    async def pinned_account_id(
+        key: str,
+        *,
+        kind: StickySessionKind,
+        max_age_seconds: int | None = None,
+    ) -> str | None:
+        del key, kind, max_age_seconds
+        return paused_team.id
+
+    monkeypatch.setattr(sticky_repo, "get_account_id", pinned_account_id)
+
+    selection_inputs = await balancer._load_selection_inputs(model=None)
+    selection = await balancer.select_account(
+        sticky_key="sticky-session-paused-team",
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+    )
+
+    assert [account.id for account in selection_inputs.accounts] == [active_free.id]
+    assert {account.id for account in selection_inputs.runtime_accounts or []} == {
+        paused_team.id,
+        active_free.id,
+    }
+    assert selection.account is not None
+    assert selection.account.id == active_free.id
+    assert sticky_repo.deletes == [("sticky-session-paused-team", StickySessionKind.CODEX_SESSION)]
+    assert all(row.account_id != paused_team.id for row in sticky_repo.upserts)
+    assert sticky_repo.upserts[-1].account_id == active_free.id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary
Fixes #478 by applying proposed fix by @Soju06: filter out `PAUSED` and `DEACTIVATED` accounts at the `_load_selection_inputs()` level so disabled accounts never enter sticky, budget, or fallback selection.

### Problem
`_load_selection_inputs()` passes **all** accounts (including paused/deactivated) into the sticky/budget/fallback selection pool. This causes paused accounts to remain eligible for sticky session reuse, budget-weighted selection, and fallback routing.

### Fix
Added `_selectable_accounts()` and called it at the top of `_load_selection_inputs()`. That means paused/deactivated accounts are removed before:

- sticky pin evaluation
- budget pressure decisions
- fallback routing

The unfiltered `all_accounts` list is still preserved for the no-accounts / model-support error paths, as requested by @Soju06:

### Changes
| File | Change |
|------|--------|
| `app/modules/proxy/load_balancer.py` | Add `_selectable_accounts()`, filter in `_load_selection_inputs()` |
| `tests/unit/test_proxy_load_balancer_refresh.py` | Regression test: paused account excluded from sticky pool and no sticky upsert for paused ID |

### Coverage
@Soju06 asked to cover some points...

1. Keep `all_accounts` for the no-accounts error path.
   - Kept. Only the working `accounts` pool is filtered.

2. Double-check sticky cleanup semantics.
   - Covered by test. A paused pinned account is no longer reachable in the filtered pool.
   - The stale sticky row is deleted when the pinned ID is no longer present.
   - The regression test asserts that no sticky row is ever upserted for the paused account ID.

3. Add regression coverage in `tests/unit/test_proxy_load_balancer_refresh.py`.
   - Added exactly there.
   - Verified red on `main`, green on this branch.

### Why I kept the sticky behavior minimal
I intentionally did **not** introduce a broader sticky-behavior redesign in this patch.

@Soju06 explicitly asked for the selection-pool filter plus a regression test. The sticky-path note (`"should be actively deleted or at least not re-upserted onto a different account"`) was phrased as a double-check, not as a hard requirement to change rebinding semantics.

So this patch stays minimal:

- it prevents paused accounts from being selected
- it ensures the paused account ID is not re-upserted
- it avoids adding new sticky migration behavior beyond what is needed for the bugfix

### Testing
```
35 passed, 3 skipped (load balancer tests)
1281 passed, 39 skipped (full unit suite)
```

Targeted regression proof:
- `main` + new regression test: **fails**
- this branch + same test: **passes**

Manual verification against running instance with real accounts:

1. Account 1 active, Account 2 paused → request → **200** → pass
2. Account 1 paused, Account 2 paused → request → **503 no_accounts** → pass
3. Account 1 paused, Account 2 active →  request → **200** → pass
4. Dashboard was checked to verify there wasn't stickyness on disabled accounts.