### PR TITLE
fix(status): add auto heal for rate-limit/ quota exceed status after reset in the ui

### DIFF
--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -8,9 +8,11 @@ from dataclasses import dataclass, field
 from typing import Protocol, cast
 
 from app.core.config.settings import get_settings
+from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.proxy.account_cache import get_account_selection_cache
+from app.modules.proxy.load_balancer import background_recovery_state_from_account
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.usage import updater as usage_updater_module
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
@@ -18,9 +20,31 @@ from app.modules.usage.updater import UsageUpdater
 
 logger = logging.getLogger(__name__)
 
+_RECOVERABLE_ACCOUNT_STATUSES = frozenset({AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED})
+
 
 class _LeaderElectionLike(Protocol):
     async def try_acquire(self) -> bool: ...
+
+
+class _RecoverableAccountsRepository(Protocol):
+    async def update_status_if_current(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None | object = None,
+        *,
+        expected_status: AccountStatus,
+        expected_deactivation_reason: str | None = None,
+        expected_reset_at: int | None = None,
+        expected_blocked_at: int | None | object = None,
+    ) -> bool: ...
+
+
+class _LatestUsageRepository(Protocol):
+    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]: ...
 
 
 def _get_leader_election() -> _LeaderElectionLike:
@@ -74,6 +98,12 @@ class UsageRefreshScheduler:
                     accounts = await accounts_repo.list_accounts()
                     updater = UsageUpdater(usage_repo, accounts_repo, additional_usage_repo)
                     await updater.refresh_accounts(accounts, latest_usage)
+                    refreshed_accounts = await accounts_repo.list_accounts()
+                    await reconcile_recoverable_account_statuses(
+                        accounts_repo=accounts_repo,
+                        usage_repo=usage_repo,
+                        accounts=refreshed_accounts,
+                    )
                     await get_rate_limit_headers_cache().invalidate()
                     get_account_selection_cache().invalidate()
             except Exception:
@@ -86,3 +116,55 @@ def build_usage_refresh_scheduler() -> UsageRefreshScheduler:
         interval_seconds=settings.usage_refresh_interval_seconds,
         enabled=settings.usage_refresh_enabled,
     )
+
+
+async def reconcile_recoverable_account_statuses(
+    *,
+    accounts_repo: _RecoverableAccountsRepository,
+    usage_repo: _LatestUsageRepository,
+    accounts: list[Account],
+) -> int:
+    candidates = [account for account in accounts if account.status in _RECOVERABLE_ACCOUNT_STATUSES]
+    if not candidates:
+        return 0
+
+    latest_primary = await usage_repo.latest_by_account(window="primary")
+    latest_secondary = await usage_repo.latest_by_account(window="secondary")
+
+    recovered = 0
+    for account in candidates:
+        state = background_recovery_state_from_account(
+            account=account,
+            primary_entry=latest_primary.get(account.id),
+            secondary_entry=latest_secondary.get(account.id),
+        )
+        if state.status != AccountStatus.ACTIVE:
+            continue
+        reset_at = int(state.reset_at) if state.reset_at else None
+        blocked_at = int(state.blocked_at) if state.blocked_at else None
+        if (
+            state.status == account.status
+            and state.deactivation_reason == account.deactivation_reason
+            and reset_at == account.reset_at
+            and blocked_at == account.blocked_at
+        ):
+            continue
+        updated = await accounts_repo.update_status_if_current(
+            account.id,
+            state.status,
+            state.deactivation_reason,
+            reset_at,
+            blocked_at=blocked_at,
+            expected_status=account.status,
+            expected_deactivation_reason=account.deactivation_reason,
+            expected_reset_at=account.reset_at,
+            expected_blocked_at=account.blocked_at,
+        )
+        if not updated:
+            continue
+        account.status = state.status
+        account.deactivation_reason = state.deactivation_reason
+        account.reset_at = reset_at
+        account.blocked_at = blocked_at
+        recovered += 1
+    return recovered

--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -8,9 +8,11 @@ from dataclasses import dataclass, field
 from typing import Protocol, cast
 
 from app.core.config.settings import get_settings
+from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.proxy.account_cache import get_account_selection_cache
+from app.modules.proxy.load_balancer import background_recovery_state_from_account
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.usage import updater as usage_updater_module
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
@@ -18,9 +20,31 @@ from app.modules.usage.updater import UsageUpdater
 
 logger = logging.getLogger(__name__)
 
+_RECOVERABLE_ACCOUNT_STATUSES = frozenset({AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED})
+
 
 class _LeaderElectionLike(Protocol):
     async def try_acquire(self) -> bool: ...
+
+
+class _RecoverableAccountsRepository(Protocol):
+    async def update_status_if_current(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None | object = None,
+        *,
+        expected_status: AccountStatus,
+        expected_deactivation_reason: str | None = None,
+        expected_reset_at: int | None = None,
+        expected_blocked_at: int | None | object = None,
+    ) -> bool: ...
+
+
+class _LatestUsageRepository(Protocol):
+    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]: ...
 
 
 def _get_leader_election() -> _LeaderElectionLike:
@@ -74,6 +98,12 @@ class UsageRefreshScheduler:
                     accounts = await accounts_repo.list_accounts()
                     updater = UsageUpdater(usage_repo, accounts_repo, additional_usage_repo)
                     await updater.refresh_accounts(accounts, latest_usage)
+                    refreshed_accounts = await accounts_repo.list_accounts()
+                    await reconcile_recoverable_account_statuses(
+                        accounts_repo=accounts_repo,
+                        usage_repo=usage_repo,
+                        accounts=refreshed_accounts,
+                    )
                     await get_rate_limit_headers_cache().invalidate()
                     get_account_selection_cache().invalidate()
             except Exception:
@@ -86,3 +116,48 @@ def build_usage_refresh_scheduler() -> UsageRefreshScheduler:
         interval_seconds=settings.usage_refresh_interval_seconds,
         enabled=settings.usage_refresh_enabled,
     )
