### PR TITLE
fix(proxy): mask single previous response misses

### DIFF
--- a/app/core/openai/model_refresh_scheduler.py
+++ b/app/core/openai/model_refresh_scheduler.py
@@ -16,6 +16,7 @@ from app.db.models import Account, AccountStatus
 from app.db.session import get_background_session
 from app.modules.accounts.auth_manager import AuthManager
 from app.modules.accounts.repository import AccountsRepository
+from app.modules.proxy.account_cache import get_account_selection_cache
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,7 @@ class ModelRefreshScheduler:
                         len(per_plan_results),
                         total_models,
                     )
+                    get_account_selection_cache().invalidate()
                 else:
                     logger.warning("Model registry refresh failed for all plans")
         except Exception:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1698,16 +1698,17 @@ async def _collect_responses(
     except ProxyResponseError as exc:
         await _release_reservation(reservation)
         error = _parse_error_envelope(exc.payload)
+        status_code, error = _mask_previous_response_not_found_error(error, default_status=exc.status_code)
         return _logged_error_json_response(
             request,
-            exc.status_code,
+            status_code,
             error.model_dump(mode="json", exclude_none=True),
             headers=rate_limit_headers,
         )
     if isinstance(response_payload, OpenAIResponsePayload):
         if response_payload.status == "failed":
             error_payload = _error_envelope_from_response(response_payload.error)
-            status_code = _status_for_error(error_payload.error)
+            status_code, error_payload = _mask_previous_response_not_found_error(error_payload)
             return _logged_error_json_response(
                 request,
                 status_code,
@@ -1718,7 +1719,7 @@ async def _collect_responses(
             content=response_payload.model_dump(mode="json", exclude_none=True),
             headers={**turn_state_headers, **rate_limit_headers},
         )
-    status_code = _status_for_error(response_payload.error)
+    status_code, response_payload = _mask_previous_response_not_found_error(response_payload)
     return _logged_error_json_response(
         request,
         status_code,
@@ -1806,9 +1807,10 @@ async def _compact_responses(
         )
     except ProxyResponseError as exc:
         error = _parse_error_envelope(exc.payload)
+        status_code, error = _mask_previous_response_not_found_error(error, default_status=exc.status_code)
         return _logged_error_json_response(
             request,
-            exc.status_code,
+            status_code,
             error.model_dump(mode="json", exclude_none=True),
             headers=rate_limit_headers,
         )

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -416,7 +416,7 @@ class LoadBalancer:
                 allowed_account_ids = set(account_ids)
                 accounts = [account for account in accounts if account.id in allowed_account_ids]
             pre_model_filter_accounts = accounts
-            if model and (effective_limit_name is None or _mapped_model_has_registry_entry(model)):
+            if model and _mapped_model_has_registry_entry(model):
                 accounts = _filter_accounts_for_model(pre_model_filter_accounts, model)
             if model and not accounts:
                 if not all_accounts:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1216,6 +1216,14 @@ class ProxyService:
                     and request_state.error_http_status_override is not None
                     and request_state.error_http_status_override >= 400
                 ):
+                    if request_state.previous_response_not_found_rewritten:
+                        raise ProxyResponseError(
+                            request_state.error_http_status_override,
+                            openai_error(
+                                "bridge_previous_response_not_found",
+                                "Upstream websocket closed before response.completed",
+                            ),
+                        )
                     raise ProxyResponseError(
                         request_state.error_http_status_override,
                         _openai_error_envelope_from_response_failed_payload(block_payload),
@@ -3016,6 +3024,19 @@ class ProxyService:
                     slim_summary["historical_images_slimmed"],
                 )
         request_state.request_text = text_data
+        if (
+            transport == _REQUEST_TRANSPORT_WEBSOCKET
+            and payload.previous_response_id is not None
+            and _http_bridge_payload_looks_like_full_resend(payload)
+        ):
+            fresh_upstream_payload = dict(upstream_payload)
+            fresh_upstream_payload.pop("previous_response_id", None)
+            request_state.fresh_upstream_request_text = json.dumps(
+                fresh_upstream_payload,
+                ensure_ascii=True,
+                separators=(",", ":"),
+            )
+            request_state.fresh_upstream_request_is_retry_safe = True
         _enforce_response_create_size_limit(request_state)
         return request_state, text_data
 
@@ -5650,9 +5671,11 @@ class ProxyService:
             status_request_state is not None
             and status_request_state.previous_response_id is not None
             and is_previous_response_not_found_event
-            and (response_id is not None or has_other_pending_requests)
         ):
             status_request_state.error_http_status_override = 502
+            status_request_state.previous_response_not_found_rewritten = (
+                response_id is None and not has_other_pending_requests
+            )
             event, payload, event_type, rewritten_text = _maybe_rewrite_websocket_previous_response_not_found_event(
                 request_state=status_request_state,
                 event=event,
@@ -6246,14 +6269,29 @@ class ProxyService:
             )
             retry_error_code = None
         if retry_error_code is not None:
-            upstream_control.reconnect_requested = True
             if retry_is_previous_response_not_found:
-                request_state.replay_count += 1
-                request_state.awaiting_response_created = True
-                request_state.response_id = None
-                upstream_control.suppress_downstream_event = True
-                upstream_control.replay_request_state = request_state
+                if not (
+                    request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text
+                ):
+                    # A short continuation depends entirely on the upstream
+                    # anchor. Replaying the same lost previous_response_id on a
+                    # new websocket just re-surfaces the raw upstream 400; only
+                    # full-resend payloads with a prepared fresh body can be
+                    # transparently retried.
+                    retry_error_code = None
+                else:
+                    upstream_control.reconnect_requested = True
+                    request_state.request_text = request_state.fresh_upstream_request_text
+                    request_state.previous_response_id = None
+                    request_state.proxy_injected_previous_response_id = False
+                    request_state.fresh_upstream_request_is_retry_safe = False
+                    request_state.replay_count += 1
+                    request_state.awaiting_response_created = True
+                    request_state.response_id = None
+                    upstream_control.suppress_downstream_event = True
+                    upstream_control.replay_request_state = request_state
             else:
+                upstream_control.reconnect_requested = True
                 request_state.replay_count += 1
                 request_state.awaiting_response_created = True
                 request_state.response_id = None
@@ -6264,7 +6302,8 @@ class ProxyService:
                     {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
                     retry_error_code,
                 )
-            return downstream_text
+            if retry_error_code is not None:
+                return downstream_text
 
         await self._finalize_websocket_request_state(
             request_state,
@@ -8436,6 +8475,7 @@ class _WebSocketRequestState:
     error_param_override: str | None = None
     error_http_status_override: int | None = None
     response_event_count: int = 0
+    previous_response_not_found_rewritten: bool = False
     response_create_gate_acquired: bool = False
     response_create_gate: asyncio.Semaphore | None = None
     response_create_admission: AdmissionLease | None = None
@@ -10769,6 +10809,7 @@ def _http_bridge_should_attempt_local_previous_response_recovery(exc: ProxyRespo
     code = error.get("code")
     if code in {
         "bridge_owner_unreachable",
+        "bridge_previous_response_not_found",
         "previous_response_not_found",
         "bridge_instance_mismatch",
     }:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3024,19 +3024,6 @@ class ProxyService:
                     slim_summary["historical_images_slimmed"],
                 )
         request_state.request_text = text_data
-        if (
-            transport == _REQUEST_TRANSPORT_WEBSOCKET
-            and payload.previous_response_id is not None
-            and _http_bridge_payload_looks_like_full_resend(payload)
-        ):
-            fresh_upstream_payload = dict(upstream_payload)
-            fresh_upstream_payload.pop("previous_response_id", None)
-            request_state.fresh_upstream_request_text = json.dumps(
-                fresh_upstream_payload,
-                ensure_ascii=True,
-                separators=(",", ":"),
-            )
-            request_state.fresh_upstream_request_is_retry_safe = True
         _enforce_response_create_size_limit(request_state)
         return request_state, text_data
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2923,6 +2923,26 @@ class ProxyService:
                 responses_payload, headers
             )
 
+        # Direct WebSocket retry-safety classification.
+        #
+        # The single-previous-response-miss masking path in
+        # ``_process_upstream_websocket_text`` only attempts a transparent
+        # reconnect-and-replay for a turn marked
+        # ``fresh_upstream_request_is_retry_safe`` with a captured
+        # ``fresh_upstream_request_text``. Without these flags, even a
+        # full-resend turn whose semantic payload does not depend on the
+        # upstream anchor (no client-supplied ``previous_response_id`` and no
+        # proxy-injected anchor) would fall through to ``stream_incomplete``
+        # instead of being recovered. That regresses the recovery behavior
+        # this PR is explicitly trying to preserve for full-resend variants.
+        #
+        # The HTTP-bridge path sets these flags at request prep time; mirror
+        # the same classification here for the direct WebSocket path so the
+        # mask in the reception path treats both variants identically.
+        if responses_payload.previous_response_id is None and not request_state.proxy_injected_previous_response_id:
+            request_state.fresh_upstream_request_text = text_data
+            request_state.fresh_upstream_request_is_retry_safe = True
+
         return _PreparedWebSocketRequest(
             text_data=text_data,
             request_state=request_state,

--- a/openspec/changes/mask-single-http-previous-response-miss/proposal.md
+++ b/openspec/changes/mask-single-http-previous-response-miss/proposal.md
@@ -1,0 +1,19 @@
+# Mask single previous-response misses
+
+## Why
+
+HTTP bridge and direct WebSocket follow-ups can receive an anonymous upstream `previous_response_not_found` error for the only pending request on a session. The multi-request and response-id cases already rewrite this continuity loss to a retryable bridge error, but the single anonymous case can leak the raw upstream 400 to Codex clients or stall the turn before a request log is written.
+
+That raw error makes clients treat the previous response as permanently invalid instead of retrying the bridge, causing intermittent session failures when continuity state was only lost inside the proxy/upstream bridge.
+
+## What Changes
+
+- Rewrite single-request anonymous HTTP bridge `previous_response_not_found` events the same way as the existing multi-request and response-id cases.
+- Keep the response HTTP status retryable (`502`) and hide `previous_response_not_found` from downstream clients.
+- For direct WebSocket full-resend follow-ups, capture a safe fresh-turn replay body and retry without `previous_response_id` when upstream rejects the just-completed anchor.
+- Add regression coverage for a single pending HTTP bridge follow-up with no upstream response id.
+- Add regression coverage for a direct WebSocket full-resend follow-up whose anchor disappears before `response.created`.
+
+## Impact
+
+Codex CLI and OpenAI-compatible clients either recover transparently from a full-resend WebSocket anchor miss or see a retryable `stream_incomplete` bridge failure instead of a raw `previous_response_not_found` 400 when an upstream session loses continuity for one pending follow-up.

--- a/openspec/changes/mask-single-http-previous-response-miss/specs/responses-api-compat/spec.md
+++ b/openspec/changes/mask-single-http-previous-response-miss/specs/responses-api-compat/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Single HTTP bridge previous-response misses recover or fail closed
+When an HTTP bridge session receives an anonymous upstream `previous_response_not_found` error for a single pending follow-up request, the service MUST treat the error as an internal continuity-loss signal. It MUST either recover through the existing previous-response rebind path or rewrite the error to a retryable continuity failure instead of forwarding the raw upstream invalid-request error.
+
+#### Scenario: single pending HTTP bridge follow-up loses previous-response continuity
+- **WHEN** an HTTP `/v1/responses` or `/backend-api/codex/responses` bridge session has exactly one pending request with `previous_response_id`
+- **AND** upstream emits `previous_response_not_found` without a `response.id`
+- **THEN** the service attempts the existing previous-response recovery path
+- **AND** if recovery is unavailable, it emits a retryable continuity failure for that request
+- **AND** the downstream error code is not `previous_response_not_found`
+
+### Requirement: WebSocket full-resend previous-response misses retry without stale anchor
+When a direct WebSocket `response.create` request includes both `previous_response_id` and a full resend payload, the service MUST retain a safe replay body without `previous_response_id`. If upstream rejects the anchor with `previous_response_not_found` before `response.created`, the service MUST reconnect and replay the retained full payload as a fresh turn instead of forwarding the raw upstream invalid-request error.
+
+#### Scenario: full-resend WebSocket follow-up loses just-completed anchor
+- **WHEN** a WebSocket `/v1/responses` or `/backend-api/codex/responses` follow-up has `previous_response_id`
+- **AND** the request payload also carries enough input to be treated as a full resend
+- **AND** upstream emits `previous_response_not_found` before assigning a response id
+- **THEN** the service reconnects the upstream WebSocket
+- **AND** it replays the same request without `previous_response_id`
+- **AND** the downstream client receives the recovered response events, not the raw `previous_response_not_found` error
+
+### Requirement: Public Responses errors mask previous-response misses
+Public Responses endpoints MUST NOT return an OpenAI-shaped `previous_response_not_found` error to clients. If a lower layer still raises or collects that error, the API layer MUST rewrite it to a retryable `stream_incomplete` continuity failure and remove the missing response id from the public payload.
+
+#### Scenario: API layer receives an upstream previous-response miss
+- **WHEN** a public `/responses`, `/v1/responses`, `/responses/compact`, or `/v1/responses/compact` handler receives an error with `code=previous_response_not_found`
+- **OR** it receives `code=invalid_request_error` with `param=previous_response_id` and a message saying the previous response was not found
+- **THEN** the response status is retryable
+- **AND** the public error code is `stream_incomplete`
+- **AND** the missing `previous_response_id` is not exposed in the response body

--- a/openspec/changes/mask-single-http-previous-response-miss/tasks.md
+++ b/openspec/changes/mask-single-http-previous-response-miss/tasks.md
@@ -1,0 +1,6 @@
+- [x] Add regression coverage for single anonymous HTTP bridge `previous_response_not_found`.
+- [x] Rewrite that error path to retryable fail-closed output.
+- [x] Add regression coverage for direct WebSocket full-resend replay without a stale `previous_response_id`.
+- [x] Retry safe direct WebSocket full-resend follow-ups without `previous_response_id` when upstream loses the anchor.
+- [x] Mask any lower-layer public Responses `previous_response_not_found` payloads to retryable `stream_incomplete`.
+- [x] Run focused tests for HTTP bridge previous-response handling.

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1237,6 +1237,151 @@ def test_v1_responses_websocket_masks_short_previous_response_not_found_without_
     assert connect_count == 1
 
 
+def test_v1_responses_websocket_marks_fresh_turn_as_retry_safe_at_prep_time(
+    app_instance,
+    monkeypatch,
+):
+    """Regression for the codex-review P1 on the original branch revision.
+
+    A direct WebSocket turn whose semantic payload does **not** depend on the
+    upstream anchor (no client-supplied ``previous_response_id``, no
+    proxy-injected anchor) must be classified as retry-safe at
+    request-preparation time, with ``fresh_upstream_request_text`` and
+    ``fresh_upstream_request_is_retry_safe`` populated on the request state.
+
+    Without that classification, the single-previous-response-miss masking
+    path in ``_process_upstream_websocket_text`` (which gates its
+    reconnect-and-replay on exactly those two flags) would short-circuit
+    every direct-WebSocket recovery into ``stream_incomplete`` -- the
+    regression the codex review on this PR flagged. The HTTP-bridge path
+    already populates these fields at prep time; this test pins that the
+    direct WebSocket path now mirrors that classification.
+    """
+
+    upstream_socket = _SequencedUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {
+                            "id": "resp_ws_fresh_turn_ok",
+                            "status": "in_progress",
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_fresh_turn_ok",
+                            "status": "completed",
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ],
+    )
+    connect_count = 0
+    connect_record: list[dict[str, object]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        nonlocal connect_count
+        connect_count += 1
+        # Pin the retry-safety classification at the moment the upstream
+        # is being connected. The masking path in
+        # ``_process_upstream_websocket_text`` reads these flags after a
+        # ``previous_response_not_found`` error and only reconnects when
+        # they are populated for this request.
+        connect_record.append(
+            {
+                "connect_count": connect_count,
+                "fresh_upstream_request_is_retry_safe": request_state.fresh_upstream_request_is_retry_safe,
+                "fresh_upstream_request_text_set": bool(request_state.fresh_upstream_request_text),
+            }
+        )
+        return SimpleNamespace(id="acct_ws_fresh_turn"), upstream_socket
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/v1/responses") as websocket:
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "input": "hello",
+                        "stream": True,
+                        # No client-supplied previous_response_id. This is a
+                        # full-resend / fresh-turn shape, so the direct
+                        # WebSocket prep path must mark it retry-safe.
+                    }
+                )
+            )
+            created = json.loads(websocket.receive_text())
+            completed = json.loads(websocket.receive_text())
+
+    assert created["type"] == "response.created"
+    assert completed["type"] == "response.completed"
+    # The direct-WebSocket retry-safety classification must run at request
+    # prep time so the masking path in
+    # ``_process_upstream_websocket_text`` (which gates its
+    # reconnect-and-replay on exactly these two fields) can recover the
+    # turn instead of short-circuiting to ``stream_incomplete``.
+    assert len(connect_record) == 1
+    assert connect_record[0]["fresh_upstream_request_is_retry_safe"] is True
+    assert connect_record[0]["fresh_upstream_request_text_set"] is True
+
+
 def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_retry(
     app_instance,
     monkeypatch,

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1237,7 +1237,7 @@ def test_v1_responses_websocket_masks_short_previous_response_not_found_without_
     assert connect_count == 1
 
 
-def test_v1_responses_websocket_retries_full_resend_previous_response_miss_without_anchor(
+def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1286,27 +1286,6 @@ def test_v1_responses_websocket_retries_full_resend_previous_response_miss_witho
             ],
         ],
     )
