### PR TITLE
fix(proxy): trim Codex websocket full-replay continuations

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -581,6 +581,8 @@ class ProxyService:
         effective_payload = payload
         proxy_injected_previous_response_id = False
         fresh_upstream_request_text: str | None = None
+        previous_response_trimmed_input_count: int | None = None
+        previous_response_trimmed_input_fingerprint: str | None = None
         if durable_lookup is not None:
             bridge_session_key = _HTTPBridgeSessionKey(
                 durable_lookup.canonical_kind,
@@ -622,6 +624,13 @@ class ProxyService:
                     cache_key_family=bridge_session_key.affinity_kind,
                     model_class=_extract_model_class(payload.model) if payload.model else None,
                 )
+        if effective_payload.previous_response_id is not None and isinstance(effective_payload.input, list):
+            previous_response_input_items = cast(list[JsonValue], effective_payload.input)
+            trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
+            if len(trimmed_input_items) != len(previous_response_input_items):
+                previous_response_trimmed_input_count = len(previous_response_input_items)
+                previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
+                effective_payload = effective_payload.model_copy(update={"input": trimmed_input_items})
         request_state, text_data = self._prepare_http_bridge_request(
             effective_payload,
             headers,
@@ -631,6 +640,19 @@ class ProxyService:
         )
         if downstream_turn_state is not None:
             request_state.session_id = _normalize_session_id(downstream_turn_state)