+
+
+async def reconcile_recoverable_account_statuses(
+    *,
+    accounts_repo: _RecoverableAccountsRepository,
+    usage_repo: _LatestUsageRepository,
+    accounts: list[Account],
+) -> int:
+    candidates = [account for account in accounts if account.status in _RECOVERABLE_ACCOUNT_STATUSES]
+    if not candidates:
+        return 0
+
+    latest_primary, latest_secondary = await asyncio.gather(
+        usage_repo.latest_by_account(window="primary"),
+        usage_repo.latest_by_account(window="secondary"),
+    )
+
+    recovered = 0
+    for account in candidates:
+        state = background_recovery_state_from_account(
+            account=account,
+            primary_entry=latest_primary.get(account.id),
+            secondary_entry=latest_secondary.get(account.id),
+        )
+        if state.status != AccountStatus.ACTIVE:
+            continue
+        updated = await accounts_repo.update_status_if_current(
+            account.id,
+            AccountStatus.ACTIVE,
+            None,
+            None,
+            blocked_at=None,
+            expected_status=account.status,
+            expected_deactivation_reason=account.deactivation_reason,
+            expected_reset_at=account.reset_at,
+            expected_blocked_at=account.blocked_at,
+        )
+        if not updated:
+            continue
+        account.status = AccountStatus.ACTIVE
+        account.deactivation_reason = None
+        account.reset_at = None
+        account.blocked_at = None
+        recovered += 1
+    return recovered

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -144,10 +144,7 @@ def _effective_status_from_usage(
         secondary_used=secondary_used_percent,
         secondary_reset=secondary_usage.reset_at if secondary_usage is not None else None,
     )
-    if (
-        account.status in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED)
-        and status == AccountStatus.ACTIVE
-    ):
+    if account.status in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED) and status == AccountStatus.ACTIVE:
         return account.status
     return status
 

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -144,6 +144,11 @@ def _effective_status_from_usage(
         secondary_used=secondary_used_percent,
         secondary_reset=secondary_usage.reset_at if secondary_usage is not None else None,
     )
+    if (
+        account.status in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED)
+        and status == AccountStatus.ACTIVE
+    ):
+        return account.status
     return status
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1149,6 +1149,32 @@ def _state_from_account(
     )
 
 
+def background_recovery_state_from_account(
+    *,
+    account: Account,
+    primary_entry: UsageHistory | None,
+    secondary_entry: UsageHistory | None,
+) -> AccountState:
+    """Evaluate recovery for a persisted blocked account without live runtime state.
+
+    The usage refresh scheduler only needs to know whether a persisted blocked
+    account can safely return to `active`. Seed a throwaway runtime snapshot
+    from the persisted block marker so fresh post-block usage rows can clear a
+    stale reset guard even when the original balancer process is gone.
+    """
+
+    runtime = RuntimeState()
+    if account.blocked_at is not None:
+        runtime.blocked_at = float(account.blocked_at)
+        runtime.cooldown_until = float(account.blocked_at)
+    return _state_from_account(
+        account=account,
+        primary_entry=primary_entry,
+        secondary_entry=secondary_entry,
+        runtime=runtime,
+    )
+
+
 def _usage_entry_is_recent_enough(recorded_at: datetime | None) -> bool:
     if recorded_at is None:
         return False

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1102,9 +1102,12 @@ def _state_from_account(
         secondary_reset=secondary_reset,
     )
 
-    next_blocked_at = (
-        effective_blocked_at if status in (AccountStatus.QUOTA_EXCEEDED, AccountStatus.RATE_LIMITED) else None
-    )
+    if status == AccountStatus.QUOTA_EXCEEDED:
+        next_blocked_at = effective_blocked_at
+    elif status == AccountStatus.RATE_LIMITED and account.status != AccountStatus.QUOTA_EXCEEDED:
+        next_blocked_at = effective_blocked_at
+    else:
+        next_blocked_at = None
 
     settings = get_settings()
     if getattr(settings, "soft_drain_enabled", True):
@@ -1158,6 +1161,70 @@ def _state_from_account(
         capacity_credits=usage_core.capacity_for_plan(account.plan_type, "secondary"),
         health_tier=new_tier,
     )
+
+
+def background_recovery_state_from_account(
+    *,
+    account: Account,
+    primary_entry: UsageHistory | None,
+    secondary_entry: UsageHistory | None,
+) -> AccountState:
+    """Evaluate recovery for a persisted blocked account without live runtime state.
+
+    The usage refresh scheduler only needs to know whether a persisted blocked
+    account can safely return to `active`. Seed a throwaway runtime snapshot
+    from the persisted block marker so fresh post-block usage rows can clear a
+    stale reset guard even when the original balancer process is gone.
+    """
+
+    runtime = RuntimeState()
+    blocked_at = float(account.blocked_at) if account.blocked_at is not None else None
+    reset_at = float(account.reset_at) if account.reset_at is not None else None
+
+    if blocked_at is not None:
+        runtime.blocked_at = blocked_at
+
+    if account.status == AccountStatus.RATE_LIMITED and blocked_at is not None:
+        if reset_at is not None:
+            runtime.cooldown_until = reset_at
+    state = _state_from_account(
+        account=account,
+        primary_entry=primary_entry,
+        secondary_entry=secondary_entry,
+        runtime=runtime,
+    )
+    if (
+        account.status == AccountStatus.RATE_LIMITED
+        and blocked_at is not None
+        and reset_at is not None
+        and reset_at <= time.time()
+        and not _usage_entry_recorded_after_block(primary_entry, blocked_at)
+    ):
+        return replace(
+            state,
+            status=AccountStatus.RATE_LIMITED,
+            reset_at=reset_at,
+            blocked_at=blocked_at,
+            cooldown_until=reset_at,
+        )
+    if account.status == AccountStatus.RATE_LIMITED and reset_at is None:
+        return replace(
+            state,
+            status=AccountStatus.RATE_LIMITED,
+            reset_at=None,
+            blocked_at=blocked_at,
+            cooldown_until=None,
+        )
+    return state
+
+
+def _usage_entry_recorded_after_block(entry: UsageHistory | None, blocked_at: float) -> bool:
+    if entry is None or entry.recorded_at is None:
+        return False
+    recorded_at = entry.recorded_at
+    if recorded_at.tzinfo is None:
+        recorded_at = recorded_at.replace(tzinfo=timezone.utc)
+    return recorded_at.timestamp() > blocked_at
 
 
 def _usage_entry_is_recent_enough(recorded_at: datetime | None) -> bool:

