### PR TITLE
Add upstream proxy bindings

### DIFF
--- a/app/core/auth/refresh.py
+++ b/app/core/auth/refresh.py
@@ -12,6 +12,7 @@ from app.core.auth import OpenAIAuthClaims, extract_id_token_claims
 from app.core.auth.models import OAuthTokenPayload
 from app.core.balancer import PERMANENT_FAILURE_CODES
 from app.core.clients.http import get_http_client
+from app.core.clients.upstream_proxy import aiohttp_proxy_url, is_socks_upstream_proxy, socks_proxy_connector
 from app.core.config.settings import get_settings
 from app.core.types import JsonObject
 from app.core.utils.request_id import get_request_id
@@ -22,6 +23,10 @@ TOKEN_REFRESH_INTERVAL_DAYS = 8
 logger = logging.getLogger(__name__)
 _TOKEN_REFRESH_TIMEOUT_OVERRIDE: contextvars.ContextVar[float | None] = contextvars.ContextVar(
     "token_refresh_timeout_override",
+    default=None,
+)
+_TOKEN_REFRESH_PROXY_URL_OVERRIDE: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "token_refresh_proxy_url_override",
     default=None,
 )
 
@@ -72,28 +77,56 @@ async def refresh_access_token(
     }
     timeout = aiohttp.ClientTimeout(total=_effective_token_refresh_timeout(settings.token_refresh_timeout_seconds))
 
-    client_session = session or get_http_client().session
+    upstream_proxy_url = _TOKEN_REFRESH_PROXY_URL_OVERRIDE.get()
+    managed_socks_session: aiohttp.ClientSession | None = None
+    if upstream_proxy_url and is_socks_upstream_proxy(upstream_proxy_url):
+        managed_socks_session = aiohttp.ClientSession(
+            connector=socks_proxy_connector(upstream_proxy_url),
+            timeout=aiohttp.ClientTimeout(total=None),
+            trust_env=False,
+        )
+    client_session = managed_socks_session or session or get_http_client().session
     headers: dict[str, str] = {}
     request_id = get_request_id()
     if request_id:
         headers["x-request-id"] = request_id
-    async with client_session.post(url, json=payload, headers=headers, timeout=timeout) as resp:
-        data = await _safe_json(resp)
-        try:
-            payload_data = OAuthTokenPayload.model_validate(data)
-        except ValidationError as exc:
-            logger.warning(
-                "Token refresh response invalid request_id=%s",
-                get_request_id(),
-            )
-            raise RefreshError("invalid_response", "Refresh response invalid", False) from exc
-        if resp.status >= 400:
-            logger.warning(
-                "Token refresh failed request_id=%s status=%s",
-                get_request_id(),
-                resp.status,
-            )
-            raise _refresh_error_from_payload(payload_data, resp.status)
+    aiohttp_proxy = aiohttp_proxy_url(upstream_proxy_url)
+    if aiohttp_proxy is None:
+        post_context = client_session.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+        )
+    else:
+        post_context = client_session.post(
+            url,
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+            proxy=aiohttp_proxy,
+        )
+    try:
+        async with post_context as resp:
+            data = await _safe_json(resp)
+            try:
+                payload_data = OAuthTokenPayload.model_validate(data)
+            except ValidationError as exc:
+                logger.warning(
+                    "Token refresh response invalid request_id=%s",
+                    get_request_id(),
+                )
+                raise RefreshError("invalid_response", "Refresh response invalid", False) from exc
+            if resp.status >= 400:
+                logger.warning(
+                    "Token refresh failed request_id=%s status=%s",
+                    get_request_id(),
+                    resp.status,
+                )
+                raise _refresh_error_from_payload(payload_data, resp.status)
+    finally:
+        if managed_socks_session is not None:
+            await managed_socks_session.close()
 
     if not payload_data.access_token or not payload_data.refresh_token or not payload_data.id_token:
         raise RefreshError("invalid_response", "Refresh response missing tokens", False)
@@ -120,6 +153,14 @@ def push_token_refresh_timeout_override(timeout_seconds: float | None) -> contex
 
 def pop_token_refresh_timeout_override(token: contextvars.Token[float | None]) -> None:
     _TOKEN_REFRESH_TIMEOUT_OVERRIDE.reset(token)