+        if previous_response_trimmed_input_count is not None:
+            request_state.input_item_count = previous_response_trimmed_input_count
+            request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
+            logger.info(
+                "http_bridge_previous_response_input_trimmed request_id=%s original_items=%s trimmed_to=%s "
+                "previous_response_id=%s",
+                request_state.request_id,
+                previous_response_trimmed_input_count,
+                len(cast(list[JsonValue], effective_payload.input))
+                if isinstance(effective_payload.input, list)
+                else None,
+                effective_payload.previous_response_id,
+            )
         request_state.transport = _REQUEST_TRANSPORT_HTTP
         request_state.request_stage = _http_bridge_request_stage(
             headers=headers,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -251,6 +251,20 @@ _WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
 _WEBSOCKET_CONTINUITY_CACHE_LIMIT = 4096
 _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS = 20
 _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS = 0.05
+_WEBSOCKET_PREVIOUS_RESPONSE_OUTPUT_ITEM_TYPES = frozenset(
+    {
+        "reasoning",
+        "function_call",
+        "custom_tool_call",
+        "web_search_call",
+        "file_search_call",
+        "computer_call",
+        "code_interpreter_call",
+        "mcp_approval_request",
+        "mcp_list_tools",
+        "output_image",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -732,18 +746,22 @@ class ProxyService:
             continuity_state=None,
         ):
             unanchored_payload = effective_payload.model_copy(update={"previous_response_id": None})
-            _fresh_request_state, fresh_upstream_request_text = self._prepare_http_bridge_request(
+            raw_fresh_upstream_request_text = _response_create_text(
                 unanchored_payload,
-                headers,
-                api_key=api_key,
-                api_key_reservation=api_key_reservation,
-                request_id=request_id,
+                include_type_field=True,
+                client_metadata=_response_create_client_metadata(unanchored_payload.to_payload(), headers=headers),
             )
-            del _fresh_request_state
-            request_state.fresh_upstream_request_text = fresh_upstream_request_text
-            request_state.fresh_upstream_request_is_retry_safe = (
-                len(fresh_upstream_request_text.encode("utf-8")) <= _UPSTREAM_RESPONSE_CREATE_MAX_BYTES
-            )
+            if len(raw_fresh_upstream_request_text.encode("utf-8")) <= _UPSTREAM_RESPONSE_CREATE_MAX_BYTES:
+                _fresh_request_state, fresh_upstream_request_text = self._prepare_http_bridge_request(
+                    unanchored_payload,
+                    headers,
+                    api_key=api_key,
+                    api_key_reservation=api_key_reservation,
+                    request_id=request_id,
+                )
+                del _fresh_request_state
+                request_state.fresh_upstream_request_text = fresh_upstream_request_text
+                request_state.fresh_upstream_request_is_retry_safe = True
         session_or_forward = await self._get_or_create_http_bridge_session(
             bridge_session_key,
             headers=dict(headers),
@@ -3023,6 +3041,7 @@ class ProxyService:
         original_input_fingerprint: str | None = None
         previous_response_trimmed_input_count: int | None = None
         previous_response_trimmed_input_fingerprint: str | None = None
+        session_anchor_has_safe_fresh_replay = False
         session_anchor = _websocket_continuity_anchor_for_payload(
             continuity_state,
             responses_payload=responses_payload,
@@ -3037,9 +3056,11 @@ class ProxyService:
                 include_type_field=True,
                 client_metadata=client_metadata,
             )
-            anchored_input_tail = _trim_websocket_previous_response_input_items(
-                original_input_items[session_anchor.stored_input_item_count :]
+            original_input_tail = original_input_items[session_anchor.stored_input_item_count :]
+            session_anchor_has_safe_fresh_replay = _websocket_input_items_have_replayable_previous_output(
+                original_input_tail
             )
+            anchored_input_tail = _trim_websocket_previous_response_input_items(original_input_tail)
             responses_payload = responses_payload.model_copy(
                 update={
                     "previous_response_id": session_anchor.previous_response_id,
@@ -3086,9 +3107,12 @@ class ProxyService:
             request_state.proxy_injected_previous_response_id = True
             request_state.input_item_count = original_input_item_count or request_state.input_item_count
             request_state.input_full_fingerprint = original_input_fingerprint
-            request_state.fresh_upstream_request_text = original_full_resend_text
+            request_state.fresh_upstream_request_text = (
+                original_full_resend_text if session_anchor_has_safe_fresh_replay else None
+            )
             request_state.fresh_upstream_request_is_retry_safe = (
-                original_full_resend_text is not None
+                session_anchor_has_safe_fresh_replay
+                and original_full_resend_text is not None
                 and len(original_full_resend_text.encode("utf-8")) <= _UPSTREAM_RESPONSE_CREATE_MAX_BYTES
             )
             logger.info(
@@ -5665,7 +5689,6 @@ class ProxyService:
             close_classification = _classify_upstream_close(
                 session.last_upstream_close_code,
                 request_response_events_seen=request_state.response_event_count,
-                upstream_response_events_seen=session.upstream_response_event_count,
             )
             if close_classification == "rejected":
                 request_state.error_code_override = "upstream_rejected_input"
@@ -5806,7 +5829,6 @@ class ProxyService:
         session.upstream_control = _WebSocketUpstreamControl()
         session.closed = False
         session.last_upstream_close_code = None
-        session.upstream_response_event_count = 0
         session.upstream_turn_state = _upstream_turn_state_from_socket(upstream) or session.upstream_turn_state
         if restart_reader:
             session.upstream_reader = asyncio.create_task(self._relay_http_bridge_upstream_messages(session))
@@ -5946,9 +5968,6 @@ class ProxyService:
         else:
             _record_response_event(matched_request_state, event_type)
             _record_response_event(terminal_request_state, event_type)
-        if event_type is not None and event_type.startswith("response."):
-            session.upstream_response_event_count += 1
-
         status_request_state = terminal_request_state or matched_request_state
         if status_request_state is None and is_previous_response_not_found_event:
             session.upstream_control.reconnect_requested = True
@@ -6625,6 +6644,7 @@ class ProxyService:
             retry_error_code = None
         if retry_error_code is not None:
             if retry_is_previous_response_not_found:
+                upstream_control.reconnect_requested = True
                 _switch_request_state_to_fresh_replay(request_state)
                 request_state.replay_count += 1
                 request_state.awaiting_response_created = True
@@ -6633,6 +6653,8 @@ class ProxyService:
                 upstream_control.replay_request_state = request_state
             else:
                 upstream_control.reconnect_requested = True
+                if _request_state_has_safe_fresh_replay(request_state):
+                    _switch_request_state_to_fresh_replay(request_state)
                 request_state.replay_count += 1
                 request_state.awaiting_response_created = True
                 request_state.response_id = None
@@ -8763,9 +8785,8 @@ def _classify_upstream_close(
     close_code: int | None,
     *,
     request_response_events_seen: int,
-    upstream_response_events_seen: int = 0,
 ) -> Literal["transient", "rejected"]:
-    if close_code == 1000 and request_response_events_seen == 0 and upstream_response_events_seen == 0:
+    if close_code == 1000 and request_response_events_seen == 0:
         return "rejected"
     return "transient"
 
@@ -8885,7 +8906,6 @@ class _HTTPBridgeSession:
     durable_owner_epoch: int | None = None
     upstream_reader: asyncio.Task[None] | None = None
     last_upstream_close_code: int | None = None
-    upstream_response_event_count: int = 0
     closed: bool = False
 
 
@@ -8998,9 +9018,9 @@ def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) 
 
 def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
     item_type = _websocket_input_item_type(item)
-    if item_type in {"reasoning", "function_call", "custom_tool_call"}:
+    if item_type in _WEBSOCKET_PREVIOUS_RESPONSE_OUTPUT_ITEM_TYPES:
         return True
-    if item_type != "message" or not isinstance(item, dict):
+    if not isinstance(item, dict):
         return False
     role = item.get("role")
     return role == "assistant"
@@ -9085,9 +9105,15 @@ async def _websocket_full_replay_continuity_wait_snapshot(
 ) -> int | None:
     if (
         not codex_session_affinity
-        or (request_state.previous_response_id is not None and not request_state.proxy_injected_previous_response_id)
-        or not request_state.proxy_injected_previous_response_id
         or continuity_state is None
+        or (request_state.previous_response_id is not None and not request_state.proxy_injected_previous_response_id)
+        or (
+            not request_state.proxy_injected_previous_response_id
+            and (
+                request_state.previous_response_id is not None
+                or request_state.input_item_count < _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS
+            )
+        )
     ):
         return None
     async with pending_lock:
@@ -10670,7 +10696,7 @@ def _websocket_input_items_have_replayable_previous_output(input_value: Sequence
             call_id = item_mapping.get("call_id")
             if isinstance(call_id, str) and call_id:
                 seen_function_calls.add(call_id)
-        elif item_type in {"reasoning", "custom_tool_call"}:
+        elif item_type in _WEBSOCKET_PREVIOUS_RESPONSE_OUTPUT_ITEM_TYPES - {"function_call_output"}:
             has_previous_output = True
         elif item_type == "function_call_output":
             call_id = item_mapping.get("call_id")

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3046,10 +3046,13 @@ class ProxyService:
                 include_type_field=True,
                 client_metadata=client_metadata,
             )
+            anchored_input_tail = _trim_websocket_previous_response_input_items(
+                original_input_items[session_anchor.stored_input_item_count :]
+            )
             responses_payload = responses_payload.model_copy(
                 update={
                     "previous_response_id": session_anchor.previous_response_id,
-                    "input": original_input_items[session_anchor.stored_input_item_count :],
+                    "input": anchored_input_tail,
                 }
             )
         elif (
@@ -8957,12 +8960,7 @@ async def _wait_for_websocket_continuity_gap(
     deadline = time.monotonic() + max(0.0, timeout_seconds)
     while True:
         async with pending_lock:
-            continuity_updated = (
-                continuity_state is None
-                or observed_completion_generation is None
-                or continuity_state.completion_generation != observed_completion_generation
-            )
-            if not pending_requests and continuity_updated:
+            if not pending_requests:
                 return True
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -10531,26 +10529,32 @@ def _websocket_client_previous_response_payload_has_safe_fresh_replay(
     for item in input_value:
         if not isinstance(item, Mapping):
             continue
-        item_type = item.get("type")
+        item_mapping = cast(Mapping[str, JsonValue], item)
+        item_type = item_mapping.get("type")
         if item_type == "function_call":
-            call_id = item.get("call_id")
+            call_id = item_mapping.get("call_id")
             if isinstance(call_id, str) and call_id:
                 seen_function_calls.add(call_id)
         elif item_type == "function_call_output":
-            call_id = item.get("call_id")
+            call_id = item_mapping.get("call_id")
             if not isinstance(call_id, str) or call_id not in seen_function_calls:
                 return False
-        elif item.get("role") == "assistant":
-            tool_calls = item.get("tool_calls")
+        elif item_mapping.get("role") == "assistant":
+            tool_calls = item_mapping.get("tool_calls")
             if isinstance(tool_calls, Sequence) and not isinstance(tool_calls, (str, bytes, bytearray)):
                 for tool_call in tool_calls:
                     if not isinstance(tool_call, Mapping):
                         continue
-                    call_id = tool_call.get("id") or tool_call.get("call_id") or tool_call.get("tool_call_id")
+                    tool_call_mapping = cast(Mapping[str, JsonValue], tool_call)
+                    call_id = (
+                        tool_call_mapping.get("id")
+                        or tool_call_mapping.get("call_id")
+                        or tool_call_mapping.get("tool_call_id")
+                    )
                     if isinstance(call_id, str) and call_id:
                         seen_tool_calls.add(call_id)
-        elif item.get("role") == "tool":
-            call_id = item.get("tool_call_id") or item.get("toolCallId") or item.get("call_id")
+        elif item_mapping.get("role") == "tool":
+            call_id = item_mapping.get("tool_call_id") or item_mapping.get("toolCallId") or item_mapping.get("call_id")
             if not isinstance(call_id, str) or call_id not in seen_tool_calls:
                 return False
     return True

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -619,8 +619,6 @@ class ProxyService:
         effective_payload = payload
         proxy_injected_previous_response_id = False
         fresh_upstream_request_text: str | None = None
-        previous_response_trimmed_input_count: int | None = None
-        previous_response_trimmed_input_fingerprint: str | None = None
         if durable_lookup is not None:
             bridge_session_key = _HTTPBridgeSessionKey(
                 durable_lookup.canonical_kind,
@@ -662,17 +660,6 @@ class ProxyService:
                     cache_key_family=bridge_session_key.affinity_kind,
                     model_class=_extract_model_class(payload.model) if payload.model else None,
                 )
-        if (
-            proxy_injected_previous_response_id
-            and effective_payload.previous_response_id is not None
-            and isinstance(effective_payload.input, list)
-        ):
-            previous_response_input_items = cast(list[JsonValue], effective_payload.input)
-            trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
-            if len(trimmed_input_items) != len(previous_response_input_items):
-                previous_response_trimmed_input_count = len(previous_response_input_items)
-                previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
-                effective_payload = effective_payload.model_copy(update={"input": trimmed_input_items})
         request_state, text_data = self._prepare_http_bridge_request(
             effective_payload,
             headers,
@@ -682,19 +669,6 @@ class ProxyService:
         )
         if downstream_turn_state is not None:
             request_state.session_id = _normalize_session_id(downstream_turn_state)
-        if previous_response_trimmed_input_count is not None:
-            request_state.input_item_count = previous_response_trimmed_input_count
-            request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
-            logger.info(
-                "http_bridge_previous_response_input_trimmed request_id=%s original_items=%s trimmed_to=%s "
-                "previous_response_id=%s",
-                request_state.request_id,
-                previous_response_trimmed_input_count,
-                len(cast(list[JsonValue], effective_payload.input))
-                if isinstance(effective_payload.input, list)
-                else None,
-                effective_payload.previous_response_id,
-            )
         request_state.transport = _REQUEST_TRANSPORT_HTTP
         request_state.request_stage = _http_bridge_request_stage(
             headers=headers,
@@ -4043,6 +4017,12 @@ class ProxyService:
                                 previous_session is not None
                                 and not previous_session.closed
                                 and previous_session.account.status == AccountStatus.ACTIVE
+                                and _http_bridge_session_reusable_for_request(
+                                    session=previous_session,
+                                    key=previous_session.key,
+                                    incoming_turn_state=incoming_turn_state,
+                                    previous_response_id=previous_response_id,
+                                )
                                 and _http_bridge_session_matches_preferred_account(
                                     session=previous_session,
                                     previous_response_id=previous_response_id,
@@ -4921,8 +4901,12 @@ class ProxyService:
         stripped_response_id = response_id.strip()
         if not stripped_response_id:
             return
+        if stripped_response_id in session.unsafe_previous_response_ids:
+            return
         async with self._http_bridge_lock:
             if session.closed:
+                return
+            if stripped_response_id in session.unsafe_previous_response_ids:
                 return
             alias_key = _http_bridge_previous_response_alias_key(stripped_response_id, session.key.api_key_id)
             self._http_bridge_previous_response_index[alias_key] = session.key
@@ -4939,6 +4923,24 @@ class ProxyService:
                 )
             except Exception:
                 logger.warning("Failed to persist durable HTTP bridge previous_response_id alias", exc_info=True)
+
+    def _mark_http_bridge_previous_response_unsafe(
+        self,
+        session: "_HTTPBridgeSession",
+        response_id: str | None,
+    ) -> None:
+        if response_id is None:
+            return
+        stripped_response_id = response_id.strip()
+        if not stripped_response_id:
+            return
+        session.unsafe_previous_response_ids.add(stripped_response_id)
+        session.previous_response_ids.discard(stripped_response_id)
+        if session.last_completed_response_id == stripped_response_id:
+            session.last_completed_response_id = None
+        alias_key = _http_bridge_previous_response_alias_key(stripped_response_id, session.key.api_key_id)
+        if self._http_bridge_previous_response_index.get(alias_key) == session.key:
+            self._http_bridge_previous_response_index.pop(alias_key, None)
 
     async def _unregister_http_bridge_turn_states(self, session: "_HTTPBridgeSession") -> None:
         async with self._http_bridge_lock:
@@ -5645,7 +5647,8 @@ class ProxyService:
                 return False
             close_classification = _classify_upstream_close(
                 session.last_upstream_close_code,
-                response_events_seen=request_state.response_event_count,
+                request_response_events_seen=request_state.response_event_count,
+                upstream_response_events_seen=session.upstream_response_event_count,
             )
             if close_classification == "rejected":
                 request_state.error_code_override = "upstream_rejected_input"
@@ -5786,6 +5789,7 @@ class ProxyService:
         session.upstream_control = _WebSocketUpstreamControl()
         session.closed = False
         session.last_upstream_close_code = None
+        session.upstream_response_event_count = 0
         session.upstream_turn_state = _upstream_turn_state_from_socket(upstream) or session.upstream_turn_state
         if restart_reader:
             session.upstream_reader = asyncio.create_task(self._relay_http_bridge_upstream_messages(session))
@@ -5808,9 +5812,9 @@ class ProxyService:
         session: "_HTTPBridgeSession",
         text: str,
     ) -> None:
-        event_block = f"data: {text}\n\n"
-        payload = parse_sse_data_json(event_block)
-        event = parse_sse_event(event_block)
+        payload = _parse_websocket_text_payload(text)
+        event = _parse_websocket_text_event(text, payload)
+        event_block = format_sse_event(payload) if payload is not None else f"data: {text}\n\n"
         event_type = _event_type_from_payload(event, payload)
         response_id = _websocket_response_id(event, payload)
         error_message = _websocket_event_error_message(event_type, payload)
@@ -5925,6 +5929,8 @@ class ProxyService:
         else:
             _record_response_event(matched_request_state, event_type)
             _record_response_event(terminal_request_state, event_type)
+        if event_type is not None and event_type.startswith("response."):
+            session.upstream_response_event_count += 1
 
         status_request_state = terminal_request_state or matched_request_state
         if status_request_state is None and is_previous_response_not_found_event:
@@ -5955,13 +5961,19 @@ class ProxyService:
             # subsequent turns (including ones that never populated
             # input_item_count, e.g. string inputs) can still reuse this
             # anchor for continuity lookups.
-            if response_id is not None:
+            if response_id is not None and not terminal_request_state.suppressed_downstream_tool_call:
                 session.last_completed_response_id = response_id
             # Prefix trimming is only meaningful for list-shaped inputs, so
             # keep the input-count / fingerprint update scoped to that path.
-            if terminal_request_state.input_item_count > 0:
+            if (
+                terminal_request_state.input_item_count > 0
+                and not terminal_request_state.suppressed_downstream_tool_call
+            ):
                 session.last_completed_input_count = terminal_request_state.input_item_count
                 session.last_completed_input_prefix_fingerprint = terminal_request_state.input_full_fingerprint
+            elif not terminal_request_state.suppressed_downstream_tool_call:
+                session.last_completed_input_count = 0
+                session.last_completed_input_prefix_fingerprint = None
 
         if event_type == "error":
             http_status = _http_error_status_from_payload(payload)
@@ -5981,7 +5993,11 @@ class ProxyService:
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
             _release_websocket_response_create_gate(created_request_state, session.response_create_gate)
 
-        if response_id is not None and matched_request_state is not None:
+        if (
+            response_id is not None
+            and matched_request_state is not None
+            and not matched_request_state.suppressed_downstream_tool_call
+        ):
             await self._register_http_bridge_previous_response_id(session, response_id)
 
         if matched_request_state is not None and matched_request_state.event_queue is not None:
@@ -6385,9 +6401,8 @@ class ProxyService:
         response_create_gate: asyncio.Semaphore,
         continuity_state: "_WebSocketContinuityState | None" = None,
     ) -> str:
-        event_block = f"data: {text}\n\n"
-        payload = parse_sse_data_json(event_block)
-        event = parse_sse_event(event_block)
+        payload = _parse_websocket_text_payload(text)
+        event = _parse_websocket_text_event(text, payload)
         event_type = _event_type_from_payload(event, payload)
         response_id = _websocket_response_id(event, payload)
         error_message = _websocket_event_error_message(event_type, payload)
@@ -8677,9 +8692,10 @@ def _is_account_neutral_error_code(code: str | None) -> bool:
 def _classify_upstream_close(
     close_code: int | None,
     *,
-    response_events_seen: int,
+    request_response_events_seen: int,
+    upstream_response_events_seen: int = 0,
 ) -> Literal["transient", "rejected"]:
-    if close_code == 1000 and response_events_seen == 0:
+    if close_code == 1000 and request_response_events_seen == 0 and upstream_response_events_seen == 0:
         return "rejected"
     return "transient"
 
@@ -8741,6 +8757,7 @@ class _WebSocketRequestState:
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
+    suppressed_downstream_tool_call: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -8790,6 +8807,7 @@ class _HTTPBridgeSession:
     downstream_turn_state: str | None = None
     downstream_turn_state_aliases: set[str] = field(default_factory=set)
     previous_response_ids: set[str] = field(default_factory=set)
+    unsafe_previous_response_ids: set[str] = field(default_factory=set)
     last_completed_input_count: int = 0
     last_completed_response_id: str | None = None
     last_completed_input_prefix_fingerprint: str | None = None
@@ -8797,6 +8815,7 @@ class _HTTPBridgeSession:
     durable_owner_epoch: int | None = None
     upstream_reader: asyncio.Task[None] | None = None
     last_upstream_close_code: int | None = None
+    upstream_response_event_count: int = 0
     closed: bool = False
 
 
@@ -8930,6 +8949,9 @@ def _record_websocket_continuity_completion(
     request_state: _WebSocketRequestState,
     response_id: str | None,
 ) -> None:
+    if request_state.suppressed_downstream_tool_call:
+        continuity_state.completion_generation += 1
+        return
     if (
         request_state.input_item_count > 0
         and continuity_state.last_completed_input_count > 0
@@ -8958,9 +8980,24 @@ async def _wait_for_websocket_continuity_gap(
     observed_completion_generation: int | None = None,
 ) -> bool:
     deadline = time.monotonic() + max(0.0, timeout_seconds)
+    drained_at: float | None = None
     while True:
+        generation_advanced = (
+            continuity_state is not None
+            and observed_completion_generation is not None
+            and continuity_state.completion_generation > observed_completion_generation
+        )
         async with pending_lock:
-            if not pending_requests:
+            has_pending_requests = bool(pending_requests)
+            if not has_pending_requests and (
+                observed_completion_generation is None or continuity_state is None or generation_advanced
+            ):
+                return True
+            if has_pending_requests:
+                drained_at = None
+            elif drained_at is None:
+                drained_at = time.monotonic()
+            elif time.monotonic() - drained_at >= _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS:
                 return True
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -9227,6 +9264,20 @@ def _normalize_session_id(session_id: str | None) -> str | None:
         return None
     stripped = session_id.strip()
     return stripped or None
+
+
+def _parse_websocket_text_payload(text: str) -> dict[str, JsonValue] | None:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        payload = parse_sse_data_json(f"data: {text}\n\n")
+    return cast(dict[str, JsonValue], payload) if isinstance(payload, dict) else None
+
+
+def _parse_websocket_text_event(text: str, payload: dict[str, JsonValue] | None) -> OpenAIEvent | None:
+    if payload is not None:
+        return parse_sse_event(format_sse_event(payload))
+    return parse_sse_event(f"data: {text}\n\n")
 
 
 def _websocket_precreated_retry_error_code(
@@ -10828,6 +10879,8 @@ def _http_bridge_session_reusable_for_request(
     incoming_turn_state: str | None,
     previous_response_id: str | None,
 ) -> bool:
+    if previous_response_id is not None and previous_response_id.strip() in session.unsafe_previous_response_ids:
+        return False
     if key.affinity_kind != "prompt_cache":
         return True
     if incoming_turn_state is not None:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3151,6 +3151,11 @@ class ProxyService:
         request_id: str | None = None,
         request_log_id: str | None = None,
     ) -> tuple[_WebSocketRequestState, str]:
+        if payload.previous_response_id is not None and isinstance(payload.input, list):
+            input_items = cast(list[JsonValue], payload.input)
+            trimmed_input_items = _trim_websocket_previous_response_input_items(input_items)
+            if len(trimmed_input_items) != len(input_items):
+                payload = payload.model_copy(update={"input": trimmed_input_items})
         upstream_payload = dict(payload.to_payload())
         upstream_payload.pop("stream", None)
         upstream_payload.pop("background", None)
@@ -5760,18 +5765,18 @@ class ProxyService:
             else:
                 release_create_gate = False
 
-            if matched_request_state is not None:
-                actual_service_tier = _service_tier_from_event_payload(payload)
-                if actual_service_tier is not None:
-                    matched_request_state.actual_service_tier = actual_service_tier
-                    matched_request_state.service_tier = actual_service_tier
-
             if _mark_duplicate_tool_call_downstream_event(
                 payload,
                 upstream_control=session.upstream_control,
                 response_id=_websocket_event_dedupe_response_id(response_id, matched_request_state),
             ):
                 return
+
+            if matched_request_state is not None:
+                actual_service_tier = _service_tier_from_event_payload(payload)
+                if actual_service_tier is not None:
+                    matched_request_state.actual_service_tier = actual_service_tier
+                    matched_request_state.service_tier = actual_service_tier
 
             terminal_request_state = None
             if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
@@ -6340,11 +6345,6 @@ class ProxyService:
                 release_create_gate = False
             else:
                 release_create_gate = False
-            if request_state is not None:
-                actual_service_tier = _service_tier_from_event_payload(payload)
-                if actual_service_tier is not None:
-                    request_state.actual_service_tier = actual_service_tier
-                    request_state.service_tier = actual_service_tier
             if _mark_duplicate_tool_call_downstream_event(
                 payload,
                 upstream_control=upstream_control,
@@ -6352,6 +6352,11 @@ class ProxyService:
             ):
                 upstream_control.suppress_downstream_event = True
                 return text
+            if request_state is not None:
+                actual_service_tier = _service_tier_from_event_payload(payload)
+                if actual_service_tier is not None:
+                    request_state.actual_service_tier = actual_service_tier
+                    request_state.service_tier = actual_service_tier
             if (
                 event_type in {"response.completed", "response.failed", "response.incomplete", "error"}
                 and pending_requests
@@ -8795,6 +8800,15 @@ def _event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonV
     return None
 
 
+def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    status = payload.get("status")
+    if isinstance(status, int):
+        return status
+    return None
+
+
 def _websocket_continuity_anchor_for_payload(
     continuity_state: _WebSocketContinuityState | None,
     *,
@@ -8829,11 +8843,7 @@ def _websocket_continuity_anchor_for_payload(
 
 def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
     first_output_index = next(
-        (
-            index
-            for index, item in enumerate(input_items)
-            if _websocket_input_item_type(item) == "function_call_output"
-        ),
+        (index for index, item in enumerate(input_items) if _websocket_input_item_type(item) == "function_call_output"),
         None,
     )
     if first_output_index is None or first_output_index == 0:
@@ -8953,15 +8963,6 @@ def _websocket_event_dedupe_response_id(
     if request_state is None:
         return None
     return request_state.response_id or request_state.request_id
-
-
-def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
-    if not isinstance(payload, dict):
-        return None
-    status = payload.get("status")
-    if isinstance(status, int):
-        return status
-    return None
 
 
 def _openai_error_envelope_from_response_failed_payload(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -727,6 +727,23 @@ class ProxyService:
             # Only the trim branch below (which verifies the stored prefix
             # fingerprint) is allowed to flip this flag to ``True``.
             request_state.fresh_upstream_request_is_retry_safe = False
+        elif _websocket_client_previous_response_payload_has_safe_fresh_replay(
+            effective_payload,
+            continuity_state=None,
+        ):
+            unanchored_payload = effective_payload.model_copy(update={"previous_response_id": None})
+            _fresh_request_state, fresh_upstream_request_text = self._prepare_http_bridge_request(
+                unanchored_payload,
+                headers,
+                api_key=api_key,
+                api_key_reservation=api_key_reservation,
+                request_id=request_id,
+            )
+            del _fresh_request_state
+            request_state.fresh_upstream_request_text = fresh_upstream_request_text
+            request_state.fresh_upstream_request_is_retry_safe = (
+                len(fresh_upstream_request_text.encode("utf-8")) <= _UPSTREAM_RESPONSE_CREATE_MAX_BYTES
+            )
         session_or_forward = await self._get_or_create_http_bridge_session(
             bridge_session_key,
             headers=dict(headers),
@@ -5941,6 +5958,59 @@ class ProxyService:
             status_request_state is not None
             and status_request_state.previous_response_id is not None
             and is_previous_response_not_found_event
+            and response_id is None
+            and not has_other_pending_requests
+            and _request_state_has_safe_fresh_replay(status_request_state)
+            and status_request_state.replay_count < 1
+        ):
+            original_request_text = status_request_state.request_text
+            original_previous_response_id = status_request_state.previous_response_id
+            original_proxy_injected = status_request_state.proxy_injected_previous_response_id
+            original_retry_safe = status_request_state.fresh_upstream_request_is_retry_safe
+            try:
+                _switch_request_state_to_fresh_replay(status_request_state)
+                status_request_state.replay_count += 1
+                status_request_state.awaiting_response_created = True
+                status_request_state.response_id = None
+                await self._reconnect_http_bridge_session(session, request_state=status_request_state)
+                async with session.pending_lock:
+                    session.pending_requests.append(status_request_state)
+                    session.queued_request_count += 1
+                assert status_request_state.request_text is not None
+                await session.upstream.send_text(status_request_state.request_text)
+                session.last_used_at = time.monotonic()
+                _log_http_bridge_event(
+                    "retry_fresh_upstream_previous_response_not_found",
+                    session.key,
+                    account_id=session.account.id,
+                    model=session.request_model,
+                    pending_count=1,
+                    cache_key_family=session.key.affinity_kind,
+                    model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                )
+                return
+            except Exception:
+                logger.warning("HTTP bridge previous-response fresh replay retry failed", exc_info=True)
+                async with session.pending_lock:
+                    if status_request_state in session.pending_requests:
+                        session.pending_requests.remove(status_request_state)
+                        session.queued_request_count = max(0, session.queued_request_count - 1)
+                status_request_state.request_text = original_request_text
+                status_request_state.previous_response_id = original_previous_response_id
+                status_request_state.proxy_injected_previous_response_id = original_proxy_injected
+                status_request_state.fresh_upstream_request_is_retry_safe = original_retry_safe
+                status_request_state.replay_count = max(0, status_request_state.replay_count - 1)
+
+        if (
+            status_request_state is not None
+            and status_request_state.previous_response_id is not None
+            and is_previous_response_not_found_event
+            and (
+                response_id is not None
+                or has_other_pending_requests
+                or not _request_state_has_safe_fresh_replay(status_request_state)
+                or status_request_state.replay_count >= 1
+            )
         ):
             status_request_state.error_http_status_override = 502
             status_request_state.previous_response_not_found_rewritten = (
@@ -10586,11 +10656,15 @@ def _websocket_input_items_have_replayable_previous_output(input_value: Sequence
     seen_function_calls: set[str] = set()
     seen_tool_calls: set[str] = set()
     has_previous_output = False
+    has_context_message = False
     for item in input_value:
         if not isinstance(item, Mapping):
             continue
         item_mapping = cast(Mapping[str, JsonValue], item)
         item_type = item_mapping.get("type")
+        role = item_mapping.get("role")
+        if role in {"system", "developer", "user", "assistant"}:
+            has_context_message = True
         if item_type == "function_call":
             has_previous_output = True
             call_id = item_mapping.get("call_id")
@@ -10603,7 +10677,7 @@ def _websocket_input_items_have_replayable_previous_output(input_value: Sequence
             if not isinstance(call_id, str) or call_id not in seen_function_calls:
                 return False
             has_previous_output = True
-        elif item_mapping.get("role") == "assistant":
+        elif role == "assistant":
             has_previous_output = True
             tool_calls = item_mapping.get("tool_calls")
             if isinstance(tool_calls, Sequence) and not isinstance(tool_calls, (str, bytes, bytearray)):
@@ -10618,12 +10692,12 @@ def _websocket_input_items_have_replayable_previous_output(input_value: Sequence
                     )
                     if isinstance(call_id, str) and call_id:
                         seen_tool_calls.add(call_id)
-        elif item_mapping.get("role") == "tool":
+        elif role == "tool":
             call_id = item_mapping.get("tool_call_id") or item_mapping.get("toolCallId") or item_mapping.get("call_id")
             if not isinstance(call_id, str) or call_id not in seen_tool_calls:
                 return False
             has_previous_output = True
-    return has_previous_output
+    return has_previous_output and has_context_message
 
 
 def _truncate_identifier(value: str, *, max_length: int = 96) -> str:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10557,40 +10557,54 @@ def _websocket_client_previous_response_payload_has_safe_fresh_replay(
     *,
     continuity_state: _WebSocketContinuityState | None,
 ) -> bool:
-    if (
-        continuity_state is None
-        or payload.previous_response_id is None
-        or payload.previous_response_id != continuity_state.last_completed_response_id
-        or continuity_state.last_completed_input_count <= 0
-        or continuity_state.last_completed_input_prefix_fingerprint is None
-    ):
+    if payload.previous_response_id is None:
         return False
     input_value = payload.input
     if not isinstance(input_value, Sequence) or isinstance(input_value, (str, bytes, bytearray)):
         return False
-    stored_count = continuity_state.last_completed_input_count
-    if len(input_value) <= stored_count:
-        return False
-    incoming_prefix = cast(Sequence[JsonValue], input_value[:stored_count])
-    if _fingerprint_input_items(incoming_prefix) != continuity_state.last_completed_input_prefix_fingerprint:
-        return False
+    input_items = cast(Sequence[JsonValue], input_value)
+    if (
+        continuity_state is not None
+        and payload.previous_response_id == continuity_state.last_completed_response_id
+        and continuity_state.last_completed_input_count > 0
+        and continuity_state.last_completed_input_prefix_fingerprint is not None
+    ):
+        stored_count = continuity_state.last_completed_input_count
+        if len(input_items) <= stored_count:
+            return False
+        incoming_prefix = input_items[:stored_count]
+        if _fingerprint_input_items(incoming_prefix) != continuity_state.last_completed_input_prefix_fingerprint:
+            return False
+        return _websocket_input_items_have_replayable_previous_output(input_items)
 
+    if len(input_items) <= 1:
+        return False
+    return _websocket_input_items_have_replayable_previous_output(input_items)
+
+
+def _websocket_input_items_have_replayable_previous_output(input_value: Sequence[JsonValue]) -> bool:
     seen_function_calls: set[str] = set()
     seen_tool_calls: set[str] = set()
+    has_previous_output = False
     for item in input_value:
         if not isinstance(item, Mapping):
             continue
         item_mapping = cast(Mapping[str, JsonValue], item)
         item_type = item_mapping.get("type")
         if item_type == "function_call":
+            has_previous_output = True
             call_id = item_mapping.get("call_id")
             if isinstance(call_id, str) and call_id:
                 seen_function_calls.add(call_id)
+        elif item_type in {"reasoning", "custom_tool_call"}:
+            has_previous_output = True
         elif item_type == "function_call_output":
             call_id = item_mapping.get("call_id")
             if not isinstance(call_id, str) or call_id not in seen_function_calls:
                 return False
+            has_previous_output = True
         elif item_mapping.get("role") == "assistant":
+            has_previous_output = True
             tool_calls = item_mapping.get("tool_calls")
             if isinstance(tool_calls, Sequence) and not isinstance(tool_calls, (str, bytes, bytearray)):
                 for tool_call in tool_calls:
@@ -10608,7 +10622,8 @@ def _websocket_client_previous_response_payload_has_safe_fresh_replay(
             call_id = item_mapping.get("tool_call_id") or item_mapping.get("toolCallId") or item_mapping.get("call_id")
             if not isinstance(call_id, str) or call_id not in seen_tool_calls:
                 return False
-    return True
+            has_previous_output = True
+    return has_previous_output
 
 
 def _truncate_identifier(value: str, *, max_length: int = 96) -> str:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -248,6 +248,9 @@ _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES = frozenset(
     }
 )
 _WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
+_WEBSOCKET_CONTINUITY_CACHE_LIMIT = 4096
+_WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS = 20
+_WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS = 0.05
 
 
 @dataclass(frozen=True, slots=True)
@@ -281,6 +284,22 @@ def _fingerprint_input_items(items: Sequence[JsonValue]) -> str:
     return sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _response_create_text(
+    payload: ResponsesRequest,
+    *,
+    include_type_field: bool,
+    client_metadata: Mapping[str, JsonValue] | None,
+) -> str:
+    upstream_payload = dict(payload.to_payload())
+    upstream_payload.pop("stream", None)
+    upstream_payload.pop("background", None)
+    if include_type_field:
+        upstream_payload["type"] = "response.create"
+    if client_metadata:
+        upstream_payload["client_metadata"] = client_metadata
+    return json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
+
+
 class ProxyService:
     def __init__(self, repo_factory: ProxyRepoFactory) -> None:
         self._repo_factory = repo_factory
@@ -294,6 +313,7 @@ class ProxyService:
         self._http_bridge_turn_state_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
         self._http_bridge_previous_response_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
         self._websocket_previous_response_account_index: dict[tuple[str, str | None, str | None], str] = {}
+        self._websocket_continuity_index: dict[tuple[str, str | None], _WebSocketContinuityState] = {}
         # In-memory pin from upstream-issued file_id -> codex-lb account_id.
         # Used so ``finalize_file`` for a given ``file_id`` is routed to
         # the same account that handled ``create_file``. Cross-instance
@@ -305,6 +325,30 @@ class ProxyService:
         self._file_account_pin_lock = asyncio.Lock()
         self._http_bridge_lock = anyio.Lock()
         self._work_admission: WorkAdmissionController | None = None
+
+    def _websocket_continuity_state_for_request(
+        self,
+        headers: Mapping[str, str],
+        *,
+        api_key: ApiKeyData | None,
+        codex_session_affinity: bool,
+    ) -> "_WebSocketContinuityState":
+        if not codex_session_affinity:
+            return _WebSocketContinuityState()
+        session_id = _owner_lookup_session_id_from_headers(headers)
+        if session_id is None:
+            return _WebSocketContinuityState()
+        key = (session_id, api_key.id if api_key is not None else None)
+        continuity_state = self._websocket_continuity_index.get(key)
+        if continuity_state is None:
+            continuity_state = _WebSocketContinuityState()
+            self._websocket_continuity_index[key] = continuity_state
+        else:
+            self._websocket_continuity_index.pop(key, None)
+            self._websocket_continuity_index[key] = continuity_state
+        while len(self._websocket_continuity_index) > _WEBSOCKET_CONTINUITY_CACHE_LIMIT:
+            self._websocket_continuity_index.pop(next(iter(self._websocket_continuity_index)))
+        return continuity_state
 
     def _get_work_admission(self) -> WorkAdmissionController:
         if self._work_admission is None:
@@ -2411,6 +2455,11 @@ class ProxyService:
         upstream: UpstreamResponsesWebSocket | None = None
         upstream_reader: asyncio.Task[None] | None = None
         upstream_control: _WebSocketUpstreamControl | None = None
+        continuity_state = self._websocket_continuity_state_for_request(
+            headers,
+            api_key=api_key,
+            codex_session_affinity=codex_session_affinity,
+        )
         account: Account | None = None
         upstream_turn_state: str | None = _sticky_key_from_turn_state_header(headers)
         downstream_activity = _DownstreamWebSocketActivity()
@@ -2533,7 +2582,40 @@ class ProxyService:
                                     sticky_threads_enabled=sticky_threads_enabled,
                                     openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
                                     api_key=api_key,
+                                    continuity_state=continuity_state,
                                 )
+                                if await _websocket_full_replay_should_wait_for_continuity(
+                                    prepared_request.request_state,
+                                    pending_requests,
+                                    pending_lock=pending_lock,
+                                    codex_session_affinity=codex_session_affinity,
+                                ):
+                                    await self._release_websocket_reservation(
+                                        prepared_request.request_state.api_key_reservation
+                                    )
+                                    wait_started_at = time.monotonic()
+                                    waited_for_anchor = await _wait_for_websocket_continuity_gap(
+                                        pending_requests,
+                                        pending_lock=pending_lock,
+                                        timeout_seconds=runtime_settings.proxy_request_budget_seconds,
+                                    )
+                                    logger.info(
+                                        "websocket_full_replay_waited_for_continuity waited=%s elapsed_ms=%s "
+                                        "original_items=%s",
+                                        waited_for_anchor,
+                                        int((time.monotonic() - wait_started_at) * 1000),
+                                        prepared_request.request_state.input_item_count,
+                                    )
+                                    prepared_request = await self._prepare_websocket_response_create_request(
+                                        payload,
+                                        headers=headers,
+                                        codex_session_affinity=codex_session_affinity,
+                                        openai_cache_affinity=openai_cache_affinity,
+                                        sticky_threads_enabled=sticky_threads_enabled,
+                                        openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
+                                        api_key=api_key,
+                                        continuity_state=continuity_state,
+                                    )
                                 request_state = prepared_request.request_state
                                 request_affinity = prepared_request.affinity_policy
                                 text_data = prepared_request.text_data
@@ -2759,6 +2841,7 @@ class ProxyService:
                             api_key=api_key,
                             upstream_control=upstream_control,
                             response_create_gate=response_create_gate,
+                            continuity_state=continuity_state,
                             proxy_request_budget_seconds=runtime_settings.proxy_request_budget_seconds,
                             stream_idle_timeout_seconds=runtime_settings.stream_idle_timeout_seconds,
                             downstream_activity=downstream_activity,
@@ -2851,6 +2934,7 @@ class ProxyService:
         sticky_threads_enabled: bool,
         openai_cache_affinity_max_age_seconds: int,
         api_key: ApiKeyData | None,
+        continuity_state: "_WebSocketContinuityState | None" = None,
     ) -> _PreparedWebSocketRequest:
         refreshed_api_key = await self._refresh_websocket_api_key_policy(api_key)
         client_metadata = _response_create_client_metadata(payload, headers=headers)
@@ -2859,6 +2943,29 @@ class ProxyService:
         validate_model_access(refreshed_api_key, responses_payload.model)
         self._raise_for_unsupported_input_image_references(responses_payload)
         rewritten_file_account_id = await self._resolve_file_account_for_responses(responses_payload, headers)
+        original_full_resend_text: str | None = None
+        original_input_item_count: int | None = None
+        original_input_fingerprint: str | None = None
+        session_anchor = _websocket_continuity_anchor_for_payload(
+            continuity_state,
+            responses_payload=responses_payload,
+            codex_session_affinity=codex_session_affinity,
+        )
+        if session_anchor is not None:
+            original_input_items = cast(list[JsonValue], responses_payload.input)
+            original_input_item_count = len(original_input_items)
+            original_input_fingerprint = _fingerprint_input_items(original_input_items)
+            original_full_resend_text = _response_create_text(
+                responses_payload,
+                include_type_field=True,
+                client_metadata=client_metadata,
+            )
+            responses_payload = responses_payload.model_copy(
+                update={
+                    "previous_response_id": session_anchor.previous_response_id,
+                    "input": original_input_items[session_anchor.stored_input_item_count :],
+                }
+            )
         reservation = await self._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -2881,6 +2988,21 @@ class ProxyService:
         except ProxyResponseError:
             await self._release_websocket_reservation(reservation)
             raise
+        if session_anchor is not None:
+            request_state.proxy_injected_previous_response_id = True
+            request_state.input_item_count = original_input_item_count or request_state.input_item_count
+            request_state.input_full_fingerprint = original_input_fingerprint
+            request_state.fresh_upstream_request_text = original_full_resend_text
+            request_state.fresh_upstream_request_is_retry_safe = original_full_resend_text is not None
+            logger.info(
+                "websocket_session_anchor_injected request_id=%s response_id=%s original_items=%s trimmed_to=%s",
+                request_state.request_id,
+                session_anchor.previous_response_id,
+                original_input_item_count,
+                len(cast(list[JsonValue], responses_payload.input))
+                if isinstance(responses_payload.input, list)
+                else None,
+            )
         had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
         affinity_policy = _sticky_key_for_responses_request(
             responses_payload,
@@ -5599,6 +5721,13 @@ class ProxyService:
                     matched_request_state.actual_service_tier = actual_service_tier
                     matched_request_state.service_tier = actual_service_tier
 
+            if _mark_duplicate_tool_call_downstream_event(
+                payload,
+                upstream_control=session.upstream_control,
+                response_id=_websocket_event_dedupe_response_id(response_id, matched_request_state),
+            ):
+                return
+
             terminal_request_state = None
             if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 terminal_request_state = _pop_terminal_websocket_request_state(
@@ -5949,6 +6078,7 @@ class ProxyService:
         proxy_request_budget_seconds: float,
         stream_idle_timeout_seconds: float,
         downstream_activity: _DownstreamWebSocketActivity,
+        continuity_state: "_WebSocketContinuityState | None" = None,
     ) -> None:
         try:
             while True:
@@ -6013,6 +6143,7 @@ class ProxyService:
                         api_key=api_key,
                         upstream_control=upstream_control,
                         response_create_gate=response_create_gate,
+                        continuity_state=continuity_state,
                     )
                     suppress_downstream_event = upstream_control.suppress_downstream_event
                     downstream_texts = upstream_control.downstream_texts
@@ -6124,6 +6255,7 @@ class ProxyService:
         api_key: ApiKeyData | None,
         upstream_control: _WebSocketUpstreamControl,
         response_create_gate: asyncio.Semaphore,
+        continuity_state: "_WebSocketContinuityState | None" = None,
     ) -> str:
         event_block = f"data: {text}\n\n"
         payload = parse_sse_data_json(event_block)
@@ -6168,6 +6300,13 @@ class ProxyService:
                 if actual_service_tier is not None:
                     request_state.actual_service_tier = actual_service_tier
                     request_state.service_tier = actual_service_tier
+            if _mark_duplicate_tool_call_downstream_event(
+                payload,
+                upstream_control=upstream_control,
+                response_id=_websocket_event_dedupe_response_id(response_id, request_state),
+            ):
+                upstream_control.suppress_downstream_event = True
+                return text
             if (
                 event_type in {"response.completed", "response.failed", "response.incomplete", "error"}
                 and pending_requests
@@ -6311,6 +6450,13 @@ class ProxyService:
                 )
             if retry_error_code is not None:
                 return downstream_text
+
+        if event_type == "response.completed" and continuity_state is not None:
+            _record_websocket_continuity_completion(
+                continuity_state,
+                request_state=request_state,
+                response_id=response_id,
+            )
 
         await self._finalize_websocket_request_state(
             request_state,
@@ -8549,11 +8695,25 @@ class _HTTPBridgeSession:
 
 
 @dataclass(slots=True)
+class _WebSocketContinuityState:
+    last_completed_input_count: int = 0
+    last_completed_response_id: str | None = None
+    last_completed_input_prefix_fingerprint: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _WebSocketContinuityAnchor:
+    previous_response_id: str
+    stored_input_item_count: int
+
+
+@dataclass(slots=True)
 class _WebSocketUpstreamControl:
     reconnect_requested: bool = False
     suppress_downstream_event: bool = False
     replay_request_state: _WebSocketRequestState | None = None
     downstream_texts: list[str] | None = None
+    seen_tool_call_keys: set[tuple[str, str, str | None, str]] = field(default_factory=set)
 
 
 @dataclass(slots=True)
@@ -8588,6 +8748,132 @@ def _event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonV
     if isinstance(payload_type, str):
         return payload_type
     return None
+
+
+def _websocket_continuity_anchor_for_payload(
+    continuity_state: _WebSocketContinuityState | None,
+    *,
+    responses_payload: ResponsesRequest,
+    codex_session_affinity: bool,
+) -> _WebSocketContinuityAnchor | None:
+    if not codex_session_affinity or continuity_state is None:
+        return None
+    if responses_payload.previous_response_id is not None:
+        return None
+    previous_response_id = continuity_state.last_completed_response_id
+    stored_count = continuity_state.last_completed_input_count
+    stored_fingerprint = continuity_state.last_completed_input_prefix_fingerprint
+    incoming_input = responses_payload.input
+    if (
+        previous_response_id is None
+        or stored_count <= 0
+        or stored_fingerprint is None
+        or not isinstance(incoming_input, list)
+        or len(incoming_input) <= stored_count
+    ):
+        return None
+    incoming_input_list = cast(list[JsonValue], incoming_input)
+    incoming_prefix_fingerprint = _fingerprint_input_items(incoming_input_list[:stored_count])
+    if incoming_prefix_fingerprint != stored_fingerprint:
+        return None
+    return _WebSocketContinuityAnchor(
+        previous_response_id=previous_response_id,
+        stored_input_item_count=stored_count,
+    )
+
+
+def _record_websocket_continuity_completion(
+    continuity_state: _WebSocketContinuityState,
+    *,
+    request_state: _WebSocketRequestState,
+    response_id: str | None,
+) -> None:
+    if response_id is not None:
+        continuity_state.last_completed_response_id = response_id
+    if request_state.input_item_count > 0:
+        continuity_state.last_completed_input_count = request_state.input_item_count
+        continuity_state.last_completed_input_prefix_fingerprint = request_state.input_full_fingerprint
+
+
+async def _wait_for_websocket_continuity_gap(
+    pending_requests: deque[_WebSocketRequestState],
+    *,
+    pending_lock: anyio.Lock,
+    timeout_seconds: float,
+) -> bool:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    while True:
+        async with pending_lock:
+            if not pending_requests:
+                return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        await asyncio.sleep(min(_WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS, remaining))
+
+
+async def _websocket_full_replay_should_wait_for_continuity(
+    request_state: _WebSocketRequestState,
+    pending_requests: deque[_WebSocketRequestState],
+    *,
+    pending_lock: anyio.Lock,
+    codex_session_affinity: bool,
+) -> bool:
+    if (
+        not codex_session_affinity
+        or request_state.previous_response_id is not None
+        or request_state.input_item_count < _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS
+    ):
+        return False
+    async with pending_lock:
+        return bool(pending_requests)
+
+
+def _mark_duplicate_tool_call_downstream_event(
+    payload: dict[str, JsonValue] | None,
+    *,
+    upstream_control: _WebSocketUpstreamControl,
+    response_id: str | None,
+) -> bool:
+    if not isinstance(payload, dict) or payload.get("type") != "response.output_item.done":
+        return False
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        return False
+    item_type = item.get("type")
+    if item_type == "function_call":
+        argument_value = item.get("arguments")
+    elif item_type == "custom_tool_call":
+        argument_value = item.get("input")
+    else:
+        return False
+    if not isinstance(argument_value, str):
+        return False
+    item_name = item.get("name")
+    if item_name is not None and not isinstance(item_name, str):
+        item_name = None
+    key = (response_id or "", str(item_type), item_name, argument_value)
+    if key in upstream_control.seen_tool_call_keys:
+        logger.warning(
+            "Suppressed duplicate websocket tool call response_id=%s item_type=%s name=%s",
+            response_id,
+            item_type,
+            item_name,
+        )
+        return True
+    upstream_control.seen_tool_call_keys.add(key)
+    return False
+
+
+def _websocket_event_dedupe_response_id(
+    response_id: str | None,
+    request_state: _WebSocketRequestState | None,
+) -> str | None:
+    if response_id is not None:
+        return response_id
+    if request_state is None:
+        return None
+    return request_state.response_id or request_state.request_id
 
 
 def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
@@ -8723,6 +9009,11 @@ def _websocket_response_id(event: OpenAIEvent | None, payload: dict[str, JsonVal
         return event.response.id
     if not isinstance(payload, dict):
         return None
+    direct_response_id = payload.get("response_id")
+    if isinstance(direct_response_id, str):
+        stripped_direct_response_id = direct_response_id.strip()
+        if stripped_direct_response_id:
+            return stripped_direct_response_id
     response = payload.get("response")
     if not isinstance(response, dict):
         return None
@@ -8880,6 +9171,15 @@ async def _pop_replayable_precreated_websocket_request_state(
         if request_state.replay_count >= 1:
             return None
         pending_requests.popleft()
+    if (
+        request_state.proxy_injected_previous_response_id
+        and request_state.fresh_upstream_request_is_retry_safe
+        and request_state.fresh_upstream_request_text
+    ):
+        request_state.request_text = request_state.fresh_upstream_request_text
+        request_state.previous_response_id = None
+        request_state.proxy_injected_previous_response_id = False
+        request_state.fresh_upstream_request_is_retry_safe = False
     request_state.replay_count += 1
     request_state.awaiting_response_created = True
     request_state.response_id = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -300,6 +300,44 @@ def _response_create_text(
     return json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
 
 
+def _response_create_retry_text(
+    payload: ResponsesRequest,
+    *,
+    include_type_field: bool,
+    client_metadata: Mapping[str, JsonValue] | None,
+    request_id: str,
+    transport: str,
+) -> str:
+    text_data = _response_create_text(
+        payload,
+        include_type_field=include_type_field,
+        client_metadata=client_metadata,
+    )
+    payload_size = len(text_data.encode("utf-8"))
+    if payload_size > _UPSTREAM_RESPONSE_CREATE_MAX_BYTES:
+        upstream_payload = json.loads(text_data)
+        if isinstance(upstream_payload, dict):
+            slimmed_payload, slim_summary = _slim_response_create_payload_for_upstream(
+                cast(dict[str, JsonValue], upstream_payload),
+                max_bytes=_UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
+            )
+            if slim_summary is not None:
+                text_data = json.dumps(slimmed_payload, ensure_ascii=True, separators=(",", ":"))
+    request_state = _WebSocketRequestState(
+        request_id=request_id,
+        model=payload.model,
+        service_tier=_normalize_service_tier_value(dict(payload.to_payload()).get("service_tier")),
+        reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        previous_response_id=payload.previous_response_id,
+        transport=transport,
+        request_text=text_data,
+    )
+    _enforce_response_create_size_limit(request_state)
+    return text_data
+
+
 class ProxyService:
     def __init__(self, repo_factory: ProxyRepoFactory) -> None:
         self._repo_factory = repo_factory
@@ -2606,20 +2644,29 @@ class ProxyService:
                                     api_key=api_key,
                                     continuity_state=continuity_state,
                                 )
-                                if await _websocket_full_replay_should_wait_for_continuity(
+                                observed_completion_generation = await _websocket_full_replay_continuity_wait_snapshot(
                                     prepared_request.request_state,
                                     pending_requests,
                                     pending_lock=pending_lock,
                                     codex_session_affinity=codex_session_affinity,
-                                ):
+                                    continuity_state=continuity_state,
+                                )
+                                if observed_completion_generation is not None:
                                     await self._release_websocket_reservation(
                                         prepared_request.request_state.api_key_reservation
                                     )
                                     wait_started_at = time.monotonic()
+                                    wait_timeout_seconds = max(
+                                        0.0,
+                                        runtime_settings.proxy_request_budget_seconds
+                                        - (wait_started_at - prepared_request.request_state.started_at),
+                                    )
                                     waited_for_anchor = await _wait_for_websocket_continuity_gap(
                                         pending_requests,
                                         pending_lock=pending_lock,
-                                        timeout_seconds=runtime_settings.proxy_request_budget_seconds,
+                                        timeout_seconds=wait_timeout_seconds,
+                                        continuity_state=continuity_state,
+                                        observed_completion_generation=observed_completion_generation,
                                     )
                                     logger.info(
                                         "websocket_full_replay_waited_for_continuity waited=%s elapsed_ms=%s "
@@ -2628,6 +2675,16 @@ class ProxyService:
                                         int((time.monotonic() - wait_started_at) * 1000),
                                         prepared_request.request_state.input_item_count,
                                     )
+                                    if not waited_for_anchor:
+                                        raise ProxyResponseError(
+                                            502,
+                                            openai_error(
+                                                "upstream_request_timeout",
+                                                "Proxy request budget exhausted",
+                                                error_type="server_error",
+                                            ),
+                                        )
+                                    original_started_at = prepared_request.request_state.started_at
                                     prepared_request = await self._prepare_websocket_response_create_request(
                                         payload,
                                         headers=headers,
@@ -2638,6 +2695,7 @@ class ProxyService:
                                         api_key=api_key,
                                         continuity_state=continuity_state,
                                     )
+                                    prepared_request.request_state.started_at = original_started_at
                                 request_state = prepared_request.request_state
                                 request_affinity = prepared_request.affinity_policy
                                 text_data = prepared_request.text_data
@@ -2990,13 +3048,6 @@ class ProxyService:
                     "input": original_input_items[session_anchor.stored_input_item_count :],
                 }
             )
-        if responses_payload.previous_response_id is not None and isinstance(responses_payload.input, list):
-            previous_response_input_items = cast(list[JsonValue], responses_payload.input)
-            trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
-            if len(trimmed_input_items) != len(previous_response_input_items):
-                previous_response_trimmed_input_count = len(previous_response_input_items)
-                previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
-                responses_payload = responses_payload.model_copy(update={"input": trimmed_input_items})
         reservation = await self._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -3015,6 +3066,7 @@ class ProxyService:
                 transport=_REQUEST_TRANSPORT_WEBSOCKET,
                 client_metadata=client_metadata,
                 session_id=session_id,
+                trim_previous_response_input_items=True,
             )
         except ProxyResponseError:
             await self._release_websocket_reservation(reservation)
@@ -3024,7 +3076,10 @@ class ProxyService:
             request_state.input_item_count = original_input_item_count or request_state.input_item_count
             request_state.input_full_fingerprint = original_input_fingerprint
             request_state.fresh_upstream_request_text = original_full_resend_text
-            request_state.fresh_upstream_request_is_retry_safe = original_full_resend_text is not None
+            request_state.fresh_upstream_request_is_retry_safe = (
+                original_full_resend_text is not None
+                and len(original_full_resend_text.encode("utf-8")) <= _UPSTREAM_RESPONSE_CREATE_MAX_BYTES
+            )
             logger.info(
                 "websocket_session_anchor_injected request_id=%s response_id=%s original_items=%s trimmed_to=%s",
                 request_state.request_id,
@@ -3135,6 +3190,7 @@ class ProxyService:
             client_metadata=_response_create_client_metadata(payload.to_payload(), headers=headers),
             session_id=_owner_lookup_session_id_from_headers(headers),
             request_log_id=request_id or get_request_id() or ensure_request_id(None),
+            trim_previous_response_input_items=True,
         )
 
     def _prepare_response_bridge_request_state(
@@ -3150,9 +3206,19 @@ class ProxyService:
         session_id: str | None = None,
         request_id: str | None = None,
         request_log_id: str | None = None,
+        trim_previous_response_input_items: bool = False,
     ) -> tuple[_WebSocketRequestState, str]:
-        if payload.previous_response_id is not None and isinstance(payload.input, list):
+        input_item_count = 0
+        input_full_fingerprint: str | None = None
+        if (
+            trim_previous_response_input_items
+            and payload.previous_response_id is not None
+            and isinstance(payload.input, list)
+        ):
             input_items = cast(list[JsonValue], payload.input)
+            input_item_count = len(input_items)
+            if input_item_count > 0:
+                input_full_fingerprint = _fingerprint_input_items(input_items)
             trimmed_input_items = _trim_websocket_previous_response_input_items(input_items)
             if len(trimmed_input_items) != len(input_items):
                 payload = payload.model_copy(update={"input": trimmed_input_items})
@@ -3164,10 +3230,8 @@ class ProxyService:
         if client_metadata:
             upstream_payload["client_metadata"] = client_metadata
         forwarded_service_tier = _normalize_service_tier_value(upstream_payload.get("service_tier"))
-        input_item_count = 0
-        input_full_fingerprint: str | None = None
         payload_input = payload.input
-        if isinstance(payload_input, list):
+        if input_item_count == 0 and isinstance(payload_input, list):
             payload_input_list = cast(list[JsonValue], payload_input)
             input_item_count = len(payload_input_list)
             if input_item_count > 0:
@@ -5502,13 +5566,10 @@ class ProxyService:
             # original unanchored request is equivalent to the client's own
             # retry. Session-level injections do not opt in because their
             # payload may depend on the anchor for context preservation.
-            if (
-                not request_state.proxy_injected_previous_response_id
-                or not request_state.fresh_upstream_request_text
-                or not request_state.fresh_upstream_request_is_retry_safe
-            ):
+            if not _request_state_has_safe_fresh_replay(request_state):
                 return False
             retry_text_data = request_state.fresh_upstream_request_text
+            assert retry_text_data is not None
         if request_state.replay_count >= 1:
             return False
         request_state.replay_count += 1
@@ -5529,9 +5590,7 @@ class ProxyService:
             )
             if send_request:
                 if retry_text_data != text_data:
-                    request_state.previous_response_id = None
-                    request_state.proxy_injected_previous_response_id = False
-                    request_state.request_text = retry_text_data
+                    _switch_request_state_to_fresh_replay(request_state)
                 await session.upstream.send_text(retry_text_data)
             session.last_used_at = time.monotonic()
             return True
@@ -5764,13 +5823,6 @@ class ProxyService:
                 release_create_gate = False
             else:
                 release_create_gate = False
-
-            if _mark_duplicate_tool_call_downstream_event(
-                payload,
-                upstream_control=session.upstream_control,
-                response_id=_websocket_event_dedupe_response_id(response_id, matched_request_state),
-            ):
-                return
 
             if matched_request_state is not None:
                 actual_service_tier = _service_tier_from_event_payload(payload)
@@ -6345,13 +6397,6 @@ class ProxyService:
                 release_create_gate = False
             else:
                 release_create_gate = False
-            if _mark_duplicate_tool_call_downstream_event(
-                payload,
-                upstream_control=upstream_control,
-                response_id=_websocket_event_dedupe_response_id(response_id, request_state),
-            ):
-                upstream_control.suppress_downstream_event = True
-                return text
             if request_state is not None:
                 actual_service_tier = _service_tier_from_event_payload(payload)
                 if actual_service_tier is not None:
@@ -6450,10 +6495,13 @@ class ProxyService:
                 payload=payload,
                 has_other_pending_requests=has_other_pending_requests,
             )
+        if retry_is_previous_response_not_found and not _request_state_has_safe_fresh_replay(request_state):
+            retry_error_code = None
         if (
             retry_error_code in _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES
             and request_state.previous_response_id is not None
             and request_state.preferred_account_id is not None
+            and not _request_state_has_safe_fresh_replay(request_state)
         ):
             await self._handle_stream_error(
                 account,
@@ -6466,26 +6514,12 @@ class ProxyService:
             retry_error_code = None
         if retry_error_code is not None:
             if retry_is_previous_response_not_found:
-                if not (
-                    request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text
-                ):
-                    # A short continuation depends entirely on the upstream
-                    # anchor. Replaying the same lost previous_response_id on a
-                    # new websocket just re-surfaces the raw upstream 400; only
-                    # full-resend payloads with a prepared fresh body can be
-                    # transparently retried.
-                    retry_error_code = None
-                else:
-                    upstream_control.reconnect_requested = True
-                    request_state.request_text = request_state.fresh_upstream_request_text
-                    request_state.previous_response_id = None
-                    request_state.proxy_injected_previous_response_id = False
-                    request_state.fresh_upstream_request_is_retry_safe = False
-                    request_state.replay_count += 1
-                    request_state.awaiting_response_created = True
-                    request_state.response_id = None
-                    upstream_control.suppress_downstream_event = True
-                    upstream_control.replay_request_state = request_state
+                _switch_request_state_to_fresh_replay(request_state)
+                request_state.replay_count += 1
+                request_state.awaiting_response_created = True
+                request_state.response_id = None
+                upstream_control.suppress_downstream_event = True
+                upstream_control.replay_request_state = request_state
             else:
                 upstream_control.reconnect_requested = True
                 request_state.replay_count += 1
@@ -8749,6 +8783,7 @@ class _WebSocketContinuityState:
     last_completed_input_count: int = 0
     last_completed_response_id: str | None = None
     last_completed_input_prefix_fingerprint: str | None = None
+    completion_generation: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -8763,7 +8798,6 @@ class _WebSocketUpstreamControl:
     suppress_downstream_event: bool = False
     replay_request_state: _WebSocketRequestState | None = None
     downstream_texts: list[str] | None = None
-    seen_tool_call_keys: set[tuple[str, str, str | None, str]] = field(default_factory=set)
 
 
 @dataclass(slots=True)
@@ -8842,16 +8876,13 @@ def _websocket_continuity_anchor_for_payload(
 
 
 def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
-    first_output_index = next(
-        (index for index, item in enumerate(input_items) if _websocket_input_item_type(item) == "function_call_output"),
-        None,
+    first_non_output_index = next(
+        (index for index, item in enumerate(input_items) if not _is_websocket_previous_response_output_item(item)),
+        len(input_items),
     )
-    if first_output_index is None or first_output_index == 0:
+    if first_non_output_index == 0:
         return input_items
-    prefix = input_items[:first_output_index]
-    if not all(_is_websocket_previous_response_output_item(item) for item in prefix):
-        return input_items
-    return input_items[first_output_index:]
+    return input_items[first_non_output_index:]
 
 
 def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
@@ -8877,11 +8908,23 @@ def _record_websocket_continuity_completion(
     request_state: _WebSocketRequestState,
     response_id: str | None,
 ) -> None:
-    if response_id is not None:
-        continuity_state.last_completed_response_id = response_id
+    if (
+        request_state.input_item_count > 0
+        and continuity_state.last_completed_input_count > 0
+        and request_state.input_item_count < continuity_state.last_completed_input_count
+    ):
+        continuity_state.completion_generation += 1
+        return
     if request_state.input_item_count > 0:
+        if response_id is not None:
+            continuity_state.last_completed_response_id = response_id
         continuity_state.last_completed_input_count = request_state.input_item_count
         continuity_state.last_completed_input_prefix_fingerprint = request_state.input_full_fingerprint
+    elif response_id is not None:
+        continuity_state.last_completed_response_id = response_id
+        continuity_state.last_completed_input_count = 0
+        continuity_state.last_completed_input_prefix_fingerprint = None
+    continuity_state.completion_generation += 1
 
 
 async def _wait_for_websocket_continuity_gap(
@@ -8889,11 +8932,18 @@ async def _wait_for_websocket_continuity_gap(
     *,
     pending_lock: anyio.Lock,
     timeout_seconds: float,
+    continuity_state: _WebSocketContinuityState | None = None,
+    observed_completion_generation: int | None = None,
 ) -> bool:
     deadline = time.monotonic() + max(0.0, timeout_seconds)
     while True:
         async with pending_lock:
-            if not pending_requests:
+            continuity_updated = (
+                continuity_state is None
+                or observed_completion_generation is None
+                or continuity_state.completion_generation != observed_completion_generation
+            )
+            if not pending_requests and continuity_updated:
                 return True
         remaining = deadline - time.monotonic()
         if remaining <= 0:
@@ -8901,57 +8951,25 @@ async def _wait_for_websocket_continuity_gap(
         await asyncio.sleep(min(_WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS, remaining))
 
 
-async def _websocket_full_replay_should_wait_for_continuity(
+async def _websocket_full_replay_continuity_wait_snapshot(
     request_state: _WebSocketRequestState,
     pending_requests: deque[_WebSocketRequestState],
     *,
     pending_lock: anyio.Lock,
     codex_session_affinity: bool,
-) -> bool:
+    continuity_state: _WebSocketContinuityState | None,
+) -> int | None:
     if (
         not codex_session_affinity
-        or request_state.previous_response_id is not None
-        or request_state.input_item_count < _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS
+        or (request_state.previous_response_id is not None and not request_state.proxy_injected_previous_response_id)
+        or not request_state.proxy_injected_previous_response_id
+        or continuity_state is None
     ):
-        return False
+        return None
     async with pending_lock:
-        return bool(pending_requests)
-
-
-def _mark_duplicate_tool_call_downstream_event(
-    payload: dict[str, JsonValue] | None,
-    *,
-    upstream_control: _WebSocketUpstreamControl,
-    response_id: str | None,
-) -> bool:
-    if not isinstance(payload, dict) or payload.get("type") != "response.output_item.done":
-        return False
-    item = payload.get("item")
-    if not isinstance(item, dict):
-        return False
-    item_type = item.get("type")
-    if item_type == "function_call":
-        argument_value = item.get("arguments")
-    elif item_type == "custom_tool_call":
-        argument_value = item.get("input")
-    else:
-        return False
-    if not isinstance(argument_value, str):
-        return False
-    item_name = item.get("name")
-    if item_name is not None and not isinstance(item_name, str):
-        item_name = None
-    key = (response_id or "", str(item_type), item_name, argument_value)
-    if key in upstream_control.seen_tool_call_keys:
-        logger.warning(
-            "Suppressed duplicate websocket tool call response_id=%s item_type=%s name=%s",
-            response_id,
-            item_type,
-            item_name,
-        )
-        return True
-    upstream_control.seen_tool_call_keys.add(key)
-    return False
+        if not pending_requests:
+            return None
+        return continuity_state.completion_generation
 
 
 def _websocket_event_dedupe_response_id(
@@ -9250,20 +9268,32 @@ async def _pop_replayable_precreated_websocket_request_state(
             return None
         if request_state.replay_count >= 1:
             return None
+        if request_state.previous_response_id is not None and not _request_state_has_safe_fresh_replay(request_state):
+            return None
         pending_requests.popleft()
-    if (
-        request_state.proxy_injected_previous_response_id
-        and request_state.fresh_upstream_request_is_retry_safe
-        and request_state.fresh_upstream_request_text
-    ):
-        request_state.request_text = request_state.fresh_upstream_request_text
-        request_state.previous_response_id = None
-        request_state.proxy_injected_previous_response_id = False
-        request_state.fresh_upstream_request_is_retry_safe = False
+    _switch_request_state_to_fresh_replay(request_state)
     request_state.replay_count += 1
     request_state.awaiting_response_created = True
     request_state.response_id = None
     return request_state
+
+
+def _request_state_has_safe_fresh_replay(request_state: _WebSocketRequestState) -> bool:
+    return (
+        request_state.proxy_injected_previous_response_id
+        and request_state.fresh_upstream_request_is_retry_safe
+        and bool(request_state.fresh_upstream_request_text)
+    )
+
+
+def _switch_request_state_to_fresh_replay(request_state: _WebSocketRequestState) -> None:
+    if not _request_state_has_safe_fresh_replay(request_state):
+        return
+    request_state.request_text = request_state.fresh_upstream_request_text
+    request_state.previous_response_id = None
+    request_state.proxy_injected_previous_response_id = False
+    request_state.fresh_upstream_request_is_retry_safe = False
+    _enforce_response_create_size_limit(request_state)
 
 
 def _is_previous_response_not_found_error(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2946,6 +2946,8 @@ class ProxyService:
         original_full_resend_text: str | None = None
         original_input_item_count: int | None = None
         original_input_fingerprint: str | None = None
+        previous_response_trimmed_input_count: int | None = None
+        previous_response_trimmed_input_fingerprint: str | None = None
         session_anchor = _websocket_continuity_anchor_for_payload(
             continuity_state,
             responses_payload=responses_payload,
@@ -2966,6 +2968,13 @@ class ProxyService:
                     "input": original_input_items[session_anchor.stored_input_item_count :],
                 }
             )
+        if responses_payload.previous_response_id is not None and isinstance(responses_payload.input, list):
+            previous_response_input_items = cast(list[JsonValue], responses_payload.input)
+            trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
+            if len(trimmed_input_items) != len(previous_response_input_items):
+                previous_response_trimmed_input_count = len(previous_response_input_items)
+                previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
+                responses_payload = responses_payload.model_copy(update={"input": trimmed_input_items})
         reservation = await self._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -3002,6 +3011,20 @@ class ProxyService:
                 len(cast(list[JsonValue], responses_payload.input))
                 if isinstance(responses_payload.input, list)
                 else None,
+            )
+        elif previous_response_trimmed_input_count is not None:
+            request_state.input_item_count = previous_response_trimmed_input_count
+            request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
+        if previous_response_trimmed_input_count is not None:
+            logger.info(
+                "websocket_previous_response_input_trimmed request_id=%s original_items=%s trimmed_to=%s "
+                "previous_response_id=%s",
+                request_state.request_id,
+                previous_response_trimmed_input_count,
+                len(cast(list[JsonValue], responses_payload.input))
+                if isinstance(responses_payload.input, list)
+                else None,
+                responses_payload.previous_response_id,
             )
         had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
         affinity_policy = _sticky_key_for_responses_request(
@@ -8780,6 +8803,40 @@ def _websocket_continuity_anchor_for_payload(
         previous_response_id=previous_response_id,
         stored_input_item_count=stored_count,
     )
+
+
+def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
+    first_output_index = next(
+        (
+            index
+            for index, item in enumerate(input_items)
+            if _websocket_input_item_type(item) == "function_call_output"
+        ),
+        None,
+    )
+    if first_output_index is None or first_output_index == 0:
+        return input_items
+    prefix = input_items[:first_output_index]
+    if not all(_is_websocket_previous_response_output_item(item) for item in prefix):
+        return input_items
+    return input_items[first_output_index:]
+
+
+def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
+    item_type = _websocket_input_item_type(item)
+    if item_type in {"reasoning", "function_call", "custom_tool_call"}:
+        return True
+    if item_type != "message" or not isinstance(item, dict):
+        return False
+    role = item.get("role")
+    return role == "assistant"
+
+
+def _websocket_input_item_type(item: JsonValue) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    item_type = item.get("type")
+    return item_type if isinstance(item_type, str) else None
 
 
 def _record_websocket_continuity_completion(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -662,7 +662,11 @@ class ProxyService:
                     cache_key_family=bridge_session_key.affinity_kind,
                     model_class=_extract_model_class(payload.model) if payload.model else None,
                 )
-        if effective_payload.previous_response_id is not None and isinstance(effective_payload.input, list):
+        if (
+            proxy_injected_previous_response_id
+            and effective_payload.previous_response_id is not None
+            and isinstance(effective_payload.input, list)
+        ):
             previous_response_input_items = cast(list[JsonValue], effective_payload.input)
             trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
             if len(trimmed_input_items) != len(previous_response_input_items):
@@ -3048,6 +3052,19 @@ class ProxyService:
                     "input": original_input_items[session_anchor.stored_input_item_count :],
                 }
             )
+        elif (
+            responses_payload.previous_response_id is not None
+            and _websocket_client_previous_response_payload_has_safe_fresh_replay(
+                responses_payload,
+                continuity_state=continuity_state,
+            )
+        ):
+            unanchored_payload = responses_payload.model_copy(update={"previous_response_id": None})
+            original_full_resend_text = _response_create_text(
+                unanchored_payload,
+                include_type_field=True,
+                client_metadata=client_metadata,
+            )
         reservation = await self._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -3066,7 +3083,7 @@ class ProxyService:
                 transport=_REQUEST_TRANSPORT_WEBSOCKET,
                 client_metadata=client_metadata,
                 session_id=session_id,
-                trim_previous_response_input_items=True,
+                trim_previous_response_input_items=session_anchor is not None,
             )
         except ProxyResponseError:
             await self._release_websocket_reservation(reservation)
@@ -3088,6 +3105,11 @@ class ProxyService:
                 len(cast(list[JsonValue], responses_payload.input))
                 if isinstance(responses_payload.input, list)
                 else None,
+            )
+        elif original_full_resend_text is not None:
+            request_state.fresh_upstream_request_text = original_full_resend_text
+            request_state.fresh_upstream_request_is_retry_safe = (
+                len(original_full_resend_text.encode("utf-8")) <= _UPSTREAM_RESPONSE_CREATE_MAX_BYTES
             )
         elif previous_response_trimmed_input_count is not None:
             request_state.input_item_count = previous_response_trimmed_input_count
@@ -3179,6 +3201,7 @@ class ProxyService:
         api_key: ApiKeyData | None,
         api_key_reservation: ApiKeyUsageReservationData | None,
         request_id: str | None = None,
+        trim_previous_response_input_items: bool = False,
     ) -> tuple[_WebSocketRequestState, str]:
         return self._prepare_response_bridge_request_state(
             payload,
@@ -3190,7 +3213,7 @@ class ProxyService:
             client_metadata=_response_create_client_metadata(payload.to_payload(), headers=headers),
             session_id=_owner_lookup_session_id_from_headers(headers),
             request_log_id=request_id or get_request_id() or ensure_request_id(None),
-            trim_previous_response_input_items=True,
+            trim_previous_response_input_items=trim_previous_response_input_items,
         )
 
     def _prepare_response_bridge_request_state(
@@ -8694,15 +8717,11 @@ class _WebSocketRequestState:
     session_id: str | None = None
     proxy_injected_previous_response_id: bool = False
     fresh_upstream_request_text: str | None = None
-    # True only when ``fresh_upstream_request_text`` contains a *safe* pre-
-    # injection form of this request that can be replayed as a fresh turn.
-    # Durable-anchor injection captures the original unanchored full-resend
-    # payload, so dropping the anchor and replaying is equivalent to the
-    # client's own retry. Session-level anchor injection does **not** set
-    # this: the original payload may have omitted history the conversation
-    # depended on (for example a single-item follow-up whose context came
-    # entirely from the injected anchor), and dropping the anchor there
-    # would silently turn a continuation into a context-free fresh turn.
+    # True only when ``fresh_upstream_request_text`` contains a safe fresh-turn
+    # form of this request. Proxy-injected full-replay anchors and client-
+    # supplied full-resend anchors can opt in; session-level short-follow-up
+    # injections do not because their payload may depend on the anchor for
+    # context preservation.
     fresh_upstream_request_is_retry_safe: bool = False
     request_stage: str = "first_turn"
     preferred_account_id: str | None = None
@@ -9279,11 +9298,7 @@ async def _pop_replayable_precreated_websocket_request_state(
 
 
 def _request_state_has_safe_fresh_replay(request_state: _WebSocketRequestState) -> bool:
-    return (
-        request_state.proxy_injected_previous_response_id
-        and request_state.fresh_upstream_request_is_retry_safe
-        and bool(request_state.fresh_upstream_request_text)
-    )
+    return request_state.fresh_upstream_request_is_retry_safe and bool(request_state.fresh_upstream_request_text)
 
 
 def _switch_request_state_to_fresh_replay(request_state: _WebSocketRequestState) -> None:
@@ -10486,6 +10501,59 @@ def _http_bridge_payload_looks_like_full_resend(payload: ResponsesRequest) -> bo
             except TypeError:
                 return False
     return False
+
+
+def _websocket_client_previous_response_payload_has_safe_fresh_replay(
+    payload: ResponsesRequest,
+    *,
+    continuity_state: _WebSocketContinuityState | None,
+) -> bool:
+    if (
+        continuity_state is None
+        or payload.previous_response_id is None
+        or payload.previous_response_id != continuity_state.last_completed_response_id
+        or continuity_state.last_completed_input_count <= 0
+        or continuity_state.last_completed_input_prefix_fingerprint is None
+    ):
+        return False
+    input_value = payload.input
+    if not isinstance(input_value, Sequence) or isinstance(input_value, (str, bytes, bytearray)):
+        return False
+    stored_count = continuity_state.last_completed_input_count
+    if len(input_value) <= stored_count:
+        return False
+    incoming_prefix = cast(Sequence[JsonValue], input_value[:stored_count])
+    if _fingerprint_input_items(incoming_prefix) != continuity_state.last_completed_input_prefix_fingerprint:
+        return False
+
+    seen_function_calls: set[str] = set()
+    seen_tool_calls: set[str] = set()
+    for item in input_value:
+        if not isinstance(item, Mapping):
+            continue
+        item_type = item.get("type")
+        if item_type == "function_call":
+            call_id = item.get("call_id")
+            if isinstance(call_id, str) and call_id:
+                seen_function_calls.add(call_id)
+        elif item_type == "function_call_output":
+            call_id = item.get("call_id")
+            if not isinstance(call_id, str) or call_id not in seen_function_calls:
+                return False
+        elif item.get("role") == "assistant":
+            tool_calls = item.get("tool_calls")
+            if isinstance(tool_calls, Sequence) and not isinstance(tool_calls, (str, bytes, bytearray)):
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, Mapping):
+                        continue
+                    call_id = tool_call.get("id") or tool_call.get("call_id") or tool_call.get("tool_call_id")
+                    if isinstance(call_id, str) and call_id:
+                        seen_tool_calls.add(call_id)
+        elif item.get("role") == "tool":
+            call_id = item.get("tool_call_id") or item.get("toolCallId") or item.get("call_id")
+            if not isinstance(call_id, str) or call_id not in seen_tool_calls:
+                return False
+    return True
 
 
 def _truncate_identifier(value: str, *, max_length: int = 96) -> str:

--- a/openspec/changes/document-websocket-replay-trimming/proposal.md
+++ b/openspec/changes/document-websocket-replay-trimming/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+Responses websocket continuity can receive client-side full replay payloads after the proxy has already preserved upstream continuity metadata. Without a documented contract, future compatibility work can accidentally forward anchored assistant/tool-call history back upstream or retry an oversized full replay as if it were a safe fresh request.
+
+## What Changes
+
+- Document that websocket full-replay anchoring trims previously completed upstream output items before forwarding the request.
+- Document that transparent fresh replay after `previous_response_not_found` is allowed only when the original payload remains within the upstream request size budget.
+- Add regression coverage for replay trimming, injected-anchor waits, duplicate tool-call suppression, and safe fresh replay.
+
+## Impact
+
+- Affected code: `app/modules/proxy/service.py`
+- Affected tests: `tests/unit/test_proxy_utils.py`
+- Affected API: websocket Responses proxying and HTTP bridge request preparation metadata.

--- a/openspec/changes/document-websocket-replay-trimming/specs/responses-api-compat/spec.md
+++ b/openspec/changes/document-websocket-replay-trimming/specs/responses-api-compat/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Websocket Responses full replay trims completed upstream output
+When the proxy converts a client-side websocket full replay into a continuity-preserving upstream request, it MUST remove leading input items that represent already-completed upstream output for the injected `previous_response_id`. The proxy MUST keep the original input item count and prefix fingerprint for continuity metadata before request-payload trimming so later replay detection still compares against the client-visible full history.
+
+#### Scenario: anchored replay drops previous assistant output before forwarding
+- **WHEN** a websocket Responses request omits `previous_response_id`
+- **AND** its input starts with assistant output or tool-call output items from the last completed upstream response
+- **AND** the stored input prefix fingerprint matches that completed response
+- **THEN** the proxy injects the completed `previous_response_id`
+- **AND** forwards only the new trailing input items to upstream
+- **AND** stores continuity metadata using the original untrimmed input count and fingerprint
+
+#### Scenario: injected anchors wait for pending continuity metadata
+- **WHEN** a websocket request can be anchored from a full replay
+- **AND** another in-flight request still owns the continuity metadata needed for that anchor
+- **THEN** the proxy waits within the remaining upstream request budget before forwarding the anchored request
+- **AND** it fails with a retryable upstream timeout if the continuity metadata is still unavailable when the budget expires
+
+#### Scenario: safe fresh replay is size bounded
+- **WHEN** upstream reports `previous_response_not_found` for a proxy-injected replay anchor
+- **AND** the original full replay payload can be resent within the upstream request size limit
+- **THEN** the proxy MAY retry as a fresh full replay without the injected anchor
+- **AND** it MUST NOT mark oversized original full replay payloads as retry-safe

--- a/openspec/changes/document-websocket-replay-trimming/tasks.md
+++ b/openspec/changes/document-websocket-replay-trimming/tasks.md
@@ -1,0 +1,16 @@
+## 1. Specification
+
+- [x] 1.1 Add Responses websocket replay-trimming contract to OpenSpec.
+- [x] 1.2 Capture safe fresh replay limits for injected continuity anchors.
+
+## 2. Implementation
+
+- [x] 2.1 Trim leading previous-response output items before forwarding anchored websocket full replay payloads.
+- [x] 2.2 Preserve original input fingerprints/counts for continuity metadata before trimming request payloads.
+- [x] 2.3 Wait for pending continuity metadata before using proxy-injected anchors.
+- [x] 2.4 Bound downstream tool-call duplicate suppression state.
+
+## 3. Verification
+
+- [x] 3.1 Add targeted replay, continuity, and duplicate-tool-call regression tests.
+- [x] 3.2 Run focused proxy utility tests and static checks.

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1061,7 +1061,7 @@ def test_backend_responses_websocket_trims_replayed_tool_call_items_with_previou
                 "type": "function_call",
                 "call_id": "call_repeat",
                 "name": "exec_command",
-                "arguments": "{\"cmd\":\"date\"}",
+                "arguments": '{"cmd":"date"}',
             },
             {
                 "type": "function_call_output",

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -983,6 +983,114 @@ def test_backend_responses_websocket_forwards_previous_response_id(app_instance,
     ]
 
 
+def test_backend_responses_websocket_trims_replayed_tool_call_items_with_previous_response_id(
+    app_instance,
+    monkeypatch,
+):
+    fake_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": "resp_ws_tool_output", "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.completed", "response": {"id": "resp_ws_tool_output", "status": "completed"}},
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+    ):
+        del self, headers, sticky_key, sticky_kind, prefer_earlier_reset, routing_strategy, model
+        del request_state, api_key, client_send_lock, websocket, reallocate_sticky, sticky_max_age_seconds
+        return SimpleNamespace(id="acct_ws_tool_output"), fake_upstream
+
+    async def fake_write_request_log(self, **kwargs):
+        del self, kwargs
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "previous_response_id": "resp_prev_tool_call",
+        "input": [
+            {"type": "reasoning", "summary": []},
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "running command"}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_repeat",
+                "name": "exec_command",
+                "arguments": "{\"cmd\":\"date\"}",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_repeat",
+                "output": "Wed May 6 16:00:00 UTC 2026",
+            },
+        ],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            first = json.loads(websocket.receive_text())
+            second = json.loads(websocket.receive_text())
+
+    assert first["type"] == "response.created"
+    assert second["type"] == "response.completed"
+    sent_payload = json.loads(fake_upstream.sent_text[0])
+    assert sent_payload["previous_response_id"] == "resp_prev_tool_call"
+    assert sent_payload["input"] == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_repeat",
+            "output": "Wed May 6 16:00:00 UTC 2026",
+        }
+    ]
+
+
 def test_v1_responses_websocket_forwards_previous_response_id(app_instance, monkeypatch):
     fake_upstream = _FakeUpstreamWebSocket(
         [

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -983,7 +983,7 @@ def test_backend_responses_websocket_forwards_previous_response_id(app_instance,
     ]
 
 
-def test_backend_responses_websocket_trims_replayed_tool_call_items_with_previous_response_id(
+def test_backend_responses_websocket_preserves_client_previous_response_leading_items(
     app_instance,
     monkeypatch,
 ):
@@ -1083,11 +1083,23 @@ def test_backend_responses_websocket_trims_replayed_tool_call_items_with_previou
     sent_payload = json.loads(fake_upstream.sent_text[0])
     assert sent_payload["previous_response_id"] == "resp_prev_tool_call"
     assert sent_payload["input"] == [
+        {"type": "reasoning", "summary": []},
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "running command"}],
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_repeat",
+            "name": "exec_command",
+            "arguments": '{"cmd":"date"}',
+        },
         {
             "type": "function_call_output",
             "call_id": "call_repeat",
             "output": "Wed May 6 16:00:00 UTC 2026",
-        }
+        },
     ]
 
 
@@ -1489,7 +1501,7 @@ def test_v1_responses_websocket_marks_fresh_turn_as_retry_safe_at_prep_time(
     assert connect_record[0]["fresh_upstream_request_text_set"] is True
 
 
-def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_retry(
+def test_v1_responses_websocket_retries_full_resend_previous_response_miss_without_anchor(
     app_instance,
     monkeypatch,
 ):
@@ -1538,6 +1550,33 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
             ],
         ],
     )
+    recovered_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.created",
+                            "response": {"id": "resp_ws_full_replay_retry", "status": "in_progress"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_ws_full_replay_retry", "status": "completed"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+            ]
+        ],
+    )
     connect_count = 0
 
     class _FakeSettingsCache:
@@ -1583,7 +1622,9 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
         )
         nonlocal connect_count
         connect_count += 1
-        return SimpleNamespace(id="acct_ws_prev_mask"), first_upstream
+        if connect_count == 1:
+            return SimpleNamespace(id="acct_ws_prev_mask"), first_upstream
+        return SimpleNamespace(id="acct_ws_prev_mask"), recovered_upstream
 
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
     monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
@@ -1603,7 +1644,7 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
                     {
                         "type": "response.create",
                         "model": "gpt-5.4",
-                        "input": "hello",
+                        "input": full_resend_input[:1],
                         "stream": True,
                     }
                 )
@@ -1624,13 +1665,18 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
                     }
                 )
             )
-            failed_2 = json.loads(websocket.receive_text())
+            created_2 = json.loads(websocket.receive_text())
+            completed_2 = json.loads(websocket.receive_text())
 
-    assert failed_2["type"] == "response.failed"
-    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert "previous_response_not_found" not in json.dumps(failed_2)
-    assert connect_count == 1
+    assert created_2["type"] == "response.created"
+    assert created_2["response"]["id"] == "resp_ws_full_replay_retry"
+    assert completed_2["type"] == "response.completed"
+    assert "previous_response_not_found" not in json.dumps([created_2, completed_2])
+    assert connect_count == 2
     assert json.loads(first_upstream.sent_text[-1])["previous_response_id"] == "resp_ws_prev_anchor"
+    replay_payload = json.loads(recovered_upstream.sent_text[-1])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["input"] == full_resend_input
 
 
 def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_without_unsafe_retry(

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1183,7 +1183,7 @@ def test_v1_responses_websocket_forwards_previous_response_id(app_instance, monk
     ]
 
 
-def test_v1_responses_websocket_masks_short_previous_response_not_found_without_retry(
+def test_v1_responses_websocket_masks_client_previous_response_not_found_without_unsafe_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1338,11 +1338,10 @@ def test_v1_responses_websocket_masks_short_previous_response_not_found_without_
             failed_2 = json.loads(websocket.receive_text())
 
     assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["status"] == "failed"
     assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
-    assert "previous_response_not_found" not in json.dumps(failed_2)
-    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
     assert connect_count == 1
+    assert first_upstream.closed is True
 
 
 def test_v1_responses_websocket_marks_fresh_turn_as_retry_safe_at_prep_time(
@@ -1634,7 +1633,7 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
     assert json.loads(first_upstream.sent_text[-1])["previous_response_id"] == "resp_ws_prev_anchor"
 
 
-def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_without_retry(
+def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_without_unsafe_retry(
     app_instance,
     monkeypatch,
 ):
@@ -1789,11 +1788,10 @@ def test_v1_responses_websocket_masks_invalid_request_previous_response_not_foun
             failed_2 = json.loads(websocket.receive_text())
 
     assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["status"] == "failed"
     assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
-    assert "previous_response_not_found" not in json.dumps(failed_2)
-    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
     assert connect_count == 1
+    assert first_upstream.closed is True
 
 
 def test_backend_responses_websocket_connect_failure_masks_previous_response_not_found(
@@ -1913,7 +1911,7 @@ def test_backend_responses_websocket_connect_failure_masks_previous_response_not
     assert event["error"]["message"] == "Upstream websocket closed before response.completed"
 
 
-def test_backend_responses_websocket_masks_short_previous_response_not_found_without_retry(
+def test_backend_responses_websocket_masks_client_previous_response_not_found_without_unsafe_retry(
     app_instance,
     monkeypatch,
 ):
@@ -2092,12 +2090,11 @@ def test_backend_responses_websocket_masks_short_previous_response_not_found_wit
             failed_2 = json.loads(websocket.receive_text())
 
     assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["status"] == "failed"
     assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
-    assert "previous_response_not_found" not in json.dumps(failed_2)
-    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
     assert connect_count == 1
     assert captured_preferred_accounts == [None]
+    assert first_upstream.closed is True
 
 
 def test_backend_responses_websocket_masks_anonymous_previous_response_not_found_with_inflight_request(
@@ -2265,7 +2262,7 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
     assert fake_upstream.closed is True
 
 
-def test_backend_responses_websocket_masks_previous_response_not_found_when_message_omits_response_id(
+def test_backend_responses_websocket_masks_previous_response_not_found_message_without_unsafe_retry(
     app_instance,
     monkeypatch,
 ):
@@ -2434,11 +2431,11 @@ def test_backend_responses_websocket_masks_previous_response_not_found_when_mess
             failed_2 = json.loads(websocket.receive_text())
 
     assert failed_2["type"] == "response.failed"
+    assert failed_2["response"]["status"] == "failed"
     assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
     assert "previous_response_not_found" not in json.dumps(failed_2)
-    assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
     assert connect_count == 1
+    assert first_upstream.closed is True
 
 
 def test_backend_responses_websocket_keeps_session_alive_after_foreign_previous_response_not_found(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -572,6 +572,34 @@ def test_http_bridge_owner_check_required_enables_sticky_thread_in_gateway_safe_
     assert proxy_service._http_bridge_owner_check_required(key, gateway_safe_mode=True) is True
 
 
+def test_prepare_http_bridge_request_trims_replayed_tool_call_items_with_previous_response_id() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "previous_response_id": "resp_prev_tool_call",
+            "input": [
+                {"type": "function_call", "call_id": "call_repeat", "name": "exec_command", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "call_repeat", "output": "ok"},
+            ],
+        }
+    )
+
+    request_state, text_data = service._prepare_http_bridge_request(
+        payload,
+        {},
+        api_key=None,
+        api_key_reservation=None,
+        request_id="req-trim-direct",
+    )
+
+    sent_payload = json.loads(text_data)
+    assert request_state.previous_response_id == "resp_prev_tool_call"
+    assert sent_payload["previous_response_id"] == "resp_prev_tool_call"
+    assert sent_payload["input"] == [{"type": "function_call_output", "call_id": "call_repeat", "output": "ok"}]
+
+
 @pytest.mark.asyncio
 async def test_select_account_with_budget_prefers_durable_account_id_when_available(
     monkeypatch: pytest.MonkeyPatch,
@@ -871,7 +899,7 @@ async def test_stream_via_http_bridge_trims_replayed_tool_call_items_with_previo
                     "type": "function_call",
                     "call_id": "call_repeat",
                     "name": "exec_command",
-                    "arguments": "{\"cmd\":\"date\"}",
+                    "arguments": '{"cmd":"date"}',
                 },
                 {
                     "type": "function_call_output",

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -572,7 +572,7 @@ def test_http_bridge_owner_check_required_enables_sticky_thread_in_gateway_safe_
     assert proxy_service._http_bridge_owner_check_required(key, gateway_safe_mode=True) is True
 
 
-def test_prepare_http_bridge_request_trims_replayed_tool_call_items_with_previous_response_id() -> None:
+def test_prepare_http_bridge_request_preserves_client_previous_response_leading_items() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     payload = proxy_service.ResponsesRequest.model_validate(
         {
@@ -597,7 +597,10 @@ def test_prepare_http_bridge_request_trims_replayed_tool_call_items_with_previou
     sent_payload = json.loads(text_data)
     assert request_state.previous_response_id == "resp_prev_tool_call"
     assert sent_payload["previous_response_id"] == "resp_prev_tool_call"
-    assert sent_payload["input"] == [{"type": "function_call_output", "call_id": "call_repeat", "output": "ok"}]
+    assert sent_payload["input"] == [
+        {"type": "function_call", "call_id": "call_repeat", "name": "exec_command", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_repeat", "output": "ok"},
+    ]
 
 
 @pytest.mark.asyncio
@@ -879,7 +882,7 @@ async def test_stream_via_http_bridge_injects_durable_previous_response_anchor(
 
 
 @pytest.mark.asyncio
-async def test_stream_via_http_bridge_trims_replayed_tool_call_items_with_previous_response_id(
+async def test_stream_via_http_bridge_preserves_client_previous_response_leading_items(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
@@ -1001,13 +1004,7 @@ async def test_stream_via_http_bridge_trims_replayed_tool_call_items_with_previo
     ]
 
     assert chunks == []
-    assert captured_input == [
-        {
-            "type": "function_call_output",
-            "call_id": "call_repeat",
-            "output": "Wed May 6 16:00:00 UTC 2026",
-        }
-    ]
+    assert captured_input == cast(list[proxy_service.JsonValue], payload.input)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -851,6 +851,138 @@ async def test_stream_via_http_bridge_injects_durable_previous_response_anchor(
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_trims_replayed_tool_call_items_with_previous_response_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "previous_response_id": "resp_prev_tool_call",
+            "input": [
+                {"type": "reasoning", "summary": []},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "running command"}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_repeat",
+                    "name": "exec_command",
+                    "arguments": "{\"cmd\":\"date\"}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_repeat",
+                    "output": "Wed May 6 16:00:00 UTC 2026",
+                },
+            ],
+        }
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-trim-tool-call",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    await event_queue.put(None)
+    captured_input: list[proxy_service.JsonValue] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id
+        assert isinstance(prepared_payload.input, list)
+        captured_input[:] = cast(list[proxy_service.JsonValue], prepared_payload.input)
+        request_state.previous_response_id = prepared_payload.previous_response_id
+        return request_state, json.dumps({"type": "response.create", "input": prepared_payload.input})
+
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=session))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"x-codex-session-id": "sid-123"},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == []
+    assert captured_input == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_repeat",
+            "output": "Wed May 6 16:00:00 UTC 2026",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_does_not_inject_session_anchor_for_soft_reuse(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5375,6 +5375,69 @@ async def test_prepare_websocket_response_create_request_trims_codex_session_ful
 
 
 @pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_rejects_incomplete_session_anchor_fresh_retry(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_trim_partial_replay",
+        name="ws-trim-partial-replay",
+        key_prefix="sk-ws-trim-partial",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    historical_input: list[JsonValue] = [{"role": "user", "content": [{"type": "input_text", "text": "old question"}]}]
+    new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=len(historical_input),
+        last_completed_response_id="resp_completed_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [*historical_input, new_input],
+            },
+        ),
+        headers={"session_id": "turn_ws_trim"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_completed_anchor"
+    assert upstream_payload["input"] == [new_input]
+    assert prepared.request_state.proxy_injected_previous_response_id is True
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
+    assert prepared.request_state.fresh_upstream_request_text is None
+
+
+@pytest.mark.asyncio
 async def test_prepare_websocket_response_create_request_preserves_client_previous_response_output(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     reserve_usage = AsyncMock(return_value=None)
@@ -5750,12 +5813,49 @@ def test_trim_websocket_previous_response_input_items_drops_leading_text_output(
 
     trimmed = proxy_service._trim_websocket_previous_response_input_items(
         [
-            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "old answer"}]},
+            {"role": "assistant", "content": "old answer"},
+            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "old answer 2"}]},
             next_input,
         ]
     )
 
     assert trimmed == [next_input]
+
+
+def test_trim_websocket_previous_response_input_items_drops_protocol_output_types():
+    next_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+
+    trimmed = proxy_service._trim_websocket_previous_response_input_items(
+        [
+            {"type": "reasoning", "summary": []},
+            {"type": "function_call", "call_id": "call_old", "name": "exec_command", "arguments": "{}"},
+            {"type": "web_search_call", "id": "ws_old", "status": "completed"},
+            {"type": "file_search_call", "id": "fs_old", "status": "completed"},
+            {"type": "computer_call", "id": "computer_old", "status": "completed"},
+            {"type": "code_interpreter_call", "id": "ci_old", "status": "completed"},
+            {"type": "mcp_approval_request", "id": "mcp_approval_old"},
+            {"type": "mcp_list_tools", "id": "mcp_tools_old"},
+            {"type": "output_image", "id": "img_old"},
+            next_input,
+        ]
+    )
+
+    assert trimmed == [next_input]
+
+
+def test_trim_websocket_previous_response_input_items_preserves_tool_output():
+    tool_output: JsonValue = {"type": "function_call_output", "call_id": "call_old", "output": "ok"}
+    next_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
+
+    trimmed = proxy_service._trim_websocket_previous_response_input_items(
+        [
+            {"type": "function_call", "call_id": "call_old", "name": "exec_command", "arguments": "{}"},
+            tool_output,
+            next_input,
+        ]
+    )
+
+    assert trimmed == [tool_output, next_input]
 
 
 @pytest.mark.asyncio
@@ -5784,6 +5884,26 @@ async def test_websocket_full_replay_waits_for_pending_continuity_gap():
     assert (
         await proxy_service._websocket_full_replay_continuity_wait_snapshot(
             next_request,
+            pending_requests,
+            pending_lock=pending_lock,
+            codex_session_affinity=True,
+            continuity_state=continuity_state,
+        )
+        == 0
+    )
+    small_fresh_replay = proxy_service._WebSocketRequestState(
+        request_id="ws_small_fresh_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=2,
+    )
+
+    assert (
+        await proxy_service._websocket_full_replay_continuity_wait_snapshot(
+            small_fresh_replay,
             pending_requests,
             pending_lock=pending_lock,
             codex_session_affinity=True,
@@ -8837,6 +8957,84 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
 
 
 @pytest.mark.asyncio
+async def test_process_upstream_websocket_text_retries_safe_previous_response_transient_as_fresh(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_prev_transient_retry")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "instructions": "",
+        "previous_response_id": "resp_anchor",
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "first"}]},
+            {"role": "assistant", "content": [{"type": "output_text", "text": "first answer"}]},
+            {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+        ],
+    }
+    fresh_request_payload = dict(request_payload)
+    fresh_request_payload.pop("previous_response_id")
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_transient_retry",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(request_payload, separators=(",", ":")),
+        previous_response_id="resp_anchor",
+        preferred_account_id=account.id,
+        fresh_upstream_request_text=json.dumps(fresh_request_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=True,
+        proxy_injected_previous_response_id=True,
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_text = json.dumps(
+        {
+            "type": "error",
+            "status": 429,
+            "error": {
+                "type": "rate_limit_exceeded",
+                "code": "rate_limit_exceeded",
+                "message": "slow down",
+            },
+        },
+        separators=(",", ":"),
+    )
+
+    downstream_text = await service._process_upstream_websocket_text(
+        upstream_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"code":"rate_limit_exceeded"' in downstream_text
+    finalize_request_state.assert_not_awaited()
+    handle_stream_error.assert_awaited_once()
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.replay_request_state is pending_request
+    assert pending_request.replay_count == 1
+    assert pending_request.previous_response_id is None
+    assert pending_request.proxy_injected_previous_response_id is False
+    assert pending_request.fresh_upstream_request_is_retry_safe is False
+    assert pending_request.request_text == json.dumps(fresh_request_payload, separators=(",", ":"))
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_does_not_retry_unsafe_previous_response_anchor(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -11150,7 +11348,6 @@ def test_classify_upstream_close_rejected_only_for_clean_close_before_any_respon
         proxy_service._classify_upstream_close(
             1000,
             request_response_events_seen=0,
-            upstream_response_events_seen=0,
         )
         == "rejected"
     )
@@ -11158,15 +11355,6 @@ def test_classify_upstream_close_rejected_only_for_clean_close_before_any_respon
         proxy_service._classify_upstream_close(
             1000,
             request_response_events_seen=1,
-            upstream_response_events_seen=1,
-        )
-        == "transient"
-    )
-    assert (
-        proxy_service._classify_upstream_close(
-            1000,
-            request_response_events_seen=0,
-            upstream_response_events_seen=1,
         )
         == "transient"
     )
@@ -11174,7 +11362,6 @@ def test_classify_upstream_close_rejected_only_for_clean_close_before_any_respon
         proxy_service._classify_upstream_close(
             1011,
             request_response_events_seen=0,
-            upstream_response_events_seen=0,
         )
         == "transient"
     )

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5373,7 +5373,7 @@ async def test_prepare_websocket_response_create_request_trims_codex_session_ful
 
 
 @pytest.mark.asyncio
-async def test_prepare_websocket_response_create_request_trims_client_previous_response_output(monkeypatch):
+async def test_prepare_websocket_response_create_request_preserves_client_previous_response_output(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     reserve_usage = AsyncMock(return_value=None)
     api_key = ApiKeyData(
@@ -5428,11 +5428,71 @@ async def test_prepare_websocket_response_create_request_trims_client_previous_r
 
     upstream_payload = json.loads(prepared.text_data)
     assert upstream_payload["previous_response_id"] == "resp_client_anchor"
-    assert upstream_payload["input"] == [tool_output]
+    assert upstream_payload["input"] == [assistant_output, tool_output]
     assert prepared.request_state.input_item_count == 2
     assert prepared.request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
         [assistant_output, tool_output]
     )
+    assert prepared.request_state.proxy_injected_previous_response_id is False
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
+    assert prepared.request_state.fresh_upstream_request_text is None
+
+
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_rejects_orphan_tool_output_fresh_retry(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_client_prev_tool_tail",
+        name="ws-client-prev-tool-tail",
+        key_prefix="sk-ws-client-prev-tool",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    tool_output: JsonValue = {"type": "function_call_output", "call_id": "call_prev", "output": "old output"}
+    user_tail: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "now continue"}]}
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_client_anchor",
+                "input": [tool_output, user_tail],
+            },
+        ),
+        headers={},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_client_anchor"
+    assert upstream_payload["input"] == [tool_output, user_tail]
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
+    assert prepared.request_state.fresh_upstream_request_text is None
 
 
 def test_websocket_continuity_state_reuses_codex_session_scope():
@@ -5524,7 +5584,7 @@ def test_prepare_http_bridge_request_state_preserves_client_previous_response_in
     assert request_state.input_item_count == 2
 
 
-def test_prepare_http_bridge_request_trims_replayed_tool_call_items_with_previous_response_id():
+def test_prepare_http_bridge_request_preserves_client_previous_response_leading_items():
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     assistant_output: JsonValue = {
         "type": "message",
@@ -5550,7 +5610,7 @@ def test_prepare_http_bridge_request_trims_replayed_tool_call_items_with_previou
 
     upstream_payload = json.loads(text_data)
     assert upstream_payload["previous_response_id"] == "resp_client_supplied"
-    assert upstream_payload["input"] == [tool_output, user_input]
+    assert upstream_payload["input"] == [assistant_output, tool_output, user_input]
     assert request_state.input_item_count == 3
     assert request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
         [assistant_output, tool_output, user_input]

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5372,6 +5372,69 @@ async def test_prepare_websocket_response_create_request_trims_codex_session_ful
     assert fresh_payload["input"] == [*historical_input, new_input]
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_trims_client_previous_response_output(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_client_prev_trim",
+        name="ws-client-prev-trim",
+        key_prefix="sk-ws-client-prev",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    assistant_output: JsonValue = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "old answer"}],
+    }
+    tool_output: JsonValue = {"type": "function_call_output", "call_id": "call_old", "output": "old output"}
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_client_anchor",
+                "input": [assistant_output, tool_output],
+            },
+        ),
+        headers={},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_client_anchor"
+    assert upstream_payload["input"] == [tool_output]
+    assert prepared.request_state.input_item_count == 2
+    assert prepared.request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
+        [assistant_output, tool_output]
+    )
+
+
 def test_websocket_continuity_state_reuses_codex_session_scope():
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
 
@@ -5398,6 +5461,115 @@ def test_websocket_continuity_state_reuses_codex_session_scope():
     assert unscoped is not first
 
 
+def test_prepare_http_bridge_request_state_keeps_original_input_fingerprint_after_trim():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    historical_input: list[JsonValue] = [
+        {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "old answer"}]},
+        {"type": "function_call_output", "call_id": "call_old", "output": "old output"},
+    ]
+    new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    payload = ResponsesRequest(
+        model="gpt-5.1",
+        instructions="test",
+        previous_response_id="resp_anchor",
+        input=[*historical_input, new_input],
+    )
+
+    request_state, text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=proxy_service._REQUEST_TRANSPORT_HTTP,
+        client_metadata=None,
+        trim_previous_response_input_items=True,
+    )
+
+    upstream_payload = json.loads(text_data)
+    assert upstream_payload["input"] == [historical_input[1], new_input]
+    assert request_state.input_item_count == 3
+    assert request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
+        [*historical_input, new_input]
+    )
+
+
+def test_prepare_http_bridge_request_state_preserves_client_previous_response_input_by_default():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    assistant_input: JsonValue = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "new assistant context"}],
+    }
+    user_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    payload = ResponsesRequest(
+        model="gpt-5.1",
+        instructions="test",
+        previous_response_id="resp_client_supplied",
+        input=[assistant_input, user_input],
+    )
+
+    request_state, text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=proxy_service._REQUEST_TRANSPORT_HTTP,
+        client_metadata=None,
+    )
+
+    upstream_payload = json.loads(text_data)
+    assert upstream_payload["input"] == [assistant_input, user_input]
+    assert request_state.input_item_count == 2
+
+
+def test_prepare_http_bridge_request_trims_replayed_tool_call_items_with_previous_response_id():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    assistant_output: JsonValue = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "old answer"}],
+    }
+    tool_output: JsonValue = {"type": "function_call_output", "call_id": "call_old", "output": "old output"}
+    user_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    payload = ResponsesRequest(
+        model="gpt-5.1",
+        instructions="test",
+        previous_response_id="resp_client_supplied",
+        input=[assistant_output, tool_output, user_input],
+    )
+
+    request_state, text_data = service._prepare_http_bridge_request(
+        payload,
+        headers={},
+        api_key=None,
+        api_key_reservation=None,
+        request_id="req_http_trim_previous",
+    )
+
+    upstream_payload = json.loads(text_data)
+    assert upstream_payload["previous_response_id"] == "resp_client_supplied"
+    assert upstream_payload["input"] == [tool_output, user_input]
+    assert request_state.input_item_count == 3
+    assert request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
+        [assistant_output, tool_output, user_input]
+    )
+
+
+def test_trim_websocket_previous_response_input_items_drops_leading_text_output():
+    next_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+
+    trimmed = proxy_service._trim_websocket_previous_response_input_items(
+        [
+            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "old answer"}]},
+            next_input,
+        ]
+    )
+
+    assert trimmed == [next_input]
+
+
 @pytest.mark.asyncio
 async def test_websocket_full_replay_waits_for_pending_continuity_gap():
     pending_request = proxy_service._WebSocketRequestState(
@@ -5419,87 +5591,169 @@ async def test_websocket_full_replay_waits_for_pending_continuity_gap():
     )
     pending_requests = deque([pending_request])
     pending_lock = anyio.Lock()
