### PR TITLE
fix(proxy): mask websocket previous response misses

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6126,14 +6126,24 @@ class ProxyService:
             )
             retry_error_code = None
         if retry_error_code is not None:
-            upstream_control.reconnect_requested = True
             if retry_is_previous_response_not_found:
-                request_state.replay_count += 1
-                request_state.awaiting_response_created = True
-                request_state.response_id = None
-                upstream_control.suppress_downstream_event = True
-                upstream_control.replay_request_state = request_state
+                if not (
+                    request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text
+                ):
+                    retry_error_code = None
+                else:
+                    upstream_control.reconnect_requested = True
+                    request_state.request_text = request_state.fresh_upstream_request_text
+                    request_state.previous_response_id = None
+                    request_state.proxy_injected_previous_response_id = False
+                    request_state.fresh_upstream_request_is_retry_safe = False
+                    request_state.replay_count += 1
+                    request_state.awaiting_response_created = True
+                    request_state.response_id = None
+                    upstream_control.suppress_downstream_event = True
+                    upstream_control.replay_request_state = request_state
             else:
+                upstream_control.reconnect_requested = True
                 request_state.replay_count += 1
                 request_state.awaiting_response_created = True
                 request_state.response_id = None
@@ -6144,7 +6154,8 @@ class ProxyService:
                     {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
                     retry_error_code,
                 )
-            return downstream_text
+            if retry_error_code is not None:
+                return downstream_text
 
         await self._finalize_websocket_request_state(
             request_state,

--- a/openspec/changes/mask-websocket-previous-response-miss/proposal.md
+++ b/openspec/changes/mask-websocket-previous-response-miss/proposal.md
@@ -1,0 +1,13 @@
+# Mask WebSocket previous-response misses
+
+## Why
+
+Direct Responses WebSocket follow-ups can receive an anonymous upstream `previous_response_not_found` after the upstream handshake has already succeeded. The proxy must treat that as continuity loss, not replay the same stale anchor in a loop or expose the raw upstream 400 to Codex clients.
+
+## What Changes
+
+- Short WebSocket continuations that depend on `previous_response_id` fail closed as retryable `stream_incomplete` without replaying the same stale anchor.
+
+## Impact
+
+Clients stop seeing raw `previous_response_not_found` frames for direct WebSocket continuity loss. Continuations receive the existing retryable `stream_incomplete` contract instead of retrying a stale anchor inside the proxy.

--- a/openspec/changes/mask-websocket-previous-response-miss/specs/responses-api-compat/spec.md
+++ b/openspec/changes/mask-websocket-previous-response-miss/specs/responses-api-compat/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Direct WebSocket previous-response misses do not expose raw upstream errors
+When a direct Responses WebSocket follow-up receives an upstream `previous_response_not_found` error, the service MUST treat it as continuity loss. It MUST NOT expose the raw upstream `previous_response_not_found` error to the downstream client.
+
+#### Scenario: short WebSocket continuation loses previous-response continuity
+- **WHEN** a WebSocket `/v1/responses` or `/backend-api/codex/responses` follow-up includes `previous_response_id`
+- **AND** upstream emits `previous_response_not_found` before assigning a response id
+- **THEN** the service emits a retryable `stream_incomplete` failure for that request
+- **AND** it does not replay the same stale `previous_response_id`
+- **AND** it does not expose `previous_response_not_found` downstream

--- a/openspec/changes/mask-websocket-previous-response-miss/tasks.md
+++ b/openspec/changes/mask-websocket-previous-response-miss/tasks.md
@@ -1,0 +1,7 @@
+## 1. Runtime
+
+- [x] 1.1 Do not transparently replay WebSocket continuations with the same stale `previous_response_id`.
+
+## 2. Tests
+
+- [x] 2.1 Cover short WebSocket previous-response misses as sanitized `stream_incomplete`.

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1075,7 +1075,7 @@ def test_v1_responses_websocket_forwards_previous_response_id(app_instance, monk
     ]
 
 
-def test_v1_responses_websocket_masks_previous_response_not_found_and_recovers_on_retry(
+def test_v1_responses_websocket_masks_short_previous_response_not_found_without_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1227,16 +1227,17 @@ def test_v1_responses_websocket_masks_previous_response_not_found_and_recovers_o
                     }
                 )
             )
-            created_2 = json.loads(websocket.receive_text())
-            completed_2 = json.loads(websocket.receive_text())
+            failed_2 = json.loads(websocket.receive_text())
 
-    assert created_2["type"] == "response.created"
-    assert completed_2["type"] == "response.completed"
-    assert connect_count == 2
-    assert first_upstream.closed is True
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
+    assert connect_count == 1
 
 
-def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_error_and_recovers_on_retry(
+def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_without_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1388,13 +1389,14 @@ def test_v1_responses_websocket_masks_invalid_request_previous_response_not_foun
                     }
                 )
             )
-            created_2 = json.loads(websocket.receive_text())
-            completed_2 = json.loads(websocket.receive_text())
+            failed_2 = json.loads(websocket.receive_text())
 
