### PR TITLE
feat(observability): add conversation archive viewer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,10 @@ CODEX_LB_METRICS_PORT=9090
 # Logging format
 CODEX_LB_LOG_FORMAT=text
 
+# Full upstream conversation archive (opt-in; stores request/response bodies/events as gzip JSONL)
+CODEX_LB_CONVERSATION_ARCHIVE_ENABLED=false
+# CODEX_LB_CONVERSATION_ARCHIVE_DIR=~/.codex-lb/conversation-archive
+
 # Leader election (opt-in)
 CODEX_LB_LEADER_ELECTION_ENABLED=false
 CODEX_LB_LEADER_ELECTION_TTL_SECONDS=30

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -36,6 +36,7 @@ from multidict import CIMultiDict
 
 from app.core.clients.http import get_http_client
 from app.core.config.settings import Settings, get_settings
+from app.core.conversation_archive import archive_json, archive_text
 from app.core.errors import (
     OpenAIErrorDetail,
     OpenAIErrorEnvelope,
@@ -1281,6 +1282,17 @@ async def _stream_responses_via_websocket(
             request_started_at,
             time.monotonic(),
         )
+        archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="websocket",
+            payload=request_payload,
+            account_id=account_id,
+            method="GET",
+            url=websocket_url,
+            headers=headers,
+            extra={"frame_type": "text"},
+        )
         if callable(send_json):
             await asyncio.wait_for(
                 cast(Callable[[JsonObject], Awaitable[None]], send_json)(request_payload),
@@ -1302,6 +1314,17 @@ async def _stream_responses_via_websocket(
             total_timeout_seconds=remaining_total_timeout,
             max_event_bytes=max_event_bytes,
         ):
+            archive_text(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                text=event,
+                account_id=account_id,
+                method="GET",
+                url=websocket_url,
+                headers=headers,
+                extra={"event_format": "sse"},
+            )
             parsed_event = parse_sse_event(event)
             if parsed_event and parsed_event.type in ("response.completed", "response.failed", "response.incomplete"):
                 seen_terminal = True
@@ -1873,7 +1896,20 @@ async def stream_responses(
                     raise ProxyResponseError(resp.status, error_payload)
                 event = await _error_event_from_response(resp)
                 error_code, error_message = _error_details_from_failed_event(event)
-                yield format_sse_event(event)
+                event_block = format_sse_event(event)
+                archive_text(
+                    direction="server_to_codex",
+                    kind="responses",
+                    transport="http",
+                    text=event_block,
+                    account_id=account_id,
+                    method="POST",
+                    url=url,
+                    status_code=status_code,
+                    headers=current_headers,
+                    extra={"event_format": "sse"},
+                )
+                yield event_block
                 return
 
             async for event_block in _iter_sse_events(
@@ -1887,6 +1923,18 @@ async def stream_responses(
                     event_type = event.type
                     if event_type in ("response.completed", "response.failed", "response.incomplete"):
                         seen_terminal = True
+                archive_text(
+                    direction="server_to_codex",
+                    kind="responses",
+                    transport="http",
+                    text=event_block,
+                    account_id=account_id,
+                    method="POST",
+                    url=url,
+                    status_code=status_code,
+                    headers=current_headers,
+                    extra={"event_format": "sse"},
+                )
                 yield event_block
                 if seen_terminal:
                     break
@@ -1899,6 +1947,17 @@ async def stream_responses(
         payload_summary=_summarize_json_payload(payload_dict),
         payload_json=payload_json if settings.log_upstream_request_payload else None,
     )
+    if transport == "http":
+        archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="http",
+            payload=payload_dict,
+            account_id=account_id,
+            method=method,
+            url=url,
+            headers=upstream_headers,
+        )
     try:
         if transport == "websocket":
             try:
@@ -1978,6 +2037,16 @@ async def stream_responses(
                     method=method,
                     payload_summary=_summarize_json_payload(payload_dict),
                     payload_json=payload_json if settings.log_upstream_request_payload else None,
+                )
+                archive_json(
+                    direction="codex_to_server",
+                    kind="responses",
+                    transport="http",
+                    payload=payload_dict,
+                    account_id=account_id,
+                    method=method,
+                    url=url,
+                    headers=upstream_headers,
                 )
                 async for event_block in _stream_via_http(upstream_headers, timeout):
                     yield event_block
@@ -2250,6 +2319,16 @@ class _CompactCommandTransport:
             if settings.log_upstream_request_payload
             else None,
         )
+        archive_json(
+            direction="codex_to_server",
+            kind="compact",
+            transport="http",
+            payload=payload_dict,
+            account_id=self.account_id,
+            method="POST",
+            url=url,
+            headers=upstream_headers,
+        )
         try:
             async with _service_circuit_breaker_context(
                 self.session.post(
@@ -2264,6 +2343,17 @@ class _CompactCommandTransport:
                 status_code = resp.status
                 if resp.status >= 400:
                     error_payload = await _error_payload_from_response(resp)
+                    archive_json(
+                        direction="server_to_codex",
+                        kind="compact",
+                        transport="http",
+                        payload=error_payload,
+                        account_id=self.account_id,
+                        method="POST",
+                        url=url,
+                        status_code=status_code,
+                        headers=upstream_headers,
+                    )
                     error_code, error_message = _error_details_from_envelope(error_payload)
                     failure_phase = "status"
                     failure_detail = error_message
@@ -2310,6 +2400,17 @@ class _CompactCommandTransport:
                         upstream_status_code=resp.status,
                     ) from exc
                 parsed = parse_compact_response_payload(data)
+                archive_json(
+                    direction="server_to_codex",
+                    kind="compact",
+                    transport="http",
+                    payload=data,
+                    account_id=self.account_id,
+                    method="POST",
+                    url=url,
+                    status_code=status_code,
+                    headers=upstream_headers,
+                )
                 if parsed:
                     payload_object = parsed.object
                     return parsed

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1893,6 +1893,17 @@ async def stream_responses(
                 if raise_for_status:
                     error_payload = await _error_payload_from_response(resp)
                     error_code, error_message = _error_details_from_envelope(error_payload)
+                    archive_json(
+                        direction="server_to_codex",
+                        kind="responses",
+                        transport="http",
+                        payload=error_payload,
+                        account_id=account_id,
+                        method="POST",
+                        url=url,
+                        status_code=status_code,
+                        headers=current_headers,
+                    )
                     raise ProxyResponseError(resp.status, error_payload)
                 event = await _error_event_from_response(resp)
                 error_code, error_message = _error_details_from_failed_event(event)

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -36,7 +36,7 @@ from multidict import CIMultiDict
 
 from app.core.clients.http import get_http_client
 from app.core.config.settings import Settings, get_settings
-from app.core.conversation_archive import archive_json, archive_text
+from app.core.conversation_archive import archive_bytes, archive_json, archive_text
 from app.core.errors import (
     OpenAIErrorDetail,
     OpenAIErrorEnvelope,
@@ -771,19 +771,35 @@ async def _iter_sse_events(
         yield bytes(buffer).decode("utf-8", errors="replace")
 
 
-async def _error_event_from_response(resp: ErrorResponse) -> ResponseFailedEvent:
+async def _error_response_body(resp: ErrorResponse) -> tuple[object | None, str | None]:
+    try:
+        return await resp.json(content_type=None), None
+    except Exception:
+        return None, await resp.text()
+
+
+def _error_archive_payload(data: object | None, text: str | None) -> object:
+    if data is not None:
+        return data
+    return {"text": text or ""}
+
+
+def _error_event_from_response_body(
+    resp: ErrorResponse,
+    *,
+    data: object | None,
+    text: str | None,
+) -> ResponseFailedEvent:
     fallback_message = f"Upstream error: HTTP {resp.status}"
     if resp.reason:
         fallback_message += f" {resp.reason}"
-    try:
-        data = await resp.json(content_type=None)
-    except Exception:
-        text = await resp.text()
-        message = text.strip() or fallback_message
+    if data is None:
+        message = (text or "").strip() or fallback_message
         return response_failed_event("upstream_error", message, response_id=get_request_id())
 
-    if isinstance(data, dict):
-        error = parse_error_payload(data)
+    if is_json_mapping(data):
+        payload_data = cast(dict[str, JsonValue], data)
+        error = parse_error_payload(payload_data)
         if error:
             payload = error.model_dump(exclude_none=True)
             event = response_failed_event(
@@ -797,31 +813,44 @@ async def _error_event_from_response(resp: ErrorResponse) -> ResponseFailedEvent
                 if key in payload:
                     event["response"]["error"][key] = payload[key]
             return event
-        message = _extract_upstream_message(data)
+        message = _extract_upstream_message(payload_data)
         if message:
             return response_failed_event("upstream_error", message, response_id=get_request_id())
     return response_failed_event("upstream_error", fallback_message, response_id=get_request_id())
 
 
-async def _error_payload_from_response(resp: ErrorResponse) -> OpenAIErrorEnvelope:
+async def _error_event_from_response(resp: ErrorResponse) -> ResponseFailedEvent:
+    data, text = await _error_response_body(resp)
+    return _error_event_from_response_body(resp, data=data, text=text)
+
+
+def _error_payload_from_response_body(
+    resp: ErrorResponse,
+    *,
+    data: object | None,
+    text: str | None,
+) -> OpenAIErrorEnvelope:
     fallback_message = f"Upstream error: HTTP {resp.status}"
     if resp.reason:
         fallback_message += f" {resp.reason}"
-    try:
-        data = await resp.json(content_type=None)
-    except Exception:
-        text = await resp.text()
-        message = text.strip() or fallback_message
+    if data is None:
+        message = (text or "").strip() or fallback_message
         return openai_error("upstream_error", message)
 
-    if isinstance(data, dict):
-        error = parse_error_payload(data)
+    if is_json_mapping(data):
+        payload_data = cast(dict[str, JsonValue], data)
+        error = parse_error_payload(payload_data)
         if error:
             return {"error": _openai_error_detail(error)}
-        message = _extract_upstream_message(data)
+        message = _extract_upstream_message(payload_data)
         if message:
             return openai_error("upstream_error", message)
     return openai_error("upstream_error", fallback_message)
+
+
+async def _error_payload_from_response(resp: ErrorResponse) -> OpenAIErrorEnvelope:
+    data, text = await _error_response_body(resp)
+    return _error_payload_from_response_body(resp, data=data, text=text)
 
 
 def _openai_error_detail(error: OpenAIError) -> OpenAIErrorDetail:
@@ -1168,6 +1197,9 @@ async def _stream_websocket_events(
     idle_timeout_seconds: float,
     total_timeout_seconds: float | None,
     max_event_bytes: int,
+    archive_account_id: str | None = None,
+    archive_url: str | None = None,
+    archive_headers: Mapping[str, str] | None = None,
 ) -> AsyncIterator[str]:
     deadline = None if total_timeout_seconds is None else time.monotonic() + total_timeout_seconds
 
@@ -1198,7 +1230,29 @@ async def _stream_websocket_events(
 
         if message.type == aiohttp.WSMsgType.TEXT:
             text = message.data
+            archive_text(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                text=text,
+                account_id=archive_account_id,
+                method="GET",
+                url=archive_url,
+                headers=archive_headers,
+                extra={"frame_type": "text"},
+            )
         else:
+            archive_bytes(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                data=message.data,
+                account_id=archive_account_id,
+                method="GET",
+                url=archive_url,
+                headers=archive_headers,
+                extra={"frame_type": "binary"},
+            )
             text = message.data.decode("utf-8", errors="replace")
         text_bytes = text.encode("utf-8")
         if len(text_bytes) > max_event_bytes:
@@ -1313,18 +1367,10 @@ async def _stream_responses_via_websocket(
             idle_timeout_seconds=effective_idle_timeout,
             total_timeout_seconds=remaining_total_timeout,
             max_event_bytes=max_event_bytes,
+            archive_account_id=account_id,
+            archive_url=websocket_url,
+            archive_headers=headers,
         ):
-            archive_text(
-                direction="server_to_codex",
-                kind="responses",
-                transport="websocket",
-                text=event,
-                account_id=account_id,
-                method="GET",
-                url=websocket_url,
-                headers=headers,
-                extra={"event_format": "sse"},
-            )
             parsed_event = parse_sse_event(event)
             if parsed_event and parsed_event.type in ("response.completed", "response.failed", "response.incomplete"):
                 seen_terminal = True
@@ -1890,36 +1936,25 @@ async def stream_responses(
         ) as resp:
             status_code = resp.status
             if resp.status >= 400:
-                if raise_for_status:
-                    error_payload = await _error_payload_from_response(resp)
-                    error_code, error_message = _error_details_from_envelope(error_payload)
-                    archive_json(
-                        direction="server_to_codex",
-                        kind="responses",
-                        transport="http",
-                        payload=error_payload,
-                        account_id=account_id,
-                        method="POST",
-                        url=url,
-                        status_code=status_code,
-                        headers=current_headers,
-                    )
-                    raise ProxyResponseError(resp.status, error_payload)
-                event = await _error_event_from_response(resp)
-                error_code, error_message = _error_details_from_failed_event(event)
-                event_block = format_sse_event(event)
-                archive_text(
+                error_body, error_text = await _error_response_body(resp)
+                archive_json(
                     direction="server_to_codex",
                     kind="responses",
                     transport="http",
-                    text=event_block,
+                    payload=_error_archive_payload(error_body, error_text),
                     account_id=account_id,
                     method="POST",
                     url=url,
                     status_code=status_code,
                     headers=current_headers,
-                    extra={"event_format": "sse"},
                 )
+                if raise_for_status:
+                    error_payload = _error_payload_from_response_body(resp, data=error_body, text=error_text)
+                    error_code, error_message = _error_details_from_envelope(error_payload)
+                    raise ProxyResponseError(resp.status, error_payload)
+                event = _error_event_from_response_body(resp, data=error_body, text=error_text)
+                error_code, error_message = _error_details_from_failed_event(event)
+                event_block = format_sse_event(event)
                 yield event_block
                 return
 
@@ -2353,18 +2388,19 @@ class _CompactCommandTransport:
             ) as resp:
                 status_code = resp.status
                 if resp.status >= 400:
-                    error_payload = await _error_payload_from_response(resp)
+                    error_body, error_text = await _error_response_body(resp)
                     archive_json(
                         direction="server_to_codex",
                         kind="compact",
                         transport="http",
-                        payload=error_payload,
+                        payload=_error_archive_payload(error_body, error_text),
                         account_id=self.account_id,
                         method="POST",
                         url=url,
                         status_code=status_code,
                         headers=upstream_headers,
                     )
+                    error_payload = _error_payload_from_response_body(resp, data=error_body, text=error_text)
                     error_code, error_message = _error_details_from_envelope(error_payload)
                     failure_phase = "status"
                     failure_detail = error_message

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -49,16 +49,29 @@ class UpstreamWebSocketMessage:
     error: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class UpstreamWebSocketArchiveMetadata:
+    url: str | None
+    headers: dict[str, str] | None
+    account_id: str | None
+
+
 class UpstreamResponsesWebSocket(Protocol):
     async def send_text(self, text: str) -> None: ...
 
+    async def send_text_with_archive_request_id(self, text: str, *, request_id: str | None) -> None: ...
+
     async def send_bytes(self, data: bytes) -> None: ...
+
+    async def send_bytes_with_archive_request_id(self, data: bytes, *, request_id: str | None) -> None: ...
 
     async def receive(self) -> UpstreamWebSocketMessage: ...
 
     async def close(self) -> None: ...
 
     def response_header(self, name: str) -> str | None: ...
+
+    def archive_metadata(self) -> UpstreamWebSocketArchiveMetadata | None: ...
 
 
 class WebsocketsResponsesWebSocket:
@@ -68,8 +81,16 @@ class WebsocketsResponsesWebSocket:
     async def send_text(self, text: str) -> None:
         await self._connection.send(text)
 
+    async def send_text_with_archive_request_id(self, text: str, *, request_id: str | None) -> None:
+        del request_id
+        await self.send_text(text)
+
     async def send_bytes(self, data: bytes) -> None:
         await self._connection.send(data)
+
+    async def send_bytes_with_archive_request_id(self, data: bytes, *, request_id: str | None) -> None:
+        del request_id
+        await self.send_bytes(data)
 
     async def receive(self) -> UpstreamWebSocketMessage:
         try:
@@ -102,6 +123,12 @@ class WebsocketsResponsesWebSocket:
             return None
         return str(value)
 
+    def set_archive_request_id(self, request_id: str | None) -> None:
+        del request_id
+
+    def archive_metadata(self) -> UpstreamWebSocketArchiveMetadata | None:
+        return None
+
 
 class ArchivingResponsesWebSocket:
     def __init__(
@@ -117,7 +144,13 @@ class ArchivingResponsesWebSocket:
         self._headers = headers
         self._account_id = account_id
 
+    def set_archive_request_id(self, request_id: str | None) -> None:
+        del request_id
+
     async def send_text(self, text: str) -> None:
+        await self.send_text_with_archive_request_id(text, request_id=None)
+
+    async def send_text_with_archive_request_id(self, text: str, *, request_id: str | None) -> None:
         archive_text(
             direction="codex_to_server",
             kind="responses",
@@ -128,10 +161,14 @@ class ArchivingResponsesWebSocket:
             url=self._url,
             headers=self._headers,
             extra={"frame_type": "text"},
+            request_id=request_id,
         )
         await self._wrapped.send_text(text)
 
     async def send_bytes(self, data: bytes) -> None:
+        await self.send_bytes_with_archive_request_id(data, request_id=None)
+
+    async def send_bytes_with_archive_request_id(self, data: bytes, *, request_id: str | None) -> None:
         archive_bytes(
             direction="codex_to_server",
             kind="responses",
@@ -142,54 +179,25 @@ class ArchivingResponsesWebSocket:
             url=self._url,
             headers=self._headers,
             extra={"frame_type": "binary"},
+            request_id=request_id,
         )
         await self._wrapped.send_bytes(data)
 
     async def receive(self) -> UpstreamWebSocketMessage:
-        message = await self._wrapped.receive()
-        if message.kind == "text" and message.text is not None:
-            archive_text(
-                direction="server_to_codex",
-                kind="responses",
-                transport="websocket",
-                text=message.text,
-                account_id=self._account_id,
-                method="GET",
-                url=self._url,
-                headers=self._headers,
-                extra={"frame_type": "text"},
-            )
-        elif message.kind == "binary" and message.data is not None:
-            archive_bytes(
-                direction="server_to_codex",
-                kind="responses",
-                transport="websocket",
-                data=message.data,
-                account_id=self._account_id,
-                method="GET",
-                url=self._url,
-                headers=self._headers,
-                extra={"frame_type": "binary"},
-            )
-        else:
-            archive_text(
-                direction="server_to_codex",
-                kind="responses",
-                transport="websocket",
-                text=message.error or "",
-                account_id=self._account_id,
-                method="GET",
-                url=self._url,
-                headers=self._headers,
-                extra={"frame_type": message.kind, "close_code": message.close_code},
-            )
-        return message
+        return await self._wrapped.receive()
 
     async def close(self) -> None:
         await self._wrapped.close()
 
     def response_header(self, name: str) -> str | None:
         return self._wrapped.response_header(name)
+
+    def archive_metadata(self) -> UpstreamWebSocketArchiveMetadata:
+        return UpstreamWebSocketArchiveMetadata(
+            url=self._url,
+            headers=self._headers,
+            account_id=self._account_id,
+        )
 
 
 def filter_inbound_websocket_headers(headers: dict[str, str]) -> dict[str, str]:

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -20,6 +20,7 @@ from websockets.typing import Origin
 
 from app.core.clients.proxy import ProxyResponseError, filter_inbound_headers
 from app.core.config.settings import get_settings
+from app.core.conversation_archive import archive_bytes, archive_text
 from app.core.errors import OpenAIErrorDetail, OpenAIErrorEnvelope, openai_error
 from app.core.openai.models import OpenAIError
 from app.core.openai.parsing import parse_error_payload
@@ -100,6 +101,95 @@ class WebsocketsResponsesWebSocket:
         if value is None:
             return None
         return str(value)
+
+
+class ArchivingResponsesWebSocket:
+    def __init__(
+        self,
+        wrapped: UpstreamResponsesWebSocket,
+        *,
+        url: str,
+        headers: dict[str, str],
+        account_id: str | None,
+    ) -> None:
+        self._wrapped = wrapped
+        self._url = url
+        self._headers = headers
+        self._account_id = account_id
+
+    async def send_text(self, text: str) -> None:
+        archive_text(
+            direction="codex_to_server",
+            kind="responses",
+            transport="websocket",
+            text=text,
+            account_id=self._account_id,
+            method="GET",
+            url=self._url,
+            headers=self._headers,
+            extra={"frame_type": "text"},
+        )
+        await self._wrapped.send_text(text)
+
+    async def send_bytes(self, data: bytes) -> None:
+        archive_bytes(
+            direction="codex_to_server",
+            kind="responses",
+            transport="websocket",
+            data=data,
+            account_id=self._account_id,
+            method="GET",
+            url=self._url,
+            headers=self._headers,
+            extra={"frame_type": "binary"},
+        )
+        await self._wrapped.send_bytes(data)
+
+    async def receive(self) -> UpstreamWebSocketMessage:
+        message = await self._wrapped.receive()
+        if message.kind == "text" and message.text is not None:
+            archive_text(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                text=message.text,
+                account_id=self._account_id,
+                method="GET",
+                url=self._url,
+                headers=self._headers,
+                extra={"frame_type": "text"},
+            )
+        elif message.kind == "binary" and message.data is not None:
+            archive_bytes(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                data=message.data,
+                account_id=self._account_id,
+                method="GET",
+                url=self._url,
+                headers=self._headers,
+                extra={"frame_type": "binary"},
+            )
+        else:
+            archive_text(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                text=message.error or "",
+                account_id=self._account_id,
+                method="GET",
+                url=self._url,
+                headers=self._headers,
+                extra={"frame_type": message.kind, "close_code": message.close_code},
+            )
+        return message
+
+    async def close(self) -> None:
+        await self._wrapped.close()
+
+    def response_header(self, name: str) -> str | None:
+        return self._wrapped.response_header(name)
 
 
 def filter_inbound_websocket_headers(headers: dict[str, str]) -> dict[str, str]:
@@ -207,7 +297,12 @@ async def connect_responses_websocket(
             openai_error("upstream_unavailable", str(exc)),
         ) from exc
 
-    return WebsocketsResponsesWebSocket(response)
+    return ArchivingResponsesWebSocket(
+        WebsocketsResponsesWebSocket(response),
+        url=url,
+        headers=upstream_headers,
+        account_id=account_id,
+    )
 
 
 def _close_code_from_exception(exc: ConnectionClosedOK | ConnectionClosedError) -> int | None:

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -181,6 +181,8 @@ class Settings(BaseSettings):
     log_proxy_service_tier_trace: bool = False
     log_upstream_request_summary: bool = False
     log_upstream_request_payload: bool = False
+    conversation_archive_enabled: bool = False
+    conversation_archive_dir: Path = DEFAULT_HOME_DIR / "conversation-archive"
     max_decompressed_body_bytes: int = Field(default=32 * 1024 * 1024, gt=0)
     image_inline_fetch_enabled: bool = True
     image_inline_allowed_hosts: Annotated[list[str], NoDecode] = Field(default_factory=list)

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import atexit
+import base64
+import errno
+import gzip
+import json
+import logging
+import queue
+import threading
+import time
+import zlib
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from app.core.config.settings import get_settings
+from app.core.utils.request_id import get_request_id
+
+logger = logging.getLogger(__name__)
+
+_REDACTED = "[redacted]"
+_SENSITIVE_HEADER_NAMES = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "openai-api-key",
+        "proxy-authorization",
+        "set-cookie",
+        "x-api-key",
+    }
+)
+_WRITE_LOCK = threading.Lock()
+_WRITER_LOCK = threading.Lock()
+_WRITE_QUEUE_MAX_RECORDS = 4096
+_WRITE_QUEUE: queue.Queue[tuple[Path, dict[str, Any]] | None] = queue.Queue(maxsize=_WRITE_QUEUE_MAX_RECORDS)
+_WRITER_THREAD: threading.Thread | None = None
+_RECOVERY_CHECKED_PATHS: set[Path] = set()
+_DISK_PRESSURE_PAUSE_SECONDS = 60.0
+_DISK_PRESSURE_WARNING_INTERVAL_SECONDS = 300.0
+_DISK_PRESSURE_PAUSED_UNTIL = 0.0
+_DISK_PRESSURE_LAST_WARNING_AT = -_DISK_PRESSURE_WARNING_INTERVAL_SECONDS
+_DISK_PRESSURE_LOCK = threading.Lock()
+
+
+def archive_enabled() -> bool:
+    return bool(getattr(get_settings(), "conversation_archive_enabled", False))
+
+
+def archive_json(
+    *,
+    direction: str,
+    kind: str,
+    transport: str,
+    payload: Any,
+    account_id: str | None = None,
+    method: str | None = None,
+    url: str | None = None,
+    status_code: int | None = None,
+    headers: Mapping[str, str] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> None:
+    if not archive_enabled():
+        return
+
+    record: dict[str, Any] = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "request_id": get_request_id(),
+        "direction": direction,
+        "kind": kind,
+        "transport": transport,
+        "account_id": account_id,
+        "method": method,
+        "url": url,
+        "status_code": status_code,
+        "headers": _redact_headers(headers),
+        "payload": payload,
+    }
+    if extra:
+        record["extra"] = dict(extra)
+    _enqueue_record(_archive_path(), record)
+
+
+def archive_text(
+    *,
+    direction: str,
+    kind: str,
+    transport: str,
+    text: str,
+    account_id: str | None = None,
+    method: str | None = None,
+    url: str | None = None,
+    status_code: int | None = None,
+    headers: Mapping[str, str] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> None:
+    archive_json(
+        direction=direction,
+        kind=kind,
+        transport=transport,
+        payload={"text": text},
+        account_id=account_id,
+        method=method,
+        url=url,
+        status_code=status_code,
+        headers=headers,
+        extra=extra,
+    )
+
+
+def archive_bytes(
+    *,
+    direction: str,
+    kind: str,
+    transport: str,
+    data: bytes,
+    account_id: str | None = None,
+    method: str | None = None,
+    url: str | None = None,
+    status_code: int | None = None,
+    headers: Mapping[str, str] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> None:
+    archive_json(
+        direction=direction,
+        kind=kind,
+        transport=transport,
+        payload={
+            "encoding": "base64",
+            "data": base64.b64encode(data).decode("ascii"),
+        },
+        account_id=account_id,
+        method=method,
+        url=url,
+        status_code=status_code,
+        headers=headers,
+        extra=extra,
+    )
+
+
+def _redact_headers(headers: Mapping[str, str] | None) -> dict[str, str] | None:
+    if headers is None:
+        return None
+    redacted: dict[str, str] = {}
+    for key, value in headers.items():
+        redacted[key] = _redact_header_value(key, value)
+    return redacted
+
+
+def _archive_path() -> Path:
+    settings = get_settings()
+    directory = Path(getattr(settings, "conversation_archive_dir"))
+    filename = f"{datetime.now(UTC).strftime('%Y-%m-%dT%H')}.jsonl.gz"
+    return directory / filename
+
+
+def flush_archive_writer() -> None:
+    _WRITE_QUEUE.join()
+
+
+def _enqueue_record(path: Path, record: dict[str, Any]) -> None:
+    if _archive_disk_pressure_active():
+        return
+    _ensure_writer_thread()
+    try:
+        _WRITE_QUEUE.put_nowait((path, record))
+    except queue.Full:
+        logger.warning(
+            "Conversation archive writer queue is full; applying synchronous archive write backpressure",
+            extra={"queue_max_records": _WRITE_QUEUE_MAX_RECORDS},
+        )
+        _append_record(path, record)
+
+
+def _ensure_writer_thread() -> None:
+    global _WRITER_THREAD
+    if _WRITER_THREAD is not None and _WRITER_THREAD.is_alive():
+        return
+    with _WRITER_LOCK:
+        if _WRITER_THREAD is not None and _WRITER_THREAD.is_alive():
+            return
+        _WRITER_THREAD = threading.Thread(
+            target=_writer_loop,
+            name="conversation-archive-writer",
+            daemon=True,
+        )
+        _WRITER_THREAD.start()
+
+
+def _writer_loop() -> None:
+    while True:
+        item = _WRITE_QUEUE.get()
+        try:
+            if item is None:
+                return
+            path, record = item
+            _append_record(path, record)
+        finally:
+            _WRITE_QUEUE.task_done()
+
+
+def _append_record(path: Path, record: Mapping[str, Any]) -> None:
+    if _archive_disk_pressure_active():
+        return
+
+    line = json.dumps(record, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    data = gzip.compress(f"{line}\n".encode("utf-8"))
+    try:
+        with _WRITE_LOCK:
+            if _archive_disk_pressure_active():
+                return
+            path.parent.mkdir(parents=True, exist_ok=True)
+            _recover_corrupt_gzip_archive(path)
+            _write_gzip_member(path, data)
+    except Exception as exc:
+        if _is_disk_pressure_error(exc):
+            _pause_archive_for_disk_pressure(path, exc)
+            return
+        logger.warning("Failed to append conversation archive record", exc_info=True)
+
+
+def _write_gzip_member(path: Path, data: bytes) -> None:
+    with path.open("ab") as fh:
+        fh.write(data)
+
+
+def _archive_disk_pressure_active() -> bool:
+    with _DISK_PRESSURE_LOCK:
+        return time.monotonic() < _DISK_PRESSURE_PAUSED_UNTIL
+
+
+def _pause_archive_for_disk_pressure(path: Path, exc: BaseException) -> None:
+    global _DISK_PRESSURE_LAST_WARNING_AT, _DISK_PRESSURE_PAUSED_UNTIL
+    now = time.monotonic()
+    with _DISK_PRESSURE_LOCK:
+        _DISK_PRESSURE_PAUSED_UNTIL = max(_DISK_PRESSURE_PAUSED_UNTIL, now + _DISK_PRESSURE_PAUSE_SECONDS)
+        should_warn = now - _DISK_PRESSURE_LAST_WARNING_AT >= _DISK_PRESSURE_WARNING_INTERVAL_SECONDS
+        if should_warn:
+            _DISK_PRESSURE_LAST_WARNING_AT = now
+
+    if should_warn:
+        logger.warning(
+            "Conversation archive disk pressure detected; pausing archive writes",
+            extra={
+                "archive_file": str(path),
+                "pause_seconds": _DISK_PRESSURE_PAUSE_SECONDS,
+                "error": str(exc),
+            },
+        )
+
+
+def _is_disk_pressure_error(exc: BaseException) -> bool:
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, OSError) and current.errno in {errno.ENOSPC, errno.EDQUOT}:
+            return True
+        message = str(current).lower()
+        if (
+            "no space left on device" in message
+            or "disk quota exceeded" in message
+            or "database or disk is full" in message
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _recover_corrupt_gzip_archive(path: Path) -> None:
+    resolved_path = path.resolve()
+    if resolved_path in _RECOVERY_CHECKED_PATHS:
+        return
+    _RECOVERY_CHECKED_PATHS.add(resolved_path)
+
+    if not path.exists() or path.stat().st_size == 0:
+        return
+    if _gzip_archive_is_readable(path):
+        return
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    backup = path.with_name(f"{path.name}.corrupt-{timestamp}")
+    recovered = path.with_name(f".{path.name}.recovered-{timestamp}")
+    recovered_count = 0
+    try:
+        with gzip.open(path, "rb") as source, recovered.open("wb") as target:
+            while True:
+                try:
+                    line = source.readline()
+                except (EOFError, gzip.BadGzipFile, zlib.error):
+                    break
+                if not line:
+                    break
+                target.write(gzip.compress(line))
+                recovered_count += 1
+        path.replace(backup)
+        recovered.replace(path)
+        logger.warning(
+            "Recovered readable conversation archive prefix from corrupt gzip file",
+            extra={
+                "archive_file": str(path),
+                "backup_file": str(backup),
+                "recovered_records": recovered_count,
+            },
+        )
+    except Exception:
+        recovered.unlink(missing_ok=True)
+        logger.warning("Failed to recover corrupt conversation archive gzip", exc_info=True)
+
+
+def _gzip_archive_is_readable(path: Path) -> bool:
+    try:
+        with gzip.open(path, "rb") as fh:
+            for _chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                pass
+    except (EOFError, gzip.BadGzipFile, zlib.error):
+        return False
+    return True
+
+
+def _stop_writer() -> None:
+    thread = _WRITER_THREAD
+    if thread is None:
+        return
+    _WRITE_QUEUE.put(None)
+    thread.join(timeout=1)
+
+
+def _redact_header_value(key: str, value: object) -> str:
+    lowered = key.lower()
+    if lowered in _SENSITIVE_HEADER_NAMES or lowered.endswith("-api-key") or "token" in lowered:
+        return _REDACTED
+    return str(value)
+
+
+atexit.register(_stop_writer)

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -62,13 +62,14 @@ def archive_json(
     status_code: int | None = None,
     headers: Mapping[str, str] | None = None,
     extra: Mapping[str, Any] | None = None,
+    request_id: str | None = None,
 ) -> None:
     if not archive_enabled():
         return
 
     record: dict[str, Any] = {
         "timestamp": datetime.now(UTC).isoformat(),
-        "request_id": get_request_id(),
+        "request_id": request_id or get_request_id(),
         "direction": direction,
         "kind": kind,
         "transport": transport,
@@ -96,6 +97,7 @@ def archive_text(
     status_code: int | None = None,
     headers: Mapping[str, str] | None = None,
     extra: Mapping[str, Any] | None = None,
+    request_id: str | None = None,
 ) -> None:
     archive_json(
         direction=direction,
@@ -108,6 +110,7 @@ def archive_text(
         status_code=status_code,
         headers=headers,
         extra=extra,
+        request_id=request_id,
     )
 
 
@@ -123,6 +126,7 @@ def archive_bytes(
     status_code: int | None = None,
     headers: Mapping[str, str] | None = None,
     extra: Mapping[str, Any] | None = None,
+    request_id: str | None = None,
 ) -> None:
     archive_json(
         direction=direction,
@@ -138,6 +142,7 @@ def archive_bytes(
         status_code=status_code,
         headers=headers,
         extra=extra,
+        request_id=request_id,
     )
 
 
@@ -216,6 +221,7 @@ def _append_record(path: Path, record: Mapping[str, Any]) -> None:
             _recover_corrupt_gzip_archive(path)
             _write_gzip_member(path, data)
     except Exception as exc:
+        _RECOVERY_CHECKED_PATHS.discard(path.resolve())
         if _is_disk_pressure_error(exc):
             _pause_archive_for_disk_pressure(path, exc)
             return
@@ -323,10 +329,27 @@ def _gzip_archive_is_readable(path: Path) -> bool:
 
 def _stop_writer() -> None:
     thread = _WRITER_THREAD
-    if thread is None:
+    if thread is None or not thread.is_alive():
+        _drain_queue_synchronously()
         return
+    _WRITE_QUEUE.join()
     _WRITE_QUEUE.put(None)
-    thread.join(timeout=1)
+    thread.join()
+
+
+def _drain_queue_synchronously() -> None:
+    while True:
+        try:
+            item = _WRITE_QUEUE.get_nowait()
+        except queue.Empty:
+            return
+        try:
+            if item is None:
+                continue
+            path, record = item
+            _append_record(path, record)
+        finally:
+            _WRITE_QUEUE.task_done()
 
 
 def _redact_header_value(key: str, value: object) -> str:

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -24,6 +24,8 @@ _REDACTED = "[redacted]"
 _SENSITIVE_HEADER_NAMES = frozenset(
     {
         "authorization",
+        "api-key",
+        "api_key",
         "cookie",
         "openai-api-key",
         "proxy-authorization",
@@ -329,7 +331,8 @@ def _stop_writer() -> None:
 
 def _redact_header_value(key: str, value: object) -> str:
     lowered = key.lower()
-    if lowered in _SENSITIVE_HEADER_NAMES or lowered.endswith("-api-key") or "token" in lowered:
+    normalized = lowered.replace("_", "-")
+    if normalized in _SENSITIVE_HEADER_NAMES or normalized.endswith("-api-key") or "token" in normalized:
         return _REDACTED
     return str(value)
 

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -150,7 +150,7 @@ def _redact_headers(headers: Mapping[str, str] | None) -> dict[str, str] | None:
 
 def _archive_path() -> Path:
     settings = get_settings()
-    directory = Path(getattr(settings, "conversation_archive_dir"))
+    directory = Path(getattr(settings, "conversation_archive_dir")).expanduser()
     filename = f"{datetime.now(UTC).strftime('%Y-%m-%dT%H')}.jsonl.gz"
     return directory / filename
 

--- a/app/db/alembic/versions/20260510_000000_add_request_log_slim_summary.py
+++ b/app/db/alembic/versions/20260510_000000_add_request_log_slim_summary.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260510_000000_add_request_log_slim_summary"
+down_revision = "20260424_000000_merge_dashboard_session_ttl_and_request_log_heads"
+branch_labels = None
+depends_on = None
+
+
+def _columns(table_name: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {column["name"] for column in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    if "slim_summary_json" in _columns("request_logs"):
+        return
+
+    with op.batch_alter_table("request_logs") as batch_op:
+        batch_op.add_column(sa.Column("slim_summary_json", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    if "slim_summary_json" not in _columns("request_logs"):
+        return
+
+    with op.batch_alter_table("request_logs") as batch_op:
+        batch_op.drop_column("slim_summary_json")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -146,6 +146,7 @@ class RequestLog(Base):
     status: Mapped[str] = mapped_column(String, nullable=False)
     error_code: Mapped[str | None] = mapped_column(String, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    slim_summary_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     account: Mapped[Account | None] = relationship(
         "Account",
         back_populates="request_logs",

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ from app.modules.accounts import api as accounts_api
 from app.modules.api_keys import api as api_keys_api
 from app.modules.api_keys.reset_scheduler import build_api_key_limit_reset_scheduler
 from app.modules.audit import api as audit_api
+from app.modules.conversation_archive import api as conversation_archive_api
 from app.modules.dashboard import api as dashboard_api
 from app.modules.dashboard_auth import api as dashboard_auth_api
 from app.modules.firewall import api as firewall_api
@@ -360,6 +361,7 @@ def create_app() -> FastAPI:
     app.include_router(dashboard_api.router)
     app.include_router(usage_api.router)
     app.include_router(request_logs_api.router)
+    app.include_router(conversation_archive_api.router)
     app.include_router(oauth_api.router)
     app.include_router(dashboard_auth_api.router)
     app.include_router(settings_api.router)

--- a/app/modules/conversation_archive/__init__.py
+++ b/app/modules/conversation_archive/__init__.py
@@ -1,0 +1,1 @@
+"""Conversation archive dashboard module."""

--- a/app/modules/conversation_archive/api.py
+++ b/app/modules/conversation_archive/api.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.concurrency import run_in_threadpool
+
+from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.modules.conversation_archive import service
+from app.modules.conversation_archive.schemas import (
+    ConversationArchiveFileResponse,
+    ConversationArchiveRecordResponse,
+    ConversationArchiveRecordsResponse,
+)
+
+router = APIRouter(
+    prefix="/api/conversation-archive",
+    tags=["dashboard"],
+    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+)
+
+
+@router.get("/files", response_model=list[ConversationArchiveFileResponse])
+async def list_conversation_archive_files() -> list[ConversationArchiveFileResponse]:
+    return [
+        ConversationArchiveFileResponse(
+            name=file.name,
+            date=file.date,
+            size_bytes=file.size_bytes,
+            compressed=file.compressed,
+            modified_at=file.modified_at,
+        )
+        for file in service.list_archive_files()
+    ]
+
+
+@router.get("/records", response_model=ConversationArchiveRecordsResponse)
+async def list_conversation_archive_records(
+    file: str | None = Query(default=None, min_length=1),
+    limit: int = Query(default=100, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    direction: str | None = Query(default=None),
+    kind: str | None = Query(default=None),
+    transport: str | None = Query(default=None),
+    request_id: str | None = Query(default=None, alias="requestId"),
+) -> ConversationArchiveRecordsResponse:
+    if file is None and not request_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="file or requestId is required",
+        )
+    try:
+        page = await run_in_threadpool(
+            service.read_archive_records,
+            filename=file,
+            limit=limit,
+            offset=offset,
+            direction=direction,
+            kind=kind,
+            transport=transport,
+            request_id=request_id,
+        )
+    except service.ConversationArchiveInvalidFileError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except service.ConversationArchiveNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    return ConversationArchiveRecordsResponse(
+        records=[_record_response(record) for record in page.records],
+        total=page.total,
+        has_more=page.has_more,
+    )
+
+
+def _record_response(record: dict[str, Any]) -> ConversationArchiveRecordResponse:
+    return ConversationArchiveRecordResponse(
+        file_name=_optional_str(record.get("_archive_file")),
+        timestamp=_parse_timestamp(record.get("timestamp")),
+        request_id=_optional_str(record.get("request_id")),
+        direction=_optional_str(record.get("direction")),
+        kind=_optional_str(record.get("kind")),
+        transport=_optional_str(record.get("transport")),
+        account_id=_optional_str(record.get("account_id")),
+        method=_optional_str(record.get("method")),
+        url=_optional_str(record.get("url")),
+        status_code=record.get("status_code") if isinstance(record.get("status_code"), int) else None,
+        headers=_headers(record.get("headers")),
+        payload=record.get("payload"),
+        extra=record.get("extra") if isinstance(record.get("extra"), dict) else None,
+    )
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _headers(value: object) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    return {str(key): str(item) for key, item in value.items()}

--- a/app/modules/conversation_archive/api.py
+++ b/app/modules/conversation_archive/api.py
@@ -23,6 +23,7 @@ router = APIRouter(
 
 @router.get("/files", response_model=list[ConversationArchiveFileResponse])
 async def list_conversation_archive_files() -> list[ConversationArchiveFileResponse]:
+    files = await run_in_threadpool(service.list_archive_files)
     return [
         ConversationArchiveFileResponse(
             name=file.name,
@@ -31,7 +32,7 @@ async def list_conversation_archive_files() -> list[ConversationArchiveFileRespo
             compressed=file.compressed,
             modified_at=file.modified_at,
         )
-        for file in service.list_archive_files()
+        for file in files
     ]
 
 

--- a/app/modules/conversation_archive/api.py
+++ b/app/modules/conversation_archive/api.py
@@ -44,6 +44,7 @@ async def list_conversation_archive_records(
     kind: str | None = Query(default=None),
     transport: str | None = Query(default=None),
     request_id: str | None = Query(default=None, alias="requestId"),
+    requested_at: datetime | None = Query(default=None, alias="requestedAt"),
 ) -> ConversationArchiveRecordsResponse:
     if file is None and not request_id:
         raise HTTPException(
@@ -60,6 +61,7 @@ async def list_conversation_archive_records(
             kind=kind,
             transport=transport,
             request_id=request_id,
+            requested_at=requested_at,
         )
     except service.ConversationArchiveInvalidFileError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/app/modules/conversation_archive/schemas.py
+++ b/app/modules/conversation_archive/schemas.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from app.modules.shared.schemas import DashboardModel
+
+
+class ConversationArchiveFileResponse(DashboardModel):
+    name: str
+    date: str | None
+    size_bytes: int
+    compressed: bool
+    modified_at: datetime
+
+
+class ConversationArchiveRecordResponse(DashboardModel):
+    file_name: str | None = None
+    timestamp: datetime | None
+    request_id: str | None
+    direction: str | None
+    kind: str | None
+    transport: str | None
+    account_id: str | None
+    method: str | None
+    url: str | None
+    status_code: int | None
+    headers: dict[str, str] | None
+    payload: Any
+    extra: dict[str, Any] | None = None
+
+
+class ConversationArchiveRecordsResponse(DashboardModel):
+    records: list[ConversationArchiveRecordResponse]
+    total: int
+    has_more: bool

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -68,8 +68,9 @@ def read_archive_records(
     kind: str | None = None,
     transport: str | None = None,
     request_id: str | None = None,
+    requested_at: datetime | None = None,
 ) -> ConversationArchivePage:
-    paths = [_resolve_archive_file(filename)] if filename else list(_iter_archive_paths(_archive_dir()))
+    paths = _archive_paths_for_lookup(filename=filename, requested_at=requested_at)
     records: list[dict[str, Any]] = []
     total = 0
     end = offset + limit
@@ -93,6 +94,25 @@ def read_archive_records(
         total=total,
         has_more=end < total,
     )
+
+
+def _archive_paths_for_lookup(*, filename: str | None, requested_at: datetime | None) -> list[Path]:
+    if filename:
+        return [_resolve_archive_file(filename)]
+    directory = _archive_dir()
+    if requested_at is None:
+        return list(_iter_archive_paths(directory))
+
+    requested_at_utc = requested_at.astimezone(UTC)
+    hourly_stem = requested_at_utc.strftime("%Y-%m-%dT%H")
+    daily_stem = requested_at_utc.strftime("%Y-%m-%d")
+    candidates = [
+        directory / f"{hourly_stem}{_GZIP_JSONL_SUFFIX}",
+        directory / f"{hourly_stem}{_JSONL_SUFFIX}",
+        directory / f"{daily_stem}{_GZIP_JSONL_SUFFIX}",
+        directory / f"{daily_stem}{_JSONL_SUFFIX}",
+    ]
+    return [path for path in candidates if path.exists() and path.is_file()]
 
 
 def _archive_dir() -> Path:

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import gzip
+import json
+import zlib
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from app.core.config.settings import get_settings
+
+_JSONL_SUFFIX = ".jsonl"
+_GZIP_JSONL_SUFFIX = ".jsonl.gz"
+
+
+@dataclass(frozen=True)
+class ConversationArchiveFile:
+    name: str
+    date: str | None
+    size_bytes: int
+    compressed: bool
+    modified_at: datetime
+
+
+@dataclass(frozen=True)
+class ConversationArchivePage:
+    records: list[dict[str, Any]]
+    total: int
+    has_more: bool
+
+
+class ConversationArchiveNotFoundError(ValueError):
+    pass
+
+
+class ConversationArchiveInvalidFileError(ValueError):
+    pass
+
+
+def list_archive_files() -> list[ConversationArchiveFile]:
+    directory = _archive_dir()
+    if not directory.exists():
+        return []
+
+    files: list[ConversationArchiveFile] = []
+    for path in sorted(_iter_archive_paths(directory), key=lambda item: item.name, reverse=True):
+        stat = path.stat()
+        files.append(
+            ConversationArchiveFile(
+                name=path.name,
+                date=_date_from_filename(path.name),
+                size_bytes=stat.st_size,
+                compressed=path.name.endswith(_GZIP_JSONL_SUFFIX),
+                modified_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
+            )
+        )
+    return files
+
+
+def read_archive_records(
+    *,
+    filename: str | None,
+    limit: int,
+    offset: int,
+    direction: str | None = None,
+    kind: str | None = None,
+    transport: str | None = None,
+    request_id: str | None = None,
+) -> ConversationArchivePage:
+    paths = [_resolve_archive_file(filename)] if filename else list(_iter_archive_paths(_archive_dir()))
+    records: list[dict[str, Any]] = []
+    total = 0
+    end = offset + limit
+
+    for path in sorted(paths, key=lambda item: item.name, reverse=True):
+        for record in _iter_records(path):
+            if not _record_matches(
+                record,
+                direction=direction,
+                kind=kind,
+                transport=transport,
+                request_id=request_id,
+            ):
+                continue
+            if offset <= total < end:
+                records.append({**record, "_archive_file": path.name})
+            total += 1
+
+    return ConversationArchivePage(
+        records=records,
+        total=total,
+        has_more=end < total,
+    )
+
+
+def _archive_dir() -> Path:
+    return Path(getattr(get_settings(), "conversation_archive_dir"))
+
+
+def _iter_archive_paths(directory: Path) -> Iterator[Path]:
+    yield from directory.glob(f"*{_JSONL_SUFFIX}")
+    yield from directory.glob(f"*{_GZIP_JSONL_SUFFIX}")
+
+
+def _date_from_filename(filename: str) -> str | None:
+    if filename.endswith(_GZIP_JSONL_SUFFIX):
+        stem = filename[: -len(_GZIP_JSONL_SUFFIX)]
+    elif filename.endswith(_JSONL_SUFFIX):
+        stem = filename[: -len(_JSONL_SUFFIX)]
+    else:
+        return None
+    for date_format in ("%Y-%m-%dT%H", "%Y-%m-%d"):
+        try:
+            datetime.strptime(stem, date_format)
+        except ValueError:
+            continue
+        return stem
+    return None
+
+
+def _resolve_archive_file(filename: str) -> Path:
+    if Path(filename).name != filename or not (
+        filename.endswith(_JSONL_SUFFIX) or filename.endswith(_GZIP_JSONL_SUFFIX)
+    ):
+        raise ConversationArchiveInvalidFileError("Invalid conversation archive file name")
+
+    path = _archive_dir() / filename
+    if not path.exists() or not path.is_file():
+        raise ConversationArchiveNotFoundError("Conversation archive file not found")
+    return path
+
+
+def _iter_records(path: Path) -> Iterator[dict[str, Any]]:
+    opener = gzip.open if path.name.endswith(_GZIP_JSONL_SUFFIX) else Path.open
+    try:
+        with opener(path, "rt", encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict):
+                    yield parsed
+    except (EOFError, gzip.BadGzipFile, zlib.error):
+        return
+
+
+def _record_matches(
+    record: dict[str, Any],
+    *,
+    direction: str | None,
+    kind: str | None,
+    transport: str | None,
+    request_id: str | None,
+) -> bool:
+    if direction and record.get("direction") != direction:
+        return False
+    if kind and record.get("kind") != kind:
+        return False
+    if transport and record.get("transport") != transport:
+        return False
+    if request_id and str(record.get("request_id") or "") != request_id:
+        return False
+    return True

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -5,7 +5,7 @@ import json
 import zlib
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -70,12 +70,14 @@ def read_archive_records(
     request_id: str | None = None,
     requested_at: datetime | None = None,
 ) -> ConversationArchivePage:
-    paths = _archive_paths_for_lookup(filename=filename, requested_at=requested_at)
+    paths = _archive_paths_for_lookup(filename=filename, requested_at=requested_at, request_id=request_id)
+    sorted_paths = sorted(paths, key=lambda item: item.name, reverse=True)
+    correlated_request_ids = _correlated_archive_request_ids(sorted_paths, request_id)
     records: list[dict[str, Any]] = []
     total = 0
     end = offset + limit
 
-    for path in sorted(paths, key=lambda item: item.name, reverse=True):
+    for path in sorted_paths:
         for record in _iter_records(path):
             if not _record_matches(
                 record,
@@ -83,6 +85,7 @@ def read_archive_records(
                 kind=kind,
                 transport=transport,
                 request_id=request_id,
+                correlated_request_ids=correlated_request_ids,
             ):
                 continue
             if offset <= total < end:
@@ -96,7 +99,12 @@ def read_archive_records(
     )
 
 
-def _archive_paths_for_lookup(*, filename: str | None, requested_at: datetime | None) -> list[Path]:
+def _archive_paths_for_lookup(
+    *,
+    filename: str | None,
+    requested_at: datetime | None,
+    request_id: str | None,
+) -> list[Path]:
     if filename:
         return [_resolve_archive_file(filename)]
     directory = _archive_dir()
@@ -104,15 +112,26 @@ def _archive_paths_for_lookup(*, filename: str | None, requested_at: datetime | 
         return list(_iter_archive_paths(directory))
 
     requested_at_utc = requested_at.astimezone(UTC)
-    hourly_stem = requested_at_utc.strftime("%Y-%m-%dT%H")
-    daily_stem = requested_at_utc.strftime("%Y-%m-%d")
+    candidate_stems: list[str] = []
+    for hour_offset in (-1, 0, 1):
+        candidate = requested_at_utc + timedelta(hours=hour_offset)
+        hourly_stem = candidate.strftime("%Y-%m-%dT%H")
+        daily_stem = candidate.strftime("%Y-%m-%d")
+        if hourly_stem not in candidate_stems:
+            candidate_stems.append(hourly_stem)
+        if daily_stem not in candidate_stems:
+            candidate_stems.append(daily_stem)
+
     candidates = [
-        directory / f"{hourly_stem}{_GZIP_JSONL_SUFFIX}",
-        directory / f"{hourly_stem}{_JSONL_SUFFIX}",
-        directory / f"{daily_stem}{_GZIP_JSONL_SUFFIX}",
-        directory / f"{daily_stem}{_JSONL_SUFFIX}",
+        directory / f"{stem}{suffix}" for stem in candidate_stems for suffix in (_GZIP_JSONL_SUFFIX, _JSONL_SUFFIX)
     ]
-    return [path for path in candidates if path.exists() and path.is_file()]
+    existing_candidates = [path for path in candidates if path.exists() and path.is_file()]
+    if not request_id:
+        return existing_candidates
+
+    candidate_set = set(existing_candidates)
+    remaining_paths = [path for path in _iter_archive_paths(directory) if path not in candidate_set]
+    return existing_candidates + remaining_paths
 
 
 def _archive_dir() -> Path:
@@ -177,6 +196,7 @@ def _record_matches(
     kind: str | None,
     transport: str | None,
     request_id: str | None,
+    correlated_request_ids: set[str],
 ) -> bool:
     if direction and record.get("direction") != direction:
         return False
@@ -184,6 +204,70 @@ def _record_matches(
         return False
     if transport and record.get("transport") != transport:
         return False
-    if request_id and str(record.get("request_id") or "") != request_id:
+    if (
+        request_id
+        and request_id not in _record_lookup_ids(record)
+        and record.get("request_id") not in correlated_request_ids
+    ):
         return False
     return True
+
+
+def _correlated_archive_request_ids(
+    paths: list[Path],
+    request_id: str | None,
+) -> set[str]:
+    if not request_id:
+        return set()
+    correlated: set[str] = set()
+    for path in paths:
+        for record in _iter_records(path):
+            if request_id not in _record_lookup_ids(record):
+                continue
+            _add_lookup_id(correlated, record.get("request_id"))
+    return correlated
+
+
+def _record_lookup_ids(record: dict[str, Any]) -> set[str]:
+    lookup_ids: set[str] = set()
+    _add_lookup_id(lookup_ids, record.get("request_id"))
+    _add_payload_lookup_ids(lookup_ids, record.get("payload"))
+    return lookup_ids
+
+
+def _add_payload_lookup_ids(lookup_ids: set[str], payload: Any) -> None:
+    if isinstance(payload, dict):
+        _add_lookup_id(lookup_ids, payload.get("id"))
+        response = payload.get("response")
+        if isinstance(response, dict):
+            _add_lookup_id(lookup_ids, response.get("id"))
+        text = payload.get("text")
+        if isinstance(text, str):
+            _add_text_lookup_ids(lookup_ids, text)
+
+
+def _add_text_lookup_ids(lookup_ids: set[str], text: str) -> None:
+    stripped = text.strip()
+    if stripped.startswith("{"):
+        _add_payload_lookup_ids(lookup_ids, _parse_json_object(stripped))
+
+    for line in stripped.splitlines():
+        if not line.startswith("data:"):
+            continue
+        data = line.removeprefix("data:").strip()
+        if not data or data == "[DONE]":
+            continue
+        _add_payload_lookup_ids(lookup_ids, _parse_json_object(data))
+
+
+def _parse_json_object(value: str) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _add_lookup_id(lookup_ids: set[str], value: Any) -> None:
+    if isinstance(value, str) and value:
+        lookup_ids.add(value)

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -96,7 +96,7 @@ def read_archive_records(
 
 
 def _archive_dir() -> Path:
-    return Path(getattr(get_settings(), "conversation_archive_dir"))
+    return Path(getattr(get_settings(), "conversation_archive_dir")).expanduser()
 
 
 def _iter_archive_paths(directory: Path) -> Iterator[Path]:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5354,11 +5354,7 @@ class ProxyService:
                     request_state.previous_response_id = None
                     request_state.proxy_injected_previous_response_id = False
                     request_state.request_text = retry_text_data
-                await _send_upstream_websocket_text(
-                    session.upstream,
-                    retry_text_data,
-                    request_state.request_log_id or request_state.request_id,
-                )
+                await session.upstream.send_text(retry_text_data)
             session.last_used_at = time.monotonic()
             return True
         except Exception:
@@ -5963,6 +5959,7 @@ class ProxyService:
         stream_idle_timeout_seconds: float,
         downstream_activity: _DownstreamWebSocketActivity,
     ) -> None:
+        upstream_control.archive_metadata = _upstream_websocket_archive_metadata(upstream)
         try:
             while True:
                 receive_timeout = await self._next_websocket_receive_timeout(
@@ -6026,7 +6023,6 @@ class ProxyService:
                         api_key=api_key,
                         upstream_control=upstream_control,
                         response_create_gate=response_create_gate,
-                        upstream_archive_metadata=_upstream_websocket_archive_metadata(upstream),
                     )
                     suppress_downstream_event = upstream_control.suppress_downstream_event
                     downstream_texts = upstream_control.downstream_texts
@@ -6162,7 +6158,6 @@ class ProxyService:
         api_key: ApiKeyData | None,
         upstream_control: _WebSocketUpstreamControl,
         response_create_gate: asyncio.Semaphore,
-        upstream_archive_metadata: UpstreamWebSocketArchiveMetadata | None = None,
     ) -> str:
         event_block = f"data: {text}\n\n"
         payload = parse_sse_data_json(event_block)
@@ -6203,12 +6198,12 @@ class ProxyService:
                 release_create_gate = False
             else:
                 release_create_gate = False
+            archive_request_state = request_state
             if request_state is not None:
                 actual_service_tier = _service_tier_from_event_payload(payload)
                 if actual_service_tier is not None:
                     request_state.actual_service_tier = actual_service_tier
                     request_state.service_tier = actual_service_tier
-            archive_request_state = request_state
             if (
                 event_type in {"response.completed", "response.failed", "response.incomplete", "error"}
                 and pending_requests
@@ -6250,7 +6245,7 @@ class ProxyService:
                 _archive_upstream_websocket_text(
                     grouped_request_state,
                     text,
-                    archive_metadata=upstream_archive_metadata,
+                    archive_metadata=upstream_control.archive_metadata,
                     account_id=account_id_value,
                 )
                 (
@@ -6286,7 +6281,7 @@ class ProxyService:
                 _archive_upstream_websocket_text(
                     archive_request_state,
                     text,
-                    archive_metadata=upstream_archive_metadata,
+                    archive_metadata=upstream_control.archive_metadata,
                     account_id=account_id_value,
                 )
             if is_previous_response_not_found_event:
@@ -6295,7 +6290,7 @@ class ProxyService:
         _archive_upstream_websocket_text(
             request_state,
             text,
-            archive_metadata=upstream_archive_metadata,
+            archive_metadata=upstream_control.archive_metadata,
             account_id=account_id_value,
         )
 
@@ -8630,9 +8625,9 @@ class _WebSocketRequestState:
     response_create_gate: asyncio.Semaphore | None = None
     response_create_admission: AdmissionLease | None = None
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
+    slim_summary: dict[str, int] | None = None
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
-    slim_summary: dict[str, int] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -8694,6 +8689,7 @@ class _HTTPBridgeSession:
 
 @dataclass(slots=True)
 class _WebSocketUpstreamControl:
+    archive_metadata: UpstreamWebSocketArchiveMetadata | None = None
     reconnect_requested: bool = False
     suppress_downstream_event: bool = False
     replay_request_state: _WebSocketRequestState | None = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -53,12 +53,14 @@ from app.core.clients.proxy import stream_responses as core_stream_responses
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio
 from app.core.clients.proxy_websocket import (
     UpstreamResponsesWebSocket,
+    UpstreamWebSocketArchiveMetadata,
     UpstreamWebSocketMessage,
     connect_responses_websocket,
     filter_inbound_websocket_headers,
 )
 from app.core.config.settings import DEFAULT_HOME_DIR, Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
+from app.core.conversation_archive import archive_bytes, archive_text
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
     OpenAIErrorDetail,
@@ -2758,10 +2760,21 @@ class ProxyService:
                     )
 
                 try:
+                    archive_request_id = (
+                        request_state.request_log_id or request_state.request_id if request_state is not None else None
+                    )
                     if text_data is not None:
-                        await upstream.send_text(text_data)
+                        await _send_upstream_websocket_text(
+                            upstream,
+                            text_data,
+                            archive_request_id,
+                        )
                     elif bytes_data is not None:
-                        await upstream.send_bytes(bytes_data)
+                        await _send_upstream_websocket_bytes(
+                            upstream,
+                            bytes_data,
+                            archive_request_id,
+                        )
                 except Exception:
                     replay_candidate = await _pop_replayable_precreated_websocket_request_state(
                         pending_requests,
@@ -3000,6 +3013,7 @@ class ProxyService:
             )
             if slim_summary is not None:
                 upstream_payload = slimmed_payload
+                request_state.slim_summary = slim_summary
                 text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
                 logger.warning(
                     (
@@ -5001,7 +5015,11 @@ class ProxyService:
             async with session.pending_lock:
                 session.pending_requests.append(request_state)
             request_enqueued = True
-            await session.upstream.send_text(text_data)
+            await _send_upstream_websocket_text(
+                session.upstream,
+                text_data,
+                request_state.request_log_id or request_state.request_id,
+            )
             session.last_used_at = time.monotonic()
         except ProxyResponseError:
             await self._cleanup_http_bridge_submit_interruption(
@@ -5119,7 +5137,11 @@ class ProxyService:
                 async with session.pending_lock:
                     session.pending_requests.append(warmup_state)
                 request_enqueued = True
-                await session.upstream.send_text(warmup_text)
+                await _send_upstream_websocket_text(
+                    session.upstream,
+                    warmup_text,
+                    warmup_state.request_log_id or warmup_state.request_id,
+                )
                 while True:
                     event_block = await event_queue.get()
                     if event_block is None:
@@ -5332,7 +5354,11 @@ class ProxyService:
                     request_state.previous_response_id = None
                     request_state.proxy_injected_previous_response_id = False
                     request_state.request_text = retry_text_data
-                await session.upstream.send_text(retry_text_data)
+                await _send_upstream_websocket_text(
+                    session.upstream,
+                    retry_text_data,
+                    request_state.request_log_id or request_state.request_id,
+                )
             session.last_used_at = time.monotonic()
             return True
         except Exception:
@@ -5384,7 +5410,11 @@ class ProxyService:
         )
         try:
             await self._reconnect_http_bridge_session(session, request_state=request_state)
-            await session.upstream.send_text(request_text)
+            await _send_upstream_websocket_text(
+                session.upstream,
+                request_text,
+                request_state.request_log_id or request_state.request_id,
+            )
             session.last_used_at = time.monotonic()
             return True
         except Exception:
@@ -5608,6 +5638,12 @@ class ProxyService:
         if len(grouped_previous_response_request_states) > 1:
             session.upstream_control.reconnect_requested = True
             for grouped_request_state in grouped_previous_response_request_states:
+                _archive_upstream_websocket_text(
+                    grouped_request_state,
+                    text,
+                    archive_metadata=_http_bridge_archive_metadata(session),
+                    account_id=session.account.id,
+                )
                 grouped_request_state.error_http_status_override = 502
                 (
                     _grouped_downstream_text,
@@ -5642,6 +5678,13 @@ class ProxyService:
             _record_response_event(terminal_request_state, event_type)
 
         status_request_state = terminal_request_state or matched_request_state
+        if status_request_state is not None:
+            _archive_upstream_websocket_text(
+                status_request_state,
+                text,
+                archive_metadata=_http_bridge_archive_metadata(session),
+                account_id=session.account.id,
+            )
         if status_request_state is None and is_previous_response_not_found_event:
             session.upstream_control.reconnect_requested = True
             return
@@ -5983,6 +6026,7 @@ class ProxyService:
                         api_key=api_key,
                         upstream_control=upstream_control,
                         response_create_gate=response_create_gate,
+                        upstream_archive_metadata=_upstream_websocket_archive_metadata(upstream),
                     )
                     suppress_downstream_event = upstream_control.suppress_downstream_event
                     downstream_texts = upstream_control.downstream_texts
@@ -6017,6 +6061,30 @@ class ProxyService:
                     continue
                 if message.kind == "binary" and message.data is not None:
                     downstream_activity.mark()
+                    async with pending_lock:
+                        archive_request_state = _match_websocket_request_state_for_anonymous_event(
+                            pending_requests,
+                            prefer_previous_response_not_found=False,
+                        )
+                    if archive_request_state is not None:
+                        _archive_upstream_websocket_bytes(
+                            archive_request_state,
+                            message.data,
+                            archive_metadata=_upstream_websocket_archive_metadata(upstream),
+                            account_id=account_id_value,
+                        )
+                    else:
+                        archive_metadata = _upstream_websocket_archive_metadata(upstream)
+                        archive_bytes(
+                            direction="server_to_codex",
+                            kind="responses",
+                            transport=_REQUEST_TRANSPORT_WEBSOCKET,
+                            data=message.data,
+                            account_id=archive_metadata.account_id if archive_metadata else account_id_value,
+                            url=archive_metadata.url if archive_metadata else None,
+                            headers=archive_metadata.headers if archive_metadata else None,
+                            extra={"frame_type": "binary"},
+                        )
                     await self._send_downstream_websocket_bytes(
                         websocket,
                         client_send_lock=client_send_lock,
@@ -6094,6 +6162,7 @@ class ProxyService:
         api_key: ApiKeyData | None,
         upstream_control: _WebSocketUpstreamControl,
         response_create_gate: asyncio.Semaphore,
+        upstream_archive_metadata: UpstreamWebSocketArchiveMetadata | None = None,
     ) -> str:
         event_block = f"data: {text}\n\n"
         payload = parse_sse_data_json(event_block)
@@ -6113,6 +6182,7 @@ class ProxyService:
 
         async with pending_lock:
             request_state = None
+            archive_request_state = None
             created_request_state = None
             has_other_pending_requests = False
             grouped_previous_response_request_states: list[_WebSocketRequestState] = []
@@ -6138,6 +6208,7 @@ class ProxyService:
                 if actual_service_tier is not None:
                     request_state.actual_service_tier = actual_service_tier
                     request_state.service_tier = actual_service_tier
+            archive_request_state = request_state
             if (
                 event_type in {"response.completed", "response.failed", "response.incomplete", "error"}
                 and pending_requests
@@ -6176,6 +6247,12 @@ class ProxyService:
             upstream_control.reconnect_requested = True
             downstream_texts: list[str] = []
             for grouped_request_state in grouped_previous_response_request_states:
+                _archive_upstream_websocket_text(
+                    grouped_request_state,
+                    text,
+                    archive_metadata=upstream_archive_metadata,
+                    account_id=account_id_value,
+                )
                 (
                     grouped_downstream_text,
                     _grouped_event_block,
@@ -6205,9 +6282,22 @@ class ProxyService:
         _record_response_event(request_state, event_type)
 
         if request_state is None:
+            if archive_request_state is not None:
+                _archive_upstream_websocket_text(
+                    archive_request_state,
+                    text,
+                    archive_metadata=upstream_archive_metadata,
+                    account_id=account_id_value,
+                )
             if is_previous_response_not_found_event:
                 upstream_control.suppress_downstream_event = True
             return text
+        _archive_upstream_websocket_text(
+            request_state,
+            text,
+            archive_metadata=upstream_archive_metadata,
+            account_id=account_id_value,
+        )
 
         retry_is_previous_response_not_found = is_previous_response_not_found_event
         retry_error_code = _websocket_precreated_retry_error_code(
@@ -6458,6 +6548,7 @@ class ProxyService:
                 actual_service_tier=request_state.actual_service_tier,
                 latency_first_token_ms=request_state.latency_first_token_ms,
                 session_id=request_state.session_id,
+                slim_summary=request_state.slim_summary,
             )
 
     async def _write_websocket_connect_failure(
@@ -6487,6 +6578,7 @@ class ProxyService:
             actual_service_tier=request_state.actual_service_tier,
             latency_first_token_ms=request_state.latency_first_token_ms,
             session_id=request_state.session_id,
+            slim_summary=request_state.slim_summary,
         )
 
     async def _emit_websocket_connect_failure(
@@ -6626,6 +6718,7 @@ class ProxyService:
                 requested_service_tier=request_state.requested_service_tier,
                 actual_service_tier=request_state.actual_service_tier,
                 latency_first_token_ms=request_state.latency_first_token_ms,
+                slim_summary=request_state.slim_summary,
             )
 
     async def _emit_websocket_terminal_error(
@@ -7926,6 +8019,7 @@ class ProxyService:
         requested_service_tier: str | None = None,
         actual_service_tier: str | None = None,
         session_id: str | None = None,
+        slim_summary: dict[str, int] | None = None,
     ) -> None:
         with anyio.CancelScope(shield=True):
             try:
@@ -7950,6 +8044,7 @@ class ProxyService:
                         status=status,
                         error_code=error_code,
                         error_message=error_message,
+                        slim_summary=slim_summary,
                     )
             except Exception:
                 logger.warning(
@@ -8388,6 +8483,101 @@ def _record_response_event(request_state: _WebSocketRequestState | None, event_t
     request_state.response_event_count += 1
 
 
+def _set_upstream_archive_request_id(upstream: UpstreamResponsesWebSocket, request_id: str | None) -> None:
+    setter = getattr(upstream, "set_archive_request_id", None)
+    if callable(setter):
+        setter(request_id)
+
+
+def _upstream_websocket_archive_metadata(
+    upstream: UpstreamResponsesWebSocket,
+) -> UpstreamWebSocketArchiveMetadata | None:
+    getter = getattr(upstream, "archive_metadata", None)
+    if not callable(getter):
+        return None
+    metadata = getter()
+    if inspect.isawaitable(metadata):
+        close = getattr(metadata, "close", None)
+        if callable(close):
+            close()
+        return None
+    return metadata if isinstance(metadata, UpstreamWebSocketArchiveMetadata) else None
+
+
+def _http_bridge_archive_metadata(session: "_HTTPBridgeSession") -> UpstreamWebSocketArchiveMetadata:
+    return _upstream_websocket_archive_metadata(session.upstream) or UpstreamWebSocketArchiveMetadata(
+        url=None,
+        headers=session.headers,
+        account_id=session.account.id,
+    )
+
+
+async def _send_upstream_websocket_text(
+    upstream: UpstreamResponsesWebSocket,
+    text: str,
+    request_id: str | None,
+) -> None:
+    sender = getattr(upstream, "send_text_with_archive_request_id", None)
+    if callable(sender):
+        await sender(text, request_id=request_id)
+        return
+    _set_upstream_archive_request_id(upstream, request_id)
+    await upstream.send_text(text)
+
+
+async def _send_upstream_websocket_bytes(
+    upstream: UpstreamResponsesWebSocket,
+    data: bytes,
+    request_id: str | None,
+) -> None:
+    sender = getattr(upstream, "send_bytes_with_archive_request_id", None)
+    if callable(sender):
+        await sender(data, request_id=request_id)
+        return
+    _set_upstream_archive_request_id(upstream, request_id)
+    await upstream.send_bytes(data)
+
+
+def _archive_upstream_websocket_text(
+    request_state: _WebSocketRequestState,
+    text: str,
+    *,
+    archive_metadata: UpstreamWebSocketArchiveMetadata | None = None,
+    account_id: str | None = None,
+) -> None:
+    archive_text(
+        direction="server_to_codex",
+        kind="responses",
+        transport=request_state.transport,
+        text=text,
+        account_id=archive_metadata.account_id if archive_metadata else account_id,
+        url=archive_metadata.url if archive_metadata else None,
+        headers=archive_metadata.headers if archive_metadata else None,
+        extra={"frame_type": "text", "response_id": request_state.response_id},
+        request_id=request_state.request_log_id or request_state.request_id,
+    )
+
+
+def _archive_upstream_websocket_bytes(
+    request_state: _WebSocketRequestState,
+    data: bytes,
+    *,
+    archive_metadata: UpstreamWebSocketArchiveMetadata | None = None,
+    account_id: str | None = None,
+) -> None:
+    archive_bytes(
+        direction="server_to_codex",
+        kind="responses",
+        transport=request_state.transport,
+        data=data,
+        account_id=archive_metadata.account_id if archive_metadata else account_id,
+        url=archive_metadata.url if archive_metadata else None,
+        headers=archive_metadata.headers if archive_metadata else None,
+        extra={"frame_type": "binary", "response_id": request_state.response_id},
+        request_id=request_state.request_log_id or request_state.request_id,
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class _FilePinEntry:
     account_id: str
@@ -8442,6 +8632,7 @@ class _WebSocketRequestState:
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
+    slim_summary: dict[str, int] | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/modules/request_logs/mappers.py
+++ b/app/modules/request_logs/mappers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import cast as typing_cast
 
 from app.core.usage.logs import RequestLogLike, cached_input_tokens_from_log, cost_from_log, total_tokens_from_log
@@ -47,4 +48,22 @@ def to_request_log_entry(log: RequestLog, *, api_key_name: str | None = None) ->
         cost_usd=cost_from_log(log_like, precision=6),
         latency_ms=log.latency_ms,
         latency_first_token_ms=log.latency_first_token_ms,
+        slim_summary=_parse_slim_summary(log.slim_summary_json),
     )
+
+
+def _parse_slim_summary(value: str | None) -> dict[str, int] | None:
+    if not value:
+        return None
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    summary: dict[str, int] = {}
+    for key in ("historical_tool_outputs_slimmed", "historical_images_slimmed"):
+        count = payload.get(key)
+        if isinstance(count, int) and count > 0:
+            summary[key] = count
+    return summary or None

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from typing import cast as typing_cast
@@ -183,6 +184,7 @@ class RequestLogsRepository:
         api_key_id: str | None = None,
         session_id: str | None = None,
         plan_type: str | None = None,
+        slim_summary: dict[str, int] | None = None,
     ) -> RequestLog:
         resolved_request_id = ensure_request_id(request_id)
         resolved_plan_type = plan_type
@@ -210,6 +212,7 @@ class RequestLogsRepository:
             status=status,
             error_code=error_code,
             error_message=error_message,
+            slim_summary_json=_serialize_slim_summary(slim_summary),
             requested_at=requested_at or utcnow(),
         )
         log.cost_usd = calculated_cost_from_log(typing_cast(RequestLogLike, log))
@@ -506,3 +509,16 @@ async def _safe_rollback(session: AsyncSession) -> None:
             await session.rollback()
     except BaseException:
         return
+
+
+def _serialize_slim_summary(summary: dict[str, int] | None) -> str | None:
+    if not summary:
+        return None
+    allowed = {
+        key: value
+        for key, value in summary.items()
+        if key in {"historical_tool_outputs_slimmed", "historical_images_slimmed"} and value > 0
+    }
+    if not allowed:
+        return None
+    return json.dumps(allowed, sort_keys=True, separators=(",", ":"))

--- a/app/modules/request_logs/schemas.py
+++ b/app/modules/request_logs/schemas.py
@@ -28,6 +28,7 @@ class RequestLogEntry(DashboardModel):
     cost_usd: float | None = None
     latency_ms: int | None = None
     latency_first_token_ms: int | None = None
+    slim_summary: dict[str, int] | None = None
 
 
 class RequestLogsResponse(DashboardModel):

--- a/frontend/src/features/conversation-archive/api.ts
+++ b/frontend/src/features/conversation-archive/api.ts
@@ -15,6 +15,7 @@ export type ConversationArchiveRecordParams = {
   kind?: string;
   transport?: string;
   requestId?: string;
+  requestedAt?: string;
 };
 
 export function listConversationArchiveFiles() {
@@ -43,6 +44,9 @@ export function listConversationArchiveRecords(params: ConversationArchiveRecord
   }
   if (params.requestId) {
     query.set("requestId", params.requestId);
+  }
+  if (params.requestedAt) {
+    query.set("requestedAt", params.requestedAt);
   }
   return get(`${CONVERSATION_ARCHIVE_PATH}/records?${query.toString()}`, ConversationArchiveRecordsResponseSchema);
 }

--- a/frontend/src/features/conversation-archive/api.ts
+++ b/frontend/src/features/conversation-archive/api.ts
@@ -1,0 +1,48 @@
+import { get } from "@/lib/api-client";
+
+import {
+  ConversationArchiveFileSchema,
+  ConversationArchiveRecordsResponseSchema,
+} from "@/features/conversation-archive/schemas";
+
+const CONVERSATION_ARCHIVE_PATH = "/api/conversation-archive";
+
+export type ConversationArchiveRecordParams = {
+  file?: string;
+  limit?: number;
+  offset?: number;
+  direction?: string;
+  kind?: string;
+  transport?: string;
+  requestId?: string;
+};
+
+export function listConversationArchiveFiles() {
+  return get(`${CONVERSATION_ARCHIVE_PATH}/files`, ConversationArchiveFileSchema.array());
+}
+
+export function listConversationArchiveRecords(params: ConversationArchiveRecordParams) {
+  const query = new URLSearchParams();
+  if (params.file) {
+    query.set("file", params.file);
+  }
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+  if (params.direction) {
+    query.set("direction", params.direction);
+  }
+  if (params.kind) {
+    query.set("kind", params.kind);
+  }
+  if (params.transport) {
+    query.set("transport", params.transport);
+  }
+  if (params.requestId) {
+    query.set("requestId", params.requestId);
+  }
+  return get(`${CONVERSATION_ARCHIVE_PATH}/records?${query.toString()}`, ConversationArchiveRecordsResponseSchema);
+}

--- a/frontend/src/features/conversation-archive/components/request-archive-panel.tsx
+++ b/frontend/src/features/conversation-archive/components/request-archive-panel.tsx
@@ -8,12 +8,19 @@ import type { ConversationArchiveRecord } from "@/features/conversation-archive/
 
 const REQUEST_ARCHIVE_LIMIT = 200;
 
-export function RequestArchivePanel({ requestId }: { requestId: string | null | undefined }) {
+export function RequestArchivePanel({
+  requestId,
+  requestedAt,
+}: {
+  requestId: string | null | undefined;
+  requestedAt?: string | null | undefined;
+}) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(0);
   const recordsQuery = useConversationArchiveRecords(
     requestId
       ? {
           requestId,
+          requestedAt: requestedAt ?? undefined,
           limit: REQUEST_ARCHIVE_LIMIT,
           offset: 0,
         }

--- a/frontend/src/features/conversation-archive/components/request-archive-panel.tsx
+++ b/frontend/src/features/conversation-archive/components/request-archive-panel.tsx
@@ -1,0 +1,155 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useConversationArchiveRecords } from "@/features/conversation-archive/hooks/use-conversation-archive";
+import type { ConversationArchiveRecord } from "@/features/conversation-archive/schemas";
+
+const REQUEST_ARCHIVE_LIMIT = 200;
+
+export function RequestArchivePanel({ requestId }: { requestId: string | null | undefined }) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(0);
+  const recordsQuery = useConversationArchiveRecords(
+    requestId
+      ? {
+          requestId,
+          limit: REQUEST_ARCHIVE_LIMIT,
+          offset: 0,
+        }
+      : null,
+  );
+
+  if (!requestId) {
+    return null;
+  }
+
+  if (recordsQuery.isPending) {
+    return (
+      <section className="space-y-2">
+        <h3 className="text-sm font-medium">Archive</h3>
+        <Skeleton className="h-20 w-full" />
+      </section>
+    );
+  }
+
+  if (recordsQuery.isError) {
+    return (
+      <section className="space-y-2">
+        <h3 className="text-sm font-medium">Archive</h3>
+        <div className="rounded-md border border-destructive/25 bg-destructive/10 p-3 text-xs text-destructive">
+          {recordsQuery.error instanceof Error ? recordsQuery.error.message : "Failed to load archive records"}
+        </div>
+      </section>
+    );
+  }
+
+  const records = recordsQuery.data?.records ?? [];
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-medium">Archive</h3>
+        <span className="text-xs text-muted-foreground">{recordsQuery.data?.total ?? 0} records</span>
+      </div>
+      {records.length === 0 ? (
+        <div className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+          No archived payloads for this request.
+        </div>
+      ) : (
+        <div className="max-h-[42vh] overflow-y-auto rounded-md border">
+          {records.map((record, index) => {
+            const expanded = expandedIndex === index;
+            return (
+              <div key={`${record.fileName ?? "archive"}-${record.timestamp ?? index}-${index}`} className="border-b last:border-b-0">
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-muted/60"
+                  onClick={() => setExpandedIndex(expanded ? null : index)}
+                >
+                  {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                  <ArchiveRecordSummary record={record} />
+                </button>
+                {expanded ? (
+                  <div className="grid gap-2 border-t bg-muted/20 p-3 md:grid-cols-2">
+                    <JsonBlock title="Payload" value={record.payload} />
+                    <JsonBlock title="Metadata" value={metadataForRecord(record)} />
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {recordsQuery.data?.hasMore ? (
+        <div className="text-xs text-muted-foreground">Showing first {REQUEST_ARCHIVE_LIMIT} records.</div>
+      ) : null}
+    </section>
+  );
+}
+
+function ArchiveRecordSummary({ record }: { record: ConversationArchiveRecord }) {
+  return (
+    <span className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+      <Badge variant="secondary">{record.direction ?? "-"}</Badge>
+      <span className="font-mono text-xs">{record.kind ?? "-"}</span>
+      <span className="text-xs text-muted-foreground">{record.transport ?? "-"}</span>
+      <span className="truncate text-xs text-muted-foreground">{record.fileName ?? formatDateTime(record.timestamp)}</span>
+    </span>
+  );
+}
+
+function JsonBlock({ title, value }: { title: string; value: unknown }) {
+  return (
+    <div className="min-w-0 rounded-md border bg-background">
+      <div className="border-b px-3 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {title}
+      </div>
+      <pre className="max-h-72 overflow-auto p-3 text-xs leading-relaxed whitespace-pre-wrap">
+        {stringifyJson(value)}
+      </pre>
+    </div>
+  );
+}
+
+function metadataForRecord(record: ConversationArchiveRecord) {
+  return {
+    fileName: record.fileName,
+    timestamp: record.timestamp,
+    requestId: record.requestId,
+    direction: record.direction,
+    kind: record.kind,
+    transport: record.transport,
+    accountId: record.accountId,
+    method: record.method,
+    url: record.url,
+    statusCode: record.statusCode,
+    headers: record.headers,
+    extra: record.extra,
+  };
+}
+
+function stringifyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+}

--- a/frontend/src/features/conversation-archive/hooks/use-conversation-archive.ts
+++ b/frontend/src/features/conversation-archive/hooks/use-conversation-archive.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  listConversationArchiveFiles,
+  listConversationArchiveRecords,
+  type ConversationArchiveRecordParams,
+} from "@/features/conversation-archive/api";
+
+export function useConversationArchiveFiles() {
+  return useQuery({
+    queryKey: ["conversation-archive", "files"],
+    queryFn: listConversationArchiveFiles,
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+  });
+}
+
+export function useConversationArchiveRecords(params: ConversationArchiveRecordParams | null) {
+  return useQuery({
+    queryKey: ["conversation-archive", "records", params],
+    queryFn: () => listConversationArchiveRecords(params!),
+    enabled: params !== null,
+  });
+}

--- a/frontend/src/features/conversation-archive/schemas.test.ts
+++ b/frontend/src/features/conversation-archive/schemas.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ConversationArchiveFileSchema,
+  ConversationArchiveRecordsResponseSchema,
+} from "@/features/conversation-archive/schemas";
+
+describe("conversation archive schemas", () => {
+  it("parses archive file metadata", () => {
+    const parsed = ConversationArchiveFileSchema.parse({
+      name: "2026-04-29.jsonl.gz",
+      date: "2026-04-29",
+      sizeBytes: 1234,
+      compressed: true,
+      modifiedAt: "2026-04-29T10:00:00Z",
+    });
+
+    expect(parsed.compressed).toBe(true);
+  });
+
+  it("parses records with arbitrary payloads", () => {
+    const parsed = ConversationArchiveRecordsResponseSchema.parse({
+      records: [
+        {
+          timestamp: "2026-04-29T10:00:00Z",
+          fileName: "2026-04-29.jsonl.gz",
+          requestId: "req_1",
+          direction: "server_to_codex",
+          kind: "responses",
+          transport: "sse",
+          accountId: "acc_1",
+          method: "POST",
+          url: "https://chatgpt.com/backend-api/codex/responses",
+          statusCode: 200,
+          headers: { authorization: "[redacted]" },
+          payload: { type: "response.completed" },
+          extra: null,
+        },
+      ],
+      total: 1,
+      hasMore: false,
+    });
+
+    expect(parsed.records[0]?.payload).toEqual({ type: "response.completed" });
+  });
+});

--- a/frontend/src/features/conversation-archive/schemas.ts
+++ b/frontend/src/features/conversation-archive/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const ConversationArchiveFileSchema = z.object({
+  name: z.string(),
+  date: z.string().nullable(),
+  sizeBytes: z.number().int().nonnegative(),
+  compressed: z.boolean(),
+  modifiedAt: z.string().datetime({ offset: true }),
+});
+
+export const ConversationArchiveRecordSchema = z.object({
+  fileName: z.string().nullable().default(null),
+  timestamp: z.string().datetime({ offset: true }).nullable(),
+  requestId: z.string().nullable(),
+  direction: z.string().nullable(),
+  kind: z.string().nullable(),
+  transport: z.string().nullable(),
+  accountId: z.string().nullable(),
+  method: z.string().nullable(),
+  url: z.string().nullable(),
+  statusCode: z.number().int().nullable(),
+  headers: z.record(z.string(), z.string()).nullable(),
+  payload: z.unknown(),
+  extra: z.record(z.string(), z.unknown()).nullable().default(null),
+});
+
+export const ConversationArchiveRecordsResponseSchema = z.object({
+  records: z.array(ConversationArchiveRecordSchema),
+  total: z.number().int().nonnegative(),
+  hasMore: z.boolean(),
+});
+
+export type ConversationArchiveFile = z.infer<typeof ConversationArchiveFileSchema>;
+export type ConversationArchiveRecord = z.infer<typeof ConversationArchiveRecordSchema>;
+export type ConversationArchiveRecordsResponse = z.infer<typeof ConversationArchiveRecordsResponseSchema>;

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -17,6 +17,12 @@ vi.mock("sonner", () => ({
   },
 }));
 
+vi.mock("@/features/conversation-archive/components/request-archive-panel", () => ({
+  RequestArchivePanel: ({ requestId }: { requestId: string }) => (
+    <div data-testid="request-archive-panel">Archive for {requestId}</div>
+  ),
+}));
+
 const PAGINATION_PROPS = {
   total: 1,
   limit: 25,
@@ -95,6 +101,7 @@ describe("RecentRequestsTable", () => {
     expect(dialog).toBeInTheDocument();
     expect(screen.getByText("Request Details")).toBeInTheDocument();
     expect(screen.getByText("req-1")).toBeInTheDocument();
+    expect(screen.getByTestId("request-archive-panel")).toHaveTextContent("Archive for req-1");
     expect(screen.getAllByText("rate_limit_exceeded")[0]).toBeInTheDocument();
     expect(dialog.textContent).toContain("Rate limit reached while processing this request");
 

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -81,6 +81,10 @@ describe("RecentRequestsTable", () => {
             reasoningEffort: "high",
             costUsd: 0.01,
             latencyMs: 1000,
+            slimSummary: {
+              historicalToolOutputsSlimmed: 2,
+              historicalImagesSlimmed: 1,
+            },
           },
         ]}
       />,
@@ -103,6 +107,8 @@ describe("RecentRequestsTable", () => {
     expect(screen.getByText("req-1")).toBeInTheDocument();
     expect(screen.getByTestId("request-archive-panel")).toHaveTextContent("Archive for req-1");
     expect(screen.getAllByText("rate_limit_exceeded")[0]).toBeInTheDocument();
+    expect(screen.getByText("2 historical tool outputs slimmed")).toBeInTheDocument();
+    expect(screen.getByText("1 historical images slimmed")).toBeInTheDocument();
     expect(dialog.textContent).toContain("Rate limit reached while processing this request");
 
     await act(async () => {

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -299,6 +299,7 @@ export function RecentRequestsTable({
                 <RequestDetailField label="Time" value={selectedRequest ? formatDateTimeInline(selectedRequest.requestedAt) : "—"} />
                 <RequestDetailField label="Error Code" value={selectedRequest?.errorCode ?? "—"} mono />
               </div>
+              <SlimSummaryBadges summary={selectedRequest?.slimSummary ?? null} />
             </div>
 
             <RequestArchivePanel requestId={selectedRequest?.requestId} requestedAt={selectedRequest?.requestedAt} />
@@ -320,6 +321,28 @@ export function RecentRequestsTable({
           <DialogFooter showCloseButton />
         </DialogContent>
       </Dialog>
+    </div>
+  );
+}
+
+function SlimSummaryBadges({ summary }: { summary: RequestLog["slimSummary"] | null }) {
+  const toolOutputs = summary?.historicalToolOutputsSlimmed ?? 0;
+  const images = summary?.historicalImagesSlimmed ?? 0;
+  if (toolOutputs <= 0 && images <= 0) {
+    return null;
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {toolOutputs > 0 ? (
+        <Badge variant="outline" className="bg-amber-500/10 text-amber-700 dark:text-amber-300">
+          {toolOutputs} historical tool outputs slimmed
+        </Badge>
+      ) : null}
+      {images > 0 ? (
+        <Badge variant="outline" className="bg-sky-500/10 text-sky-700 dark:text-sky-300">
+          {images} historical images slimmed
+        </Badge>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -24,6 +24,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { PaginationControls } from "@/features/dashboard/components/filters/pagination-controls";
+import { RequestArchivePanel } from "@/features/conversation-archive/components/request-archive-panel";
 import type { AccountSummary, RequestLog } from "@/features/dashboard/schemas";
 import { REQUEST_STATUS_LABELS } from "@/utils/constants";
 import {
@@ -129,7 +130,7 @@ export function RecentRequestsTable({
               <TableHead className="w-24 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Status</TableHead>
               <TableHead className="w-24 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Tokens</TableHead>
               <TableHead className="w-16 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Cost</TableHead>
-              <TableHead className="w-72 pr-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Error</TableHead>
+              <TableHead className="w-72 pr-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Details</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -244,7 +245,15 @@ export function RecentRequestsTable({
                         </Button>
                       </div>
                     ) : (
-                      <span className="text-xs text-muted-foreground">-</span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 px-2 text-[11px]"
+                        onClick={() => setSelectedRequest(request)}
+                      >
+                        View Details
+                      </Button>
                     )}
                   </TableCell>
                 </TableRow>
@@ -291,6 +300,8 @@ export function RecentRequestsTable({
                 <RequestDetailField label="Error Code" value={selectedRequest?.errorCode ?? "—"} mono />
               </div>
             </div>
+
+            <RequestArchivePanel requestId={selectedRequest?.requestId} />
 
             <div className="space-y-2">
               <div className="flex items-center gap-2">

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -301,7 +301,7 @@ export function RecentRequestsTable({
               </div>
             </div>
 
-            <RequestArchivePanel requestId={selectedRequest?.requestId} />
+            <RequestArchivePanel requestId={selectedRequest?.requestId} requestedAt={selectedRequest?.requestedAt} />
 
             <div className="space-y-2">
               <div className="flex items-center gap-2">

--- a/frontend/src/features/dashboard/schemas.test.ts
+++ b/frontend/src/features/dashboard/schemas.test.ts
@@ -149,6 +149,10 @@ describe("RequestLogsResponseSchema", () => {
           reasoningEffort: null,
           costUsd: 0.001,
           latencyMs: 42,
+          slimSummary: {
+            historical_tool_outputs_slimmed: 2,
+            historical_images_slimmed: 1,
+          },
         },
       ],
       total: 1,
@@ -159,6 +163,10 @@ describe("RequestLogsResponseSchema", () => {
     expect(parsed.requests[0]?.apiKeyId).toBe("key-1");
     expect(parsed.requests[0]?.planType).toBe("plus");
     expect(parsed.requests[0]?.transport).toBe("websocket");
+    expect(parsed.requests[0]?.slimSummary).toEqual({
+      historicalToolOutputsSlimmed: 2,
+      historicalImagesSlimmed: 1,
+    });
   });
 
   it("parses request-log filter options including API keys", () => {

--- a/frontend/src/features/dashboard/schemas.ts
+++ b/frontend/src/features/dashboard/schemas.ts
@@ -99,6 +99,24 @@ export const DashboardOverviewSchema = z.object({
   depletionSecondary: DepletionSchema.nullable().optional(),
 });
 
+const RequestLogSlimSummarySchema = z.preprocess(
+  (value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return value;
+    }
+    const summary = value as Record<string, unknown>;
+    return {
+      historicalToolOutputsSlimmed:
+        summary.historicalToolOutputsSlimmed ?? summary.historical_tool_outputs_slimmed,
+      historicalImagesSlimmed: summary.historicalImagesSlimmed ?? summary.historical_images_slimmed,
+    };
+  },
+  z.object({
+    historicalToolOutputsSlimmed: z.number().int().nonnegative().optional(),
+    historicalImagesSlimmed: z.number().int().nonnegative().optional(),
+  }),
+);
+
 export const RequestLogSchema = z.object({
   requestedAt: z.string().datetime({ offset: true }),
   accountId: z.string().nullable(),
@@ -119,6 +137,7 @@ export const RequestLogSchema = z.object({
   reasoningEffort: z.string().nullable(),
   costUsd: z.number().nullable(),
   latencyMs: z.number().nullable(),
+  slimSummary: RequestLogSlimSummarySchema.nullable().optional(),
 });
 
 export const RequestLogsResponseSchema = z.object({

--- a/openspec/changes/archive-codex-upstream-dialogs/proposal.md
+++ b/openspec/changes/archive-codex-upstream-dialogs/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Operators need a durable, replayable record of Codex-to-upstream traffic for later incident audit and possible offline dataset preparation. Existing request logs and audit logs only preserve metadata, while console payload logging is transient and not structured as a training-friendly archive.
+
+## What Changes
+
+- Add an opt-in gzip JSONL conversation archive for upstream Codex Responses traffic.
+- Store upstream request payloads, streamed SSE events, compact responses, and websocket frames with request/account metadata.
+- Redact credential-bearing headers while preserving payload bodies and upstream events verbatim.
+- Add archived payload inspection to the existing dashboard request details flow.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: operators can enable a durable full-fidelity upstream conversation archive.
+
+## Impact
+
+- Affected code: `app/core/conversation_archive.py`, upstream HTTP/SSE/compact/websocket clients, dashboard archive APIs, frontend archive viewer, settings, and tests.
+- Operational impact: disabled by default; when enabled, archive files may contain private prompts, tool outputs, and model responses and must be stored as sensitive data.

--- a/openspec/changes/archive-codex-upstream-dialogs/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/archive-codex-upstream-dialogs/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Full upstream conversation archive
+The proxy MUST provide an opt-in durable archive of Codex-to-upstream conversation traffic. When enabled, the archive MUST write gzip-compressed newline-delimited JSON records for upstream request payloads, streamed Responses events, compact response payloads, and websocket text or binary frames without performing gzip file I/O in the request event loop during normal operation. The archive writer queue MUST be bounded and MUST apply synchronous write backpressure instead of growing without limit when the background writer is saturated. Archive records MUST include request id, timestamp, direction, traffic kind, transport, account id when known, upstream target metadata, redacted headers, and the full payload or frame body. Credential-bearing headers such as authorization, cookies, proxy authorization, token headers, and API key headers MUST be redacted before persistence. JSON records MUST preserve non-ASCII payload text as UTF-8 rather than Unicode escape sequences. When disabled, no archive file MUST be created by the archive writer.
+
+#### Scenario: operator enables archive for audit
+- **WHEN** `CODEX_LB_CONVERSATION_ARCHIVE_ENABLED=true`
+- **AND** a Codex Responses request is proxied upstream
+- **THEN** the archive records both the outbound upstream payload and inbound upstream events or response body as gzip JSONL
+- **AND** credential-bearing headers are stored as redacted values
+
+#### Scenario: archive remains disabled by default
+- **WHEN** the archive setting is not enabled
+- **THEN** the archive writer does not create conversation archive files
+
+#### Scenario: operator views archived traffic
+- **GIVEN** conversation archive files exist as `.jsonl.gz` or legacy `.jsonl`
+- **WHEN** an authenticated dashboard operator opens an existing request log detail
+- **THEN** the dashboard can find matching archive records by request id across archive files and display payload plus metadata for that request

--- a/openspec/changes/archive-codex-upstream-dialogs/tasks.md
+++ b/openspec/changes/archive-codex-upstream-dialogs/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] 1.1 Add opt-in settings for full conversation archival.
+- [x] 1.2 Persist upstream request/response payloads and stream events as JSONL.
+- [x] 1.3 Redact credential-bearing headers in archive records.
+- [x] 1.4 Compress new archive files as gzip JSONL and keep legacy JSONL readable.
+- [x] 1.5 Add dashboard APIs and request detail UI for browsing archived records.
+- [x] 1.6 Keep archive gzip writes and archive reads off the request event loop.
+- [x] 1.7 Bound archive writer memory and preserve non-ASCII text as readable UTF-8.
+
+## 2. Verification
+
+- [x] 2.1 Add unit tests for archive writing, disabled mode, binary frame encoding, bounded queue fallback, UTF-8 text, and archive reading.
+- [x] 2.2 Run targeted pytest, ruff, type checks, frontend build, and OpenSpec validation.

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import base64
+import errno
+import gzip
+import json
+import queue
+from pathlib import Path
+from typing import cast
+
+from app.core import conversation_archive
+from app.core.utils.request_id import reset_request_id, set_request_id
+from app.modules.conversation_archive import service as conversation_archive_service
+
+
+def _reset_archive_disk_pressure() -> None:
+    with conversation_archive._DISK_PRESSURE_LOCK:
+        conversation_archive._DISK_PRESSURE_PAUSED_UNTIL = 0.0
+        conversation_archive._DISK_PRESSURE_LAST_WARNING_AT = (
+            -conversation_archive._DISK_PRESSURE_WARNING_INTERVAL_SECONDS
+        )
+
+
+class _ArchiveSettings:
+    def __init__(self, *, enabled: bool, directory: Path) -> None:
+        self.conversation_archive_enabled = enabled
+        self.conversation_archive_dir = directory
+
+
+def _archive_records(directory: Path) -> list[dict[str, object]]:
+    files = sorted(directory.glob("*.jsonl.gz"))
+    assert len(files) == 1
+    with gzip.open(files[0], "rt", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh.read().splitlines()]
+
+
+def _archive_lines(directory: Path) -> list[str]:
+    files = sorted(directory.glob("*.jsonl.gz"))
+    assert len(files) == 1
+    with gzip.open(files[0], "rt", encoding="utf-8") as fh:
+        return fh.read().splitlines()
+
+
+def test_archive_json_writes_redacted_jsonl_record(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    token = set_request_id("req_archive_1")
+    try:
+        conversation_archive.archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="http",
+            account_id="acc_1",
+            method="POST",
+            url="https://chatgpt.com/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer secret",
+                "session_id": "sid_1",
+                "x-session-token": "tok_1",
+            },
+            payload={"model": "gpt-5.4", "input": "привет без юникод-эскейпов"},
+        )
+    finally:
+        reset_request_id(token)
+    conversation_archive.flush_archive_writer()
+
+    [record] = _archive_records(tmp_path)
+    assert record["request_id"] == "req_archive_1"
+    assert record["direction"] == "codex_to_server"
+    assert record["kind"] == "responses"
+    assert record["transport"] == "http"
+    assert record["account_id"] == "acc_1"
+    assert record["payload"] == {"model": "gpt-5.4", "input": "привет без юникод-эскейпов"}
+    assert record["headers"] == {
+        "Authorization": "[redacted]",
+        "session_id": "sid_1",
+        "x-session-token": "[redacted]",
+    }
+    [line] = _archive_lines(tmp_path)
+    assert "привет без юникод-эскейпов" in line
+    assert "\\u043f" not in line
+
+
+def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    bounded_queue: queue.Queue[tuple[Path, dict[str, object]] | None] = queue.Queue(maxsize=1)
+    bounded_queue.put((tmp_path / "blocked.jsonl.gz", {"payload": "queued"}))
+    monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", bounded_queue)
+    monkeypatch.setattr(conversation_archive, "_ensure_writer_thread", lambda: None)
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "синхронный fallback"},
+    )
+
+    [line] = _archive_lines(tmp_path)
+    assert "синхронный fallback" in line
+    assert bounded_queue.qsize() == 1
+
+
+def test_archive_appends_complete_gzip_members(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "first"},
+    )
+    conversation_archive.archive_json(
+        direction="server_to_codex",
+        kind="responses",
+        transport="http",
+        payload={"text": "second"},
+    )
+    conversation_archive.flush_archive_writer()
+
+    records = _archive_records(tmp_path)
+    assert [record["payload"] for record in records] == [{"text": "first"}, {"text": "second"}]
+
+
+def test_archive_uses_hourly_gzip_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "hourly"},
+    )
+    conversation_archive.flush_archive_writer()
+
+    [path] = list(tmp_path.glob("*.jsonl.gz"))
+    assert len(path.stem) == len("2026-04-30T12.jsonl")
+    assert path.name.endswith(".jsonl.gz")
+    assert "T" in path.name
+
+
+def test_archive_writer_recovers_corrupt_gzip_tail_before_append(tmp_path):
+    path = tmp_path / "2026-04-30.jsonl.gz"
+    conversation_archive._RECOVERY_CHECKED_PATHS.discard(path.resolve())
+    path.write_bytes(
+        gzip.compress(json.dumps({"request_id": "req_ok", "payload": "old"}).encode("utf-8") + b"\n")
+        + b"not a complete gzip member"
+    )
+
+    conversation_archive._append_record(path, {"request_id": "req_new", "payload": "new"})
+
+    with gzip.open(path, "rt", encoding="utf-8") as fh:
+        rows = [json.loads(line) for line in fh.read().splitlines()]
+    assert [row["request_id"] for row in rows] == ["req_ok", "req_new"]
+    backups = list(tmp_path.glob("2026-04-30.jsonl.gz.corrupt-*"))
+    assert len(backups) == 1
+
+
+def test_archive_recovery_check_runs_once_per_file(monkeypatch, tmp_path):
+    path = tmp_path / "2026-04-30T12.jsonl.gz"
+    conversation_archive._RECOVERY_CHECKED_PATHS.discard(path.resolve())
+    path.write_bytes(gzip.compress(json.dumps({"request_id": "req_ok"}).encode("utf-8") + b"\n"))
+    calls = 0
+
+    def fake_readable(read_path: Path) -> bool:
+        nonlocal calls
+        assert read_path == path
+        calls += 1
+        return True
+
+    monkeypatch.setattr(conversation_archive, "_gzip_archive_is_readable", fake_readable)
+
+    conversation_archive._append_record(path, {"request_id": "req_new_1"})
+    conversation_archive._append_record(path, {"request_id": "req_new_2"})
+
+    assert calls == 1
+
+
+def test_archive_disk_full_pauses_writes_without_traceback_spam(monkeypatch, tmp_path, caplog):
+    _reset_archive_disk_pressure()
+    path = tmp_path / "2026-04-30T12.jsonl.gz"
+
+    def fail_write(_path: Path, _data: bytes) -> None:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(conversation_archive, "_write_gzip_member", fail_write)
+    caplog.set_level("WARNING", logger="app.core.conversation_archive")
+
+    conversation_archive._append_record(path, {"request_id": "req_full", "payload": "old"})
+
+    assert not path.exists()
+    assert "Conversation archive disk pressure detected; pausing archive writes" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert conversation_archive._archive_disk_pressure_active() is True
+
+    calls = 0
+
+    def record_write(_path: Path, _data: bytes) -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(conversation_archive, "_write_gzip_member", record_write)
+    conversation_archive._append_record(path, {"request_id": "req_dropped", "payload": "new"})
+    assert calls == 0
+
+    with conversation_archive._DISK_PRESSURE_LOCK:
+        conversation_archive._DISK_PRESSURE_PAUSED_UNTIL = 0.0
+    conversation_archive._append_record(path, {"request_id": "req_retry", "payload": "new"})
+    assert calls == 1
+
+
+def test_archive_enqueue_drops_records_while_disk_pressure_pause_is_active(monkeypatch, tmp_path):
+    _reset_archive_disk_pressure()
+    with conversation_archive._DISK_PRESSURE_LOCK:
+        conversation_archive._DISK_PRESSURE_PAUSED_UNTIL = conversation_archive.time.monotonic() + 60
+    monkeypatch.setattr(
+        conversation_archive,
+        "_ensure_writer_thread",
+        lambda: (_ for _ in ()).throw(AssertionError("writer should not start while paused")),
+    )
+
+    conversation_archive._enqueue_record(tmp_path / "paused.jsonl.gz", {"request_id": "req_paused"})
+
+    assert list(tmp_path.iterdir()) == []
+    _reset_archive_disk_pressure()
+
+
+def test_archive_disk_pressure_detection_walks_exception_causes():
+    wrapped = RuntimeError("outer")
+    wrapped.__cause__ = OSError(errno.EDQUOT, "Disk quota exceeded")
+
+    assert conversation_archive._is_disk_pressure_error(wrapped) is True
+    assert conversation_archive._is_disk_pressure_error(RuntimeError("database or disk is full")) is True
+    assert conversation_archive._is_disk_pressure_error(RuntimeError("regular archive failure")) is False
+
+
+def test_archive_disabled_does_not_create_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=False, directory=tmp_path),
+    )
+
+    conversation_archive.archive_text(
+        direction="server_to_codex",
+        kind="responses",
+        transport="websocket",
+        text='{"type":"response.completed"}',
+    )
+    conversation_archive.flush_archive_writer()
+
+    assert list(tmp_path.glob("*.jsonl*")) == []
+
+
+def test_archive_bytes_uses_base64_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    conversation_archive.archive_bytes(
+        direction="server_to_codex",
+        kind="responses",
+        transport="websocket",
+        data=b"\x00\x01binary",
+    )
+    conversation_archive.flush_archive_writer()
+
+    [record] = _archive_records(tmp_path)
+    payload = cast(dict[str, object], record["payload"])
+    assert payload["encoding"] == "base64"
+    assert payload["data"] == base64.b64encode(b"\x00\x01binary").decode("ascii")
+
+
+def test_archive_service_reads_gzip_and_legacy_jsonl(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    legacy_path = tmp_path / "2026-04-28.jsonl"
+    legacy_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-28T10:00:00+00:00",
+                "request_id": "req_legacy",
+                "direction": "codex_to_server",
+                "kind": "responses",
+                "transport": "http",
+                "payload": {"input": "old"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    gzip_path = tmp_path / "2026-04-29T10.jsonl.gz"
+    with gzip.open(gzip_path, "wt", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-04-29T10:00:00+00:00",
+                    "request_id": "req_gzip",
+                    "direction": "server_to_codex",
+                    "kind": "responses",
+                    "transport": "sse",
+                    "payload": {"type": "response.completed"},
+                }
+            )
+            + "\n"
+        )
+
+    files = conversation_archive_service.list_archive_files()
+    assert [file.name for file in files] == ["2026-04-29T10.jsonl.gz", "2026-04-28.jsonl"]
+    assert [file.date for file in files] == ["2026-04-29T10", "2026-04-28"]
+    assert files[0].compressed is True
+    assert files[1].compressed is False
+
+    page = conversation_archive_service.read_archive_records(
+        filename="2026-04-29T10.jsonl.gz",
+        limit=10,
+        offset=0,
+        direction="server_to_codex",
+    )
+    assert page.total == 1
+    assert page.has_more is False
+    assert page.records[0]["request_id"] == "req_gzip"
+    assert page.records[0]["_archive_file"] == "2026-04-29T10.jsonl.gz"
+
+    legacy_page = conversation_archive_service.read_archive_records(
+        filename="2026-04-28.jsonl",
+        limit=10,
+        offset=0,
+        request_id="req_legacy",
+    )
+    assert legacy_page.total == 1
+    assert legacy_page.records[0]["payload"] == {"input": "old"}
+
+    all_files_page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="req_gzip",
+    )
+    assert [record["request_id"] for record in all_files_page.records] == ["req_gzip"]
+
+
+def test_archive_service_keeps_readable_records_before_corrupt_gzip_tail(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    path = tmp_path / "2026-04-30.jsonl.gz"
+    path.write_bytes(
+        gzip.compress(json.dumps({"request_id": "req_ok", "direction": "codex_to_server"}).encode("utf-8") + b"\n")
+        + b"not a complete gzip member"
+    )
+
+    page = conversation_archive_service.read_archive_records(
+        filename=path.name,
+        limit=10,
+        offset=0,
+    )
+
+    assert [record["request_id"] for record in page.records] == ["req_ok"]
+
+
+def test_archive_service_rejects_path_traversal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    try:
+        conversation_archive_service.read_archive_records(
+            filename="../2026-04-29.jsonl.gz",
+            limit=10,
+            offset=0,
+        )
+    except conversation_archive_service.ConversationArchiveInvalidFileError:
+        pass
+    else:
+        raise AssertionError("expected invalid archive file error")

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -239,7 +239,7 @@ def test_archive_disk_full_pauses_writes_without_traceback_spam(monkeypatch, tmp
 def test_archive_enqueue_drops_records_while_disk_pressure_pause_is_active(monkeypatch, tmp_path):
     _reset_archive_disk_pressure()
     with conversation_archive._DISK_PRESSURE_LOCK:
-        conversation_archive._DISK_PRESSURE_PAUSED_UNTIL = conversation_archive.time.monotonic() + 60
+        conversation_archive._DISK_PRESSURE_PAUSED_UNTIL = float(conversation_archive.time.monotonic() + 60)
     monkeypatch.setattr(
         conversation_archive,
         "_ensure_writer_thread",

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -154,6 +154,18 @@ def test_archive_uses_hourly_gzip_files(monkeypatch, tmp_path):
     assert "T" in path.name
 
 
+def test_archive_path_expands_user_home(monkeypatch, tmp_path):
+    archive_dir = tmp_path / "archive"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=Path("~/archive")),
+    )
+
+    assert conversation_archive._archive_path().parent == archive_dir
+
+
 def test_archive_writer_recovers_corrupt_gzip_tail_before_append(tmp_path):
     path = tmp_path / "2026-04-30.jsonl.gz"
     conversation_archive._RECOVERY_CHECKED_PATHS.discard(path.resolve())
@@ -358,6 +370,24 @@ def test_archive_service_reads_gzip_and_legacy_jsonl(monkeypatch, tmp_path):
         request_id="req_gzip",
     )
     assert [record["request_id"] for record in all_files_page.records] == ["req_gzip"]
+
+
+def test_archive_service_expands_user_home(monkeypatch, tmp_path):
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    archive_path = archive_dir / "2026-04-29T10.jsonl.gz"
+    with gzip.open(archive_path, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps({"timestamp": "2026-04-29T10:00:00+00:00"}) + "\n")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=Path("~/archive")),
+    )
+
+    [file] = conversation_archive_service.list_archive_files()
+    assert file.name == archive_path.name
 
 
 def test_archive_service_keeps_readable_records_before_corrupt_gzip_tail(monkeypatch, tmp_path):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -113,6 +113,24 @@ def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_
     assert bounded_queue.qsize() == 1
 
 
+def test_stop_writer_drains_queued_records_without_thread(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    pending_queue: queue.Queue[tuple[Path, dict[str, object]] | None] = queue.Queue()
+    pending_queue.put((tmp_path / "drained.jsonl.gz", {"payload": {"text": "queued before shutdown"}}))
+    monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", pending_queue)
+    monkeypatch.setattr(conversation_archive, "_WRITER_THREAD", None)
+
+    conversation_archive._stop_writer()
+
+    [record] = _archive_records(tmp_path)
+    assert record["payload"] == {"text": "queued before shutdown"}
+    assert pending_queue.empty()
+
+
 def test_archive_appends_complete_gzip_members(monkeypatch, tmp_path):
     monkeypatch.setattr(
         conversation_archive,
@@ -221,6 +239,7 @@ def test_archive_disk_full_pauses_writes_without_traceback_spam(monkeypatch, tmp
     conversation_archive._append_record(path, {"request_id": "req_full", "payload": "old"})
 
     assert not path.exists()
+    assert path.resolve() not in conversation_archive._RECOVERY_CHECKED_PATHS
     assert "Conversation archive disk pressure detected; pausing archive writes" in caplog.text
     assert "Traceback" not in caplog.text
     assert conversation_archive._archive_disk_pressure_active() is True
@@ -341,12 +360,87 @@ def test_archive_service_reads_gzip_and_legacy_jsonl(monkeypatch, tmp_path):
             )
             + "\n"
         )
+    crossing_hour_path = tmp_path / "2026-04-29T09.jsonl.gz"
+    with gzip.open(crossing_hour_path, "wt", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-04-29T09:59:30+00:00",
+                    "request_id": "req_crossing_hour",
+                    "direction": "codex_to_server",
+                    "kind": "responses",
+                    "transport": "http",
+                    "payload": {"input": "started before completion hour"},
+                }
+            )
+            + "\n"
+        )
+    response_id_alias_path = tmp_path / "2026-04-29T11.jsonl.gz"
+    with gzip.open(response_id_alias_path, "wt", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-04-29T11:00:00+00:00",
+                    "request_id": "req_header_id",
+                    "direction": "codex_to_server",
+                    "kind": "responses",
+                    "transport": "http",
+                    "payload": {"model": "gpt-5.4", "input": "original request body"},
+                }
+            )
+            + "\n"
+        )
+        fh.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-04-29T11:00:00+00:00",
+                    "request_id": "req_header_id",
+                    "direction": "server_to_codex",
+                    "kind": "responses",
+                    "transport": "http",
+                    "payload": {
+                        "text": (
+                            'event: response.completed\ndata: {"type":"response.completed",'
+                            '"response":{"id":"resp_logged_id"}}\n\n'
+                        )
+                    },
+                }
+            )
+            + "\n"
+        )
+    long_running_path = tmp_path / "2026-04-29T13.jsonl.gz"
+    with gzip.open(long_running_path, "wt", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-04-29T13:05:00+00:00",
+                    "request_id": "req_long_running",
+                    "direction": "server_to_codex",
+                    "kind": "responses",
+                    "transport": "http",
+                    "payload": {"text": "late event"},
+                }
+            )
+            + "\n"
+        )
 
     files = conversation_archive_service.list_archive_files()
-    assert [file.name for file in files] == ["2026-04-29T10.jsonl.gz", "2026-04-28.jsonl"]
-    assert [file.date for file in files] == ["2026-04-29T10", "2026-04-28"]
+    assert [file.name for file in files] == [
+        "2026-04-29T13.jsonl.gz",
+        "2026-04-29T11.jsonl.gz",
+        "2026-04-29T10.jsonl.gz",
+        "2026-04-29T09.jsonl.gz",
+        "2026-04-28.jsonl",
+    ]
+    assert [file.date for file in files] == [
+        "2026-04-29T13",
+        "2026-04-29T11",
+        "2026-04-29T10",
+        "2026-04-29T09",
+        "2026-04-28",
+    ]
     assert files[0].compressed is True
-    assert files[1].compressed is False
+    assert files[4].compressed is False
 
     page = conversation_archive_service.read_archive_records(
         filename="2026-04-29T10.jsonl.gz",
@@ -384,6 +478,36 @@ def test_archive_service_reads_gzip_and_legacy_jsonl(monkeypatch, tmp_path):
         requested_at=datetime.fromisoformat("2026-04-29T10:30:00+00:00"),
     )
     assert [record["request_id"] for record in requested_at_page.records] == ["req_gzip"]
+
+    crossing_hour_page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="req_crossing_hour",
+        requested_at=datetime.fromisoformat("2026-04-29T10:01:00+00:00"),
+    )
+    assert [record["request_id"] for record in crossing_hour_page.records] == ["req_crossing_hour"]
+
+    long_running_page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="req_long_running",
+        requested_at=datetime.fromisoformat("2026-04-29T10:01:00+00:00"),
+    )
+    assert [record["request_id"] for record in long_running_page.records] == ["req_long_running"]
+
+    response_id_alias_page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="resp_logged_id",
+        requested_at=datetime.fromisoformat("2026-04-29T11:00:03+00:00"),
+    )
+    assert [record["direction"] for record in response_id_alias_page.records] == [
+        "codex_to_server",
+        "server_to_codex",
+    ]
 
 
 def test_archive_service_expands_user_home(monkeypatch, tmp_path):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -5,6 +5,7 @@ import errno
 import gzip
 import json
 import queue
+from datetime import datetime
 from pathlib import Path
 from typing import cast
 
@@ -59,6 +60,8 @@ def test_archive_json_writes_redacted_jsonl_record(monkeypatch, tmp_path):
             url="https://chatgpt.com/backend-api/codex/responses",
             headers={
                 "Authorization": "Bearer secret",
+                "api-key": "bare-secret",
+                "api_key": "underscore-secret",
                 "session_id": "sid_1",
                 "x-session-token": "tok_1",
             },
@@ -77,6 +80,8 @@ def test_archive_json_writes_redacted_jsonl_record(monkeypatch, tmp_path):
     assert record["payload"] == {"model": "gpt-5.4", "input": "привет без юникод-эскейпов"}
     assert record["headers"] == {
         "Authorization": "[redacted]",
+        "api-key": "[redacted]",
+        "api_key": "[redacted]",
         "session_id": "sid_1",
         "x-session-token": "[redacted]",
     }
@@ -370,6 +375,15 @@ def test_archive_service_reads_gzip_and_legacy_jsonl(monkeypatch, tmp_path):
         request_id="req_gzip",
     )
     assert [record["request_id"] for record in all_files_page.records] == ["req_gzip"]
+
+    requested_at_page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="req_gzip",
+        requested_at=datetime.fromisoformat("2026-04-29T10:30:00+00:00"),
+    )
+    assert [record["request_id"] for record in requested_at_page.records] == ["req_gzip"]
 
 
 def test_archive_service_expands_user_home(monkeypatch, tmp_path):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1732,6 +1732,70 @@ async def test_stream_responses_starts_upstream_timer_after_image_inlining(monke
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_archives_http_error_before_raising(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 1.0
+        stream_idle_timeout_seconds = 1.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 15.0
+        upstream_stream_transport = "http"
+        log_upstream_request_summary = False
+
+    class ErrorPostResponse:
+        status = 429
+        reason = "Too Many Requests"
+        content = _DummyContent([])
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self, *, content_type=None):
+            del content_type
+            return {"error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"}}
+
+        async def text(self):
+            return "slow down"
+
+    archived: list[dict[str, object]] = []
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "archive_json", lambda **kwargs: archived.append(kwargs))
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        _ = [
+            event
+            async for event in proxy_module.stream_responses(
+                payload,
+                headers={},
+                access_token="token",
+                account_id="acc_1",
+                session=cast(proxy_module.aiohttp.ClientSession, _SseSession(ErrorPostResponse())),
+                raise_for_status=True,
+            )
+        ]
+
+    assert exc_info.value.status_code == 429
+    assert len(archived) == 2
+    assert archived[-1]["direction"] == "server_to_codex"
+    assert archived[-1]["status_code"] == 429
+    assert archived[-1]["payload"] == {
+        "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"}
+    }
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_honors_timeout_overrides(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1160,7 +1160,7 @@ class _SsePostResponse:
 
 
 class _SseSession:
-    def __init__(self, response: _SsePostResponse) -> None:
+    def __init__(self, response: object) -> None:
         self._response = response
         self.calls: list[dict[str, object]] = []
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10584,9 +10584,9 @@ async def test_process_http_bridge_upstream_text_archives_inbound_event(monkeypa
         json.dumps(payload, separators=(",", ":")),
     )
 
-    assert await asyncio.wait_for(event_queue.get(), timeout=0.1) == (
-        'data: {"type":"response.created","response":{"id":"resp_bridge_archive"}}\n\n'
-    )
+    event_block = await asyncio.wait_for(event_queue.get(), timeout=0.1)
+    assert event_block is not None
+    assert parse_sse_data_json(event_block) == payload
     assert archive_calls[-1]["request_id"] == "req_bridge_log"
     assert archive_calls[-1]["transport"] == "http"
     assert archive_calls[-1]["extra"] == {"frame_type": "text", "response_id": "resp_bridge_archive"}

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
 from typing import Protocol, Self, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -1757,7 +1757,10 @@ async def test_stream_responses_archives_http_error_before_raising(monkeypatch):
 
         async def json(self, *, content_type=None):
             del content_type
-            return {"error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"}}
+            return {
+                "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"},
+                "upstream_trace": {"bucket": "weekly", "resets_in_seconds": 12},
+            }
 
         async def text(self):
             return "slow down"
@@ -1791,8 +1794,79 @@ async def test_stream_responses_archives_http_error_before_raising(monkeypatch):
     assert archived[-1]["direction"] == "server_to_codex"
     assert archived[-1]["status_code"] == 429
     assert archived[-1]["payload"] == {
-        "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"}
+        "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"},
+        "upstream_trace": {"bucket": "weekly", "resets_in_seconds": 12},
     }
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_archives_raw_http_error_body_without_raising(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 1.0
+        stream_idle_timeout_seconds = 1.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 15.0
+        upstream_stream_transport = "http"
+        log_upstream_request_summary = False
+
+    class ErrorPostResponse:
+        status = 429
+        reason = "Too Many Requests"
+        content = _DummyContent([])
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self, *, content_type=None):
+            del content_type
+            return {
+                "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"},
+                "upstream_trace": {"bucket": "weekly", "resets_in_seconds": 12},
+            }
+
+        async def text(self):
+            return "slow down"
+
+    archived_json: list[dict[str, object]] = []
+    archived_text: list[dict[str, object]] = []
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "archive_json", lambda **kwargs: archived_json.append(kwargs))
+    monkeypatch.setattr(proxy_module, "archive_text", lambda **kwargs: archived_text.append(kwargs))
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, _SseSession(ErrorPostResponse())),
+            raise_for_status=False,
+        )
+    ]
+
+    assert events
+    assert "response.failed" in events[0]
+    assert archived_json[-1]["direction"] == "server_to_codex"
+    assert archived_json[-1]["status_code"] == 429
+    assert archived_json[-1]["payload"] == {
+        "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"},
+        "upstream_trace": {"bucket": "weekly", "resets_in_seconds": 12},
+    }
+    assert archived_text == []
 
 
 @pytest.mark.asyncio
@@ -2392,7 +2466,11 @@ async def test_stream_responses_via_websocket_counts_connect_and_send_against_to
         idle_timeout_seconds: float,
         total_timeout_seconds: float | None,
         max_event_bytes: int,
+        archive_account_id: str | None = None,
+        archive_url: str | None = None,
+        archive_headers: Mapping[str, str] | None = None,
     ):
+        del archive_account_id, archive_url, archive_headers
         recorded["total_timeout_seconds"] = total_timeout_seconds
         if False:
             yield ""
@@ -2419,6 +2497,51 @@ async def test_stream_responses_via_websocket_counts_connect_and_send_against_to
     assert events == []
     assert recorded["connect_timeout_seconds"] == pytest.approx(5.0)
     assert recorded["total_timeout_seconds"] == pytest.approx(0.25)
+
+
+@pytest.mark.asyncio
+async def test_stream_websocket_events_archives_raw_text_and_binary_frames(monkeypatch):
+    archived_text = []
+    archived_bytes = []
+    websocket = _WsResponse(
+        [
+            _WsMessage(proxy_module.aiohttp.WSMsgType.TEXT, "not json"),
+            _WsMessage(proxy_module.aiohttp.WSMsgType.BINARY, b"\x00not-json"),
+            _WsMessage(
+                proxy_module.aiohttp.WSMsgType.TEXT,
+                json.dumps({"type": "response.completed", "response": {"id": "resp_raw_frame"}}),
+            ),
+        ]
+    )
+
+    monkeypatch.setattr(proxy_module, "archive_text", lambda **kwargs: archived_text.append(kwargs))
+    monkeypatch.setattr(proxy_module, "archive_bytes", lambda **kwargs: archived_bytes.append(kwargs))
+
+    events = [
+        event
+        async for event in proxy_module._stream_websocket_events(
+            cast(proxy_module.aiohttp.ClientWebSocketResponse, websocket),
+            idle_timeout_seconds=1.0,
+            total_timeout_seconds=None,
+            max_event_bytes=1024,
+            archive_account_id="acc_raw_frame",
+            archive_url="wss://chatgpt.com/backend-api/codex/responses",
+            archive_headers={"Authorization": "Bearer secret"},
+        )
+    ]
+
+    assert len(events) == 1
+    assert "resp_raw_frame" in events[0]
+    assert [call["text"] for call in archived_text] == [
+        "not json",
+        '{"type": "response.completed", "response": {"id": "resp_raw_frame"}}',
+    ]
+    assert archived_text[0]["extra"] == {"frame_type": "text"}
+    assert archived_text[0]["account_id"] == "acc_raw_frame"
+    assert archived_text[0]["headers"] == {"Authorization": "Bearer secret"}
+    assert archived_bytes[0]["data"] == b"\x00not-json"
+    assert archived_bytes[0]["extra"] == {"frame_type": "binary"}
+    assert archived_bytes[0]["account_id"] == "acc_raw_frame"
 
 
 @pytest.mark.asyncio
@@ -3645,6 +3768,55 @@ async def test_compact_responses_starts_upstream_timer_after_image_inlining(monk
     assert dumped["object"] == "response.compaction"
     assert dumped["compaction_summary"]["encrypted_content"] == "enc_summary_1"
     assert recorded["started_at"] == 205.5
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_archives_raw_http_error_body(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 1.0
+        upstream_compact_timeout_seconds = 12.0
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+
+    class ErrorCompactResponse(_JsonCompactResponse):
+        def __init__(self) -> None:
+            super().__init__(
+                {
+                    "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"},
+                    "upstream_trace": {"bucket": "weekly", "resets_in_seconds": 12},
+                }
+            )
+            self.status = 429
+            self.reason = "Too Many Requests"
+
+    archived: list[dict[str, object]] = []
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "archive_json", lambda **kwargs: archived.append(kwargs))
+
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module.compact_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, _CompactSession(ErrorCompactResponse())),
+        )
+
+    assert exc_info.value.status_code == 429
+    assert archived[-1]["direction"] == "server_to_codex"
+    assert archived[-1]["kind"] == "compact"
+    assert archived[-1]["payload"] == {
+        "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"},
+        "upstream_trace": {"bucket": "weekly", "resets_in_seconds": 12},
+    }
 
 
 @pytest.mark.asyncio
@@ -10204,6 +10376,305 @@ def test_classify_upstream_close_rejected_only_for_clean_close_before_any_respon
     assert proxy_service._classify_upstream_close(1000, response_events_seen=0) == "rejected"
     assert proxy_service._classify_upstream_close(1000, response_events_seen=1) == "transient"
     assert proxy_service._classify_upstream_close(1011, response_events_seen=0) == "transient"
+
+
+def test_archive_upstream_websocket_text_uses_request_log_id(monkeypatch):
+    calls = []
+
+    def fake_archive_text(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(proxy_service, "archive_text", fake_archive_text)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_transport",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_log_id="req_log_1",
+        response_id="resp_upstream_1",
+    )
+    archive_metadata = proxy_service.UpstreamWebSocketArchiveMetadata(
+        url="wss://upstream.example/ws",
+        headers={"openai-beta": "responses_websockets=2026-02-06"},
+        account_id="acc_1",
+    )
+
+    proxy_service._archive_upstream_websocket_text(
+        request_state,
+        "data: {}\n\n",
+        archive_metadata=archive_metadata,
+    )
+
+    assert calls == [
+        {
+            "direction": "server_to_codex",
+            "kind": "responses",
+            "transport": proxy_service._REQUEST_TRANSPORT_WEBSOCKET,
+            "text": "data: {}\n\n",
+            "account_id": "acc_1",
+            "url": "wss://upstream.example/ws",
+            "headers": {"openai-beta": "responses_websockets=2026-02-06"},
+            "extra": {"frame_type": "text", "response_id": "resp_upstream_1"},
+            "request_id": "req_log_1",
+        }
+    ]
+
+
+def test_archive_upstream_websocket_bytes_uses_request_log_id(monkeypatch):
+    calls = []
+
+    def fake_archive_bytes(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(proxy_service, "archive_bytes", fake_archive_bytes)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_transport",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_log_id="req_log_1",
+        response_id="resp_upstream_1",
+    )
+    archive_metadata = proxy_service.UpstreamWebSocketArchiveMetadata(
+        url="wss://upstream.example/ws",
+        headers={"openai-beta": "responses_websockets=2026-02-06"},
+        account_id="acc_1",
+    )
+
+    proxy_service._archive_upstream_websocket_bytes(
+        request_state,
+        b"\x00\x01",
+        archive_metadata=archive_metadata,
+    )
+
+    assert calls == [
+        {
+            "direction": "server_to_codex",
+            "kind": "responses",
+            "transport": proxy_service._REQUEST_TRANSPORT_WEBSOCKET,
+            "data": b"\x00\x01",
+            "account_id": "acc_1",
+            "url": "wss://upstream.example/ws",
+            "headers": {"openai-beta": "responses_websockets=2026-02-06"},
+            "extra": {"frame_type": "binary", "response_id": "resp_upstream_1"},
+            "request_id": "req_log_1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_upstream_websocket_text_passes_archive_id_per_send():
+    calls = []
+
+    class ArchiveAwareUpstream:
+        async def send_text_with_archive_request_id(self, text: str, *, request_id: str | None) -> None:
+            calls.append((text, request_id))
+
+        async def send_text(self, text: str) -> None:
+            raise AssertionError(f"fallback send should not be used for {text}")
+
+        async def send_bytes(self, data: bytes) -> None:
+            del data
+
+        async def receive(self):
+            raise AssertionError("receive should not be used")
+
+        async def close(self) -> None:
+            pass
+
+        def response_header(self, name: str) -> str | None:
+            del name
+            return None
+
+        def set_archive_request_id(self, request_id: str | None) -> None:
+            raise AssertionError(f"mutable archive id should not be used for {request_id}")
+
+    upstream = cast(proxy_service.UpstreamResponsesWebSocket, ArchiveAwareUpstream())
+
+    await proxy_service._send_upstream_websocket_text(upstream, "first", "req_1")
+    await proxy_service._send_upstream_websocket_text(upstream, "second", "req_2")
+
+    assert calls == [("first", "req_1"), ("second", "req_2")]
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_archives_non_terminal_event(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_archive")
+    archive_calls = []
+    finalize_request_state = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "archive_text", lambda **kwargs: archive_calls.append(kwargs))
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="req_ws_transport",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_log_id="req_ws_log",
+        awaiting_response_created=True,
+    )
+    payload = {"type": "response.created", "response": {"id": "resp_ws_archive"}}
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=deque([pending_request]),
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert downstream_text == json.dumps(payload, separators=(",", ":"))
+    finalize_request_state.assert_not_awaited()
+    assert archive_calls[-1]["request_id"] == "req_ws_log"
+    assert archive_calls[-1]["extra"] == {"frame_type": "text", "response_id": "resp_ws_archive"}
+
+
+@pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_archives_inbound_event(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    archive_calls = []
+
+    monkeypatch.setattr(proxy_service, "archive_text", lambda **kwargs: archive_calls.append(kwargs))
+
+    event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_transport",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_log_id="req_bridge_log",
+        awaiting_response_created=True,
+        event_queue=event_queue,
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_archive"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    payload = {"type": "response.created", "response": {"id": "resp_bridge_archive"}}
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(payload, separators=(",", ":")),
+    )
+
+    assert await asyncio.wait_for(event_queue.get(), timeout=0.1) == (
+        'data: {"type":"response.created","response":{"id":"resp_bridge_archive"}}\n\n'
+    )
+    assert archive_calls[-1]["request_id"] == "req_bridge_log"
+    assert archive_calls[-1]["transport"] == "http"
+    assert archive_calls[-1]["extra"] == {"frame_type": "text", "response_id": "resp_bridge_archive"}
+
+
+@pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_archives_grouped_previous_response_errors(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    archive_calls = []
+    finalize_request_state = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "archive_text", lambda **kwargs: archive_calls.append(kwargs))
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+
+    request_a_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    request_b_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    request_a = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_grouped_a",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor",
+        request_log_id="req_bridge_grouped_log_a",
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor"}',
+        event_queue=request_a_queue,
+        transport="http",
+    )
+    request_b = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_grouped_b",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor",
+        request_log_id="req_bridge_grouped_log_b",
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor"}',
+        event_queue=request_b_queue,
+        transport="http",
+    )
+    account = _make_account("acc_bridge_grouped_archive")
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_a, request_b]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(2),
+        queued_request_count=2,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "previous_response_not_found",
+            "message": "Previous response with id 'resp_anchor' not found.",
+            "param": "previous_response_id",
+        },
+    }
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(payload, separators=(",", ":")),
+    )
+
+    assert [call["request_id"] for call in archive_calls[-2:]] == [
+        "req_bridge_grouped_log_a",
+        "req_bridge_grouped_log_b",
+    ]
+    assert {call["transport"] for call in archive_calls[-2:]} == {"http"}
+    assert all(call["account_id"] == account.id for call in archive_calls[-2:])
+    assert await asyncio.wait_for(request_a_queue.get(), timeout=0.1) is not None
+    assert await asyncio.wait_for(request_a_queue.get(), timeout=0.1) is None
+    assert await asyncio.wait_for(request_b_queue.get(), timeout=0.1) is not None
+    assert await asyncio.wait_for(request_b_queue.get(), timeout=0.1) is None
+    assert finalize_request_state.await_count == 2
+    assert session.upstream_control.reconnect_requested is True
+    assert list(session.pending_requests) == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -53,6 +53,7 @@ class _FakeConnection:
 async def test_connect_responses_websocket_uses_websockets_transport(monkeypatch):
     fake_connection = _FakeConnection()
     seen: dict[str, object] = {}
+    archived: list[dict[str, object]] = []
 
     async def fake_websocket_connect(url: str, **kwargs):
         seen["url"] = url
@@ -61,6 +62,7 @@ async def test_connect_responses_websocket_uses_websockets_transport(monkeypatch
 
     monkeypatch.setattr(proxy_websocket_module, "get_http_client", lambda: _UnexpectedHttpClient(), raising=False)
     monkeypatch.setattr(proxy_websocket_module, "websocket_connect", fake_websocket_connect, raising=False)
+    monkeypatch.setattr(proxy_websocket_module, "archive_text", lambda **kwargs: archived.append(kwargs))
     monkeypatch.setattr(
         proxy_websocket_module,
         "get_settings",
@@ -84,9 +86,11 @@ async def test_connect_responses_websocket_uses_websockets_transport(monkeypatch
         "account-123",
     )
 
-    await websocket.send_text("hello")
+    await websocket.send_text_with_archive_request_id("hello", request_id="req_log_1")
+    await websocket.receive()
 
     assert fake_connection.sent == ["hello"]
+    assert [record["request_id"] for record in archived] == ["req_log_1"]
     assert seen["url"] == "wss://chatgpt.com/backend-api/codex/responses"
     kwargs = cast(dict[str, object], seen["kwargs"])
     assert kwargs["origin"] == "https://chatgpt.com"

--- a/tests/unit/test_request_logs_repository.py
+++ b/tests/unit/test_request_logs_repository.py
@@ -7,11 +7,12 @@ import pytest
 from sqlalchemy.exc import ResourceClosedError
 
 from app.db.session import SessionLocal
+from app.modules.request_logs.mappers import to_request_log_entry
 from app.modules.request_logs.repository import RequestLogsRepository
 
 
 @pytest.mark.asyncio
-async def test_add_log_ignores_closed_transaction(monkeypatch) -> None:
+async def test_add_log_ignores_closed_transaction(monkeypatch, db_setup) -> None:
     async with SessionLocal() as session:
         repo = RequestLogsRepository(session)
 
@@ -37,6 +38,35 @@ async def test_add_log_ignores_closed_transaction(monkeypatch) -> None:
 
         assert log.request_id == "req"
         assert log.cost_usd is not None
+
+
+@pytest.mark.asyncio
+async def test_add_log_persists_response_create_slim_summary(db_setup) -> None:
+    async with SessionLocal() as session:
+        repo = RequestLogsRepository(session)
+
+        log = await repo.add_log(
+            account_id=None,
+            request_id="req_slim",
+            model="gpt-5.2",
+            input_tokens=1000,
+            output_tokens=500,
+            latency_ms=1,
+            status="success",
+            error_code=None,
+            slim_summary={
+                "historical_tool_outputs_slimmed": 2,
+                "historical_images_slimmed": 1,
+                "unrelated_counter": 99,
+            },
+        )
+
+        assert log.slim_summary_json == '{"historical_images_slimmed":1,"historical_tool_outputs_slimmed":2}'
+        entry = to_request_log_entry(log)
+        assert entry.slim_summary == {
+            "historical_tool_outputs_slimmed": 2,
+            "historical_images_slimmed": 1,
+        }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add opt-in gzip JSONL archive for upstream Codex request/response, compact, SSE, and websocket traffic
- redact credential-bearing and token-like headers while keeping payloads available for audit/export
- write gzip records via a bounded background writer; if the queue saturates, apply synchronous write backpressure instead of growing memory without limit
- store archive output in hourly `YYYY-MM-DDTHH.jsonl.gz` files to limit live blast radius and keep recovery/scans bounded
- append each record as a complete gzip member and recover a readable prefix from a corrupt tail once per active file before appending
- treat `ENOSPC`, disk quota, and sqlite-style disk-full failures as archive disk pressure: pause archive writes briefly, drop archive records during the pause, and emit a rate-limited warning without traceback spam
- preserve non-ASCII payload text as readable UTF-8 in JSONL, not Unicode escape soup
- read archives through a threadpool so archive scans do not block the request event loop
- expose archived payloads inside the existing Dashboard request log detail flow, keyed by exact request id across gzip and legacy JSONL archive files

## Review notes
- this PR is a single clean commit on top of upstream main; neighboring PRs #516/#517 are only included in local custom runtime images, not in this PR diff
- the request detail archive query does not poll; it loads when the details dialog asks for a request id
- the writer queue is bounded at 4096 records; under sustained disk stalls the proxy backpressures on synchronous archive writes rather than leaking memory or silently dropping records
- gzip readability/recovery is intentionally not re-run before every append; it is checked once per process/file to avoid repeatedly scanning a hot archive during live traffic
- when the filesystem is full, archive writes pause for a cooldown instead of repeatedly queueing work and logging tracebacks; after the cooldown the next archive write retries normally

## Verification
- `/home/kom/proj/codex-lb/.venv/bin/python -m pytest tests/unit/test_conversation_archive.py -q` (`14 passed`)
- `/home/kom/proj/codex-lb/.venv/bin/ruff check app/core/conversation_archive.py tests/unit/test_conversation_archive.py`
- `/home/kom/proj/codex-lb/.venv/bin/ruff format --check app/core/conversation_archive.py tests/unit/test_conversation_archive.py`
- `git diff --check`
- combined release tree with #516/#517/#519: `/home/kom/proj/codex-lb/.venv/bin/python -m pytest tests/unit/test_conversation_archive.py tests/unit/test_proxy_api_websocket_auth.py tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_rebinds_after_upstream_previous_response_not_found tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_masks_anonymous_previous_response_not_found_with_inflight_request -q` (`27 passed`)
- combined release tree: ruff check/format and `git diff --check` on touched backend/proxy test files
- `npx --yes @fission-ai/openspec validate --specs` (`19 passed`)
- Docker image build: `codex-lb:release-diskpressure-46789ab`
- staging smoke on ports `11455/12455`: stable `/health`, hourly archive write smoke, and simulated `ENOSPC` disk-pressure pause smoke
- live smoke after deploy: stable `/health`, hourly archive write smoke, and simulated `ENOSPC` disk-pressure pause smoke
- previous broader PR verification: `.venv/bin/python -m ty check app/core/conversation_archive.py app/modules/conversation_archive tests/unit/test_conversation_archive.py`; `bun run test -- src/features/conversation-archive/schemas.test.ts src/features/dashboard/components/recent-requests-table.test.tsx`; `bun run typecheck`; `bun run lint -- src/features/conversation-archive src/features/dashboard/components/recent-requests-table.tsx` (passes with pre-existing warnings in account-multi-select.tsx); `bun run build`

## Related issues
- Supports diagnosis and audit for #285, #530, and #550 style proxy continuity incidents.