--- a/openspec/changes/reconcile-background-account-status/.openspec.yaml
+++ b/openspec/changes/reconcile-background-account-status/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/reconcile-background-account-status/design.md
+++ b/openspec/changes/reconcile-background-account-status/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The request path already knows how to derive effective account state from persisted account rows plus the latest usage snapshots. That logic lives in `_state_from_account()` in the load balancer. The bug is that persisted account status is only corrected when request-path selection runs, while the background usage scheduler only refreshes usage rows and invalidates caches.
+
+The change needs to stay narrow: only recover already-blocked accounts, never make fresh blocking decisions in the scheduler, and avoid load-balancer runtime side effects. The exact stuck case includes `rate_limited` rows whose persisted `reset_at` remains in the future even though a fresh primary usage row recorded after the block event is already below 100%.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reconcile persisted `rate_limited` and `quota_exceeded` accounts back to `active` after background usage refresh writes fresh recovery data.
+- Reuse existing account-state derivation rules instead of inventing a second status model.
+- Keep scheduler writes limited to persisted account recovery fields: `status`, `reset_at`, `blocked_at`, and `deactivation_reason`.
+- Cover both a unit-level scheduler reconciliation path and a SQLite-backed stale-status reproduction.
+
+**Non-Goals:**
+- Do not let the scheduler promote `active` accounts into `rate_limited` or `quota_exceeded`.
+- Do not change request-path selection, sticky-session routing, or dashboard payload shape.
+- Do not add new persisted cooldown columns or new background jobs.
+
+## Decisions
+
+### Reuse load-balancer state derivation from the scheduler
+
+Add a small helper in `app/modules/proxy/load_balancer.py` that evaluates recoverable background state for one persisted account using `_state_from_account()` and a synthetic runtime snapshot derived only from persisted markers. This keeps the scheduler aligned with existing quota semantics while isolating the background use case from live balancer runtime mutation.
+
+Alternative considered: implement a second pure reconciliation function in the scheduler. Rejected because it would duplicate the nuanced weekly/primary-secondary usage normalization already handled in the load balancer.
+
+### Seed a synthetic expired cooldown for background-only recovery evaluation
+
+For scheduler evaluation, create a throwaway `RuntimeState` whose `blocked_at` mirrors persisted `accounts.blocked_at` and whose `cooldown_until` is treated as already expired when a persisted block marker exists. This lets `_state_from_account()` clear a stale `rate_limited` reset guard when a fresh post-block primary usage row proves recovery, without depending on live process memory.
+
+Alternative considered: require the real runtime cooldown to exist. Rejected because the scheduler has no access to another process's in-memory balancer state and would not fix the stuck persisted row.
+
+### Persist only recovery transitions
+
+The scheduler MUST only write when a currently blocked account evaluates to `active`. On recovery, persist `status=active`, `reset_at=NULL`, `blocked_at=NULL`, and `deactivation_reason=NULL` through `update_status_if_current()` so concurrent request-path state changes still win.
+
+Alternative considered: update only `status`. Rejected because leaving stale reset/block markers on an active row creates inconsistent persisted state.
+
+## Risks / Trade-offs
+
+- Synthetic cooldown expiry can recover a blocked account earlier than request-path retry backoff would have allowed. Mitigation: recovery still requires fresh post-block usage rows under 100%, so stale pre-block rows cannot trigger it.
+- Scheduler reconciliation and request-path persistence can race. Mitigation: use `update_status_if_current()` and skip writes when the stored row changed underneath the scheduler.
+- `_state_from_account()` remains a privateish load-balancer primitive. Mitigation: wrap scheduler reuse in a dedicated helper with a narrow contract instead of importing internal pieces into the scheduler.

--- a/openspec/changes/reconcile-background-account-status/design.md
+++ b/openspec/changes/reconcile-background-account-status/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The request path already knows how to derive effective account state from persisted account rows plus the latest usage snapshots. That logic lives in `_state_from_account()` in the load balancer. The bug is that persisted account status is only corrected when request-path selection runs, while the background usage scheduler only refreshes usage rows and invalidates caches.
+
+The change needs to stay narrow: only recover already-blocked accounts, never make fresh blocking decisions in the scheduler, and avoid load-balancer runtime side effects. The exact stuck case includes `rate_limited` rows whose persisted `reset_at` remains in the future even though a fresh primary usage row recorded after the block event is already below 100%.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reconcile persisted `rate_limited` and `quota_exceeded` accounts back to `active` after background usage refresh writes fresh recovery data.
+- Reuse existing account-state derivation rules instead of inventing a second status model.
+- Keep scheduler writes limited to persisted account recovery fields: `status`, `reset_at`, `blocked_at`, and `deactivation_reason`.
+- Cover both a unit-level scheduler reconciliation path and a SQLite-backed stale-status reproduction.
+
+**Non-Goals:**
+- Do not let the scheduler promote `active` accounts into `rate_limited` or `quota_exceeded`.
+- Do not change request-path selection, sticky-session routing, or dashboard payload shape.
+- Do not add new persisted cooldown columns or new background jobs.
+
+## Decisions
+
+### Reuse load-balancer state derivation from the scheduler
+
+Add a small helper in `app/modules/proxy/load_balancer.py` that evaluates recoverable background state for one persisted account using `_state_from_account()` and a synthetic runtime snapshot derived only from persisted markers. This keeps the scheduler aligned with existing quota semantics while isolating the background use case from live balancer runtime mutation.
+
+Alternative considered: implement a second pure reconciliation function in the scheduler. Rejected because it would duplicate the nuanced weekly/primary-secondary usage normalization already handled in the load balancer.
+
+### Seed the persisted cooldown deadline for background-only recovery evaluation
+
+For scheduler evaluation, create a throwaway `RuntimeState` whose `blocked_at` mirrors persisted `accounts.blocked_at`. For `rate_limited` accounts, seed `cooldown_until` from the persisted reset deadline (`accounts.reset_at`) instead of treating the cooldown as already expired. This keeps scheduler reconciliation aligned with the original retry window while still letting `_state_from_account()` recover the account once the persisted cooldown deadline has actually elapsed and a fresh post-block primary usage row proves recovery.
+
+If a `rate_limited` row has no persisted reset deadline, the scheduler must leave it blocked. The background path has no authoritative cooldown duration in that case, so it cannot safely clear the status without risking an early reactivation.
+
+Alternative considered: always synthesize an expired cooldown. Rejected because it can reactivate a still-cooling `rate_limited` account as soon as any fresh primary usage row arrives, causing premature retries and repeated `429` loops.
+
+### Persist only recovery transitions
+
+The scheduler MUST only write when a currently blocked account evaluates to `active`. On recovery, persist `status=active`, `reset_at=NULL`, `blocked_at=NULL`, and `deactivation_reason=NULL` through `update_status_if_current()` so concurrent request-path state changes still win.
+
+Alternative considered: update only `status`. Rejected because leaving stale reset/block markers on an active row creates inconsistent persisted state.
+
+## Risks / Trade-offs
+
+- Background recovery for `rate_limited` rows now depends on a persisted reset deadline. Trade-off: rows created without `reset_at` will remain blocked until a request-path runtime or operator clears them. Mitigation: this is safer than guessing a cooldown duration and prematurely reactivating a still-cooling account.
+- Scheduler reconciliation and request-path persistence can race. Mitigation: use `update_status_if_current()` and skip writes when the stored row changed underneath the scheduler.
+- `_state_from_account()` remains a privateish load-balancer primitive. Mitigation: wrap scheduler reuse in a dedicated helper with a narrow contract instead of importing internal pieces into the scheduler.