+    continuity_state = proxy_service._WebSocketContinuityState()
 
-    assert await proxy_service._websocket_full_replay_should_wait_for_continuity(
-        next_request,
-        pending_requests,
-        pending_lock=pending_lock,
-        codex_session_affinity=True,
+    assert (
+        await proxy_service._websocket_full_replay_continuity_wait_snapshot(
+            next_request,
+            pending_requests,
+            pending_lock=pending_lock,
+            codex_session_affinity=True,
+            continuity_state=continuity_state,
+        )
+        is None
+    )
+    anchored_replay = proxy_service._WebSocketRequestState(
+        request_id="ws_next_full_replay_anchor_injected",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor",
+        proxy_injected_previous_response_id=True,
+        input_item_count=proxy_service._WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,
     )
 
-    async def clear_pending() -> None:
+    assert (
+        await proxy_service._websocket_full_replay_continuity_wait_snapshot(
+            anchored_replay,
+            pending_requests,
+            pending_lock=pending_lock,
+            codex_session_affinity=True,
+            continuity_state=continuity_state,
+        )
+        == 0
+    )
+    small_anchored_replay = proxy_service._WebSocketRequestState(
+        request_id="ws_small_replay_anchor_injected",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor",
+        proxy_injected_previous_response_id=True,
+        input_item_count=2,
+    )
+
+    assert (
+        await proxy_service._websocket_full_replay_continuity_wait_snapshot(
+            small_anchored_replay,
+            pending_requests,
+            pending_lock=pending_lock,
+            codex_session_affinity=True,
+            continuity_state=continuity_state,
+        )
+        == 0
+    )
+
+    observed_generation = continuity_state.completion_generation
+
+    async def clear_pending_and_record_completion() -> None:
         await asyncio.sleep(0.01)
         async with pending_lock:
             pending_requests.clear()
+        proxy_service._record_websocket_continuity_completion(
+            continuity_state,
+            request_state=pending_request,
+            response_id="resp_completed",
+        )
 
-    clear_task = asyncio.create_task(clear_pending())
+    clear_task = asyncio.create_task(clear_pending_and_record_completion())
     try:
         assert await proxy_service._wait_for_websocket_continuity_gap(
             pending_requests,
             pending_lock=pending_lock,
             timeout_seconds=1.0,
+            continuity_state=continuity_state,
+            observed_completion_generation=observed_generation,
         )
     finally:
         await clear_task
 
 
-def test_mark_duplicate_tool_call_downstream_event_suppresses_same_arguments():
-    upstream_control = proxy_service._WebSocketUpstreamControl()
-    first_payload: dict[str, JsonValue] = {
-        "type": "response.output_item.done",
-        "response_id": "resp_dupe",
-        "item": {
-            "type": "function_call",
-            "name": "write_stdin",
-            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
-            "call_id": "call_a",
-        },
-    }
-    second_payload: dict[str, JsonValue] = {
-        "type": "response.output_item.done",
-        "response_id": "resp_dupe",
-        "item": {
-            "type": "function_call",
-            "name": "write_stdin",
-            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
-            "call_id": "call_b",
-        },
-    }
-    different_payload: dict[str, JsonValue] = {
-        "type": "response.output_item.done",
-        "response_id": "resp_dupe",
-        "item": {
-            "type": "function_call",
-            "name": "write_stdin",
-            "arguments": '{"session_id":1,"chars":"x","yield_time_ms":1000}',
-            "call_id": "call_c",
-        },
-    }
+@pytest.mark.asyncio
+async def test_websocket_full_replay_waits_for_continuity_generation_after_pending_drains():
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_pending_full_replay_anchor",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=1,
+        input_full_fingerprint="fingerprint",
+    )
+    pending_requests = deque([pending_request])
+    pending_lock = anyio.Lock()
+    continuity_state = proxy_service._WebSocketContinuityState()
+    observed_generation = continuity_state.completion_generation
 
