### PR TITLE
feat(dashboard): show weekly token pace

### DIFF
--- a/app/core/usage/types.py
+++ b/app/core/usage/types.py
@@ -107,6 +107,7 @@ class UsageTrendBucket:
     samples: int
     reset_at: int | None = None
     window_minutes: int | None = None
+    recorded_at: datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/app/core/usage/types.py
+++ b/app/core/usage/types.py
@@ -105,6 +105,8 @@ class UsageTrendBucket:
     window: str
     avg_used_percent: float
     samples: int
+    reset_at: int | None = None
+    window_minutes: int | None = None
 
 
 @dataclass(frozen=True)

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -206,11 +206,8 @@ def build_account_usage_trends(
     # Group buckets by (account_id, window)
     grouped: dict[tuple[str, str], dict[int, float]] = {}
     secondary_schedule: dict[str, dict[int, tuple[int, int]]] = {}
-    secondary_bucket_keys = {(b.account_id, b.bucket_epoch) for b in buckets if b.window == "secondary"}
-    for b in buckets:
+    for b in _effective_usage_trend_buckets(buckets):
         is_weekly_primary = b.window == "primary" and usage_core.is_weekly_window_minutes(b.window_minutes)
-        if is_weekly_primary and (b.account_id, b.bucket_epoch) in secondary_bucket_keys:
-            continue
         window = "secondary" if is_weekly_primary else b.window
         key = (b.account_id, window)
         grouped.setdefault(key, {})[b.bucket_epoch] = b.avg_used_percent
@@ -250,6 +247,46 @@ def build_account_usage_trends(
         )
 
     return result
+
+
+def _effective_usage_trend_buckets(buckets: list[UsageTrendBucket]) -> list[UsageTrendBucket]:
+    secondary_by_key = {
+        (bucket.account_id, bucket.bucket_epoch): bucket for bucket in buckets if bucket.window == "secondary"
+    }
+    weekly_primary_by_key = {
+        (bucket.account_id, bucket.bucket_epoch): bucket
+        for bucket in buckets
+        if bucket.window == "primary" and usage_core.is_weekly_window_minutes(bucket.window_minutes)
+    }
+    result: list[UsageTrendBucket] = []
+    for bucket in buckets:
+        key = (bucket.account_id, bucket.bucket_epoch)
+        weekly_primary = weekly_primary_by_key.get(key)
+        if bucket.window == "secondary" and weekly_primary is not None:
+            if usage_core.should_use_weekly_primary(
+                _trend_bucket_to_window_row(weekly_primary),
+                _trend_bucket_to_window_row(bucket),
+            ):
+                continue
+        if bucket is weekly_primary and key in secondary_by_key:
+            secondary = secondary_by_key[key]
+            if not usage_core.should_use_weekly_primary(
+                _trend_bucket_to_window_row(bucket),
+                _trend_bucket_to_window_row(secondary),
+            ):
+                continue
+        result.append(bucket)
+    return result
+
+
+def _trend_bucket_to_window_row(bucket: UsageTrendBucket) -> UsageWindowRow:
+    return UsageWindowRow(
+        account_id=bucket.account_id,
+        used_percent=bucket.avg_used_percent,
+        reset_at=bucket.reset_at,
+        window_minutes=bucket.window_minutes,
+        recorded_at=bucket.recorded_at,
+    )
 
 
 def _fill_trend_points(

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -207,10 +207,12 @@ def build_account_usage_trends(
     grouped: dict[tuple[str, str], dict[int, float]] = {}
     secondary_schedule: dict[str, dict[int, tuple[int, int]]] = {}
     for b in buckets:
-        key = (b.account_id, b.window)
+        is_weekly_primary = b.window == "primary" and usage_core.is_weekly_window_minutes(b.window_minutes)
+        window = "secondary" if is_weekly_primary else b.window
+        key = (b.account_id, window)
         grouped.setdefault(key, {})[b.bucket_epoch] = b.avg_used_percent
         if (
-            (b.window == "secondary" or usage_core.is_weekly_window_minutes(b.window_minutes))
+            (window == "secondary" or usage_core.is_weekly_window_minutes(b.window_minutes))
             and b.reset_at is not None
             and b.window_minutes
         ):

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -205,9 +205,15 @@ def build_account_usage_trends(
     """
     # Group buckets by (account_id, window)
     grouped: dict[tuple[str, str], dict[int, float]] = {}
+    secondary_schedule: dict[str, dict[int, tuple[int, int]]] = {}
     for b in buckets:
         key = (b.account_id, b.window)
         grouped.setdefault(key, {})[b.bucket_epoch] = b.avg_used_percent
+        if b.window == "secondary" and b.reset_at is not None and b.window_minutes:
+            secondary_schedule.setdefault(b.account_id, {})[b.bucket_epoch] = (
+                b.reset_at,
+                b.window_minutes,
+            )
 
     # Generate the full time grid, aligned to bucket boundaries (same as SQL)
     aligned_start = (since_epoch // bucket_seconds) * bucket_seconds
@@ -223,10 +229,15 @@ def build_account_usage_trends(
 
         primary_points = _fill_trend_points(time_grid, primary_data) if primary_data else []
         secondary_points = _fill_trend_points(time_grid, secondary_data) if secondary_data else []
+        secondary_scheduled_points = _fill_scheduled_secondary_points(
+            time_grid,
+            secondary_schedule.get(account_id, {}),
+        )
 
         result[account_id] = AccountUsageTrend(
             primary=primary_points,
             secondary=secondary_points,
+            secondary_scheduled=secondary_scheduled_points,
         )
 
     return result
@@ -251,4 +262,33 @@ def _fill_trend_points(
                 v=round(remaining, 2),
             )
         )
+    return points
+
+
+def _fill_scheduled_secondary_points(
+    time_grid: list[int],
+    schedule_data: dict[int, tuple[int, int]],
+) -> list[UsageTrendPoint]:
+    """Build the ideal weekly remaining line from each sample's own reset deadline."""
+    points: list[UsageTrendPoint] = []
+    current_reset_at: int | None = None
+    current_window_minutes: int | None = None
+
+    for epoch in time_grid:
+        if epoch in schedule_data:
+            current_reset_at, current_window_minutes = schedule_data[epoch]
+
+        if current_reset_at is None or not current_window_minutes:
+            continue
+
+        window_seconds = current_window_minutes * 60
+        remaining_seconds = max(0, min(window_seconds, current_reset_at - epoch))
+        scheduled_remaining = 100.0 * remaining_seconds / window_seconds
+        points.append(
+            UsageTrendPoint(
+                t=datetime.fromtimestamp(epoch, tz=timezone.utc),
+                v=round(scheduled_remaining, 2),
+            )
+        )
+
     return points

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -209,7 +209,11 @@ def build_account_usage_trends(
     for b in buckets:
         key = (b.account_id, b.window)
         grouped.setdefault(key, {})[b.bucket_epoch] = b.avg_used_percent
-        if b.window == "secondary" and b.reset_at is not None and b.window_minutes:
+        if (
+            (b.window == "secondary" or usage_core.is_weekly_window_minutes(b.window_minutes))
+            and b.reset_at is not None
+            and b.window_minutes
+        ):
             secondary_schedule.setdefault(b.account_id, {})[b.bucket_epoch] = (
                 b.reset_at,
                 b.window_minutes,

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -206,8 +206,11 @@ def build_account_usage_trends(
     # Group buckets by (account_id, window)
     grouped: dict[tuple[str, str], dict[int, float]] = {}
     secondary_schedule: dict[str, dict[int, tuple[int, int]]] = {}
+    secondary_bucket_keys = {(b.account_id, b.bucket_epoch) for b in buckets if b.window == "secondary"}
     for b in buckets:
         is_weekly_primary = b.window == "primary" and usage_core.is_weekly_window_minutes(b.window_minutes)
+        if is_weekly_primary and (b.account_id, b.bucket_epoch) in secondary_bucket_keys:
+            continue
         window = "secondary" if is_weekly_primary else b.window
         key = (b.account_id, window)
         grouped.setdefault(key, {})[b.bucket_epoch] = b.avg_used_percent

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -16,6 +16,7 @@ class UsageTrendPoint(DashboardModel):
 class AccountUsageTrend(DashboardModel):
     primary: list[UsageTrendPoint] = Field(default_factory=list)
     secondary: list[UsageTrendPoint] = Field(default_factory=list)
+    secondary_scheduled: list[UsageTrendPoint] = Field(default_factory=list)
 
 
 class AccountUsage(DashboardModel):
@@ -105,3 +106,4 @@ class AccountTrendsResponse(DashboardModel):
     account_id: str
     primary: list[UsageTrendPoint] = Field(default_factory=list)
     secondary: list[UsageTrendPoint] = Field(default_factory=list)
+    secondary_scheduled: list[UsageTrendPoint] = Field(default_factory=list)

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -140,6 +140,7 @@ class AccountsService:
             account_id=account_id,
             primary=trend.primary if trend else [],
             secondary=trend.secondary if trend else [],
+            secondary_scheduled=trend.secondary_scheduled if trend else [],
         )
 
     async def import_account(self, raw: bytes) -> AccountImportResponse:

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -270,6 +270,8 @@ class UsageRepository:
                 window_expr.label("window"),
                 func.avg(UsageHistory.used_percent).label("avg_used_percent"),
                 func.count(UsageHistory.id).label("samples"),
+                func.max(UsageHistory.reset_at).label("reset_at"),
+                func.max(UsageHistory.window_minutes).label("window_minutes"),
             )
             .where(*conditions)
             .group_by(
@@ -287,6 +289,8 @@ class UsageRepository:
                 window=row.window,
                 avg_used_percent=float(row.avg_used_percent) if row.avg_used_percent is not None else 0.0,
                 samples=int(row.samples),
+                reset_at=int(row.reset_at) if row.reset_at is not None else None,
+                window_minutes=int(row.window_minutes) if row.window_minutes is not None else None,
             )
             for row in result.all()
         ]

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -272,6 +272,7 @@ class UsageRepository:
                 func.count(UsageHistory.id).label("samples"),
                 func.max(UsageHistory.reset_at).label("reset_at"),
                 func.max(UsageHistory.window_minutes).label("window_minutes"),
+                func.max(UsageHistory.recorded_at).label("recorded_at"),
             )
             .where(*conditions)
             .group_by(
@@ -291,6 +292,7 @@ class UsageRepository:
                 samples=int(row.samples),
                 reset_at=int(row.reset_at) if row.reset_at is not None else None,
                 window_minutes=int(row.window_minutes) if row.window_minutes is not None else None,
+                recorded_at=row.recorded_at,
             )
             for row in result.all()
         ]

--- a/frontend/src/features/accounts/components/account-trend-chart.tsx
+++ b/frontend/src/features/accounts/components/account-trend-chart.tsx
@@ -3,6 +3,7 @@ import {
   Area,
   AreaChart,
   CartesianGrid,
+  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -18,25 +19,29 @@ type MergedPoint = {
   t: string;
   primary: number;
   secondary: number;
+  secondaryScheduled?: number;
 };
 
 function mergePoints(
   primary: UsageTrendPoint[],
   secondary: UsageTrendPoint[],
+  secondaryScheduled: UsageTrendPoint[],
 ): MergedPoint[] {
   const secondaryMap = new Map(secondary.map((p) => [p.t, p.v]));
   const primaryMap = new Map(primary.map((p) => [p.t, p.v]));
-  
-  if (primary.length === 0 && secondary.length === 0) {
+  const secondaryScheduledMap = new Map(secondaryScheduled.map((p) => [p.t, p.v]));
+
+  if (primary.length === 0 && secondary.length === 0 && secondaryScheduled.length === 0) {
     return [];
   }
-  
-  const basePoints = primary.length > 0 ? primary : secondary;
-  
+
+  const basePoints = primary.length > 0 ? primary : secondary.length > 0 ? secondary : secondaryScheduled;
+
   return basePoints.map((p) => ({
     t: p.t,
     primary: primaryMap.get(p.t) ?? 0,
     secondary: secondaryMap.get(p.t) ?? 0,
+    secondaryScheduled: secondaryScheduledMap.get(p.t),
   }));
 }
 
@@ -48,6 +53,7 @@ function formatXTick(isoStr: string): string {
 const SERIES_META: Record<string, { label: string }> = {
   primary: { label: "Primary" },
   secondary: { label: "Secondary" },
+  secondaryScheduled: { label: "Weekly plan" },
 };
 
 type ChartTooltipPayloadEntry = {
@@ -90,14 +96,22 @@ const CHART_MARGIN = { top: 4, right: 8, bottom: 0, left: 0 } as const;
 export type AccountTrendChartProps = {
   primary: UsageTrendPoint[];
   secondary: UsageTrendPoint[];
+  secondaryScheduled?: UsageTrendPoint[];
 };
 
-export function AccountTrendChart({ primary, secondary }: AccountTrendChartProps) {
+export function AccountTrendChart({
+  primary,
+  secondary,
+  secondaryScheduled = [],
+}: AccountTrendChartProps) {
   const chartColors = useChartColors();
   const reducedMotion = useReducedMotion();
   const c1 = chartColors[0];
   const c2 = chartColors[1];
-  const data = useMemo(() => mergePoints(primary, secondary), [primary, secondary]);
+  const data = useMemo(
+    () => mergePoints(primary, secondary, secondaryScheduled),
+    [primary, secondary, secondaryScheduled],
+  );
 
   if (data.length === 0) {
     return (
@@ -168,6 +182,21 @@ export function AccountTrendChart({ primary, secondary }: AccountTrendChartProps
             isAnimationActive={!reducedMotion}
             animationDuration={500}
             animationBegin={100}
+          />
+        )}
+        {secondaryScheduled.length > 0 && (
+          <Line
+            type="linear"
+            dataKey="secondaryScheduled"
+            stroke={c2}
+            strokeWidth={1.25}
+            strokeDasharray="5 5"
+            dot={false}
+            activeDot={{ r: 3, strokeWidth: 1.5, fill: "hsl(var(--popover))" }}
+            connectNulls={false}
+            isAnimationActive={!reducedMotion}
+            animationDuration={500}
+            animationBegin={150}
           />
         )}
       </AreaChart>

--- a/frontend/src/features/accounts/components/account-usage-panel.test.tsx
+++ b/frontend/src/features/accounts/components/account-usage-panel.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AccountUsagePanel } from "@/features/accounts/components/account-usage-panel";
-import { createAccountSummary } from "@/test/mocks/factories";
+import { createAccountSummary, createAccountTrends } from "@/test/mocks/factories";
 
 describe("AccountUsagePanel", () => {
   beforeEach(() => {
@@ -86,5 +86,19 @@ describe("AccountUsagePanel", () => {
     expect(screen.getByText("Request logs total")).toBeInTheDocument();
     expect(screen.getByText(/\$0\.13/)).toBeInTheDocument();
     expect(screen.getByText(/51\.48K tok/)).toBeInTheDocument();
+  });
+
+  it("shows the weekly plan legend when scheduled trend data exists", () => {
+    const account = createAccountSummary();
+    const trends = createAccountTrends(account.accountId, {
+      secondaryScheduled: [
+        { t: "2026-01-01T00:00:00.000Z", v: 100 },
+        { t: "2026-01-01T01:00:00.000Z", v: 99.4 },
+      ],
+    });
+
+    render(<AccountUsagePanel account={account} trends={trends} />);
+
+    expect(screen.getByText("Weekly plan")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/accounts/components/account-usage-panel.tsx
+++ b/frontend/src/features/accounts/components/account-usage-panel.tsx
@@ -189,9 +189,19 @@ export function AccountUsagePanel({ account, trends }: AccountUsagePanelProps) {
                 <span className="inline-block h-2 w-2 rounded-full bg-chart-2" />
                 Weekly
               </span>
+              {trends.secondaryScheduled.length > 0 ? (
+                <span className="flex items-center gap-1.5">
+                  <span className="inline-block h-0 w-4 border-t border-dashed border-chart-2" />
+                  Weekly plan
+                </span>
+              ) : null}
             </div>
           </div>
-          <AccountTrendChart primary={trends.primary} secondary={trends.secondary} />
+          <AccountTrendChart
+            primary={trends.primary}
+            secondary={trends.secondary}
+            secondaryScheduled={trends.secondaryScheduled}
+          />
         </div>
       )}
     </div>

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -8,6 +8,7 @@ export const UsageTrendPointSchema = z.object({
 export const AccountUsageTrendSchema = z.object({
   primary: z.array(UsageTrendPointSchema),
   secondary: z.array(UsageTrendPointSchema),
+  secondaryScheduled: z.array(UsageTrendPointSchema).default([]),
 });
 
 export const AccountUsageSchema = z.object({
@@ -59,6 +60,8 @@ export const AccountSummarySchema = z.object({
   resetAtSecondary: z.string().datetime({ offset: true }).nullable().optional(),
   windowMinutesPrimary: z.number().nullable().optional(),
   windowMinutesSecondary: z.number().nullable().optional(),
+  capacityCreditsSecondary: z.number().nullable().optional(),
+  remainingCreditsSecondary: z.number().nullable().optional(),
   requestUsage: AccountRequestUsageSchema.nullable().optional(),
   auth: AccountAuthSchema.nullable().optional(),
   additionalQuotas: z.array(AccountAdditionalQuotaSchema).default([]),
@@ -68,6 +71,7 @@ export const AccountTrendsResponseSchema = z.object({
   accountId: z.string(),
   primary: z.array(UsageTrendPointSchema),
   secondary: z.array(UsageTrendPointSchema),
+  secondaryScheduled: z.array(UsageTrendPointSchema).default([]),
 });
 
 export const AccountsResponseSchema = z.object({

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -12,6 +12,7 @@ import { RequestFilters } from "@/features/dashboard/components/filters/request-
 import { RecentRequestsTable } from "@/features/dashboard/components/recent-requests-table";
 import { StatsGrid } from "@/features/dashboard/components/stats-grid";
 import { UsageDonuts } from "@/features/dashboard/components/usage-donuts";
+import { WeeklyCreditsPaceCard } from "@/features/dashboard/components/weekly-credits-pace-card";
 import { useDashboard } from "@/features/dashboard/hooks/use-dashboard";
 import { useRequestLogs } from "@/features/dashboard/hooks/use-request-logs";
 import { buildDashboardView } from "@/features/dashboard/utils";
@@ -171,6 +172,21 @@ export function DashboardPage() {
         <>
           <StatsGrid stats={view.stats} />
 
+          {view.weeklyCreditPace ? (
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(18rem,1fr)]">
+              <UsageDonuts
+                primaryItems={view.primaryUsageItems}
+                secondaryItems={view.secondaryUsageItems}
+                primaryTotal={overview?.summary.primaryWindow.capacityCredits ?? 0}
+                secondaryTotal={overview?.summary.secondaryWindow?.capacityCredits ?? 0}
+                primaryCenterValue={view.primaryTotal}
+                secondaryCenterValue={view.secondaryTotal}
+                safeLinePrimary={view.safeLinePrimary}
+                safeLineSecondary={view.safeLineSecondary}
+              />
+              <WeeklyCreditsPaceCard pace={view.weeklyCreditPace} />
+            </div>
+          ) : (
             <UsageDonuts
               primaryItems={view.primaryUsageItems}
               secondaryItems={view.secondaryUsageItems}
@@ -181,6 +197,7 @@ export function DashboardPage() {
               safeLinePrimary={view.safeLinePrimary}
               safeLineSecondary={view.safeLineSecondary}
             />
+          )}
 
           <section className="space-y-4">
             <div className="flex items-center gap-3">

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
@@ -48,7 +48,7 @@ describe("WeeklyCreditsPaceCard", () => {
     expect(screen.getByText("Schedule marker")).toBeInTheDocument();
   });
 
-  it("shows that no pause is needed when pace is behind schedule", () => {
+  it("hides recovery options when the pool is on the safe side of schedule", () => {
     render(
       <WeeklyCreditsPaceCard
         pace={{
@@ -67,9 +67,10 @@ describe("WeeklyCreditsPaceCard", () => {
       />,
     );
 
-    expect(screen.getByText("No pause needed")).toBeInTheDocument();
+    expect(screen.queryByText("Recovery options")).not.toBeInTheDocument();
+    expect(screen.queryByText("No pause needed")).not.toBeInTheDocument();
     expect(screen.getByText("8% below schedule")).toBeInTheDocument();
-    expect(screen.getByText("80K credits projected low-water mark")).toBeInTheDocument();
+    expect(screen.queryByText("80K credits projected low-water mark")).not.toBeInTheDocument();
   });
 
   it("shows fractional pro account capacity before the rounded account count", () => {

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { WeeklyCreditsPaceCard } from "@/features/dashboard/components/weekly-credits-pace-card";
+import type { WeeklyCreditPace } from "@/features/dashboard/utils";
+
+const BASE_PACE: WeeklyCreditPace = {
+  totalFullCredits: 1_000_000,
+  totalActualRemainingCredits: 500_000,
+  totalExpectedRemainingCredits: 860_000,
+  actualUsedPercent: 50,
+  scheduledUsedPercent: 14,
+  deltaPercent: 36,
+  overPlanCredits: 360_000,
+  pauseForBreakEvenHours: 60.5,
+  paceMultiplier: 50 / 14,
+  throttleToPercent: 28,
+  reduceByPercent: 72,
+  proAccountEquivalentToCoverOverPlan: 360_000 / 50_400,
+  proAccountsToCoverOverPlan: 8,
+  projectedDepletionHours: 8,
+  projectedMinimumRemainingCredits: 0,
+  status: "danger",
+  accountCount: 2,
+};
+
+describe("WeeklyCreditsPaceCard", () => {
+  it("renders weekly pace percentages and over-plan credits", () => {
+    render(<WeeklyCreditsPaceCard pace={BASE_PACE} />);
+
+    expect(screen.getByText("Weekly credits pace")).toBeInTheDocument();
+    expect(screen.queryByText("2 accounts with weekly timing")).not.toBeInTheDocument();
+    expect(screen.getByText("Used now")).toBeInTheDocument();
+    expect(screen.getByText("Scheduled by now")).toBeInTheDocument();
+    expect(screen.getByText("Pace gap")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getByText("14%")).toBeInTheDocument();
+    expect(screen.getByText("3.57x scheduled pace")).toBeInTheDocument();
+    expect(screen.getByText("Recovery options")).toBeInTheDocument();
+    expect(screen.getByText("Pause")).toBeInTheDocument();
+    expect(screen.getByText("2d 12h until reset")).toBeInTheDocument();
+    expect(screen.getByText("Throttle")).toBeInTheDocument();
+    expect(screen.getByText("Reduce ongoing weekly-credit load by ~72%")).toBeInTheDocument();
+    expect(screen.getByText("Add capacity")).toBeInTheDocument();
+    expect(screen.getByText("7.1x Pro weekly pool (~8 accounts)")).toBeInTheDocument();
+    expect(screen.getByText("360K credits short before reset")).toBeInTheDocument();
+    expect(screen.queryByText("500K")).not.toBeInTheDocument();
+    expect(screen.getByText("Schedule marker")).toBeInTheDocument();
+  });
+
+  it("shows that no pause is needed when pace is behind schedule", () => {
+    render(
+      <WeeklyCreditsPaceCard
+        pace={{
+          ...BASE_PACE,
+          deltaPercent: -8,
+          overPlanCredits: -80_000,
+          pauseForBreakEvenHours: null,
+          paceMultiplier: null,
+          throttleToPercent: null,
+          reduceByPercent: null,
+          proAccountEquivalentToCoverOverPlan: null,
+          proAccountsToCoverOverPlan: null,
+          projectedMinimumRemainingCredits: 80_000,
+          status: "behind",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("No pause needed")).toBeInTheDocument();
+    expect(screen.getByText("8% below schedule")).toBeInTheDocument();
+    expect(screen.getByText("80K credits projected low-water mark")).toBeInTheDocument();
+  });
+
+  it("shows fractional pro account capacity before the rounded account count", () => {
+    render(
+      <WeeklyCreditsPaceCard
+        pace={{
+          ...BASE_PACE,
+          overPlanCredits: 26_750,
+          proAccountEquivalentToCoverOverPlan: 26_750 / 50_400,
+          proAccountsToCoverOverPlan: 1,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("0.53x Pro weekly pool (~1 account)")).toBeInTheDocument();
+  });
+
+  it("does not render fake pace when data is unavailable", () => {
+    const { container } = render(<WeeklyCreditsPaceCard pace={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
@@ -106,6 +106,7 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
     pace.status === "danger" ? "bg-red-500" : pace.status === "ahead" ? "bg-amber-500" : "bg-primary";
   const throttle = throttleLine(pace);
   const proAccounts = proAccountsLine(pace);
+  const showRecovery = pace.overPlanCredits > 0 || Boolean(throttle) || Boolean(proAccounts);
 
   return (
     <section className="rounded-xl border bg-card p-5" aria-label="Weekly credits pace">
@@ -153,28 +154,30 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
           </div>
         </div>
 
-        <div className="rounded-lg border bg-background/60 px-3 py-2 text-xs">
-          <p className="font-medium">Recovery options</p>
-          <div className="mt-2 grid gap-1.5">
-            <div className="flex items-baseline justify-between gap-3">
-              <span className="shrink-0 text-muted-foreground">Pause</span>
-              <span className="min-w-0 text-right tabular-nums">{breakEvenLine(pace)}</span>
+        {showRecovery ? (
+          <div className="rounded-lg border bg-background/60 px-3 py-2 text-xs">
+            <p className="font-medium">Recovery options</p>
+            <div className="mt-2 grid gap-1.5">
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="shrink-0 text-muted-foreground">Pause</span>
+                <span className="min-w-0 text-right tabular-nums">{breakEvenLine(pace)}</span>
+              </div>
+              {throttle ? (
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="shrink-0 text-muted-foreground">Throttle</span>
+                  <span className="min-w-0 text-right tabular-nums">{throttle}</span>
+                </div>
+              ) : null}
+              {proAccounts ? (
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="shrink-0 text-muted-foreground">Add capacity</span>
+                  <span className="min-w-0 text-right tabular-nums">{proAccounts}</span>
+                </div>
+              ) : null}
             </div>
-            {throttle ? (
-              <div className="flex items-baseline justify-between gap-3">
-                <span className="shrink-0 text-muted-foreground">Throttle</span>
-                <span className="min-w-0 text-right tabular-nums">{throttle}</span>
-              </div>
-            ) : null}
-            {proAccounts ? (
-              <div className="flex items-baseline justify-between gap-3">
-                <span className="shrink-0 text-muted-foreground">Add capacity</span>
-                <span className="min-w-0 text-right tabular-nums">{proAccounts}</span>
-              </div>
-            ) : null}
+            <p className="mt-2 text-muted-foreground">{scheduleGapLine(pace)}</p>
           </div>
-          <p className="mt-2 text-muted-foreground">{scheduleGapLine(pace)}</p>
-        </div>
+        ) : null}
       </div>
     </section>
   );

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
@@ -1,0 +1,181 @@
+import { Gauge } from "lucide-react";
+
+import type { WeeklyCreditPace } from "@/features/dashboard/utils";
+import { cn } from "@/lib/utils";
+import { formatCompactNumber } from "@/utils/formatters";
+
+export type WeeklyCreditsPaceCardProps = {
+  pace: WeeklyCreditPace | null;
+};
+
+function formatPercent(value: number): string {
+  return `${Math.round(value)}%`;
+}
+
+function formatApproxPercent(value: number): string {
+  return `~${Math.round(value)}%`;
+}
+
+function formatSignedPercent(value: number): string {
+  return `${Math.round(Math.abs(value))}%`;
+}
+
+function formatProAccountEquivalent(value: number): string {
+  if (value < 1) {
+    return value >= 0.1 ? value.toFixed(2) : value.toFixed(3);
+  }
+  return value < 10 ? value.toFixed(1) : value.toFixed(0);
+}
+
+function statusLabel(pace: WeeklyCreditPace): string {
+  if (pace.status === "on_track") return "On pace";
+  const direction = pace.deltaPercent > 0 ? "above schedule" : "below schedule";
+  if (pace.paceMultiplier != null && pace.paceMultiplier > 0) {
+    return `${pace.paceMultiplier.toFixed(2)}x scheduled pace`;
+  }
+  return `${formatSignedPercent(pace.deltaPercent)} ${direction}`;
+}
+
+function scheduleGapLine(pace: WeeklyCreditPace): string {
+  if (pace.overPlanCredits > 0) {
+    return `${formatCompactNumber(pace.overPlanCredits)} credits short before reset`;
+  }
+  if (pace.projectedMinimumRemainingCredits != null) {
+    return `${formatCompactNumber(pace.projectedMinimumRemainingCredits)} credits projected low-water mark`;
+  }
+  return "Pool covers current pace through upcoming resets";
+}
+
+function formatDurationHours(hours: number): string {
+  const totalMinutes = Math.max(1, Math.ceil(hours * 60));
+  const days = Math.floor(totalMinutes / 1440);
+  const hoursPart = Math.floor((totalMinutes % 1440) / 60);
+  const minutesPart = totalMinutes % 60;
+
+  if (days > 0) {
+    return hoursPart > 0 ? `${days}d ${hoursPart}h` : `${days}d`;
+  }
+  if (hoursPart > 0) {
+    return minutesPart > 0 ? `${hoursPart}h ${minutesPart}m` : `${hoursPart}h`;
+  }
+  return `${minutesPart}m`;
+}
+
+function breakEvenLine(pace: WeeklyCreditPace): string {
+  if (pace.overPlanCredits <= 0) {
+    return "No pause needed";
+  }
+  if (pace.pauseForBreakEvenHours == null) {
+    return "Until reset";
+  }
+  return `${formatDurationHours(pace.pauseForBreakEvenHours)} until reset`;
+}
+
+function proAccountsLine(pace: WeeklyCreditPace): string | null {
+  if (!pace.proAccountsToCoverOverPlan || pace.proAccountEquivalentToCoverOverPlan == null) {
+    return null;
+  }
+  const equivalent = formatProAccountEquivalent(pace.proAccountEquivalentToCoverOverPlan);
+  const roundedLabel = pace.proAccountsToCoverOverPlan === 1 ? "account" : "accounts";
+  return `${equivalent}x Pro weekly pool (~${pace.proAccountsToCoverOverPlan} ${roundedLabel})`;
+}
+
+function throttleLine(pace: WeeklyCreditPace): string | null {
+  if (pace.throttleToPercent == null || pace.reduceByPercent == null) {
+    return null;
+  }
+  return `Reduce ongoing weekly-credit load by ${formatApproxPercent(pace.reduceByPercent)}`;
+}
+
+export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
+  if (!pace) {
+    return null;
+  }
+
+  const statusClass =
+    pace.status === "danger"
+      ? "border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-300"
+      : pace.status === "ahead"
+        ? "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+        : pace.status === "behind"
+          ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+          : "border-border bg-muted/40 text-muted-foreground";
+  const actualBarWidth = Math.max(0, Math.min(100, pace.actualUsedPercent));
+  const scheduledMarkerLeft = Math.max(0, Math.min(100, pace.scheduledUsedPercent));
+  const actualBarClass =
+    pace.status === "danger" ? "bg-red-500" : pace.status === "ahead" ? "bg-amber-500" : "bg-primary";
+  const throttle = throttleLine(pace);
+  const proAccounts = proAccountsLine(pace);
+
+  return (
+    <section className="rounded-xl border bg-card p-5" aria-label="Weekly credits pace">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold">Weekly credits pace</h3>
+        </div>
+        <div className={cn("flex h-9 w-9 items-center justify-center rounded-lg", statusClass)}>
+          <Gauge className="h-4 w-4" aria-hidden="true" />
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div className="space-y-3">
+          <div className="grid grid-cols-3 gap-2 text-xs">
+            <div className="min-w-0 rounded-md bg-muted/30 px-3 py-2">
+              <p className="text-muted-foreground">Used now</p>
+              <p className="mt-1 text-sm font-semibold tabular-nums">{formatPercent(pace.actualUsedPercent)}</p>
+            </div>
+            <div className="min-w-0 rounded-md bg-muted/30 px-3 py-2">
+              <p className="text-muted-foreground">Scheduled by now</p>
+              <p className="mt-1 text-sm font-semibold tabular-nums">{formatPercent(pace.scheduledUsedPercent)}</p>
+            </div>
+            <div className="min-w-0 rounded-md bg-muted/30 px-3 py-2">
+              <p className="text-muted-foreground">Pace gap</p>
+              <p className="mt-1 text-sm font-semibold tabular-nums">{statusLabel(pace)}</p>
+            </div>
+          </div>
+          <div className="relative h-1.5 rounded-full bg-muted">
+            <div className={cn("h-full rounded-full", actualBarClass)} style={{ width: `${actualBarWidth}%` }} />
+            <div
+              className="absolute top-1/2 h-3 w-0.5 -translate-y-1/2 rounded-full bg-foreground/70"
+              style={{ left: `${scheduledMarkerLeft}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <span className={cn("h-1.5 w-4 rounded-full", actualBarClass)} />
+              Actual
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="h-3 w-0.5 rounded-full bg-foreground/70" />
+              Schedule marker
+            </span>
+          </div>
+        </div>
+
+        <div className="rounded-lg border bg-background/60 px-3 py-2 text-xs">
+          <p className="font-medium">Recovery options</p>
+          <div className="mt-2 grid gap-1.5">
+            <div className="flex items-baseline justify-between gap-3">
+              <span className="shrink-0 text-muted-foreground">Pause</span>
+              <span className="min-w-0 text-right tabular-nums">{breakEvenLine(pace)}</span>
+            </div>
+            {throttle ? (
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="shrink-0 text-muted-foreground">Throttle</span>
+                <span className="min-w-0 text-right tabular-nums">{throttle}</span>
+              </div>
+            ) : null}
+            {proAccounts ? (
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="shrink-0 text-muted-foreground">Add capacity</span>
+                <span className="min-w-0 text-right tabular-nums">{proAccounts}</span>
+              </div>
+            ) : null}
+          </div>
+          <p className="mt-2 text-muted-foreground">{scheduleGapLine(pace)}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/dashboard/schemas.test.ts
+++ b/frontend/src/features/dashboard/schemas.test.ts
@@ -218,6 +218,21 @@ describe("UsageWindowSchema", () => {
 });
 
 describe("AccountSummarySchema light contract", () => {
+  it("keeps weekly credit budget fields for dashboard pace math", () => {
+    const parsed = AccountSummarySchema.parse({
+      accountId: "acc-1",
+      email: "user@example.com",
+      displayName: "User",
+      planType: "pro",
+      status: "active",
+      capacityCreditsSecondary: 2000,
+      remainingCreditsSecondary: 900,
+    });
+
+    expect(parsed.capacityCreditsSecondary).toBe(2000);
+    expect(parsed.remainingCreditsSecondary).toBe(900);
+  });
+
   it("does not expose removed legacy fields", () => {
     const parsed = AccountSummarySchema.parse({
       accountId: "acc-1",

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -6,6 +6,7 @@ import {
   buildDashboardView,
   buildDepletionView,
   buildRemainingItems,
+  buildWeeklyCreditPace,
   sumRemaining,
   type RemainingItem,
 } from "@/features/dashboard/utils";
@@ -22,6 +23,10 @@ function account(overrides: Partial<AccountSummary> & Pick<AccountSummary, "acco
     usage: overrides.usage ?? null,
     resetAtPrimary: overrides.resetAtPrimary ?? null,
     resetAtSecondary: overrides.resetAtSecondary ?? null,
+    windowMinutesPrimary: overrides.windowMinutesPrimary ?? null,
+    windowMinutesSecondary: overrides.windowMinutesSecondary ?? null,
+    capacityCreditsSecondary: overrides.capacityCreditsSecondary ?? null,
+    remainingCreditsSecondary: overrides.remainingCreditsSecondary ?? null,
     auth: overrides.auth ?? null,
     additionalQuotas: overrides.additionalQuotas ?? [],
   };
@@ -289,6 +294,243 @@ describe("sumRemaining", () => {
       remainingItem({ accountId: "b", value: -20 }),
     ];
     expect(sumRemaining(items)).toBe(0);
+  });
+});
+
+describe("buildWeeklyCreditPace", () => {
+  const now = new Date("2026-01-07T12:00:00Z");
+
+  type WeeklyAccountOverrides = Partial<AccountSummary> & {
+    accountId: string;
+    fullCredits?: number | null;
+    remainingCredits?: number | null;
+    timeLeftPercent?: number;
+  };
+
+  function weeklyAccount(overrides: WeeklyAccountOverrides): AccountSummary {
+    const { accountId, fullCredits, remainingCredits, timeLeftPercent: timeLeftOverride, ...accountOverrides } = overrides;
+    const windowMinutes = 10_080;
+    const timeLeftPercent = timeLeftOverride ?? 50;
+    const resetAt = new Date(now.getTime() + windowMinutes * 60_000 * (timeLeftPercent / 100)).toISOString();
+    const fullCreditBudget = fullCredits !== undefined ? fullCredits : accountOverrides.capacityCreditsSecondary ?? 100_000;
+    const remainingCreditBudget =
+      remainingCredits !== undefined ? remainingCredits : accountOverrides.remainingCreditsSecondary ?? 50_000;
+    return account({
+      ...accountOverrides,
+      accountId,
+      email: `${accountId}@example.com`,
+      usage: {
+        primaryRemainingPercent: null,
+        secondaryRemainingPercent:
+          fullCreditBudget && remainingCreditBudget != null
+            ? (remainingCreditBudget / fullCreditBudget) * 100
+            : null,
+      },
+      resetAtSecondary: accountOverrides.resetAtSecondary !== undefined ? accountOverrides.resetAtSecondary : resetAt,
+      windowMinutesSecondary: accountOverrides.windowMinutesSecondary !== undefined
+        ? accountOverrides.windowMinutesSecondary
+        : windowMinutes,
+      capacityCreditsSecondary: fullCreditBudget,
+      remainingCreditsSecondary: remainingCreditBudget,
+    });
+  }
+
+  it("treats a 99% used account at 99% elapsed as on pace", () => {
+    const pace = buildWeeklyCreditPace(
+      [weeklyAccount({ accountId: "acc-close", fullCredits: 100_000, remainingCredits: 1_000, timeLeftPercent: 1 })],
+      now,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.totalExpectedRemainingCredits).toBeCloseTo(1_000);
+    expect(pace?.overPlanCredits).toBeCloseTo(0);
+    expect(pace?.deltaPercent).toBeCloseTo(0);
+    expect(pace?.pauseForBreakEvenHours).toBeNull();
+    expect(pace?.paceMultiplier).toBeNull();
+    expect(pace?.throttleToPercent).toBeNull();
+    expect(pace?.reduceByPercent).toBeNull();
+    expect(pace?.proAccountsToCoverOverPlan).toBeNull();
+    expect(pace?.status).toBe("on_track");
+  });
+
+  it("aggregates credit budgets instead of averaging account percentages", () => {
+    const pace = buildWeeklyCreditPace(
+      [
+        weeklyAccount({ accountId: "acc-small", fullCredits: 100_000, remainingCredits: 1_000, timeLeftPercent: 1 }),
+        weeklyAccount({ accountId: "acc-large", fullCredits: 900_000, remainingCredits: 800_000, timeLeftPercent: 80 }),
+      ],
+      now,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.accountCount).toBe(2);
+    expect(pace?.totalActualRemainingCredits).toBeCloseTo(801_000);
+    expect(pace?.totalExpectedRemainingCredits).toBeCloseTo(721_000);
+    expect(pace?.overPlanCredits).toBeCloseTo(0);
+    expect(pace?.actualUsedPercent).toBeCloseTo(19.9);
+    expect(pace?.scheduledUsedPercent).toBeCloseTo(27.9);
+    expect(pace?.pauseForBreakEvenHours).toBeNull();
+    expect(pace?.paceMultiplier).toBeNull();
+    expect(pace?.proAccountsToCoverOverPlan).toBeNull();
+    expect(pace?.status).toBe("behind");
+  });
+
+  it("marks a large account depleted too early as danger", () => {
+    const pace = buildWeeklyCreditPace(
+      [weeklyAccount({ accountId: "acc-early", fullCredits: 1_000_000, remainingCredits: 10_000, timeLeftPercent: 80 })],
+      now,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.totalExpectedRemainingCredits).toBeCloseTo(800_000);
+    expect(pace?.overPlanCredits).toBeCloseTo(3_950_000);
+    expect(pace?.deltaPercent).toBeCloseTo(79);
+    expect(pace?.pauseForBreakEvenHours).toBeCloseTo(134.06);
+    expect(pace?.paceMultiplier).toBeCloseTo(4.95);
+    expect(pace?.throttleToPercent).toBeCloseTo(0.25);
+    expect(pace?.reduceByPercent).toBeCloseTo(99.75);
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeCloseTo(78.37);
+    expect(pace?.proAccountsToCoverOverPlan).toBe(79);
+    expect(pace?.projectedDepletionHours).toBeCloseTo(0.34);
+    expect(pace?.status).toBe("danger");
+  });
+
+  it("uses each account reset time before summing credits", () => {
+    const pace = buildWeeklyCreditPace(
+      [
+        weeklyAccount({ accountId: "acc-near", fullCredits: 100_000, remainingCredits: 50_000, timeLeftPercent: 10 }),
+        weeklyAccount({ accountId: "acc-far", fullCredits: 100_000, remainingCredits: 50_000, timeLeftPercent: 90 }),
+      ],
+      now,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.totalExpectedRemainingCredits).toBeCloseTo(100_000);
+    expect(pace?.scheduledUsedPercent).toBeCloseTo(50);
+    expect(pace?.actualUsedPercent).toBeCloseTo(50);
+    expect(pace?.pauseForBreakEvenHours).toBeNull();
+    expect(pace?.paceMultiplier).toBeNull();
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeNull();
+    expect(pace?.proAccountsToCoverOverPlan).toBeNull();
+    expect(pace?.status).toBe("on_track");
+  });
+
+  it("does not let a tiny near reset hide depletion before the next meaningful reset", () => {
+    const pace = buildWeeklyCreditPace(
+      [
+        weeklyAccount({ accountId: "tiny-reset", fullCredits: 2, remainingCredits: 0, timeLeftPercent: 1 }),
+        weeklyAccount({ accountId: "large-later", fullCredits: 100_000, remainingCredits: 20_000, timeLeftPercent: 50 }),
+      ],
+      now,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.overPlanCredits).toBeCloseTo(20_403.05);
+    expect(pace?.projectedDepletionHours).toBeCloseTo(39.9);
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeCloseTo(0.4);
+    expect(pace?.proAccountsToCoverOverPlan).toBe(1);
+    expect(pace?.status).toBe("danger");
+  });
+
+  it("computes break-even pause across different reset deadlines", () => {
+    const pace = buildWeeklyCreditPace(
+      [
+        weeklyAccount({ accountId: "acc-near", fullCredits: 100_000, remainingCredits: 0, timeLeftPercent: 10 }),
+        weeklyAccount({ accountId: "acc-far", fullCredits: 100_000, remainingCredits: 0, timeLeftPercent: 90 }),
+      ],
+      now,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.overPlanCredits).toBeCloseTo(22_222.22);
+    expect(pace?.pauseForBreakEvenHours).toBeCloseTo(16.8);
+    expect(pace?.paceMultiplier).toBeCloseTo(2);
+    expect(pace?.throttleToPercent).toBeCloseTo(0);
+    expect(pace?.reduceByPercent).toBeCloseTo(100);
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeCloseTo(0.44);
+    expect(pace?.proAccountsToCoverOverPlan).toBe(1);
+    expect(pace?.projectedDepletionHours).toBeCloseTo(0);
+    expect(pace?.status).toBe("danger");
+  });
+
+  it("keeps the recovery warning hidden when the current pool survives repeated reset events", () => {
+    const liveLikeNow = new Date("2026-05-03T19:19:35Z");
+    const pace = buildWeeklyCreditPace(
+      [
+        account({
+          accountId: "old-pro-1",
+          email: "old-pro-1@example.com",
+          planType: "pro",
+          capacityCreditsSecondary: 50_400,
+          remainingCreditsSecondary: 1_008,
+          resetAtSecondary: "2026-05-05T05:34:05Z",
+          windowMinutesSecondary: 10_080,
+        }),
+        account({
+          accountId: "old-pro-2",
+          email: "old-pro-2@example.com",
+          planType: "pro",
+          capacityCreditsSecondary: 50_400,
+          remainingCreditsSecondary: 1_512,
+          resetAtSecondary: "2026-05-05T05:51:53Z",
+          windowMinutesSecondary: 10_080,
+        }),
+        account({
+          accountId: "team-1",
+          email: "team-1@example.com",
+          planType: "team",
+          capacityCreditsSecondary: 7_560,
+          remainingCreditsSecondary: 1_587.6,
+          resetAtSecondary: "2026-05-05T13:31:20Z",
+          windowMinutesSecondary: 10_080,
+        }),
+        account({
+          accountId: "team-2",
+          email: "team-2@example.com",
+          planType: "team",
+          capacityCreditsSecondary: 7_560,
+          remainingCreditsSecondary: 5_443.2,
+          resetAtSecondary: "2026-05-06T14:45:02Z",
+          windowMinutesSecondary: 10_080,
+        }),
+        account({
+          accountId: "new-pro",
+          email: "new-pro@example.com",
+          planType: "pro",
+          capacityCreditsSecondary: 50_400,
+          remainingCreditsSecondary: 48_888,
+          resetAtSecondary: "2026-05-10T18:19:10Z",
+          windowMinutesSecondary: 10_080,
+        }),
+      ],
+      liveLikeNow,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.accountCount).toBe(5);
+    expect(pace?.totalActualRemainingCredits).toBeCloseTo(58_438.8);
+    expect(pace?.overPlanCredits).toBeCloseTo(0);
+    expect(pace?.pauseForBreakEvenHours).toBeNull();
+    expect(pace?.paceMultiplier).toBeNull();
+    expect(pace?.throttleToPercent).toBeNull();
+    expect(pace?.reduceByPercent).toBeNull();
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeNull();
+    expect(pace?.proAccountsToCoverOverPlan).toBeNull();
+    expect(pace?.projectedMinimumRemainingCredits).toBeCloseTo(3_204.38);
+    expect(pace?.status).toBe("on_track");
+  });
+
+  it("skips accounts without complete weekly credit timing data", () => {
+    const pace = buildWeeklyCreditPace(
+      [
+        weeklyAccount({ accountId: "missing-full", fullCredits: null, remainingCredits: 1_000, timeLeftPercent: 50 }),
+        weeklyAccount({ accountId: "missing-reset", fullCredits: 100_000, remainingCredits: 50_000, resetAtSecondary: null }),
+        weeklyAccount({ accountId: "missing-window", fullCredits: 100_000, remainingCredits: 50_000, windowMinutesSecondary: null }),
+      ],
+      now,
+    );
+
+    expect(pace).toBeNull();
   });
 });
 

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -421,11 +421,12 @@ describe("buildWeeklyCreditPace", () => {
     expect(pace?.totalExpectedRemainingCredits).toBeCloseTo(100_000);
     expect(pace?.scheduledUsedPercent).toBeCloseTo(50);
     expect(pace?.actualUsedPercent).toBeCloseTo(50);
-    expect(pace?.pauseForBreakEvenHours).toBeNull();
-    expect(pace?.paceMultiplier).toBeNull();
-    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeNull();
-    expect(pace?.proAccountsToCoverOverPlan).toBeNull();
-    expect(pace?.status).toBe("on_track");
+    expect(pace?.overPlanCredits).toBeGreaterThan(0);
+    expect(pace?.pauseForBreakEvenHours).toBeCloseTo(90.72);
+    expect(pace?.paceMultiplier).toBeCloseTo(1);
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeGreaterThan(0);
+    expect(pace?.proAccountsToCoverOverPlan).toBe(6);
+    expect(pace?.status).toBe("danger");
   });
 
   it("expires unused account credits at reset instead of carrying them forward", () => {
@@ -439,7 +440,7 @@ describe("buildWeeklyCreditPace", () => {
 
     expect(pace).not.toBeNull();
     expect(pace?.overPlanCredits).toBeCloseTo(0);
-    expect(pace?.projectedMinimumRemainingCredits).toBeCloseTo(111.11);
+    expect(pace?.projectedMinimumRemainingCredits).toBeCloseTo(0);
   });
 
   it("does not let a tiny near reset hide depletion before the next meaningful reset", () => {
@@ -452,10 +453,10 @@ describe("buildWeeklyCreditPace", () => {
     );
 
     expect(pace).not.toBeNull();
-    expect(pace?.overPlanCredits).toBeCloseTo(20_403.05);
-    expect(pace?.projectedDepletionHours).toBeCloseTo(39.9);
-    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeCloseTo(0.4);
-    expect(pace?.proAccountsToCoverOverPlan).toBe(1);
+    expect(pace?.overPlanCredits).toBeCloseTo(59_999.01);
+    expect(pace?.projectedDepletionHours).toBeLessThan(40);
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeGreaterThan(1);
+    expect(pace?.proAccountsToCoverOverPlan).toBe(2);
     expect(pace?.status).toBe("danger");
   });
 
@@ -469,18 +470,18 @@ describe("buildWeeklyCreditPace", () => {
     );
 
     expect(pace).not.toBeNull();
-    expect(pace?.overPlanCredits).toBeCloseTo(22_222.22);
-    expect(pace?.pauseForBreakEvenHours).toBeCloseTo(16.8);
+    expect(pace?.overPlanCredits).toBeCloseTo(111_111.11);
+    expect(pace?.pauseForBreakEvenHours).toBeGreaterThan(0);
     expect(pace?.paceMultiplier).toBeCloseTo(2);
     expect(pace?.throttleToPercent).toBeCloseTo(0);
     expect(pace?.reduceByPercent).toBeCloseTo(100);
-    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeCloseTo(0.44);
-    expect(pace?.proAccountsToCoverOverPlan).toBe(1);
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeCloseTo(2.2);
+    expect(pace?.proAccountsToCoverOverPlan).toBe(3);
     expect(pace?.projectedDepletionHours).toBeCloseTo(0);
     expect(pace?.status).toBe("danger");
   });
 
-  it("keeps the recovery warning hidden when the current pool survives repeated reset events", () => {
+  it("shows recovery pressure when per-account weekly burn exceeds staggered resets", () => {
     const liveLikeNow = new Date("2026-05-03T19:19:35Z");
     const pace = buildWeeklyCreditPace(
       [
@@ -536,15 +537,15 @@ describe("buildWeeklyCreditPace", () => {
     expect(pace).not.toBeNull();
     expect(pace?.accountCount).toBe(5);
     expect(pace?.totalActualRemainingCredits).toBeCloseTo(58_438.8);
-    expect(pace?.overPlanCredits).toBeCloseTo(0);
-    expect(pace?.pauseForBreakEvenHours).toBeNull();
-    expect(pace?.paceMultiplier).toBeNull();
-    expect(pace?.throttleToPercent).toBeNull();
-    expect(pace?.reduceByPercent).toBeNull();
-    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeNull();
-    expect(pace?.proAccountsToCoverOverPlan).toBeNull();
-    expect(pace?.projectedMinimumRemainingCredits).toBeCloseTo(30_821.59);
-    expect(pace?.status).toBe("on_track");
+    expect(pace?.overPlanCredits).toBeCloseTo(20_510.96);
+    expect(pace?.pauseForBreakEvenHours).toBeGreaterThan(0);
+    expect(pace?.paceMultiplier).toBeGreaterThan(1);
+    expect(pace?.throttleToPercent).toBeGreaterThanOrEqual(0);
+    expect(pace?.reduceByPercent).toBeGreaterThan(0);
+    expect(pace?.proAccountEquivalentToCoverOverPlan).toBeGreaterThan(0);
+    expect(pace?.proAccountsToCoverOverPlan).toBe(1);
+    expect(pace?.projectedMinimumRemainingCredits).toBeCloseTo(0);
+    expect(pace?.status).toBe("danger");
   });
 
   it("skips accounts without complete weekly credit timing data", () => {

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -428,6 +428,20 @@ describe("buildWeeklyCreditPace", () => {
     expect(pace?.status).toBe("on_track");
   });
 
+  it("expires unused account credits at reset instead of carrying them forward", () => {
+    const pace = buildWeeklyCreditPace(
+      [
+        weeklyAccount({ accountId: "unused-near-reset", fullCredits: 1_000, remainingCredits: 1_000, timeLeftPercent: 10 }),
+        weeklyAccount({ accountId: "empty-later-reset", fullCredits: 1_000, remainingCredits: 0, timeLeftPercent: 90 }),
+      ],
+      now,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.overPlanCredits).toBeCloseTo(0);
+    expect(pace?.projectedMinimumRemainingCredits).toBeCloseTo(111.11);
+  });
+
   it("does not let a tiny near reset hide depletion before the next meaningful reset", () => {
     const pace = buildWeeklyCreditPace(
       [

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -353,6 +353,19 @@ describe("buildWeeklyCreditPace", () => {
     expect(pace?.status).toBe("on_track");
   });
 
+  it("does not report a shortfall when the weekly reset replenishes a sustainable account", () => {
+    const pace = buildWeeklyCreditPace(
+      [weeklyAccount({ accountId: "acc-sustainable", fullCredits: 100_000, remainingCredits: 50_000, timeLeftPercent: 50 })],
+      now,
+    );
+
+    expect(pace).not.toBeNull();
+    expect(pace?.overPlanCredits).toBeCloseTo(0);
+    expect(pace?.projectedDepletionHours).toBeNull();
+    expect(pace?.pauseForBreakEvenHours).toBeNull();
+    expect(pace?.status).toBe("on_track");
+  });
+
   it("aggregates credit budgets instead of averaging account percentages", () => {
     const pace = buildWeeklyCreditPace(
       [
@@ -516,7 +529,7 @@ describe("buildWeeklyCreditPace", () => {
     expect(pace?.reduceByPercent).toBeNull();
     expect(pace?.proAccountEquivalentToCoverOverPlan).toBeNull();
     expect(pace?.proAccountsToCoverOverPlan).toBeNull();
-    expect(pace?.projectedMinimumRemainingCredits).toBeCloseTo(3_204.38);
+    expect(pace?.projectedMinimumRemainingCredits).toBeCloseTo(30_821.59);
     expect(pace?.status).toBe("on_track");
   });
 

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -8,6 +8,7 @@ import {
   buildRemainingItems,
   buildWeeklyCreditPace,
   sumRemaining,
+  weeklyCreditPaceStatus,
   type RemainingItem,
 } from "@/features/dashboard/utils";
 import { createDashboardOverview, createDefaultRequestLogs } from "@/test/mocks/factories";
@@ -334,6 +335,11 @@ describe("buildWeeklyCreditPace", () => {
       remainingCreditsSecondary: remainingCreditBudget,
     });
   }
+
+  it("marks over-schedule weekly usage as ahead before hard shortfall states", () => {
+    expect(weeklyCreditPaceStatus(6, 0)).toBe("ahead");
+    expect(weeklyCreditPaceStatus(6, 1)).toBe("danger");
+  });
 
   it("treats a 99% used account at 99% elapsed as on pace", () => {
     const pace = buildWeeklyCreditPace(

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -270,7 +270,7 @@ function buildWeeklyPoolProjection(accounts: WeeklyPoolAccount[], nowMs: number)
     .filter((account) => account.resetAtMs > nowMs)
     .map((account) => ({
       resetAtMs: account.resetAtMs,
-      topUpCredits: Math.max(0, account.fullCredits - account.remainingCredits),
+      topUpCredits: account.fullCredits,
       recurringTopUpCredits: account.fullCredits,
       windowMs: account.windowMs,
     }));
@@ -296,7 +296,7 @@ function buildWeeklyPoolProjection(accounts: WeeklyPoolAccount[], nowMs: number)
     const nextEventAtMs = Math.min(event.resetAtMs, horizonMs);
     const intervalMs = nextEventAtMs - cursorMs;
     const intervalBurnCredits = burnRateCreditsPerMs * intervalMs;
-    if (intervalBurnCredits >= balanceCredits) {
+    if (intervalBurnCredits > balanceCredits) {
       const projectedShortfallCredits = intervalBurnCredits - balanceCredits;
       return {
         burnRateCreditsPerMs,

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -222,6 +222,10 @@ type WeeklyPoolAccount = {
   windowMs: number;
 };
 
+type WeeklyPoolSimulationAccount = WeeklyPoolAccount & {
+  balanceCredits: number;
+};
+
 type WeeklyPoolProjection = {
   burnRateCreditsPerMs: number;
   projectedShortfallCredits: number;
@@ -231,11 +235,30 @@ type WeeklyPoolProjection = {
 };
 
 type WeeklyResetEvent = {
+  fullCredits: number;
+  balanceCredits: number;
   resetAtMs: number;
-  topUpCredits: number;
-  recurringTopUpCredits: number;
   windowMs: number;
 };
+
+function totalWeeklyBalanceCredits(accounts: WeeklyPoolSimulationAccount[]): number {
+  return accounts.reduce((sum, account) => sum + account.balanceCredits, 0);
+}
+
+function consumeWeeklyBalanceCredits(accounts: WeeklyPoolSimulationAccount[], amountCredits: number): void {
+  let remainingToConsume = amountCredits;
+  const spendOrder = [...accounts].sort((a, b) => a.resetAtMs - b.resetAtMs);
+
+  for (const account of spendOrder) {
+    if (remainingToConsume <= 0) {
+      return;
+    }
+
+    const consumed = Math.min(account.balanceCredits, remainingToConsume);
+    account.balanceCredits -= consumed;
+    remainingToConsume -= consumed;
+  }
+}
 
 function buildWeeklyPoolProjection(accounts: WeeklyPoolAccount[], nowMs: number): WeeklyPoolProjection | null {
   const totalRemainingCredits = accounts.reduce((sum, account) => sum + account.remainingCredits, 0);
@@ -266,14 +289,13 @@ function buildWeeklyPoolProjection(accounts: WeeklyPoolAccount[], nowMs: number)
     };
   }
 
-  const resetEvents: WeeklyResetEvent[] = accounts
+  const simulationAccounts: WeeklyPoolSimulationAccount[] = accounts.map((account) => ({
+    ...account,
+    balanceCredits: account.remainingCredits,
+  }));
+  const resetEvents: WeeklyResetEvent[] = simulationAccounts
     .filter((account) => account.resetAtMs > nowMs)
-    .map((account) => ({
-      resetAtMs: account.resetAtMs,
-      topUpCredits: account.fullCredits,
-      recurringTopUpCredits: account.fullCredits,
-      windowMs: account.windowMs,
-    }));
+    .map((account) => account);
   if (resetEvents.length === 0) {
     return {
       burnRateCreditsPerMs,
@@ -307,16 +329,17 @@ function buildWeeklyPoolProjection(accounts: WeeklyPoolAccount[], nowMs: number)
       };
     }
 
-    balanceCredits -= intervalBurnCredits;
+    consumeWeeklyBalanceCredits(simulationAccounts, intervalBurnCredits);
+    balanceCredits = totalWeeklyBalanceCredits(simulationAccounts);
     minimumRemainingCredits = Math.min(minimumRemainingCredits, balanceCredits);
     cursorMs = nextEventAtMs;
     if (cursorMs >= horizonMs) {
       break;
     }
 
-    balanceCredits += event.topUpCredits;
-    event.topUpCredits = event.recurringTopUpCredits;
+    event.balanceCredits = event.fullCredits;
     event.resetAtMs += event.windowMs;
+    balanceCredits = totalWeeklyBalanceCredits(simulationAccounts);
   }
 
   return {

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -209,9 +209,10 @@ function isNonNegativeFinite(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
-function weeklyCreditPaceStatus(deltaPercent: number, projectedShortfallCredits: number): WeeklyCreditPaceStatus {
+export function weeklyCreditPaceStatus(deltaPercent: number, projectedShortfallCredits: number): WeeklyCreditPaceStatus {
   if (projectedShortfallCredits > 0) return "danger";
   if (deltaPercent < -5) return "behind";
+  if (deltaPercent > 5) return "ahead";
   return "on_track";
 }
 

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -262,21 +262,19 @@ function consumeWeeklyBalanceCredits(accounts: WeeklyPoolSimulationAccount[], am
 
 function buildWeeklyPoolProjection(accounts: WeeklyPoolAccount[], nowMs: number): WeeklyPoolProjection | null {
   const totalRemainingCredits = accounts.reduce((sum, account) => sum + account.remainingCredits, 0);
-  const totalUsedCredits = accounts.reduce(
-    (sum, account) => sum + Math.max(0, account.fullCredits - account.remainingCredits),
-    0,
-  );
-  const oldestWindowStartMs = Math.min(...accounts.map((account) => account.resetAtMs - account.windowMs));
-  const elapsedMs = nowMs - oldestWindowStartMs;
-  if (
-    totalUsedCredits <= 0 ||
-    !Number.isFinite(elapsedMs) ||
-    elapsedMs <= 0
-  ) {
+  const burnRateCreditsPerMs = accounts.reduce((sum, account) => {
+    const usedCredits = Math.max(0, account.fullCredits - account.remainingCredits);
+    const windowStartMs = account.resetAtMs - account.windowMs;
+    const elapsedMs = nowMs - windowStartMs;
+    if (usedCredits <= 0 || !Number.isFinite(elapsedMs) || elapsedMs <= 0) {
+      return sum;
+    }
+    return sum + usedCredits / elapsedMs;
+  }, 0);
+  if (burnRateCreditsPerMs <= 0) {
     return null;
   }
 
-  const burnRateCreditsPerMs = totalUsedCredits / elapsedMs;
   const firstResetAtMs = Math.min(...accounts.map((account) => account.resetAtMs));
   if (totalRemainingCredits <= 0) {
     const firstReplenishmentWaitMs = Number.isFinite(firstResetAtMs) ? Math.max(0, firstResetAtMs - nowMs) : 0;

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -44,6 +44,28 @@ export interface SafeLineView {
   riskLevel: "safe" | "warning" | "danger" | "critical";
 }
 
+export type WeeklyCreditPaceStatus = "behind" | "on_track" | "ahead" | "danger";
+
+export type WeeklyCreditPace = {
+  totalFullCredits: number;
+  totalActualRemainingCredits: number;
+  totalExpectedRemainingCredits: number;
+  actualUsedPercent: number;
+  scheduledUsedPercent: number;
+  deltaPercent: number;
+  overPlanCredits: number;
+  pauseForBreakEvenHours: number | null;
+  paceMultiplier: number | null;
+  throttleToPercent: number | null;
+  reduceByPercent: number | null;
+  proAccountEquivalentToCoverOverPlan: number | null;
+  proAccountsToCoverOverPlan: number | null;
+  projectedDepletionHours: number | null;
+  projectedMinimumRemainingCredits: number | null;
+  status: WeeklyCreditPaceStatus;
+  accountCount: number;
+};
+
 export type DashboardView = {
   stats: DashboardStat[];
   primaryUsageItems: RemainingItem[];
@@ -55,6 +77,7 @@ export type DashboardView = {
   requestLogs: RequestLog[];
   safeLinePrimary: SafeLineView | null;
   safeLineSecondary: SafeLineView | null;
+  weeklyCreditPace: WeeklyCreditPace | null;
 };
 
 export function buildDepletionView(depletion: Depletion | null | undefined): SafeLineView | null {
@@ -163,6 +186,7 @@ function avgPerUnit(total: number, units: number): number {
 }
 
 const TREND_COLORS = ["#3b82f6", "#8b5cf6", "#10b981", "#f59e0b"];
+const PRO_WEEKLY_CAPACITY_CREDITS = 50_400;
 
 function trendPointsToValues(points: TrendPoint[]): { value: number }[] {
   return points.map((p) => ({ value: p.v }));
@@ -171,6 +195,235 @@ function trendPointsToValues(points: TrendPoint[]): { value: number }[] {
 /** Sum the `value` fields of remaining items (clamped to >= 0). */
 export function sumRemaining(items: RemainingItem[]): number {
   return items.reduce((sum, item) => sum + Math.max(0, item.value), 0);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function isPositiveFinite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function isNonNegativeFinite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function weeklyCreditPaceStatus(deltaPercent: number, projectedShortfallCredits: number): WeeklyCreditPaceStatus {
+  if (projectedShortfallCredits > 0) return "danger";
+  if (deltaPercent < -5) return "behind";
+  return "on_track";
+}
+
+type WeeklyPoolAccount = {
+  fullCredits: number;
+  remainingCredits: number;
+  resetAtMs: number;
+  windowMs: number;
+};
+
+type WeeklyPoolProjection = {
+  burnRateCreditsPerMs: number;
+  projectedShortfallCredits: number;
+  projectedDepletionHours: number | null;
+  projectedMinimumRemainingCredits: number;
+  firstReplenishmentWaitMs: number | null;
+};
+
+type WeeklyResetEvent = {
+  resetAtMs: number;
+  topUpCredits: number;
+  recurringTopUpCredits: number;
+  windowMs: number;
+};
+
+function buildWeeklyPoolProjection(accounts: WeeklyPoolAccount[], nowMs: number): WeeklyPoolProjection | null {
+  const totalRemainingCredits = accounts.reduce((sum, account) => sum + account.remainingCredits, 0);
+  const totalUsedCredits = accounts.reduce(
+    (sum, account) => sum + Math.max(0, account.fullCredits - account.remainingCredits),
+    0,
+  );
+  const oldestWindowStartMs = Math.min(...accounts.map((account) => account.resetAtMs - account.windowMs));
+  const elapsedMs = nowMs - oldestWindowStartMs;
+  if (
+    totalUsedCredits <= 0 ||
+    !Number.isFinite(elapsedMs) ||
+    elapsedMs <= 0
+  ) {
+    return null;
+  }
+
+  const burnRateCreditsPerMs = totalUsedCredits / elapsedMs;
+  const firstResetAtMs = Math.min(...accounts.map((account) => account.resetAtMs));
+  if (totalRemainingCredits <= 0) {
+    const firstReplenishmentWaitMs = Number.isFinite(firstResetAtMs) ? Math.max(0, firstResetAtMs - nowMs) : 0;
+    return {
+      burnRateCreditsPerMs,
+      projectedShortfallCredits: burnRateCreditsPerMs * firstReplenishmentWaitMs,
+      projectedDepletionHours: 0,
+      projectedMinimumRemainingCredits: 0,
+      firstReplenishmentWaitMs,
+    };
+  }
+
+  const resetEvents: WeeklyResetEvent[] = accounts
+    .filter((account) => account.resetAtMs > nowMs)
+    .map((account) => ({
+      resetAtMs: account.resetAtMs,
+      topUpCredits: Math.max(0, account.fullCredits - account.remainingCredits),
+      recurringTopUpCredits: account.fullCredits,
+      windowMs: account.windowMs,
+    }));
+  if (resetEvents.length === 0) {
+    return {
+      burnRateCreditsPerMs,
+      projectedShortfallCredits: 0,
+      projectedDepletionHours: null,
+      projectedMinimumRemainingCredits: totalRemainingCredits,
+      firstReplenishmentWaitMs: null,
+    };
+  }
+
+  let cursorMs = nowMs;
+  let balanceCredits = totalRemainingCredits;
+  let minimumRemainingCredits = totalRemainingCredits;
+  const longestWindowMs = Math.max(...accounts.map((account) => account.windowMs));
+  const horizonMs = nowMs + longestWindowMs * 2;
+
+  while (cursorMs < horizonMs) {
+    resetEvents.sort((a, b) => a.resetAtMs - b.resetAtMs);
+    const event = resetEvents[0];
+    const nextEventAtMs = Math.min(event.resetAtMs, horizonMs);
+    const intervalMs = nextEventAtMs - cursorMs;
+    const intervalBurnCredits = burnRateCreditsPerMs * intervalMs;
+    if (intervalBurnCredits >= balanceCredits) {
+      const projectedShortfallCredits = intervalBurnCredits - balanceCredits;
+      return {
+        burnRateCreditsPerMs,
+        projectedShortfallCredits,
+        projectedDepletionHours: balanceCredits / burnRateCreditsPerMs / 3_600_000,
+        projectedMinimumRemainingCredits: 0,
+        firstReplenishmentWaitMs: nextEventAtMs - cursorMs,
+      };
+    }
+
+    balanceCredits -= intervalBurnCredits;
+    minimumRemainingCredits = Math.min(minimumRemainingCredits, balanceCredits);
+    cursorMs = nextEventAtMs;
+    if (cursorMs >= horizonMs) {
+      break;
+    }
+
+    balanceCredits += event.topUpCredits;
+    event.topUpCredits = event.recurringTopUpCredits;
+    event.resetAtMs += event.windowMs;
+  }
+
+  return {
+    burnRateCreditsPerMs,
+    projectedShortfallCredits: 0,
+    projectedDepletionHours: null,
+    projectedMinimumRemainingCredits: minimumRemainingCredits,
+    firstReplenishmentWaitMs: null,
+  };
+}
+
+export function buildWeeklyCreditPace(
+  accounts: AccountSummary[],
+  now: Date = new Date(),
+): WeeklyCreditPace | null {
+  const nowMs = now.getTime();
+  if (!Number.isFinite(nowMs)) {
+    return null;
+  }
+
+  let totalFullCredits = 0;
+  let totalActualRemainingCredits = 0;
+  let totalExpectedRemainingCredits = 0;
+  let accountCount = 0;
+  const weeklyAccounts: WeeklyPoolAccount[] = [];
+
+  for (const account of accounts) {
+    const fullCredits = account.capacityCreditsSecondary;
+    const remainingCredits = account.remainingCreditsSecondary;
+    const resetAtMs = account.resetAtSecondary ? Date.parse(account.resetAtSecondary) : Number.NaN;
+    const windowMinutes = account.windowMinutesSecondary;
+
+    if (
+      !isPositiveFinite(fullCredits) ||
+      !isNonNegativeFinite(remainingCredits) ||
+      !Number.isFinite(resetAtMs) ||
+      !isPositiveFinite(windowMinutes)
+    ) {
+      continue;
+    }
+
+    const windowMs = windowMinutes * 60_000;
+    const timeLeftMs = clamp(resetAtMs - nowMs, 0, windowMs);
+    const expectedRemainingCredits = fullCredits * (timeLeftMs / windowMs);
+    const actualRemainingCredits = clamp(remainingCredits, 0, fullCredits);
+
+    totalFullCredits += fullCredits;
+    totalActualRemainingCredits += actualRemainingCredits;
+    totalExpectedRemainingCredits += expectedRemainingCredits;
+    accountCount += 1;
+    weeklyAccounts.push({
+      fullCredits,
+      remainingCredits: actualRemainingCredits,
+      resetAtMs: Math.max(resetAtMs, nowMs),
+      windowMs,
+    });
+  }
+
+  if (accountCount === 0 || totalFullCredits <= 0) {
+    return null;
+  }
+
+  const actualUsedPercent = (100 * (totalFullCredits - totalActualRemainingCredits)) / totalFullCredits;
+  const scheduledUsedPercent = (100 * (totalFullCredits - totalExpectedRemainingCredits)) / totalFullCredits;
+  const deltaPercent = actualUsedPercent - scheduledUsedPercent;
+  const projection = buildWeeklyPoolProjection(weeklyAccounts, nowMs);
+  const overPlanCredits = projection?.projectedShortfallCredits ?? 0;
+  const pauseForBreakEvenHours =
+    projection && overPlanCredits > 0 && projection.burnRateCreditsPerMs > 0
+      ? overPlanCredits / projection.burnRateCreditsPerMs / 3_600_000
+      : null;
+  const paceMultiplier = overPlanCredits > 0 && scheduledUsedPercent > 0 ? actualUsedPercent / scheduledUsedPercent : null;
+  const throttleToPercent =
+    projection && overPlanCredits > 0 && projection.firstReplenishmentWaitMs && projection.burnRateCreditsPerMs > 0
+      ? clamp(
+          ((projection.firstReplenishmentWaitMs * projection.burnRateCreditsPerMs - overPlanCredits) /
+            (projection.firstReplenishmentWaitMs * projection.burnRateCreditsPerMs)) *
+            100,
+          0,
+          100,
+        )
+      : null;
+  const reduceByPercent = throttleToPercent != null ? 100 - throttleToPercent : null;
+  const proAccountEquivalentToCoverOverPlan =
+    overPlanCredits > 0 ? overPlanCredits / PRO_WEEKLY_CAPACITY_CREDITS : null;
+  const proAccountsToCoverOverPlan =
+    overPlanCredits > 0 ? Math.ceil(overPlanCredits / PRO_WEEKLY_CAPACITY_CREDITS) : null;
+
+  return {
+    totalFullCredits,
+    totalActualRemainingCredits,
+    totalExpectedRemainingCredits,
+    actualUsedPercent,
+    scheduledUsedPercent,
+    deltaPercent,
+    overPlanCredits,
+    pauseForBreakEvenHours,
+    paceMultiplier,
+    throttleToPercent,
+    reduceByPercent,
+    proAccountEquivalentToCoverOverPlan,
+    proAccountsToCoverOverPlan,
+    projectedDepletionHours: projection?.projectedDepletionHours ?? null,
+    projectedMinimumRemainingCredits: projection?.projectedMinimumRemainingCredits ?? null,
+    status: weeklyCreditPaceStatus(deltaPercent, overPlanCredits),
+    accountCount,
+  };
 }
 
 export function buildDashboardView(
@@ -192,10 +445,14 @@ export function buildDashboardView(
     timeframeHours <= 24
       ? `Avg/hr ${formatCompactNumber(Math.round(avgPerUnit(metrics?.requests ?? 0, timeframeHours)))}`
       : `Avg/day ${formatCompactNumber(Math.round(avgPerUnit(metrics?.requests ?? 0, timeframeDays)))}`;
-  const costMeta =
+  const costAverage =
     timeframeHours <= 24
       ? `Avg/hr ${formatCurrency(avgPerUnit(cost, timeframeHours))}`
       : `Avg/day ${formatCurrency(avgPerUnit(cost, timeframeDays))}`;
+  const costMeta =
+    metrics?.cachedInputTokens && metrics.cachedInputTokens > 0
+      ? `${costAverage} · API estimate, ${formatCompactNumber(metrics.cachedInputTokens)} cached`
+      : `${costAverage} · API estimate`;
   const trends = overview.trends;
 
   const stats: DashboardStat[] = [
@@ -216,7 +473,7 @@ export function buildDashboardView(
       trendColor: TREND_COLORS[1],
     },
     {
-      label: `Cost (${timeframeLabel})`,
+      label: `Est. API Cost (${timeframeLabel})`,
       value: formatCurrency(cost),
       meta: costMeta,
       icon: DollarSign,
@@ -250,5 +507,6 @@ export function buildDashboardView(
     requestLogs,
     safeLinePrimary: buildDepletionView(overview.depletionPrimary),
     safeLineSecondary: buildDepletionView(overview.depletionSecondary),
+    weeklyCreditPace: buildWeeklyCreditPace(overview.accounts),
   };
 }

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -87,6 +87,8 @@ export function createAccountSummary(
 		resetAtSecondary: offsetIso(24 * 60),
 		windowMinutesPrimary: 300,
 		windowMinutesSecondary: 10_080,
+		capacityCreditsSecondary: 7_560,
+		remainingCreditsSecondary: 5_065.2,
 		auth: {
 			access: { expiresAt: offsetIso(30), state: null },
 			refresh: { state: "stored" },
@@ -207,9 +209,11 @@ export function createDashboardOverview(
 				accounts: accounts.map((account) => ({
 					accountId: account.accountId,
 					remainingPercentAvg: account.usage?.secondaryRemainingPercent ?? 0,
-					capacityCredits: 7560,
+					capacityCredits: account.capacityCreditsSecondary ?? 7560,
 					remainingCredits:
-						((account.usage?.secondaryRemainingPercent ?? 0) / 100) * 7560,
+						account.remainingCreditsSecondary ??
+						((account.usage?.secondaryRemainingPercent ?? 0) / 100) *
+							(account.capacityCreditsSecondary ?? 7560),
 				})),
 			},
 		},

--- a/openspec/changes/add-weekly-token-pace/proposal.md
+++ b/openspec/changes/add-weekly-token-pace/proposal.md
@@ -1,0 +1,17 @@
+# Proposal: add-weekly-token-pace
+
+## Why
+
+The dashboard shows weekly quota remaining, but it does not show whether the pool is being spent faster or slower than the time left until each account's weekly reset. Comparing average account percentages is misleading when accounts have different capacities or different reset deadlines, and raw request tokens are not the same unit as ChatGPT weekly quota credits.
+
+## What Changes
+
+- Add a weekly pace card to the dashboard.
+- Compute pace from weekly credit budget totals, not average account percentages.
+- For each account, compare actual weekly credits remaining with expected credits remaining at that account's own reset deadline, then sum the credit values and derive display percentages from the totals.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `frontend-architecture`

--- a/openspec/changes/add-weekly-token-pace/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-weekly-token-pace/specs/frontend-architecture/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Dashboard weekly credits pace
+
+The dashboard SHALL show weekly quota pace when account weekly capacity credits, remaining credits, reset time, and window length are available. The pace calculation MUST use credit totals rather than averaging per-account percentages, because weekly ChatGPT quota credits are not the same unit as raw request tokens.
+
+#### Scenario: Weekly credits pace uses account reset deadlines
+
+- **WHEN** multiple accounts have weekly quota data with different `resetAtSecondary` values
+- **THEN** the frontend computes each account's expected remaining weekly credits from that account's own reset time and window length before summing totals
+
+#### Scenario: Over-plan pace shows pause needed to break even
+
+- **WHEN** actual remaining weekly credits are lower than scheduled remaining weekly credits
+- **THEN** the dashboard shows recovery options including how long weekly usage should pause for scheduled remaining credits to catch up
+- **AND** the dashboard shows a throttle option for reducing parallel weekly-credit load
+- **AND** the dashboard shows how many Pro-sized weekly credit pools would cover the current over-plan credits
+- **AND** the Pro-sized pool recommendation shows the fractional pool equivalent before any rounded whole-account count
+- **AND** the pause calculation accounts for each account's own reset deadline rather than using one global weekly burn rate
+
+#### Scenario: Near-reset depletion is not a false alarm
+
+- **WHEN** an account has consumed 99% of its weekly quota and 99% of its weekly window has elapsed
+- **THEN** the weekly pace treats that account as on pace rather than over plan
+
+#### Scenario: Missing weekly credit data is omitted
+
+- **WHEN** an account is missing weekly capacity credits, remaining credits, reset time, or window length
+- **THEN** that account is omitted from weekly pace calculation
+
+#### Scenario: No valid weekly credit data hides pace
+
+- **WHEN** no account has complete weekly credits pace data
+- **THEN** the dashboard does not render a fake weekly pace value
+
+### Requirement: Account weekly trend planned line
+
+The account detail usage trend SHALL include an ideal weekly remaining line when weekly reset timing is available, so operators can compare actual weekly remaining credits against the linear schedule between weekly resets.
+
+#### Scenario: Weekly trend shows planned depletion between resets
+
+- **WHEN** account trend buckets include weekly reset time and window length
+- **THEN** the account 7-day trend includes a dashed weekly plan line computed from each bucket's reset deadline and window length
+
+#### Scenario: Weekly trend plan restarts after reset
+
+- **WHEN** weekly trend buckets cross into a new reset window with a new reset deadline
+- **THEN** the planned line jumps back toward full remaining capacity for the new weekly window instead of continuing one global diagonal

--- a/openspec/changes/add-weekly-token-pace/tasks.md
+++ b/openspec/changes/add-weekly-token-pace/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: add-weekly-token-pace
+
+## 1. Specs
+
+- [x] 1.1 Add dashboard weekly credits pace requirements.
+
+## 2. Implementation
+
+- [x] 2.1 Preserve weekly capacity and remaining credit fields in the frontend account schema.
+- [x] 2.2 Add weekly credits pace calculation from per-account reset deadlines.
+- [x] 2.3 Render a compact weekly pace card on the dashboard.
+- [x] 2.4 Add a dashed planned weekly depletion line to the account 7-day trend.
+
+## 3. Tests
+
+- [x] 3.1 Cover on-pace near-reset accounts, early depletion, different reset times, and missing data.
+- [x] 3.2 Cover the weekly pace card render path.
+- [x] 3.3 Cover account trend planned-line calculation and legend rendering.

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -71,6 +71,8 @@ async def test_dashboard_overview_combines_data(async_client, db_setup):
     payload = response.json()
 
     assert payload["accounts"][0]["accountId"] == "acc_dash"
+    assert payload["accounts"][0]["capacityCreditsSecondary"] == pytest.approx(7560.0)
+    assert payload["accounts"][0]["remainingCreditsSecondary"] == pytest.approx(4536.0)
     assert payload["timeframe"] == {
         "key": "7d",
         "windowMinutes": 10080,

--- a/tests/unit/test_account_usage_trends.py
+++ b/tests/unit/test_account_usage_trends.py
@@ -131,6 +131,8 @@ class TestBuildAccountUsageTrends:
         ]
         result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
 
+        assert result["a1"].primary == []
+        assert [point.v for point in result["a1"].secondary] == [70.0, 70.0, 70.0, 70.0]
         scheduled = result["a1"].secondary_scheduled
         assert [point.v for point in scheduled] == [100.0, 96.43, 92.86, 89.29]
 

--- a/tests/unit/test_account_usage_trends.py
+++ b/tests/unit/test_account_usage_trends.py
@@ -136,6 +136,32 @@ class TestBuildAccountUsageTrends:
         scheduled = result["a1"].secondary_scheduled
         assert [point.v for point in scheduled] == [100.0, 96.43, 92.86, 89.29]
 
+    def test_secondary_trend_prefers_real_secondary_over_weekly_primary_bucket(self):
+        reset_at = SINCE_EPOCH + 10080 * 60
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "primary",
+                90.0,
+                reset_at=reset_at + BUCKET_SECONDS,
+                window_minutes=10080,
+            ),
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                20.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+            ),
+        ]
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        assert result["a1"].primary == []
+        assert [point.v for point in result["a1"].secondary] == [80.0, 80.0, 80.0, 80.0]
+        assert result["a1"].secondary_scheduled[1].v == 96.43
+
     def test_secondary_scheduled_line_jumps_after_weekly_reset(self):
         first_reset = SINCE_EPOCH + BUCKET_SECONDS
         second_reset = SINCE_EPOCH + 5 * BUCKET_SECONDS

--- a/tests/unit/test_account_usage_trends.py
+++ b/tests/unit/test_account_usage_trends.py
@@ -117,6 +117,23 @@ class TestBuildAccountUsageTrends:
         scheduled = result["a1"].secondary_scheduled
         assert [point.v for point in scheduled] == [100.0, 75.0, 50.0, 25.0]
 
+    def test_secondary_scheduled_line_uses_weekly_primary_bucket(self):
+        reset_at = SINCE_EPOCH + 10080 * 60
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "primary",
+                30.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+            ),
+        ]
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        scheduled = result["a1"].secondary_scheduled
+        assert [point.v for point in scheduled] == [100.0, 96.43, 92.86, 89.29]
+
     def test_secondary_scheduled_line_jumps_after_weekly_reset(self):
         first_reset = SINCE_EPOCH + BUCKET_SECONDS
         second_reset = SINCE_EPOCH + 5 * BUCKET_SECONDS

--- a/tests/unit/test_account_usage_trends.py
+++ b/tests/unit/test_account_usage_trends.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from app.core.usage.types import UsageTrendBucket
 from app.modules.accounts.mappers import build_account_usage_trends
 
@@ -12,6 +14,7 @@ def _bucket(
     samples: int = 1,
     reset_at: int | None = None,
     window_minutes: int | None = None,
+    recorded_at: datetime | None = None,
 ) -> UsageTrendBucket:
     return UsageTrendBucket(
         bucket_epoch=epoch,
@@ -21,6 +24,7 @@ def _bucket(
         samples=samples,
         reset_at=reset_at,
         window_minutes=window_minutes,
+        recorded_at=recorded_at,
     )
 
 
@@ -138,6 +142,8 @@ class TestBuildAccountUsageTrends:
 
     def test_secondary_trend_prefers_real_secondary_over_weekly_primary_bucket(self):
         reset_at = SINCE_EPOCH + 10080 * 60
+        stale_recorded_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        fresh_recorded_at = datetime(2026, 5, 2, tzinfo=timezone.utc)
         buckets = [
             _bucket(
                 SINCE_EPOCH,
@@ -146,6 +152,7 @@ class TestBuildAccountUsageTrends:
                 90.0,
                 reset_at=reset_at + BUCKET_SECONDS,
                 window_minutes=10080,
+                recorded_at=stale_recorded_at,
             ),
             _bucket(
                 SINCE_EPOCH,
@@ -154,6 +161,7 @@ class TestBuildAccountUsageTrends:
                 20.0,
                 reset_at=reset_at,
                 window_minutes=10080,
+                recorded_at=fresh_recorded_at,
             ),
         ]
         result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
@@ -161,6 +169,66 @@ class TestBuildAccountUsageTrends:
         assert result["a1"].primary == []
         assert [point.v for point in result["a1"].secondary] == [80.0, 80.0, 80.0, 80.0]
         assert result["a1"].secondary_scheduled[1].v == 96.43
+
+    def test_secondary_trend_prefers_fresher_weekly_primary_over_stale_secondary(self):
+        reset_at = SINCE_EPOCH + 10080 * 60
+        stale_recorded_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        fresh_recorded_at = datetime(2026, 5, 2, tzinfo=timezone.utc)
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "primary",
+                10.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=fresh_recorded_at,
+            ),
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                80.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=stale_recorded_at,
+            ),
+        ]
+
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        assert result["a1"].primary == []
+        assert [point.v for point in result["a1"].secondary] == [90.0, 90.0, 90.0, 90.0]
+
+    def test_secondary_trend_prefers_fresher_secondary_over_stale_weekly_primary(self):
+        reset_at = SINCE_EPOCH + 10080 * 60
+        stale_recorded_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        fresh_recorded_at = datetime(2026, 5, 2, tzinfo=timezone.utc)
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "primary",
+                10.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=stale_recorded_at,
+            ),
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                80.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=fresh_recorded_at,
+            ),
+        ]
+
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        assert result["a1"].primary == []
+        assert [point.v for point in result["a1"].secondary] == [20.0, 20.0, 20.0, 20.0]
 
     def test_secondary_scheduled_line_jumps_after_weekly_reset(self):
         first_reset = SINCE_EPOCH + BUCKET_SECONDS

--- a/tests/unit/test_account_usage_trends.py
+++ b/tests/unit/test_account_usage_trends.py
@@ -4,13 +4,23 @@ from app.core.usage.types import UsageTrendBucket
 from app.modules.accounts.mappers import build_account_usage_trends
 
 
-def _bucket(epoch: int, account_id: str, window: str, avg_used: float, samples: int = 1) -> UsageTrendBucket:
+def _bucket(
+    epoch: int,
+    account_id: str,
+    window: str,
+    avg_used: float,
+    samples: int = 1,
+    reset_at: int | None = None,
+    window_minutes: int | None = None,
+) -> UsageTrendBucket:
     return UsageTrendBucket(
         bucket_epoch=epoch,
         account_id=account_id,
         window=window,
         avg_used_percent=avg_used,
         samples=samples,
+        reset_at=reset_at,
+        window_minutes=window_minutes,
     )
 
 
@@ -89,6 +99,49 @@ class TestBuildAccountUsageTrends:
         result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
         # secondary was not in any bucket → empty list
         assert result["a1"].secondary == []
+
+    def test_secondary_scheduled_line_uses_bucket_reset_deadline(self):
+        reset_at = SINCE_EPOCH + 4 * BUCKET_SECONDS
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                30.0,
+                reset_at=reset_at,
+                window_minutes=(4 * BUCKET_SECONDS) // 60,
+            ),
+        ]
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        scheduled = result["a1"].secondary_scheduled
+        assert [point.v for point in scheduled] == [100.0, 75.0, 50.0, 25.0]
+
+    def test_secondary_scheduled_line_jumps_after_weekly_reset(self):
+        first_reset = SINCE_EPOCH + BUCKET_SECONDS
+        second_reset = SINCE_EPOCH + 5 * BUCKET_SECONDS
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                95.0,
+                reset_at=first_reset,
+                window_minutes=(4 * BUCKET_SECONDS) // 60,
+            ),
+            _bucket(
+                SINCE_EPOCH + 2 * BUCKET_SECONDS,
+                "a1",
+                "secondary",
+                5.0,
+                reset_at=second_reset,
+                window_minutes=(4 * BUCKET_SECONDS) // 60,
+            ),
+        ]
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        scheduled = result["a1"].secondary_scheduled
+        assert [point.v for point in scheduled] == [25.0, 0.0, 75.0, 50.0]
 
     def test_timestamps_are_utc(self):
         buckets = [_bucket(SINCE_EPOCH, "a1", "primary", 0.0)]


### PR DESCRIPTION
## Summary

- add a dashboard Weekly pace card that compares actual weekly token consumption against schedule
- compute pace by summing token/credit budgets per account, using each account's own reset time and window
- model weekly reset replenishment as the full account budget, not only current unused credits
- hide Recovery options when the pool is on pace and no throttle/account action is needed
- preserve weekly capacity/remaining fields in the frontend schema and document the behavior in OpenSpec

## Why

A nearly empty account near its weekly reset should not look scary, and a healthy pool should not tell the operator to do recovery work. The card compares actual remaining tokens to expected remaining tokens per account, then derives display percentages from aggregate token totals instead of averaging account percentages.

## Live data sanity check

Checked the real codex-lb usage history around the "tokens were insufficient, then an account was added, then tokens were sufficient" case:

- `2026-05-03 18:13 UTC`: 6-account pool was danger, about 91.5% used vs 76.4% scheduled, short by about 18.8K credits.
- `2026-05-03 18:16 UTC`: after adding the unused Pro account, actual 7-account pool became on track, about 64.1% used vs 53.6% scheduled, projected low-water about 31.7K credits.
- Counterfactual without the new Pro account at `2026-05-03 18:16 UTC` stayed danger, short by about 18.7K credits.

That matches the intended continuity context: adding a real account turns the pool from insufficient to sufficient, and the card should stop showing Recovery options once the pool is safe.

## Validation

- `cd frontend && bun run test -- ./src/features/dashboard/utils.test.ts ./src/features/dashboard/components/weekly-credits-pace-card.test.tsx`
- `cd frontend && bun run typecheck`
- `cd frontend && bun run lint` (passes with two pre-existing warnings in `account-multi-select.tsx`)
- `cd frontend && bun run build` (passes with existing Vite chunk-size/dynamic-import warnings)
- `git diff --check`
- earlier branch validation also covered `.venv/bin/python -m pytest tests/integration/test_dashboard_overview.py::test_dashboard_overview_combines_data`

`openspec` CLI is not installed in this workspace, so I could not run local OpenSpec validation.

## Related issues
- Addresses part of #409 (weekly credit pace / burn-rate visibility).
- Addresses part of #371 (weekly credit display semantics).
