### PR TITLE
fix(proxy): emit text deltas for final response output

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2055,6 +2055,7 @@ def _merge_collected_output_items(
 async def _normalize_public_responses_stream(stream: AsyncIterator[str]) -> AsyncIterator[str]:
     terminal_seen = False
     contract_violation_kind: str | None = None
+    seen_text_delta_keys: set[tuple[str | None, int | None]] = set()
     async for event_block in stream:
         if event_block.strip() == "data: [DONE]":
             if terminal_seen:
@@ -2071,6 +2072,10 @@ async def _normalize_public_responses_stream(stream: AsyncIterator[str]) -> Asyn
         if normalized_payload is None:
             continue
         event_type = normalized_payload.get("type")
+        if event_type == "response.output_text.delta":
+            seen_text_delta_keys.add(_text_delta_stream_key(normalized_payload))
+        for synthetic_payload in _synthetic_text_delta_events(normalized_payload, seen_text_delta_keys):
+            yield format_sse_event(synthetic_payload)
         if isinstance(event_type, str) and event_type in {
             "response.completed",
             "response.incomplete",
@@ -2138,6 +2143,98 @@ def _normalize_public_stream_payload(
             violation_kind = "invalid_output_item"
         return normalized_payload, violation_kind
     return payload, None
+
+
+def _synthetic_text_delta_events(
+    payload: Mapping[str, JsonValue],
+    seen_text_delta_keys: set[tuple[str | None, int | None]],
+) -> list[dict[str, JsonValue]]:
+    event_type = payload.get("type")
+    if event_type == "response.output_item.done":
+        output_index = payload.get("output_index")
+        item = payload.get("item")
+        if isinstance(output_index, int) and is_json_mapping(item):
+            synthetic = _synthetic_text_delta_for_output_item(output_index, item, seen_text_delta_keys)
+            return [synthetic] if synthetic is not None else []
+    if event_type not in {"response.completed", "response.incomplete"}:
+        return []
+    response = payload.get("response")
+    if not is_json_mapping(response):
+        return []
+    output = response.get("output")
+    if not isinstance(output, list):
+        return []
+
+    synthetic_events: list[dict[str, JsonValue]] = []
+    for output_index, item in enumerate(output):
+        if not is_json_mapping(item):
+            continue
+        synthetic = _synthetic_text_delta_for_output_item(output_index, item, seen_text_delta_keys)
+        if synthetic is not None:
+            synthetic_events.append(synthetic)
+    return synthetic_events
+
+
+def _synthetic_text_delta_for_output_item(
+    output_index: int,
+    item: Mapping[str, JsonValue],
+    seen_text_delta_keys: set[tuple[str | None, int | None]],
+) -> dict[str, JsonValue] | None:
+    normalized_item = _normalize_public_output_item(item)
+    if normalized_item is None:
+        return None
+    text = _extract_public_output_item_text(normalized_item)
+    if text is None:
+        return None
+    key = _output_item_stream_key(output_index, normalized_item)
+    if _seen_text_delta_for_output_item(key, seen_text_delta_keys):
+        return None
+    seen_text_delta_keys.add(key)
+
+    event: dict[str, JsonValue] = {
+        "type": "response.output_text.delta",
+        "output_index": output_index,
+        "content_index": 0,
+        "delta": text,
+    }
+    item_id = normalized_item.get("id")
+    if isinstance(item_id, str) and item_id:
+        event["item_id"] = item_id
+    return event
+
+
+def _text_delta_stream_key(payload: Mapping[str, JsonValue]) -> tuple[str | None, int | None]:
+    item_id = payload.get("item_id")
+    output_index = payload.get("output_index")
+    return (
+        item_id if isinstance(item_id, str) and item_id else None,
+        output_index if isinstance(output_index, int) else None,
+    )
+
+
+def _output_item_stream_key(
+    output_index: int,
+    item: Mapping[str, JsonValue],
+) -> tuple[str | None, int | None]:
+    item_id = item.get("id")
+    return (item_id if isinstance(item_id, str) and item_id else None, output_index)
+
+
+def _seen_text_delta_for_output_item(
+    key: tuple[str | None, int | None],
+    seen_text_delta_keys: set[tuple[str | None, int | None]],
+) -> bool:
+    item_id, output_index = key
+    return any(
+        candidate in seen_text_delta_keys
+        for candidate in (
+            key,
+            (item_id, None) if item_id is not None else None,
+            (None, output_index) if output_index is not None else None,
+            (None, None),
+        )
+        if candidate is not None
+    )
 
 
 def _normalize_public_response_mapping(

--- a/openspec/changes/fix-empty-public-response-stream/proposal.md
+++ b/openspec/changes/fix-empty-public-response-stream/proposal.md
@@ -1,0 +1,15 @@
+# Fix Empty Public Response Streams
+
+## Why
+
+OpenAI-provider clients can receive a successful `/v1/responses` stream that contains terminal usage and output metadata but no renderable text deltas when upstream only emits final message content in item/terminal events.
+
+## What Changes
+
+- Synthesize a public `response.output_text.delta` event from final message output when no text delta was already observed for that output item.
+- Keep the original terminal/item events so existing clients that consume full Responses objects continue to work.
+
+## Impact
+
+- Improves compatibility for OpenCode's built-in OpenAI provider with a `baseURL` override.
+- Does not alter streams that already include text deltas.

--- a/openspec/changes/fix-empty-public-response-stream/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-empty-public-response-stream/specs/responses-api-compat/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Public Responses streams expose renderable final text
+For OpenAI-style streaming `/v1/responses` and `/backend-api/codex/responses`, the service MUST expose renderable `response.output_text.delta` events for assistant message text when upstream provides final text only in output item or terminal response output payloads. The service MUST NOT duplicate text deltas for an output item that already emitted a text delta.
+
+#### Scenario: final output item text is exposed as a text delta
+- **WHEN** upstream emits a `response.output_item.done` event with assistant message text and no prior text delta for that output item
+- **THEN** the service emits a corresponding `response.output_text.delta` event before forwarding the final item event
+
+#### Scenario: terminal response output text is exposed as a text delta
+- **WHEN** upstream emits only a terminal `response.completed` event with assistant message text in `response.output`
+- **THEN** the service emits a corresponding `response.output_text.delta` event before forwarding the terminal event
+
+#### Scenario: existing text deltas are preserved without duplication
+- **WHEN** upstream already emits a `response.output_text.delta` for an output item
+- **THEN** the service forwards the stream without synthesizing another text delta for that same output item

--- a/openspec/changes/fix-empty-public-response-stream/tasks.md
+++ b/openspec/changes/fix-empty-public-response-stream/tasks.md
@@ -1,0 +1,6 @@
+## Tasks
+
+- [x] Add stream normalization fallback for terminal message content without text deltas.
+- [x] Cover item-done and terminal-response-only streams with unit tests.
+- [x] Run focused tests and lint.
+- [x] Run OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -97,6 +97,15 @@ async def _collect_sse_events_with_headers(
     return [json.loads(line[6:]) for line in lines], response_headers
 
 
+def _assert_created_text_delta_completed(events: list[dict]) -> None:
+    assert [event["type"] for event in events] == [
+        "response.created",
+        "response.output_text.delta",
+        "response.completed",
+    ]
+    assert events[1]["delta"] == "OK"
+
+
 async def _import_account(async_client, account_id: str, email: str) -> str:
     auth_json = _make_auth_json(account_id, email)
     files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
@@ -3818,8 +3827,8 @@ async def test_backend_responses_http_bridge_reuses_upstream_websocket_and_prese
     )
     second_response = second_events[-1]["response"]
 
-    assert [event["type"] for event in first_events] == ["response.created", "response.completed"]
-    assert [event["type"] for event in second_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(first_events)
+    _assert_created_text_delta_completed(second_events)
     assert first_response["id"] == "resp_bridge_1"
     assert second_response["id"] == "resp_bridge_2"
     assert connect_calls == [(account_id, account.chatgpt_account_id)]
@@ -3923,8 +3932,8 @@ async def test_backend_responses_http_bridge_prefers_codex_session_header_over_p
         headers=headers,
     )
 
-    assert [event["type"] for event in first_events] == ["response.created", "response.completed"]
-    assert [event["type"] for event in second_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(first_events)
+    _assert_created_text_delta_completed(second_events)
     assert len(connect_calls) == 1
     assert connect_calls[0] == ("backend-http-session-1", proxy_module.StickySessionKind.CODEX_SESSION)
     assert len(fake_upstream.sent_text) == 2
@@ -4026,8 +4035,8 @@ async def test_backend_responses_http_emits_turn_state_header_and_reuses_when_re
         headers={"x-codex-turn-state": turn_state},
     )
 
-    assert [event["type"] for event in first_events] == ["response.created", "response.completed"]
-    assert [event["type"] for event in second_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(first_events)
+    _assert_created_text_delta_completed(second_events)
     assert turn_state.startswith("http_turn_")
     assert connect_calls == [("backend-http-turn-state-a", proxy_module.StickySessionKind.PROMPT_CACHE)]
 
@@ -4400,7 +4409,7 @@ async def test_v1_responses_http_bridge_streaming_path_uses_persistent_upstream_
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
 
     events = [json.loads(line[6:]) for line in lines]
-    assert [event["type"] for event in events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(events)
     assert connect_count == 1
 
 
@@ -8027,9 +8036,9 @@ async def test_v1_responses_http_bridge_stream_keeps_session_alive_after_foreign
         },
     )
 
-    assert [event["type"] for event in first_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(first_events)
     assert [event["type"] for event in second_events] == ["response.created", "response.failed"]
-    assert [event["type"] for event in third_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(third_events)
     assert second_events[-1]["response"]["error"]["code"] == "stream_incomplete"
     assert "previous_response_not_found" not in json.dumps(second_events[-1])
     assert third_events[-1]["response"]["output"][0]["content"][0]["text"] == "OK"
@@ -8163,13 +8172,13 @@ async def test_v1_responses_http_bridge_stream_keeps_session_alive_after_anonymo
                 },
             )
 
-    assert [event["type"] for event in first_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(first_events)
     assert [event["type"] for event in second_events] == ["response.created", "response.failed"]
     assert second_events[0]["response"]["id"] == "resp_bridge_followup_created"
     assert second_events[1]["response"]["id"] == "resp_bridge_followup_created"
     assert second_events[1]["response"]["error"]["code"] == "stream_incomplete"
     assert "previous_response_not_found" not in json.dumps(second_events[1])
-    assert [event["type"] for event in third_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(third_events)
     assert third_events[-1]["response"]["output"][0]["content"][0]["text"] == "OK"
     assert connect_count == 1
 
@@ -8326,15 +8335,15 @@ async def test_v1_responses_http_bridge_stream_matches_previous_response_error_t
             )
 
     assert [event["type"] for event in third_events] == ["response.created", "response.failed"]
-    assert [event["type"] for event in fourth_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(fourth_events)
     assert third_events[0]["response"]["id"] == "resp_bridge_followup_a"
     assert third_events[1]["response"]["id"] == "resp_bridge_followup_a"
     assert third_events[1]["response"]["error"]["code"] == "stream_incomplete"
     assert "previous_response_not_found" not in json.dumps(third_events[1])
     assert fourth_events[0]["response"]["id"] == "resp_bridge_followup_b"
-    assert fourth_events[1]["response"]["id"] == "resp_bridge_followup_b"
-    assert fourth_events[1]["response"]["output"][0]["content"][0]["text"] == "OK"
-    assert [event["type"] for event in fifth_events] == ["response.created", "response.completed"]
+    assert fourth_events[-1]["response"]["id"] == "resp_bridge_followup_b"
+    assert fourth_events[-1]["response"]["output"][0]["content"][0]["text"] == "OK"
+    _assert_created_text_delta_completed(fifth_events)
     assert fifth_events[-1]["response"]["output"][0]["content"][0]["text"] == "OK"
     assert connect_count == 1
 
@@ -8486,7 +8495,7 @@ async def test_v1_responses_http_bridge_stream_masks_anonymous_previous_response
     assert third_events[1]["response"]["error"]["code"] == "stream_incomplete"
     assert "previous_response_not_found" not in json.dumps(second_events[1])
     assert "previous_response_not_found" not in json.dumps(third_events[1])
-    assert [event["type"] for event in fourth_events] == ["response.created", "response.completed"]
+    _assert_created_text_delta_completed(fourth_events)
     assert fourth_events[-1]["response"]["id"] == "resp_bridge_after_same_anchor_error"
     assert connect_count == 1
 

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -84,8 +84,12 @@ async def test_normalize_public_responses_stream_normalizes_unknown_terminal_out
         )
     ]
 
-    assert len(blocks) == 1
-    payload = proxy_api_module._parse_sse_payload(blocks[0])
+    assert len(blocks) == 2
+    delta_payload = proxy_api_module._parse_sse_payload(blocks[0])
+    assert delta_payload is not None
+    assert delta_payload["type"] == "response.output_text.delta"
+    assert delta_payload["delta"] == "normalized"
+    payload = proxy_api_module._parse_sse_payload(blocks[1])
     assert payload is not None
     assert payload["type"] == "response.completed"
     response = payload["response"]
@@ -100,6 +104,95 @@ async def test_normalize_public_responses_stream_normalizes_unknown_terminal_out
             "status": "completed",
             "content": [{"type": "output_text", "text": "normalized"}],
         }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_synthesizes_delta_from_done_message() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.output_item.done","output_index":0,'
+                    '"item":{"id":"msg_1","type":"message","role":"assistant",'
+                    '"content":[{"type":"output_text","text":"visible text"}]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","response":{"id":"resp_1","object":"response",'
+                    '"status":"completed","output":[]}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    assert payloads[0] == {
+        "type": "response.output_text.delta",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": "visible text",
+        "item_id": "msg_1",
+    }
+    assert payloads[1] is not None
+    assert payloads[1]["type"] == "response.output_item.done"
+    assert payloads[2] is not None
+    assert payloads[2]["type"] == "response.completed"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_synthesizes_delta_from_completed_output() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.completed","response":{"id":"resp_1","object":"response",'
+                    '"status":"completed","output":[{"id":"msg_1","type":"message",'
+                    '"content":[{"type":"output_text","text":"terminal text"}]}]}}\n\n'
+                )
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    assert payloads[0] == {
+        "type": "response.output_text.delta",
+        "output_index": 0,
+        "content_index": 0,
+        "delta": "terminal text",
+        "item_id": "msg_1",
+    }
+    assert payloads[1] is not None
+    assert payloads[1]["type"] == "response.completed"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_does_not_duplicate_existing_delta() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                'data: {"type":"response.output_text.delta","item_id":"msg_1","delta":"already visible"}\n\n',
+                (
+                    'data: {"type":"response.output_item.done","output_index":0,'
+                    '"item":{"id":"msg_1","type":"message","role":"assistant",'
+                    '"content":[{"type":"output_text","text":"already visible"}]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","response":{"id":"resp_1","object":"response",'
+                    '"status":"completed","output":[]}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    event_types = [payload["type"] for payload in payloads if payload is not None]
+    assert event_types == [
+        "response.output_text.delta",
+        "response.output_item.done",
+        "response.completed",
     ]
 
 


### PR DESCRIPTION
## Summary
- Synthesize `response.output_text.delta` for public Responses streams when upstream only provides assistant text in final output-item or terminal response output payloads.
- Avoid duplicate deltas when upstream already emitted text for the same output item.
- Add OpenSpec change artifacts and regression tests for item-done-only, terminal-output-only, existing-delta streams, and HTTP bridge stream expectations.

## Related Issue
- Related to #430

## Issue Found
OpenCode's built-in OpenAI provider with `baseURL` overridden to codex-lb can complete a streamed `/v1/responses` request with usage/finish metadata but no visible assistant content if the stream lacks `response.output_text.delta` events. In the captured incident, codex-lb 1.15.0 logged the main `gpt-5.5` request as successful with non-zero output/reasoning tokens, while OpenCode persisted only `step-start` and `step-finish` parts.

This matches the #430 class of new-session requests that appear successful/processed server-side but leave the client without a usable response.

## Validation
- `uv run pytest tests\unit\test_proxy_api_responses_contract.py -q`
- `uv run pytest tests\integration\test_proxy_responses.py -k "v1_responses_stream_preserves_done_text_events or v1_responses_stream_keeps_non_text_content_part_done_events" -q`
- `uv run pytest tests\integration\test_http_responses_bridge.py::test_v1_responses_http_bridge_stream_matches_previous_response_error_to_anchor_with_two_followups -q`
- `uv run pytest tests\integration\test_http_responses_bridge.py::test_v1_responses_http_bridge_cancellation_releases_queued_slot -q`
- `uv run ruff check app\modules\proxy\api.py tests\unit\test_proxy_api_responses_contract.py tests\integration\test_http_responses_bridge.py`
- `uv run ruff format --check app\modules\proxy\api.py tests\unit\test_proxy_api_responses_contract.py tests\integration\test_http_responses_bridge.py`
- `openspec validate fix-empty-public-response-stream --strict`
- `openspec validate --specs`

Note: Running the full bridge slice locally on Windows now passes the changed assertions, but the run can hit an unrelated SQLite `database is locked` setup error after many tests. The CI bridge slice runs on Ubuntu.