-    recovered_upstream = _SequencedUpstreamWebSocket(
-        [],
-        deferred_message_batches=[
-            [
-                _FakeUpstreamMessage(
-                    "text",
-                    text=json.dumps(
-                        {"type": "response.created", "response": {"id": "resp_ws_prev_retry", "status": "in_progress"}},
-                        separators=(",", ":"),
-                    ),
-                ),
-                _FakeUpstreamMessage(
-                    "text",
-                    text=json.dumps(
-                        {"type": "response.completed", "response": {"id": "resp_ws_prev_retry", "status": "completed"}},
-                        separators=(",", ":"),
-                    ),
-                ),
-            ]
-        ],
-    )
     connect_count = 0
 
     class _FakeSettingsCache:
@@ -1352,9 +1331,7 @@ def test_v1_responses_websocket_retries_full_resend_previous_response_miss_witho
         )
         nonlocal connect_count
         connect_count += 1
-        if connect_count == 1:
-            return SimpleNamespace(id="acct_ws_prev_mask"), first_upstream
-        return SimpleNamespace(id="acct_ws_prev_mask"), recovered_upstream
+        return SimpleNamespace(id="acct_ws_prev_mask"), first_upstream
 
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
     monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
@@ -1395,15 +1372,13 @@ def test_v1_responses_websocket_retries_full_resend_previous_response_miss_witho
                     }
                 )
             )