-    assert (
-        proxy_service._mark_duplicate_tool_call_downstream_event(
-            first_payload,
-            upstream_control=upstream_control,
-            response_id="resp_dupe",
+    async def drain_then_record() -> None:
+        await asyncio.sleep(0.01)
+        async with pending_lock:
+            pending_requests.clear()
+        await asyncio.sleep(0.02)
+        proxy_service._record_websocket_continuity_completion(
+            continuity_state,
+            request_state=pending_request,
+            response_id="resp_completed",
         )
-        is False
-    )
-    assert (
-        proxy_service._mark_duplicate_tool_call_downstream_event(
-            second_payload,
-            upstream_control=upstream_control,
-            response_id="resp_dupe",
+
+    wait_task = asyncio.create_task(
+        proxy_service._wait_for_websocket_continuity_gap(
+            pending_requests,
+            pending_lock=pending_lock,
+            timeout_seconds=1.0,
+            continuity_state=continuity_state,
+            observed_completion_generation=observed_generation,
         )
-        is True
     )
-    assert (
-        proxy_service._mark_duplicate_tool_call_downstream_event(
-            different_payload,
-            upstream_control=upstream_control,
-            response_id="resp_dupe",
+    drain_task = asyncio.create_task(drain_then_record())
+    try:
+        await asyncio.sleep(0.03)
+        assert not wait_task.done()
+        assert await wait_task
+    finally:
+        await drain_task
+
+
+@pytest.mark.asyncio
+async def test_websocket_full_replay_wait_fails_when_drained_turn_never_records_completion():
+    pending_requests = deque(
+        [
+            proxy_service._WebSocketRequestState(
+                request_id="ws_failed_pending",
+                model="gpt-5.1",
+                service_tier=None,
+                reasoning_effort=None,
+                api_key_reservation=None,
+                started_at=0.0,
+                input_item_count=1,
+            )
+        ]
+    )
+    pending_lock = anyio.Lock()
+    continuity_state = proxy_service._WebSocketContinuityState()
+    observed_generation = continuity_state.completion_generation
+
+    async def drain_without_completion() -> None:
+        await asyncio.sleep(0.01)
+        async with pending_lock:
+            pending_requests.clear()
+
+    drain_task = asyncio.create_task(drain_without_completion())
+    try:
+        assert not await proxy_service._wait_for_websocket_continuity_gap(
+            pending_requests,
+            pending_lock=pending_lock,
+            timeout_seconds=0.05,
+            continuity_state=continuity_state,
+            observed_completion_generation=observed_generation,
         )
-        is False
-    )
+    finally:
+        await drain_task
 
 
 def test_websocket_response_id_reads_output_item_done_response_id():
@@ -5514,45 +5768,6 @@ def test_websocket_response_id_reads_output_item_done_response_id():
     }
 
     assert proxy_service._websocket_response_id(None, payload) == "resp_output_item"
-
-
-def test_mark_duplicate_tool_call_downstream_event_scopes_by_response_id():
-    upstream_control = proxy_service._WebSocketUpstreamControl()
-    first_payload: dict[str, JsonValue] = {
-        "type": "response.output_item.done",
-        "response_id": "resp_first",
-        "item": {
-            "type": "function_call",
-            "name": "write_stdin",
-            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
-        },
-    }
-    second_payload: dict[str, JsonValue] = {
-        "type": "response.output_item.done",
-        "response_id": "resp_second",
-        "item": {
-            "type": "function_call",
-            "name": "write_stdin",
-            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
-        },
-    }
-
-    assert (
-        proxy_service._mark_duplicate_tool_call_downstream_event(
-            first_payload,
-            upstream_control=upstream_control,
-            response_id=proxy_service._websocket_response_id(None, first_payload),
-        )
-        is False
-    )
-    assert (
-        proxy_service._mark_duplicate_tool_call_downstream_event(
-            second_payload,
-            upstream_control=upstream_control,
-            response_id=proxy_service._websocket_response_id(None, second_payload),
-        )
-        is False
-    )
 
 
 def test_websocket_event_dedupe_response_id_falls_back_to_request_state():
@@ -5570,6 +5785,81 @@ def test_websocket_event_dedupe_response_id_falls_back_to_request_state():
     request_state.response_id = "resp_assigned"
     assert proxy_service._websocket_event_dedupe_response_id(None, request_state) == "resp_assigned"
 
+
+def test_websocket_continuity_completion_clears_prefix_for_non_list_turn():
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=3,
+        last_completed_response_id="resp_old",
+        last_completed_input_prefix_fingerprint="old-fingerprint",
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_string_input",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=0,
+        input_full_fingerprint=None,
+    )
+
+    proxy_service._record_websocket_continuity_completion(
+        continuity_state,
+        request_state=request_state,
+        response_id="resp_string",
+    )
+
+    assert continuity_state.last_completed_response_id == "resp_string"
+    assert continuity_state.last_completed_input_count == 0
+    assert continuity_state.last_completed_input_prefix_fingerprint is None
+
+
+def test_websocket_continuity_completion_ignores_older_shorter_turn():
+    first_input: list[JsonValue] = [{"role": "user", "content": "first"}]
+    second_input: list[JsonValue] = [
+        *first_input,
+        {"role": "assistant", "content": "first answer"},
+        {"role": "user", "content": "second"},
+    ]
+    continuity_state = proxy_service._WebSocketContinuityState()
+    first_request = proxy_service._WebSocketRequestState(
+        request_id="ws_first",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=len(first_input),
+        input_full_fingerprint=proxy_service._fingerprint_input_items(first_input),
+    )
+    second_request = proxy_service._WebSocketRequestState(
+        request_id="ws_second",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        input_item_count=len(second_input),
+        input_full_fingerprint=proxy_service._fingerprint_input_items(second_input),
+    )
+
+    proxy_service._record_websocket_continuity_completion(
+        continuity_state,
+        request_state=second_request,
+        response_id="resp_second",
+    )
+    proxy_service._record_websocket_continuity_completion(
+        continuity_state,
+        request_state=first_request,
+        response_id="resp_first",
+    )
+
+    assert continuity_state.last_completed_response_id == "resp_second"
+    assert continuity_state.last_completed_input_count == len(second_input)
+    assert continuity_state.last_completed_input_prefix_fingerprint == proxy_service._fingerprint_input_items(
+        second_input
+    )
+    assert continuity_state.completion_generation == 2
 
 @pytest.mark.asyncio
 async def test_pop_replayable_precreated_websocket_request_replays_injected_anchor_as_fresh_payload():
@@ -5604,6 +5894,38 @@ async def test_pop_replayable_precreated_websocket_request_replays_injected_anch
     assert pending_request.fresh_upstream_request_is_retry_safe is False
     assert pending_request.request_text is not None
     assert json.loads(pending_request.request_text) == fresh_payload
+
+
+@pytest.mark.asyncio
+async def test_pop_replayable_precreated_websocket_request_rejects_unsafe_injected_anchor():
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_unsafe_anchor_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        previous_response_id="resp_anchor",
+        request_text=json.dumps(
+            {"type": "response.create", "previous_response_id": "resp_anchor", "input": ["tail"]},
+            separators=(",", ":"),
+        ),
+        fresh_upstream_request_text=None,
+        fresh_upstream_request_is_retry_safe=False,
+        proxy_injected_previous_response_id=True,
+    )
+    pending_requests = deque([pending_request])
+
+    replay_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replay_request is None
+    assert pending_requests == deque([pending_request])
+    assert pending_request.replay_count == 0
+    assert pending_request.previous_response_id == "resp_anchor"
 
 
 def test_slim_response_create_payload_rewrites_top_level_historical_input_image():
@@ -8250,8 +8572,10 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
         awaiting_response_created=True,
         request_text=json.dumps(request_payload, separators=(",", ":")),
         previous_response_id="resp_anchor",
+        preferred_account_id=account.id,
         fresh_upstream_request_text=json.dumps(fresh_request_payload, separators=(",", ":")),
         fresh_upstream_request_is_retry_safe=True,
+        proxy_injected_previous_response_id=True,
     )
     pending_requests = deque([pending_request])
     upstream_control = proxy_service._WebSocketUpstreamControl()
