### PR TITLE
fix(proxy): handle model fetch timeouts

### DIFF
--- a/app/core/clients/model_fetcher.py
+++ b/app/core/clients/model_fetcher.py
@@ -111,12 +111,17 @@ async def fetch_models_for_plan(
     timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
     session = get_http_client().session
 
-    async with session.get(url, headers=headers, timeout=timeout) as resp:
-        if resp.status >= 400:
-            text = await resp.text()
-            raise ModelFetchError(resp.status, f"HTTP {resp.status}: {text[:200]}")
+    try:
+        async with session.get(url, headers=headers, timeout=timeout) as resp:
+            if resp.status >= 400:
+                text = await resp.text()
+                raise ModelFetchError(resp.status, f"HTTP {resp.status}: {text[:200]}")
 
-        data = await resp.json(content_type=None)
+            data = await resp.json(content_type=None)
+    except TimeoutError as exc:
+        raise ModelFetchError(504, "Upstream models API timed out") from exc
+    except aiohttp.ClientError as exc:
+        raise ModelFetchError(502, f"Upstream models API request failed: {exc}") from exc
 
     if not isinstance(data, dict):
         raise ModelFetchError(502, "Invalid response format from upstream models API")

--- a/tests/unit/test_model_fetcher.py
+++ b/tests/unit/test_model_fetcher.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.clients.model_fetcher import ModelFetchError, fetch_models_for_plan
+
+pytestmark = pytest.mark.unit
+
+
+class _TimeoutResponse:
+    status = 200
+
+    async def __aenter__(self) -> "_TimeoutResponse":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def json(self, *, content_type: str | None = None) -> object:
+        raise asyncio.TimeoutError
+
+
+class _Session:
+    def get(self, *args: object, **kwargs: object) -> _TimeoutResponse:
+        return _TimeoutResponse()
+
+
+class _VersionCache:
+    async def get_version(self) -> str:
+        return "0.128.0"
+
+
+async def test_fetch_models_for_plan_maps_read_timeout_to_model_fetch_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.core.clients.model_fetcher.get_settings",
+        lambda: SimpleNamespace(upstream_base_url="https://upstream.example"),
+    )
+    monkeypatch.setattr(
+        "app.core.clients.model_fetcher.get_codex_version_cache",
+        lambda: _VersionCache(),
+    )
+    monkeypatch.setattr(
+        "app.core.clients.model_fetcher.get_http_client",
+        lambda: SimpleNamespace(session=_Session()),
+    )
+
+    with pytest.raises(ModelFetchError) as exc_info:
+        await fetch_models_for_plan("access-token", "account-id")
+
+    assert exc_info.value.status_code == 504
+    assert exc_info.value.message == "Upstream models API timed out"


### PR DESCRIPTION
## Summary

- convert upstream model-list timeouts into `ModelFetchError(504)` responses
- preserve the existing upstream status/body handling for classified model-list failures
- add a regression test for `asyncio.TimeoutError` from the model fetch client

## Why

Transient upstream `/models` stalls should be reported as a gateway timeout instead of bubbling up as an unexpected traceback. This keeps proxy reliability failures classified consistently for callers and logs.

This was split out of #534 so the weekly credits dashboard PR no longer carries an unrelated proxy reliability fix.

## Validation

- `/home/kom/proj/codex-lb/.venv/bin/python -m pytest tests/unit/test_model_fetcher.py`


## Related issues
- Related to #480 model metadata/fetch reliability, but only covers upstream model-list timeout classification.