-            created_2 = json.loads(websocket.receive_text())
-            completed_2 = json.loads(websocket.receive_text())
+            failed_2 = json.loads(websocket.receive_text())
 
-    assert created_2["type"] == "response.created"
-    assert completed_2["type"] == "response.completed"
-    assert connect_count == 2
-    assert first_upstream.closed is True
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert connect_count == 1
     assert json.loads(first_upstream.sent_text[-1])["previous_response_id"] == "resp_ws_prev_anchor"
-    assert "previous_response_id" not in json.loads(recovered_upstream.sent_text[0])
 
 
 def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_without_retry(

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1075,7 +1075,7 @@ def test_v1_responses_websocket_forwards_previous_response_id(app_instance, monk
     ]
 
 
-def test_v1_responses_websocket_masks_previous_response_not_found_and_recovers_on_retry(
+def test_v1_responses_websocket_masks_short_previous_response_not_found_without_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1227,6 +1227,174 @@ def test_v1_responses_websocket_masks_previous_response_not_found_and_recovers_o
                     }
                 )
             )
+            failed_2 = json.loads(websocket.receive_text())
+
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
+    assert connect_count == 1
+
+
+def test_v1_responses_websocket_retries_full_resend_previous_response_miss_without_anchor(
+    app_instance,
+    monkeypatch,
+):
+    first_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.created",
+                            "response": {"id": "resp_ws_prev_anchor", "status": "in_progress"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_ws_prev_anchor", "status": "completed"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+            ],
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "error",
+                            "status": 400,
+                            "error": {
+                                "type": "invalid_request_error",
+                                "code": "previous_response_not_found",
+                                "message": "Previous response with id 'resp_ws_prev_anchor' not found.",
+                                "param": "previous_response_id",
+                            },
+                        },
+                        separators=(",", ":"),
+                    ),
+                )
+            ],
+        ],
+    )
+    recovered_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {"type": "response.created", "response": {"id": "resp_ws_prev_retry", "status": "in_progress"}},
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {"type": "response.completed", "response": {"id": "resp_ws_prev_retry", "status": "completed"}},
+                        separators=(",", ":"),
+                    ),
+                ),
+            ]
+        ],
+    )
+    connect_count = 0
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        nonlocal connect_count
+        connect_count += 1
+        if connect_count == 1:
+            return SimpleNamespace(id="acct_ws_prev_mask"), first_upstream
+        return SimpleNamespace(id="acct_ws_prev_mask"), recovered_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    full_resend_input = [
+        {"role": "user", "content": [{"type": "input_text", "text": "first"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "first response"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/v1/responses") as websocket:
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "input": "hello",
+                        "stream": True,
+                    }
+                )
+            )
+            created_1 = json.loads(websocket.receive_text())
+            completed_1 = json.loads(websocket.receive_text())
+            assert created_1["type"] == "response.created"
+            assert completed_1["type"] == "response.completed"
+
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "input": full_resend_input,
+                        "previous_response_id": "resp_ws_prev_anchor",
+                        "stream": True,
+                    }
+                )
+            )
             created_2 = json.loads(websocket.receive_text())
             completed_2 = json.loads(websocket.receive_text())
 