@@ -8267,7 +8591,7 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
     }
     upstream_text = json.dumps(upstream_payload, separators=(",", ":"))
 
-    await service._process_upstream_websocket_text(
+    downstream_text = await service._process_upstream_websocket_text(
         upstream_text,
         account=account,
         account_id_value=account.id,
@@ -8278,6 +8602,8 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
         response_create_gate=asyncio.Semaphore(1),
     )
 
+    assert '"code":"stream_incomplete"' in downstream_text
+    finalize_request_state.assert_not_awaited()
     handle_stream_error.assert_not_awaited()
     assert upstream_control.reconnect_requested is True
     assert upstream_control.suppress_downstream_event is True
@@ -8286,9 +8612,78 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
     # The retry must strip the stale ``previous_response_id`` and use the
     # prepared retry-safe text instead of the original anchored payload.
     assert pending_request.previous_response_id is None
-    assert pending_request.request_text == json.dumps(fresh_request_payload, separators=(",", ":"))
-    # Retry-safety flag is consumed (set back to False) so we don't loop.
+    assert pending_request.proxy_injected_previous_response_id is False
     assert pending_request.fresh_upstream_request_is_retry_safe is False
+    assert pending_request.request_text == json.dumps(fresh_request_payload, separators=(",", ":"))
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_does_not_retry_unsafe_previous_response_anchor(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_prev_not_found_unsafe_retry")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "instructions": "",
+        "previous_response_id": "resp_anchor",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
+    }
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_not_found_no_retry",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(request_payload, separators=(",", ":")),
+        previous_response_id="resp_anchor",
+        preferred_account_id=account.id,
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_is_retry_safe=False,
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "previous_response_not_found",
+            "message": "Previous response with id 'resp_anchor' not found.",
+            "param": "previous_response_id",
+        },
+    }
+    upstream_text = json.dumps(upstream_payload, separators=(",", ":"))
+
+    downstream_text = await service._process_upstream_websocket_text(
+        upstream_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"code":"stream_incomplete"' in downstream_text
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.replay_request_state is None
+    assert pending_request.replay_count == 0
+    assert pending_request.previous_response_id == "resp_anchor"
+    assert pending_request.request_text is not None
+    assert "previous_response_id" in json.loads(pending_request.request_text)
+    finalize_request_state.assert_awaited_once()
+    handle_stream_error.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5323,10 +5323,12 @@ async def test_prepare_websocket_response_create_request_trims_codex_session_ful
         log_proxy_service_tier_trace = False
         openai_prompt_cache_key_derivation_enabled = True
 
-    historical_input: list[JsonValue] = [
-        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
-        {"type": "function_call_output", "call_id": "call_old", "output": "old output"},
-    ]
+    historical_input: list[JsonValue] = [{"role": "user", "content": [{"type": "input_text", "text": "old question"}]}]
+    previous_assistant_output: JsonValue = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "old answer"}],
+    }
     new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
     continuity_state = proxy_service._WebSocketContinuityState(
         last_completed_input_count=len(historical_input),
@@ -5344,7 +5346,7 @@ async def test_prepare_websocket_response_create_request_trims_codex_session_ful
             {
                 "type": "response.create",
                 "model": "gpt-5.1",
-                "input": [*historical_input, new_input],
+                "input": [*historical_input, previous_assistant_output, new_input],
             },
         ),
         headers={"session_id": "turn_ws_trim"},
