### PR TITLE
fix(proxy): return API-key limits from v1 usage

### DIFF
--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -765,7 +765,7 @@ class ApiKeysService:
                 remaining_value=max(0, limit.max_value - max(0, min(limit.current_value, limit.max_value))),
                 model_filter=limit.model_filter,
                 reset_at=limit.reset_at,
-                source="api_key_override" if limit.limit_type == LimitType.CREDITS else "api_key_limit",
+                source="api_key_limit",
             )
             for limit in refreshed.limits
         ]

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -59,7 +59,6 @@ from app.modules.api_keys.service import (
     ApiKeyInvalidError,
     ApiKeyRateLimitExceededError,
     ApiKeySelfLimitData,
-    ApiKeySelfUsageData,
     ApiKeysService,
     ApiKeyUsageReservationData,
 )
@@ -357,32 +356,13 @@ async def v1_usage(
         total_tokens=usage.total_tokens,
         cached_input_tokens=usage.cached_input_tokens,
         total_cost_usd=usage.total_cost_usd,
-        limits=_build_v1_usage_limits(usage, aggregate_limits),
+        limits=[_to_v1_usage_limit_response(limit) for limit in usage.limits],
+        upstream_limits=_ordered_aggregate_limits(aggregate_limits),
     )
 
 
-def _build_v1_usage_limits(
-    usage: ApiKeySelfUsageData,
-    aggregate_limits: dict[str, V1UsageLimitResponse],
-) -> list[V1UsageLimitResponse]:
-    raw_limits = [_to_v1_usage_limit_response(limit) for limit in usage.limits]
-    credit_overrides = {
-        limit.limit_window: limit
-        for limit in usage.limits
-        if limit.limit_type == "credits" and limit.model_filter is None
-    }
-
-    if aggregate_limits:
-        merged: list[V1UsageLimitResponse] = []
-        for window in ("5h", "7d"):
-            aggregate = aggregate_limits.get(window)
-            if aggregate is None:
-                continue
-            merged.append(_apply_credit_override(aggregate, credit_overrides.get(window)))
-        if {item.limit_window for item in merged} == {"5h", "7d"}:
-            return merged
-
-    return raw_limits
+def _ordered_aggregate_limits(aggregate_limits: dict[str, V1UsageLimitResponse]) -> list[V1UsageLimitResponse]:
+    return [limit for window in ("5h", "7d") if (limit := aggregate_limits.get(window)) is not None]
 
 
 def _to_v1_usage_limit_response(limit: ApiKeySelfLimitData) -> V1UsageLimitResponse:
@@ -396,27 +376,6 @@ def _to_v1_usage_limit_response(limit: ApiKeySelfLimitData) -> V1UsageLimitRespo
         model_filter=limit.model_filter,
         reset_at=limit.reset_at.isoformat() + "Z",
         source=limit.source,
-    )
-
-
-def _apply_credit_override(
-    aggregate_limit: V1UsageLimitResponse,
-    override_limit: ApiKeySelfLimitData | None,
-) -> V1UsageLimitResponse:
-    if override_limit is None:
-        return aggregate_limit
-
-    override_max = max(0, override_limit.max_value)
-    current_value = max(0, min(aggregate_limit.current_value, override_max))
-    return V1UsageLimitResponse(
-        limit_type="credits",
-        limit_window=aggregate_limit.limit_window,
-        max_value=override_max,
-        current_value=current_value,
-        remaining_value=max(0, override_max - current_value),
-        model_filter=None,
-        reset_at=aggregate_limit.reset_at,
-        source="api_key_override",
     )
 
 

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -199,3 +199,4 @@ class V1UsageResponse(BaseModel):
     cached_input_tokens: int
     total_cost_usd: float
     limits: list[V1UsageLimitResponse]
+    upstream_limits: list[V1UsageLimitResponse] = []

--- a/openspec/changes/add-v1-api-key-usage/specs/api-keys/spec.md
+++ b/openspec/changes/add-v1-api-key-usage/specs/api-keys/spec.md
@@ -8,7 +8,8 @@ The system SHALL expose `GET /v1/usage` for self-service usage lookup by API-key
 - `total_tokens`
 - `cached_input_tokens`
 - `total_cost_usd`
