### PR TITLE
fix(proxy): retry transient stream timeouts

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -219,7 +219,13 @@ _ACCOUNT_RECOVERY_RETRY_CODES = frozenset(
         *PERMANENT_FAILURE_CODES.keys(),
     }
 )
-_TRANSIENT_RETRY_CODES = frozenset({"server_error"})
+_TRANSIENT_RETRY_CODES = frozenset(
+    {
+        "server_error",
+        "stream_incomplete",
+        "upstream_request_timeout",
+    }
+)
 _MAX_TRANSIENT_SAME_ACCOUNT_RETRIES = 3
 _COMPACT_MAX_ACCOUNT_ATTEMPTS = 2
 _STREAM_MAX_ACCOUNT_ATTEMPTS = 3

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -1,7 +1,7 @@
-"""Tests for transient (500 server_error) retry logic.
+"""Tests for transient stream retry logic.
 
 Covers:
-- Streaming: SSE-level server_error → same-account retry → failover
+- Streaming: SSE-level transient errors → same-account retry → failover
 - Streaming: HTTP-level 500 → same-account retry → failover
 - Compact: HTTP 500 → same-account retry with backoff → account failover
 - Budget exhaustion during inner retry
@@ -89,6 +89,20 @@ def _server_error_sse_event() -> str:
     )
 
 
+def _stream_timeout_sse_event() -> str:
+    return _sse_event(
+        {
+            "type": "response.failed",
+            "response": {
+                "error": {
+                    "code": "upstream_request_timeout",
+                    "message": "Proxy request budget exhausted",
+                },
+            },
+        }
+    )
+
+
 def _success_sse_event(response_id: str = "resp_ok") -> str:
     return _sse_event(
         {
@@ -143,6 +157,39 @@ async def test_stream_server_error_succeeds_on_second_try_same_account(async_cli
     assert len(completed) == 1
 
     # Both calls should be to the same account
+    assert len(seen_account_ids) == 2
+    assert seen_account_ids[0] == seen_account_ids[1]
+
+
+@pytest.mark.asyncio
+async def test_stream_timeout_succeeds_on_second_try_same_account(async_client, monkeypatch):
+    """Timeout as the first SSE event is a reconnectable transient failure."""
+    await _import_account(async_client, "acc_trans_timeout", "timeout@example.com")
+
+    call_count = 0
+    seen_account_ids: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        nonlocal call_count
+        call_count += 1
+        seen_account_ids.append(account_id)
+        if call_count == 1:
+            yield _stream_timeout_sse_event()
+            return
+        yield _success_sse_event()
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    completed = [e for e in events if e.get("type") == "response.completed"]
+    failed = [e for e in events if e.get("type") == "response.failed"]
+    assert len(completed) == 1
+    assert failed == []
     assert len(seen_account_ids) == 2
     assert seen_account_ids[0] == seen_account_ids[1]
 


### PR DESCRIPTION
## Summary
- Treat first-event stream timeouts and incomplete upstream websocket closes as transient stream failures.
- Retry those failures through the existing same-account retry path before failing over to another account.
- Keep downstream-visible streams fail-closed once bytes have already been emitted, so retries do not duplicate output/tool events.

## Why
`Proxy request budget exhausted` is emitted for proxy stream/request budget expiry, not necessarily account quota exhaustion. When it arrives as the first stream event, the proxy can safely reconnect/retry instead of surfacing a terminal `response.failed` to Codex/OpenClaw.

## Verification
- `.venv/bin/pytest tests/integration/test_proxy_transient_retry.py -q`


## Related issues
- Addresses the first-event timeout/retry part of #530.
- Related to #521 and #474 stream hang reports.
