### PR TITLE
fix(model-registry): populate bootstrap models to prevent missing metadata on startup

### DIFF
--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -50,6 +50,117 @@ class ModelRegistrySnapshot:
 
 _BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = ("gpt-5.5", "gpt-5.5-*", "gpt-5.4", "gpt-5.4-*")
 
+_REASONING_LEVELS_STANDARD = (
+    ReasoningLevel(effort="low", description="Low reasoning effort"),
+    ReasoningLevel(effort="medium", description="Medium reasoning effort"),
+    ReasoningLevel(effort="high", description="High reasoning effort"),
+)
+
+_REASONING_LEVELS_EXTENDED = (
+    ReasoningLevel(effort="low", description="Low reasoning effort"),
+    ReasoningLevel(effort="medium", description="Medium reasoning effort"),
+    ReasoningLevel(effort="high", description="High reasoning effort"),
+    ReasoningLevel(effort="xhigh", description="Extra high reasoning effort"),
+)
+
+# Static fallback models used before the first upstream registry refresh.
+# These ensure /models and /backend-api/codex/models return known slugs
+# immediately on startup (e.g. before any account is added or the first
+# refresh completes). Values are conservative best-effort approximations;
+# the live upstream data always takes precedence once available.
+_BOOTSTRAP_STATIC_MODELS: tuple[UpstreamModel, ...] = (
+    UpstreamModel(
+        slug="gpt-5.5",
+        display_name="GPT-5.5",
+        description="GPT-5.5",
+        context_window=1_050_000,
+        input_modalities=("text",),
+        supported_reasoning_levels=_REASONING_LEVELS_EXTENDED,
+        default_reasoning_level="high",
+        supports_reasoning_summaries=True,
+        support_verbosity=False,
+        default_verbosity=None,
+        prefer_websockets=True,
+        supports_parallel_tool_calls=False,
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"plus", "pro", "team", "business", "enterprise"}),
+    ),
+    UpstreamModel(
+        slug="gpt-5.5-pro",
+        display_name="GPT-5.5 Pro",
+        description="GPT-5.5 Pro",
+        context_window=1_050_000,
+        input_modalities=("text",),
+        supported_reasoning_levels=_REASONING_LEVELS_EXTENDED,
+        default_reasoning_level="high",
+        supports_reasoning_summaries=True,
+        support_verbosity=False,
+        default_verbosity=None,
+        prefer_websockets=True,
+        supports_parallel_tool_calls=False,
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"pro", "enterprise"}),
+    ),
+    UpstreamModel(
+        slug="gpt-5.4",
+        display_name="GPT-5.4",
+        description="GPT-5.4",
+        context_window=1_050_000,
+        input_modalities=("text",),
+        supported_reasoning_levels=_REASONING_LEVELS_EXTENDED,
+        default_reasoning_level="high",
+        supports_reasoning_summaries=True,
+        support_verbosity=False,
+        default_verbosity=None,
+        prefer_websockets=True,
+        supports_parallel_tool_calls=False,
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"plus", "pro", "team", "business", "enterprise"}),
+    ),
+    UpstreamModel(
+        slug="gpt-5.4-mini",
+        display_name="GPT-5.4 Mini",
+        description="GPT-5.4 Mini",
+        context_window=400_000,
+        input_modalities=("text",),
+        supported_reasoning_levels=_REASONING_LEVELS_STANDARD,
+        default_reasoning_level="medium",
+        supports_reasoning_summaries=True,
+        support_verbosity=False,
+        default_verbosity=None,
+        prefer_websockets=False,
+        supports_parallel_tool_calls=False,
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"free", "plus", "pro", "team", "business", "enterprise"}),
+    ),
+    UpstreamModel(
+        slug="gpt-5.3-codex",
+        display_name="GPT-5.3 Codex",
+        description="GPT-5.3 Codex",
+        context_window=272_000,
+        input_modalities=("text",),
+        supported_reasoning_levels=_REASONING_LEVELS_EXTENDED,
+        default_reasoning_level="high",
+        supports_reasoning_summaries=True,
+        support_verbosity=False,
+        default_verbosity=None,
+        prefer_websockets=True,
+        supports_parallel_tool_calls=False,
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"plus", "pro", "team", "business", "enterprise"}),
+    ),
+)
+
 
 class ModelRegistry:
     def __init__(self, *, ttl_seconds: float = 300.0) -> None:
@@ -57,7 +168,7 @@ class ModelRegistry:
             raise ValueError("ttl_seconds must be positive")
         self._ttl_seconds = ttl_seconds
         self._snapshot: ModelRegistrySnapshot | None = None
-        self._bootstrap_models: dict[str, UpstreamModel] = {}
+        self._bootstrap_models: dict[str, UpstreamModel] = {m.slug: m for m in _BOOTSTRAP_STATIC_MODELS}
         self._lock = anyio.Lock()
 
     def get_snapshot(self) -> ModelRegistrySnapshot | None:

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -69,14 +69,15 @@ async def test_v1_models_list(async_client):
 
 
 @pytest.mark.asyncio
-async def test_v1_models_empty_when_registry_not_populated(async_client):
+async def test_v1_models_uses_bootstrap_models_when_registry_not_populated(async_client):
     registry = get_model_registry()
     registry._snapshot = None
     resp = await async_client.get("/v1/models")
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["object"] == "list"
-    assert payload["data"] == []
+    ids = {item["id"] for item in payload["data"]}
+    assert {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"}.issubset(ids)
 
 
 @pytest.mark.asyncio
@@ -235,13 +236,14 @@ async def test_backend_codex_models_includes_supported_in_api_false_models(async
 
 
 @pytest.mark.asyncio
-async def test_backend_codex_models_empty_when_registry_not_populated(async_client):
+async def test_backend_codex_models_uses_bootstrap_models_when_registry_not_populated(async_client):
     registry = get_model_registry()
     registry._snapshot = None
     resp = await async_client.get("/backend-api/codex/models")
     assert resp.status_code == 200
     payload = resp.json()
-    assert payload["models"] == []
+    slugs = {item["slug"] for item in payload["models"]}
+    assert {"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex"}.issubset(slugs)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Problem

Fixes #480

On startup — before the first upstream model refresh completes — `ModelRegistry._bootstrap_models` was an empty dict `{}`. This caused `GET /models` and `GET /backend-api/codex/models` to return empty lists, making Codex CLI log:

> Model metadata for gpt-5.5 not found. Defaulting to fallback metadata; this can degrade performance and cause issues.

This affects:
- Fresh installs before any account is added
- Server restarts during the ~60s window before the first refresh cycle
- Accounts that temporarily fail token refresh

 Root Cause:

`_bootstrap_models` existed as a fallback path in `get_models_with_fallback()` but was never populated:

```python
# Before
self._bootstrap_models: dict[str, UpstreamModel] = {}

Fix:
Added _BOOTSTRAP_STATIC_MODELS with conservative static entries for the 5 most commonly used models. The registry now initializes from these instead of an empty dict.

# After
self._bootstrap_models: dict[str, UpstreamModel] = {m.slug: m for m in _BOOTSTRAP_STATIC_MODELS}
Models added: gpt-5.5, gpt-5.5-pro, gpt-5.4, gpt-5.4-mini, gpt-5.3-codex
