### PR TITLE
fix(model-refresh): refresh HTTP client on transport errors

### DIFF
--- a/app/core/auth/refresh.py
+++ b/app/core/auth/refresh.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import logging
 from dataclasses import dataclass
@@ -11,7 +12,7 @@ from pydantic import ValidationError
 from app.core.auth import OpenAIAuthClaims, extract_id_token_claims
 from app.core.auth.models import OAuthTokenPayload
 from app.core.balancer import PERMANENT_FAILURE_CODES
-from app.core.clients.http import get_http_client
+from app.core.clients.http import lease_http_session
 from app.core.config.settings import get_settings
 from app.core.types import JsonObject
 from app.core.utils.request_id import get_request_id
@@ -37,11 +38,12 @@ class TokenRefreshResult:
 
 
 class RefreshError(Exception):
-    def __init__(self, code: str, message: str, is_permanent: bool) -> None:
+    def __init__(self, code: str, message: str, is_permanent: bool, *, transport_error: bool = False) -> None:
         super().__init__(message)
         self.code = code
         self.message = message
         self.is_permanent = is_permanent
+        self.transport_error = transport_error
 
 
 def should_refresh(last_refresh: datetime, now: datetime | None = None) -> bool:
@@ -72,28 +74,39 @@ async def refresh_access_token(
     }
     timeout = aiohttp.ClientTimeout(total=_effective_token_refresh_timeout(settings.token_refresh_timeout_seconds))
 
-    client_session = session or get_http_client().session
     headers: dict[str, str] = {}
     request_id = get_request_id()
     if request_id:
         headers["x-request-id"] = request_id
-    async with client_session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
-        data = await _safe_json(resp)
-        try:
-            payload_data = OAuthTokenPayload.model_validate(data)
-        except ValidationError as exc:
-            logger.warning(
-                "Token refresh response invalid request_id=%s",
-                get_request_id(),
-            )
-            raise RefreshError("invalid_response", "Refresh response invalid", False) from exc
-        if resp.status >= 400:
-            logger.warning(
-                "Token refresh failed request_id=%s status=%s",
-                get_request_id(),
-                resp.status,
-            )
-            raise _refresh_error_from_payload(payload_data, resp.status)
+    try:
+        async with lease_http_session(session) as client_session:
+            async with client_session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
+                data = await _safe_json(resp)
+                try:
+                    payload_data = OAuthTokenPayload.model_validate(data)
+                except ValidationError as exc:
+                    logger.warning(
+                        "Token refresh response invalid request_id=%s",
+                        get_request_id(),
+                    )
+                    raise RefreshError("invalid_response", "Refresh response invalid", False) from exc
+                if resp.status >= 400:
+                    logger.warning(
+                        "Token refresh failed request_id=%s status=%s",
+                        get_request_id(),
+                        resp.status,
+                    )
+                    raise _refresh_error_from_payload(payload_data, resp.status)
+    except RefreshError:
+        raise
+    except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
+        message = str(exc) or exc.__class__.__name__
+        raise RefreshError(
+            "transport_error",
+            f"Transport error during token refresh: {message}",
+            False,
+            transport_error=True,
+        ) from exc
 
     if not payload_data.access_token or not payload_data.refresh_token or not payload_data.id_token:
         raise RefreshError("invalid_response", "Refresh response missing tokens", False)

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+import contextlib
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from types import TracebackType
 
 import aiohttp
 from aiohttp_retry import RetryClient
 
 from app.core.config.settings import get_settings
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -16,8 +22,43 @@ class HttpClient:
     retry_client: RetryClient
 
 
-_http_client: HttpClient | None = None
+@dataclass(slots=True, eq=False)
+class _ManagedHttpClient:
+    client: HttpClient
+    active_leases: int = 0
+    close_requested: bool = False
+    close_task: asyncio.Task[None] | None = None
+    closed: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+_http_client: _ManagedHttpClient | None = None
 _http_client_lock = asyncio.Lock()
+_retired_http_clients: list[_ManagedHttpClient] = []
+_closing_http_clients: list[_ManagedHttpClient] = []
+
+
+class HttpClientLease:
+    def __init__(self, managed_client: _ManagedHttpClient) -> None:
+        self.client = managed_client.client
+        self._managed_client = managed_client
+        self._closed = False
+
+    async def __aenter__(self) -> HttpClient:
+        return self.client
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        await self.close()
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await _release_http_client(self._managed_client)
 
 
 async def _build_http_client() -> HttpClient:
@@ -56,24 +97,113 @@ async def _close_client(client: HttpClient) -> None:
         await client.retry_client.close()
 
 
+async def _close_managed_client(managed_client: _ManagedHttpClient) -> None:
+    try:
+        await _close_client(managed_client.client)
+    finally:
+        managed_client.closed.set()
+
+
+def _complete_managed_client_close(managed_client: _ManagedHttpClient, task: asyncio.Task[None]) -> None:
+    with contextlib.suppress(ValueError):
+        _closing_http_clients.remove(managed_client)
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        return
+    except Exception:
+        logger.exception("HTTP client close failed")
+
+
+def _start_client_close_locked(managed_client: _ManagedHttpClient) -> asyncio.Task[None]:
+    if managed_client.close_task is not None:
+        return managed_client.close_task
+    with contextlib.suppress(ValueError):
+        _retired_http_clients.remove(managed_client)
+    _closing_http_clients.append(managed_client)
+    task = asyncio.create_task(_close_managed_client(managed_client))
+    managed_client.close_task = task
+    task.add_done_callback(lambda completed_task: _complete_managed_client_close(managed_client, completed_task))
+    return task
+
+
+def _request_client_close_locked(managed_client: _ManagedHttpClient, *, force: bool = False) -> None:
+    managed_client.close_requested = True
+    if managed_client.active_leases > 0 and not force:
+        if managed_client not in _retired_http_clients:
+            _retired_http_clients.append(managed_client)
+        return
+    _start_client_close_locked(managed_client)
+
+
+async def _release_http_client(managed_client: _ManagedHttpClient) -> None:
+    async with _http_client_lock:
+        managed_client.active_leases -= 1
+        if managed_client.active_leases < 0:
+            raise RuntimeError("HTTP client lease released too many times")
+        if managed_client.close_requested and managed_client.active_leases == 0:
+            _start_client_close_locked(managed_client)
+
+
+async def acquire_http_client() -> HttpClientLease:
+    async with _http_client_lock:
+        if _http_client is None:
+            raise RuntimeError("HTTP client not initialized")
+        _http_client.active_leases += 1
+        return HttpClientLease(_http_client)
+
+
+@contextlib.asynccontextmanager
+async def lease_http_client() -> AsyncIterator[HttpClient]:
+    lease = await acquire_http_client()
+    try:
+        yield lease.client
+    finally:
+        await lease.close()
+
+
+@contextlib.asynccontextmanager
+async def lease_http_session(
+    session: aiohttp.ClientSession | None = None,
+) -> AsyncIterator[aiohttp.ClientSession]:
+    if session is not None:
+        yield session
+        return
+    async with lease_http_client() as client:
+        yield client.session
+
+
+@contextlib.asynccontextmanager
+async def lease_retry_client(
+    client: RetryClient | None = None,
+) -> AsyncIterator[RetryClient]:
+    if client is not None:
+        yield client
+        return
+    async with lease_http_client() as http_client:
+        yield http_client.retry_client
+
+
 async def init_http_client() -> HttpClient:
     global _http_client
     async with _http_client_lock:
         if _http_client is not None:
