### PR TITLE
fix: remove codex_spark quota gating causing 503 for plus plan accounts

### DIFF
--- a/config/additional_quota_registry.json
+++ b/config/additional_quota_registry.json
@@ -1,9 +1,1 @@
-[
-  {
-    "quota_key": "codex_spark",
-    "display_label": "GPT-5.3-Codex-Spark",
-    "model_ids": ["gpt-5.3-codex-spark"],
-    "limit_name_aliases": ["codex_other", "GPT-5.3-Codex-Spark", "gpt-5.3-codex-spark"],
-    "metered_feature_aliases": ["codex_bengalfox"]
-  }
-]
+[]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - --reload
     volumes:
       - codex-lb-data:/var/lib/codex-lb
+      - ./config:/app/config
     develop:
       watch:
         - action: sync


### PR DESCRIPTION
## Summary

- Remove `codex_spark` entry from `additional_quota_registry.json` to fix 503 errors for plus plan accounts
- Add `./config:/app/config` volume mount to `docker-compose.yml` so config changes persist across container rebuilds

## Issue

Plus plan accounts do not return `additional_rate_limits` from the ChatGPT upstream API (`/backend-api/wham/usage`). The upstream response has `additional_rate_limits: None` for plus plan users.

When the `codex_spark` entry exists in the additional quota registry, the load balancer's `_filter_accounts_for_additional_limit()` method checks `additional_usage_history` for fresh quota data. Since plus plan accounts never populate this table (the usage refresh scheduler only writes to `additional_usage_history` when `payload.additional_rate_limits` is not None/empty), all accounts are classified as `"data_unavailable"` by `_additional_quota_eligibility()`.

This results in a 503 error for every request using `gpt-5.3-codex-spark`:

```
Blocked gated model routing model=gpt-5.3-codex-spark limit_name=codex_spark reason=additional_quota_data_unavailable freshness_since=2026-04-29T03:31:41.106110 candidate_accounts=9 fresh_accounts=0
```

Even though the accounts have valid primary/secondary usage quota and could serve the request, the additional quota gate blocks them entirely because no `additional_usage_history` rows exist.

## Root Cause

The `codex_spark` quota registry entry assumes that upstream accounts return `additional_rate_limits` data, but plus plan accounts do not. This makes the additional quota gate impossible to satisfy for deployments that only have plus plan accounts.

## Fix

Remove the `codex_spark` entry from the registry so that `gpt-5.3-codex-spark` is no longer subject to additional quota gating. This allows plus plan accounts to route requests for this model using their standard usage quota.

## Alternative Approaches Considered

1. **Make additional quota gating optional when data is unavailable** — Would require changes to `_additional_quota_eligibility()` to return `"eligible"` instead of `"data_unavailable"` when no `additional_usage_history` rows exist at all. This is a more invasive change and changes the semantics of the eligibility check.
2. **Add a config flag to disable additional quota gating** — Would add complexity for a case that only affects plus plan accounts.
3. **Upgrade accounts to pro/team** — Not always feasible for self-hosted deployments.

## Test Plan

- [x] Verified `gpt-5.5` requests succeed (200) after removing the registry entry
- [x] Verified `gpt-5.3-codex-spark` quota key returns `None` after clearing registry
- [x] Verified config persists across container rebuilds with the new volume mount
- [ ] Confirm no regression for pro/team plan accounts that do return `additional_rate_limits`

🤖 Generated with [Claude Code](https://claude.com/claude-code)