### PR TITLE
fix(proxy): emit response.created before buffered stream events

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5215,6 +5215,7 @@ class ProxyService:
             retry_text_data = request_state.fresh_upstream_request_text
         if request_state.replay_count >= 1:
             return False
+        request_state.pre_response_created_event_texts = []
         request_state.replay_count += 1
         _log_http_bridge_event(
             "retry_fresh_upstream",
@@ -5264,7 +5265,7 @@ class ProxyService:
                 return False
             request_text = request_state.request_text
             assert isinstance(request_text, str)
-            request_state.replay_count += 1
+            request_state.reset_for_replay()
         _log_http_bridge_event(
             "retry_precreated",
             session.key,
@@ -6155,15 +6156,11 @@ class ProxyService:
         if retry_error_code is not None:
             upstream_control.reconnect_requested = True
             if retry_is_previous_response_not_found:
-                request_state.replay_count += 1
-                request_state.awaiting_response_created = True
-                request_state.response_id = None
+                request_state.reset_for_replay()
                 upstream_control.suppress_downstream_event = True
                 upstream_control.replay_request_state = request_state
             else:
-                request_state.replay_count += 1
-                request_state.awaiting_response_created = True
-                request_state.response_id = None
+                request_state.reset_for_replay()
                 upstream_control.suppress_downstream_event = True
                 upstream_control.replay_request_state = request_state
                 await self._handle_stream_error(
@@ -8322,6 +8319,12 @@ class _WebSocketRequestState:
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
 
+    def reset_for_replay(self) -> None:
+        self.pre_response_created_event_texts = []
+        self.replay_count += 1
+        self.awaiting_response_created = True
+        self.response_id = None
+
 
 @dataclass(frozen=True, slots=True)
 class _HTTPBridgeSessionKey:
@@ -8724,9 +8727,7 @@ async def _pop_replayable_precreated_websocket_request_state(
         if request_state.replay_count >= 1:
             return None
         pending_requests.popleft()
-    request_state.replay_count += 1
-    request_state.awaiting_response_created = True
-    request_state.response_id = None
+    request_state.reset_for_replay()
     return request_state
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -205,6 +205,9 @@ async def _await_cancelled_task(
 
 
 _TEXT_DELTA_EVENT_TYPES = frozenset({"response.output_text.delta", "response.refusal.delta"})
+_RESPONSE_STREAM_TERMINAL_EVENT_TYPES = frozenset(
+    {"response.completed", "response.failed", "response.incomplete", "error"}
+)
 _TEXT_DONE_CONTENT_PART_TYPES = frozenset({"output_text", "refusal"})
 _REQUEST_TRANSPORT_HTTP = "http"
 _REQUEST_TRANSPORT_WEBSOCKET = "websocket"
@@ -5430,6 +5433,7 @@ class ProxyService:
         async with session.pending_lock:
             matched_request_state = None
             created_request_state = None
+            precreated_request_state = None
             has_other_pending_requests = False
             grouped_previous_response_request_states: list[_WebSocketRequestState] = []
             if event_type == "response.created":
@@ -5459,8 +5463,11 @@ class ProxyService:
                     matched_request_state.actual_service_tier = actual_service_tier
                     matched_request_state.service_tier = actual_service_tier
 
+            if _should_buffer_pre_response_created_event(matched_request_state, event_type=event_type):
+                precreated_request_state = matched_request_state
+
             terminal_request_state = None
-            if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
+            if event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
                 terminal_request_state = _pop_terminal_websocket_request_state(
                     session.pending_requests,
                     response_id=response_id,
@@ -5492,6 +5499,10 @@ class ProxyService:
                             session.queued_request_count - len(grouped_previous_response_request_states),
                         )
                 has_other_pending_requests = bool(session.pending_requests)
+
+        if precreated_request_state is not None:
+            precreated_request_state.pre_response_created_event_texts.append(text)
+            return
 
         if len(grouped_previous_response_request_states) > 1:
             session.upstream_control.reconnect_requested = True
@@ -5575,12 +5586,18 @@ class ProxyService:
 
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
             _release_websocket_response_create_gate(created_request_state, session.response_create_gate)
+            buffered_event_texts = created_request_state.pre_response_created_event_texts
+            created_request_state.pre_response_created_event_texts = []
+        else:
+            buffered_event_texts = []
 
         if response_id is not None and matched_request_state is not None:
             await self._register_http_bridge_previous_response_id(session, response_id)
 
         if matched_request_state is not None and matched_request_state.event_queue is not None:
             await matched_request_state.event_queue.put(event_block)
+            for buffered_text in buffered_event_texts:
+                await matched_request_state.event_queue.put(f"data: {buffered_text}\n\n")
 
         if terminal_request_state is None:
             return
@@ -5996,6 +6013,7 @@ class ProxyService:
         async with pending_lock:
             request_state = None
             created_request_state = None
+            precreated_request_state = None
             has_other_pending_requests = False
             grouped_previous_response_request_states: list[_WebSocketRequestState] = []
             if event_type == "response.created":
@@ -6020,10 +6038,9 @@ class ProxyService:
                 if actual_service_tier is not None:
                     request_state.actual_service_tier = actual_service_tier
                     request_state.service_tier = actual_service_tier
-            if (
-                event_type in {"response.completed", "response.failed", "response.incomplete", "error"}
-                and pending_requests
-            ):
+            if _should_buffer_pre_response_created_event(request_state, event_type=event_type):
+                precreated_request_state = request_state
+            if event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES and pending_requests:
                 request_state = _pop_terminal_websocket_request_state(
                     pending_requests,
                     response_id=response_id,
@@ -6051,8 +6068,18 @@ class ProxyService:
             else:
                 request_state = None
 
+        if precreated_request_state is not None:
+            precreated_request_state.pre_response_created_event_texts.append(text)
+            upstream_control.suppress_downstream_event = True
+            return text
+
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
             _release_websocket_response_create_gate(created_request_state, response_create_gate)
+            if created_request_state.pre_response_created_event_texts:
+                buffered_texts = created_request_state.pre_response_created_event_texts
+                created_request_state.pre_response_created_event_texts = []
+                upstream_control.suppress_downstream_event = True
+                upstream_control.downstream_texts = [text, *buffered_texts]
 
         if len(grouped_previous_response_request_states) > 1:
             upstream_control.reconnect_requested = True
@@ -8260,6 +8287,7 @@ class _WebSocketRequestState:
     actual_service_tier: str | None = None
     response_id: str | None = None
     awaiting_response_created: bool = False
+    pre_response_created_event_texts: list[str] = field(default_factory=list)
     event_queue: asyncio.Queue[str | None] | None = None
     transport: str = _REQUEST_TRANSPORT_WEBSOCKET
     api_key: ApiKeyData | None = None
@@ -8391,6 +8419,19 @@ def _event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonV
     if isinstance(payload_type, str):
         return payload_type
     return None
+
+
+def _should_buffer_pre_response_created_event(
+    request_state: _WebSocketRequestState | None,
+    *,
+    event_type: str | None,
+) -> bool:
+    return (
+        request_state is not None
+        and request_state.awaiting_response_created
+        and event_type != "response.created"
+        and event_type not in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+    )
 
 
 def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from collections import deque
@@ -5604,3 +5605,66 @@ async def test_websocket_reader_unexpected_processing_error_fails_pending_reques
     assert "reader" in terminal_payload
     assert list(pending_requests) == []
     write_request_log.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_buffers_nonterminal_events_until_response_created() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-http-precreated-buffer",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=event_queue,
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    delta_text = json.dumps(
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_precreated",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "hello",
+        },
+        separators=(",", ":"),
+    )
+
+    await service._process_http_bridge_upstream_text(session, delta_text)
+
+    assert event_queue.empty()
+    assert request_state.pre_response_created_event_texts == [delta_text]
+
+    created_text = json.dumps(
+        {
+            "type": "response.created",
+            "response": {"id": "resp_http_precreated_buffer", "status": "in_progress"},
+        },
+        separators=(",", ":"),
+    )
+
+    await service._process_http_bridge_upstream_text(session, created_text)
+
+    assert await asyncio.wait_for(event_queue.get(), timeout=0.1) == f"data: {created_text}\n\n"
+    assert await asyncio.wait_for(event_queue.get(), timeout=0.1) == f"data: {delta_text}\n\n"
+    assert request_state.pre_response_created_event_texts == []
+    assert request_state.awaiting_response_created is False
+    assert request_state.response_id == "resp_http_precreated_buffer"

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5608,6 +5608,55 @@ async def test_websocket_reader_unexpected_processing_error_fails_pending_reques
 
 
 @pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_drops_precreated_buffer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    request_text = '{"type":"response.create","model":"gpt-5.4","input":[]}'
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-http-precreated-retry-buffer",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        pre_response_created_event_texts=['{"type":"response.in_progress"}'],
+        request_text=request_text,
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    retried = await service._retry_http_bridge_precreated_request(session)
+
+    assert retried is True
+    reconnect.assert_awaited_once_with(session, request_state=request_state)
+    send_text.assert_awaited_once_with(request_text)
+    assert request_state.pre_response_created_event_texts == []
+    assert request_state.replay_count == 1
+    assert request_state.awaiting_response_created is True
+    assert request_state.response_id is None
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_buffers_nonterminal_events_until_response_created() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     event_queue: asyncio.Queue[str | None] = asyncio.Queue()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5493,6 +5493,57 @@ async def test_process_upstream_websocket_text_buffers_nonterminal_events_until_
     finalize_request_state.assert_not_awaited()
 
 
+def test_websocket_request_state_reset_for_replay_drops_precreated_buffer():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_reset_replay",
+        model="gpt-5.1",
+        service_tier="auto",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_stale",
+        awaiting_response_created=False,
+        pre_response_created_event_texts=['{"type":"response.in_progress"}'],
+        replay_count=2,
+    )
+
+    request_state.reset_for_replay()
+
+    assert request_state.pre_response_created_event_texts == []
+    assert request_state.replay_count == 3
+    assert request_state.awaiting_response_created is True
+    assert request_state.response_id is None
+
+
+@pytest.mark.asyncio
+async def test_pop_replayable_precreated_websocket_request_state_drops_precreated_buffer():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_pop_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id=None,
+        awaiting_response_created=True,
+        pre_response_created_event_texts=['{"type":"response.in_progress"}'],
+        request_text='{"type":"response.create","model":"gpt-5.1","input":[]}',
+    )
+    pending_requests = deque([request_state])
+
+    replay_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replay_request is request_state
+    assert list(pending_requests) == []
+    assert request_state.pre_response_created_event_texts == []
+    assert request_state.replay_count == 1
+    assert request_state.awaiting_response_created is True
+    assert request_state.response_id is None
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -6285,6 +6336,7 @@ async def test_process_upstream_websocket_text_transparently_retries_precreated_
         api_key_reservation=None,
         started_at=0.0,
         awaiting_response_created=True,
+        pre_response_created_event_texts=['{"type":"response.in_progress"}'],
         request_text=json.dumps(request_payload, separators=(",", ":")),
     )
     pending_requests = deque([pending_request])
@@ -6321,6 +6373,7 @@ async def test_process_upstream_websocket_text_transparently_retries_precreated_
     assert upstream_control.reconnect_requested is True
     assert upstream_control.suppress_downstream_event is True
     assert upstream_control.replay_request_state is pending_request
+    assert pending_request.pre_response_created_event_texts == []
     assert pending_request.replay_count == 1
     assert list(pending_requests) == []
 
@@ -6915,6 +6968,185 @@ async def test_proxy_responses_websocket_replays_precreated_request_after_upstre
     assert len(second_upstream.sent_text) == 1
     assert len(first_upstream.sent_text) >= 1
     assert json.loads(first_upstream.sent_text[-1]) == json.loads(second_upstream.sent_text[0])
+
+
+@pytest.mark.asyncio
+async def test_proxy_responses_websocket_drops_precreated_buffer_when_replaying_after_upstream_close(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    connect_calls: list[dict[str, object]] = []
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.stream_idle_timeout_seconds = 300.0
+    settings.proxy_downstream_websocket_idle_timeout_seconds = 120.0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    class _FakeDownstreamWebSocket:
+        def __init__(self, request_text: str) -> None:
+            self._request_text = request_text
+            self._request_sent = False
+            self._disconnect_sent = False
+            self._done = asyncio.Event()
+            self.sent_text: list[str] = []
+
+        async def receive(self) -> dict[str, object]:
+            if not self._request_sent:
+                self._request_sent = True
+                return {"type": "websocket.receive", "text": self._request_text}
+            if not self._disconnect_sent:
+                await self._done.wait()
+                self._disconnect_sent = True
+                return {"type": "websocket.disconnect"}
+            await asyncio.sleep(0)
+            return {"type": "websocket.disconnect"}
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+            payload = json.loads(text)
+            if payload.get("type") in {"response.completed", "response.failed", "error"}:
+                self._done.set()
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+        async def close(self, code: int = 1000, reason: str | None = None) -> None:
+            del code, reason
+            self._done.set()
+
+    class _ReplayUpstreamWebSocket:
+        def __init__(self, messages: list[SimpleNamespace]) -> None:
+            self.sent_text: list[str] = []
+            self.closed = False
+            self._messages: asyncio.Queue[SimpleNamespace] = asyncio.Queue()
+            for message in messages:
+                self._messages.put_nowait(message)
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+        async def receive(self) -> SimpleNamespace:
+            return await self._messages.get()
+
+        async def close(self) -> None:
+            self.closed = True
+
+    stale_delta_text = json.dumps(
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_stale_precreated",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "stale",
+        },
+        separators=(",", ":"),
+    )
+    first_upstream = _ReplayUpstreamWebSocket(
+        [
+            SimpleNamespace(kind="text", text=stale_delta_text, data=None, close_code=None, error=None),
+            SimpleNamespace(kind="close", text=None, data=None, close_code=1001, error=None),
+        ]
+    )
+    second_upstream = _ReplayUpstreamWebSocket(
+        [
+            SimpleNamespace(
+                kind="text",
+                text=json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_ws_replayed_clean", "status": "in_progress"},
+                    },
+                    separators=(",", ":"),
+                ),
+                data=None,
+                close_code=None,
+                error=None,
+            ),
+            SimpleNamespace(
+                kind="text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_replayed_clean",
+                            "status": "completed",
+                            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+                data=None,
+                close_code=None,
+                error=None,
+            ),
+        ]
+    )
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        connect_calls.append({"model": model, "reallocate_sticky": reallocate_sticky})
+        if len(connect_calls) == 1:
+            return _make_account("acc_ws_replay_stale_1"), first_upstream
+        return _make_account("acc_ws_replay_stale_2"), second_upstream
+
+    monkeypatch.setattr(proxy_service.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    request = {
+        "type": "response.create",
+        "model": "gpt-5.4-mini",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "retry cleanly"}]}],
+        "stream": True,
+    }
+    downstream = _FakeDownstreamWebSocket(json.dumps(request, separators=(",", ":")))
+
+    await service.proxy_responses_websocket(
+        cast(WebSocket, downstream),
+        {"x-codex-turn-state": "turn_replay_drop_stale"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        api_key=None,
+    )
+
+    emitted_events = [json.loads(event) for event in downstream.sent_text]
+    assert [event["type"] for event in emitted_events] == ["response.created", "response.completed"]
+    assert all(event.get("item_id") != "msg_stale_precreated" for event in emitted_events)
+    assert len(connect_calls) == 2
+    assert len(first_upstream.sent_text) == 1
+    assert len(second_upstream.sent_text) == 1
+    assert json.loads(first_upstream.sent_text[0]) == json.loads(second_upstream.sent_text[0])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5406,6 +5406,93 @@ async def test_process_upstream_websocket_text_does_not_match_foreign_completed_
     assert list(pending_requests) == [pending_request]
 
 
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_buffers_nonterminal_events_until_response_created(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    account = _make_account("acc_ws_precreated_buffer")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_precreated_buffer",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            },
+            separators=(",", ":"),
+        ),
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    pending_lock = anyio.Lock()
+    response_create_gate = asyncio.Semaphore(1)
+    delta_text = json.dumps(
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_precreated",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "hello",
+        },
+        separators=(",", ":"),
+    )
+
+    downstream_text = await service._process_upstream_websocket_text(
+        delta_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=pending_lock,
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=response_create_gate,
+    )
+
+    assert downstream_text == delta_text
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.downstream_texts is None
+    assert pending_request.pre_response_created_event_texts == [delta_text]
+    finalize_request_state.assert_not_awaited()
+
+    upstream_control.suppress_downstream_event = False
+    created_text = json.dumps(
+        {
+            "type": "response.created",
+            "response": {"id": "resp_precreated_buffer", "status": "in_progress"},
+        },
+        separators=(",", ":"),
+    )
+
+    downstream_text = await service._process_upstream_websocket_text(
+        created_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=pending_lock,
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=response_create_gate,
+    )
+
+    assert downstream_text == created_text
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.downstream_texts == [created_text, delta_text]
+    assert pending_request.pre_response_created_event_texts == []
+    assert pending_request.awaiting_response_created is False
+    assert pending_request.response_id == "resp_precreated_buffer"
+    finalize_request_state.assert_not_awaited()
+
+
 @pytest.mark.parametrize(
     "payload",
     [


### PR DESCRIPTION
## Summary

Fixes #473.

Related: #392, NousResearch/hermes-agent#8133.

Responses streams can currently forward non-terminal events before `response.created`. Strict OpenAI SDK Responses parsers expect `response.created` first so they can build the initial response snapshot; otherwise clients such as Hermes fail before consuming the stream.

This buffers pre-`response.created` non-terminal events per request, emits `response.created` first, then flushes the buffered events in their original order.

## Changes

- Add per-request buffering for pre-`response.created` events.
- Apply the ordering fix to both WebSocket and HTTP bridge stream paths.
- Add unit coverage for both paths.

## Testing

- `python -m pytest tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
- `ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
