### PR TITLE
fix(proxy): map unsupported reasoning effort 'minimal' to a supported value

### DIFF
--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.exceptions import ProxyModelNotAllowed
+from app.core.openai.model_registry import ModelRegistry, get_model_registry
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesReasoning, ResponsesRequest
 from app.core.openai.v1_requests import V1ResponsesRequest
 from app.core.types import JsonValue
@@ -13,6 +14,16 @@ from app.core.utils.request_id import get_request_id
 from app.modules.api_keys.service import ApiKeyData
 
 logger = logging.getLogger(__name__)
+
+# Reasoning efforts that the upstream ChatGPT/Codex backend silently drops
+# (the WebSocket never produces ``response.completed``). When a client sends
+# one of these we transparently rewrite it to a value the resolved model
+# advertises in its ``supported_reasoning_levels`` so the request does not
+# hang. ``minimal`` is a valid value on the OpenAI Platform Responses API for
+# GPT-5 family models, but the ChatGPT backend codex-lb proxies to does not
+# accept it as of 2026-04. See https://github.com/Soju06/codex-lb/issues/493
+_UNSUPPORTED_UPSTREAM_REASONING_EFFORTS: frozenset[str] = frozenset({"minimal"})
+_DEFAULT_REASONING_EFFORT_FALLBACK = "low"
 
 
 def validate_model_access(api_key: ApiKeyData | None, model: str | None) -> None:
@@ -31,6 +42,7 @@ def apply_api_key_enforcement(
     api_key: ApiKeyData | None,
 ) -> None:
     if api_key is None:
+        normalize_unsupported_reasoning_effort(payload)
         return
 
     if api_key.enforced_model and payload.model != api_key.enforced_model:
@@ -58,6 +70,8 @@ def apply_api_key_enforcement(
                 api_key.enforced_reasoning_effort,
             )
 
+    normalize_unsupported_reasoning_effort(payload)
+
     if api_key.enforced_service_tier is not None:
         requested_service_tier = getattr(payload, "service_tier", None)
         setattr(payload, "service_tier", api_key.enforced_service_tier)
@@ -70,6 +84,67 @@ def apply_api_key_enforcement(
                 requested_service_tier,
                 api_key.enforced_service_tier,
             )
+
+
+def normalize_unsupported_reasoning_effort(
+    payload: ResponsesRequest | ResponsesCompactRequest,
+    *,
+    registry: ModelRegistry | None = None,
+) -> None:
+    """Rewrite ``reasoning.effort`` values the upstream backend rejects.
+
+    Some efforts that codex-lb accepts at the API surface (notably
+    ``"minimal"``) are silently dropped by the ChatGPT/Codex WebSocket
+    backend, which causes the response stream to hang with no completion.
+    For those values we map to a value the resolved model actually supports
+    so clients (e.g. Codex CLI's ``--reasoning-effort minimal``) keep
+    working. Mapping picks the model's lowest advertised effort, falling
+    back to ``low`` when the registry has no metadata yet.
+    """
+
+    if payload.reasoning is None or payload.reasoning.effort is None:
+        return
+
+    requested_effort = payload.reasoning.effort
+    normalized_effort = requested_effort.strip().lower()
+    if normalized_effort not in _UNSUPPORTED_UPSTREAM_REASONING_EFFORTS:
+        return
+
+    fallback = _resolve_reasoning_effort_fallback(
+        payload.model,
+        registry=registry or get_model_registry(),
+    )
+    payload.reasoning.effort = fallback
+    logger.info(
+        "reasoning_effort_normalized request_id=%s model=%s requested_effort=%s normalized_effort=%s",
+        get_request_id(),
+        payload.model,
+        requested_effort,
+        fallback,
+    )
+
+
+def _resolve_reasoning_effort_fallback(
+    model: str | None,
+    *,
+    registry: ModelRegistry,
+) -> str:
+    if not model:
+        return _DEFAULT_REASONING_EFFORT_FALLBACK
+    snapshot = registry.get_snapshot()
+    if snapshot is None:
+        return _DEFAULT_REASONING_EFFORT_FALLBACK
+    upstream = snapshot.models.get(model) or snapshot.models.get(model.strip().lower())
+    if upstream is None:
+        return _DEFAULT_REASONING_EFFORT_FALLBACK
+    advertised = [level.effort for level in upstream.supported_reasoning_levels if level.effort]
+    # Prefer the order the model registry advertises (already lowest -> highest
+    # for the GPT-5 family), but always pick the first advertised effort that
+    # is not itself an unsupported value.
+    for effort in advertised:
+        if effort.strip().lower() not in _UNSUPPORTED_UPSTREAM_REASONING_EFFORTS:
+            return effort
+    return _DEFAULT_REASONING_EFFORT_FALLBACK
 
 
 def openai_validation_error(exc: ValidationError) -> OpenAIErrorEnvelope:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -143,6 +143,123 @@ def test_apply_api_key_enforcement_overrides_service_tier_aliases_to_priority():
     assert payload.service_tier == "priority"
 
 