-- `limits[]` containing `limit_type`, `limit_window`, `max_value`, `current_value`, `remaining_value`, `model_filter`, and `reset_at`
+- `limits[]` containing only limits configured on the authenticated API key, with `limit_type`, `limit_window`, `max_value`, `current_value`, `remaining_value`, `model_filter`, `reset_at`, and `source`
+- `upstream_limits[]` containing aggregate upstream Codex credit windows when available, with the same fields and `source: "aggregate"`
 
 Validation failures MUST use the existing OpenAI error envelope used by `/v1/*` routes.
 
@@ -31,6 +32,13 @@ Validation failures MUST use the existing OpenAI error envelope used by `/v1/*` 
 
 - **WHEN** multiple API keys have request-log history and one of them calls `GET /v1/usage`
 - **THEN** the response includes only the usage totals and limits for that authenticated key
+
+#### Scenario: Upstream limits are separate from API-key limits
+
+- **WHEN** an API key with its own limit calls `GET /v1/usage`
+- **AND** upstream Codex aggregate usage data exists
+- **THEN** `limits[]` contains the API-key limit values
+- **AND** `upstream_limits[]` contains the aggregate Codex credit windows
 
 #### Scenario: Self-usage works while global proxy auth is disabled
 

--- a/openspec/changes/add-v1-api-key-usage/tasks.md
+++ b/openspec/changes/add-v1-api-key-usage/tasks.md
@@ -8,9 +8,11 @@
 - [ ] 2.1 Add integration coverage for missing/invalid API keys.
 - [ ] 2.2 Add integration coverage for zero-usage responses, per-key usage scoping, and returned limit state.
 - [ ] 2.3 Add integration coverage that `GET /v1/usage` still works when global proxy API-key auth is disabled.
+- [ ] 2.4 Add integration coverage that upstream Codex aggregate limits are returned separately from API-key limits.
 
 ## 3. Implementation
 
 - [ ] 3.1 Add self-usage API-key validation that always requires a valid Bearer key.
 - [ ] 3.2 Add `GET /v1/usage` and return usage totals plus current limits for the authenticated key.
 - [ ] 3.3 Reuse API-key repository/service aggregation instead of scanning all keys.
+- [ ] 3.4 Include upstream aggregate Codex credit windows without replacing authenticated key limits.

--- a/tests/integration/test_v1_usage.py
+++ b/tests/integration/test_v1_usage.py
@@ -289,6 +289,7 @@ async def test_v1_usage_returns_zero_usage_for_key_without_logs(async_client):
         "cached_input_tokens": 0,
         "total_cost_usd": 0.0,
         "limits": [],
+        "upstream_limits": [],
     }
 
 
@@ -440,32 +441,33 @@ async def test_v1_usage_returns_aggregate_credit_limits_when_upstream_usage_exis
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["limits"][0] == {
+    assert payload["limits"] == []
+    assert payload["upstream_limits"][0] == {
         "limit_type": "credits",
         "limit_window": "5h",
         "max_value": 450,
         "current_value": 68,
         "remaining_value": 382,
         "model_filter": None,
-        "reset_at": payload["limits"][0]["reset_at"],
+        "reset_at": payload["upstream_limits"][0]["reset_at"],
         "source": "aggregate",
     }
-    assert payload["limits"][1] == {
+    assert payload["upstream_limits"][1] == {
         "limit_type": "credits",
         "limit_window": "7d",
         "max_value": 15120,
         "current_value": 3780,
         "remaining_value": 11340,
         "model_filter": None,
-        "reset_at": payload["limits"][1]["reset_at"],
+        "reset_at": payload["upstream_limits"][1]["reset_at"],
         "source": "aggregate",
     }
-    assert payload["limits"][0]["reset_at"].endswith("Z")
-    assert payload["limits"][1]["reset_at"].endswith("Z")
+    assert payload["upstream_limits"][0]["reset_at"].endswith("Z")
+    assert payload["upstream_limits"][1]["reset_at"].endswith("Z")
 
 
 @pytest.mark.asyncio
-async def test_v1_usage_overrides_aggregate_credit_windows_with_api_key_credit_limits(async_client):
+async def test_v1_usage_returns_api_key_and_upstream_credit_limits_separately(async_client):
     key_id, plain_key = await _create_api_key(
         name="credit-override",
         limits=[
@@ -515,19 +517,21 @@ async def test_v1_usage_overrides_aggregate_credit_windows_with_api_key_credit_l
             "remaining_value": 0,
             "model_filter": None,
             "reset_at": payload["limits"][0]["reset_at"],
-            "source": "api_key_override",
+            "source": "api_key_limit",
         },
         {
             "limit_type": "credits",
             "limit_window": "7d",
             "max_value": 1000,
-            "current_value": 1000,
-            "remaining_value": 0,
+            "current_value": 10,
+            "remaining_value": 990,
             "model_filter": None,
             "reset_at": payload["limits"][1]["reset_at"],
-            "source": "api_key_override",
+            "source": "api_key_limit",
         },
     ]
+    assert [limit["source"] for limit in payload["upstream_limits"]] == ["aggregate", "aggregate"]
+    assert [limit["limit_window"] for limit in payload["upstream_limits"]] == ["5h", "7d"]
 
 
 @pytest.mark.asyncio
@@ -597,6 +601,7 @@ async def test_v1_usage_prefers_raw_limits_when_aggregate_credit_pair_is_partial
             "source": "api_key_limit",
         },
     ]
