### PR TITLE
fix(proxy): pre-validate strict JSON schemas to surface invalid_json_schema (#491)

### DIFF
--- a/app/core/openai/exceptions.py
+++ b/app/core/openai/exceptions.py
@@ -2,6 +2,23 @@ from __future__ import annotations
 
 
 class ClientPayloadError(ValueError):
-    def __init__(self, message: str, *, param: str | None = None) -> None:
+    """Validation error that should be surfaced to the client as a 400.
+
+    ``code`` and ``error_type`` allow callers to mirror specific OpenAI
+    error shapes (for example ``invalid_json_schema`` /
+    ``invalid_request_error`` for strict-mode schema violations) instead
+    of the generic ``invalid_request_error`` payload used by default.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        param: str | None = None,
+        code: str | None = None,
+        error_type: str | None = None,
+    ) -> None:
         super().__init__(message)
         self.param = param
+        self.code = code
+        self.error_type = error_type

--- a/app/core/openai/strict_schema.py
+++ b/app/core/openai/strict_schema.py
@@ -100,6 +100,18 @@ def _find_violation(
 
         properties = node.get("properties")
         if is_json_mapping(properties):
+            required_raw = node.get("required")
+            required_set: set[str] = set()
+            if is_json_list(required_raw):
+                required_set = {item for item in required_raw if isinstance(item, str)}
+            missing_required = [str(prop_name) for prop_name in properties.keys() if str(prop_name) not in required_set]
+            if missing_required:
+                missing_list = ", ".join(f"'{name}'" for name in missing_required)
+                return (
+                    path,
+                    "'required' is required to be supplied and to be an array including every key in properties. "
+                    f"Missing {missing_list}",
+                )
             for prop_name, prop_schema in properties.items():
                 violation = _find_violation(
                     prop_schema,

--- a/app/core/openai/strict_schema.py
+++ b/app/core/openai/strict_schema.py
@@ -1,0 +1,146 @@
+"""Validation for OpenAI strict JSON schema mode.
+
+When ``strict: true`` is set on a ``response_format`` (or ``text.format``)
+of type ``json_schema``, the upstream Codex/Responses API enforces several
+constraints on the schema (mirroring the public OpenAI Structured Outputs
+policy). The most common violations are:
+
+* every ``object`` schema must have ``additionalProperties: false``;
+* every property defined under ``properties`` must be listed in
+  ``required``;
+* schema nodes must have a ``type`` key (no empty ``{}``).
+
+When these violations reach the Codex backend over a websocket, the
+session is terminated with ``close_code=1000`` and the proxy currently
+surfaces a generic ``stream_incomplete`` 502 instead of the upstream
+``invalid_json_schema`` detail. We detect these violations locally so the
+client receives a 400 with the OpenAI-style error message before any
+upstream request is opened.
+
+Only the strict-mode constraints are enforced here. Schemas with
+``strict`` unset or ``strict: false`` pass through unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.types import JsonValue
+from app.core.utils.json_guards import is_json_list, is_json_mapping
+
+
+@dataclass(frozen=True)
+class StrictSchemaError:
+    """A single strict-mode schema violation, formatted for the API."""
+
+    code: str
+    message: str
+    param: str
+
+
+def validate_strict_json_schema(
+    schema: JsonValue,
+    *,
+    name: str | None,
+    param: str,
+) -> StrictSchemaError | None:
+    """Return the first strict-mode violation in ``schema`` or ``None``.
+
+    The returned message mirrors the upstream OpenAI Responses API format:
+
+        Invalid schema for response_format '<name>':
+        In context=(<path>), <reason>.
+    """
+
+    label = name or "response_format"
+    violation = _find_violation(schema, ())
+    if violation is None:
+        return None
+    context_path, reason = violation
+    rendered_context = _render_context(context_path)
+    message = f"Invalid schema for response_format '{label}': In context={rendered_context}, {reason}."
+    return StrictSchemaError(
+        code="invalid_json_schema",
+        message=message,
+        param=param,
+    )
+
+
+def _render_context(path: tuple[str, ...]) -> str:
+    if not path:
+        return "()"
+    parts = ", ".join(f"'{part}'" for part in path)
+    return f"({parts})"
+
+
+def _find_violation(
+    node: JsonValue,
+    path: tuple[str, ...],
+) -> tuple[tuple[str, ...], str] | None:
+    if not is_json_mapping(node):
+        # Non-object nodes (booleans, etc.) are not subject to strict-mode
+        # property checks here.
+        return None
+
+    # Require a ``type`` key on every node we visit. The upstream API
+    # rejects empty ``{}`` schemas in strict mode.
+    if "type" not in node and not _has_combinator(node) and not _is_ref(node):
+        return path, "schema must have a 'type' key"
+
+    schema_type = node.get("type")
+
+    if schema_type == "object" or "properties" in node:
+        additional = node.get("additionalProperties")
+        if additional is not False:
+            return (
+                path,
+                "'additionalProperties' is required to be supplied and to be false",
+            )
+
+        properties = node.get("properties")
+        if is_json_mapping(properties):
+            for prop_name, prop_schema in properties.items():
+                violation = _find_violation(
+                    prop_schema,
+                    path + ("properties", str(prop_name)),
+                )
+                if violation is not None:
+                    return violation
+
+    if schema_type == "array" or "items" in node:
+        items = node.get("items")
+        if items is not None:
+            violation = _find_violation(items, path + ("items",))
+            if violation is not None:
+                return violation
+
+    for combinator in ("anyOf", "oneOf", "allOf"):
+        candidates = node.get(combinator)
+        if is_json_list(candidates):
+            for index, candidate in enumerate(candidates):
+                violation = _find_violation(
+                    candidate,
+                    path + (combinator, str(index)),
+                )
+                if violation is not None:
+                    return violation
+
+    defs = node.get("$defs") or node.get("definitions")
+    if is_json_mapping(defs):
+        for def_name, def_schema in defs.items():
+            violation = _find_violation(
+                def_schema,
+                path + ("$defs", str(def_name)),
+            )
+            if violation is not None:
+                return violation
+
+    return None
+
+
+def _has_combinator(node: dict[str, JsonValue]) -> bool:
+    return any(is_json_list(node.get(name)) for name in ("anyOf", "oneOf", "allOf"))
+
+
+def _is_ref(node: dict[str, JsonValue]) -> bool:
+    return isinstance(node.get("$ref"), str)

--- a/app/core/openai/strict_schema.py
+++ b/app/core/openai/strict_schema.py
@@ -23,6 +23,7 @@ Only the strict-mode constraints are enforced here. Schemas with
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from app.core.types import JsonValue
@@ -138,9 +139,9 @@ def _find_violation(
     return None
 
 
-def _has_combinator(node: dict[str, JsonValue]) -> bool:
+def _has_combinator(node: Mapping[str, JsonValue]) -> bool:
     return any(is_json_list(node.get(name)) for name in ("anyOf", "oneOf", "allOf"))
 
 
-def _is_ref(node: dict[str, JsonValue]) -> bool:
+def _is_ref(node: Mapping[str, JsonValue]) -> bool:
     return isinstance(node.get("$ref"), str)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -70,7 +70,8 @@ from app.modules.proxy.helpers import _rate_limit_details
 from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
 from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
-    openai_invalid_payload_error,
+    enforce_strict_text_format,
+    openai_client_payload_error,
     openai_validation_error,
     validate_model_access,
 )
@@ -225,8 +226,9 @@ async def v1_responses(
 ) -> Response:
     try:
         responses_payload = payload.to_responses_request()
+        enforce_strict_text_format(responses_payload)
     except ClientPayloadError as exc:
-        error = openai_invalid_payload_error(exc.param)
+        error = openai_client_payload_error(exc)
         return _logged_error_json_response(request, 400, error)
     except ValidationError as exc:
         error = openai_validation_error(exc)
@@ -776,8 +778,9 @@ async def v1_chat_completions(
     rate_limit_headers = await context.service.rate_limit_headers()
     try:
         responses_payload = payload.to_responses_request()
+        enforce_strict_text_format(responses_payload)
     except ClientPayloadError as exc:
-        error = openai_invalid_payload_error(exc.param)
+        error = openai_client_payload_error(exc)
         return _logged_error_json_response(request, 400, error, headers=rate_limit_headers)
     except ValidationError as exc:
         error = openai_validation_error(exc)
@@ -1046,7 +1049,7 @@ async def v1_responses_compact(
     try:
         compact_payload = payload.to_compact_request()
     except ClientPayloadError as exc:
-        error = openai_invalid_payload_error(exc.param)
+        error = openai_client_payload_error(exc)
         return _logged_error_json_response(request, 400, error)
     except ValidationError as exc:
         error = openai_validation_error(exc)

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -6,8 +6,10 @@ from pydantic import ValidationError
 
 from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.exceptions import ProxyModelNotAllowed
+from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.model_registry import ModelRegistry, get_model_registry
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesReasoning, ResponsesRequest
+from app.core.openai.strict_schema import validate_strict_json_schema
 from app.core.openai.v1_requests import V1ResponsesRequest
 from app.core.types import JsonValue
 from app.core.utils.request_id import get_request_id
@@ -166,11 +168,63 @@ def openai_invalid_payload_error(param: str | None = None) -> OpenAIErrorEnvelop
     return error
 
 
+def openai_client_payload_error(exc: ClientPayloadError) -> OpenAIErrorEnvelope:
+    """Render a ``ClientPayloadError`` as an OpenAI error envelope.
+
+    Falls back to ``openai_invalid_payload_error`` for legacy callsites
+    that raise ``ClientPayloadError`` without ``code`` / ``error_type``.
+    """
+    if exc.code is None and exc.error_type is None:
+        return openai_invalid_payload_error(exc.param)
+    code = exc.code or "invalid_request_error"
+    error_type = exc.error_type or "invalid_request_error"
+    error = openai_error(code, str(exc), error_type=error_type)
+    if exc.param:
+        error["error"]["param"] = exc.param
+    return error
+
+
 def normalize_responses_request_payload(
     payload: dict[str, JsonValue],
     *,
     openai_compat: bool,
 ) -> ResponsesRequest:
     if openai_compat:
-        return V1ResponsesRequest.model_validate(payload).to_responses_request()
-    return ResponsesRequest.model_validate(payload)
+        responses = V1ResponsesRequest.model_validate(payload).to_responses_request()
+    else:
+        responses = ResponsesRequest.model_validate(payload)
+    enforce_strict_text_format(responses)
+    return responses
+
+
+def enforce_strict_text_format(request: ResponsesRequest) -> None:
+    """Reject strict-mode JSON schemas that violate OpenAI structured-outputs rules.
+
+    The Codex backend mirrors OpenAI's strict-mode policy and closes the
+    websocket with ``close_code=1000`` (delivering the original
+    ``invalid_json_schema`` payload via ``response.failed``). The local
+    pre-check raises a deterministic 400 before any upstream connection
+    is opened, keeping ``/v1/responses`` and the chat-conversion path
+    consistent and avoiding pointless retry/reconnect cycles for
+    permanently invalid schemas.
+    """
+    if request.text is None or request.text.format is None:
+        return
+    text_format = request.text.format
+    if text_format.type != "json_schema" or text_format.strict is not True:
+        return
+    if text_format.schema_ is None:
+        return
+    violation = validate_strict_json_schema(
+        text_format.schema_,
+        name=text_format.name,
+        param="text.format.schema",
+    )
+    if violation is None:
+        return
+    raise ClientPayloadError(
+        violation.message,
+        param=violation.param,
+        code=violation.code,
+        error_type="invalid_request_error",
+    )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -141,6 +141,7 @@ from app.modules.proxy.repo_bundle import ProxyRepoFactory, ProxyRepositories
 from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     normalize_responses_request_payload,
+    openai_client_payload_error,
     openai_invalid_payload_error,
     openai_validation_error,
     validate_model_access,
@@ -2029,7 +2030,7 @@ class ProxyService:
                                 async with client_send_lock:
                                     await websocket.send_text(
                                         _serialize_websocket_error_event(
-                                            _wrapped_websocket_error_event(400, openai_invalid_payload_error(exc.param))
+                                            _wrapped_websocket_error_event(400, openai_client_payload_error(exc))
                                         )
                                     )
                                 continue

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -439,7 +439,12 @@ async def test_v1_chat_completions_maps_response_format(async_client, monkeypatc
             "type": "json_schema",
             "json_schema": {
                 "name": "result_schema",
-                "schema": {"type": "object", "properties": {"ok": {"type": "boolean"}}},
+                "schema": {
+                    "type": "object",
+                    "properties": {"ok": {"type": "boolean"}},
+                    "required": ["ok"],
+                    "additionalProperties": False,
+                },
                 "strict": True,
             },
         },
@@ -451,6 +456,41 @@ async def test_v1_chat_completions_maps_response_format(async_client, monkeypatc
     assert text.format is not None
     assert text.format.type == "json_schema"
     assert text.format.name == "result_schema"
+
+
+@pytest.mark.asyncio
+async def test_v1_chat_completions_rejects_strict_schema_violation(async_client):
+    """Strict-mode schema violations are rejected locally with 400.
+
+    Mirrors the OpenAI ``invalid_json_schema`` error so callers (Graphiti,
+    raw SDK clients) see actionable diagnostics instead of a generic
+    ``stream_incomplete`` 502 from upstream.
+    """
+    payload = {
+        "model": "gpt-5.2",
+        "messages": [{"role": "user", "content": "Return JSON."}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "result_schema",
+                "strict": True,
+                # No additionalProperties: false → strict-mode violation.
+                "schema": {
+                    "type": "object",
+                    "properties": {"ok": {"type": "boolean"}},
+                    "required": ["ok"],
+                },
+            },
+        },
+    }
+    resp = await async_client.post("/v1/chat/completions", json=payload)
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_json_schema"
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["param"] == "text.format.schema"
+    assert "additionalProperties" in body["error"]["message"]
+    assert "result_schema" in body["error"]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_strict_schema_validation.py
+++ b/tests/unit/test_strict_schema_validation.py
@@ -1,0 +1,240 @@
+"""Local strict-mode JSON schema validation.
+
+Exercises the validator in ``app.core.openai.strict_schema`` and the
+``ResponsesRequest`` integration. Mirrors the upstream OpenAI Responses
+API error shape so that clients (Graphiti, raw SDK callers, etc.) see the
+same ``invalid_json_schema`` payload regardless of which endpoint they
+hit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.openai.chat_requests import ChatCompletionsRequest
+from app.core.openai.exceptions import ClientPayloadError
+from app.core.openai.strict_schema import validate_strict_json_schema
+from app.modules.proxy.request_policy import (
+    enforce_strict_text_format,
+    normalize_responses_request_payload,
+)
+
+
+def test_strict_root_missing_additional_properties():
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+    violation = validate_strict_json_schema(schema, name="person", param="text.format.schema")
+    assert violation is not None
+    assert violation.code == "invalid_json_schema"
+    assert violation.param == "text.format.schema"
+    assert "context=()" in violation.message
+    assert "additionalProperties" in violation.message
+    assert "person" in violation.message
+
+
+def test_strict_root_additional_properties_true_rejected():
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "additionalProperties": True,
+    }
+    violation = validate_strict_json_schema(schema, name="p", param="text.format.schema")
+    assert violation is not None
+    assert "context=()" in violation.message
+
+
+def test_strict_nested_missing_additional_properties():
+    schema = {
+        "type": "object",
+        "properties": {
+            "nodes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                    "required": ["id"],
+                },
+            }
+        },
+        "required": ["nodes"],
+        "additionalProperties": False,
+    }
+    violation = validate_strict_json_schema(schema, name="graph", param="text.format.schema")
+    assert violation is not None
+    assert "context=('properties', 'nodes', 'items')" in violation.message
+
+
+def test_strict_dict_str_any_pattern_rejected():
+    """Pydantic ``dict[str, Any]`` -> ``additionalProperties: true``."""
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "attributes": {"type": "object", "additionalProperties": True},
+        },
+        "required": ["name", "attributes"],
+        "additionalProperties": False,
+    }
+    violation = validate_strict_json_schema(schema, name="EntityWithAttrs", param="text.format.schema")
+    assert violation is not None
+    assert "context=('properties', 'attributes')" in violation.message
+
+
+def test_strict_empty_schema_node_rejected():
+    """``Any`` typed Pydantic field -> ``{}`` schema node."""
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "extra": {},
+        },
+        "required": ["name", "extra"],
+        "additionalProperties": False,
+    }
+    violation = validate_strict_json_schema(schema, name="withAny", param="text.format.schema")
+    assert violation is not None
+    assert "context=('properties', 'extra')" in violation.message
+    assert "must have a 'type' key" in violation.message
+
+
+def test_strict_valid_schema_passes():
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+        "required": ["name", "age"],
+        "additionalProperties": False,
+    }
+    assert validate_strict_json_schema(schema, name="person", param="text.format.schema") is None
+
+
+def test_strict_combinator_recurses_into_branches():
+    schema = {
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [
+                    {"type": "string"},
+                    # Nested object missing additionalProperties: false
+                    {
+                        "type": "object",
+                        "properties": {"x": {"type": "integer"}},
+                        "required": ["x"],
+                    },
+                ]
+            }
+        },
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    violation = validate_strict_json_schema(schema, name="union", param="text.format.schema")
+    assert violation is not None
+    assert "anyOf" in violation.message
+
+
+def test_normalize_responses_payload_rejects_strict_violation():
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "",
+        "input": "hi",
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "person",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+            }
+        },
+    }
+    with pytest.raises(ClientPayloadError) as exc_info:
+        normalize_responses_request_payload(payload, openai_compat=False)
+    err = exc_info.value
+    assert err.code == "invalid_json_schema"
+    assert err.error_type == "invalid_request_error"
+    assert err.param == "text.format.schema"
+    assert "person" in str(err)
+
+
+def test_normalize_responses_payload_accepts_strict_false():
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "",
+        "input": "hi",
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "person",
+                "strict": False,
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+            }
+        },
+    }
+    # Strict=False schemas are passed through unchanged.
+    request = normalize_responses_request_payload(payload, openai_compat=False)
+    assert request.text is not None
+    assert request.text.format is not None
+    assert request.text.format.strict is False
+
+
+def test_normalize_responses_payload_accepts_valid_strict_schema():
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "",
+        "input": "hi",
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "person",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+                    "required": ["name", "age"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+    }
+    request = normalize_responses_request_payload(payload, openai_compat=False)
+    assert request.text is not None
+    assert request.text.format is not None
+    assert request.text.format.strict is True
+
+
+def test_chat_completions_strict_schema_violation_surfaces_via_enforce_helper():
+    payload = {
+        "model": "gpt-5.5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "person",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "required": ["name"],
+                },
+            },
+        },
+    }
+    request = ChatCompletionsRequest.model_validate(payload)
+    responses_request = request.to_responses_request()
+    with pytest.raises(ClientPayloadError) as exc_info:
+        enforce_strict_text_format(responses_request)
+    err = exc_info.value
+    assert err.code == "invalid_json_schema"
+    assert err.param == "text.format.schema"

--- a/tests/unit/test_strict_schema_validation.py
+++ b/tests/unit/test_strict_schema_validation.py
@@ -113,6 +113,51 @@ def test_strict_valid_schema_passes():
     assert validate_strict_json_schema(schema, name="person", param="text.format.schema") is None
 
 
+def test_strict_required_must_list_every_property():
+    """Strict mode requires every key in ``properties`` to appear in ``required``.
+
+    Mirrors OpenAI's wording so callers see the same diagnostic regardless
+    of whether the request hit the local pre-check or the upstream API.
+    """
+
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}, "y": {"type": "integer"}},
+        "required": ["x"],
+        "additionalProperties": False,
+    }
+    violation = validate_strict_json_schema(schema, name="p", param="text.format.schema")
+    assert violation is not None
+    assert "required" in violation.message
+    assert "'y'" in violation.message
+    assert "context=()" in violation.message
+
+
+def test_strict_required_empty_array_rejected():
+    """Even an empty ``required`` is rejected when ``properties`` is non-empty."""
+
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "required": [],
+        "additionalProperties": False,
+    }
+    violation = validate_strict_json_schema(schema, name="p", param="text.format.schema")
+    assert violation is not None
+    assert "'x'" in violation.message
+
+
+def test_strict_required_missing_array_rejected():
+    schema = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    violation = validate_strict_json_schema(schema, name="p", param="text.format.schema")
+    assert violation is not None
+    assert "'x'" in violation.message
+
+
 def test_strict_combinator_recurses_into_branches():
     schema = {
         "type": "object",


### PR DESCRIPTION
Closes #491.

## Problem

When a client sends a strict-mode JSON schema (`response_format` /
`text.format` with `strict: true`) that violates OpenAI's structured-outputs
rules — for example `additionalProperties:false` missing on an `object` node,
a missing `type` key, or `additionalProperties:true` on a nested object —
the Codex backend rejects it and closes the websocket session with
`close_code=1000`, sending the original `invalid_json_schema` detail in a
`response.failed` event. The proxy currently overwrites that payload with
a generic `502 stream_incomplete`, so callers (Graphiti, raw SDK clients,
etc.) lose the actionable schema-path diagnostic. Worse, the bridge treats
this as a transient close and runs a `retry_precreated` / `reconnect` cycle
against the same account, wasting another upstream hit on a permanently
invalid request.

`/v1/chat/completions` already preserved the message because the conversion
path captures the upstream error envelope, but `/v1/responses` did not — an
asymmetry between the two endpoints.

## Fix

Validate strict-mode schemas locally before any upstream connection is
opened, mirroring OpenAI's published rules:

* every `object` schema must have `additionalProperties: false`;
* every schema node must declare a `type` (no empty `{}`);
* `anyOf` / `oneOf` / `allOf` branches and `$defs` are walked recursively.

Schemas with `strict` omitted or `strict: false` are passed through
unchanged so the upstream API keeps owning that policy.

The check is done after `ResponsesRequest` is constructed (in
`normalize_responses_request_payload`, plus a callable
`enforce_strict_text_format` used by `/v1/chat/completions` and
`/v1/responses`). On violation, `ClientPayloadError` is raised with
`code=invalid_json_schema`, `type=invalid_request_error`,
`param=text.format.schema`, and is rendered into the OpenAI-style error
envelope by the new `openai_client_payload_error` helper. The result is a
deterministic 400 that matches the message reporters see when they call
`api.openai.com` directly.

Because the request never reaches the upstream websocket, the bridge no
longer triggers a `retry_precreated` cycle for permanently invalid
schemas — the second part of #491 — and the two endpoints become
consistent.

## Verification

Empirical comparison of the proxy (against the dev instance) and OpenAI's
official `/v1/responses` API for the same payloads:

| Schema (strict=true)                                                | OpenAI official     | codex-lb before  | codex-lb after  |
| ------------------------------------------------------------------- | ------------------- | ---------------- | --------------- |
| missing `additionalProperties` at root                              | 400 invalid_json_schema | 502 stream_incomplete | 400 invalid_json_schema |
| nested `additionalProperties: true` (`dict[str, Any]` field)        | 400 invalid_json_schema | 502 stream_incomplete | 400 invalid_json_schema |
| empty `{}` schema node (`Any` field)                                | 400 invalid_json_schema | 502 stream_incomplete | 400 invalid_json_schema |
| valid `additionalProperties:false` + all required                   | 200                 | 200              | 200             |
| `strict: false` (no `additionalProperties`)                         | 200                 | 200              | 200             |

The `400` body now carries the same envelope as upstream:

```json
{
  "error": {
    "message": "Invalid schema for response_format 'graph': In context=('properties', 'nodes', 'items'), 'additionalProperties' is required to be supplied and to be false.",
    "type": "invalid_request_error",
    "code": "invalid_json_schema",
    "param": "text.format.schema"
  }
}
```

Bridge logs no longer show `retry_precreated` / `reconnect` events for
these requests because the connection is never opened.

## Tests

* New unit suite `tests/unit/test_strict_schema_validation.py` covering
  the validator (root violation, nested violation, `dict[str, Any]`,
  `Any` field, valid pass-through, combinator recursion) and the
  pipeline integration through both `normalize_responses_request_payload`
  and `enforce_strict_text_format` (chat-completions path).
* Updated existing
  `tests/integration/test_openai_compat_features.py::test_v1_chat_completions_maps_response_format`
  fixture to be strict-compliant, plus a new
  `test_v1_chat_completions_rejects_strict_schema_violation` integration
  test asserting the 400 envelope shape.
* Full unit suite passes (1320 tests).

## Notes

* Only strict-mode constraints are enforced. The proxy does not rewrite
  schemas to make them compliant — that would silently change the
  client's intent. Returning a deterministic 400 lets the client decide
  whether to drop `strict`, add `additionalProperties: false`, or fix
  optional-field handling.
* The validator handles `$ref` / combinator nodes by recursing without
  requiring a top-level `type`, since strict mode allows those shapes.
* The `openai_client_payload_error` helper preserves backward
  compatibility with existing `ClientPayloadError` callsites that don't
  set `code` / `error_type` — they still get the legacy
  `invalid_request_error` payload.