+def _build_registry_with_model(slug: str, efforts: list[str]):
+    from app.core.openai.model_registry import (
+        ModelRegistry,
+        ModelRegistrySnapshot,
+        ReasoningLevel,
+        UpstreamModel,
+    )
+
+    upstream = UpstreamModel(
+        slug=slug,
+        display_name=slug,
+        description="",
+        context_window=128000,
+        input_modalities=("text",),
+        supported_reasoning_levels=tuple(
+            ReasoningLevel(effort=e, description="") for e in efforts
+        ),
+        default_reasoning_level=efforts[1] if len(efforts) > 1 else None,
+        supports_reasoning_summaries=False,
+        support_verbosity=False,
+        default_verbosity=None,
+        prefer_websockets=True,
+        supports_parallel_tool_calls=True,
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"pro"}),
+    )
+    snapshot = ModelRegistrySnapshot(
+        models={slug: upstream},
+        model_plans={slug: frozenset({"pro"})},
+        plan_models={"pro": frozenset({slug})},
+        fetched_at=0.0,
+    )
+    registry = ModelRegistry()
+    registry._snapshot = snapshot  # type: ignore[attr-defined]
+    return registry
+
+
+def test_normalize_unsupported_reasoning_effort_rewrites_minimal_to_low(caplog):
+    from app.core.openai.requests import ResponsesReasoning
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+    payload.reasoning = ResponsesReasoning(effort="minimal")
+    registry = _build_registry_with_model("gpt-5.5", ["low", "medium", "high", "xhigh"])
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.request_policy"):
+        proxy_request_policy.normalize_unsupported_reasoning_effort(payload, registry=registry)
+
+    assert payload.reasoning is not None
+    assert payload.reasoning.effort == "low"
+    assert any("reasoning_effort_normalized" in record.message for record in caplog.records)
+
+
+def test_normalize_unsupported_reasoning_effort_falls_back_to_low_without_registry():
+    from app.core.openai.model_registry import ModelRegistry
+    from app.core.openai.requests import ResponsesReasoning
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-unknown",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+    payload.reasoning = ResponsesReasoning(effort="MINIMAL")
+
+    proxy_request_policy.normalize_unsupported_reasoning_effort(
+        payload, registry=ModelRegistry()
+    )
+
+    assert payload.reasoning is not None
+    assert payload.reasoning.effort == "low"
+
+
+def test_normalize_unsupported_reasoning_effort_preserves_supported_effort():
+    from app.core.openai.requests import ResponsesReasoning
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+    payload.reasoning = ResponsesReasoning(effort="high")
+    registry = _build_registry_with_model("gpt-5.5", ["low", "medium", "high", "xhigh"])
+
+    proxy_request_policy.normalize_unsupported_reasoning_effort(payload, registry=registry)
+
+    assert payload.reasoning.effort == "high"
+
+
+def test_apply_api_key_enforcement_normalizes_minimal_without_api_key():
+    from app.core.openai.requests import ResponsesReasoning
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+    payload.reasoning = ResponsesReasoning(effort="minimal")
+
+    proxy_request_policy.apply_api_key_enforcement(payload, None)
+
+    assert payload.reasoning is not None
+    assert payload.reasoning.effort == "low"
+
+
 class _RingMembershipStub:
     def __init__(self, members: list[str]) -> None:
         self.members = members

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -157,9 +157,7 @@ def _build_registry_with_model(slug: str, efforts: list[str]):
         description="",
         context_window=128000,
         input_modalities=("text",),