+
+
+def push_token_refresh_proxy_url_override(proxy_url: str | None) -> contextvars.Token[str | None]:
+    return _TOKEN_REFRESH_PROXY_URL_OVERRIDE.set(proxy_url)
+
+
+def pop_token_refresh_proxy_url_override(token: contextvars.Token[str | None]) -> None:
+    _TOKEN_REFRESH_PROXY_URL_OVERRIDE.reset(token)
 
 
 async def _safe_json(resp: aiohttp.ClientResponse) -> JsonObject:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import (
+    Any,
     AsyncContextManager,
     AsyncIterator,
     Awaitable,
@@ -34,6 +35,7 @@ from aiohttp.http_websocket import WS_KEY, WebSocketReader, WebSocketWriter
 from multidict import CIMultiDict
 
 from app.core.clients.http import get_http_client
+from app.core.clients.upstream_proxy import aiohttp_proxy_url, is_socks_upstream_proxy, socks_proxy_connector
 from app.core.config.settings import Settings, get_settings
 from app.core.errors import (
     OpenAIErrorDetail,
@@ -130,6 +132,17 @@ _NATIVE_CODEX_STREAM_HEADER_KEYS = frozenset(
         "x-codex-beta-features",
     }
 )
+
+
+def _with_optional_aiohttp_proxy(
+    call: Callable[..., Any], *args: Any, upstream_proxy_url: str | None, **kwargs: Any
+) -> Any:
+    proxy_url = aiohttp_proxy_url(upstream_proxy_url)
+    if proxy_url is None:
+        return call(*args, **kwargs)
+    return call(*args, proxy=proxy_url, **kwargs)
+
+
 _HOP_BY_HOP_HEADER_NAMES = frozenset(
     {
         "accept",
@@ -1015,6 +1028,7 @@ async def _open_upstream_websocket(
     max_msg_size: int,
     account_id: str | None = None,
     hold_half_open_probe: bool = False,
+    upstream_proxy_url: str | None = None,
 ) -> tuple[AsyncContextManager[aiohttp.ClientWebSocketResponse], aiohttp.ClientWebSocketResponse]:
     settings = get_settings()
     circuit_breaker = get_circuit_breaker_for_account(account_id, settings) if account_id else None
@@ -1025,8 +1039,10 @@ async def _open_upstream_websocket(
     request_obj = getattr(session, "request", None)
     if not callable(request_obj):
         try:
-            websocket_cm = session.ws_connect(
+            websocket_cm = _with_optional_aiohttp_proxy(
+                session.ws_connect,
                 url,
+                upstream_proxy_url=upstream_proxy_url,
                 headers=headers,
                 receive_timeout=None,
                 autoping=True,
@@ -1056,9 +1072,11 @@ async def _open_upstream_websocket(
     timeout = aiohttp.ClientTimeout(total=connect_timeout_seconds, sock_connect=connect_timeout_seconds)
     try:
         try:
-            resp = await request(
+            resp = await _with_optional_aiohttp_proxy(
+                request,
                 hdrs.METH_GET,
                 url,
+                upstream_proxy_url=upstream_proxy_url,
                 headers=request_headers,
                 timeout=timeout,
                 read_until_eof=False,
@@ -1216,6 +1234,7 @@ async def _stream_responses_via_websocket(
     max_event_bytes: int,
     raise_for_status: bool,
     account_id: str | None = None,
+    upstream_proxy_url: str | None = None,
 ) -> AsyncIterator[str]:
     websocket_url = _to_websocket_upstream_url(url)
     request_started_at = time.monotonic()
@@ -1248,15 +1267,27 @@ async def _stream_responses_via_websocket(
         _remaining_total_timeout(effective_total_timeout, request_started_at, time.monotonic())
         or effective_connect_timeout,
     )
-    websocket_cm, websocket = await _open_upstream_websocket(
-        session=client_session,
-        url=websocket_url,
-        headers=headers,
-        connect_timeout_seconds=connect_timeout_seconds,
-        max_msg_size=max_event_bytes,
-        account_id=account_id,
-        hold_half_open_probe=True,
-    )
+    if upstream_proxy_url is not None:
+        websocket_cm, websocket = await _open_upstream_websocket(
+            session=client_session,
+            url=websocket_url,
+            headers=headers,
+            connect_timeout_seconds=connect_timeout_seconds,
+            max_msg_size=max_event_bytes,
+            account_id=account_id,
+            hold_half_open_probe=True,
+            upstream_proxy_url=upstream_proxy_url,
+        )
+    else:
+        websocket_cm, websocket = await _open_upstream_websocket(
+            session=client_session,
+            url=websocket_url,
+            headers=headers,
+            connect_timeout_seconds=connect_timeout_seconds,
+            max_msg_size=max_event_bytes,
+            account_id=account_id,
+            hold_half_open_probe=True,
+        )
 
     try:
         send_json = getattr(websocket, "send_json", None)
@@ -1773,6 +1804,7 @@ async def stream_responses(
     raise_for_status: bool = False,
     session: aiohttp.ClientSession | None = None,
     upstream_stream_transport_override: str | None = None,
+    upstream_proxy_url: str | None = None,
 ) -> AsyncIterator[str]:
     settings = get_settings()
     upstream_base = (base_url or settings.upstream_base_url).rstrip("/")
@@ -1792,7 +1824,14 @@ async def stream_responses(
     status_code: int | None = None
     error_code: str | None = None
     error_message: str | None = None
-    client_session = session or get_http_client().session
+    managed_socks_session: aiohttp.ClientSession | None = None
+    if upstream_proxy_url and is_socks_upstream_proxy(upstream_proxy_url):
+        managed_socks_session = aiohttp.ClientSession(
+            connector=socks_proxy_connector(upstream_proxy_url),
+            timeout=aiohttp.ClientTimeout(total=None),
+            trust_env=False,
+        )
+    client_session = managed_socks_session or session or get_http_client().session
     payload_dict = payload.to_payload()
     if settings.image_inline_fetch_enabled:
         payload_dict = await _inline_input_image_urls(
@@ -1836,8 +1875,10 @@ async def stream_responses(
         nonlocal status_code, error_code, error_message, seen_terminal
 
         async with _service_circuit_breaker_context(
-            client_session.post(
+            _with_optional_aiohttp_proxy(
+                client_session.post,
                 url,
+                upstream_proxy_url=upstream_proxy_url,
                 json=payload_dict,
                 headers=current_headers,
                 timeout=current_timeout,
@@ -1895,6 +1936,7 @@ async def stream_responses(
                     max_event_bytes=settings.max_sse_event_bytes,
                     raise_for_status=raise_for_status,
                     account_id=account_id,
+                    upstream_proxy_url=upstream_proxy_url,
                 ):
                     if status_code is None:
                         status_code = 101
@@ -2054,6 +2096,8 @@ async def stream_responses(
             error_code=error_code,
             error_message=error_message,
         )
+        if managed_socks_session is not None:
+            await managed_socks_session.close()
 
 
 def push_stream_timeout_overrides(
@@ -2152,13 +2196,30 @@ async def compact_responses(
     access_token: str,
     account_id: str | None,
     session: aiohttp.ClientSession | None = None,
+    upstream_proxy_url: str | None = None,
 ) -> CompactResponsePayload:
+    if upstream_proxy_url and is_socks_upstream_proxy(upstream_proxy_url):
+        async with aiohttp.ClientSession(
+            connector=socks_proxy_connector(upstream_proxy_url),
+            timeout=aiohttp.ClientTimeout(total=None),
+            trust_env=False,
+        ) as proxy_session:
+            transport = _CompactCommandTransport(
+                payload=payload,
+                headers=headers,
+                access_token=access_token,
+                account_id=account_id,
+                session=proxy_session,
+                upstream_proxy_url=upstream_proxy_url,
+            )
+            return await transport.execute()
     transport = _CompactCommandTransport(
         payload=payload,
         headers=headers,
         access_token=access_token,
         account_id=account_id,
         session=session or get_http_client().session,
+        upstream_proxy_url=upstream_proxy_url,
     )
     return await transport.execute()
 
@@ -2174,6 +2235,7 @@ class _CompactCommandTransport:
     access_token: str
     account_id: str | None
     session: aiohttp.ClientSession
+    upstream_proxy_url: str | None = None
 
     async def execute(self) -> CompactResponsePayload:
         settings = get_settings()
@@ -2236,8 +2298,10 @@ class _CompactCommandTransport:
         )
         try:
             async with _service_circuit_breaker_context(
-                self.session.post(
+                _with_optional_aiohttp_proxy(
+                    self.session.post,
                     url,
+                    upstream_proxy_url=self.upstream_proxy_url,
                     json=payload_dict,
                     headers=upstream_headers,
                     timeout=timeout,
@@ -2377,6 +2441,7 @@ async def transcribe_audio(
     account_id: str | None,
     base_url: str | None = None,
     session: aiohttp.ClientSession | None = None,
+    upstream_proxy_url: str | None = None,
 ) -> dict[str, JsonValue]:
     settings = get_settings()
     upstream_base = (base_url or settings.upstream_base_url).rstrip("/")
@@ -2414,7 +2479,14 @@ async def transcribe_audio(
     if prompt is not None:
         form.add_field("prompt", prompt)
 
-    client_session = session or get_http_client().session
+    managed_socks_session: aiohttp.ClientSession | None = None
+    if upstream_proxy_url and is_socks_upstream_proxy(upstream_proxy_url):
+        managed_socks_session = aiohttp.ClientSession(
+            connector=socks_proxy_connector(upstream_proxy_url),
+            timeout=aiohttp.ClientTimeout(total=None),
+            trust_env=False,
+        )
+    client_session = managed_socks_session or session or get_http_client().session
     started_at = time.monotonic()
     status_code: int | None = None
     error_code: str | None = None
@@ -2437,8 +2509,10 @@ async def transcribe_audio(
     )
     try:
         async with _service_circuit_breaker_context(
-            client_session.post(
+            _with_optional_aiohttp_proxy(
+                client_session.post,
                 url,
+                upstream_proxy_url=upstream_proxy_url,
                 data=form,
                 headers=upstream_headers,
                 timeout=timeout,
@@ -2504,3 +2578,5 @@ async def transcribe_audio(
             error_code=error_code,
             error_message=error_message,
         )
+        if managed_socks_session is not None:
+            await managed_socks_session.close()

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -19,6 +19,7 @@ from websockets.exceptions import (
 from websockets.typing import Origin
 
 from app.core.clients.proxy import ProxyResponseError, filter_inbound_headers
+from app.core.clients.upstream_proxy import normalize_upstream_proxy_url
 from app.core.config.settings import get_settings
 from app.core.errors import OpenAIErrorDetail, OpenAIErrorEnvelope, openai_error
 from app.core.openai.models import OpenAIError
@@ -160,6 +161,7 @@ async def connect_responses_websocket(
     account_id: str | None,
     *,
     base_url: str | None = None,
+    upstream_proxy_url: str | None = None,
 ) -> UpstreamResponsesWebSocket:
     settings = get_settings()
     upstream_base = (base_url or settings.upstream_base_url).rstrip("/")
@@ -167,13 +169,18 @@ async def connect_responses_websocket(
     upstream_headers = _build_upstream_websocket_headers(headers, access_token, account_id)
     origin = cast(Origin | None, _pop_header_case_insensitive(upstream_headers, "origin"))
     user_agent = _pop_header_case_insensitive(upstream_headers, "user-agent")
+    proxy = (
+        normalize_upstream_proxy_url(upstream_proxy_url)
+        if upstream_proxy_url
+        else (True if settings.upstream_websocket_trust_env else None)
+    )
     try:
         response = await websocket_connect(
             url,
             origin=origin,
             additional_headers=upstream_headers or None,
             user_agent_header=user_agent,
-            proxy=True if settings.upstream_websocket_trust_env else None,
+            proxy=proxy,
             open_timeout=settings.upstream_connect_timeout_seconds,
             max_size=settings.max_sse_event_bytes,
         )

--- a/app/core/clients/upstream_proxy.py
+++ b/app/core/clients/upstream_proxy.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from aiohttp_socks import ProxyConnector
+
+SUPPORTED_UPSTREAM_PROXY_SCHEMES = frozenset({"http", "https", "socks5", "socks5h"})
+
+
+class UpstreamProxyConfigurationError(ValueError):
+    pass
+
+
+def normalize_upstream_proxy_url(value: str) -> str:
+    url = value.strip()
+    if not url:
+        raise UpstreamProxyConfigurationError("Proxy URL is empty")
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in SUPPORTED_UPSTREAM_PROXY_SCHEMES:
+        raise UpstreamProxyConfigurationError("Proxy URL scheme must be http, https, socks5, or socks5h")
+    if not parsed.hostname:
+        raise UpstreamProxyConfigurationError("Proxy URL must include a host")
+    return url
+
+
+def redact_upstream_proxy_url(value: str | None) -> str | None:
+    if not value:
+        return None
+    parsed = urlparse(value)
+    if not parsed.username and not parsed.password:
+        return value
+    host = parsed.hostname or ""
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return parsed._replace(netloc=host).geturl()
+
+
+def is_socks_upstream_proxy(value: str | None) -> bool:
+    if not value:
+        return False
+    return urlparse(value).scheme.lower() in {"socks5", "socks5h"}
+
+
+def aiohttp_proxy_kwargs(value: str | None) -> dict[str, str]:
+    if not value or is_socks_upstream_proxy(value):
+        return {}
+    return {"proxy": value}
+
+
+def aiohttp_proxy_url(value: str | None) -> str | None:
+    if not value or is_socks_upstream_proxy(value):
+        return None
+    return value
+
+
+def socks_proxy_connector(value: str) -> ProxyConnector:
+    return ProxyConnector.from_url(value)

--- a/app/db/alembic/versions/20260503_000000_add_upstream_proxy_bindings.py
+++ b/app/db/alembic/versions/20260503_000000_add_upstream_proxy_bindings.py
@@ -1,0 +1,83 @@
+"""add upstream proxy bindings
+
+Revision ID: 20260503_000000_add_upstream_proxy_bindings
+Revises: 20260424_000000_merge_dashboard_session_ttl_and_request_log_heads
+Create Date: 2026-05-03 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260503_000000_add_upstream_proxy_bindings"
+down_revision = "20260424_000000_merge_dashboard_session_ttl_and_request_log_heads"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(column["name"] == column_name for column in inspector.get_columns(table_name))
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(index["name"] == index_name for index in inspector.get_indexes(table_name))
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    add_account_proxy_url = not _has_column("accounts", "upstream_proxy_url_encrypted")
+    add_account_proxy_group = not _has_column("accounts", "upstream_proxy_group")
+    add_account_proxy_group_index = not _has_index("accounts", "ix_accounts_upstream_proxy_group")
+    if add_account_proxy_url or add_account_proxy_group or add_account_proxy_group_index:
+        with op.batch_alter_table("accounts") as batch_op:
+            if add_account_proxy_url:
+                batch_op.add_column(sa.Column("upstream_proxy_url_encrypted", sa.LargeBinary(), nullable=True))
+            if add_account_proxy_group:
+                batch_op.add_column(sa.Column("upstream_proxy_group", sa.String(), nullable=True))
+            if add_account_proxy_group_index:
+                batch_op.create_index("ix_accounts_upstream_proxy_group", ["upstream_proxy_group"])
+
+    if not _has_column("dashboard_settings", "upstream_proxy_url_encrypted"):
+        with op.batch_alter_table("dashboard_settings") as batch_op:
+            batch_op.add_column(sa.Column("upstream_proxy_url_encrypted", sa.LargeBinary(), nullable=True))
+
+    if not _has_table("upstream_proxy_groups"):
+        op.create_table(
+            "upstream_proxy_groups",
+            sa.Column("name", sa.String(), nullable=False),
+            sa.Column("proxy_url_encrypted", sa.LargeBinary(), nullable=False),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.PrimaryKeyConstraint("name"),
+        )
+
+
+def downgrade() -> None:
+    if _has_table("upstream_proxy_groups"):
+        op.drop_table("upstream_proxy_groups")
+    if _has_column("dashboard_settings", "upstream_proxy_url_encrypted"):
+        with op.batch_alter_table("dashboard_settings") as batch_op:
+            batch_op.drop_column("upstream_proxy_url_encrypted")
+    drop_account_proxy_url = _has_column("accounts", "upstream_proxy_url_encrypted")
+    drop_account_proxy_group = _has_column("accounts", "upstream_proxy_group")
+    drop_account_proxy_group_index = _has_index("accounts", "ix_accounts_upstream_proxy_group")
+    if drop_account_proxy_url or drop_account_proxy_group or drop_account_proxy_group_index:
+        with op.batch_alter_table("accounts") as batch_op:
+            if drop_account_proxy_group_index:
+                batch_op.drop_index("ix_accounts_upstream_proxy_group")
+            if drop_account_proxy_group:
+                batch_op.drop_column("upstream_proxy_group")
+            if drop_account_proxy_url:
+                batch_op.drop_column("upstream_proxy_url_encrypted")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -50,6 +50,7 @@ class StickySessionKind(str, Enum):
 
 class Account(Base):
     __tablename__ = "accounts"
+    __table_args__ = (Index("ix_accounts_upstream_proxy_group", "upstream_proxy_group"),)
 
     id: Mapped[str] = mapped_column(String, primary_key=True)
     chatgpt_account_id: Mapped[str | None] = mapped_column(String, nullable=True)
@@ -76,6 +77,8 @@ class Account(Base):
     deactivation_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     reset_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
     blocked_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    upstream_proxy_url_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    upstream_proxy_group: Mapped[str | None] = mapped_column(String, nullable=True)
 
     api_key_assignments: Mapped[list["ApiKeyAccountAssignment"]] = relationship(
         "ApiKeyAccountAssignment",
@@ -269,6 +272,21 @@ class DashboardSettings(Base):
         server_default=text("95.0"),
         nullable=False,
     )
+    upstream_proxy_url_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class UpstreamProxyGroup(Base):
+    __tablename__ = "upstream_proxy_groups"
+
+    name: Mapped[str] = mapped_column(String, primary_key=True)
+    proxy_url_encrypted: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -175,6 +175,7 @@ async def _proxy_repo_context() -> AsyncIterator[ProxyRepositories]:
             sticky_sessions=StickySessionsRepository(session),
             api_keys=ApiKeysRepository(session),
             additional_usage=AdditionalUsageRepository(session),
+            settings=SettingsRepository(session),
         )
 
 

--- a/app/modules/accounts/api.py
+++ b/app/modules/accounts/api.py
@@ -14,6 +14,8 @@ from app.modules.accounts.schemas import (
     AccountReactivateResponse,
     AccountsResponse,
     AccountTrendsResponse,
+    AccountUpstreamProxyUpdateRequest,
+    AccountUpstreamProxyUpdateResponse,
 )
 from app.modules.accounts.service import InvalidAuthJsonError
 
@@ -84,6 +86,30 @@ async def pause_account(
     if not success:
         raise DashboardNotFoundError("Account not found", code="account_not_found")
     return AccountPauseResponse(status="paused")
+
+
+@router.patch("/{account_id}/upstream-proxy", response_model=AccountUpstreamProxyUpdateResponse)
+async def update_account_upstream_proxy(
+    account_id: str,
+    payload: AccountUpstreamProxyUpdateRequest,
+    context: AccountsContext = Depends(get_accounts_context),
+) -> AccountUpstreamProxyUpdateResponse:
+    try:
+        account = await context.service.update_upstream_proxy(
+            account_id,
+            upstream_proxy_url=payload.upstream_proxy_url,
+            upstream_proxy_url_set="upstream_proxy_url" in payload.model_fields_set,
+            upstream_proxy_group=payload.upstream_proxy_group,
+            upstream_proxy_group_set="upstream_proxy_group" in payload.model_fields_set,
+        )
+    except ValueError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_upstream_proxy") from exc
+    if account is None:
+        raise DashboardNotFoundError("Account not found", code="account_not_found")
+    return AccountUpstreamProxyUpdateResponse(
+        account_id=account.id,
+        upstream_proxy=context.service.upstream_proxy_status(account),
+    )
 
 
 @router.delete("/{account_id}", response_model=AccountDeleteResponse)

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 from app.core import usage as usage_core
 from app.core.auth import DEFAULT_PLAN, extract_id_token_claims
+from app.core.clients.upstream_proxy import redact_upstream_proxy_url
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.usage.types import UsageTrendBucket, UsageWindowRow
@@ -15,6 +16,7 @@ from app.modules.accounts.schemas import (
     AccountRequestUsage,
     AccountSummary,
     AccountTokenStatus,
+    AccountUpstreamProxyStatus,
     AccountUsage,
     AccountUsageTrend,
     UsageTrendPoint,
@@ -117,6 +119,7 @@ def _account_to_summary(
         additional_quotas=additional_quotas or [],
         deactivation_reason=account.deactivation_reason,
         auth=auth_status,
+        upstream_proxy=_build_upstream_proxy_status(account, encryptor),
     )
 
 
@@ -162,6 +165,15 @@ def _build_auth_status(account: Account, encryptor: TokenEncryptor) -> AccountAu
         access=AccountTokenStatus(expires_at=access_expires),
         refresh=AccountTokenStatus(state=refresh_state),
         id_token=AccountTokenStatus(state=id_state),
+    )
+
+
+def _build_upstream_proxy_status(account: Account, encryptor: TokenEncryptor) -> AccountUpstreamProxyStatus:
+    proxy_url = _decrypt_token(encryptor, account.upstream_proxy_url_encrypted)
+    return AccountUpstreamProxyStatus(
+        configured=proxy_url is not None or account.upstream_proxy_group is not None,
+        proxy_url=redact_upstream_proxy_url(proxy_url),
+        proxy_group=account.upstream_proxy_group,
     )
 
 

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -12,7 +12,13 @@ from app.db.models import Account, AccountStatus, DashboardSettings, RequestLog,
 
 _SETTINGS_ROW_ID = 1
 _DUPLICATE_ACCOUNT_SUFFIX = "__copy"
-_UNSET = object()
+
+
+class _Unset:
+    pass
+
+
+_UNSET = _Unset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -237,6 +243,24 @@ class AccountsRepository:
         )
         await self._session.commit()
         return result.scalar_one_or_none() is not None
+
+    async def update_upstream_proxy(
+        self,
+        account_id: str,
+        *,
+        upstream_proxy_url_encrypted: bytes | None | _Unset = _UNSET,
+        upstream_proxy_group: str | None | _Unset = _UNSET,
+    ) -> Account | None:
+        account = await self._session.get(Account, account_id)
+        if account is None:
+            return None
+        if not isinstance(upstream_proxy_url_encrypted, _Unset):
+            account.upstream_proxy_url_encrypted = upstream_proxy_url_encrypted
+        if not isinstance(upstream_proxy_group, _Unset):
+            account.upstream_proxy_group = upstream_proxy_group
+        await self._session.commit()
+        await self._session.refresh(account)
+        return account
 
     async def _merge_by_email_enabled(self) -> bool:
         settings = await self._session.get(DashboardSettings, _SETTINGS_ROW_ID)

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -41,6 +41,12 @@ class AccountAuthStatus(DashboardModel):
     id_token: AccountTokenStatus | None = None
 
 
+class AccountUpstreamProxyStatus(DashboardModel):
+    configured: bool = False
+    proxy_url: str | None = None
+    proxy_group: str | None = None
+
+
 class AccountAdditionalWindow(DashboardModel):
     used_percent: float
     reset_at: int | None = None
@@ -76,6 +82,7 @@ class AccountSummary(DashboardModel):
     additional_quotas: list[AccountAdditionalQuota] = Field(default_factory=list)
     deactivation_reason: str | None = None
     auth: AccountAuthStatus | None = None
+    upstream_proxy: AccountUpstreamProxyStatus = Field(default_factory=AccountUpstreamProxyStatus)
 
 
 class AccountsResponse(DashboardModel):
@@ -99,6 +106,16 @@ class AccountReactivateResponse(DashboardModel):
 
 class AccountDeleteResponse(DashboardModel):
     status: str
+
+
+class AccountUpstreamProxyUpdateRequest(DashboardModel):
+    upstream_proxy_url: str | None = None
+    upstream_proxy_group: str | None = None
+
+
+class AccountUpstreamProxyUpdateResponse(DashboardModel):
+    account_id: str
+    upstream_proxy: AccountUpstreamProxyStatus
 
 
 class AccountTrendsResponse(DashboardModel):

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -15,12 +15,13 @@ from app.core.auth import (
 )
 from app.core.auth.api_key_cache import get_api_key_cache
 from app.core.cache.invalidation import NAMESPACE_API_KEY, get_cache_invalidation_poller
+from app.core.clients.upstream_proxy import normalize_upstream_proxy_url, redact_upstream_proxy_url
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
 from app.db.models import Account, AccountStatus
 from app.modules.accounts.mappers import build_account_summaries, build_account_usage_trends
-from app.modules.accounts.repository import AccountsRepository
+from app.modules.accounts.repository import _UNSET, AccountsRepository, _Unset
 from app.modules.accounts.schemas import (
     AccountAdditionalQuota,
     AccountAdditionalWindow,
@@ -28,6 +29,7 @@ from app.modules.accounts.schemas import (
     AccountRequestUsage,
     AccountSummary,
     AccountTrendsResponse,
+    AccountUpstreamProxyStatus,
 )
 from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.usage.additional_quota_keys import get_additional_display_label_for_quota_key
@@ -201,3 +203,47 @@ class AccountsService:
             if poller is not None:
                 await poller.bump(NAMESPACE_API_KEY)
         return result
+
+    async def update_upstream_proxy(
+        self,
+        account_id: str,
+        *,
+        upstream_proxy_url: str | None | object,
+        upstream_proxy_url_set: bool,
+        upstream_proxy_group: str | None | object,
+        upstream_proxy_group_set: bool,
+    ) -> Account | None:
+        encrypted_url: bytes | None | _Unset = _UNSET
+        if upstream_proxy_url_set:
+            encrypted_url = (
+                self._encryptor.encrypt(normalize_upstream_proxy_url(upstream_proxy_url))
+                if isinstance(upstream_proxy_url, str)
+                else None
+            )
+        group: str | None | _Unset = _UNSET
+        if upstream_proxy_group_set:
+            group = _normalize_proxy_group(upstream_proxy_group) if isinstance(upstream_proxy_group, str) else None
+        return await self._repo.update_upstream_proxy(
+            account_id,
+            upstream_proxy_url_encrypted=encrypted_url,
+            upstream_proxy_group=group,
+        )
+
+    def upstream_proxy_status(self, account: Account) -> AccountUpstreamProxyStatus:
+        proxy_url = None
+        if account.upstream_proxy_url_encrypted is not None:
+            proxy_url = redact_upstream_proxy_url(self._encryptor.decrypt(account.upstream_proxy_url_encrypted))
+        return AccountUpstreamProxyStatus(
+            configured=account.upstream_proxy_url_encrypted is not None or account.upstream_proxy_group is not None,
+            proxy_url=proxy_url,
+            proxy_group=account.upstream_proxy_group,
+        )
+
+
+def _normalize_proxy_group(value: str) -> str:
+    group = value.strip()
+    if not group:
+        raise ValueError("Proxy group name is required")
+    if len(group) > 100:
+        raise ValueError("Proxy group name is too long")
+    return group

--- a/app/modules/proxy/repo_bundle.py
+++ b/app/modules/proxy/repo_bundle.py
@@ -8,6 +8,7 @@ from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.proxy.sticky_repository import StickySessionsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.settings.repository import SettingsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
 
@@ -19,6 +20,7 @@ class ProxyRepositories:
     sticky_sessions: StickySessionsRepository
     api_keys: ApiKeysRepository
     additional_usage: AdditionalUsageRepository
+    settings: SettingsRepository | None = None
 
 
 ProxyRepoFactory = Callable[[], AsyncContextManager[ProxyRepositories]]

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -28,7 +28,9 @@ from app.core import shutdown as shutdown_state
 from app.core import usage as usage_core
 from app.core.auth.refresh import (
     RefreshError,
+    pop_token_refresh_proxy_url_override,
     pop_token_refresh_timeout_override,
+    push_token_refresh_proxy_url_override,
     push_token_refresh_timeout_override,
 )
 from app.core.balancer import PERMANENT_FAILURE_CODES, RoutingStrategy, failover_decision
@@ -1473,6 +1475,15 @@ class ProxyService:
                     )
                 create_lease = await self._get_work_admission().acquire_response_create(compact=True)
                 try:
+                    upstream_proxy_url = await self._resolve_upstream_proxy_url(target)
+                    if upstream_proxy_url is not None:
+                        return await core_compact_responses(
+                            payload,
+                            filtered,
+                            access_token,
+                            account_id,
+                            upstream_proxy_url=upstream_proxy_url,
+                        )
                     return await core_compact_responses(payload, filtered, access_token, account_id)
                 finally:
                     create_lease.release()
@@ -1792,6 +1803,18 @@ class ProxyService:
                     total_timeout_seconds=remaining_budget,
                 )
                 try:
+                    upstream_proxy_url = await self._resolve_upstream_proxy_url(target)
+                    if upstream_proxy_url is not None:
+                        return await core_transcribe_audio(
+                            audio_bytes,
+                            filename=filename,
+                            content_type=content_type,
+                            prompt=prompt,
+                            headers=filtered,
+                            access_token=access_token,
+                            account_id=account_id,
+                            upstream_proxy_url=upstream_proxy_url,
+                        )
                     return await core_transcribe_audio(
                         audio_bytes,
                         filename=filename,
@@ -3430,9 +3453,21 @@ class ProxyService:
     ) -> UpstreamResponsesWebSocket:
         access_token = self._encryptor.decrypt(account.access_token_encrypted)
         account_id = _header_account_id(account.chatgpt_account_id)
+        upstream_proxy_url = await self._resolve_upstream_proxy_url(account)
         connect_lease = await self._get_work_admission().acquire_websocket_connect()
         try:
-            return await connect_responses_websocket(headers, access_token, account_id)
+            if upstream_proxy_url is not None:
+                return await connect_responses_websocket(
+                    headers,
+                    access_token,
+                    account_id,
+                    upstream_proxy_url=upstream_proxy_url,
+                )
+            return await connect_responses_websocket(
+                headers,
+                access_token,
+                account_id,
+            )
         finally:
             connect_lease.release()
 
@@ -7495,26 +7530,42 @@ class ProxyService:
         saw_text_delta = False
         latency_first_token_ms: int | None = None
         response_create_lease = AdmissionLease(None)
+        upstream_proxy_url = await self._resolve_upstream_proxy_url(account)
 
         try:
             response_create_lease = await self._get_work_admission().acquire_response_create()
             if upstream_stream_transport is not None:
-                stream = core_stream_responses(
-                    payload,
-                    headers,
-                    access_token,
-                    account_id,
-                    raise_for_status=True,
-                    upstream_stream_transport_override=upstream_stream_transport,
-                )
+                if upstream_proxy_url is not None:
+                    stream = core_stream_responses(
+                        payload,
+                        headers,
+                        access_token,
+                        account_id,
+                        raise_for_status=True,
+                        upstream_stream_transport_override=upstream_stream_transport,
+                        upstream_proxy_url=upstream_proxy_url,
+                    )
+                else:
+                    stream = core_stream_responses(
+                        payload,
+                        headers,
+                        access_token,
+                        account_id,
+                        raise_for_status=True,
+                        upstream_stream_transport_override=upstream_stream_transport,
+                    )
             else:
-                stream = core_stream_responses(
-                    payload,
-                    headers,
-                    access_token,
-                    account_id,
-                    raise_for_status=True,
-                )
+                if upstream_proxy_url is not None:
+                    stream = core_stream_responses(
+                        payload,
+                        headers,
+                        access_token,
+                        account_id,
+                        raise_for_status=True,
+                        upstream_proxy_url=upstream_proxy_url,
+                    )
+                else:
+                    stream = core_stream_responses(payload, headers, access_token, account_id, raise_for_status=True)
             iterator = stream.__aiter__()
             try:
                 first = await iterator.__anext__()
@@ -8032,6 +8083,7 @@ class ProxyService:
         timeout_seconds: float | None = None,
     ) -> Account:
         token = push_token_refresh_timeout_override(timeout_seconds)
+        proxy_token = push_token_refresh_proxy_url_override(await self._resolve_upstream_proxy_url(account))
         try:
             async with self._repo_factory() as repos:
                 auth_manager = AuthManager(
@@ -8040,6 +8092,7 @@ class ProxyService:
                 )
                 return await auth_manager.ensure_fresh(account, force=force)
         finally:
+            pop_token_refresh_proxy_url_override(proxy_token)
             pop_token_refresh_timeout_override(token)
 
     async def _ensure_fresh_with_budget(
@@ -8053,6 +8106,22 @@ class ProxyService:
         if "timeout_seconds" in parameters:
             return await self._ensure_fresh(account, force=force, timeout_seconds=timeout_seconds)
         return await self._ensure_fresh(account, force=force)
+
+    async def _resolve_upstream_proxy_url(self, account: Account) -> str | None:
+        if account.upstream_proxy_url_encrypted is not None:
+            return self._encryptor.decrypt(account.upstream_proxy_url_encrypted)
+        async with self._repo_factory() as repos:
+            settings_repo = getattr(repos, "settings", None)
+            if settings_repo is None:
+                return None
+            if account.upstream_proxy_group:
+                group = await settings_repo.get_upstream_proxy_group(account.upstream_proxy_group)
+                if group is not None:
+                    return self._encryptor.decrypt(group.proxy_url_encrypted)
+            settings = await settings_repo.get_or_create()
+            if settings.upstream_proxy_url_encrypted is not None:
+                return self._encryptor.decrypt(settings.upstream_proxy_url_encrypted)
+        return None
 
     async def _select_account_with_budget(
         self,

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -15,6 +15,8 @@ from app.modules.settings.schemas import (
     DashboardSettingsResponse,
     DashboardSettingsUpdateRequest,
     RuntimeConnectAddressResponse,
+    UpstreamProxyGroupResponse,
+    UpstreamProxyGroupUpsertRequest,
 )
 from app.modules.settings.service import DashboardSettingsUpdateData
 
@@ -89,6 +91,8 @@ async def get_settings(
         totp_required_on_login=settings.totp_required_on_login,
         totp_configured=settings.totp_configured,
         api_key_auth_enabled=settings.api_key_auth_enabled,
+        upstream_proxy_configured=settings.upstream_proxy_configured,
+        upstream_proxy_url=settings.upstream_proxy_url,
     )
 
 
@@ -151,10 +155,13 @@ async def update_settings(
                     if payload.api_key_auth_enabled is not None
                     else current.api_key_auth_enabled
                 ),
+                upstream_proxy_url=payload.upstream_proxy_url,
+                upstream_proxy_url_set="upstream_proxy_url" in payload.model_fields_set,
             )
         )
     except ValueError as exc:
-        raise DashboardBadRequestError(str(exc), code="invalid_totp_config") from exc
+        code = "invalid_totp_config" if "TOTP" in str(exc) else "invalid_upstream_proxy"
+        raise DashboardBadRequestError(str(exc), code=code) from exc
 
     await get_settings_cache().invalidate()
     changed_fields = [
@@ -170,6 +177,7 @@ async def update_settings(
             "import_without_overwrite",
             "totp_required_on_login",
             "api_key_auth_enabled",
+            "upstream_proxy_configured",
         )
         if getattr(current, field_name) != getattr(updated, field_name)
     ]
@@ -192,4 +200,36 @@ async def update_settings(
         totp_required_on_login=updated.totp_required_on_login,
         totp_configured=updated.totp_configured,
         api_key_auth_enabled=updated.api_key_auth_enabled,
+        upstream_proxy_configured=updated.upstream_proxy_configured,
+        upstream_proxy_url=updated.upstream_proxy_url,
     )
+
+
+@router.get("/upstream-proxy-groups", response_model=list[UpstreamProxyGroupResponse])
+async def list_upstream_proxy_groups(
+    context: SettingsContext = Depends(get_settings_context),
+) -> list[UpstreamProxyGroupResponse]:
+    groups = await context.service.list_upstream_proxy_groups()
+    return [UpstreamProxyGroupResponse(name=name, proxy_url=proxy_url) for name, proxy_url in groups]
+
+
+@router.put("/upstream-proxy-groups/{name}", response_model=UpstreamProxyGroupResponse)
+async def upsert_upstream_proxy_group(
+    name: str,
+    payload: UpstreamProxyGroupUpsertRequest,
+    context: SettingsContext = Depends(get_settings_context),
+) -> UpstreamProxyGroupResponse:
+    try:
+        group_name, proxy_url = await context.service.upsert_upstream_proxy_group(name, payload.proxy_url)
+    except ValueError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_upstream_proxy") from exc
+    return UpstreamProxyGroupResponse(name=group_name, proxy_url=proxy_url)
+
+
+@router.delete("/upstream-proxy-groups/{name}")
+async def delete_upstream_proxy_group(
+    name: str,
+    context: SettingsContext = Depends(get_settings_context),
+) -> dict[str, str]:
+    deleted = await context.service.delete_upstream_proxy_group(name)
+    return {"status": "deleted" if deleted else "not_found"}

--- a/app/modules/settings/repository.py
+++ b/app/modules/settings/repository.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.settings import get_settings
-from app.db.models import DashboardSettings
+from app.db.models import DashboardSettings, UpstreamProxyGroup
 
 _SETTINGS_ID = 1
+
+
+class _Unset:
+    pass
+
+
+_UNSET = _Unset()
 
 
 class SettingsRepository:
@@ -62,6 +70,7 @@ class SettingsRepository:
         import_without_overwrite: bool | None = None,
         totp_required_on_login: bool | None = None,
         api_key_auth_enabled: bool | None = None,
+        upstream_proxy_url_encrypted: bytes | None | _Unset = _UNSET,
     ) -> DashboardSettings:
         settings = await self.get_or_create()
         if sticky_threads_enabled is not None:
@@ -90,9 +99,36 @@ class SettingsRepository:
             settings.totp_required_on_login = totp_required_on_login
         if api_key_auth_enabled is not None:
             settings.api_key_auth_enabled = api_key_auth_enabled
+        if not isinstance(upstream_proxy_url_encrypted, _Unset):
+            settings.upstream_proxy_url_encrypted = upstream_proxy_url_encrypted
         await self.commit_refresh(settings)
         return settings
 
     async def commit_refresh(self, settings: DashboardSettings) -> None:
         await self._session.commit()
         await self._session.refresh(settings)
+
+    async def list_upstream_proxy_groups(self) -> list[UpstreamProxyGroup]:
+        result = await self._session.execute(select(UpstreamProxyGroup).order_by(UpstreamProxyGroup.name))
+        return list(result.scalars().all())
+
+    async def get_upstream_proxy_group(self, name: str) -> UpstreamProxyGroup | None:
+        return await self._session.get(UpstreamProxyGroup, name)
+
+    async def upsert_upstream_proxy_group(self, name: str, proxy_url_encrypted: bytes) -> UpstreamProxyGroup:
+        row = await self._session.get(UpstreamProxyGroup, name)
+        if row is None:
+            row = UpstreamProxyGroup(name=name, proxy_url_encrypted=proxy_url_encrypted)
+            self._session.add(row)
+        else:
+            row.proxy_url_encrypted = proxy_url_encrypted
+        await self._session.commit()
+        await self._session.refresh(row)
+        return row
+
+    async def delete_upstream_proxy_group(self, name: str) -> bool:
+        result = await self._session.execute(
+            delete(UpstreamProxyGroup).where(UpstreamProxyGroup.name == name).returning(UpstreamProxyGroup.name)
+        )
+        await self._session.commit()
+        return result.scalar_one_or_none() is not None

--- a/app/modules/settings/schemas.py
+++ b/app/modules/settings/schemas.py
@@ -19,6 +19,8 @@ class DashboardSettingsResponse(DashboardModel):
     totp_required_on_login: bool
     totp_configured: bool
     api_key_auth_enabled: bool
+    upstream_proxy_configured: bool = False
+    upstream_proxy_url: str | None = None
 
 
 class DashboardSettingsUpdateRequest(DashboardModel):
@@ -37,6 +39,16 @@ class DashboardSettingsUpdateRequest(DashboardModel):
     import_without_overwrite: bool | None = None
     totp_required_on_login: bool | None = None
     api_key_auth_enabled: bool | None = None
+    upstream_proxy_url: str | None = None
+
+
+class UpstreamProxyGroupResponse(DashboardModel):
+    name: str
+    proxy_url: str
+
+
+class UpstreamProxyGroupUpsertRequest(DashboardModel):
+    proxy_url: str
 
 
 class RuntimeConnectAddressResponse(DashboardModel):

--- a/app/modules/settings/service.py
+++ b/app/modules/settings/service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from app.core.clients.upstream_proxy import normalize_upstream_proxy_url, redact_upstream_proxy_url
+from app.core.crypto import TokenEncryptor
 from app.modules.settings.repository import SettingsRepository
 
 
@@ -20,6 +22,8 @@ class DashboardSettingsData:
     totp_required_on_login: bool
     totp_configured: bool
     api_key_auth_enabled: bool
+    upstream_proxy_configured: bool
+    upstream_proxy_url: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,11 +40,14 @@ class DashboardSettingsUpdateData:
     import_without_overwrite: bool
     totp_required_on_login: bool
     api_key_auth_enabled: bool
+    upstream_proxy_url: str | None
+    upstream_proxy_url_set: bool = False
 
 
 class SettingsService:
     def __init__(self, repository: SettingsRepository) -> None:
         self._repository = repository
+        self._encryptor = TokenEncryptor()
 
     async def get_settings(self) -> DashboardSettingsData:
         row = await self._repository.get_or_create()
@@ -60,28 +67,49 @@ class SettingsService:
             totp_required_on_login=row.totp_required_on_login,
             totp_configured=row.totp_secret_encrypted is not None,
             api_key_auth_enabled=row.api_key_auth_enabled,
+            upstream_proxy_configured=row.upstream_proxy_url_encrypted is not None,
+            upstream_proxy_url=redact_upstream_proxy_url(self._decrypt_optional(row.upstream_proxy_url_encrypted)),
         )
 
     async def update_settings(self, payload: DashboardSettingsUpdateData) -> DashboardSettingsData:
         current = await self._repository.get_or_create()
         if payload.totp_required_on_login and current.totp_secret_encrypted is None:
             raise ValueError("Configure TOTP before enabling login enforcement")
-        row = await self._repository.update(
-            sticky_threads_enabled=payload.sticky_threads_enabled,
-            upstream_stream_transport=payload.upstream_stream_transport,
-            prefer_earlier_reset_accounts=payload.prefer_earlier_reset_accounts,
-            routing_strategy=payload.routing_strategy,
-            openai_cache_affinity_max_age_seconds=payload.openai_cache_affinity_max_age_seconds,
-            dashboard_session_ttl_seconds=payload.dashboard_session_ttl_seconds,
-            http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
-                payload.http_responses_session_bridge_prompt_cache_idle_ttl_seconds
-            ),
-            http_responses_session_bridge_gateway_safe_mode=payload.http_responses_session_bridge_gateway_safe_mode,
-            sticky_reallocation_budget_threshold_pct=payload.sticky_reallocation_budget_threshold_pct,
-            import_without_overwrite=payload.import_without_overwrite,
-            totp_required_on_login=payload.totp_required_on_login,
-            api_key_auth_enabled=payload.api_key_auth_enabled,
-        )
+        if payload.upstream_proxy_url_set:
+            row = await self._repository.update(
+                sticky_threads_enabled=payload.sticky_threads_enabled,
+                upstream_stream_transport=payload.upstream_stream_transport,
+                prefer_earlier_reset_accounts=payload.prefer_earlier_reset_accounts,
+                routing_strategy=payload.routing_strategy,
+                openai_cache_affinity_max_age_seconds=payload.openai_cache_affinity_max_age_seconds,
+                dashboard_session_ttl_seconds=payload.dashboard_session_ttl_seconds,
+                http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
+                    payload.http_responses_session_bridge_prompt_cache_idle_ttl_seconds
+                ),
+                http_responses_session_bridge_gateway_safe_mode=payload.http_responses_session_bridge_gateway_safe_mode,
+                sticky_reallocation_budget_threshold_pct=payload.sticky_reallocation_budget_threshold_pct,
+                import_without_overwrite=payload.import_without_overwrite,
+                totp_required_on_login=payload.totp_required_on_login,
+                api_key_auth_enabled=payload.api_key_auth_enabled,
+                upstream_proxy_url_encrypted=self._encrypt_optional_proxy_url(payload.upstream_proxy_url),
+            )
+        else:
+            row = await self._repository.update(
+                sticky_threads_enabled=payload.sticky_threads_enabled,
+                upstream_stream_transport=payload.upstream_stream_transport,
+                prefer_earlier_reset_accounts=payload.prefer_earlier_reset_accounts,
+                routing_strategy=payload.routing_strategy,
+                openai_cache_affinity_max_age_seconds=payload.openai_cache_affinity_max_age_seconds,
+                dashboard_session_ttl_seconds=payload.dashboard_session_ttl_seconds,
+                http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
+                    payload.http_responses_session_bridge_prompt_cache_idle_ttl_seconds
+                ),
+                http_responses_session_bridge_gateway_safe_mode=payload.http_responses_session_bridge_gateway_safe_mode,
+                sticky_reallocation_budget_threshold_pct=payload.sticky_reallocation_budget_threshold_pct,
+                import_without_overwrite=payload.import_without_overwrite,
+                totp_required_on_login=payload.totp_required_on_login,
+                api_key_auth_enabled=payload.api_key_auth_enabled,
+            )
         return DashboardSettingsData(
             sticky_threads_enabled=row.sticky_threads_enabled,
             upstream_stream_transport=row.upstream_stream_transport,
@@ -98,4 +126,41 @@ class SettingsService:
             totp_required_on_login=row.totp_required_on_login,
             totp_configured=row.totp_secret_encrypted is not None,
             api_key_auth_enabled=row.api_key_auth_enabled,
+            upstream_proxy_configured=row.upstream_proxy_url_encrypted is not None,
+            upstream_proxy_url=redact_upstream_proxy_url(self._decrypt_optional(row.upstream_proxy_url_encrypted)),
         )
+
+    async def list_upstream_proxy_groups(self) -> list[tuple[str, str]]:
+        groups = await self._repository.list_upstream_proxy_groups()
+        return [
+            (group.name, redact_upstream_proxy_url(self._encryptor.decrypt(group.proxy_url_encrypted)) or "")
+            for group in groups
+        ]
+
+    async def upsert_upstream_proxy_group(self, name: str, proxy_url: str) -> tuple[str, str]:
+        normalized_name = _normalize_group_name(name)
+        encrypted = self._encryptor.encrypt(normalize_upstream_proxy_url(proxy_url))
+        row = await self._repository.upsert_upstream_proxy_group(normalized_name, encrypted)
+        return row.name, redact_upstream_proxy_url(self._encryptor.decrypt(row.proxy_url_encrypted)) or ""
+
+    async def delete_upstream_proxy_group(self, name: str) -> bool:
+        return await self._repository.delete_upstream_proxy_group(_normalize_group_name(name))
+
+    def _encrypt_optional_proxy_url(self, proxy_url: str | None) -> bytes | None:
+        if proxy_url is None:
+            return None
+        return self._encryptor.encrypt(normalize_upstream_proxy_url(proxy_url))
+
+    def _decrypt_optional(self, encrypted: bytes | None) -> str | None:
+        if encrypted is None:
+            return None
+        return self._encryptor.decrypt(encrypted)
+
+
+def _normalize_group_name(name: str) -> str:
+    normalized = name.strip()
+    if not normalized:
+        raise ValueError("Proxy group name is required")
+    if len(normalized) > 100:
+        raise ValueError("Proxy group name is too long")
+    return normalized

--- a/frontend/src/features/accounts/api.ts
+++ b/frontend/src/features/accounts/api.ts
@@ -1,8 +1,10 @@
-import { del, get, post } from "@/lib/api-client";
+import { del, get, patch, post } from "@/lib/api-client";
 
 import {
   AccountActionResponseSchema,
   AccountImportResponseSchema,
+  AccountUpstreamProxyUpdateRequestSchema,
+  AccountUpstreamProxyUpdateResponseSchema,
   AccountsResponseSchema,
   AccountTrendsResponseSchema,
   ManualOauthCallbackRequestSchema,
@@ -55,6 +57,15 @@ export function deleteAccount(accountId: string) {
   return del(
     `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}`,
     AccountActionResponseSchema,
+  );
+}
+
+export function updateAccountUpstreamProxy(accountId: string, payload: unknown) {
+  const validated = AccountUpstreamProxyUpdateRequestSchema.parse(payload);
+  return patch(
+    `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/upstream-proxy`,
+    AccountUpstreamProxyUpdateResponseSchema,
+    { body: validated },
   );
 }
 

--- a/frontend/src/features/accounts/components/account-detail.tsx
+++ b/frontend/src/features/accounts/components/account-detail.tsx
@@ -3,6 +3,7 @@ import { User } from "lucide-react";
 import { isEmailLabel } from "@/components/blur-email";
 import { usePrivacyStore } from "@/hooks/use-privacy";
 import { AccountActions } from "@/features/accounts/components/account-actions";
+import { AccountProxySettings } from "@/features/accounts/components/account-proxy-settings";
 import { AccountTokenInfo } from "@/features/accounts/components/account-token-info";
 import { AccountUsagePanel } from "@/features/accounts/components/account-usage-panel";
 import type { AccountSummary } from "@/features/accounts/schemas";
@@ -17,6 +18,10 @@ export type AccountDetailProps = {
   onResume: (accountId: string) => void;
   onDelete: (accountId: string) => void;
   onReauth: () => void;
+  onProxySave: (
+    accountId: string,
+    payload: { upstreamProxyUrl?: string | null; upstreamProxyGroup?: string | null },
+  ) => void;
 };
 
 export function AccountDetail({
@@ -27,6 +32,7 @@ export function AccountDetail({
   onResume,
   onDelete,
   onReauth,
+  onProxySave,
 }: AccountDetailProps) {
   const { data: trends } = useAccountTrends(account?.accountId ?? null);
   const blurred = usePrivacyStore((s) => s.blurred);
@@ -67,6 +73,11 @@ export function AccountDetail({
 
       <AccountUsagePanel account={account} trends={trends} />
       <AccountTokenInfo account={account} />
+      <AccountProxySettings
+        account={account}
+        busy={busy}
+        onSave={(payload) => onProxySave(account.accountId, payload)}
+      />
       <AccountActions
         account={account}
         busy={busy}

--- a/frontend/src/features/accounts/components/account-proxy-settings.tsx
+++ b/frontend/src/features/accounts/components/account-proxy-settings.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { Network } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { AccountSummary } from "@/features/accounts/schemas";
+
+export type AccountProxySettingsProps = {
+  account: AccountSummary;
+  busy: boolean;
+  onSave: (payload: { upstreamProxyUrl?: string | null; upstreamProxyGroup?: string | null }) => void;
+};
+
+export function AccountProxySettings({ account, busy, onSave }: AccountProxySettingsProps) {
+  const currentProxyUrl = account.upstreamProxy?.proxyUrl ?? "";
+  const currentProxyGroup = account.upstreamProxy?.proxyGroup ?? "";
+
+  return (
+    <AccountProxySettingsFields
+      key={`${account.accountId}:${currentProxyUrl}:${currentProxyGroup}`}
+      account={account}
+      busy={busy}
+      currentProxyGroup={currentProxyGroup}
+      currentProxyUrl={currentProxyUrl}
+      onSave={onSave}
+    />
+  );
+}
+
+type AccountProxySettingsFieldsProps = AccountProxySettingsProps & {
+  currentProxyGroup: string;
+  currentProxyUrl: string;
+};
+
+function AccountProxySettingsFields({
+  account,
+  busy,
+  currentProxyGroup,
+  currentProxyUrl,
+  onSave,
+}: AccountProxySettingsFieldsProps) {
+  const [proxyUrl, setProxyUrl] = useState(currentProxyUrl);
+  const [proxyGroup, setProxyGroup] = useState(currentProxyGroup);
+  const proxyUrlChanged = proxyUrl.trim() !== currentProxyUrl;
+  const proxyGroupChanged = proxyGroup.trim() !== currentProxyGroup;
+
+  return (
+    <section className="rounded-lg border p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Network className="h-4 w-4 text-primary" aria-hidden="true" />
+        <div>
+          <h3 className="text-sm font-semibold">Account proxy</h3>
+          <p className="text-xs text-muted-foreground">
+            Overrides the global proxy. If URL is empty, this account can inherit its group or global proxy.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="grid gap-2 sm:grid-cols-[8rem_minmax(0,1fr)_auto] sm:items-center">
+          <p className="text-xs font-medium text-muted-foreground">Proxy URL</p>
+          <Input
+            value={proxyUrl}
+            disabled={busy}
+            placeholder="http://user:pass@host:port"
+            onChange={(event) => setProxyUrl(event.target.value)}
+            className="h-8 text-xs"
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            disabled={busy || !proxyUrlChanged}
+            onClick={() => onSave({ upstreamProxyUrl: proxyUrl.trim() || null })}
+          >
+            Save URL
+          </Button>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-[8rem_minmax(0,1fr)_auto] sm:items-center">
+          <p className="text-xs font-medium text-muted-foreground">Proxy group</p>
+          <Input
+            value={proxyGroup}
+            disabled={busy}
+            placeholder="group name"
+            onChange={(event) => setProxyGroup(event.target.value)}
+            className="h-8 text-xs"
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 text-xs"
+            disabled={busy || !proxyGroupChanged}
+            onClick={() => onSave({ upstreamProxyGroup: proxyGroup.trim() || null })}
+          >
+            Save group
+          </Button>
+        </div>
+
+        {account.upstreamProxy?.configured ? (
+          <p className="text-xs text-muted-foreground">
+            Effective account binding is configured. Saved credentials are hidden after saving.
+          </p>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -26,6 +26,7 @@ export function AccountsPage() {
     pauseMutation,
     resumeMutation,
     deleteMutation,
+    updateProxyMutation,
   } = useAccounts();
   const oauth = useOauth();
 
@@ -65,13 +66,15 @@ export function AccountsPage() {
     importMutation.isPending ||
     pauseMutation.isPending ||
     resumeMutation.isPending ||
-    deleteMutation.isPending;
+    deleteMutation.isPending ||
+    updateProxyMutation.isPending;
 
   const mutationError =
     getErrorMessageOrNull(importMutation.error) ||
     getErrorMessageOrNull(pauseMutation.error) ||
     getErrorMessageOrNull(resumeMutation.error) ||
-    getErrorMessageOrNull(deleteMutation.error);
+    getErrorMessageOrNull(deleteMutation.error) ||
+    getErrorMessageOrNull(updateProxyMutation.error);
 
   return (
     <div className="animate-fade-in-up space-y-6">
@@ -107,6 +110,9 @@ export function AccountsPage() {
             onResume={(accountId) => void resumeMutation.mutateAsync(accountId)}
             onDelete={(accountId) => deleteDialog.show(accountId)}
             onReauth={() => oauthDialog.show()}
+            onProxySave={(accountId, payload) =>
+              void updateProxyMutation.mutateAsync({ accountId, ...payload })
+            }
           />
         </div>
       )}

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -8,6 +8,7 @@ import {
   listAccounts,
   pauseAccount,
   reactivateAccount,
+  updateAccountUpstreamProxy,
 } from "@/features/accounts/api";
 
 function invalidateAccountRelatedQueries(queryClient: ReturnType<typeof useQueryClient>) {
@@ -67,7 +68,26 @@ export function useAccountMutations() {
     },
   });
 
-  return { importMutation, pauseMutation, resumeMutation, deleteMutation };
+  const updateProxyMutation = useMutation({
+    mutationFn: ({
+      accountId,
+      upstreamProxyUrl,
+      upstreamProxyGroup,
+    }: {
+      accountId: string;
+      upstreamProxyUrl?: string | null;
+      upstreamProxyGroup?: string | null;
+    }) => updateAccountUpstreamProxy(accountId, { upstreamProxyUrl, upstreamProxyGroup }),
+    onSuccess: () => {
+      toast.success("Account proxy saved");
+      invalidateAccountRelatedQueries(queryClient);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Proxy update failed");
+    },
+  });
+
+  return { importMutation, pauseMutation, resumeMutation, deleteMutation, updateProxyMutation };
 }
 
 export function useAccountTrends(accountId: string | null) {

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -33,6 +33,12 @@ export const AccountAuthSchema = z.object({
   idToken: AccountTokenStatusSchema.nullable().optional(),
 });
 
+export const AccountUpstreamProxyStatusSchema = z.object({
+  configured: z.boolean().default(false),
+  proxyUrl: z.string().nullable().optional(),
+  proxyGroup: z.string().nullable().optional(),
+});
+
 export const AccountAdditionalWindowSchema = z.object({
   usedPercent: z.number(),
   resetAt: z.number().nullable().optional(),
@@ -61,6 +67,7 @@ export const AccountSummarySchema = z.object({
   windowMinutesSecondary: z.number().nullable().optional(),
   requestUsage: AccountRequestUsageSchema.nullable().optional(),
   auth: AccountAuthSchema.nullable().optional(),
+  upstreamProxy: AccountUpstreamProxyStatusSchema.optional(),
   additionalQuotas: z.array(AccountAdditionalQuotaSchema).default([]),
 });
 
@@ -83,6 +90,16 @@ export const AccountImportResponseSchema = z.object({
 
 export const AccountActionResponseSchema = z.object({
   status: z.string(),
+});
+
+export const AccountUpstreamProxyUpdateRequestSchema = z.object({
+  upstreamProxyUrl: z.string().nullable().optional(),
+  upstreamProxyGroup: z.string().nullable().optional(),
+});
+
+export const AccountUpstreamProxyUpdateResponseSchema = z.object({
+  accountId: z.string(),
+  upstreamProxy: AccountUpstreamProxyStatusSchema,
 });
 
 export const OauthStartRequestSchema = z.object({
@@ -148,6 +165,7 @@ export const ImportStateSchema = z.object({
 export type UsageTrendPoint = z.infer<typeof UsageTrendPointSchema>;
 export type AccountUsageTrend = z.infer<typeof AccountUsageTrendSchema>;
 export type AccountSummary = z.infer<typeof AccountSummarySchema>;
+export type AccountUpstreamProxyStatus = z.infer<typeof AccountUpstreamProxyStatusSchema>;
 export type AccountAdditionalWindow = z.infer<typeof AccountAdditionalWindowSchema>;
 export type AccountAdditionalQuota = z.infer<typeof AccountAdditionalQuotaSchema>;
 export type AccountTrendsResponse = z.infer<typeof AccountTrendsResponseSchema>;

--- a/frontend/src/features/settings/api.ts
+++ b/frontend/src/features/settings/api.ts
@@ -1,7 +1,9 @@
-import { get, put } from "@/lib/api-client";
+import { del, get, put } from "@/lib/api-client";
 import {
   DashboardSettingsSchema,
   SettingsUpdateRequestSchema,
+  UpstreamProxyGroupSchema,
+  UpstreamProxyGroupUpsertRequestSchema,
 } from "@/features/settings/schemas";
 
 const SETTINGS_PATH = "/api/settings";
@@ -15,4 +17,19 @@ export function updateSettings(payload: unknown) {
   return put(SETTINGS_PATH, DashboardSettingsSchema, {
     body: validated,
   });
+}
+
+export function listUpstreamProxyGroups() {
+  return get(`${SETTINGS_PATH}/upstream-proxy-groups`, UpstreamProxyGroupSchema.array());
+}
+
+export function upsertUpstreamProxyGroup(name: string, payload: unknown) {
+  const validated = UpstreamProxyGroupUpsertRequestSchema.parse(payload);
+  return put(`${SETTINGS_PATH}/upstream-proxy-groups/${encodeURIComponent(name)}`, UpstreamProxyGroupSchema, {
+    body: validated,
+  });
+}
+
+export function deleteUpstreamProxyGroup(name: string) {
+  return del(`${SETTINGS_PATH}/upstream-proxy-groups/${encodeURIComponent(name)}`);
 }

--- a/frontend/src/features/settings/components/routing-settings.tsx
+++ b/frontend/src/features/settings/components/routing-settings.tsx
@@ -153,8 +153,81 @@ export function RoutingSettings({ settings, busy, onSave }: RoutingSettingsProps
               </Button>
             </div>
           </div>
+
+          <UpstreamProxyControl
+            key={`${settings.upstreamProxyConfigured}:${settings.upstreamProxyUrl ?? ""}`}
+            busy={busy}
+            configured={settings.upstreamProxyConfigured ?? false}
+            currentValue={settings.upstreamProxyUrl ?? ""}
+            onSave={save}
+          />
         </div>
       </div>
     </section>
+  );
+}
+
+type UpstreamProxyControlProps = {
+  busy: boolean;
+  configured: boolean;
+  currentValue: string;
+  onSave: (patch: Partial<SettingsUpdateRequest>) => void;
+};
+
+function UpstreamProxyControl({ busy, configured, currentValue, onSave }: UpstreamProxyControlProps) {
+  const [upstreamProxyUrl, setUpstreamProxyUrl] = useState(currentValue);
+  const upstreamProxyUrlTrimmed = upstreamProxyUrl.trim();
+  const upstreamProxyChanged = upstreamProxyUrlTrimmed !== currentValue;
+
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <div>
+        <p className="text-sm font-medium">Upstream proxy</p>
+        <p className="text-xs text-muted-foreground">
+          Optional global proxy for all upstream account traffic. Supports http, https, socks5, and socks5h URLs.
+        </p>
+      </div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Input
+          type="text"
+          value={upstreamProxyUrl}
+          disabled={busy}
+          placeholder="http://user:pass@host:port"
+          onChange={(event) => setUpstreamProxyUrl(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && upstreamProxyChanged) {
+              onSave({ upstreamProxyUrl: upstreamProxyUrlTrimmed || null });
+            }
+          }}
+          className="h-8 text-xs"
+        />
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 text-xs"
+          disabled={busy || !upstreamProxyChanged}
+          onClick={() => onSave({ upstreamProxyUrl: upstreamProxyUrlTrimmed || null })}
+        >
+          Save proxy
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-8 text-xs"
+          disabled={busy || !configured}
+          onClick={() => {
+            setUpstreamProxyUrl("");
+            onSave({ upstreamProxyUrl: null });
+          }}
+        >
+          Clear
+        </Button>
+      </div>
+      {configured ? (
+        <p className="text-xs text-muted-foreground">Current proxy is configured. Credentials are hidden after saving.</p>
+      ) : null}
+    </div>
   );
 }

--- a/frontend/src/features/settings/components/settings-page.tsx
+++ b/frontend/src/features/settings/components/settings-page.tsx
@@ -12,6 +12,7 @@ import { PasswordSettings } from "@/features/settings/components/password-settin
 import { RoutingSettings } from "@/features/settings/components/routing-settings";
 import { SessionSettings } from "@/features/settings/components/session-settings";
 import { SettingsSkeleton } from "@/features/settings/components/settings-skeleton";
+import { UpstreamProxyGroupsSettings } from "@/features/settings/components/upstream-proxy-groups-settings";
 import { StickySessionsSection } from "@/features/sticky-sessions/components/sticky-sessions-section";
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
 import { useSettings } from "@/features/settings/hooks/use-settings";
@@ -23,14 +24,28 @@ const TotpSettings = lazy(() =>
 );
 
 export function SettingsPage() {
-  const { settingsQuery, updateSettingsMutation } = useSettings();
+  const {
+    settingsQuery,
+    updateSettingsMutation,
+    proxyGroupsQuery,
+    upsertProxyGroupMutation,
+    deleteProxyGroupMutation,
+  } = useSettings();
   const authMode = useAuthStore((state) => state.authMode);
   const passwordManagementEnabled = useAuthStore((state) => state.passwordManagementEnabled);
   const passwordSessionActive = useAuthStore((state) => state.passwordSessionActive);
 
   const settings = settingsQuery.data;
-  const busy = updateSettingsMutation.isPending;
-  const error = getErrorMessageOrNull(settingsQuery.error) || getErrorMessageOrNull(updateSettingsMutation.error);
+  const busy =
+    updateSettingsMutation.isPending ||
+    upsertProxyGroupMutation.isPending ||
+    deleteProxyGroupMutation.isPending;
+  const error =
+    getErrorMessageOrNull(settingsQuery.error) ||
+    getErrorMessageOrNull(updateSettingsMutation.error) ||
+    getErrorMessageOrNull(proxyGroupsQuery.error) ||
+    getErrorMessageOrNull(upsertProxyGroupMutation.error) ||
+    getErrorMessageOrNull(deleteProxyGroupMutation.error);
 
   const handleSave = async (payload: SettingsUpdateRequest) => {
     await updateSettingsMutation.mutateAsync(payload);
@@ -74,6 +89,12 @@ export function SettingsPage() {
               settings={settings}
               busy={busy}
               onSave={handleSave}
+            />
+            <UpstreamProxyGroupsSettings
+              groups={proxyGroupsQuery.data ?? []}
+              busy={busy}
+              onSave={(name, proxyUrl) => void upsertProxyGroupMutation.mutateAsync({ name, proxyUrl })}
+              onDelete={(name) => void deleteProxyGroupMutation.mutateAsync(name)}
             />
             <ImportSettings settings={settings} busy={busy} onSave={handleSave} />
             <PasswordSettings disabled={busy} />

--- a/frontend/src/features/settings/components/upstream-proxy-groups-settings.tsx
+++ b/frontend/src/features/settings/components/upstream-proxy-groups-settings.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Network } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { UpstreamProxyGroup } from "@/features/settings/schemas";
+
+export type UpstreamProxyGroupsSettingsProps = {
+  groups: UpstreamProxyGroup[];
+  busy: boolean;
+  onSave: (name: string, proxyUrl: string) => void;
+  onDelete: (name: string) => void;
+};
+
+export function UpstreamProxyGroupsSettings({
+  groups,
+  busy,
+  onSave,
+  onDelete,
+}: UpstreamProxyGroupsSettingsProps) {
+  const [name, setName] = useState("");
+  const [proxyUrl, setProxyUrl] = useState("");
+  const canSave = name.trim().length > 0 && proxyUrl.trim().length > 0;
+
+  return (
+    <section className="rounded-xl border bg-card p-5">
+      <div className="space-y-3">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+            <Network className="h-4 w-4 text-primary" aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold">Proxy groups</h3>
+            <p className="text-xs text-muted-foreground">
+              Create reusable upstream proxies and assign accounts to a group.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-3 rounded-lg border p-3">
+          <div className="grid gap-2 sm:grid-cols-[12rem_minmax(0,1fr)_auto]">
+            <Input
+              value={name}
+              disabled={busy}
+              placeholder="group name"
+              onChange={(event) => setName(event.target.value)}
+              className="h-8 text-xs"
+            />
+            <Input
+              value={proxyUrl}
+              disabled={busy}
+              placeholder="http://user:pass@host:port"
+              onChange={(event) => setProxyUrl(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && canSave) {
+                  onSave(name.trim(), proxyUrl.trim());
+                  setProxyUrl("");
+                }
+              }}
+              className="h-8 text-xs"
+            />
+            <Button
+              type="button"
+              size="sm"
+              className="h-8 text-xs"
+              disabled={busy || !canSave}
+              onClick={() => {
+                onSave(name.trim(), proxyUrl.trim());
+                setProxyUrl("");
+              }}
+            >
+              Save group
+            </Button>
+          </div>
+
+          {groups.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No proxy groups configured.</p>
+          ) : (
+            <div className="divide-y rounded-md border">
+              {groups.map((group) => (
+                <div key={group.name} className="flex items-center justify-between gap-3 p-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">{group.name}</p>
+                    <p className="truncate text-xs text-muted-foreground">{group.proxyUrl}</p>
+                  </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-8 text-xs"
+                    disabled={busy}
+                    onClick={() => onDelete(group.name)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/settings/hooks/use-settings.ts
+++ b/frontend/src/features/settings/hooks/use-settings.ts
@@ -1,7 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { getSettings, updateSettings } from "@/features/settings/api";
+import {
+  deleteUpstreamProxyGroup,
+  getSettings,
+  listUpstreamProxyGroups,
+  updateSettings,
+  upsertUpstreamProxyGroup,
+} from "@/features/settings/api";
 import type { SettingsUpdateRequest } from "@/features/settings/schemas";
 
 export function useSettings() {
@@ -23,8 +29,39 @@ export function useSettings() {
     },
   });
 
+  const proxyGroupsQuery = useQuery({
+    queryKey: ["settings", "upstream-proxy-groups"],
+    queryFn: listUpstreamProxyGroups,
+  });
+
+  const upsertProxyGroupMutation = useMutation({
+    mutationFn: ({ name, proxyUrl }: { name: string; proxyUrl: string }) =>
+      upsertUpstreamProxyGroup(name, { proxyUrl }),
+    onSuccess: () => {
+      toast.success("Proxy group saved");
+      void queryClient.invalidateQueries({ queryKey: ["settings", "upstream-proxy-groups"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to save proxy group");
+    },
+  });
+
+  const deleteProxyGroupMutation = useMutation({
+    mutationFn: deleteUpstreamProxyGroup,
+    onSuccess: () => {
+      toast.success("Proxy group deleted");
+      void queryClient.invalidateQueries({ queryKey: ["settings", "upstream-proxy-groups"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Failed to delete proxy group");
+    },
+  });
+
   return {
     settingsQuery,
     updateSettingsMutation,
+    proxyGroupsQuery,
+    upsertProxyGroupMutation,
+    deleteProxyGroupMutation,
   };
 }

--- a/frontend/src/features/settings/schemas.ts
+++ b/frontend/src/features/settings/schemas.ts
@@ -14,6 +14,8 @@ export const DashboardSettingsSchema = z.object({
   totpRequiredOnLogin: z.boolean(),
   totpConfigured: z.boolean(),
   apiKeyAuthEnabled: z.boolean(),
+  upstreamProxyConfigured: z.boolean().optional(),
+  upstreamProxyUrl: z.string().nullable().optional(),
 });
 
 export const SettingsUpdateRequestSchema = z.object({
@@ -26,7 +28,18 @@ export const SettingsUpdateRequestSchema = z.object({
   importWithoutOverwrite: z.boolean().optional(),
   totpRequiredOnLogin: z.boolean().optional(),
   apiKeyAuthEnabled: z.boolean().optional(),
+  upstreamProxyUrl: z.string().nullable().optional(),
+});
+
+export const UpstreamProxyGroupSchema = z.object({
+  name: z.string(),
+  proxyUrl: z.string(),
+});
+
+export const UpstreamProxyGroupUpsertRequestSchema = z.object({
+  proxyUrl: z.string(),
 });
 
 export type DashboardSettings = z.infer<typeof DashboardSettingsSchema>;
 export type SettingsUpdateRequest = z.infer<typeof SettingsUpdateRequestSchema>;
+export type UpstreamProxyGroup = z.infer<typeof UpstreamProxyGroupSchema>;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ requires-python = ">=3.13"
 dependencies = [
     "aiohttp>=3.13.3",
     "aiohttp-retry>=2.9.1",
+    "aiohttp-socks>=0.10.1",
     "alembic>=1.16.5",
     "aiosqlite>=0.22.1",
     "asyncpg>=0.30.0",

--- a/tests/unit/test_upstream_proxy_bindings.py
+++ b/tests/unit/test_upstream_proxy_bindings.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from app.core.clients.upstream_proxy import (
+    UpstreamProxyConfigurationError,
+    aiohttp_proxy_kwargs,
+    is_socks_upstream_proxy,
+    normalize_upstream_proxy_url,
+    redact_upstream_proxy_url,
+)
+from app.core.crypto import TokenEncryptor
+from app.db.models import Account
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.proxy.repo_bundle import ProxyRepoFactory, ProxyRepositories
+from app.modules.proxy.service import ProxyService
+from app.modules.proxy.sticky_repository import StickySessionsRepository
+from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.settings.repository import SettingsRepository
+from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+
+
+def test_normalize_upstream_proxy_url_accepts_http_https_and_socks() -> None:
+    assert normalize_upstream_proxy_url("http://user:pass@127.0.0.1:8080") == "http://user:pass@127.0.0.1:8080"
+    assert normalize_upstream_proxy_url("https://proxy.example:8443") == "https://proxy.example:8443"
+    assert (
+        normalize_upstream_proxy_url("socks5://user:pass@proxy.example:1080") == "socks5://user:pass@proxy.example:1080"
+    )
+
+
+def test_normalize_upstream_proxy_url_rejects_unsupported_scheme() -> None:
+    with pytest.raises(UpstreamProxyConfigurationError):
+        normalize_upstream_proxy_url("ftp://proxy.example:21")
+
+
+def test_redact_upstream_proxy_url_hides_credentials() -> None:
+    assert redact_upstream_proxy_url("socks5://user:pass@proxy.example:1080") == "socks5://proxy.example:1080"
+
+
+def test_aiohttp_proxy_kwargs_are_only_for_http_proxy_schemes() -> None:
+    assert aiohttp_proxy_kwargs("https://proxy.example:8443") == {"proxy": "https://proxy.example:8443"}
+    assert aiohttp_proxy_kwargs("socks5://proxy.example:1080") == {}
+    assert is_socks_upstream_proxy("socks5h://proxy.example:1080")
+
+
+def _repos(settings: SettingsRepository) -> ProxyRepositories:
+    return ProxyRepositories(
+        accounts=cast(AccountsRepository, None),
+        usage=cast(UsageRepository, None),
+        request_logs=cast(RequestLogsRepository, None),
+        sticky_sessions=cast(StickySessionsRepository, None),
+        api_keys=cast(ApiKeysRepository, None),
+        additional_usage=cast(AdditionalUsageRepository, None),
+        settings=settings,
+    )
+
+
+@pytest.mark.asyncio
+async def test_proxy_service_resolves_account_proxy_before_group_and_global() -> None:
+    encryptor = TokenEncryptor()
+    account = Account(
+        id="acc_proxy",
+        email="proxy@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"a",
+        refresh_token_encrypted=b"r",
+        id_token_encrypted=b"i",
+        last_refresh=cast(object, None),
+        upstream_proxy_url_encrypted=encryptor.encrypt("http://account-proxy:8080"),
+        upstream_proxy_group="team-a",
+    )
+    settings_repo = SimpleNamespace(
+        get_upstream_proxy_group=lambda name: SimpleNamespace(
+            proxy_url_encrypted=encryptor.encrypt("http://group-proxy:8080")
+        ),
+        get_or_create=lambda: SimpleNamespace(
+            upstream_proxy_url_encrypted=encryptor.encrypt("http://global-proxy:8080")
+        ),
+    )
+
+    @asynccontextmanager
+    async def repo_factory():
+        yield _repos(cast(SettingsRepository, settings_repo))
+
+    service = ProxyService(cast(ProxyRepoFactory, repo_factory))
+
+    assert await service._resolve_upstream_proxy_url(account) == "http://account-proxy:8080"
+
+
+@pytest.mark.asyncio
+async def test_proxy_service_resolves_group_before_global() -> None:
+    encryptor = TokenEncryptor()
+    account = Account(
+        id="acc_proxy_group",
+        email="proxy-group@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"a",
+        refresh_token_encrypted=b"r",
+        id_token_encrypted=b"i",
+        last_refresh=cast(object, None),
+        upstream_proxy_group="team-a",
+    )
+
+    class SettingsRepo:
+        async def get_upstream_proxy_group(self, name: str):
+            return SimpleNamespace(proxy_url_encrypted=encryptor.encrypt(f"http://{name}-proxy:8080"))
+
+        async def get_or_create(self):
+            return SimpleNamespace(upstream_proxy_url_encrypted=encryptor.encrypt("http://global-proxy:8080"))
+
+    @asynccontextmanager
+    async def repo_factory():
+        yield _repos(cast(SettingsRepository, SettingsRepo()))
+
+    service = ProxyService(cast(ProxyRepoFactory, repo_factory))
+
+    assert await service._resolve_upstream_proxy_url(account) == "http://team-a-proxy:8080"
+
+
+@pytest.mark.asyncio
+async def test_proxy_service_resolves_global_proxy_when_account_has_no_binding() -> None:
+    encryptor = TokenEncryptor()
+    account = Account(
+        id="acc_proxy_global",
+        email="proxy-global@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"a",
+        refresh_token_encrypted=b"r",
+        id_token_encrypted=b"i",
+        last_refresh=cast(object, None),
+    )
+
+    class SettingsRepo:
+        async def get_upstream_proxy_group(self, name: str):
+            return None
+
+        async def get_or_create(self):
+            return SimpleNamespace(upstream_proxy_url_encrypted=encryptor.encrypt("http://global-proxy:8080"))
+
+    @asynccontextmanager
+    async def repo_factory():
+        yield _repos(cast(SettingsRepository, SettingsRepo()))
+
+    service = ProxyService(cast(ProxyRepoFactory, repo_factory))
+
+    assert await service._resolve_upstream_proxy_url(account) == "http://global-proxy:8080"

--- a/uv.lock
+++ b/uv.lock
@@ -96,6 +96,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-socks"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "python-socks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/e5bbd54f76bd56291522251e47267b645dac76327b2657ade9545e30522c/aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0", size = 11196, upload-time = "2025-12-09T13:35:52.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7d/4b633d709b8901d59444d2e512b93e72fe62d2b492a040097c3f7ba017bb/aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1", size = 10556, upload-time = "2025-12-09T13:35:50.18Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -443,6 +456,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
+    { name = "aiohttp-socks" },
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "asyncpg" },
@@ -494,6 +508,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
     { name = "aiohttp-retry", specifier = ">=2.9.1" },
+    { name = "aiohttp-socks", specifier = ">=0.10.1" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic", specifier = ">=1.16.5" },
     { name = "asyncpg", specifier = ">=0.30.0" },
@@ -1943,6 +1958,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "python-socks"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This change adds upstream proxy support for account traffic with encrypted storage and a clear precedence order of account override, account proxy group, then global proxy. It supports http, https, socks5, and socks5h proxy URLs, including credentials in the URL, and routes Responses HTTP/WebSocket, compact, transcription, and OAuth token refresh calls through the selected proxy.

The dashboard now exposes global proxy configuration in Settings, reusable proxy group management in Settings, and per-account proxy URL or group binding in the account detail view. Saved proxy credentials are redacted when returned to the UI.

The database migration adds global, group, and account-level proxy bindings. Tests cover proxy URL validation, credential redaction, aiohttp proxy transport kwargs, and account/group/global resolution precedence. I also verified the frontend production build, targeted proxy unit tests, Ruff checks, and Alembic schema drift check.