### PR TITLE
fix(chat): resolve parallel tool_call argument duplication via output_index routing

### DIFF
--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -149,7 +149,10 @@ class ToolCallIndex:
         if key not in self.indexes:
             self.indexes[key] = self.next_index
             self.next_index += 1
-        return self.indexes[key]
+        idx = self.indexes[key]
+        if output_index is not None and output_index not in self.output_index_map:
+            self.output_index_map[output_index] = idx
+        return idx
 
     def register_alias(self, alias_id: str, index: int) -> None:
         """Register an additional ID that maps to the same index."""
@@ -659,7 +662,14 @@ def _tool_call_delta_from_payload(payload: Mapping[str, JsonValue], indexer: Too
         return None
     call_id, name, arguments, tool_type = fields
     output_index = _resolve_output_index(payload)
-    index = indexer.index_for_output_index(output_index, call_id, name)
+    routing_id = call_id
+    if routing_id is None:
+        item = payload.get("item")
+        routing_id = _first_str(
+            payload.get("item_id"),
+            item.get("id") if isinstance(item, dict) else None,
+        )
+    index = indexer.index_for_output_index(output_index, routing_id, name)
     _register_item_id_alias(payload, index, indexer)
     return ToolCallDelta(
         index=index,
@@ -701,14 +711,12 @@ def _extract_tool_call_fields(
         candidate.get("call_id"),
         candidate.get("tool_call_id"),
         candidate.get("id"),
-        candidate.get("item_id"),
     )
     if call_id is None and delta_map is not None:
         call_id = _first_str(
             delta_map.get("id"),
             delta_map.get("call_id"),
             delta_map.get("tool_call_id"),
-            delta_map.get("item_id"),
         )
 
     name = _first_str(candidate.get("name"), candidate.get("tool_name"))

--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -122,6 +122,7 @@ ChatCompletionResult = ChatCompletion | OpenAIErrorEnvelope
 class ToolCallIndex:
     indexes: dict[str, int] = field(default_factory=dict)
     next_index: int = 0
+    output_index_map: dict[int, int] = field(default_factory=dict)
 
     def index_for(self, call_id: str | None, name: str | None) -> int:
         key = _tool_call_key(call_id, name)
@@ -131,6 +132,35 @@ class ToolCallIndex:
             self.indexes[key] = self.next_index
             self.next_index += 1
         return self.indexes[key]
+
+    def index_for_output_index(self, output_index: int | None, call_id: str | None, name: str | None) -> int:
+        """Resolve tool call index, preferring output_index mapping when available."""
+        if output_index is not None and output_index in self.output_index_map:
+            return self.output_index_map[output_index]
+        key = _tool_call_key(call_id, name)
+        if key is None:
+            if output_index is not None:
+                idx = self.output_index_map.get(output_index, self.next_index)
+                if output_index not in self.output_index_map:
+                    self.output_index_map[output_index] = idx
+                    self.next_index = max(self.next_index, idx + 1)
+                return idx
+            return 0
+        if key not in self.indexes:
+            self.indexes[key] = self.next_index
+            self.next_index += 1
+        return self.indexes[key]
+
+    def register_alias(self, alias_id: str, index: int) -> None:
+        """Register an additional ID that maps to the same index."""
+        key = f"id:{alias_id}"
+        if key not in self.indexes:
+            self.indexes[key] = index
+
+    def register_output_index(self, output_index: int, index: int) -> None:
+        """Map a Responses API output_index to a tool call index."""
+        if output_index not in self.output_index_map:
+            self.output_index_map[output_index] = index
 
 
 @dataclass
@@ -589,6 +619,38 @@ def _coerce_number(value: JsonValue) -> int | float | None:
     return None
 
 
+def _resolve_output_index(payload: Mapping[str, JsonValue]) -> int | None:
+    """Extract output_index from a Responses API event payload."""
+    val = payload.get("output_index")
+    if isinstance(val, int):
+        return val
+    return None
+
+
+def _register_item_id_alias(payload: Mapping[str, JsonValue], index: int, indexer: ToolCallIndex) -> None:
+    """Register item.id from output_item events as an index alias.
+
+    The Responses API emits output_item.added/done events with item.id
+    (e.g. "fc_01ee...") and item.call_id (e.g. "call_kI8y...").
+    Subsequent function_call_arguments.delta/done events reference the
+    tool call via item_id (= item.id), not call_id.  By registering
+    item.id as an alias when we first see the output_item event, later
+    delta/done events can resolve to the correct index.
+    """
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        return
+    item_id = item.get("id")
+    call_id = item.get("call_id")
+    if isinstance(item_id, str) and item_id:
+        if item_id != call_id:
+            indexer.register_alias(item_id, index)
+
+    output_index = _resolve_output_index(payload)
+    if output_index is not None:
+        indexer.register_output_index(output_index, index)
+
+
 def _tool_call_delta_from_payload(payload: Mapping[str, JsonValue], indexer: ToolCallIndex) -> ToolCallDelta | None:
     if not _is_tool_call_event(payload):
         return None
@@ -596,7 +658,9 @@ def _tool_call_delta_from_payload(payload: Mapping[str, JsonValue], indexer: Too
     if fields is None:
         return None
     call_id, name, arguments, tool_type = fields
-    index = indexer.index_for(call_id, name)
+    output_index = _resolve_output_index(payload)
+    index = indexer.index_for_output_index(output_index, call_id, name)
+    _register_item_id_alias(payload, index, indexer)
     return ToolCallDelta(
         index=index,
         call_id=call_id,
@@ -637,12 +701,14 @@ def _extract_tool_call_fields(
         candidate.get("call_id"),
         candidate.get("tool_call_id"),
         candidate.get("id"),
+        candidate.get("item_id"),
     )
     if call_id is None and delta_map is not None:
         call_id = _first_str(
             delta_map.get("id"),
             delta_map.get("call_id"),
             delta_map.get("tool_call_id"),
+            delta_map.get("item_id"),
         )
 
     name = _first_str(candidate.get("name"), candidate.get("tool_name"))

--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -134,10 +134,23 @@ class ToolCallIndex:
         return self.indexes[key]
 
     def index_for_output_index(self, output_index: int | None, call_id: str | None, name: str | None) -> int:
-        """Resolve tool call index, preferring output_index mapping when available."""
-        if output_index is not None and output_index in self.output_index_map:
-            return self.output_index_map[output_index]
+        """Resolve tool call index, preferring output_index mapping when available.
+
+        Always records the resolved index against every routing key that is
+        present (``output_index``, ``call_id``/``name``) so a later event for
+        the same logical tool call that only carries one of those identifiers
+        does not get assigned a new slot. Without this, a stream that first
+        routes by ``item_id`` + ``output_index`` and later emits a
+        ``call_id``-only event without ``output_index`` (e.g. legacy delta
+        formats) would split one tool call into two ``tool_calls[]`` slots and
+        reintroduce the duplication this change fixes.
+        """
         key = _tool_call_key(call_id, name)
+        if output_index is not None and output_index in self.output_index_map:
+            idx = self.output_index_map[output_index]
+            if key is not None and key not in self.indexes:
+                self.indexes[key] = idx
+            return idx
         if key is None:
             if output_index is not None:
                 idx = self.output_index_map.get(output_index, self.next_index)

--- a/openspec/changes/fix-parallel-tool-call-arguments-routing/proposal.md
+++ b/openspec/changes/fix-parallel-tool-call-arguments-routing/proposal.md
@@ -1,0 +1,24 @@
+## Why
+Issue #542 reports that `/v1/chat/completions` corrupts parallel tool-call arguments. The Responses API emits `response.function_call_arguments.delta` / `.done` events that identify their owning call only via `item_id` (e.g. `"fc_..."`). The previous `ToolCallIndex.index_for` keyed only on `call_id`/`name`, so argument events for the second and subsequent parallel calls fell back to index `0` and overwrote the first call's payload. Downstream agents then silently executed the wrong actions with corrupted parameters.
+
+The fix uses a three-layer routing strategy to be robust against ordering and identifier variations the upstream may emit:
+
+1. **`output_index` routing (primary).** Every Responses API event carries a stable `output_index`, matching the routing key used by OpenAI's own reference client (`openai-python`) and the LiteLLM proxy (BerriAI/litellm#17652). Once `output_index` is observed, all events for that slot resolve through the same `output_index_map` regardless of which identifier they carry.
+2. **`call_id` / `name` keying (existing).** Preserved for legacy Chat-Completions-style event streams and any path that already routed by `call_id`.
+3. **`item_id` alias (fallback).** When `output_item.added` / `.done` events expose both `item.id` (e.g. `fc_...`) and `item.call_id` (e.g. `call_...`), the `item.id` is registered as an alias to the same slot, so later argument-only events that only carry `item_id` resolve correctly even if their `output_index` was not seen.
+
+A small secondary fix in the same change prevents the upstream `fc_...` item id from leaking into the public `tool_calls[].id` / `call_id` fields exposed to clients: clients continue to see the upstream `call_...` value and never the internal `fc_...` routing handle.
+
+## What Changes
+- Add `index_for_output_index(output_index, call_id, name)` on `ToolCallIndex` that prefers a registered `output_index` mapping and falls back to the existing `call_id`/`name` keying. The original `index_for` is preserved unchanged for callers that have no `output_index` (chat completions legacy).
+- Add `register_alias(alias_id, index)` and `register_output_index(output_index, index)` helpers, plus a new `output_index_map: dict[int, int]` field, so the indexer can be primed from `output_item.added` / `.done` events.
+- Route `response.function_call_arguments.delta` / `.done` events through the new method using their `output_index` as the primary key and the available `item_id` (top-level `item_id` or nested `item.id`) as a routing-id fallback when `call_id` is absent.
+- On `output_item.added` / `.done` events that carry both `item.id` and `item.call_id`, register the `item.id` as an alias for the slot, so subsequent argument-only events resolve to the same `tool_calls[]` index.
+- Guard `tool_calls[].id` / `call_id` against accepting an `fc_...` item id when the public `call_...` value is what should be surfaced.
+- Add regression coverage for the parallel tool-call routing in both the streaming and non-streaming `/v1/chat/completions` adapters.
+
+## Impact
+- Restores correct `tool_calls[].function.arguments` per call when upstream emits multiple parallel function calls.
+- No effect on single-tool-call paths, raw `/v1/responses` forwarding, or non-tool text handling.
+- Public client surface unchanged: `tool_calls[].id` / `call_id` continue to expose the upstream `call_...` value; the `fc_...` item id is only used internally for routing.
+- Aligns codex-lb's tool-call routing with OpenAI's reference Responses streaming client and LiteLLM's equivalent fix.

--- a/openspec/changes/fix-parallel-tool-call-arguments-routing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-parallel-tool-call-arguments-routing/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+### Requirement: Tool call events and output items are preserved
+If the upstream model emits tool call deltas or output items, the service MUST forward those events in streaming mode and MUST include tool call items in the final response output for non-streaming mode.
+
+#### Scenario: Tool call emitted
+- **WHEN** the upstream emits a tool call delta event
+- **THEN** the service forwards the delta event and includes the finalized tool call in the completed response output
+
+#### Scenario: Chat Completions tool arguments avoid snapshot duplication
+- **WHEN** `/v1/chat/completions` maps Responses tool-call events that include incremental deltas and later finalized snapshots for the same tool call
+- **THEN** the final `tool_calls[].function.arguments` value is exactly one valid JSON string for that tool call
+- **AND** the adapter MUST NOT append full snapshot payloads on top of already-collected incremental argument deltas
+
+#### Scenario: Parallel tool calls route arguments by output_index
+- **WHEN** `/v1/chat/completions` maps Responses events for two or more parallel function calls
+- **THEN** the adapter MUST route each event to its `tool_calls[]` slot using the event's `output_index` as the primary routing key
+- **AND** the adapter MUST preserve a stable mapping from `output_index` to the same slot across `output_item.added`, `output_item.done`, `response.function_call_arguments.delta`, and `response.function_call_arguments.done` events for that call
+- **AND** parallel tool calls MUST NOT collapse to index `0` when their argument-only events identify the owning call only via `item_id`
+
+#### Scenario: Parallel tool calls also resolve through item_id aliases
+- **WHEN** an `output_item.added` or `output_item.done` event exposes both `item.id` (e.g. `"fc_..."`) and `item.call_id` (e.g. `"call_..."`)
+- **THEN** the adapter MUST register `item.id` as an alias to the same `tool_calls[]` slot as the `call_id`
+- **AND** subsequent argument-only events that carry only `item_id` MUST resolve to that aliased slot, even if their `output_index` has not yet been observed
+
+#### Scenario: Internal item_id never leaks into the public call identifier
+- **WHEN** the adapter exposes a tool call to the client as `tool_calls[].id` or `tool_calls[].call_id`
+- **THEN** the value MUST be the upstream `call_...` identifier and MUST NOT be substituted with the internal `fc_...` item id used solely for routing

--- a/openspec/changes/fix-parallel-tool-call-arguments-routing/tasks.md
+++ b/openspec/changes/fix-parallel-tool-call-arguments-routing/tasks.md
@@ -1,0 +1,6 @@
+- [x] Add `output_index_map` field and `index_for_output_index`, `register_alias`, `register_output_index` helpers to `ToolCallIndex`, keeping the existing `index_for` signature for legacy callers.
+- [x] Route `response.function_call_arguments.delta` / `.done` events through `index_for_output_index` using `output_index` as the primary routing key and falling back to `call_id` / `item_id` when present.
+- [x] On `output_item.added` / `.done`, register `item.id` as an alias to the same slot as the resolved `call_id`-keyed index when both are observed.
+- [x] Guard the public `tool_calls[].id` / `call_id` surfaces so the internal `fc_...` item id never replaces the upstream `call_...` value.
+- [x] Add regression tests covering parallel tool-call routing for both `collect_chat_completion` and `stream_chat_chunks` using realistic `output_item` + `function_call_arguments` event sequences (call_id-only, item_id-only, and out-of-order variants).
+- [x] Document the parallel tool-call routing requirement (output_index primary, item_id alias, no fc_ leakage) in the Responses compatibility spec.

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -6,11 +6,36 @@ import pytest
 
 from app.core.openai.chat_responses import (
     ChatCompletion,
+    ChatMessageToolCall,
     collect_chat_completion,
     iter_chat_chunks,
     stream_chat_chunks,
 )
 from app.core.openai.models import OpenAIErrorEnvelope
+
+
+def _tool_call_args(tool_call: ChatMessageToolCall) -> str:
+    """Type-narrowing accessor for ``tool_call.function.arguments`` in tests.
+
+    The pydantic model declares both ``function`` and ``arguments`` as
+    ``Optional`` for upstream compatibility, but the streaming/non-streaming
+    adapters always populate them by the time a tool call is surfaced to the
+    client. The helper makes that invariant explicit so ``ty`` does not flag
+    every ``tool_call.function.arguments`` access as a possibly-missing
+    attribute, without weakening the production model definitions.
+    """
+
+    assert tool_call.function is not None
+    assert tool_call.function.arguments is not None
+    return tool_call.function.arguments
+
+
+def _tool_call_name(tool_call: ChatMessageToolCall) -> str:
+    """Type-narrowing accessor for ``tool_call.function.name`` in tests."""
+
+    assert tool_call.function is not None
+    assert tool_call.function.name is not None
+    return tool_call.function.name
 
 
 def test_output_text_delta_to_chat_chunk():
@@ -545,8 +570,8 @@ async def test_collect_completion_parallel_tool_calls_distinct_arguments():
     assert tool_calls is not None
     assert len(tool_calls) == 2
 
-    args_0 = json.loads(tool_calls[0].function.arguments)
-    args_1 = json.loads(tool_calls[1].function.arguments)
+    args_0 = json.loads(_tool_call_args(tool_calls[0]))
+    args_1 = json.loads(_tool_call_args(tool_calls[1]))
     assert args_0["category"] == "activity"
     assert args_0["content"] == "Biked 20km"
     assert args_1["category"] == "food"
@@ -613,9 +638,9 @@ async def test_collect_completion_three_parallel_tool_calls():
     tool_calls = result.choices[0].message.tool_calls
     assert tool_calls is not None
     assert len(tool_calls) == 3
-    assert json.loads(tool_calls[0].function.arguments) == {"cat": "activity"}
-    assert json.loads(tool_calls[1].function.arguments) == {"cat": "food"}
-    assert json.loads(tool_calls[2].function.arguments) == {"cat": "mood"}
+    assert json.loads(_tool_call_args(tool_calls[0])) == {"cat": "activity"}
+    assert json.loads(_tool_call_args(tool_calls[1])) == {"cat": "food"}
+    assert json.loads(_tool_call_args(tool_calls[2])) == {"cat": "mood"}
     assert tool_calls[0].id == "call_1"
     assert tool_calls[1].id == "call_2"
     assert tool_calls[2].id == "call_3"
@@ -665,10 +690,10 @@ async def test_collect_completion_parallel_different_functions():
     tool_calls = result.choices[0].message.tool_calls
     assert tool_calls is not None
     assert len(tool_calls) == 2
-    assert tool_calls[0].function.name == "get_weather"
-    assert json.loads(tool_calls[0].function.arguments) == {"city": "Zurich"}
-    assert tool_calls[1].function.name == "record_observation"
-    assert json.loads(tool_calls[1].function.arguments) == {"category": "activity"}
+    assert _tool_call_name(tool_calls[0]) == "get_weather"
+    assert json.loads(_tool_call_args(tool_calls[0])) == {"city": "Zurich"}
+    assert _tool_call_name(tool_calls[1]) == "record_observation"
+    assert json.loads(_tool_call_args(tool_calls[1])) == {"category": "activity"}
 
 
 @pytest.mark.asyncio
@@ -715,9 +740,11 @@ async def test_collect_completion_parallel_calls_item_id_equals_call_id():
     tool_calls = result.choices[0].message.tool_calls
     assert tool_calls is not None
     assert len(tool_calls) == 2
-    assert json.loads(tool_calls[0].function.arguments) == {"city": "Paris"}
-    assert json.loads(tool_calls[1].function.arguments) == {"city": "London"}
-    assert tool_calls[0].function.arguments != tool_calls[1].function.arguments
+    args_paris = _tool_call_args(tool_calls[0])
+    args_london = _tool_call_args(tool_calls[1])
+    assert json.loads(args_paris) == {"city": "Paris"}
+    assert json.loads(args_london) == {"city": "London"}
+    assert args_paris != args_london
 
 
 @pytest.mark.asyncio
@@ -769,5 +796,5 @@ async def test_collect_completion_registers_call_id_when_output_index_already_ma
     assert tool_calls is not None
     # The call_id-only legacy event must not have allocated a new slot.
     assert len(tool_calls) == 1
-    assert tool_calls[0].function.name == "get_weather"
-    assert json.loads(tool_calls[0].function.arguments) == {"city": "Paris"}
+    assert _tool_call_name(tool_calls[0]) == "get_weather"
+    assert json.loads(_tool_call_args(tool_calls[0])) == {"city": "Paris"}

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -477,3 +477,244 @@ async def test_collect_completion_zero_token_preserves_empty_content():
     message = result.choices[0].message
     assert message.content == ""
     assert message.refusal is None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Parallel tool-call tests (item_id-based routing, bug fix verification)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_parallel_tool_calls_distinct_arguments():
+    """Two parallel calls to the SAME function with different args.
+
+    Verifies that function_call_arguments.delta/done events routed via
+    item_id produce distinct arguments per tool call.
+    """
+    lines = [
+        (
+            'data: {"type":"response.output_item.added","output_index":0,'
+            '"item":{"id":"fc_001","type":"function_call","call_id":"call_aaa",'
+            '"name":"record_observation","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.added","output_index":1,'
+            '"item":{"id":"fc_002","type":"function_call","call_id":"call_bbb",'
+            '"name":"record_observation","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.delta","output_index":0,'
+            '"item_id":"fc_001","delta":"{\\"category\\":\\"activity\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.delta","output_index":1,'
+            '"item_id":"fc_002","delta":"{\\"category\\":\\"food\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":0,'
+            '"item_id":"fc_001","arguments":"{\\"category\\":\\"activity\\",\\"content\\":\\"Biked 20km\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":1,'
+            '"item_id":"fc_002","arguments":"{\\"category\\":\\"food\\",\\"content\\":\\"Had pasta\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":0,'
+            '"item":{"id":"fc_001","type":"function_call","call_id":"call_aaa",'
+            '"name":"record_observation",'
+            '"arguments":"{\\"category\\":\\"activity\\",\\"content\\":\\"Biked 20km\\"}"}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":1,'
+            '"item":{"id":"fc_002","type":"function_call","call_id":"call_bbb",'
+            '"name":"record_observation",'
+            '"arguments":"{\\"category\\":\\"food\\",\\"content\\":\\"Had pasta\\"}"}}\n\n'
+        ),
+        'data: {"type":"response.completed","response":{"id":"resp_001"}}\n\n',
+    ]
+
+    async def _stream():
+        for line in lines:
+            yield line
+
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+    assert isinstance(result, ChatCompletion)
+    choice = result.choices[0]
+    assert choice.finish_reason == "tool_calls"
+    tool_calls = choice.message.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+
+    args_0 = json.loads(tool_calls[0].function.arguments)
+    args_1 = json.loads(tool_calls[1].function.arguments)
+    assert args_0["category"] == "activity"
+    assert args_0["content"] == "Biked 20km"
+    assert args_1["category"] == "food"
+    assert args_1["content"] == "Had pasta"
+    assert tool_calls[0].id == "call_aaa"
+    assert tool_calls[1].id == "call_bbb"
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_three_parallel_tool_calls():
+    """Three parallel tool calls to verify indexing beyond 2."""
+    lines = [
+        (
+            'data: {"type":"response.output_item.added","output_index":0,'
+            '"item":{"id":"fc_A","type":"function_call","call_id":"call_1",'
+            '"name":"record_observation","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.added","output_index":1,'
+            '"item":{"id":"fc_B","type":"function_call","call_id":"call_2",'
+            '"name":"record_observation","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.added","output_index":2,'
+            '"item":{"id":"fc_C","type":"function_call","call_id":"call_3",'
+            '"name":"record_observation","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":0,'
+            '"item_id":"fc_A","arguments":"{\\"cat\\":\\"activity\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":1,'
+            '"item_id":"fc_B","arguments":"{\\"cat\\":\\"food\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":2,'
+            '"item_id":"fc_C","arguments":"{\\"cat\\":\\"mood\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":0,'
+            '"item":{"id":"fc_A","type":"function_call","call_id":"call_1",'
+            '"name":"record_observation","arguments":"{\\"cat\\":\\"activity\\"}"}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":1,'
+            '"item":{"id":"fc_B","type":"function_call","call_id":"call_2",'
+            '"name":"record_observation","arguments":"{\\"cat\\":\\"food\\"}"}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":2,'
+            '"item":{"id":"fc_C","type":"function_call","call_id":"call_3",'
+            '"name":"record_observation","arguments":"{\\"cat\\":\\"mood\\"}"}}\n\n'
+        ),
+        'data: {"type":"response.completed","response":{"id":"resp_003"}}\n\n',
+    ]
+
+    async def _stream():
+        for line in lines:
+            yield line
+
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+    assert isinstance(result, ChatCompletion)
+    tool_calls = result.choices[0].message.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 3
+    assert json.loads(tool_calls[0].function.arguments) == {"cat": "activity"}
+    assert json.loads(tool_calls[1].function.arguments) == {"cat": "food"}
+    assert json.loads(tool_calls[2].function.arguments) == {"cat": "mood"}
+    assert tool_calls[0].id == "call_1"
+    assert tool_calls[1].id == "call_2"
+    assert tool_calls[2].id == "call_3"
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_parallel_different_functions():
+    """Two parallel calls with DIFFERENT function names via item_id routing."""
+    lines = [
+        (
+            'data: {"type":"response.output_item.added","output_index":0,'
+            '"item":{"id":"fc_w","type":"function_call","call_id":"call_weather",'
+            '"name":"get_weather","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.added","output_index":1,'
+            '"item":{"id":"fc_r","type":"function_call","call_id":"call_record",'
+            '"name":"record_observation","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":0,'
+            '"item_id":"fc_w","arguments":"{\\"city\\":\\"Zurich\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":1,'
+            '"item_id":"fc_r","arguments":"{\\"category\\":\\"activity\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":0,'
+            '"item":{"id":"fc_w","type":"function_call","call_id":"call_weather",'
+            '"name":"get_weather","arguments":"{\\"city\\":\\"Zurich\\"}"}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":1,'
+            '"item":{"id":"fc_r","type":"function_call","call_id":"call_record",'
+            '"name":"record_observation","arguments":"{\\"category\\":\\"activity\\"}"}}\n\n'
+        ),
+        'data: {"type":"response.completed","response":{"id":"resp_diff"}}\n\n',
+    ]
+
+    async def _stream():
+        for line in lines:
+            yield line
+
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+    assert isinstance(result, ChatCompletion)
+    tool_calls = result.choices[0].message.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert tool_calls[0].function.name == "get_weather"
+    assert json.loads(tool_calls[0].function.arguments) == {"city": "Zurich"}
+    assert tool_calls[1].function.name == "record_observation"
+    assert json.loads(tool_calls[1].function.arguments) == {"category": "activity"}
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_parallel_calls_item_id_equals_call_id():
+    """Edge case: item.id == item.call_id (some models emit identical values)."""
+    lines = [
+        (
+            'data: {"type":"response.output_item.added","output_index":0,'
+            '"item":{"id":"call_same_1","type":"function_call","call_id":"call_same_1",'
+            '"name":"get_weather","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.added","output_index":1,'
+            '"item":{"id":"call_same_2","type":"function_call","call_id":"call_same_2",'
+            '"name":"get_weather","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":0,'
+            '"item_id":"call_same_1","arguments":"{\\"city\\":\\"Paris\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","output_index":1,'
+            '"item_id":"call_same_2","arguments":"{\\"city\\":\\"London\\"}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":0,'
+            '"item":{"id":"call_same_1","type":"function_call","call_id":"call_same_1",'
+            '"name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":1,'
+            '"item":{"id":"call_same_2","type":"function_call","call_id":"call_same_2",'
+            '"name":"get_weather","arguments":"{\\"city\\":\\"London\\"}"}}\n\n'
+        ),
+        'data: {"type":"response.completed","response":{"id":"resp_same"}}\n\n',
+    ]
+
+    async def _stream():
+        for line in lines:
+            yield line
+
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+    assert isinstance(result, ChatCompletion)
+    tool_calls = result.choices[0].message.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert json.loads(tool_calls[0].function.arguments) == {"city": "Paris"}
+    assert json.loads(tool_calls[1].function.arguments) == {"city": "London"}
+    assert tool_calls[0].function.arguments != tool_calls[1].function.arguments

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -718,3 +718,56 @@ async def test_collect_completion_parallel_calls_item_id_equals_call_id():
     assert json.loads(tool_calls[0].function.arguments) == {"city": "Paris"}
     assert json.loads(tool_calls[1].function.arguments) == {"city": "London"}
     assert tool_calls[0].function.arguments != tool_calls[1].function.arguments
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_registers_call_id_when_output_index_already_mapped():
+    """Regression: a stream that first routes a tool call via item_id + output_index
+    (no call_id yet) and later emits a call_id-only event without output_index
+    must NOT split the call into two tool_calls[] slots.
+
+    Mirrors codex review P2 (chat_responses.py:139): index_for_output_index
+    used to return early on a known output_index without registering the
+    newly observed call_id/name key, so a follow-up call_id-only event was
+    assigned a fresh index, fragmenting the arguments.
+    """
+
+    lines = [
+        'data: {"type":"response.created","response":{"id":"resp_split"}}\n\n',
+        # First: an output_item.added that exposes both item.id and item.call_id.
+        # This is enough for the indexer to associate output_index=0 with the
+        # call_id-keyed slot.
+        'data: {"type":"response.output_item.added","output_index":0,'
+        '"item":{"id":"fc_001","call_id":"call_001","type":"function_call",'
+        '"name":"get_weather","arguments":""}}\n\n',
+        # Then: an argument event that carries item_id + output_index (no call_id).
+        # This locks in output_index_map[0] -> the same slot.
+        'data: {"type":"response.function_call_arguments.delta",'
+        '"item_id":"fc_001","output_index":0,"delta":"{\\"city\\":\\"Paris\\"}"}\n\n',
+        # Then: a legacy-style tool_call delta event that carries only the
+        # call_id+name (no output_index, no item_id). Previously this fell into
+        # `if key not in self.indexes:` and got a fresh next_index, splitting
+        # the call into a second tool_calls[] slot.
+        'data: {"type":"response.output_tool_call.delta","call_id":"call_001","name":"get_weather","delta":""}\n\n',
+        # Final completion.
+        'data: {"type":"response.function_call_arguments.done",'
+        '"item_id":"fc_001","output_index":0,'
+        '"arguments":"{\\"city\\":\\"Paris\\"}"}\n\n',
+        'data: {"type":"response.output_item.done","output_index":0,'
+        '"item":{"id":"fc_001","call_id":"call_001","type":"function_call",'
+        '"name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}\n\n',
+        'data: {"type":"response.completed","response":{"id":"resp_split"}}\n\n',
+    ]
+
+    async def _stream():
+        for line in lines:
+            yield line
+
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+    assert isinstance(result, ChatCompletion)
+    tool_calls = result.choices[0].message.tool_calls
+    assert tool_calls is not None
+    # The call_id-only legacy event must not have allocated a new slot.
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "get_weather"
+    assert json.loads(tool_calls[0].function.arguments) == {"city": "Paris"}


### PR DESCRIPTION
## Summary

Fixes #542 — parallel `tool_calls` receive duplicated/identical `function.arguments` when proxying Responses API → Chat Completions format.

**Root cause:** `response.function_call_arguments.delta/done` events identify their target tool call via `item_id`, but `_extract_tool_call_fields()` only checked `call_id`, `tool_call_id`, and `id`. With `item_id` unrecognized, `_tool_call_key()` returned `None`, and `index_for()` defaulted all events to **index 0** — overwriting the first call's arguments and duplicating them across all slots.

## Fix approach (3 layers of defense)

### 1. Alias registration
When processing `output_item.added/done` events (which carry both `item.id` and `item.call_id`), register `item.id` as an alias mapping to the same tool call index as `call_id`. Subsequent delta/done events (carrying only `item_id`) then resolve to the correct index.

### 2. `output_index` routing
Every Responses API event carries `output_index`. Added `index_for_output_index()` which uses this as the primary routing key, providing robust fallback even if IDs are missing or arrive in unexpected order. This follows the pattern used by [OpenAI's own reference implementation](https://github.com/openai/openai-python/blob/722d3fff/src/openai/lib/streaming/responses/_responses.py) and matches the fix approach in [LiteLLM #17652](https://github.com/BerriAI/litellm/pull/17652). The `output_index` mapping is now registered in **both** the key-based and keyless code paths, preventing out-of-order events from splitting one logical tool call into phantom indices.

### 3. Routing vs. emitted ID separation
`item_id` is used **only for index routing** via a separate `routing_id` variable — it is never returned as `call_id` on the `ToolCallDelta` and never leaks into the public Chat Completions response. This prevents internal `fc_xxx` Responses API IDs from appearing in streaming chunks; clients only see proper `call_xxx` IDs.

## Verification

### Unit tests (4 new, all 24 pass)
- `test_collect_completion_parallel_tool_calls_distinct_arguments` — 2 calls, same function, distinct args
- `test_collect_completion_three_parallel_tool_calls` — 3 calls, verifies indexing scales
- `test_collect_completion_parallel_different_functions` — 2 calls, different function names
- `test_collect_completion_parallel_calls_item_id_equals_call_id` — edge case where `item.id == call_id`

### End-to-end (live gpt-5.4-mini)

**Non-streaming:**
```
Before fix: {"category":"food","content":"Had pasta"} × 2  (duplicated)
After fix:  {"category":"activity","content":"Biked 20 km today"} +
            {"category":"food","content":"Ate pasta for dinner"}   ✓
```

**Streaming (fc_ ID leak fixed):**
```
Before fix: id alternates between call_xxx and fc_xxx per tool call
After fix:  id=call_xxx on first chunk only, id=None on subsequent chunks  ✓
```

Tested streaming, non-streaming, single-tool (regression), multi-tool with 2+ calls, and 3-call scenarios.

## Related issues
- #284 — Original report, closed with incomplete fix (PR #287 only addressed single-call triplication)
- #392 — Same root cause manifesting as "Invalid JSON in tool call arguments: Extra data" in Hermes
- #113 — Potentially related streaming tool_call issues

## Similar bugs fixed in other projects
| Project | Issue | Fix |
|---------|-------|-----|
| LiteLLM | [#17246](https://github.com/BerriAI/litellm/issues/17246) | Only signal finish on `response.completed`, not `output_item.done` |
| Ollama | [#15457](https://github.com/ollama/ollama/issues/15457) | Map `output_index` → sequential `tool_calls[N].index` |
| LangChain | [#32562](https://github.com/langchain-ai/langchain/issues/32562) | Separate state machines for annotations vs. tool args |
| PromptKit | [#940](https://github.com/AltairaLabs/PromptKit/issues/940) | Key accumulator on `output_index` directly |

## Test plan
- [x] All 20 existing unit tests pass (no regressions)
- [x] 4 new unit tests covering parallel tool_calls
- [x] E2E: multi-tool with same function name → distinct arguments
- [x] E2E: single tool call still works (regression)
- [x] E2E: non-streaming multi-tool → distinct arguments
- [x] E2E: streaming no longer leaks internal `fc_` IDs
- [x] E2E: 3 parallel tool calls with system message → all distinct