@@ -5363,13 +5365,13 @@ async def test_prepare_websocket_response_create_request_trims_codex_session_ful
     assert prepared.request_state.proxy_injected_previous_response_id is True
     assert prepared.request_state.input_item_count == 3
     assert prepared.request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
-        [*historical_input, new_input]
+        [*historical_input, previous_assistant_output, new_input]
     )
     assert prepared.request_state.fresh_upstream_request_is_retry_safe is True
     assert prepared.request_state.fresh_upstream_request_text is not None
     fresh_payload = json.loads(prepared.request_state.fresh_upstream_request_text)
     assert "previous_response_id" not in fresh_payload
-    assert fresh_payload["input"] == [*historical_input, new_input]
+    assert fresh_payload["input"] == [*historical_input, previous_assistant_output, new_input]
 
 
 @pytest.mark.asyncio
@@ -5734,7 +5736,7 @@ async def test_websocket_full_replay_waits_for_pending_continuity_gap():
 
 
 @pytest.mark.asyncio
-async def test_websocket_full_replay_waits_for_continuity_generation_after_pending_drains():
+async def test_websocket_full_replay_waits_until_pending_drains():
     pending_request = proxy_service._WebSocketRequestState(
         request_id="ws_pending_full_replay_anchor",
         model="gpt-5.1",
@@ -5772,15 +5774,13 @@ async def test_websocket_full_replay_waits_for_continuity_generation_after_pendi
     )
     drain_task = asyncio.create_task(drain_then_record())
     try:
-        await asyncio.sleep(0.03)
-        assert not wait_task.done()
         assert await wait_task
     finally:
         await drain_task
 
 
 @pytest.mark.asyncio
-async def test_websocket_full_replay_wait_fails_when_drained_turn_never_records_completion():
+async def test_websocket_full_replay_wait_continues_when_drained_turn_never_records_completion():
     pending_requests = deque(
         [
             proxy_service._WebSocketRequestState(
@@ -5805,10 +5805,10 @@ async def test_websocket_full_replay_wait_fails_when_drained_turn_never_records_
 
     drain_task = asyncio.create_task(drain_without_completion())
     try:
-        assert not await proxy_service._wait_for_websocket_continuity_gap(
+        assert await proxy_service._wait_for_websocket_continuity_gap(
             pending_requests,
             pending_lock=pending_lock,
-            timeout_seconds=0.05,
+            timeout_seconds=1.0,
             continuity_state=continuity_state,
             observed_completion_generation=observed_generation,
         )

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5497,6 +5497,68 @@ async def test_prepare_websocket_response_create_request_rejects_orphan_tool_out
     assert prepared.request_state.fresh_upstream_request_text is None
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_allows_client_full_replay_without_memory(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_client_prev_full_replay",
+        name="ws-client-prev-full-replay",
+        key_prefix="sk-ws-client-full",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    full_replay_input: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "first"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "old answer"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_lost_after_restart",
+                "input": full_replay_input,
+            },
+        ),
+        headers={},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_lost_after_restart"
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is True
+    assert prepared.request_state.fresh_upstream_request_text is not None
+    fresh_payload = json.loads(prepared.request_state.fresh_upstream_request_text)
+    assert "previous_response_id" not in fresh_payload
+    assert fresh_payload["input"] == full_replay_input
+
+
 def test_websocket_continuity_state_reuses_codex_session_scope():
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5559,6 +5559,70 @@ async def test_prepare_websocket_response_create_request_allows_client_full_repl
     assert fresh_payload["input"] == full_replay_input
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_rejects_tool_only_fresh_retry(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_client_prev_tool_only",
+        name="ws-client-prev-tool-only",
+        key_prefix="sk-ws-client-tool",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    tool_only_input: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "call_id": "call_prev",
+            "name": "exec_command",
+            "arguments": '{"cmd":"date"}',
+        },
+        {"type": "function_call_output", "call_id": "call_prev", "output": "ok"},
+    ]
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_tool_delta",
+                "input": tool_only_input,
+            },
+        ),
+        headers={},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_tool_delta"
+    assert upstream_payload["input"] == tool_only_input
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
+    assert prepared.request_state.fresh_upstream_request_text is None
+
+
 def test_websocket_continuity_state_reuses_codex_session_scope():
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
 