--- a/openspec/changes/reconcile-background-account-status/proposal.md
+++ b/openspec/changes/reconcile-background-account-status/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Accounts that have already recovered in persisted usage data can remain stuck in `rate_limited` or `quota_exceeded` until a later request happens to run request-path selection logic or an operator manually reactivates the account. That leaves the dashboard showing recovered 5h/7d usage alongside a stale blocked status.
+
+Background usage refresh already writes the authoritative usage snapshots that prove recovery. The same scheduler should reconcile recoverable account statuses back to `active` so persisted account state catches up without waiting for live traffic.
+
+## What Changes
+
+- Add a background account-status reconciliation step after each usage refresh cycle.
+- Limit reconciliation to accounts currently persisted as `rate_limited` or `quota_exceeded`.
+- Recover those accounts to `active` only when fresh persisted usage data proves the blocked window has recovered.
+- Clear persisted `reset_at` and `blocked_at` markers when background reconciliation restores an account to `active`.
+- Keep reconciliation recovery-only; it MUST NOT tighten `active` accounts into blocked statuses.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `usage-refresh-policy`: background usage refresh now reconciles recoverable blocked statuses back to `active` using fresh persisted usage snapshots.
+
+## Impact
+
+- Affects `app/core/usage/refresh_scheduler.py`, `app/modules/proxy/load_balancer.py`, and account repository write paths.
+- Affects persisted `accounts.status`, `accounts.reset_at`, and `accounts.blocked_at` maintenance.
+- Adds regression coverage for background recovery and stale dashboard/account-list status behavior.

--- a/openspec/changes/reconcile-background-account-status/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/reconcile-background-account-status/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Background usage refresh reconciles recoverable blocked statuses
+Background usage refresh SHALL reconcile persisted `rate_limited` and `quota_exceeded` accounts back to `active` after it writes fresh usage snapshots that prove the blocked window has recovered. This reconciliation SHALL be recovery-only and SHALL NOT promote `active` accounts into blocked statuses.
+
+#### Scenario: Scheduler recovers a stale rate-limited account from fresh primary usage
+- **WHEN** an account is persisted as `rate_limited`
+- **AND** a later background usage refresh writes a fresh primary usage row recorded after the persisted block marker
+- **AND** that primary usage row reports usage below `100%`
+- **THEN** the scheduler marks the account `active`
+- **AND** it clears persisted `reset_at` and `blocked_at`
+
+#### Scenario: Scheduler recovers a stale quota-exceeded account from fresh secondary usage
+- **WHEN** an account is persisted as `quota_exceeded`
+- **AND** a later background usage refresh writes a fresh secondary usage row that reports usage below `100%`
+- **THEN** the scheduler marks the account `active`
+- **AND** it clears persisted `reset_at` and `blocked_at`
+
+#### Scenario: Scheduler does not tighten active accounts into blocked statuses
+- **WHEN** background usage refresh evaluates an account currently persisted as `active`
+- **THEN** the scheduler does not change that account to `rate_limited` or `quota_exceeded`
+
+#### Scenario: Scheduler ignores stale pre-block recovery evidence
+- **WHEN** an account is persisted as `rate_limited`
+- **AND** the latest primary usage row was recorded before the persisted block marker
+- **THEN** the scheduler leaves the account blocked
+
+#### Scenario: Scheduler skips recovery when the account row changed concurrently
+- **WHEN** background usage refresh determines that a blocked account is recoverable
+- **AND** the persisted account status or reset markers change before the scheduler writes recovery
+- **THEN** the scheduler skips the stale recovery write

--- a/openspec/changes/reconcile-background-account-status/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/reconcile-background-account-status/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Background usage refresh reconciles recoverable blocked statuses
+Background usage refresh SHALL reconcile persisted `rate_limited` and `quota_exceeded` accounts back to `active` after it writes fresh usage snapshots that prove the blocked window has recovered. This reconciliation SHALL be recovery-only and SHALL NOT promote `active` accounts into blocked statuses.
+
+#### Scenario: Scheduler recovers a stale rate-limited account from fresh primary usage
+- **WHEN** an account is persisted as `rate_limited`
+- **AND** the persisted rate-limit reset deadline has already elapsed
+- **AND** a later background usage refresh writes a fresh primary usage row recorded after the persisted block marker
+- **AND** that primary usage row reports usage below `100%`
+- **THEN** the scheduler marks the account `active`
+- **AND** it clears persisted `reset_at` and `blocked_at`
+
+#### Scenario: Scheduler preserves an unexpired rate-limit cooldown
+- **WHEN** an account is persisted as `rate_limited`
+- **AND** its persisted rate-limit reset deadline is still in the future
+- **AND** a later background usage refresh writes a fresh primary usage row recorded after the persisted block marker
+- **AND** that primary usage row reports usage below `100%`
+- **THEN** the scheduler leaves the account `rate_limited`
+
+#### Scenario: Scheduler recovers a stale quota-exceeded account from fresh secondary usage
+- **WHEN** an account is persisted as `quota_exceeded`
+- **AND** a later background usage refresh writes a fresh secondary usage row that reports usage below `100%`
+- **THEN** the scheduler marks the account `active`
+- **AND** it clears persisted `reset_at` and `blocked_at`
+
+#### Scenario: Scheduler does not tighten active accounts into blocked statuses
+- **WHEN** background usage refresh evaluates an account currently persisted as `active`
+- **THEN** the scheduler does not change that account to `rate_limited` or `quota_exceeded`
+
+#### Scenario: Scheduler ignores stale pre-block recovery evidence
+- **WHEN** an account is persisted as `rate_limited`
+- **AND** the latest primary usage row was recorded before the persisted block marker
+- **THEN** the scheduler leaves the account blocked
+
+#### Scenario: Scheduler skips recovery when the account row changed concurrently
+- **WHEN** background usage refresh determines that a blocked account is recoverable
+- **AND** the persisted account status or reset markers change before the scheduler writes recovery
+- **THEN** the scheduler skips the stale recovery write