-        supported_reasoning_levels=tuple(
-            ReasoningLevel(effort=e, description="") for e in efforts
-        ),
+        supported_reasoning_levels=tuple(ReasoningLevel(effort=e, description="") for e in efforts),
         default_reasoning_level=efforts[1] if len(efforts) > 1 else None,
         supports_reasoning_summaries=False,
         support_verbosity=False,
@@ -216,9 +214,7 @@ def test_normalize_unsupported_reasoning_effort_falls_back_to_low_without_regist
     )
     payload.reasoning = ResponsesReasoning(effort="MINIMAL")
 
-    proxy_request_policy.normalize_unsupported_reasoning_effort(
-        payload, registry=ModelRegistry()
-    )
+    proxy_request_policy.normalize_unsupported_reasoning_effort(payload, registry=ModelRegistry())
 
     assert payload.reasoning is not None
     assert payload.reasoning.effort == "low"

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.13.1"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Closes #493.

`reasoning.effort: "minimal"` is a valid value on the OpenAI Platform Responses API for the GPT-5 family, but the ChatGPT/Codex WebSocket backend codex-lb proxies to silently drops it: the stream emits `codex.rate_limits` and then never produces `response.completed`, so clients (Codex CLI's `--reasoning-effort minimal`, custom integrations, etc.) hang until they time out.

This PR normalizes `minimal` to a value the resolved model advertises in `supported_reasoning_levels` (lowest, defaulting to `low` when the registry has no metadata yet) inside `apply_api_key_enforcement`, with an info log so operators can see the rewrite. Schema- and key-level acceptance of `minimal` stays permissive, but it never reaches the upstream as `minimal`.

## Changes

- `app/modules/proxy/request_policy.py`
  - New `normalize_unsupported_reasoning_effort(payload, registry=...)` helper. Picks the lowest non-blocked effort the resolved model advertises in `/v1/models`, falling back to `low` when no snapshot is loaded or the model is unknown.
  - Called from `apply_api_key_enforcement` after `enforced_reasoning_effort` rewriting (so even keys that pin `minimal` get the safe value), and on the early-return branch where `api_key is None`.
  - `_UNSUPPORTED_UPSTREAM_REASONING_EFFORTS = {"minimal"}` is the single source of truth, easy to extend if other values turn out to behave the same way.
- `tests/unit/test_proxy_utils.py`
  - Rewrites `minimal` → `low` against a registry that advertises `low/medium/high/xhigh` for `gpt-5.5` and emits the `reasoning_effort_normalized` log line.
  - Falls back to `low` (case-insensitively) when the registry has no snapshot yet or the model is unknown.
  - Leaves supported efforts (`high`) untouched.
  - `apply_api_key_enforcement(..., None)` still normalizes `minimal` for unauthenticated/internal call sites that go through the same helper.

## Why this layer

`apply_api_key_enforcement` is the only place that already touches `payload.reasoning` after the request has been validated and any key-level enforcement applied, and it runs on every request path that hits the Responses bridge (`app/modules/proxy/api.py` × 3 + `app/modules/proxy/service.py`). Doing the rewrite here keeps the upstream code paths unchanged and avoids touching the WebSocket sender, where this would otherwise have to be repeated.

## Out of scope / follow-ups

- Aligning `_SUPPORTED_REASONING_EFFORTS` validation with each model's advertised `supported_reasoning_levels` is a separate, larger change (it currently accepts any of `none/minimal/low/medium/high/xhigh` regardless of the resolved model). I left this for a follow-up so this PR is small and easy to revert if `minimal` starts working upstream.
- A future strict-mode flag (`policy.reject_unsupported_reasoning_effort`) that returns 400 instead of rewriting would also be reasonable, but most operator feedback so far prefers "just make it work".

## Test plan

```bash
uv run pytest tests/unit/test_proxy_utils.py -k "reasoning or service_tier_aliases" -q
# 5 passed
```

Manual reproduction against dev compose (port 2456, ChatGPT Pro account):

Before:
```
event: codex.rate_limits
data: {...}
curl: (28) Operation timed out after 85002 milliseconds with 688 bytes received
```

After (same payload, `reasoning.effort: "minimal"`, gpt-5.5):
```
event: codex.rate_limits
event: response.created
event: response.in_progress
...
event: response.completed
```

with the proxy log emitting `reasoning_effort_normalized request_id=... model=gpt-5.5 requested_effort=minimal normalized_effort=low`.
