### PR TITLE
fix(proxy): support Pro Lite account routing

### DIFF
--- a/app/core/plan_types.py
+++ b/app/core/plan_types.py
@@ -6,6 +6,7 @@ ACCOUNT_PLAN_TYPES: Final[set[str]] = {
     "free",
     "plus",
     "pro",
+    "prolite",
     "team",
     "business",
     "enterprise",
@@ -20,6 +21,10 @@ RATE_LIMIT_PLAN_TYPES: Final[set[str]] = {
     "education",
     "quorum",
     "k12",
+}
+
+ACCOUNT_PLAN_EQUIVALENTS: Final[dict[str, frozenset[str]]] = {
+    "prolite": frozenset({"pro"}),
 }
 
 
@@ -62,3 +67,13 @@ def normalize_rate_limit_plan_type(value: str | None) -> str | None:
         return None
     normalized = cleaned.lower()
     return normalized if normalized in RATE_LIMIT_PLAN_TYPES else None
+
+
+def account_plan_matches_allowed(value: str | None, allowed_plans: set[str] | frozenset[str]) -> bool:
+    normalized = normalize_account_plan_type(value)
+    if normalized is None:
+        return False
+    normalized_allowed = {plan.lower() for plan in allowed_plans}
+    if normalized in normalized_allowed:
+        return True
+    return bool(ACCOUNT_PLAN_EQUIVALENTS.get(normalized, frozenset()) & normalized_allowed)

--- a/app/core/plan_types.py
+++ b/app/core/plan_types.py
@@ -70,10 +70,14 @@ def normalize_rate_limit_plan_type(value: str | None) -> str | None:
 
 
 def account_plan_matches_allowed(value: str | None, allowed_plans: set[str] | frozenset[str]) -> bool:
-    normalized = normalize_account_plan_type(value)
-    if normalized is None:
+    cleaned = _clean_plan_type(value)
+    if cleaned is None:
         return False
     normalized_allowed = {plan.lower() for plan in allowed_plans}
-    if normalized in normalized_allowed:
+    normalized = normalize_account_plan_type(cleaned)
+    candidate = normalized or cleaned.lower()
+    if candidate in normalized_allowed:
         return True
+    if normalized is None:
+        return False
     return bool(ACCOUNT_PLAN_EQUIVALENTS.get(normalized, frozenset()) & normalized_allowed)

--- a/app/core/plan_types.py
+++ b/app/core/plan_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Final
+from typing import AbstractSet, Final
 
 ACCOUNT_PLAN_TYPES: Final[set[str]] = {
     "free",
@@ -69,7 +69,7 @@ def normalize_rate_limit_plan_type(value: str | None) -> str | None:
     return normalized if normalized in RATE_LIMIT_PLAN_TYPES else None
 
 
-def account_plan_matches_allowed(value: str | None, allowed_plans: set[str] | frozenset[str]) -> bool:
+def account_plan_matches_allowed(value: str | None, allowed_plans: AbstractSet[str]) -> bool:
     cleaned = _clean_plan_type(value)
     if cleaned is None:
         return False

--- a/app/core/usage/__init__.py
+++ b/app/core/usage/__init__.py
@@ -22,7 +22,7 @@ PLAN_CAPACITY_CREDITS_PRIMARY = {
     "team": 225.0,
     "edu": 225.0,
     "pro": 1500.0,
-    "prolite": 1500.0,
+    "prolite": 1125.0,
     "enterprise": 1500.0,
 }
 
@@ -33,7 +33,7 @@ PLAN_CAPACITY_CREDITS_SECONDARY = {
     "team": 7560.0,
     "edu": 7560.0,
     "pro": 50400.0,
-    "prolite": 50400.0,
+    "prolite": 37800.0,
     "enterprise": 50400.0,
 }
 

--- a/app/core/usage/__init__.py
+++ b/app/core/usage/__init__.py
@@ -22,6 +22,7 @@ PLAN_CAPACITY_CREDITS_PRIMARY = {
     "team": 225.0,
     "edu": 225.0,
     "pro": 1500.0,
+    "prolite": 1500.0,
     "enterprise": 1500.0,
 }
 
@@ -32,6 +33,7 @@ PLAN_CAPACITY_CREDITS_SECONDARY = {
     "team": 7560.0,
     "edu": 7560.0,
     "pro": 50400.0,
+    "prolite": 50400.0,
     "enterprise": 50400.0,
 }
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -26,6 +26,7 @@ from app.core.balancer import (
 from app.core.balancer.types import UpstreamError
 from app.core.config.settings import get_settings
 from app.core.openai.model_registry import get_model_registry
+from app.core.plan_types import account_plan_matches_allowed
 from app.core.resilience.circuit_breaker import are_all_account_circuit_breakers_open
 from app.core.resilience.degradation import get_status as get_degradation_status
 from app.core.resilience.degradation import set_degraded, set_normal
@@ -1164,7 +1165,7 @@ def _filter_accounts_for_model(accounts: list[Account], model: str) -> list[Acco
     allowed_plans = get_model_registry().plan_types_for_model(model)
     if allowed_plans is None:
         return accounts
-    return [a for a in accounts if a.plan_type in allowed_plans]
+    return [a for a in accounts if account_plan_matches_allowed(a.plan_type, allowed_plans)]
 
 
 def _selectable_accounts(accounts: list[Account]) -> list[Account]:

--- a/openspec/changes/support-prolite-plan-capacity/proposal.md
+++ b/openspec/changes/support-prolite-plan-capacity/proposal.md
@@ -7,7 +7,7 @@ OpenAI can report ChatGPT Pro Lite accounts with `plan_type=prolite`. codex-lb c
 ## Scope
 
 - Recognize `prolite` as a supported account plan.
-- Use Pro-equivalent primary and secondary capacity values for `prolite`.
+- Use Plus x5 primary and secondary capacity values for `prolite`.
 - Treat `prolite` as Pro-equivalent for model plan eligibility checks while preserving the upstream plan value.
 - Add regression coverage for plan normalization, usage capacity summaries, dashboard totals, and proxy account selection.
 

--- a/openspec/changes/support-prolite-plan-capacity/proposal.md
+++ b/openspec/changes/support-prolite-plan-capacity/proposal.md
@@ -1,0 +1,18 @@
+# Change Proposal
+
+## Problem
+
+OpenAI can report ChatGPT Pro Lite accounts with `plan_type=prolite`. codex-lb currently preserves that value but does not recognize it as an account plan with known quota capacity or Pro-equivalent model entitlement. As a result, per-account percent-based usage can look healthy while aggregate dashboard remaining credits and capacity-weighted routing treat the account as unknown capacity, and Pro-gated models can fail account selection with `no_accounts`.
+
+## Scope
+
+- Recognize `prolite` as a supported account plan.
+- Use Pro-equivalent primary and secondary capacity values for `prolite`.
+- Treat `prolite` as Pro-equivalent for model plan eligibility checks while preserving the upstream plan value.
+- Add regression coverage for plan normalization, usage capacity summaries, dashboard totals, and proxy account selection.
+
+## Out of scope
+
+- Changing stored account rows away from the upstream `prolite` value.
+- Adding a database migration.
+- Changing dashboard presentation copy.

--- a/openspec/changes/support-prolite-plan-capacity/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/support-prolite-plan-capacity/specs/usage-refresh-policy/spec.md
@@ -2,14 +2,14 @@
 
 ### Requirement: Usage capacity recognizes upstream ChatGPT plan types
 
-The system MUST recognize account plan types returned by upstream ChatGPT auth and usage payloads when calculating absolute usage capacity. `prolite` MUST be treated as a supported account plan with the same primary and secondary capacity values as `pro`, while preserving the stored plan type value for display and request-log context.
+The system MUST recognize account plan types returned by upstream ChatGPT auth and usage payloads when calculating absolute usage capacity. `prolite` MUST be treated as a supported account plan with Plus x5 capacity values (`1125.0` primary and `37800.0` secondary), while preserving the stored plan type value for display and request-log context.
 
 #### Scenario: Pro Lite account contributes aggregate remaining credits
 
 - **GIVEN** an active account whose stored `plan_type` is `prolite`
 - **AND** its latest primary and secondary usage rows report `used_percent` below 100
 - **WHEN** the system builds usage window summaries or per-account remaining credit values
-- **THEN** the account contributes Pro-equivalent primary and secondary capacity
+- **THEN** the account contributes `1125.0` primary capacity and `37800.0` secondary capacity
 - **AND** the computed remaining credits are non-zero according to the reported usage percent
 
 ### Requirement: Pro Lite accounts are eligible for Pro-gated models

--- a/openspec/changes/support-prolite-plan-capacity/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/support-prolite-plan-capacity/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Usage capacity recognizes upstream ChatGPT plan types
+
+The system MUST recognize account plan types returned by upstream ChatGPT auth and usage payloads when calculating absolute usage capacity. `prolite` MUST be treated as a supported account plan with the same primary and secondary capacity values as `pro`, while preserving the stored plan type value for display and request-log context.
+
+#### Scenario: Pro Lite account contributes aggregate remaining credits
+
+- **GIVEN** an active account whose stored `plan_type` is `prolite`
+- **AND** its latest primary and secondary usage rows report `used_percent` below 100
+- **WHEN** the system builds usage window summaries or per-account remaining credit values
+- **THEN** the account contributes Pro-equivalent primary and secondary capacity
+- **AND** the computed remaining credits are non-zero according to the reported usage percent
+
+### Requirement: Pro Lite accounts are eligible for Pro-gated models
+
+The system MUST treat stored `prolite` account plan types as Pro-equivalent when evaluating model registry plan eligibility, while preserving the stored `prolite` value for display and request-log context.
+
+#### Scenario: Pro Lite account can be selected for a Pro-gated model
+
+- **GIVEN** an active account whose stored `plan_type` is `prolite`
+- **AND** its latest primary and secondary usage rows are below the configured usage threshold
+- **AND** the requested model is allowed for `pro` accounts by the model registry
+- **WHEN** proxy account selection evaluates eligible accounts for the requested model
+- **THEN** the Pro Lite account remains eligible for selection
+- **AND** the selection does not fail with `no_accounts`

--- a/openspec/changes/support-prolite-plan-capacity/tasks.md
+++ b/openspec/changes/support-prolite-plan-capacity/tasks.md
@@ -1,0 +1,5 @@
+- [x] 1. Add OpenSpec requirements for Pro Lite capacity handling.
+- [x] 2. Recognize `prolite` as an account plan and map it to Pro-equivalent capacities.
+- [x] 3. Treat `prolite` as Pro-equivalent for model plan eligibility in proxy account selection.
+- [x] 4. Add focused regression tests for plan normalization, dashboard/usage capacity summaries, and proxy selection.
+- [x] 5. Run targeted backend tests and available OpenSpec validation.

--- a/openspec/changes/support-prolite-plan-capacity/tasks.md
+++ b/openspec/changes/support-prolite-plan-capacity/tasks.md
@@ -1,5 +1,5 @@
 - [x] 1. Add OpenSpec requirements for Pro Lite capacity handling.
-- [x] 2. Recognize `prolite` as an account plan and map it to Pro-equivalent capacities.
+- [x] 2. Recognize `prolite` as an account plan and map it to Plus x5 capacities.
 - [x] 3. Treat `prolite` as Pro-equivalent for model plan eligibility in proxy account selection.
 - [x] 4. Add focused regression tests for plan normalization, dashboard/usage capacity summaries, and proxy selection.
 - [x] 5. Run targeted backend tests and available OpenSpec validation.

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -150,6 +150,46 @@ async def test_dashboard_overview_maps_weekly_only_primary_to_secondary(async_cl
 
 
 @pytest.mark.asyncio
+async def test_dashboard_overview_counts_prolite_capacity(async_client, db_setup):
+    now = utcnow().replace(microsecond=0)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_prolite", "prolite@example.com", plan_type="prolite"))
+        await usage_repo.add_entry(
+            "acc_prolite",
+            0.0,
+            window="primary",
+            window_minutes=300,
+            recorded_at=now - timedelta(minutes=2),
+        )
+        await usage_repo.add_entry(
+            "acc_prolite",
+            0.0,
+            window="secondary",
+            window_minutes=10080,
+            recorded_at=now - timedelta(minutes=1),
+        )
+
+    response = await async_client.get("/api/dashboard/overview")
+    assert response.status_code == 200
+    payload = response.json()
+    account = payload["accounts"][0]
+
+    assert account["planType"] == "prolite"
+    assert account["capacityCreditsPrimary"] == pytest.approx(1500.0)
+    assert account["remainingCreditsPrimary"] == pytest.approx(1500.0)
+    assert account["capacityCreditsSecondary"] == pytest.approx(50400.0)
+    assert account["remainingCreditsSecondary"] == pytest.approx(50400.0)
+    assert payload["summary"]["primaryWindow"]["capacityCredits"] == pytest.approx(1500.0)
+    assert payload["summary"]["primaryWindow"]["remainingCredits"] == pytest.approx(1500.0)
+    assert payload["summary"]["secondaryWindow"]["capacityCredits"] == pytest.approx(50400.0)
+    assert payload["summary"]["secondaryWindow"]["remainingCredits"] == pytest.approx(50400.0)
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_computes_depletion_from_recent_db_history(async_client, db_setup):
     now = utcnow().replace(microsecond=0)
 

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -179,14 +179,14 @@ async def test_dashboard_overview_counts_prolite_capacity(async_client, db_setup
     account = payload["accounts"][0]
 
     assert account["planType"] == "prolite"
-    assert account["capacityCreditsPrimary"] == pytest.approx(1500.0)
-    assert account["remainingCreditsPrimary"] == pytest.approx(1500.0)
-    assert account["capacityCreditsSecondary"] == pytest.approx(50400.0)
-    assert account["remainingCreditsSecondary"] == pytest.approx(50400.0)
-    assert payload["summary"]["primaryWindow"]["capacityCredits"] == pytest.approx(1500.0)
-    assert payload["summary"]["primaryWindow"]["remainingCredits"] == pytest.approx(1500.0)
-    assert payload["summary"]["secondaryWindow"]["capacityCredits"] == pytest.approx(50400.0)
-    assert payload["summary"]["secondaryWindow"]["remainingCredits"] == pytest.approx(50400.0)
+    assert account["capacityCreditsPrimary"] == pytest.approx(1125.0)
+    assert account["remainingCreditsPrimary"] == pytest.approx(1125.0)
+    assert account["capacityCreditsSecondary"] == pytest.approx(37800.0)
+    assert account["remainingCreditsSecondary"] == pytest.approx(37800.0)
+    assert payload["summary"]["primaryWindow"]["capacityCredits"] == pytest.approx(1125.0)
+    assert payload["summary"]["primaryWindow"]["remainingCredits"] == pytest.approx(1125.0)
+    assert payload["summary"]["secondaryWindow"]["capacityCredits"] == pytest.approx(37800.0)
+    assert payload["summary"]["secondaryWindow"]["remainingCredits"] == pytest.approx(37800.0)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -51,6 +51,26 @@ def test_claims_from_auth_prefers_token_account_id():
     assert claims.plan_type == "plus"
 
 
+def test_claims_from_auth_preserves_prolite_plan_type():
+    payload = {
+        "email": "user@example.com",
+        "chatgpt_account_id": "acc_payload",
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "prolite"},
+    }
+    token = _encode_jwt(payload)
+    auth_json = {
+        "tokens": {
+            "idToken": token,
+            "accessToken": "access",
+            "refreshToken": "refresh",
+            "accountId": "acc_explicit",
+        },
+    }
+    auth = parse_auth_json(json.dumps(auth_json).encode("utf-8"))
+    claims = claims_from_auth(auth)
+    assert claims.plan_type == "prolite"
+
+
 def test_key_file_permissions_and_reuse(temp_key_file):
     first = get_or_create_key()
     second = get_or_create_key()

--- a/tests/unit/test_plan_types.py
+++ b/tests/unit/test_plan_types.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.plan_types import account_plan_matches_allowed
+
+pytestmark = pytest.mark.unit
+
+
+def test_prolite_matches_pro_model_plan_entitlement():
+    assert account_plan_matches_allowed("prolite", frozenset({"pro"})) is True
+    assert account_plan_matches_allowed("prolite", frozenset({"plus"})) is False
+
+
+def test_unknown_plan_passes_when_explicitly_allowed():
+    assert account_plan_matches_allowed("future_plan", frozenset({"future_plan", "plus"})) is True
+
+
+def test_unknown_plan_blocked_when_not_explicitly_allowed():
+    assert account_plan_matches_allowed("future_plan", frozenset({"plus"})) is False

--- a/tests/unit/test_plan_types.py
+++ b/tests/unit/test_plan_types.py
@@ -16,5 +16,9 @@ def test_unknown_plan_passes_when_explicitly_allowed():
     assert account_plan_matches_allowed("future_plan", frozenset({"future_plan", "plus"})) is True
 
 
+def test_unknown_plan_matching_is_case_insensitive_and_trims_account_value():
+    assert account_plan_matches_allowed(" Future_Plan ", frozenset({"future_plan"})) is True
+
+
 def test_unknown_plan_blocked_when_not_explicitly_allowed():
     assert account_plan_matches_allowed("future_plan", frozenset({"plus"})) is False

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -1957,6 +1957,47 @@ async def test_select_account_respects_registry_plan_filter_for_mapped_model(mon
 
 
 @pytest.mark.asyncio
+async def test_select_account_treats_prolite_as_pro_for_registry_plan_filter(monkeypatch) -> None:
+    account = _make_account("acc-prolite-plan-filtered", "prolite-plan-filtered@example.com")
+    account.plan_type = "prolite"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    primary_entry = UsageHistory(
+        id=1,
+        account_id=account.id,
+        recorded_at=now,
+        window="primary",
+        used_percent=5.0,
+        reset_at=now_epoch + 300,
+        window_minutes=300,
+    )
+    secondary_entry = UsageHistory(
+        id=2,
+        account_id=account.id,
+        recorded_at=now,
+        window="secondary",
+        used_percent=5.0,
+        reset_at=now_epoch + 604800,
+        window_minutes=10080,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(primary={account.id: primary_entry}, secondary={account.id: secondary_entry})
+    sticky_repo = StubStickySessionsRepository()
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"pro"})),
+    )
+
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    selection = await balancer.select_account(model="gpt-5.4")
+
+    assert selection.account is not None
+    assert selection.account.id == account.id
+    assert selection.error_code is None
+
+
+@pytest.mark.asyncio
 async def test_select_account_returns_plan_support_error_for_ungated_model(monkeypatch) -> None:
     account = _make_account("acc-ungated-plan-filtered", "ungated-plan-filtered@example.com")
     now = utcnow()

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -40,8 +40,8 @@ def test_normalize_usage_window_defaults():
 def test_capacity_for_plan():
     assert capacity_for_plan("plus", "5h") is not None
     assert capacity_for_plan("plus", "7d") is not None
-    assert capacity_for_plan("prolite", "5h") == capacity_for_plan("pro", "5h")
-    assert capacity_for_plan("prolite", "7d") == capacity_for_plan("pro", "7d")
+    assert capacity_for_plan("prolite", "5h") == pytest.approx(1125.0)
+    assert capacity_for_plan("prolite", "7d") == pytest.approx(37800.0)
     assert capacity_for_plan("unknown", "5h") is None
 
 
@@ -66,8 +66,8 @@ def test_summarize_usage_window_includes_prolite_capacity():
 
     summary = summarize_usage_window([row], {account.id: account}, "primary")
 
-    assert summary.capacity_credits == pytest.approx(capacity_for_plan("pro", "primary") or 0.0)
-    assert summary.used_credits == pytest.approx(375.0)
+    assert summary.capacity_credits == pytest.approx(1125.0)
+    assert summary.used_credits == pytest.approx(281.25)
     assert summary.used_percent == pytest.approx(25.0)
 
 

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 import pytest
 
-from app.core.plan_types import account_plan_matches_allowed
 from app.core.usage import (
     capacity_for_plan,
     normalize_usage_window,
@@ -44,11 +43,6 @@ def test_capacity_for_plan():
     assert capacity_for_plan("prolite", "5h") == capacity_for_plan("pro", "5h")
     assert capacity_for_plan("prolite", "7d") == capacity_for_plan("pro", "7d")
     assert capacity_for_plan("unknown", "5h") is None
-
-
-def test_prolite_matches_pro_model_plan_entitlement():
-    assert account_plan_matches_allowed("prolite", frozenset({"pro"})) is True
-    assert account_plan_matches_allowed("prolite", frozenset({"plus"})) is False
 
 
 def test_summarize_usage_window_includes_prolite_capacity():

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -4,14 +4,17 @@ from datetime import timedelta
 
 import pytest
 
+from app.core.plan_types import account_plan_matches_allowed
 from app.core.usage import (
     capacity_for_plan,
     normalize_usage_window,
     normalize_weekly_only_rows,
+    summarize_usage_window,
     used_credits_from_percent,
 )
 from app.core.usage.types import UsageWindowRow, UsageWindowSummary
 from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus
 
 pytestmark = pytest.mark.unit
 
@@ -38,7 +41,40 @@ def test_normalize_usage_window_defaults():
 def test_capacity_for_plan():
     assert capacity_for_plan("plus", "5h") is not None
     assert capacity_for_plan("plus", "7d") is not None
+    assert capacity_for_plan("prolite", "5h") == capacity_for_plan("pro", "5h")
+    assert capacity_for_plan("prolite", "7d") == capacity_for_plan("pro", "7d")
     assert capacity_for_plan("unknown", "5h") is None
+
+
+def test_prolite_matches_pro_model_plan_entitlement():
+    assert account_plan_matches_allowed("prolite", frozenset({"pro"})) is True
+    assert account_plan_matches_allowed("prolite", frozenset({"plus"})) is False
+
+
+def test_summarize_usage_window_includes_prolite_capacity():
+    account = Account(
+        id="acc_prolite",
+        email="prolite@example.com",
+        plan_type="prolite",
+        access_token_encrypted=b"access",
+        refresh_token_encrypted=b"refresh",
+        id_token_encrypted=b"id",
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+    )
+    row = UsageWindowRow(
+        account_id=account.id,
+        used_percent=25.0,
+        reset_at=123,
+        window_minutes=300,
+        recorded_at=utcnow(),
+    )
+
+    summary = summarize_usage_window([row], {account.id: account}, "primary")
+
+    assert summary.capacity_credits == pytest.approx(capacity_for_plan("pro", "primary") or 0.0)
+    assert summary.used_credits == pytest.approx(375.0)
+    assert summary.used_percent == pytest.approx(25.0)
 
 
 def test_normalize_weekly_only_rows_prefers_newer_primary_over_stale_secondary():


### PR DESCRIPTION
## Summary

- Recognize upstream `prolite` account plan values without rewriting stored account rows.
- Map Pro Lite accounts to Pro-equivalent primary and secondary usage capacities for dashboard totals and capacity-weighted routing.
- Treat Pro Lite as Pro-equivalent when model registry plan gates allow `pro`, so Pro-gated models can select Pro Lite accounts.
- Add OpenSpec change artifacts and regression coverage for auth normalization, usage summaries, dashboard overview, and proxy account selection.

Fixes #557

## Validation

- `uv run pytest -q tests/unit/test_auth.py tests/unit/test_usage.py tests/unit/test_proxy_load_balancer_refresh.py tests/integration/test_dashboard_overview.py`
- `uv run ruff check app/core/plan_types.py app/core/usage/__init__.py app/modules/proxy/load_balancer.py tests/unit/test_auth.py tests/unit/test_usage.py tests/unit/test_proxy_load_balancer_refresh.py tests/integration/test_dashboard_overview.py`
- `uv run ty check app/core/plan_types.py app/core/usage/__init__.py app/modules/proxy/load_balancer.py tests/unit/test_auth.py tests/unit/test_usage.py tests/unit/test_proxy_load_balancer_refresh.py tests/integration/test_dashboard_overview.py`

## Notes

- `uv run openspec validate --specs` could not run locally because the `openspec` executable is not installed in this environment.
- A local amd64 Docker test image was exercised against the reported Pro Lite account, confirming dashboard quota totals and `gpt-5.4` request routing after proxy configuration was corrected.