--- a/openspec/changes/reconcile-background-account-status/tasks.md
+++ b/openspec/changes/reconcile-background-account-status/tasks.md
@@ -1,0 +1,17 @@
+## 1. OpenSpec And Test Coverage
+
+- [ ] 1.1 Add the OpenSpec proposal, design, and usage-refresh-policy delta for background recovery reconciliation.
+- [ ] 1.2 Add a failing unit test that proves scheduler reconciliation restores a recoverable blocked account to `active` and leaves active accounts untouched.
+- [ ] 1.3 Add a failing SQLite-backed integration test that reproduces a persisted `rate_limited` account showing recovered usage while `/api/accounts` still returns the stale blocked status.
+
+## 2. Background Reconciliation Implementation
+
+- [ ] 2.1 Add a narrow load-balancer helper that evaluates background-recoverable account state from persisted account and usage rows without mutating live runtime state.
+- [ ] 2.2 Add a scheduler reconciliation step after usage refresh that re-reads latest usage snapshots, evaluates only `rate_limited` and `quota_exceeded` accounts, and persists only recovery transitions.
+- [ ] 2.3 Use optimistic persisted writes so scheduler recovery does not overwrite newer request-path status changes.
+
+## 3. Verification
+
+- [ ] 3.1 Update tests to green for scheduler recovery and stale-status reproduction.
+- [ ] 3.2 Run the repository checks touched by CI for this change.
+- [ ] 3.3 Review the final diff and address any findings before completion.

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -9,6 +9,7 @@ from sqlalchemy import update
 
 from app.core.auth import fallback_account_id, generate_unique_account_id
 from app.core.crypto import TokenEncryptor