+    assert [limit["limit_window"] for limit in payload["upstream_limits"]] == ["5h"]
 
 
 @pytest.mark.asyncio
@@ -644,7 +649,8 @@ async def test_v1_usage_falls_back_to_raw_credit_limits_when_aggregate_reset_is_
     response = await async_client.get("/v1/usage", headers={"Authorization": f"Bearer {plain_key}"})
 
     assert response.status_code == 200
-    assert response.json()["limits"] == [
+    payload = response.json()
+    assert payload["limits"] == [
         {
             "limit_type": "credits",
             "limit_window": "5h",
@@ -653,7 +659,7 @@ async def test_v1_usage_falls_back_to_raw_credit_limits_when_aggregate_reset_is_
             "remaining_value": 48,
             "model_filter": None,
             "reset_at": primary_reset.isoformat() + "Z",
-            "source": "api_key_override",
+            "source": "api_key_limit",
         },
         {
             "limit_type": "credits",
@@ -663,9 +669,10 @@ async def test_v1_usage_falls_back_to_raw_credit_limits_when_aggregate_reset_is_
             "remaining_value": 750,
             "model_filter": None,
             "reset_at": secondary_reset.isoformat() + "Z",
-            "source": "api_key_override",
+            "source": "api_key_limit",
         },
     ]
+    assert [limit["limit_window"] for limit in payload["upstream_limits"]] == ["7d"]
 
 
 @pytest.mark.asyncio
@@ -678,7 +685,8 @@ async def test_v1_usage_ignores_paused_and_deactivated_accounts_in_aggregate_cre
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["limits"] == [
+    assert payload["limits"] == []
+    assert payload["upstream_limits"] == [
         {
             "limit_type": "credits",
             "limit_window": "5h",
@@ -686,7 +694,7 @@ async def test_v1_usage_ignores_paused_and_deactivated_accounts_in_aggregate_cre
             "current_value": 45,
             "remaining_value": 180,
             "model_filter": None,
-            "reset_at": payload["limits"][0]["reset_at"],
+            "reset_at": payload["upstream_limits"][0]["reset_at"],
             "source": "aggregate",
         },
         {
@@ -696,7 +704,7 @@ async def test_v1_usage_ignores_paused_and_deactivated_accounts_in_aggregate_cre
             "current_value": 1890,
             "remaining_value": 5670,
             "model_filter": None,
-            "reset_at": payload["limits"][1]["reset_at"],
+            "reset_at": payload["upstream_limits"][1]["reset_at"],
             "source": "aggregate",
         },
     ]


### PR DESCRIPTION
## Summary
- Keep `/v1/usage.limits` scoped to the authenticated API key.
- Add `upstream_limits` for aggregate upstream Codex credit windows so both datasets remain available without merging them.
- Update OpenSpec delta and integration coverage for the separated limit sources.

Fixes #499

## Tests
- `.venv/bin/python -m pytest tests/integration/test_v1_usage.py tests/integration/test_codex_usage_api.py`
- `.venv/bin/python -m ruff check app/modules/proxy/api.py app/modules/proxy/schemas.py app/modules/api_keys/service.py tests/integration/test_v1_usage.py`

## Notes
- `openspec validate --specs` could not be run locally because the `openspec` executable is not available on PATH in this environment.