@@ -1234,9 +1402,11 @@ def test_v1_responses_websocket_masks_previous_response_not_found_and_recovers_o
     assert completed_2["type"] == "response.completed"
     assert connect_count == 2
     assert first_upstream.closed is True
+    assert json.loads(first_upstream.sent_text[-1])["previous_response_id"] == "resp_ws_prev_anchor"
+    assert "previous_response_id" not in json.loads(recovered_upstream.sent_text[0])
 
 
-def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_error_and_recovers_on_retry(
+def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_without_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1388,13 +1558,14 @@ def test_v1_responses_websocket_masks_invalid_request_previous_response_not_foun
                     }
                 )
             )
-            created_2 = json.loads(websocket.receive_text())
-            completed_2 = json.loads(websocket.receive_text())
+            failed_2 = json.loads(websocket.receive_text())
 
-    assert created_2["type"] == "response.created"
-    assert completed_2["type"] == "response.completed"
-    assert connect_count == 2
-    assert first_upstream.closed is True
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
+    assert connect_count == 1
 
 
 def test_backend_responses_websocket_connect_failure_masks_previous_response_not_found(
@@ -1514,7 +1685,7 @@ def test_backend_responses_websocket_connect_failure_masks_previous_response_not
     assert event["error"]["message"] == "Upstream websocket closed before response.completed"
 
 
-def test_backend_responses_websocket_masks_previous_response_not_found_and_recovers_on_retry(
+def test_backend_responses_websocket_masks_short_previous_response_not_found_without_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1690,16 +1861,15 @@ def test_backend_responses_websocket_masks_previous_response_not_found_and_recov
                     }
                 )
             )