-            return _http_client
-        _http_client = await _build_http_client()
-        return _http_client
+            return _http_client.client
+        client = await _build_http_client()
+        _http_client = _ManagedHttpClient(client=client)
+        return client
 
 
 async def refresh_http_client() -> HttpClient:
     global _http_client
     async with _http_client_lock:
         previous = _http_client
-        replacement = await _build_http_client()
+        replacement_client = await _build_http_client()
+        replacement = _ManagedHttpClient(client=replacement_client)
         _http_client = replacement
-    if previous is not None:
-        await _close_client(previous)
-    return replacement
+        if previous is not None:
+            _request_client_close_locked(previous)
+    return replacement_client
 
 
 async def close_http_client() -> None:
@@ -81,11 +211,21 @@ async def close_http_client() -> None:
     async with _http_client_lock:
         client = _http_client
         _http_client = None
-    if client is not None:
-        await _close_client(client)
+        clients = (
+            *((client,) if client is not None else ()),
+            *_retired_http_clients,
+            *_closing_http_clients,
+        )
+        for managed_client in clients:
+            # Global shutdown has already bounded request drain; do not let
+            # long-lived streams keep process shutdown waiting on active leases.
+            _request_client_close_locked(managed_client, force=True)
+    if clients:
+        await asyncio.gather(*(managed_client.closed.wait() for managed_client in clients))
 
 
 def get_http_client() -> HttpClient:
+    """Return the current client for compatibility; network use should lease it."""
     if _http_client is None:
         raise RuntimeError("HTTP client not initialized")
-    return _http_client
+    return _http_client.client

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 
 import aiohttp
@@ -16,12 +17,10 @@ class HttpClient:
 
 
 _http_client: HttpClient | None = None