+from app.core.usage.refresh_scheduler import reconcile_recoverable_account_statuses
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
@@ -543,3 +544,78 @@ async def test_accounts_list_prefers_newer_weekly_primary_over_stale_secondary(a
     assert account["windowMinutesPrimary"] is None
     assert account["windowMinutesSecondary"] == 10080
     assert account["resetAtSecondary"] == _iso_utc(weekly_reset)
+
+
+@pytest.mark.asyncio
+async def test_accounts_list_stale_rate_limited_status_recovers_after_background_reconcile(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    blocked_at = int(now - 130)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.utcnow",
+        lambda: datetime.fromtimestamp(now, tz=timezone.utc).replace(tzinfo=None),
+    )
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_stuck_status", "stuck@example.com"))
+        await session.execute(
+            update(Account)
+            .where(Account.id == "acc_stuck_status")
+            .values(
+                status=AccountStatus.RATE_LIMITED,
+                reset_at=future_reset,
+                blocked_at=blocked_at,
+                deactivation_reason=None,
+            )
+        )
+        await session.commit()
+
+        await usage_repo.add_entry(
+            "acc_stuck_status",
+            10.0,
+            window="primary",
+            reset_at=future_reset,
+            window_minutes=300,
+            recorded_at=datetime.fromtimestamp(now - 10, tz=timezone.utc).replace(tzinfo=None),
+        )
+        await usage_repo.add_entry(
+            "acc_stuck_status",
+            20.0,
+            window="secondary",
+            reset_at=int(now + 7200),
+            window_minutes=10080,
+            recorded_at=datetime.fromtimestamp(now - 10, tz=timezone.utc).replace(tzinfo=None),
+        )
+
+    stale = await async_client.get("/api/accounts")
+    assert stale.status_code == 200
+    stale_account = next(item for item in stale.json()["accounts"] if item["accountId"] == "acc_stuck_status")
+    assert stale_account["status"] == "rate_limited"
+    assert stale_account["usage"]["primaryRemainingPercent"] == pytest.approx(90.0)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        account = await accounts_repo.get_by_id("acc_stuck_status")
+        assert account is not None
+        recovered = await reconcile_recoverable_account_statuses(
+            accounts_repo=accounts_repo,
+            usage_repo=usage_repo,
+            accounts=[account],
+        )
+        assert recovered == 1
+
+    reconciled = await async_client.get("/api/accounts")
+    assert reconciled.status_code == 200
+    reconciled_account = next(item for item in reconciled.json()["accounts"] if item["accountId"] == "acc_stuck_status")
+    assert reconciled_account["status"] == "active"
+    assert reconciled_account["usage"]["primaryRemainingPercent"] == pytest.approx(90.0)

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -9,6 +9,7 @@ from sqlalchemy import select, update
 
 from app.core.auth import fallback_account_id, generate_unique_account_id
 from app.core.crypto import TokenEncryptor
+from app.core.usage.refresh_scheduler import reconcile_recoverable_account_statuses
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, RequestLog
 from app.db.session import SessionLocal
@@ -580,3 +581,78 @@ async def test_accounts_list_prefers_newer_weekly_primary_over_stale_secondary(a
     assert account["windowMinutesPrimary"] is None
     assert account["windowMinutesSecondary"] == 10080
     assert account["resetAtSecondary"] == _iso_utc(weekly_reset)
+
+
+@pytest.mark.asyncio
+async def test_accounts_list_stale_rate_limited_status_recovers_after_background_reconcile(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    now = 1_700_000_000.0
+    past_reset = int(now - 300)
+    blocked_at = int(now - 7200)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.utcnow",
+        lambda: datetime.fromtimestamp(now, tz=timezone.utc).replace(tzinfo=None),
+    )
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_stuck_status", "stuck@example.com"))
+        await session.execute(
+            update(Account)
+            .where(Account.id == "acc_stuck_status")
+            .values(
+                status=AccountStatus.RATE_LIMITED,
+                reset_at=past_reset,
+                blocked_at=blocked_at,
+                deactivation_reason=None,
+            )
+        )
+        await session.commit()
+
+        await usage_repo.add_entry(
+            "acc_stuck_status",
+            10.0,
+            window="primary",
+            reset_at=past_reset,
+            window_minutes=300,
+            recorded_at=datetime.fromtimestamp(now - 10, tz=timezone.utc).replace(tzinfo=None),
+        )
+        await usage_repo.add_entry(
+            "acc_stuck_status",
+            20.0,
+            window="secondary",
+            reset_at=int(now + 7200),
+            window_minutes=10080,
+            recorded_at=datetime.fromtimestamp(now - 10, tz=timezone.utc).replace(tzinfo=None),
+        )
+
+    stale = await async_client.get("/api/accounts")
+    assert stale.status_code == 200
+    stale_account = next(item for item in stale.json()["accounts"] if item["accountId"] == "acc_stuck_status")
+    assert stale_account["status"] == "rate_limited"
+    assert stale_account["usage"]["primaryRemainingPercent"] == pytest.approx(90.0)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        account = await accounts_repo.get_by_id("acc_stuck_status")
+        assert account is not None
+        recovered = await reconcile_recoverable_account_statuses(
+            accounts_repo=accounts_repo,
+            usage_repo=usage_repo,
+            accounts=[account],
+        )
+        assert recovered == 1
+
+    reconciled = await async_client.get("/api/accounts")
+    assert reconciled.status_code == 200
+    reconciled_account = next(item for item in reconciled.json()["accounts"] if item["accountId"] == "acc_stuck_status")
+    assert reconciled_account["status"] == "active"
+    assert reconciled_account["usage"]["primaryRemainingPercent"] == pytest.approx(90.0)

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -21,6 +21,7 @@ from app.modules.proxy.load_balancer import (
     _select_account_preferring_budget_safe,
     _state_above_sticky_budget_threshold,
     _state_from_account,
+    background_recovery_state_from_account,
 )
 
 pytestmark = pytest.mark.unit
@@ -828,6 +829,123 @@ def test_state_from_account_rate_limited_clears_with_fresh_primary(monkeypatch):
         runtime=runtime,
     )
     assert state.status == AccountStatus.ACTIVE
+
+
+def test_background_recovery_state_preserves_rate_limit_cooldown_when_reset_is_in_future(monkeypatch):
+    now = 1_700_000_000.0
+    blocked = now - 300.0
+    future_reset = int(now + 1500)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    account = _make_test_account(
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=future_reset,
+        blocked_at=int(blocked),
+    )
+    fresh_primary = _make_test_usage(
+        window="primary",
+        used_percent=10.0,
+        reset_at=future_reset,
+        recorded_at=_epoch_to_naive_utc(now - 10),
+    )
+
+    state = background_recovery_state_from_account(
+        account=account,
+        primary_entry=fresh_primary,
+        secondary_entry=None,
+    )
+
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.cooldown_until == pytest.approx(future_reset)
+
+
+def test_background_recovery_state_recovers_rate_limited_after_reset_elapses(monkeypatch):
+    now = 1_700_000_000.0
+    blocked = now - 7200.0
+    past_reset = int(now - 300)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    account = _make_test_account(
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=past_reset,
+        blocked_at=int(blocked),
+    )
+    fresh_primary = _make_test_usage(
+        window="primary",
+        used_percent=10.0,
+        reset_at=past_reset,
+        recorded_at=_epoch_to_naive_utc(now - 10),
+    )
+
+    state = background_recovery_state_from_account(
+        account=account,
+        primary_entry=fresh_primary,
+        secondary_entry=None,
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+
+
+def test_background_recovery_state_keeps_rate_limited_when_primary_predates_block(monkeypatch):
+    now = 1_700_000_000.0
+    blocked = now - 7200.0
+    past_reset = int(now - 300)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    account = _make_test_account(
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=past_reset,
+        blocked_at=int(blocked),
+    )
+    stale_primary = _make_test_usage(
+        window="primary",
+        used_percent=10.0,
+        reset_at=past_reset,
+        recorded_at=_epoch_to_naive_utc(blocked - 30),
+    )
+
+    state = background_recovery_state_from_account(
+        account=account,
+        primary_entry=stale_primary,
+        secondary_entry=None,
+    )
+
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.reset_at == pytest.approx(past_reset)
+    assert state.blocked_at == pytest.approx(blocked)
+    assert state.cooldown_until == pytest.approx(past_reset)
+
+
+def test_background_recovery_state_keeps_rate_limited_without_persisted_reset(monkeypatch):
+    now = 1_700_000_000.0
+    blocked = now - 7200.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    account = _make_test_account(
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=None,
+        blocked_at=int(blocked),
+    )
+    fresh_primary = _make_test_usage(
+        window="primary",
+        used_percent=10.0,
+        reset_at=int(now + 300),
+        recorded_at=_epoch_to_naive_utc(now - 10),
+    )
+
+    state = background_recovery_state_from_account(
+        account=account,
+        primary_entry=fresh_primary,
+        secondary_entry=None,
+    )
+
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.reset_at is None
+    assert state.blocked_at == pytest.approx(blocked)
 
 
 def test_state_from_account_uses_configured_drain_primary_threshold(monkeypatch):

--- a/tests/unit/test_request_locality.py
+++ b/tests/unit/test_request_locality.py
@@ -9,6 +9,15 @@ import app.core.request_locality as request_locality
 from app.core.request_locality import is_local_request
 
 
+@pytest.fixture(autouse=True)
+def _default_request_locality_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        request_locality,
+        "get_settings",
+        lambda: SimpleNamespace(firewall_trust_proxy_headers=False, firewall_trusted_proxy_cidrs=[]),
+    )
+
+
 def _request(*, client_host: str, host: str) -> Request:
     scope = {
         "type": "http",

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+from app.core.usage import refresh_scheduler as refresh_scheduler_module
+from app.db.models import Account, AccountStatus, UsageHistory
+
+pytestmark = pytest.mark.unit
+
+_UNSET = object()
+
+
+def _make_account(
+    account_id: str,
+    *,
+    status: AccountStatus,
+    reset_at: int | None = None,
+    blocked_at: int | None = None,
+) -> Account:
+    return Account(
+        id=account_id,
+        chatgpt_account_id=f"workspace-{account_id}",
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"access",
+        refresh_token_encrypted=b"refresh",
+        id_token_encrypted=b"id",
+        last_refresh=datetime(2025, 1, 1),
+        status=status,
+        reset_at=reset_at,
+        blocked_at=blocked_at,
+        deactivation_reason=None,
+    )
+
+
+def _make_usage(
+    account_id: str,
+    *,
+    window: str,
+    used_percent: float,
+    reset_at: int,
+    recorded_at: datetime,
+    window_minutes: int,
+) -> UsageHistory:
+    return UsageHistory(
+        id=1,
+        account_id=account_id,
+        recorded_at=recorded_at,
+        window=window,
+        used_percent=used_percent,
+        reset_at=reset_at,
+        window_minutes=window_minutes,
+    )
+
+
+def _epoch_to_naive_utc(epoch: float) -> datetime:
+    return datetime.fromtimestamp(epoch, timezone.utc).replace(tzinfo=None)
+
+
+class StubAccountsRepository:
+    def __init__(self, accounts: list[Account]) -> None:
+        self._accounts = {account.id: account for account in accounts}
+        self.status_updates: list[dict[str, Any]] = []
+
+    async def update_status_if_current(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None | object = _UNSET,
+        *,
+        expected_status: AccountStatus,
+        expected_deactivation_reason: str | None = None,
+        expected_reset_at: int | None = None,
+        expected_blocked_at: int | None | object = _UNSET,
+    ) -> bool:
+        account = self._accounts.get(account_id)
+        if account is None:
+            return False
+        if account.status != expected_status or account.deactivation_reason != expected_deactivation_reason:
+            return False
+        if account.reset_at != expected_reset_at:
+            return False
+        if expected_blocked_at is not _UNSET and account.blocked_at != expected_blocked_at:
+            return False
+        account.status = status
+        account.deactivation_reason = deactivation_reason
+        account.reset_at = reset_at
+        if blocked_at is not _UNSET:
+            account.blocked_at = cast("int | None", blocked_at)
+        self.status_updates.append(
+            {
+                "account_id": account_id,
+                "status": status,
+                "deactivation_reason": deactivation_reason,
+                "reset_at": reset_at,
+                "blocked_at": blocked_at,
+            }
+        )
+        return True
+
+
+class StubUsageRepository:
+    def __init__(
+        self,
+        *,
+        primary: dict[str, UsageHistory] | None = None,
+        secondary: dict[str, UsageHistory] | None = None,
+    ) -> None:
+        self._primary = primary or {}
+        self._secondary = secondary or {}
+
+    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+        if window == "secondary":
+            return self._secondary
+        return self._primary
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_restores_rate_limited_from_fresh_primary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    blocked_at = int(now - 130)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_rate_limited",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=future_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=future_reset,
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=300,
+            )
+        },
+        secondary={
+            account.id: _make_usage(
+                account.id,
+                window="secondary",
+                used_percent=20.0,
+                reset_at=int(now + 7200),
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=10080,
+            )
+        },
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 1
+    assert account.status == AccountStatus.ACTIVE
+    assert account.reset_at is None
+    assert account.blocked_at is None
+    assert accounts_repo.status_updates == [
+        {
+            "account_id": account.id,
+            "status": AccountStatus.ACTIVE,
+            "deactivation_reason": None,
+            "reset_at": None,
+            "blocked_at": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_restores_quota_exceeded_from_fresh_secondary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    blocked_at = int(now - 130)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_quota_exceeded",
+        status=AccountStatus.QUOTA_EXCEEDED,
+        reset_at=future_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=5.0,
+                reset_at=int(now + 300),
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=300,
+            )
+        },
+        secondary={
+            account.id: _make_usage(
+                account.id,
+                window="secondary",
+                used_percent=10.0,
+                reset_at=future_reset,
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=10080,
+            )
+        },
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 1
+    assert account.status == AccountStatus.ACTIVE
+    assert account.reset_at is None
+    assert account.blocked_at is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_ignores_active_accounts() -> None:
+    account = _make_account("acc_active", status=AccountStatus.ACTIVE)
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository()
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert accounts_repo.status_updates == []
+    assert account.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_keeps_rate_limited_when_primary_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    blocked_at = int(now - 130)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_rate_limited_stale",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=future_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=future_reset,
+                recorded_at=_epoch_to_naive_utc(blocked_at - 30),
+                window_minutes=300,
+            )
+        }
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert accounts_repo.status_updates == []
+    assert account.status == AccountStatus.RATE_LIMITED

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -1,0 +1,480 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+from app.core.usage import refresh_scheduler as refresh_scheduler_module
+from app.db.models import Account, AccountStatus, UsageHistory
+
+pytestmark = pytest.mark.unit
+
+_UNSET = object()
+
+
+def _make_account(
+    account_id: str,
+    *,
+    status: AccountStatus,
+    reset_at: int | None = None,
+    blocked_at: int | None = None,
+) -> Account:
+    return Account(
+        id=account_id,
+        chatgpt_account_id=f"workspace-{account_id}",
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"access",
+        refresh_token_encrypted=b"refresh",
+        id_token_encrypted=b"id",
+        last_refresh=datetime(2025, 1, 1),
+        status=status,
+        reset_at=reset_at,
+        blocked_at=blocked_at,
+        deactivation_reason=None,
+    )
+
+
+def _make_usage(
+    account_id: str,
+    *,
+    window: str,
+    used_percent: float,
+    reset_at: int,
+    recorded_at: datetime,
+    window_minutes: int,
+) -> UsageHistory:
+    return UsageHistory(
+        id=1,
+        account_id=account_id,
+        recorded_at=recorded_at,
+        window=window,
+        used_percent=used_percent,
+        reset_at=reset_at,
+        window_minutes=window_minutes,
+    )
+
+
+def _epoch_to_naive_utc(epoch: float) -> datetime:
+    return datetime.fromtimestamp(epoch, timezone.utc).replace(tzinfo=None)
+
+
+class StubAccountsRepository:
+    def __init__(self, accounts: list[Account]) -> None:
+        self._accounts = {account.id: account for account in accounts}
+        self.status_updates: list[dict[str, Any]] = []
+
+    async def update_status_if_current(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None | object = _UNSET,
+        *,
+        expected_status: AccountStatus,
+        expected_deactivation_reason: str | None = None,
+        expected_reset_at: int | None = None,
+        expected_blocked_at: int | None | object = _UNSET,
+    ) -> bool:
+        account = self._accounts.get(account_id)
+        if account is None:
+            return False
+        if account.status != expected_status or account.deactivation_reason != expected_deactivation_reason:
+            return False
+        if account.reset_at != expected_reset_at:
+            return False
+        if expected_blocked_at is not _UNSET and account.blocked_at != expected_blocked_at:
+            return False
+        account.status = status
+        account.deactivation_reason = deactivation_reason
+        account.reset_at = reset_at
+        if blocked_at is not _UNSET:
+            account.blocked_at = cast("int | None", blocked_at)
+        self.status_updates.append(
+            {
+                "account_id": account_id,
+                "status": status,
+                "deactivation_reason": deactivation_reason,
+                "reset_at": reset_at,
+                "blocked_at": blocked_at,
+            }
+        )
+        return True
+
+
+class StubUsageRepository:
+    def __init__(
+        self,
+        *,
+        primary: dict[str, UsageHistory] | None = None,
+        secondary: dict[str, UsageHistory] | None = None,
+    ) -> None:
+        self._primary = primary or {}
+        self._secondary = secondary or {}
+
+    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+        if window == "secondary":
+            return self._secondary
+        return self._primary
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_keeps_rate_limited_until_reset_elapses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    blocked_at = int(now - 130)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_rate_limited",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=future_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=future_reset,
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=300,
+            )
+        },
+        secondary={
+            account.id: _make_usage(
+                account.id,
+                window="secondary",
+                used_percent=20.0,
+                reset_at=int(now + 7200),
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=10080,
+            )
+        },
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert account.status == AccountStatus.RATE_LIMITED
+    assert account.reset_at == future_reset
+    assert account.blocked_at == blocked_at
+    assert accounts_repo.status_updates == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_restores_rate_limited_after_reset_elapses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    past_reset = int(now - 300)
+    blocked_at = int(now - 7200)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_rate_limited_recovered",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=past_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=past_reset,
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=300,
+            )
+        }
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 1
+    assert account.status == AccountStatus.ACTIVE
+    assert account.reset_at is None
+    assert account.blocked_at is None
+    assert accounts_repo.status_updates == [
+        {
+            "account_id": account.id,
+            "status": AccountStatus.ACTIVE,
+            "deactivation_reason": None,
+            "reset_at": None,
+            "blocked_at": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_keeps_rate_limited_without_persisted_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    blocked_at = int(now - 7200)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_rate_limited_no_reset_recovered",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=None,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=int(now + 300),
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=300,
+            )
+        }
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert account.status == AccountStatus.RATE_LIMITED
+    assert account.reset_at is None
+    assert account.blocked_at == blocked_at
+    assert accounts_repo.status_updates == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_restores_quota_exceeded_from_fresh_secondary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    blocked_at = int(now - 130)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_quota_exceeded",
+        status=AccountStatus.QUOTA_EXCEEDED,
+        reset_at=future_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=5.0,
+                reset_at=int(now + 300),
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=300,
+            )
+        },
+        secondary={
+            account.id: _make_usage(
+                account.id,
+                window="secondary",
+                used_percent=10.0,
+                reset_at=future_reset,
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=10080,
+            )
+        },
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 1
+    assert account.status == AccountStatus.ACTIVE
+    assert account.reset_at is None
+    assert account.blocked_at is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_does_not_demote_quota_exceeded_to_rate_limited(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    primary_reset = int(now + 300)
+    secondary_reset = int(now + 7200)
+    blocked_at = int(now - 7200)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_quota_exceeded_demoted",
+        status=AccountStatus.QUOTA_EXCEEDED,
+        reset_at=secondary_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=100.0,
+                reset_at=primary_reset,
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=300,
+            )
+        },
+        secondary={
+            account.id: _make_usage(
+                account.id,
+                window="secondary",
+                used_percent=10.0,
+                reset_at=secondary_reset,
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=10080,
+            )
+        },
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert account.status == AccountStatus.QUOTA_EXCEEDED
+    assert account.reset_at == secondary_reset
+    assert account.blocked_at == blocked_at
+    assert accounts_repo.status_updates == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_ignores_active_accounts() -> None:
+    account = _make_account("acc_active", status=AccountStatus.ACTIVE)
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository()
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert accounts_repo.status_updates == []
+    assert account.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_keeps_rate_limited_when_primary_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    blocked_at = int(now - 130)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_rate_limited_stale",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=future_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=future_reset,
+                recorded_at=_epoch_to_naive_utc(blocked_at - 30),
+                window_minutes=300,
+            )
+        }
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert accounts_repo.status_updates == []
+    assert account.status == AccountStatus.RATE_LIMITED
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_keeps_rate_limited_when_reset_elapsed_but_primary_predates_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    past_reset = int(now - 300)
+    blocked_at = int(now - 7200)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_rate_limited_stale_pre_block",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=past_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=past_reset,
+                recorded_at=_epoch_to_naive_utc(blocked_at - 30),
+                window_minutes=300,
+            )
+        }
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert accounts_repo.status_updates == []
+    assert account.status == AccountStatus.RATE_LIMITED
+    assert account.reset_at == past_reset
+    assert account.blocked_at == blocked_at


### PR DESCRIPTION
Address #479 

Probably fix the issue that the UI still show the stale status after the time resets
As currently the status update is more like `lazy update`, if there is no request to `codex-lb` or the account does not tide to any API, the status shown in UI will never be updated.
Not sure why the request does not get routed, but this would best effort reset the status, as a fallback, with the help of scheduler

This fix is to introduce the account status for those account status = rate-limit/ quota exceed in the scheduler