-            created_2 = json.loads(websocket.receive_text())
-            completed_2 = json.loads(websocket.receive_text())
+            failed_2 = json.loads(websocket.receive_text())
 
-    assert created_2["type"] == "response.created"
-    assert completed_2["type"] == "response.completed"
-    assert created_2["response"]["id"] == "resp_ws_prev_retry"
-    assert completed_2["response"]["id"] == "resp_ws_prev_retry"
-    assert connect_count == 2
-    assert captured_preferred_accounts == [None, "acct_ws_prev_mask"]
-    assert first_upstream.closed is True
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
+    assert connect_count == 1
+    assert captured_preferred_accounts == [None]
 
 
 def test_backend_responses_websocket_masks_anonymous_previous_response_not_found_with_inflight_request(
@@ -1867,7 +2037,7 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
     assert fake_upstream.closed is True
 
 
-def test_backend_responses_websocket_recovers_when_previous_response_not_found_message_omits_response_id(
+def test_backend_responses_websocket_masks_previous_response_not_found_when_message_omits_response_id(
     app_instance,
     monkeypatch,
 ):
@@ -2033,17 +2203,14 @@ def test_backend_responses_websocket_recovers_when_previous_response_not_found_m
                     }
                 )
             )
-            created_2 = json.loads(websocket.receive_text())
-            completed_2 = json.loads(websocket.receive_text())
+            failed_2 = json.loads(websocket.receive_text())
 