+_http_client_lock = asyncio.Lock()
 
 
-async def init_http_client() -> HttpClient:
-    global _http_client
-    if _http_client is not None:
-        return _http_client
+async def _build_http_client() -> HttpClient:
     settings = get_settings()
     connector = aiohttp.TCPConnector(
         limit=settings.http_connector_limit,
@@ -43,24 +42,47 @@ async def init_http_client() -> HttpClient:
         await session.close()
         raise
     retry_client = RetryClient(client_session=session, raise_for_status=False)
-    _http_client = HttpClient(
+    return HttpClient(
         session=session,
         websocket_session=websocket_session,
         retry_client=retry_client,
     )
-    return _http_client
 
 
-async def close_http_client() -> None:
-    global _http_client
-    if _http_client is None:
-        return
-    client = _http_client
+async def _close_client(client: HttpClient) -> None:
     try:
         await client.websocket_session.close()
     finally:
         await client.retry_client.close()
-    _http_client = None
+
+
+async def init_http_client() -> HttpClient:
+    global _http_client
+    async with _http_client_lock:
+        if _http_client is not None:
+            return _http_client
+        _http_client = await _build_http_client()
+        return _http_client
+
+
+async def refresh_http_client() -> HttpClient:
+    global _http_client
+    async with _http_client_lock:
+        previous = _http_client
+        replacement = await _build_http_client()
+        _http_client = replacement
+    if previous is not None:
+        await _close_client(previous)
+    return replacement
+
+
+async def close_http_client() -> None:
+    global _http_client
+    async with _http_client_lock:
+        client = _http_client
+        _http_client = None
+    if client is not None:
+        await _close_client(client)
 
 
 def get_http_client() -> HttpClient:

--- a/app/core/clients/model_fetcher.py
+++ b/app/core/clients/model_fetcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import cast
 
@@ -18,10 +19,11 @@ _FILTERED_FIELDS = {"model_messages"}
 
 
 class ModelFetchError(Exception):
-    def __init__(self, status_code: int, message: str) -> None:
+    def __init__(self, status_code: int, message: str, *, transport_error: bool = False) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.message = message
+        self.transport_error = transport_error
 
 
 def _str(data: dict[str, JsonValue], key: str, default: str = "") -> str:
@@ -111,12 +113,18 @@ async def fetch_models_for_plan(
     timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
     session = get_http_client().session
 
-    async with session.get(url, headers=headers, timeout=timeout) as resp:
-        if resp.status >= 400:
-            text = await resp.text()
-            raise ModelFetchError(resp.status, f"HTTP {resp.status}: {text[:200]}")
+    try:
+        async with session.get(url, headers=headers, timeout=timeout) as resp:
+            if resp.status >= 400:
+                text = await resp.text()
+                raise ModelFetchError(resp.status, f"HTTP {resp.status}: {text[:200]}")
 
-        data = await resp.json(content_type=None)
+            data = await resp.json(content_type=None)
+    except ModelFetchError:
+        raise
+    except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
+        message = str(exc) or exc.__class__.__name__
+        raise ModelFetchError(0, f"Transport error during model fetch: {message}", transport_error=True) from exc
 
     if not isinstance(data, dict):
         raise ModelFetchError(502, "Invalid response format from upstream models API")

--- a/app/core/clients/model_fetcher.py
+++ b/app/core/clients/model_fetcher.py
@@ -7,7 +7,7 @@ from typing import cast
 import aiohttp
 
 from app.core.clients.codex_version import get_codex_version_cache
-from app.core.clients.http import get_http_client
+from app.core.clients.http import lease_http_session
 from app.core.config.settings import get_settings
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel
 from app.core.types import JsonValue
@@ -111,15 +111,14 @@ async def fetch_models_for_plan(
         headers["chatgpt-account-id"] = account_id
 
     timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
-    session = get_http_client().session
-
     try:
-        async with session.get(url, headers=headers, timeout=timeout) as resp:
-            if resp.status >= 400:
-                text = await resp.text()
-                raise ModelFetchError(resp.status, f"HTTP {resp.status}: {text[:200]}")
+        async with lease_http_session() as session:
+            async with session.get(url, headers=headers, timeout=timeout) as resp:
+                if resp.status >= 400:
+                    text = await resp.text()
+                    raise ModelFetchError(resp.status, f"HTTP {resp.status}: {text[:200]}")
 
-            data = await resp.json(content_type=None)
+                data = await resp.json(content_type=None)
     except ModelFetchError:
         raise
     except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:

--- a/app/core/clients/oauth.py
+++ b/app/core/clients/oauth.py
@@ -12,7 +12,7 @@ import aiohttp
 from pydantic import ValidationError
 
 from app.core.auth.models import DeviceCodePayload, OAuthTokenPayload
-from app.core.clients.http import get_http_client
+from app.core.clients.http import lease_http_session
 from app.core.config.settings import get_settings
 from app.core.types import JsonObject
 from app.core.utils.request_id import get_request_id
@@ -105,33 +105,33 @@ async def exchange_authorization_code(
     encoded = urlencode(payload, quote_via=quote)
     timeout = aiohttp.ClientTimeout(total=timeout_seconds or settings.oauth_timeout_seconds)
 
-    client_session = session or get_http_client().session
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     request_id = get_request_id()
     if request_id:
         headers["x-request-id"] = request_id
-    async with client_session.post(
-        url,
-        data=encoded,
-        headers=headers,
-        timeout=timeout,
-    ) as resp:
-        data = await _safe_json(resp)
-        try:
-            payload = OAuthTokenPayload.model_validate(data)
-        except ValidationError as exc:
-            logger.warning(
-                "OAuth token response invalid request_id=%s",
-                get_request_id(),
-            )
-            raise OAuthError("invalid_response", "OAuth response invalid") from exc
-        if resp.status >= 400:
-            logger.warning(
-                "OAuth token request failed request_id=%s status=%s",
-                get_request_id(),
-                resp.status,
-            )
-            raise _oauth_error_from_payload(payload, resp.status)
+    async with lease_http_session(session) as client_session:
+        async with client_session.post(
+            url,
+            data=encoded,
+            headers=headers,
+            timeout=timeout,
+        ) as resp:
+            data = await _safe_json(resp)
+            try:
+                payload = OAuthTokenPayload.model_validate(data)
+            except ValidationError as exc:
+                logger.warning(
+                    "OAuth token response invalid request_id=%s",
+                    get_request_id(),
+                )
+                raise OAuthError("invalid_response", "OAuth response invalid") from exc
+            if resp.status >= 400:
+                logger.warning(
+                    "OAuth token request failed request_id=%s status=%s",
+                    get_request_id(),
+                    resp.status,
+                )
+                raise _oauth_error_from_payload(payload, resp.status)
 
     return _parse_tokens(payload)
 
@@ -151,41 +151,41 @@ async def request_device_code(
     }
     timeout = aiohttp.ClientTimeout(total=timeout_seconds or settings.oauth_timeout_seconds)
 
-    client_session = session or get_http_client().session
     headers: dict[str, str] = {}
     request_id = get_request_id()
     if request_id:
         headers["x-request-id"] = request_id
-    async with client_session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
-        data = await _safe_json(resp)
-        if resp.status >= 400:
-            if resp.status == 404:
-                raise OAuthError(
-                    "device_auth_unavailable",
-                    (
-                        "Device code login is not enabled for this Codex server. "
-                        "Use the browser login or verify the server URL."
-                    ),
+    async with lease_http_session(session) as client_session:
+        async with client_session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
+            data = await _safe_json(resp)
+            if resp.status >= 400:
+                if resp.status == 404:
+                    raise OAuthError(
+                        "device_auth_unavailable",
+                        (
+                            "Device code login is not enabled for this Codex server. "
+                            "Use the browser login or verify the server URL."
+                        ),
+                        resp.status,
+                    )
+                logger.warning(
+                    "Device auth request failed request_id=%s status=%s",
+                    get_request_id(),
                     resp.status,
                 )
-            logger.warning(
-                "Device auth request failed request_id=%s status=%s",
-                get_request_id(),
-                resp.status,
-            )
-            raise OAuthError(
-                "device_auth_failed",
-                f"Device code request failed with status {resp.status}",
-                resp.status,
-            )
-        try:
-            payload_data = DeviceCodePayload.model_validate(data)
-        except ValidationError as exc:
-            logger.warning(
-                "Device auth response invalid request_id=%s",
-                get_request_id(),
-            )
-            raise OAuthError("invalid_response", "Device auth response invalid") from exc
+                raise OAuthError(
+                    "device_auth_failed",
+                    f"Device code request failed with status {resp.status}",
+                    resp.status,
+                )
+            try:
+                payload_data = DeviceCodePayload.model_validate(data)
+            except ValidationError as exc:
+                logger.warning(
+                    "Device auth response invalid request_id=%s",
+                    get_request_id(),
+                )
+                raise OAuthError("invalid_response", "Device auth response invalid") from exc
     verification_url = f"{auth_base}/codex/device"
     user_code = payload_data.user_code
     device_auth_id = payload_data.device_auth_id
@@ -219,34 +219,34 @@ async def exchange_device_token(
     payload = {"device_auth_id": device_auth_id, "user_code": user_code}
     timeout = aiohttp.ClientTimeout(total=timeout_seconds or settings.oauth_timeout_seconds)
 
-    client_session = session or get_http_client().session
     headers: dict[str, str] = {}
     request_id = get_request_id()
     if request_id:
         headers["x-request-id"] = request_id
-    async with client_session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
-        data = await _safe_json(resp)
-        try:
-            payload_data = OAuthTokenPayload.model_validate(data)
-        except ValidationError as exc:
-            logger.warning(
-                "Device token response invalid request_id=%s",
-                get_request_id(),
-            )
-            raise OAuthError("invalid_response", "Device auth response invalid") from exc
-        if resp.status in (403, 404):
-            return None
-        if resp.status >= 400:
+    async with lease_http_session(session) as client_session:
+        async with client_session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
+            data = await _safe_json(resp)
+            try:
+                payload_data = OAuthTokenPayload.model_validate(data)
+            except ValidationError as exc:
+                logger.warning(
+                    "Device token response invalid request_id=%s",
+                    get_request_id(),
+                )
+                raise OAuthError("invalid_response", "Device auth response invalid") from exc
+            if resp.status in (403, 404):
+                return None
+            if resp.status >= 400:
+                if _is_pending_error(payload_data):
+                    return None
+                logger.warning(
+                    "Device token request failed request_id=%s status=%s",
+                    get_request_id(),
+                    resp.status,
+                )
+                raise _oauth_error_from_payload(payload_data, resp.status)
             if _is_pending_error(payload_data):
                 return None
-            logger.warning(
-                "Device token request failed request_id=%s status=%s",
-                get_request_id(),
-                resp.status,
-            )
-            raise _oauth_error_from_payload(payload_data, resp.status)
-        if _is_pending_error(payload_data):
-            return None
 
     if payload_data.authorization_code:
         if not payload_data.code_verifier:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -33,7 +33,7 @@ from aiohttp.client_ws import DEFAULT_WS_CLIENT_TIMEOUT, WebSocketDataQueue
 from aiohttp.http_websocket import WS_KEY, WebSocketReader, WebSocketWriter
 from multidict import CIMultiDict
 
-from app.core.clients.http import get_http_client
+from app.core.clients.http import lease_http_session
 from app.core.config.settings import Settings, get_settings
 from app.core.errors import (
     OpenAIErrorDetail,
@@ -1774,6 +1774,30 @@ async def stream_responses(
     session: aiohttp.ClientSession | None = None,
     upstream_stream_transport_override: str | None = None,
 ) -> AsyncIterator[str]:
+    async with lease_http_session(session) as client_session:
+        async for event_block in _stream_responses_with_session(
+            payload=payload,
+            headers=headers,
+            access_token=access_token,
+            account_id=account_id,
+            base_url=base_url,
+            raise_for_status=raise_for_status,
+            session=client_session,
+            upstream_stream_transport_override=upstream_stream_transport_override,
+        ):
+            yield event_block
+
+
+async def _stream_responses_with_session(
+    payload: ResponsesRequest,
+    headers: Mapping[str, str],
+    access_token: str,
+    account_id: str | None,
+    session: aiohttp.ClientSession,
+    base_url: str | None = None,
+    raise_for_status: bool = False,
+    upstream_stream_transport_override: str | None = None,
+) -> AsyncIterator[str]:
     settings = get_settings()
     upstream_base = (base_url or settings.upstream_base_url).rstrip("/")
     url = f"{upstream_base}/codex/responses"
@@ -1792,7 +1816,7 @@ async def stream_responses(
     status_code: int | None = None
     error_code: str | None = None
     error_message: str | None = None
-    client_session = session or get_http_client().session
+    client_session = session
     payload_dict = payload.to_payload()
     if settings.image_inline_fetch_enabled:
         payload_dict = await _inline_input_image_urls(
@@ -2153,14 +2177,15 @@ async def compact_responses(
     account_id: str | None,
     session: aiohttp.ClientSession | None = None,
 ) -> CompactResponsePayload:
-    transport = _CompactCommandTransport(
-        payload=payload,
-        headers=headers,
-        access_token=access_token,
-        account_id=account_id,
-        session=session or get_http_client().session,
-    )
-    return await transport.execute()
+    async with lease_http_session(session) as client_session:
+        transport = _CompactCommandTransport(
+            payload=payload,
+            headers=headers,
+            access_token=access_token,
+            account_id=account_id,
+            session=client_session,
+        )
+        return await transport.execute()
 
 
 def _is_retryable_compact_status(status_code: int) -> bool:
@@ -2378,6 +2403,32 @@ async def transcribe_audio(
     base_url: str | None = None,
     session: aiohttp.ClientSession | None = None,
 ) -> dict[str, JsonValue]:
+    async with lease_http_session(session) as client_session:
+        return await _transcribe_audio_with_session(
+            audio_bytes,
+            filename=filename,
+            content_type=content_type,
+            prompt=prompt,
+            headers=headers,
+            access_token=access_token,
+            account_id=account_id,
+            base_url=base_url,
+            session=client_session,
+        )
+
+
+async def _transcribe_audio_with_session(
+    audio_bytes: bytes,
+    *,
+    filename: str,
+    content_type: str | None,
+    prompt: str | None,
+    headers: Mapping[str, str],
+    access_token: str,
+    account_id: str | None,
+    session: aiohttp.ClientSession,
+    base_url: str | None = None,
+) -> dict[str, JsonValue]:
     settings = get_settings()
     upstream_base = (base_url or settings.upstream_base_url).rstrip("/")
     url = f"{upstream_base}/transcribe"
@@ -2414,7 +2465,7 @@ async def transcribe_audio(
     if prompt is not None:
         form.add_field("prompt", prompt)
 
-    client_session = session or get_http_client().session
+    client_session = session
     started_at = time.monotonic()
     status_code: int | None = None
     error_code: str | None = None

--- a/app/core/clients/usage.py
+++ b/app/core/clients/usage.py
@@ -7,7 +7,7 @@ import aiohttp
 from aiohttp_retry import ExponentialRetry, RetryClient
 from pydantic import BaseModel, ConfigDict, ValidationError
 
-from app.core.clients.http import get_http_client
+from app.core.clients.http import lease_retry_client
 from app.core.config.settings import get_settings
 from app.core.types import JsonObject
 from app.core.usage.models import UsagePayload
@@ -59,37 +59,37 @@ async def fetch_usage(
     timeout = aiohttp.ClientTimeout(total=timeout_seconds or settings.usage_fetch_timeout_seconds)
     retries = max_retries if max_retries is not None else settings.usage_fetch_max_retries
     headers = _usage_headers(access_token, account_id)
-    retry_client = client or get_http_client().retry_client
     retry_options = _retry_options(retries + 1)
 
     try:
-        async with retry_client.request(
-            "GET",
-            url,
-            headers=headers,
-            timeout=timeout,
-            retry_options=retry_options,
-        ) as resp:
-            data = await _safe_json(resp)
-            if resp.status >= 400:
-                code = _extract_error_code(data)
-                message = _extract_error_message(data) or f"Usage fetch failed ({resp.status})"
-                logger.warning(
-                    "Usage fetch failed request_id=%s status=%s code=%s message=%s",
-                    get_request_id(),
-                    resp.status,
-                    code,
-                    message,
-                )
-                raise UsageFetchError(resp.status, message, code=code)
-            try:
-                return UsagePayload.model_validate(data)
-            except ValidationError as exc:
-                logger.warning(
-                    "Usage fetch invalid payload request_id=%s",
-                    get_request_id(),
-                )
-                raise UsageFetchError(502, "Invalid usage payload") from exc
+        async with lease_retry_client(client) as retry_client:
+            async with retry_client.request(
+                "GET",
+                url,
+                headers=headers,
+                timeout=timeout,
+                retry_options=retry_options,
+            ) as resp:
+                data = await _safe_json(resp)
+                if resp.status >= 400:
+                    code = _extract_error_code(data)
+                    message = _extract_error_message(data) or f"Usage fetch failed ({resp.status})"
+                    logger.warning(
+                        "Usage fetch failed request_id=%s status=%s code=%s message=%s",
+                        get_request_id(),
+                        resp.status,
+                        code,
+                        message,
+                    )
+                    raise UsageFetchError(resp.status, message, code=code)
+                try:
+                    return UsagePayload.model_validate(data)
+                except ValidationError as exc:
+                    logger.warning(
+                        "Usage fetch invalid payload request_id=%s",
+                        get_request_id(),
+                    )
+                    raise UsageFetchError(502, "Invalid usage payload") from exc
     except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
         logger.warning(
             "Usage fetch error request_id=%s error=%s",

--- a/app/core/openai/model_refresh_scheduler.py
+++ b/app/core/openai/model_refresh_scheduler.py
@@ -25,6 +25,11 @@ class _LeaderElectionLike(Protocol):
     async def try_acquire(self) -> bool: ...
 
 
+@dataclass(slots=True)
+class _TransportRecoveryState:
+    attempted: bool = False
+
+
 def _get_leader_election() -> _LeaderElectionLike:
     module = importlib.import_module("app.core.scheduling.leader_election")
     return cast(_LeaderElectionLike, module.get_leader_election())
@@ -121,6 +126,11 @@ def _error_summary(exc: BaseException) -> str:
         if exc.message:
             summary = f"{summary} message={_compact_error_message(exc.message)}"
         return summary
+    if isinstance(exc, RefreshError):
+        summary = f"code={exc.code} permanent={exc.is_permanent} transport={exc.transport_error}"
+        if exc.message:
+            summary = f"{summary} message={_compact_error_message(exc.message)}"
+        return summary
 
     message = _compact_error_message(str(exc))
     if message:
@@ -137,26 +147,35 @@ async def _fetch_with_failover(
     encryptor: TokenEncryptor,
     accounts_repo: AccountsRepository,
 ) -> list[UpstreamModel] | None:
-    transport_recovery_attempted = False
+    transport_recovery = _TransportRecoveryState()
 
     for account in candidates:
         auth_manager = AuthManager(accounts_repo)
         try:
-            account = await auth_manager.ensure_fresh(account)
-            models, transport_recovery_attempted = await _fetch_models_with_transport_recovery(
+            account = await _ensure_fresh_with_transport_recovery(
+                auth_manager,
+                account,
+                transport_recovery=transport_recovery,
+            )
+            models = await _fetch_models_with_transport_recovery(
                 account,
                 encryptor,
-                transport_recovery_attempted=transport_recovery_attempted,
+                transport_recovery=transport_recovery,
             )
             return models
         except ModelFetchError as exc:
             if exc.status_code == 401:
                 try:
-                    account = await auth_manager.ensure_fresh(account, force=True)
-                    models, transport_recovery_attempted = await _fetch_models_with_transport_recovery(
+                    account = await _ensure_fresh_with_transport_recovery(
+                        auth_manager,
+                        account,
+                        force=True,
+                        transport_recovery=transport_recovery,
+                    )
+                    models = await _fetch_models_with_transport_recovery(
                         account,
                         encryptor,
-                        transport_recovery_attempted=transport_recovery_attempted,
+                        transport_recovery=transport_recovery,
                     )
                     return models
                 except (ModelFetchError, RefreshError) as retry_exc:
@@ -195,28 +214,47 @@ async def _fetch_with_failover(
     return None
 
 
+async def _ensure_fresh_with_transport_recovery(
+    auth_manager: AuthManager,
+    account: Account,
+    *,
+    transport_recovery: _TransportRecoveryState,
+    force: bool = False,
+) -> Account:
+    try:
+        return await auth_manager.ensure_fresh(account, force=force)
+    except RefreshError as exc:
+        if not exc.transport_error or transport_recovery.attempted:
+            raise
+
+        await _refresh_http_client_after_transport_error(account, exc)
+        transport_recovery.attempted = True
+        return await auth_manager.ensure_fresh(account, force=force)
+
+
 async def _fetch_models_with_transport_recovery(
     account: Account,
     encryptor: TokenEncryptor,
     *,
-    transport_recovery_attempted: bool,
-) -> tuple[list[UpstreamModel], bool]:
+    transport_recovery: _TransportRecoveryState,
+) -> list[UpstreamModel]:
     access_token = encryptor.decrypt(account.access_token_encrypted)
     account_id = account.chatgpt_account_id
 
     try:
-        return await fetch_models_for_plan(access_token, account_id), transport_recovery_attempted
+        return await fetch_models_for_plan(access_token, account_id)
     except ModelFetchError as exc:
-        if not exc.transport_error or transport_recovery_attempted:
+        if not exc.transport_error or transport_recovery.attempted:
             raise
 
         await _refresh_http_client_after_transport_error(account, exc)
+        transport_recovery.attempted = True
         access_token = encryptor.decrypt(account.access_token_encrypted)
         account_id = account.chatgpt_account_id
-        return await fetch_models_for_plan(access_token, account_id), True
+        return await fetch_models_for_plan(access_token, account_id)
 
 
-async def _refresh_http_client_after_transport_error(account: Account, transport_exc: ModelFetchError) -> None:
+async def _refresh_http_client_after_transport_error(account: Account, transport_exc: BaseException) -> None:
     try:
         await refresh_http_client()
     except Exception as refresh_exc:

--- a/app/core/openai/model_refresh_scheduler.py
+++ b/app/core/openai/model_refresh_scheduler.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Protocol, cast
 
 from app.core.auth.refresh import RefreshError
+from app.core.clients.http import refresh_http_client
 from app.core.clients.model_fetcher import ModelFetchError, fetch_models_for_plan
 from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
@@ -114,57 +115,125 @@ def _group_by_plan(accounts: list[Account]) -> dict[str, list[Account]]:
     return grouped
 
 
+def _error_summary(exc: BaseException) -> str:
+    if isinstance(exc, ModelFetchError):
+        summary = f"status={exc.status_code} transport={exc.transport_error}"
+        if exc.message:
+            summary = f"{summary} message={_compact_error_message(exc.message)}"
+        return summary
+
+    message = _compact_error_message(str(exc))
+    if message:
+        return f"{exc.__class__.__name__}: {message}"
+    return exc.__class__.__name__
+
+
+def _compact_error_message(message: str) -> str:
+    return " ".join(message.split())
+
+
 async def _fetch_with_failover(
     candidates: list[Account],
     encryptor: TokenEncryptor,
     accounts_repo: AccountsRepository,
 ) -> list[UpstreamModel] | None:
+    transport_recovery_attempted = False
+
     for account in candidates:
         auth_manager = AuthManager(accounts_repo)
         try:
             account = await auth_manager.ensure_fresh(account)
-            access_token = encryptor.decrypt(account.access_token_encrypted)
-            account_id = account.chatgpt_account_id
-            return await fetch_models_for_plan(access_token, account_id)
+            models, transport_recovery_attempted = await _fetch_models_with_transport_recovery(
+                account,
+                encryptor,
+                transport_recovery_attempted=transport_recovery_attempted,
+            )
+            return models
         except ModelFetchError as exc:
             if exc.status_code == 401:
                 try:
                     account = await auth_manager.ensure_fresh(account, force=True)
-                    access_token = encryptor.decrypt(account.access_token_encrypted)
-                    return await fetch_models_for_plan(access_token, account.chatgpt_account_id)
-                except (ModelFetchError, RefreshError):
+                    models, transport_recovery_attempted = await _fetch_models_with_transport_recovery(
+                        account,
+                        encryptor,
+                        transport_recovery_attempted=transport_recovery_attempted,
+                    )
+                    return models
+                except (ModelFetchError, RefreshError) as retry_exc:
                     logger.warning(
-                        "Model fetch 401 retry failed account=%s plan=%s",
+                        "Model fetch auth retry failed account=%s plan=%s initial_error=%s retry_error=%s",
                         account.id,
                         account.plan_type,
-                        exc_info=True,
+                        _error_summary(exc),
+                        _error_summary(retry_exc),
                     )
                     continue
             logger.warning(
-                "Model fetch failed account=%s plan=%s status=%d",
+                "Model fetch failed account=%s plan=%s error=%s",
                 account.id,
                 account.plan_type,
-                exc.status_code,
-                exc_info=True,
+                _error_summary(exc),
             )
             continue
-        except RefreshError:
+        except RefreshError as exc:
             logger.warning(
-                "Token refresh failed for model fetch account=%s plan=%s",
+                "Token refresh failed for model fetch account=%s plan=%s error=%s",
                 account.id,
                 account.plan_type,
-                exc_info=True,
+                _error_summary(exc),
             )
             continue
-        except Exception:
+        except Exception as exc:
             logger.warning(
-                "Unexpected error during model fetch account=%s plan=%s",
+                "Unexpected error during model fetch account=%s plan=%s error=%s",
                 account.id,
                 account.plan_type,
+                _error_summary(exc),
                 exc_info=True,
             )
             continue
     return None
+
+
+async def _fetch_models_with_transport_recovery(
+    account: Account,
+    encryptor: TokenEncryptor,
+    *,
+    transport_recovery_attempted: bool,
+) -> tuple[list[UpstreamModel], bool]:
+    access_token = encryptor.decrypt(account.access_token_encrypted)
+    account_id = account.chatgpt_account_id
+
+    try:
+        return await fetch_models_for_plan(access_token, account_id), transport_recovery_attempted
+    except ModelFetchError as exc:
+        if not exc.transport_error or transport_recovery_attempted:
+            raise
+
+        await _refresh_http_client_after_transport_error(account, exc)
+        access_token = encryptor.decrypt(account.access_token_encrypted)
+        account_id = account.chatgpt_account_id
+        return await fetch_models_for_plan(access_token, account_id), True
+
+
+async def _refresh_http_client_after_transport_error(account: Account, transport_exc: ModelFetchError) -> None:
+    try:
+        await refresh_http_client()
+    except Exception as refresh_exc:
+        logger.warning(
+            "Model fetch transport recovery failed account=%s plan=%s transport_error=%s refresh_error=%s",
+            account.id,
+            account.plan_type,
+            _error_summary(transport_exc),
+            _error_summary(refresh_exc),
+        )
+        raise
+    logger.info(
+        "Refreshed shared HTTP client after model fetch transport error; retrying account=%s plan=%s error=%s",
+        account.id,
+        account.plan_type,
+        _error_summary(transport_exc),
+    )
 
 
 def build_model_refresh_scheduler() -> ModelRefreshScheduler:

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -100,11 +100,13 @@ class _RefreshSingleflight:
                     task.result()
                 except RefreshError as exc:
                     ttl = max(0.0, float(get_settings().proxy_refresh_failure_cooldown_seconds))
-                    if ttl > 0:
+                    if ttl > 0 and not exc.transport_error:
                         self._recent_failures[key] = (
                             time.monotonic() + ttl,
                             (exc.code, exc.message, exc.is_permanent),
                         )
+                    else:
+                        self._recent_failures.pop(key, None)
                 except BaseException:
                     self._recent_failures.pop(key, None)
                 else:

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import json
 from datetime import timedelta, timezone
-from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -248,7 +248,12 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
         )
     )
 
-    monkeypatch.setattr(proxy_client_module, "get_http_client", lambda: SimpleNamespace(session=session))
+    @contextlib.asynccontextmanager
+    async def lease_session(session_override=None):
+        assert session_override is None
+        yield session
+
+    monkeypatch.setattr(proxy_client_module, "lease_http_session", lease_session)
 
     payload = {"model": "gpt-5.1", "instructions": "hi", "input": []}
     response = await async_client.post("/backend-api/codex/responses/compact", json=payload)

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -259,6 +259,47 @@ async def test_ensure_fresh_reuses_recent_failure_without_reissuing_refresh(monk
 
 
 @pytest.mark.asyncio
+async def test_ensure_fresh_does_not_reuse_recent_transport_failure(monkeypatch):
+    refresh_calls = 0
+
+    async def _fake_refresh(_: str) -> TokenRefreshResult:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        raise RefreshError("transport_error", "temporary dns failure", False, transport_error=True)
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+    monkeypatch.setattr(
+        auth_manager_module,
+        "get_settings",
+        lambda: SimpleNamespace(proxy_refresh_failure_cooldown_seconds=30.0),
+    )
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    account = Account(
+        id="acc_transport_fail_cache",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    repo = _DummyRepo()
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    with pytest.raises(RefreshError):
+        await manager.ensure_fresh(account, force=True)
+    await asyncio.sleep(0)
+    with pytest.raises(RefreshError):
+        await manager.ensure_fresh(account, force=True)
+
+    assert refresh_calls == 2
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_does_not_reuse_failure_after_refresh_token_changes(monkeypatch):
     refresh_calls = 0
 

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -64,3 +64,46 @@ async def test_init_http_client_creates_tcp_connector_with_limits() -> None:
     assert client_session_cls.call_args_list[0].kwargs["connector"] is connector
 
     await http_module.close_http_client()
+
+
+@pytest.mark.asyncio
+async def test_refresh_http_client_replaces_existing_sessions() -> None:
+    await http_module.close_http_client()
+
+    first_http_session = MagicMock()
+    first_websocket_session = MagicMock()
+    first_websocket_session.close = AsyncMock()
+    first_retry_client = MagicMock()
+    first_retry_client.close = AsyncMock()
+
+    second_http_session = MagicMock()
+    second_websocket_session = MagicMock()
+    second_websocket_session.close = AsyncMock()
+    second_retry_client = MagicMock()
+    second_retry_client.close = AsyncMock()
+
+    with (
+        patch("app.core.clients.http.aiohttp.TCPConnector"),
+        patch(
+            "app.core.clients.http.aiohttp.ClientSession",
+            side_effect=[
+                first_http_session,
+                first_websocket_session,
+                second_http_session,
+                second_websocket_session,
+            ],
+        ),
+        patch(
+            "app.core.clients.http.RetryClient",
+            side_effect=[first_retry_client, second_retry_client],
+        ),
+    ):
+        initial = await http_module.init_http_client()
+        refreshed = await http_module.refresh_http_client()
+
+    assert initial.session is first_http_session
+    assert refreshed.session is second_http_session
+    first_websocket_session.close.assert_awaited_once()
+    first_retry_client.close.assert_awaited_once()
+
+    await http_module.close_http_client()

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,6 +9,19 @@ import pytest
 import app.core.clients.http as http_module
 
 pytestmark = pytest.mark.unit
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        http_connector_limit=100,
+        http_connector_limit_per_host=50,
+        upstream_websocket_trust_env=False,
+    )
+
+
+async def _drain_close_tasks() -> None:
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
@@ -20,6 +35,7 @@ async def test_init_http_client_uses_separate_http_and_websocket_sessions() -> N
     retry_client.close = AsyncMock()
 
     with (
+        patch("app.core.clients.http.get_settings", return_value=_settings()),
         patch("app.core.clients.http.aiohttp.TCPConnector"),
         patch(
             "app.core.clients.http.aiohttp.ClientSession",
@@ -51,6 +67,7 @@ async def test_init_http_client_creates_tcp_connector_with_limits() -> None:
     connector = MagicMock()
 
     with (
+        patch("app.core.clients.http.get_settings", return_value=_settings()),
         patch("app.core.clients.http.aiohttp.TCPConnector", return_value=connector) as tcp_connector_cls,
         patch(
             "app.core.clients.http.aiohttp.ClientSession",
@@ -67,7 +84,7 @@ async def test_init_http_client_creates_tcp_connector_with_limits() -> None:
 
 
 @pytest.mark.asyncio
-async def test_refresh_http_client_replaces_existing_sessions() -> None:
+async def test_refresh_http_client_closes_idle_previous_sessions() -> None:
     await http_module.close_http_client()
 
     first_http_session = MagicMock()
@@ -83,6 +100,7 @@ async def test_refresh_http_client_replaces_existing_sessions() -> None:
     second_retry_client.close = AsyncMock()
 
     with (
+        patch("app.core.clients.http.get_settings", return_value=_settings()),
         patch("app.core.clients.http.aiohttp.TCPConnector"),
         patch(
             "app.core.clients.http.aiohttp.ClientSession",
@@ -103,7 +121,136 @@ async def test_refresh_http_client_replaces_existing_sessions() -> None:
 
     assert initial.session is first_http_session
     assert refreshed.session is second_http_session
+
+    await _drain_close_tasks()
+
     first_websocket_session.close.assert_awaited_once()
     first_retry_client.close.assert_awaited_once()
+    second_websocket_session.close.assert_not_awaited()
+    second_retry_client.close.assert_not_awaited()
 
     await http_module.close_http_client()
+
+    first_websocket_session.close.assert_awaited_once()
+    first_retry_client.close.assert_awaited_once()
+    second_websocket_session.close.assert_awaited_once()
+    second_retry_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_http_client_keeps_active_previous_session_open_until_lease_released() -> None:
+    await http_module.close_http_client()
+
+    first_http_session = MagicMock()
+    first_websocket_session = MagicMock()
+    first_websocket_session.close = AsyncMock()
+    first_retry_client = MagicMock()
+    first_retry_client.close = AsyncMock()
+
+    second_http_session = MagicMock()
+    second_websocket_session = MagicMock()
+    second_websocket_session.close = AsyncMock()
+    second_retry_client = MagicMock()
+    second_retry_client.close = AsyncMock()
+
+    with (
+        patch("app.core.clients.http.get_settings", return_value=_settings()),
+        patch("app.core.clients.http.aiohttp.TCPConnector"),
+        patch(
+            "app.core.clients.http.aiohttp.ClientSession",
+            side_effect=[
+                first_http_session,
+                first_websocket_session,
+                second_http_session,
+                second_websocket_session,
+            ],
+        ),
+        patch(
+            "app.core.clients.http.RetryClient",
+            side_effect=[first_retry_client, second_retry_client],
+        ),
+    ):
+        initial = await http_module.init_http_client()
+        lease = await http_module.acquire_http_client()
+        refreshed = await http_module.refresh_http_client()
+
+    assert lease.client is initial
+    assert refreshed.session is second_http_session
+
+    await _drain_close_tasks()
+
+    first_websocket_session.close.assert_not_awaited()
+    first_retry_client.close.assert_not_awaited()
+    second_websocket_session.close.assert_not_awaited()
+    second_retry_client.close.assert_not_awaited()
+
+    await lease.close()
+    await _drain_close_tasks()
+
+    first_websocket_session.close.assert_awaited_once()
+    first_retry_client.close.assert_awaited_once()
+    second_websocket_session.close.assert_not_awaited()
+    second_retry_client.close.assert_not_awaited()
+
+    await http_module.close_http_client()
+
+    second_websocket_session.close.assert_awaited_once()
+    second_retry_client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_http_client_force_closes_active_current_and_retired_sessions() -> None:
+    await http_module.close_http_client()
+
+    first_http_session = MagicMock()
+    first_websocket_session = MagicMock()
+    first_websocket_session.close = AsyncMock()
+    first_retry_client = MagicMock()
+    first_retry_client.close = AsyncMock()
+
+    second_http_session = MagicMock()
+    second_websocket_session = MagicMock()
+    second_websocket_session.close = AsyncMock()
+    second_retry_client = MagicMock()
+    second_retry_client.close = AsyncMock()
+
+    with (
+        patch("app.core.clients.http.get_settings", return_value=_settings()),
+        patch("app.core.clients.http.aiohttp.TCPConnector"),
+        patch(
+            "app.core.clients.http.aiohttp.ClientSession",
+            side_effect=[
+                first_http_session,
+                first_websocket_session,
+                second_http_session,
+                second_websocket_session,
+            ],
+        ),
+        patch(
+            "app.core.clients.http.RetryClient",
+            side_effect=[first_retry_client, second_retry_client],
+        ),
+    ):
+        initial = await http_module.init_http_client()
+        first_lease = await http_module.acquire_http_client()
+        refreshed = await http_module.refresh_http_client()
+        second_lease = await http_module.acquire_http_client()
+
+    assert first_lease.client is initial
+    assert second_lease.client is refreshed
+
+    await asyncio.wait_for(http_module.close_http_client(), timeout=0.1)
+
+    first_websocket_session.close.assert_awaited_once()
+    first_retry_client.close.assert_awaited_once()
+    second_websocket_session.close.assert_awaited_once()
+    second_retry_client.close.assert_awaited_once()
+
+    await first_lease.close()
+    await second_lease.close()
+    await _drain_close_tasks()
+
+    first_websocket_session.close.assert_awaited_once()
+    first_retry_client.close.assert_awaited_once()
+    second_websocket_session.close.assert_awaited_once()
+    second_retry_client.close.assert_awaited_once()

--- a/tests/unit/test_model_refresh_scheduler.py
+++ b/tests/unit/test_model_refresh_scheduler.py
@@ -1,24 +1,33 @@
 from __future__ import annotations
 
+import contextlib
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
 
+import app.core.auth.refresh as refresh_module
 import app.core.clients.model_fetcher as model_fetcher_module
 import app.core.openai.model_refresh_scheduler as scheduler_module
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel
+from app.db.models import Account, AccountStatus
 
 pytestmark = pytest.mark.unit
 
 
-def _account() -> SimpleNamespace:
-    return SimpleNamespace(
-        id="account-1",
+def _account(account_id: str = "account-1") -> Account:
+    return Account(
+        id=account_id,
+        email=f"{account_id}@example.test",
         plan_type="team",
-        chatgpt_account_id="chatgpt-account-1",
+        chatgpt_account_id=f"chatgpt-{account_id}",
         access_token_encrypted=b"encrypted-access-token",
+        refresh_token_encrypted=b"encrypted-refresh-token",
+        id_token_encrypted=b"encrypted-id-token",
+        last_refresh=datetime(2026, 1, 1),
+        status=AccountStatus.ACTIVE,
     )
 
 
@@ -48,7 +57,7 @@ class _StubAuthManager:
     def __init__(self, _repo: object) -> None:
         pass
 
-    async def ensure_fresh(self, account: SimpleNamespace, *, force: bool = False) -> SimpleNamespace:
+    async def ensure_fresh(self, account: Account, *, force: bool = False) -> Account:
         return account
 
 
@@ -62,11 +71,11 @@ async def test_fetch_models_for_plan_marks_transport_errors(monkeypatch: pytest.
         "get_codex_version_cache",
         lambda: SimpleNamespace(get_version=AsyncMock(return_value="1.2.3")),
     )
-    monkeypatch.setattr(
-        model_fetcher_module,
-        "get_http_client",
-        lambda: SimpleNamespace(session=session),
-    )
+    @contextlib.asynccontextmanager
+    async def lease_session():
+        yield session
+
+    monkeypatch.setattr(model_fetcher_module, "lease_http_session", lease_session)
     monkeypatch.setattr(
         model_fetcher_module,
         "get_settings",
@@ -78,6 +87,32 @@ async def test_fetch_models_for_plan_marks_transport_errors(monkeypatch: pytest.
 
     exc = excinfo.value
     assert exc.status_code == 0
+    assert exc.transport_error is True
+    assert "dns failed" in exc.message
+
+
+@pytest.mark.asyncio
+async def test_refresh_access_token_marks_transport_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock()
+    session.post.side_effect = aiohttp.ClientError("dns failed")
+
+    monkeypatch.setattr(
+        refresh_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            auth_base_url="https://auth.example.test",
+            oauth_client_id="client-id",
+            oauth_scope="openid profile",
+            token_refresh_timeout_seconds=15.0,
+        ),
+    )
+
+    with pytest.raises(refresh_module.RefreshError) as excinfo:
+        await refresh_module.refresh_access_token("refresh-token", session=session)
+
+    exc = excinfo.value
+    assert exc.code == "transport_error"
+    assert exc.is_permanent is False
     assert exc.transport_error is True
     assert "dns failed" in exc.message
 
@@ -109,3 +144,73 @@ async def test_fetch_with_failover_refreshes_http_client_after_transport_error(
     refresh_http_client.assert_awaited_once()
     assert fetch_models_for_plan.await_count == 2
     assert encryptor.decrypt.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_failover_refreshes_http_client_after_token_refresh_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _account()
+    encryptor = MagicMock()
+    encryptor.decrypt.return_value = "access-token"
+    expected_models = [_model("gpt-5.4")]
+    ensure_fresh_calls = 0
+
+    class TransportFailingAuthManager:
+        def __init__(self, _repo: object) -> None:
+            pass
+
+        async def ensure_fresh(self, account: Account, *, force: bool = False) -> Account:
+            nonlocal ensure_fresh_calls
+            ensure_fresh_calls += 1
+            if ensure_fresh_calls == 1:
+                raise scheduler_module.RefreshError(
+                    "transport_error",
+                    "Transport error during token refresh: dns failed",
+                    False,
+                    transport_error=True,
+                )
+            return account
+
+    fetch_models_for_plan = AsyncMock(return_value=expected_models)
+    refresh_http_client = AsyncMock()
+
+    monkeypatch.setattr(scheduler_module, "AuthManager", TransportFailingAuthManager)
+    monkeypatch.setattr(scheduler_module, "fetch_models_for_plan", fetch_models_for_plan)
+    monkeypatch.setattr(scheduler_module, "refresh_http_client", refresh_http_client)
+
+    result = await scheduler_module._fetch_with_failover([account], encryptor, MagicMock())
+
+    assert result == expected_models
+    refresh_http_client.assert_awaited_once()
+    assert ensure_fresh_calls == 2
+    fetch_models_for_plan.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_failover_attempts_transport_recovery_once_when_retry_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accounts = [_account("account-1"), _account("account-2")]
+    encryptor = MagicMock()
+    encryptor.decrypt.return_value = "access-token"
+
+    fetch_models_for_plan = AsyncMock(
+        side_effect=[
+            scheduler_module.ModelFetchError(0, "temporary dns failure", transport_error=True),
+            scheduler_module.ModelFetchError(0, "temporary dns failure", transport_error=True),
+            scheduler_module.ModelFetchError(0, "temporary dns failure", transport_error=True),
+        ]
+    )
+    refresh_http_client = AsyncMock()
+
+    monkeypatch.setattr(scheduler_module, "AuthManager", _StubAuthManager)
+    monkeypatch.setattr(scheduler_module, "fetch_models_for_plan", fetch_models_for_plan)
+    monkeypatch.setattr(scheduler_module, "refresh_http_client", refresh_http_client)
+
+    result = await scheduler_module._fetch_with_failover(accounts, encryptor, MagicMock())
+
+    assert result is None
+    refresh_http_client.assert_awaited_once()
+    assert fetch_models_for_plan.await_count == 3
+    assert encryptor.decrypt.call_count == 3

--- a/tests/unit/test_model_refresh_scheduler.py
+++ b/tests/unit/test_model_refresh_scheduler.py
@@ -71,6 +71,7 @@ async def test_fetch_models_for_plan_marks_transport_errors(monkeypatch: pytest.
         "get_codex_version_cache",
         lambda: SimpleNamespace(get_version=AsyncMock(return_value="1.2.3")),
     )
+
     @contextlib.asynccontextmanager
     async def lease_session():
         yield session

--- a/tests/unit/test_model_refresh_scheduler.py
+++ b/tests/unit/test_model_refresh_scheduler.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+import app.core.clients.model_fetcher as model_fetcher_module
+import app.core.openai.model_refresh_scheduler as scheduler_module
+from app.core.openai.model_registry import ReasoningLevel, UpstreamModel
+
+pytestmark = pytest.mark.unit
+
+
+def _account() -> SimpleNamespace:
+    return SimpleNamespace(
+        id="account-1",
+        plan_type="team",
+        chatgpt_account_id="chatgpt-account-1",
+        access_token_encrypted=b"encrypted-access-token",
+    )
+
+
+def _model(slug: str) -> UpstreamModel:
+    return UpstreamModel(
+        slug=slug,
+        display_name=slug,
+        description=f"Model {slug}",
+        context_window=128000,
+        input_modalities=("text",),
+        supported_reasoning_levels=(ReasoningLevel(effort="medium", description="balanced"),),
+        default_reasoning_level="medium",
+        supports_reasoning_summaries=False,
+        support_verbosity=False,
+        default_verbosity=None,
+        prefer_websockets=False,
+        supports_parallel_tool_calls=True,
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset(),
+        raw={},
+    )
+
+
+class _StubAuthManager:
+    def __init__(self, _repo: object) -> None:
+        pass
+
+    async def ensure_fresh(self, account: SimpleNamespace, *, force: bool = False) -> SimpleNamespace:
+        return account
+
+
+@pytest.mark.asyncio
+async def test_fetch_models_for_plan_marks_transport_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = MagicMock()
+    session.get.side_effect = aiohttp.ClientError("dns failed")
+
+    monkeypatch.setattr(
+        model_fetcher_module,
+        "get_codex_version_cache",
+        lambda: SimpleNamespace(get_version=AsyncMock(return_value="1.2.3")),
+    )
+    monkeypatch.setattr(
+        model_fetcher_module,
+        "get_http_client",
+        lambda: SimpleNamespace(session=session),
+    )
+    monkeypatch.setattr(
+        model_fetcher_module,
+        "get_settings",
+        lambda: SimpleNamespace(upstream_base_url="https://example.test/backend-api"),
+    )
+
+    with pytest.raises(model_fetcher_module.ModelFetchError) as excinfo:
+        await model_fetcher_module.fetch_models_for_plan("access-token", "account-1")
+
+    exc = excinfo.value
+    assert exc.status_code == 0
+    assert exc.transport_error is True
+    assert "dns failed" in exc.message
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_failover_refreshes_http_client_after_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _account()
+    encryptor = MagicMock()
+    encryptor.decrypt.return_value = "access-token"
+    expected_models = [_model("gpt-5.4")]
+
+    fetch_models_for_plan = AsyncMock(
+        side_effect=[
+            scheduler_module.ModelFetchError(0, "temporary dns failure", transport_error=True),
+            expected_models,
+        ]
+    )
+    refresh_http_client = AsyncMock()
+
+    monkeypatch.setattr(scheduler_module, "AuthManager", _StubAuthManager)
+    monkeypatch.setattr(scheduler_module, "fetch_models_for_plan", fetch_models_for_plan)
+    monkeypatch.setattr(scheduler_module, "refresh_http_client", refresh_http_client)
+
+    result = await scheduler_module._fetch_with_failover([account], encryptor, MagicMock())
+
+    assert result == expected_models
+    refresh_http_client.assert_awaited_once()
+    assert fetch_models_for_plan.await_count == 2
+    assert encryptor.decrypt.call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
-[options]
-exclude-newer = "2026-04-20T00:27:32.598033Z"
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[options]
+exclude-newer = "2026-04-20T00:27:32.598033Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary

This PR makes model refresh recover from transport-level upstream failures by rebuilding the shared `aiohttp` client and retrying the fetch once.

Handled failures now include compact error details, while unexpected exceptions still keep stack traces.

## Observed Bug Evidence

Running codex-lb via `uvx` in low-reliability network environments (VPN, laptop sleep/wake, etc.) often resulted in the software entering a state in which the upstream connection was lost and could not be regained without restarting the process. These present changes make codex-lb behave seamlessly under the same condtions.

## Root Cause

The model refresh path uses the shared `aiohttp.ClientSession`.

When the network changes underneath the process, the model fetch can fail before an HTTP response is received, surfacing as transport exceptions.

Previously, model refresh treated these the same as other model-fetch failures. It did not rebuild the shared HTTP client, so a bad/stale session or connector could continue to be reused after the network came back.

## Fix

Model-fetch transport exceptions are now wrapped as ModelFetchError with transport_error=True.

When the scheduler sees the first transport error in a refresh cycle, it refreshes the shared HTTP client, closes the previous client, and retries the model fetch once.

HTTP status errors, auth failures, and invalid upstream responses stay on the existing paths.

The recovery logs now include the original transport error tersely, so failures are easier to diagnose without turning expected retry paths into stack traces.

## Test Plan

- [x] `uv run ruff check app/core/openai/model_refresh_scheduler.py tests/unit/test_model_refresh_scheduler.py`
- [x] `uv run pytest tests/unit/test_model_refresh_scheduler.py`
- [x] `uv run pytest tests/unit/test_http_client.py`
- [x] `uv run pytest tests/unit/test_model_refresh_scheduler.py`
- [x] `git diff --check`