-    assert created_2["type"] == "response.created"
-    assert completed_2["type"] == "response.completed"
-    assert connect_count == 2
-    assert first_upstream.closed is True
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
+    assert connect_count == 1
 
 
 def test_backend_responses_websocket_connect_failure_masks_previous_response_not_found(
@@ -1514,7 +1516,7 @@ def test_backend_responses_websocket_connect_failure_masks_previous_response_not
     assert event["error"]["message"] == "Upstream websocket closed before response.completed"
 
 
-def test_backend_responses_websocket_masks_previous_response_not_found_and_recovers_on_retry(
+def test_backend_responses_websocket_masks_short_previous_response_not_found_without_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1690,16 +1692,15 @@ def test_backend_responses_websocket_masks_previous_response_not_found_and_recov
                     }
                 )
             )
-            created_2 = json.loads(websocket.receive_text())
-            completed_2 = json.loads(websocket.receive_text())
+            failed_2 = json.loads(websocket.receive_text())
 
-    assert created_2["type"] == "response.created"
-    assert completed_2["type"] == "response.completed"
-    assert created_2["response"]["id"] == "resp_ws_prev_retry"
-    assert completed_2["response"]["id"] == "resp_ws_prev_retry"
-    assert connect_count == 2
-    assert captured_preferred_accounts == [None, "acct_ws_prev_mask"]
-    assert first_upstream.closed is True
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
+    assert connect_count == 1
+    assert captured_preferred_accounts == [None]
 
 
 def test_backend_responses_websocket_masks_anonymous_previous_response_not_found_with_inflight_request(
@@ -1867,7 +1868,7 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
     assert fake_upstream.closed is True
 
 
-def test_backend_responses_websocket_recovers_when_previous_response_not_found_message_omits_response_id(
+def test_backend_responses_websocket_masks_previous_response_not_found_when_message_omits_response_id(
     app_instance,
     monkeypatch,
 ):
@@ -2033,17 +2034,14 @@ def test_backend_responses_websocket_recovers_when_previous_response_not_found_m
                     }
                 )
             )
-            created_2 = json.loads(websocket.receive_text())
-            completed_2 = json.loads(websocket.receive_text())
+            failed_2 = json.loads(websocket.receive_text())
 
-    assert created_2["type"] == "response.created"
-    assert completed_2["type"] == "response.completed"
-    assert created_2["response"]["id"] == "resp_ws_followup_replayed"
-    assert completed_2["response"]["id"] == "resp_ws_followup_replayed"
-    assert "previous_response_not_found" not in json.dumps(created_2)
-    assert "previous_response_not_found" not in json.dumps(completed_2)
-    assert connect_count == 2
-    assert first_upstream.closed is True
+    assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in json.dumps(failed_2)
+    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
+    assert connect_count == 1
 
 
 def test_backend_responses_websocket_keeps_session_alive_after_foreign_previous_response_not_found(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7636,7 +7636,7 @@ def test_remember_websocket_previous_response_owner_eviction_keeps_latest_entrie
 
 
 @pytest.mark.asyncio
-async def test_process_upstream_websocket_text_retries_precreated_previous_response_not_found(monkeypatch):
+async def test_process_upstream_websocket_text_masks_short_previous_response_not_found_without_replay(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     finalize_request_state = AsyncMock()
@@ -7690,12 +7690,13 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
     )
 
     assert '"code":"stream_incomplete"' in downstream_text
-    finalize_request_state.assert_not_awaited()
+    finalize_request_state.assert_awaited_once()
+    assert finalize_request_state.await_args.kwargs["event_type"] == "response.failed"
     handle_stream_error.assert_not_awaited()
     assert upstream_control.reconnect_requested is True
-    assert upstream_control.suppress_downstream_event is True
-    assert upstream_control.replay_request_state is pending_request
-    assert pending_request.replay_count == 1
+    assert upstream_control.suppress_downstream_event is False
+    assert upstream_control.replay_request_state is None
+    assert pending_request.replay_count == 0
     assert list(pending_requests) == []
 
 


### PR DESCRIPTION
## Summary

- Mask direct Responses WebSocket `previous_response_not_found` frames as retryable `stream_incomplete` instead of replaying the same stale `previous_response_id`.
- Keep the existing transparent replay path only for states that already have a verified safe fresh upstream request body.
- Add OpenSpec coverage and update WebSocket/unit tests around the sanitized failure contract.

## Existing tracker check

- Refs #221: existing open issue already covers this `previous_response_not_found` / `stream_incomplete` failure mode, so I did not open a duplicate issue.
- Also checked #516, which overlaps but is stale against current `main` and carries a broader old diff. This PR is a smaller current-main fix.

## Validation

- `.venv/bin/pytest -q tests/integration/test_proxy_websocket_responses.py tests/unit/test_proxy_utils.py`
- `.venv/bin/ruff check app/modules/proxy/service.py tests/integration/test_proxy_websocket_responses.py tests/unit/test_proxy_utils.py`
- `git diff --check`
- `npx --yes @fission-ai/openspec validate mask-websocket-previous-response-miss --strict`
- `npx --yes @fission-ai/openspec validate --specs`
- `codex-review-high --base origin/main`