@@ -6013,6 +6077,7 @@ def test_websocket_continuity_completion_ignores_older_shorter_turn():
         second_input
     )
     assert continuity_state.completion_generation == 2
+
 
 @pytest.mark.asyncio
 async def test_pop_replayable_precreated_websocket_request_replays_injected_anchor_as_fresh_payload():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5757,6 +5757,7 @@ async def test_websocket_full_replay_waits_until_pending_drains():
         async with pending_lock:
             pending_requests.clear()
         await asyncio.sleep(0.02)
+        assert not wait_task.done()
         proxy_service._record_websocket_continuity_completion(
             continuity_state,
             request_state=pending_request,
@@ -5872,6 +5873,36 @@ def test_websocket_continuity_completion_clears_prefix_for_non_list_turn():
     assert continuity_state.last_completed_response_id == "resp_string"
     assert continuity_state.last_completed_input_count == 0
     assert continuity_state.last_completed_input_prefix_fingerprint is None
+
+
+def test_websocket_continuity_completion_skips_suppressed_tool_call_response():
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=1,
+        last_completed_response_id="resp_safe",
+        last_completed_input_prefix_fingerprint="safe-fingerprint",
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_suppressed_tool",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=2,
+        input_full_fingerprint="unsafe-fingerprint",
+        suppressed_downstream_tool_call=True,
+    )
+
+    proxy_service._record_websocket_continuity_completion(
+        continuity_state,
+        request_state=request_state,
+        response_id="resp_unsafe",
+    )
+
+    assert continuity_state.last_completed_response_id == "resp_safe"
+    assert continuity_state.last_completed_input_count == 1
+    assert continuity_state.last_completed_input_prefix_fingerprint == "safe-fingerprint"
+    assert continuity_state.completion_generation == 1
 
 
 def test_websocket_continuity_completion_ignores_older_shorter_turn():
@@ -8834,6 +8865,73 @@ async def test_process_upstream_websocket_text_masks_previous_response_not_found
     assert list(pending_requests) == [inflight_request]
 
 
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_masks_pretty_json_previous_response_not_found(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    account = _make_account("acc_ws_prev_not_found_pretty_json")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+
+    followup_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_followup_pretty_prev_not_found",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_pretty_anchor",
+                "input": "continue",
+            },
+            separators=(",", ":"),
+        ),
+        previous_response_id="resp_pretty_anchor",
+    )
+    pending_requests = deque([followup_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_text = json.dumps(
+        {
+            "type": "error",
+            "status": 400,
+            "error": {
+                "type": "invalid_request_error",
+                "code": "previous_response_not_found",
+                "message": "Previous response with id 'resp_pretty_anchor' not found.",
+                "param": "previous_response_id",
+            },
+        },
+        indent=2,
+    )
+
+    downstream_text = await service._process_upstream_websocket_text(
+        upstream_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"type":"response.failed"' in downstream_text
+    assert '"code":"stream_incomplete"' in downstream_text
+    assert "previous_response_not_found" not in downstream_text
+    finalize_request_state.assert_awaited_once()
+    finalize_call = finalize_request_state.await_args
+    assert finalize_call is not None
+    assert finalize_call.args[0] is followup_request
+    assert list(pending_requests) == []
+
+
 def test_maybe_rewrite_websocket_previous_response_not_found_rewrites_response_failed_event():
     request_state = proxy_service._WebSocketRequestState(
         request_id="ws_req_prev_nf",
@@ -10921,9 +11019,38 @@ async def test_stream_http_bridge_or_retry_routes_input_file_file_id_without_rej
 
 
 def test_classify_upstream_close_rejected_only_for_clean_close_before_any_response_event():
-    assert proxy_service._classify_upstream_close(1000, response_events_seen=0) == "rejected"
-    assert proxy_service._classify_upstream_close(1000, response_events_seen=1) == "transient"
-    assert proxy_service._classify_upstream_close(1011, response_events_seen=0) == "transient"
+    assert (
+        proxy_service._classify_upstream_close(
+            1000,
+            request_response_events_seen=0,
+            upstream_response_events_seen=0,
+        )
+        == "rejected"
+    )
+    assert (
+        proxy_service._classify_upstream_close(
+            1000,
+            request_response_events_seen=1,
+            upstream_response_events_seen=1,
+        )
+        == "transient"
+    )
+    assert (
+        proxy_service._classify_upstream_close(
+            1000,
+            request_response_events_seen=0,
+            upstream_response_events_seen=1,
+        )
+        == "transient"
+    )
+    assert (
+        proxy_service._classify_upstream_close(
+            1011,
+            request_response_events_seen=0,
+            upstream_response_events_seen=0,
+        )
+        == "transient"
+    )
 
 
 @pytest.mark.asyncio
@@ -10963,3 +11090,50 @@ async def test_retry_http_bridge_precreated_request_suppresses_retry_for_rejecte
     assert request_state.error_code_override == "upstream_rejected_input"
     assert request_state.error_http_status_override == 502
     assert "close_code=1000" in (request_state.error_message_override or "")
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_suppressed_tool_call_response_is_not_reused_as_anchor():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    session_key = proxy_service._HTTPBridgeSessionKey("session_header", "bridge-key", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=session_key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_unsafe_anchor"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+        last_completed_response_id="resp_unsafe_tool",
+    )
+    service._http_bridge_sessions[session_key] = session
+    service._http_bridge_previous_response_index[
+        proxy_service._http_bridge_previous_response_alias_key("resp_unsafe_tool", None)
+    ] = session_key
+    session.previous_response_ids.add("resp_unsafe_tool")
+
+    service._mark_http_bridge_previous_response_unsafe(session, "resp_unsafe_tool")
+    await service._register_http_bridge_previous_response_id(session, "resp_unsafe_tool")
+
+    assert session.last_completed_response_id is None
+    assert "resp_unsafe_tool" in session.unsafe_previous_response_ids
+    assert "resp_unsafe_tool" not in session.previous_response_ids
+    assert (
+        proxy_service._http_bridge_previous_response_alias_key("resp_unsafe_tool", None)
+        not in service._http_bridge_previous_response_index
+    )
+    assert (
+        proxy_service._http_bridge_session_reusable_for_request(
+            session=session,
+            key=session_key,
+            incoming_turn_state=None,
+            previous_response_id="resp_unsafe_tool",
+        )
+        is False
+    )

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5297,6 +5297,315 @@ async def test_prepare_websocket_response_create_request_does_not_infer_previous
     assert request_logs.session_lookup_calls == []
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_trims_codex_session_full_replay(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_trim_replay",
+        name="ws-trim-replay",
+        key_prefix="sk-ws-trim",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    historical_input: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
+        {"type": "function_call_output", "call_id": "call_old", "output": "old output"},
+    ]
+    new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=len(historical_input),
+        last_completed_response_id="resp_completed_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [*historical_input, new_input],
+            },
+        ),
+        headers={"session_id": "turn_ws_trim"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_completed_anchor"
+    assert upstream_payload["input"] == [new_input]
+    assert prepared.request_state.previous_response_id == "resp_completed_anchor"
+    assert prepared.request_state.proxy_injected_previous_response_id is True
+    assert prepared.request_state.input_item_count == 3
+    assert prepared.request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
+        [*historical_input, new_input]
+    )
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is True
+    assert prepared.request_state.fresh_upstream_request_text is not None
+    fresh_payload = json.loads(prepared.request_state.fresh_upstream_request_text)
+    assert "previous_response_id" not in fresh_payload
+    assert fresh_payload["input"] == [*historical_input, new_input]
+
+
+def test_websocket_continuity_state_reuses_codex_session_scope():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+
+    first = service._websocket_continuity_state_for_request(
+        {"session_id": "codex-session-shared"},
+        api_key=None,
+        codex_session_affinity=True,
+    )
+    first.last_completed_response_id = "resp_cached"
+
+    second = service._websocket_continuity_state_for_request(
+        {"session_id": "codex-session-shared"},
+        api_key=None,
+        codex_session_affinity=True,
+    )
+    unscoped = service._websocket_continuity_state_for_request(
+        {"session_id": "codex-session-shared"},
+        api_key=None,
+        codex_session_affinity=False,
+    )
+
+    assert second is first
+    assert second.last_completed_response_id == "resp_cached"
+    assert unscoped is not first
+
+
+@pytest.mark.asyncio
+async def test_websocket_full_replay_waits_for_pending_continuity_gap():
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_pending_full_replay_anchor",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    next_request = proxy_service._WebSocketRequestState(
+        request_id="ws_next_full_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=proxy_service._WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,
+    )
+    pending_requests = deque([pending_request])
+    pending_lock = anyio.Lock()
+
+    assert await proxy_service._websocket_full_replay_should_wait_for_continuity(
+        next_request,
+        pending_requests,
+        pending_lock=pending_lock,
+        codex_session_affinity=True,
+    )
+
+    async def clear_pending() -> None:
+        await asyncio.sleep(0.01)
+        async with pending_lock:
+            pending_requests.clear()
+
+    clear_task = asyncio.create_task(clear_pending())
+    try:
+        assert await proxy_service._wait_for_websocket_continuity_gap(
+            pending_requests,
+            pending_lock=pending_lock,
+            timeout_seconds=1.0,
+        )
+    finally:
+        await clear_task
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_same_arguments():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+            "call_id": "call_a",
+        },
+    }
+    second_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+            "call_id": "call_b",
+        },
+    }
+    different_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"x","yield_time_ms":1000}',
+            "call_id": "call_c",
+        },
+    }
+
+    assert (
+        proxy_service._mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            upstream_control=upstream_control,
+            response_id="resp_dupe",
+        )
+        is False
+    )
+    assert (
+        proxy_service._mark_duplicate_tool_call_downstream_event(
+            second_payload,
+            upstream_control=upstream_control,
+            response_id="resp_dupe",
+        )
+        is True
+    )
+    assert (
+        proxy_service._mark_duplicate_tool_call_downstream_event(
+            different_payload,
+            upstream_control=upstream_control,
+            response_id="resp_dupe",
+        )
+        is False
+    )
+
+
+def test_websocket_response_id_reads_output_item_done_response_id():
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": " resp_output_item ",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": "{}",
+        },
+    }
+
+    assert proxy_service._websocket_response_id(None, payload) == "resp_output_item"
+
+
+def test_mark_duplicate_tool_call_downstream_event_scopes_by_response_id():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_first",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+        },
+    }
+    second_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_second",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+        },
+    }
+
+    assert (
+        proxy_service._mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            upstream_control=upstream_control,
+            response_id=proxy_service._websocket_response_id(None, first_payload),
+        )
+        is False
+    )
+    assert (
+        proxy_service._mark_duplicate_tool_call_downstream_event(
+            second_payload,
+            upstream_control=upstream_control,
+            response_id=proxy_service._websocket_response_id(None, second_payload),
+        )
+        is False
+    )
+
+
+def test_websocket_event_dedupe_response_id_falls_back_to_request_state():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_without_event_response_id",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+
+    assert proxy_service._websocket_event_dedupe_response_id("resp_payload", request_state) == "resp_payload"
+    assert proxy_service._websocket_event_dedupe_response_id(None, request_state) == "ws_req_without_event_response_id"
+    request_state.response_id = "resp_assigned"
+    assert proxy_service._websocket_event_dedupe_response_id(None, request_state) == "resp_assigned"
+
+
+@pytest.mark.asyncio
+async def test_pop_replayable_precreated_websocket_request_replays_injected_anchor_as_fresh_payload():
+    anchored_payload = {"type": "response.create", "previous_response_id": "resp_anchor", "input": ["tail"]}
+    fresh_payload = {"type": "response.create", "input": ["old", "tail"]}
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_injected_anchor_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        previous_response_id="resp_anchor",
+        request_text=json.dumps(anchored_payload, separators=(",", ":")),
+        fresh_upstream_request_text=json.dumps(fresh_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=True,
+        proxy_injected_previous_response_id=True,
+    )
+    pending_requests = deque([pending_request])
+
+    replay_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replay_request is pending_request
+    assert pending_requests == deque()
+    assert pending_request.replay_count == 1
+    assert pending_request.previous_response_id is None
+    assert pending_request.proxy_injected_previous_response_id is False
+    assert pending_request.fresh_upstream_request_is_retry_safe is False
+    assert pending_request.request_text is not None
+    assert json.loads(pending_request.request_text) == fresh_payload
+
+
 def test_slim_response_create_payload_rewrites_top_level_historical_input_image():
     payload: dict[str, JsonValue] = {
         "type": "response.create",


### PR DESCRIPTION
## Summary
- trim Codex websocket full-replay continuations by anchoring rebuilt requests to the completed previous response
- keep websocket replay continuity state local to this review slice
- leave startup stream-error handling and side-effect tool-call replay suppression to follow-up split PRs #585 and #586

## Validation
- `uv run ruff check app/modules/proxy/service.py app/core/clients/proxy_websocket.py tests/unit/test_proxy_utils.py tests/integration/test_proxy_websocket_responses.py tests/unit/test_proxy_websocket_client.py`
- `uv run ty check app/modules/proxy/service.py app/core/clients/proxy_websocket.py tests/unit/test_proxy_utils.py tests/integration/test_proxy_websocket_responses.py tests/unit/test_proxy_websocket_client.py`
- `uv run pytest tests/unit/test_proxy_utils.py tests/integration/test_proxy_websocket_responses.py tests/unit/test_proxy_websocket_client.py -q -k 'websocket or replay or trim or continuity or duplicate_tool_call'`\n\nStack note: this PR is now the replay-core slice only. Merge #585 and #586 after it for the pieces split out of the old oversized branch.
