### PR TITLE
fix(upstream): drop top_p because majority of gpt-5 don't support it

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -456,6 +456,7 @@ _UNSUPPORTED_UPSTREAM_FIELDS = {
     "prompt_cache_retention",
     "safety_identifier",
     "temperature",
+    "top_p",
 }
 
 

--- a/tests/unit/test_chat_request_mapping.py
+++ b/tests/unit/test_chat_request_mapping.py
@@ -78,17 +78,19 @@ def test_chat_max_tokens_are_stripped():
     assert "max_completion_tokens" not in dumped
 
 
-def test_chat_temperature_is_stripped_for_upstream_compat():
+def test_temperature_and_top_p_are_stripped_for_upstream_compat():
     payload = {
         "model": "gpt-5.2",
         "messages": [{"role": "user", "content": "hi"}],
         "temperature": 0.2,
+        "top_p": 0.9,
         "safety_identifier": "safe_123",
     }
     req = ChatCompletionsRequest.model_validate(payload)
     responses = req.to_responses_request()
     dumped = responses.to_payload()
     assert "temperature" not in dumped
+    assert "top_p" not in dumped
     assert "safety_identifier" not in dumped
 
 

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -73,6 +73,7 @@ def test_known_unsupported_upstream_fields_are_stripped():
         "prompt_cache_retention": "4h",
         "safety_identifier": "safe_123",
         "temperature": 0.2,
+        "top_p": 0.9,
         "custom_field": "kept",
     }
     request = ResponsesRequest.model_validate(payload)
@@ -82,6 +83,7 @@ def test_known_unsupported_upstream_fields_are_stripped():
     assert "prompt_cache_retention" not in dumped
     assert "safety_identifier" not in dumped
     assert "temperature" not in dumped
+    assert "top_p" not in dumped
     assert dumped["custom_field"] == "kept"
 
 
@@ -120,6 +122,7 @@ def test_compact_known_unsupported_upstream_fields_are_stripped():
         "prompt_cache_retention": "4h",
         "safety_identifier": "safe_123",
         "temperature": 0.2,
+        "top_p": 0.9,
     }
     request = ResponsesCompactRequest.model_validate(payload)
 
@@ -127,6 +130,7 @@ def test_compact_known_unsupported_upstream_fields_are_stripped():
     assert "prompt_cache_retention" not in dumped
     assert "safety_identifier" not in dumped
     assert "temperature" not in dumped
+    assert "top_p" not in dumped
 
 
 def test_compact_normalizes_fast_service_tier_to_priority_for_upstream():


### PR DESCRIPTION
Fixes #391 

The majority of gpt-5 models does not support `top_p` and `temperature`
And the `temperature` is now discarded before sending it to upstream, so the `top_p` should align with this. 

`codex-lb` will now *not* fail the request and send the request normally to upstream