-    assert created_2["type"] == "response.created"
-    assert completed_2["type"] == "response.completed"
-    assert created_2["response"]["id"] == "resp_ws_followup_replayed"
-    assert completed_2["response"]["id"] == "resp_ws_followup_replayed"
-    assert "previous_response_not_found" not in json.dumps(created_2)
-    assert "previous_response_not_found" not in json.dumps(completed_2)
-    assert connect_count == 2
-    assert first_upstream.closed is True
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
+    assert connect_count == 1
 
 
 def test_backend_responses_websocket_keeps_session_alive_after_foreign_previous_response_not_found(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -4975,6 +4975,83 @@ async def test_maybe_prewarm_http_bridge_session_skips_continuity_turns(
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_masks_single_previous_response_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-prev-miss",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_missing_single",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "previous_response_not_found",
+                    "message": "Previous response with id 'resp_missing_single' not found.",
+                    "param": "previous_response_id",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    event_block = await event_queue.get()
+    assert event_block is not None
+    assert await event_queue.get() is None
+    payload = proxy_service.parse_sse_data_json(event_block)
+    assert isinstance(payload, dict)
+    response = payload.get("response")
+    assert isinstance(response, dict)
+    error = response.get("error")
+    assert isinstance(error, dict)
+
+    assert payload["type"] == "response.failed"
+    assert error["code"] == "stream_incomplete"
+    assert error["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(payload)
+    assert request_state.error_http_status_override == 502
+    assert request_state.previous_response_not_found_rewritten is True
+    assert session.upstream_control.reconnect_requested is True
+    assert session.pending_requests == deque()
+    assert session.queued_request_count == 0
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_request_on_fresh_upstream_reconnects_without_resending_previous_response_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -2164,7 +2164,15 @@ async def test_select_account_returns_plan_support_error_for_ungated_model(monke
 
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_model_registry",
-        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"pro"})),
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: ModelRegistrySnapshot(
+                models={},
+                model_plans={"gpt-5.3-codex": frozenset({"pro"})},
+                plan_models={"pro": frozenset({"gpt-5.3-codex"})},
+                fetched_at=0.0,
+            ),
+            plan_types_for_model=lambda _model: frozenset({"pro"}),
+        ),
     )
 
     balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
