### PR TITLE
fix(types): clear existing ty diagnostics

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1322,7 +1322,7 @@ def _prepare_websocket_response_create_payload(payload_dict: JsonObject) -> Json
             max_bytes=_UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
         )
         if slim_summary is not None:
-            request_payload = cast(JsonObject, slimmed_payload)
+            request_payload = slimmed_payload
             slimmed_text = json.dumps(request_payload, ensure_ascii=True, separators=(",", ":"))
             logger.warning(
                 (

--- a/app/main.py
+++ b/app/main.py
@@ -437,7 +437,6 @@ async def _wait_for_bridge_advertise_endpoint(
     probe_base_url = bridge_endpoint_base_url or f"http://127.0.0.1:{local_port}"
     probe_base_url = probe_base_url.rstrip("/")
     probe_url = f"{probe_base_url}/health/live"
-    probe_scheme = urlparse(probe_url).scheme.lower()
     timeout = aiohttp.ClientTimeout(
         total=connect_timeout_seconds,
         sock_connect=connect_timeout_seconds,
@@ -451,7 +450,7 @@ async def _wait_for_bridge_advertise_endpoint(
         attempt += 1
         try:
             async with aiohttp.ClientSession(timeout=timeout, trust_env=False) as session:
-                async with session.get(probe_url, ssl=None if probe_scheme == "https" else None) as response:
+                async with session.get(probe_url) as response:
                     if response.status == 200:
                         return
         except Exception:

--- a/app/modules/dashboard/builders.py
+++ b/app/modules/dashboard/builders.py
@@ -88,12 +88,14 @@ def build_dashboard_overview_summary(
             currency=activity_cost.currency,
             totalUsd=activity_cost.total_usd,
         ),
-        metrics=DashboardUsageMetrics(
-            requests=activity_metrics.requests,
-            tokens=activity_metrics.tokens,
-            cached_input_tokens=activity_metrics.cached_input_tokens,
-            error_rate=activity_metrics.error_rate,
-            error_count=activity_metrics.error_count,
-            top_error=activity_metrics.top_error,
+        metrics=DashboardUsageMetrics.model_validate(
+            {
+                "requests": activity_metrics.requests,
+                "tokens": activity_metrics.tokens,
+                "cached_input_tokens": activity_metrics.cached_input_tokens,
+                "error_rate": activity_metrics.error_rate,
+                "error_count": activity_metrics.error_count,
+                "top_error": activity_metrics.top_error,
+            }
         ),
     )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8978,32 +8978,35 @@ def _summarize_response_create_input(input_value: JsonValue) -> dict[str, JsonVa
     if not isinstance(input_value, list):
         return None
 
+    input_items = cast(list[JsonValue], input_value)
     role_counts: dict[str, int] = {}
     item_type_counts: dict[str, int] = {}
     content_part_type_counts: dict[str, int] = {}
     largest_items: list[dict[str, JsonValue]] = []
 
-    for index, item in enumerate(input_value):
+    for index, item in enumerate(input_items):
         item_summary: dict[str, JsonValue] = {
             "index": index,
             "size_bytes": _json_size_bytes(item),
         }
         if isinstance(item, dict):
-            role = item.get("role")
+            item_object = cast(dict[str, JsonValue], item)
+            role = item_object.get("role")
             if isinstance(role, str):
                 item_summary["role"] = role
                 role_counts[role] = role_counts.get(role, 0) + 1
-            item_type = item.get("type")
+            item_type = item_object.get("type")
             if isinstance(item_type, str):
                 item_summary["type"] = item_type
                 item_type_counts[item_type] = item_type_counts.get(item_type, 0) + 1
-            content = item.get("content")
+            content = item_object.get("content")
             if isinstance(content, list):
                 item_summary["content_parts"] = len(content)
                 for part in content:
                     if not isinstance(part, dict):
                         continue
-                    part_type = part.get("type")
+                    part_object = cast(dict[str, JsonValue], part)
+                    part_type = part_object.get("type")
                     if isinstance(part_type, str):
                         content_part_type_counts[part_type] = content_part_type_counts.get(part_type, 0) + 1
         largest_items.append(item_summary)

--- a/app/modules/usage/builders.py
+++ b/app/modules/usage/builders.py
@@ -378,12 +378,14 @@ def _cost_summary_to_model(cost: UsageCostSummary) -> UsageCost:
 
 
 def _metrics_summary_to_model(metrics: UsageMetricsSummary) -> UsageMetrics:
-    return UsageMetrics(
-        requests_7d=metrics.requests_7d,
-        tokens_secondary_window=metrics.tokens_secondary_window,
-        cached_tokens_secondary_window=metrics.cached_tokens_secondary_window,
-        error_rate_7d=metrics.error_rate_7d,
-        top_error=metrics.top_error,
+    return UsageMetrics.model_validate(
+        {
+            "requests_7d": metrics.requests_7d,
+            "tokens_secondary_window": metrics.tokens_secondary_window,
+            "cached_tokens_secondary_window": metrics.cached_tokens_secondary_window,
+            "error_rate_7d": metrics.error_rate_7d,
+            "top_error": metrics.top_error,
+        }
     )
 
 

--- a/tests/integration/test_db_models.py
+++ b/tests/integration/test_db_models.py
@@ -49,7 +49,7 @@ async def test_status_enum_rejects_invalid_value(db_setup):
         await session.commit()
 
         bad = _make_account("acc4", "enum2@example.com", AccountStatus.ACTIVE)
-        bad.status = "invalid"  # type: ignore[assignment]
+        setattr(bad, "status", "invalid")
         session.add(bad)
         with pytest.raises((LookupError, StatementError)):
             await session.commit()

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from anyio import to_thread
 from sqlalchemy import text
@@ -33,9 +35,11 @@ from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 
 try:
-    from app.db.migrate import check_migration_policy
+    from app.db.migrate import check_migration_policy as _check_migration_policy
 except ImportError:
-    check_migration_policy = None  # type: ignore[assignment]
+    check_migration_policy: Callable[[str], tuple[str, ...]] | None = None
+else:
+    check_migration_policy = _check_migration_policy
 pytestmark = pytest.mark.integration
 _DATABASE_URL = get_settings().database_url
 _HEAD_REVISION = inspect_migration_state(_DATABASE_URL).head_revision

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
+from app.core.types import JsonValue
 
 pytestmark = pytest.mark.integration
 
@@ -12,8 +13,13 @@ def _make_upstream_model(
     *,
     supported_in_api: bool = True,
     base_instructions: str = "",
-    raw: dict | None = None,
+    raw: dict[str, JsonValue] | None = None,
 ) -> UpstreamModel:
+    default_raw: dict[str, JsonValue] = {
+        "shell_type": "shell_command",
+        "visibility": "list",
+        "availability_nux": None,
+    }
     return UpstreamModel(
         slug=slug,
         display_name=slug,
@@ -32,12 +38,7 @@ def _make_upstream_model(
         priority=0,
         available_in_plans=frozenset({"plus", "pro"}),
         base_instructions=base_instructions,
-        raw=raw
-        or {
-            "shell_type": "shell_command",
-            "visibility": "list",
-            "availability_nux": None,
-        },
+        raw=raw or default_raw,
     )
 
 

--- a/tests/integration/test_v1_usage.py
+++ b/tests/integration/test_v1_usage.py
@@ -110,7 +110,7 @@ async def _seed_upstream_usage_partial(
     suffix = str(int(now.timestamp() * 1_000_000))
     account_id = f"acc-plus-partial-{suffix}"
 
-    entries = [
+    entries: list[Account | UsageHistory] = [
         Account(
             id=account_id,
             chatgpt_account_id=f"chatgpt-plus-partial-{suffix}",

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -691,7 +691,7 @@ def test_ensure_alembic_version_table_capacity_creates_table_when_missing(monkey
     inspector = _FakeInspector(has_table=False)
     monkeypatch.setattr("app.db.migrate.inspect", lambda _: inspector)
 
-    _ensure_alembic_version_table_capacity_for_connection(connection, required_length=64)  # type: ignore[arg-type]
+    _ensure_alembic_version_table_capacity_for_connection(cast(Connection, connection), required_length=64)
 
     assert connection.executed_sql == [
         "CREATE TABLE alembic_version ( version_num VARCHAR(64) NOT NULL, PRIMARY KEY (version_num) )"
@@ -703,7 +703,7 @@ def test_ensure_alembic_version_table_capacity_alters_short_column(monkeypatch) 
     inspector = _FakeInspector(has_table=True, version_num_length=32)
     monkeypatch.setattr("app.db.migrate.inspect", lambda _: inspector)
 
-    _ensure_alembic_version_table_capacity_for_connection(connection, required_length=64)  # type: ignore[arg-type]
+    _ensure_alembic_version_table_capacity_for_connection(cast(Connection, connection), required_length=64)
 
     assert connection.executed_sql == ["ALTER TABLE alembic_version ALTER COLUMN version_num TYPE VARCHAR(64)"]
 

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 from sqlalchemy.pool import NullPool
@@ -402,7 +403,7 @@ async def test_init_background_db_uses_smaller_pool_for_postgres() -> None:
     if os.environ.get("CODEX_LB_TEST_DATABASE_URL"):
         assert isinstance(pool, NullPool)
     else:
-        assert pool.size() == 3  # type: ignore[attr-defined]
+        assert cast(Any, pool).size() == 3
 
     if session_module._background_engine is not None:
         await session_module._background_engine.dispose()

--- a/tests/unit/test_hot_path_caches.py
+++ b/tests/unit/test_hot_path_caches.py
@@ -18,7 +18,7 @@ from app.core.crypto import TokenEncryptor
 from app.core.middleware.api_firewall import add_api_firewall_middleware
 from app.core.middleware.firewall_cache import get_firewall_ip_cache
 from app.db.models import Account, AccountStatus, UsageHistory
-from app.modules.api_keys.service import ApiKeyData
+from app.modules.api_keys.service import ApiKeyData, ApiKeysRepositoryProtocol
 from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.load_balancer import LoadBalancer
 from app.modules.proxy.repo_bundle import ProxyRepoFactory
@@ -262,7 +262,7 @@ async def test_deleted_key_rejected_immediately() -> None:
 
     from app.modules.api_keys.service import ApiKeysService
 
-    service = ApiKeysService(_DeleteOnlyRepo())  # type: ignore[arg-type]
+    service = ApiKeysService(cast(ApiKeysRepositoryProtocol, _DeleteOnlyRepo()))
     await service.delete_key("key-del-1")
 
     # BUG: after deletion the cache should be empty, but it still holds stale data
@@ -333,7 +333,7 @@ async def test_regenerated_key_old_token_rejected_immediately() -> None:
 
     from app.modules.api_keys.service import ApiKeysService
 
-    service = ApiKeysService(_RegenRepo())  # type: ignore[arg-type]
+    service = ApiKeysService(cast(ApiKeysRepositoryProtocol, _RegenRepo()))
     await service.regenerate_key("key-regen-1")
 
     # BUG: old token should be evicted from cache but it still authorises requests
@@ -394,7 +394,7 @@ async def test_deactivated_key_rejected_immediately() -> None:
 
     from app.modules.api_keys.service import ApiKeysService, ApiKeyUpdateData
 
-    service = ApiKeysService(_UpdateOnlyRepo())  # type: ignore[arg-type]
+    service = ApiKeysService(cast(ApiKeysRepositoryProtocol, _UpdateOnlyRepo()))
     await service.update_key("key-deact-1", ApiKeyUpdateData(is_active=False, is_active_set=True))
 
     # BUG: deactivated key should be evicted from cache but it still returns stale active data

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -11,8 +11,11 @@ import pytest
 
 from app.core.crypto import TokenEncryptor
 from app.db.models import Account, AccountStatus, UsageHistory
+from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.proxy.load_balancer import LoadBalancer
 from app.modules.proxy.repo_bundle import ProxyRepositories
+from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.usage.repository import AdditionalUsageRepository
 
 pytestmark = pytest.mark.unit
 
@@ -82,10 +85,10 @@ async def _repo_factory(
     yield ProxyRepositories(
         accounts=cast(Any, accounts_repo),
         usage=cast(Any, usage_repo),
-        request_logs=object(),  # type: ignore[arg-type]
+        request_logs=cast(RequestLogsRepository, object()),
         sticky_sessions=cast(Any, _StubStickySessionsRepository()),
-        api_keys=object(),  # type: ignore[arg-type]
-        additional_usage=object(),  # type: ignore[arg-type]
+        api_keys=cast(ApiKeysRepository, object()),
+        additional_usage=cast(AdditionalUsageRepository, object()),
     )
 
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -4246,7 +4246,7 @@ async def test_get_or_create_http_bridge_session_recovers_locally_without_anchor
     claim_durable = AsyncMock()
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
-    service._ring_membership = None
+    setattr(service, "_ring_membership", None)
     monkeypatch.setattr(
         proxy_service,
         "_active_http_bridge_instance_ring",
@@ -4311,7 +4311,7 @@ async def test_get_or_create_http_bridge_session_prompt_cache_takes_over_stale_s
     claim_durable = AsyncMock()
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
-    service._ring_membership = None
+    setattr(service, "_ring_membership", None)
     monkeypatch.setattr(
         proxy_service,
         "_active_http_bridge_instance_ring",

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -1175,9 +1175,9 @@ async def test_select_account_does_not_hold_runtime_lock_during_input_loading(mo
             accounts=accounts_repo,
             usage=usage_repo,
             additional_usage=StubAdditionalUsageRepository(),
-            request_logs=object(),  # type: ignore[arg-type]
+            request_logs=cast(RequestLogsRepository, object()),
             sticky_sessions=sticky_repo,
-            api_keys=object(),  # type: ignore[arg-type]
+            api_keys=cast(ApiKeysRepository, object()),
         )
 
     balancer = LoadBalancer(repo_factory)

--- a/tests/unit/test_strict_schema_validation.py
+++ b/tests/unit/test_strict_schema_validation.py
@@ -9,19 +9,26 @@ hit.
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from app.core.openai.chat_requests import ChatCompletionsRequest
 from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.strict_schema import validate_strict_json_schema
+from app.core.types import JsonValue
 from app.modules.proxy.request_policy import (
     enforce_strict_text_format,
     normalize_responses_request_payload,
 )
 
 
+def _json_object(value: object) -> dict[str, JsonValue]:
+    return cast(dict[str, JsonValue], value)
+
+
 def test_strict_root_missing_additional_properties():
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {"name": {"type": "string"}},
         "required": ["name"],
@@ -36,7 +43,7 @@ def test_strict_root_missing_additional_properties():
 
 
 def test_strict_root_additional_properties_true_rejected():
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {"name": {"type": "string"}},
         "required": ["name"],
@@ -48,7 +55,7 @@ def test_strict_root_additional_properties_true_rejected():
 
 
 def test_strict_nested_missing_additional_properties():
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {
             "nodes": {
@@ -71,7 +78,7 @@ def test_strict_nested_missing_additional_properties():
 def test_strict_dict_str_any_pattern_rejected():
     """Pydantic ``dict[str, Any]`` -> ``additionalProperties: true``."""
 
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {
             "name": {"type": "string"},
@@ -88,7 +95,7 @@ def test_strict_dict_str_any_pattern_rejected():
 def test_strict_empty_schema_node_rejected():
     """``Any`` typed Pydantic field -> ``{}`` schema node."""
 
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {
             "name": {"type": "string"},
@@ -104,7 +111,7 @@ def test_strict_empty_schema_node_rejected():
 
 
 def test_strict_valid_schema_passes():
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
         "required": ["name", "age"],
@@ -120,7 +127,7 @@ def test_strict_required_must_list_every_property():
     of whether the request hit the local pre-check or the upstream API.
     """
 
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {"x": {"type": "string"}, "y": {"type": "integer"}},
         "required": ["x"],
@@ -136,7 +143,7 @@ def test_strict_required_must_list_every_property():
 def test_strict_required_empty_array_rejected():
     """Even an empty ``required`` is rejected when ``properties`` is non-empty."""
 
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {"x": {"type": "string"}},
         "required": [],
@@ -148,7 +155,7 @@ def test_strict_required_empty_array_rejected():
 
 
 def test_strict_required_missing_array_rejected():
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {"x": {"type": "string"}},
         "additionalProperties": False,
@@ -159,7 +166,7 @@ def test_strict_required_missing_array_rejected():
 
 
 def test_strict_combinator_recurses_into_branches():
-    schema = {
+    schema: JsonValue = {
         "type": "object",
         "properties": {
             "value": {
@@ -183,23 +190,25 @@ def test_strict_combinator_recurses_into_branches():
 
 
 def test_normalize_responses_payload_rejects_strict_violation():
-    payload = {
-        "model": "gpt-5.5",
-        "instructions": "",
-        "input": "hi",
-        "text": {
-            "format": {
-                "type": "json_schema",
-                "name": "person",
-                "strict": True,
-                "schema": {
-                    "type": "object",
-                    "properties": {"name": {"type": "string"}},
-                    "required": ["name"],
-                },
-            }
-        },
-    }
+    payload = _json_object(
+        {
+            "model": "gpt-5.5",
+            "instructions": "",
+            "input": "hi",
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "person",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    },
+                }
+            },
+        }
+    )
     with pytest.raises(ClientPayloadError) as exc_info:
         normalize_responses_request_payload(payload, openai_compat=False)
     err = exc_info.value
@@ -210,23 +219,25 @@ def test_normalize_responses_payload_rejects_strict_violation():
 
 
 def test_normalize_responses_payload_accepts_strict_false():
-    payload = {
-        "model": "gpt-5.5",
-        "instructions": "",
-        "input": "hi",
-        "text": {
-            "format": {
-                "type": "json_schema",
-                "name": "person",
-                "strict": False,
-                "schema": {
-                    "type": "object",
-                    "properties": {"name": {"type": "string"}},
-                    "required": ["name"],
-                },
-            }
-        },
-    }
+    payload = _json_object(
+        {
+            "model": "gpt-5.5",
+            "instructions": "",
+            "input": "hi",
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "person",
+                    "strict": False,
+                    "schema": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}},
+                        "required": ["name"],
+                    },
+                }
+            },
+        }
+    )
     # Strict=False schemas are passed through unchanged.
     request = normalize_responses_request_payload(payload, openai_compat=False)
     assert request.text is not None
@@ -235,24 +246,26 @@ def test_normalize_responses_payload_accepts_strict_false():
 
 
 def test_normalize_responses_payload_accepts_valid_strict_schema():
-    payload = {
-        "model": "gpt-5.5",
-        "instructions": "",
-        "input": "hi",
-        "text": {
-            "format": {
-                "type": "json_schema",
-                "name": "person",
-                "strict": True,
-                "schema": {
-                    "type": "object",
-                    "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
-                    "required": ["name", "age"],
-                    "additionalProperties": False,
-                },
-            }
-        },
-    }
+    payload = _json_object(
+        {
+            "model": "gpt-5.5",
+            "instructions": "",
+            "input": "hi",
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "person",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+                        "required": ["name", "age"],
+                        "additionalProperties": False,
+                    },
+                }
+            },
+        }
+    )
     request = normalize_responses_request_payload(payload, openai_compat=False)
     assert request.text is not None
     assert request.text.format is not None


### PR DESCRIPTION
## Summary
- clean up the existing `ty check` diagnostics on `main`
- keep Pydantic builder code on snake_case field names via `model_validate` instead of alias-only constructor kwargs
- make test-only invalid assignments, partial fake repositories, and recursive JSON payloads explicit to the type checker

## Validation
- `.venv/bin/ty check`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest -q tests/unit tests/test_request_logs_options_api.py` (`1429 passed, 39 skipped`)
- `.venv/bin/pytest -q tests/integration/test_db_models.py tests/integration/test_migrations.py tests/integration/test_v1_models.py tests/integration/test_v1_usage.py` (`36 passed, 3 skipped`)
