### PR TITLE
fix(openspec): satisfy strict purpose validation

### DIFF
--- a/openspec/specs/admin-auth/spec.md
+++ b/openspec/specs/admin-auth/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define dashboard authentication behavior so login, bootstrap, TOTP, and session handling stay secure and predictable.
 
 ## Requirements
 

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define API key lifecycle, enforcement, accounting, and dashboard management contracts for downstream clients.
 
 ## Requirements
 

--- a/openspec/specs/database-backends/spec.md
+++ b/openspec/specs/database-backends/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define supported database backend wiring so local, Helm, SQLite, and external PostgreSQL deployments behave consistently.
 
 ## Requirements
 

--- a/openspec/specs/database-migrations/spec.md
+++ b/openspec/specs/database-migrations/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define migration, drift detection, and Alembic governance contracts so deployments fail closed on schema mismatch.
 
 ## Requirements
 

--- a/openspec/specs/deployment-installation/spec.md
+++ b/openspec/specs/deployment-installation/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define installation modes and smoke-test expectations so the Helm chart remains portable across supported deployments.
 
 ## Requirements
 

--- a/openspec/specs/deployment-networking/spec.md
+++ b/openspec/specs/deployment-networking/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define network exposure and policy contracts so chart deployments default to explicit, least-privilege connectivity.
 
 ## Requirements
 

--- a/openspec/specs/frontend-architecture/spec.md
+++ b/openspec/specs/frontend-architecture/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define dashboard surface contracts so settings, account management, and operational views stay coherent across the SPA.
 
 ## Requirements
 ### Requirement: Settings page

--- a/openspec/specs/outbound-http-clients/spec.md
+++ b/openspec/specs/outbound-http-clients/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define outbound HTTP client behavior so upstream OAuth and API calls use stable headers, personas, and proxy handling.
 
 ## Requirements
 ### Requirement: OAuth authorize requests use a configurable originator persona

--- a/openspec/specs/proxy-runtime-observability/spec.md
+++ b/openspec/specs/proxy-runtime-observability/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define proxy observability contracts so runtime failures, routing decisions, and admission rejections remain diagnosable.
 
 ## Requirements
 ### Requirement: Proxy 4xx/5xx responses are logged with error detail

--- a/openspec/specs/query-caching/spec.md
+++ b/openspec/specs/query-caching/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define query caching and quota-key normalization contracts so selection and dashboard reads remain fast and consistent.
 
 ## Requirements
 

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define Responses API compatibility contracts so Codex, OpenCode, and OpenAI-style clients preserve expected behavior.
 
 ## Requirements
 ### Requirement: Use prompt_cache_key as OpenAI cache affinity

--- a/openspec/specs/runtime-portability/spec.md
+++ b/openspec/specs/runtime-portability/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define runtime portability contracts so resilience features degrade safely across supported operating systems.
 
 ## Requirements
 

--- a/openspec/specs/sticky-session-operations/spec.md
+++ b/openspec/specs/sticky-session-operations/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-See context docs for background.
+Define sticky-session operation contracts so durable sessions, dashboard affinity, and prompt-cache affinity stay distinct.
 
 ## Requirements
 ### Requirement: Sticky sessions are explicitly typed


### PR DESCRIPTION
## Summary
- replace placeholder Purpose text in 13 OpenSpec capability specs with concrete descriptions
- keep requirements unchanged while making strict spec validation pass

## Validation
- `openspec validate --specs --strict --no-interactive` -> 19 passed, 0 failed