@@ -2173,6 +2181,45 @@ async def test_select_account_returns_plan_support_error_for_ungated_model(monke
     assert selection.account is None
     assert selection.error_code == NO_PLAN_SUPPORT_FOR_MODEL
     assert selection.error_message == "No accounts with a plan supporting model 'gpt-5.3-codex'"
+
+
+@pytest.mark.asyncio
+async def test_select_account_skips_plan_filter_when_registry_snapshot_lacks_model(monkeypatch) -> None:
+    account = _make_account("acc-partial-registry", "partial-registry@example.com")
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    primary_entry = UsageHistory(
+        id=1,
+        account_id=account.id,
+        recorded_at=now,
+        window="primary",
+        used_percent=5.0,
+        reset_at=now_epoch + 300,
+        window_minutes=5,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(primary={account.id: primary_entry}, secondary={})
+    sticky_repo = StubStickySessionsRepository()
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: ModelRegistrySnapshot(
+                models={},
+                model_plans={"gpt-5.3-codex": frozenset({"pro"})},
+                plan_models={"pro": frozenset({"gpt-5.3-codex"})},
+                fetched_at=0.0,
+            ),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    selection = await balancer.select_account(model="gpt-5.5")
+
+    assert selection.account is not None
+    assert selection.account.id == account.id
+    assert selection.error_code is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7899,7 +7899,20 @@ def test_remember_websocket_previous_response_owner_eviction_keeps_latest_entrie
 
 
 @pytest.mark.asyncio
-async def test_process_upstream_websocket_text_masks_precreated_previous_response_not_found(monkeypatch):
+async def test_process_upstream_websocket_text_retries_precreated_previous_response_not_found(monkeypatch):
+    """A precreated retry-safe full-resend turn (with both
+    ``fresh_upstream_request_is_retry_safe=True`` and
+    ``fresh_upstream_request_text`` populated by the request-prep path) must
+    be transparently retried on a fresh upstream when upstream returns
+    ``previous_response_not_found``. The retry strips the stale
+    ``previous_response_id`` and replays the prepared fresh text.
+
+    This is the inverse of
+    ``test_process_upstream_websocket_text_short_previous_response_not_found_fails_closed`` below: when the request prep path has
+    classified the turn as retry-safe, the masking path must replay rather
+    than fail closed.
+    """
+
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     finalize_request_state = AsyncMock()
@@ -7916,6 +7929,8 @@ async def test_process_upstream_websocket_text_masks_precreated_previous_respons
         "previous_response_id": "resp_anchor",
         "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
     }
+    fresh_request_payload = dict(request_payload)
+    fresh_request_payload.pop("previous_response_id")
     pending_request = proxy_service._WebSocketRequestState(
         request_id="ws_req_prev_not_found_retry",
         model="gpt-5.1",
@@ -7926,6 +7941,8 @@ async def test_process_upstream_websocket_text_masks_precreated_previous_respons
         awaiting_response_created=True,
         request_text=json.dumps(request_payload, separators=(",", ":")),
         previous_response_id="resp_anchor",
+        fresh_upstream_request_text=json.dumps(fresh_request_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=True,
     )
     pending_requests = deque([pending_request])
     upstream_control = proxy_service._WebSocketUpstreamControl()
@@ -7952,15 +7969,17 @@ async def test_process_upstream_websocket_text_masks_precreated_previous_respons
         response_create_gate=asyncio.Semaphore(1),
     )
 
-    assert '"code":"stream_incomplete"' in downstream_text
-    assert "previous_response_not_found" not in downstream_text
-    finalize_request_state.assert_awaited_once()
     handle_stream_error.assert_not_awaited()
     assert upstream_control.reconnect_requested is True
-    assert upstream_control.suppress_downstream_event is False
-    assert upstream_control.replay_request_state is None
-    assert pending_request.replay_count == 0
-    assert list(pending_requests) == []
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.replay_request_state is pending_request
+    assert pending_request.replay_count == 1
+    # The retry must strip the stale ``previous_response_id`` and use the
+    # prepared retry-safe text instead of the original anchored payload.
+    assert pending_request.previous_response_id is None
+    assert pending_request.request_text == json.dumps(fresh_request_payload, separators=(",", ":"))
+    # Retry-safety flag is consumed (set back to False) so we don't loop.
+    assert pending_request.fresh_upstream_request_is_retry_safe is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7899,7 +7899,7 @@ def test_remember_websocket_previous_response_owner_eviction_keeps_latest_entrie
 
 
 @pytest.mark.asyncio
-async def test_process_upstream_websocket_text_retries_precreated_previous_response_not_found(monkeypatch):
+async def test_process_upstream_websocket_text_masks_precreated_previous_response_not_found(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     finalize_request_state = AsyncMock()
@@ -7953,12 +7953,13 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
     )
 
     assert '"code":"stream_incomplete"' in downstream_text
-    finalize_request_state.assert_not_awaited()
+    assert "previous_response_not_found" not in downstream_text
+    finalize_request_state.assert_awaited_once()
     handle_stream_error.assert_not_awaited()
     assert upstream_control.reconnect_requested is True
-    assert upstream_control.suppress_downstream_event is True
-    assert upstream_control.replay_request_state is pending_request
-    assert pending_request.replay_count == 1
+    assert upstream_control.suppress_downstream_event is False
+    assert upstream_control.replay_request_state is None
+    assert pending_request.replay_count == 0
     assert list(pending_requests) == []
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7908,9 +7908,9 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
     ``previous_response_id`` and replays the prepared fresh text.
 
     This is the inverse of
-    ``test_process_upstream_websocket_text_short_previous_response_not_found_fails_closed`` below: when the request prep path has
-    classified the turn as retry-safe, the masking path must replay rather
-    than fail closed.
+    ``test_process_upstream_websocket_text_short_previous_response_not_found_fails_closed``
+    below: when the request prep path has classified the turn as retry-safe,
+    the masking path must replay rather than fail closed.
     """
 
     request_logs = _RequestLogsRecorder()
@@ -7958,7 +7958,7 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
     }
     upstream_text = json.dumps(upstream_payload, separators=(",", ":"))
 
-    downstream_text = await service._process_upstream_websocket_text(
+    await service._process_upstream_websocket_text(
         upstream_text,
         account=account,
         account_id_value=account.id,


### PR DESCRIPTION
## Summary

- mask single-request anonymous HTTP bridge `previous_response_not_found` as an internal continuity-loss signal instead of leaking the raw upstream 400
- preserve the existing local previous-response rebind path by raising an internal `bridge_previous_response_not_found` marker only for the single anonymous HTTP bridge case
- retry direct WebSocket full-resend follow-ups without a stale `previous_response_id` when upstream loses a just-completed anchor before `response.created`
- sanitize direct WebSocket short continuations that hit upstream `previous_response_not_found` into `stream_incomplete` instead of replaying the same stale anchor and exposing the raw upstream 400
- avoid false local `no_plan_support_for_model` 503s after partial model-registry refreshes: account selection now only applies the plan filter when the registry has an authoritative entry for the requested model, and model refresh invalidates cached selection inputs
- mask any lower-layer public Responses or compact `previous_response_not_found` payload to retryable `stream_incomplete` so the missing response id cannot leak even if a lower recovery path misses it
- add OpenSpec change artifacts plus HTTP bridge, WebSocket, and model-registry/load-balancer regression coverage

## Root Cause

The HTTP bridge only rewrote upstream `previous_response_not_found` when the upstream event had a `response.id` or there were other pending requests. A single pending follow-up with an anonymous upstream error could therefore propagate the raw invalid-request error to Codex clients.

Live archive follow-up showed direct WebSocket Codex turns can receive `response.completed` for an anchor and then hit `previous_response_not_found` on the next turn seconds later on the same account/session. Full-resend turns can be recovered by reconnecting upstream and replaying the full payload without `previous_response_id`; short continuation turns cannot, because the only semantic payload is the stale anchor, so they now fail closed as a sanitized continuity-loss signal.

A DNS outage exposed a separate local-routing edge while the live container was running this PR stack: partial model registry data could make `responses/compact` apply a plan filter for a model the registry did not actually know yet, producing local 503 `No accounts with a plan supporting model 'gpt-5.5'` while adjacent `responses` calls on pro accounts were already succeeding.

## Fresh live incident check

Checked the live raw leak with `previous_response_id=resp_0bebc32c66e5a5990169f9d272ffbc8191801046ca030a311b` from `2026-05-05`:

- `2026-05-05 11:20:19 UTC`: upstream created `resp_0beb...d272...`.
- `2026-05-05 11:20:24 UTC`: upstream returned `response.completed` for that response.
- `2026-05-05 11:21:27 UTC`: the same response stream recorded `no close frame received or sent`.
- `2026-05-05 11:22:25 UTC`: the next turn sent `previous_response_id=resp_0beb...d272...` and got raw `previous_response_not_found` / `previous_response_id` / `400` downstream.

This was not a cross-account routing miss: the created/completed response, follow-up request, and raw error all used the same account family `c26b2ebf...`. A new account `fe2708b6...` appeared nearby in the archive, but for a different parallel request.

So this PR's desired behavior is fail-closed masking: when upstream loses continuity even on the owner account, downstream gets `502 stream_incomplete`, not raw `previous_response_not_found` or a `resp_*` id.

## Validation

- `.venv/bin/pytest -q tests/integration/test_proxy_websocket_responses.py` (37 passed, 2 pre-existing aiosqlite thread warnings)
- `.venv/bin/pytest -q tests/integration/test_proxy_websocket_responses.py::test_v1_responses_websocket_masks_short_previous_response_not_found_without_retry tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_short_previous_response_not_found_without_retry tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_previous_response_not_found_when_message_omits_response_id tests/integration/test_proxy_websocket_responses.py::test_v1_responses_websocket_retries_full_resend_previous_response_miss_without_anchor` (4 passed)
- `.venv/bin/pytest -q tests/unit/test_proxy_load_balancer_refresh.py tests/unit/test_graceful_degradation.py` (42 passed, 3 skipped)
- `.venv/bin/ruff check app/modules/proxy/service.py tests/integration/test_proxy_websocket_responses.py`
- `.venv/bin/ruff check app/modules/proxy/load_balancer.py app/core/openai/model_refresh_scheduler.py tests/unit/test_proxy_load_balancer_refresh.py`
- `.venv/bin/ruff format --check app/modules/proxy/service.py tests/integration/test_proxy_websocket_responses.py`
- `.venv/bin/ruff format --check app/modules/proxy/load_balancer.py app/core/openai/model_refresh_scheduler.py tests/unit/test_proxy_load_balancer_refresh.py`
- `npx --yes @fission-ai/openspec validate --specs` (19 passed)
- `git diff --check`
- `/home/kom/proj/codex-lb/.venv/bin/python -m pytest -q tests/unit/test_proxy_api_websocket_auth.py::test_public_previous_response_not_found_error_is_masked_to_stream_incomplete tests/unit/test_proxy_api_websocket_auth.py::test_public_previous_response_invalid_request_param_is_masked_to_stream_incomplete tests/integration/test_proxy_websocket_responses.py tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_rebinds_after_upstream_previous_response_not_found tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_masks_anonymous_previous_response_not_found_with_inflight_request` (41 passed, rerun on `2026-05-05`)
- `/home/kom/proj/codex-lb/.venv/bin/ruff check app/modules/proxy/service.py tests/unit/test_proxy_api_websocket_auth.py tests/integration/test_proxy_websocket_responses.py tests/integration/test_http_responses_bridge.py` (rerun on `2026-05-05`)
- `git diff --check` (rerun on `2026-05-05`)

GitHub CI for this PR head is green: 18/18 checks passed.

## Notes

- `make -f src/Makefile precommit` is not available in this repository; that Makefile belongs to the surrounding OpenClaw workspace.
- `.venv/bin/ty check app/modules/proxy/service.py tests/integration/test_proxy_websocket_responses.py` still reports the pre-existing `service.py:9018..9029` diagnostics that are handled by neighboring PR #517.

## Related issues
- Related to #210, #285, #471, #530, and #550 previous-response / Codex continuity reports.
- Supersedes the fail-closed/rebind subset of #301 for the current HTTP/WebSocket bridge paths.
