### PR TITLE
fix(accounts): recover quota status from usage refresh

### DIFF
--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -468,9 +468,7 @@ class UsageUpdater:
             secondary is None
             or not _window_has_available_quota(secondary)
             or any(_window_is_exhausted(window) for window in windows)
-            or not any(
-                _window_has_available_quota(window) for window in windows
-            )
+            or not any(_window_has_available_quota(window) for window in windows)
         ):
             return
 

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -464,8 +464,13 @@ class UsageUpdater:
         if account.status != AccountStatus.QUOTA_EXCEEDED or not self._auth_manager:
             return
         windows = [window for window in (primary, secondary) if window is not None]
-        if any(_window_is_exhausted(window) for window in windows) or not any(
-            _window_has_available_quota(window) for window in windows
+        if (
+            secondary is None
+            or not _window_has_available_quota(secondary)
+            or any(_window_is_exhausted(window) for window in windows)
+            or not any(
+                _window_has_available_quota(window) for window in windows
+            )
         ):
             return
 

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -17,7 +17,7 @@ from app.core.clients.usage import UsageFetchError, fetch_usage
 from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
-from app.core.usage.models import AdditionalRateLimitPayload, UsagePayload
+from app.core.usage.models import AdditionalRateLimitPayload, UsagePayload, UsageWindow
 from app.core.utils.request_id import get_request_id
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, UsageHistory
@@ -416,6 +416,7 @@ class UsageUpdater:
                 window_minutes=_window_minutes(secondary.limit_window_seconds),
             )
             usage_written = usage_written or _usage_entry_written(entry)
+        await self._recover_quota_status_from_usage(account, primary=primary, secondary=secondary)
         return AccountRefreshResult(usage_written=usage_written)
 
     async def _deactivate_for_client_error(self, account: Account, exc: UsageFetchError) -> None:
@@ -453,6 +454,31 @@ class UsageUpdater:
             chatgpt_account_id=account.chatgpt_account_id,
         )
 
+    async def _recover_quota_status_from_usage(
+        self,
+        account: Account,
+        *,
+        primary: UsageWindow | None,
+        secondary: UsageWindow | None,
+    ) -> None:
+        if account.status != AccountStatus.QUOTA_EXCEEDED or not self._auth_manager:
+            return
+        windows = [window for window in (primary, secondary) if window is not None]
+        if not any(_window_has_available_quota(window) for window in windows):
+            return
+
+        await self._auth_manager._repo.update_status(
+            account.id,
+            AccountStatus.ACTIVE,
+            None,
+            None,
+            blocked_at=None,
+        )
+        account.status = AccountStatus.ACTIVE
+        account.deactivation_reason = None
+        account.reset_at = None
+        account.blocked_at = None
+
     async def _sync_account_from_repo(self, account: Account) -> None:
         if not self._accounts_repo:
             return
@@ -483,6 +509,11 @@ def _credits_snapshot(payload: UsagePayload) -> tuple[bool | None, bool | None, 
 
 def _usage_entry_written(entry: UsageHistory | None) -> bool:
     return entry is not None
+
+
+def _window_has_available_quota(window: UsageWindow) -> bool:
+    used_percent = window.used_percent
+    return used_percent is not None and float(used_percent) < 100.0
 
 
 def _prefer_merged_additional_window(

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -464,7 +464,9 @@ class UsageUpdater:
         if account.status != AccountStatus.QUOTA_EXCEEDED or not self._auth_manager:
             return
         windows = [window for window in (primary, secondary) if window is not None]
-        if not any(_window_has_available_quota(window) for window in windows):
+        if any(_window_is_exhausted(window) for window in windows) or not any(
+            _window_has_available_quota(window) for window in windows
+        ):
             return
 
         await self._auth_manager._repo.update_status(
@@ -514,6 +516,11 @@ def _usage_entry_written(entry: UsageHistory | None) -> bool:
 def _window_has_available_quota(window: UsageWindow) -> bool:
     used_percent = window.used_percent
     return used_percent is not None and float(used_percent) < 100.0
+
+
+def _window_is_exhausted(window: UsageWindow) -> bool:
+    used_percent = window.used_percent
+    return used_percent is not None and float(used_percent) >= 100.0
 
 
 def _prefer_merged_additional_window(

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -9,10 +9,10 @@ import time
 from collections.abc import Awaitable, Callable, Collection
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Mapping, Protocol
+from typing import Mapping, Protocol, cast
 
 from app.core.auth.refresh import RefreshError
-from app.core.balancer import PERMANENT_FAILURE_CODES
+from app.core.balancer import PERMANENT_FAILURE_CODES, QUOTA_EXCEEDED_COOLDOWN_SECONDS
 from app.core.clients.usage import UsageFetchError, fetch_usage
 from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
@@ -101,6 +101,22 @@ class AdditionalUsageRepositoryPort(Protocol):
     ) -> list[str]: ...
 
     async def latest_recorded_at_for_account(self, account_id: str) -> datetime | None: ...
+
+
+class AccountsRepositoryWithStatusComparePort(AccountsRepositoryPort, Protocol):
+    async def update_status_if_current(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None = None,
+        *,
+        expected_status: AccountStatus,
+        expected_deactivation_reason: str | None = None,
+        expected_reset_at: int | None = None,
+        expected_blocked_at: int | None = None,
+    ) -> bool: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -212,7 +228,8 @@ class UsageUpdater:
             if _is_usage_refresh_in_cooldown(account.id):
                 continue
             latest = latest_usage.get(account.id)
-            if _latest_usage_is_fresh(latest, now=now, interval_seconds=interval):
+            bypass_freshness = _quota_recovery_should_bypass_freshness(account, latest=latest)
+            if not bypass_freshness and _latest_usage_is_fresh(latest, now=now, interval_seconds=interval):
                 continue
             # Additional-only accounts have no main UsageHistory entry.
             # Check DB-backed freshness (works across workers/restarts)
@@ -223,13 +240,17 @@ class UsageUpdater:
             # prevents redundant calls within the same worker.
             if latest is None:
                 last_ok = _last_successful_refresh.get(account.id)
-                if last_ok and (now - last_ok).total_seconds() < interval:
+                if not bypass_freshness and last_ok and (now - last_ok).total_seconds() < interval:
                     continue
                 if self._additional_usage_repo is not None:
                     additional_fresh_at = await self._additional_usage_repo.latest_recorded_at_for_account(
                         account.id,
                     )
-                    if additional_fresh_at and (now - additional_fresh_at).total_seconds() < interval:
+                    if (
+                        not bypass_freshness
+                        and additional_fresh_at
+                        and (now - additional_fresh_at).total_seconds() < interval
+                    ):
                         _last_successful_refresh[account.id] = additional_fresh_at
                         continue
             # NOTE: AsyncSession is not safe for concurrent use. Run sequentially
@@ -272,7 +293,11 @@ class UsageUpdater:
         interval_seconds: int,
     ) -> AccountRefreshResult:
         latest = await self._usage_repo.latest_entry_for_account(account.id, window="primary")
-        if _latest_usage_is_fresh(latest, now=utcnow(), interval_seconds=interval_seconds):
+        if not _quota_recovery_should_bypass_freshness(account, latest=latest) and _latest_usage_is_fresh(
+            latest,
+            now=utcnow(),
+            interval_seconds=interval_seconds,
+        ):
             return AccountRefreshResult(usage_written=False)
         return await self._refresh_account(
             account,
@@ -463,25 +488,40 @@ class UsageUpdater:
     ) -> None:
         if account.status != AccountStatus.QUOTA_EXCEEDED or not self._auth_manager:
             return
+        if account.blocked_at is not None and time.time() < account.blocked_at + QUOTA_EXCEEDED_COOLDOWN_SECONDS:
+            return
         windows = [window for window in (primary, secondary) if window is not None]
-        if (
-            secondary is None
-            or not _window_has_available_quota(secondary)
-            or any(_window_is_exhausted(window) for window in windows)
-            or not any(_window_has_available_quota(window) for window in windows)
-        ):
+        if secondary is None or not _window_has_available_quota(secondary):
+            return
+        if primary is not None and _window_is_exhausted(primary):
+            target_status = AccountStatus.RATE_LIMITED
+            target_reset_at = _reset_at(primary.reset_at, primary.reset_after_seconds, _now_epoch())
+        else:
+            if any(_window_is_exhausted(window) for window in windows):
+                return
+            target_status = AccountStatus.ACTIVE
+            target_reset_at = None
+        if not any(_window_has_available_quota(window) for window in windows):
             return
 
-        await self._auth_manager._repo.update_status(
+        repo = cast(AccountsRepositoryWithStatusComparePort, self._auth_manager._repo)
+        updated = await repo.update_status_if_current(
             account.id,
-            AccountStatus.ACTIVE,
+            target_status,
             None,
-            None,
+            target_reset_at,
             blocked_at=None,
+            expected_status=AccountStatus.QUOTA_EXCEEDED,
+            expected_deactivation_reason=account.deactivation_reason,
+            expected_reset_at=account.reset_at,
+            expected_blocked_at=account.blocked_at,
         )
-        account.status = AccountStatus.ACTIVE
+        if not updated:
+            await self._sync_account_from_repo(account)
+            return
+        account.status = target_status
         account.deactivation_reason = None
-        account.reset_at = None
+        account.reset_at = target_reset_at
         account.blocked_at = None
 
     async def _sync_account_from_repo(self, account: Account) -> None:
@@ -500,6 +540,7 @@ class UsageUpdater:
         account.status = stored.status
         account.deactivation_reason = stored.deactivation_reason
         account.reset_at = stored.reset_at
+        account.blocked_at = stored.blocked_at
 
 
 def _credits_snapshot(payload: UsagePayload) -> tuple[bool | None, bool | None, float | None]:
@@ -708,6 +749,22 @@ def _latest_usage_is_fresh(
     interval_seconds: int,
 ) -> bool:
     return latest is not None and (now - latest.recorded_at).total_seconds() < interval_seconds
+
+
+def _quota_recovery_should_bypass_freshness(account: Account, *, latest: UsageHistory | None) -> bool:
+    if account.status != AccountStatus.QUOTA_EXCEEDED:
+        return False
+    if account.blocked_at is None:
+        return latest is None
+    cooldown_expires_at = account.blocked_at + QUOTA_EXCEEDED_COOLDOWN_SECONDS
+    if time.time() < cooldown_expires_at:
+        return False
+    if latest is None:
+        return True
+    recorded_at = latest.recorded_at
+    if recorded_at.tzinfo is None:
+        recorded_at = recorded_at.replace(tzinfo=timezone.utc)
+    return recorded_at.timestamp() < cooldown_expires_at
 
 
 def _parse_credits_balance(value: str | int | float | None) -> float | None:

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -438,6 +438,248 @@ async def test_usage_refresh_recovers_quota_exceeded_account_when_usage_is_avail
 
 
 @pytest.mark.asyncio
+async def test_usage_refresh_keeps_recent_quota_exceeded_cooldown(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 0.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 60,
+                    },
+                    "secondary_window": {
+                        "used_percent": 10.0,
+                        "reset_at": 1736208000,
+                        "limit_window_seconds": 7 * 24 * 60 * 60,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+    monkeypatch.setattr("app.modules.usage.updater.time.time", lambda: 1735600060.0)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_recent_cooldown", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1735689600
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert account.status == AccountStatus.QUOTA_EXCEEDED
+    assert account.reset_at == 1735689600
+    assert account.blocked_at == 1735600000
+    assert accounts_repo.status_updates == []
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_bypasses_freshness_after_quota_cooldown(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_INTERVAL_SECONDS", "3600")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 0.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 60,
+                    },
+                    "secondary_window": {
+                        "used_percent": 10.0,
+                        "reset_at": 1736208000,
+                        "limit_window_seconds": 7 * 24 * 60 * 60,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+    monkeypatch.setattr("app.modules.usage.updater.time.time", lambda: 1735601000.0)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_fresh_after_cooldown", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1735689600
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+    fresh_usage = UsageHistory(
+        id=1,
+        account_id=account.id,
+        used_percent=100.0,
+        input_tokens=None,
+        output_tokens=None,
+        recorded_at=datetime.fromtimestamp(1735600500),
+        window="primary",
+    )
+
+    await updater.refresh_accounts([account], latest_usage={account.id: fresh_usage})
+
+    assert account.status == AccountStatus.ACTIVE
+    assert account.blocked_at is None
+    assert len(usage_repo.entries) == 2
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_preserves_freshness_after_failed_quota_recovery_probe(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_INTERVAL_SECONDS", "3600")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        raise AssertionError("fresh post-cooldown quota probe should not refetch")
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+    monkeypatch.setattr("app.modules.usage.updater.time.time", lambda: 1735601000.0)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_fresh_probe", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1735689600
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+    fresh_usage = UsageHistory(
+        id=1,
+        account_id=account.id,
+        used_percent=100.0,
+        input_tokens=None,
+        output_tokens=None,
+        recorded_at=datetime.fromtimestamp(1735600950),
+        window="primary",
+    )
+
+    await updater.refresh_accounts([account], latest_usage={account.id: fresh_usage})
+
+    assert usage_repo.entries == []
+    assert account.status == AccountStatus.QUOTA_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_does_not_overwrite_newer_status_change(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 0.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 60,
+                    },
+                    "secondary_window": {
+                        "used_percent": 10.0,
+                        "reset_at": 1736208000,
+                        "limit_window_seconds": 7 * 24 * 60 * 60,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_paused_during_refresh", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1735689600
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+
+    async def pause_before_compare(*args: Any, **kwargs: Any) -> bool:
+        account.status = AccountStatus.PAUSED
+        return False
+
+    monkeypatch.setattr(accounts_repo, "update_status_if_current", pause_before_compare)
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert account.status == AccountStatus.PAUSED
+    assert account.reset_at == 1735689600
+    assert account.blocked_at == 1735600000
+    assert accounts_repo.status_updates == []
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_syncs_blocked_at_after_compare_failure(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 0.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 60,
+                    },
+                    "secondary_window": {
+                        "used_percent": 10.0,
+                        "reset_at": 1736208000,
+                        "limit_window_seconds": 7 * 24 * 60 * 60,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_blocked_at_changed", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1735689600
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+
+    async def change_blocked_at_before_compare(*args: Any, **kwargs: Any) -> bool:
+        account.blocked_at = 1735601234
+        return False
+
+    monkeypatch.setattr(accounts_repo, "update_status_if_current", change_blocked_at_before_compare)
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert account.status == AccountStatus.QUOTA_EXCEEDED
+    assert account.reset_at == 1735689600
+    assert account.blocked_at == 1735601234
+    assert accounts_repo.status_updates == []
+
+
+@pytest.mark.asyncio
 async def test_usage_refresh_does_not_recover_when_secondary_quota_is_missing(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings
@@ -528,6 +770,57 @@ async def test_usage_refresh_does_not_recover_when_secondary_quota_is_still_exha
 
 
 @pytest.mark.asyncio
+async def test_usage_refresh_demotes_quota_exceeded_to_rate_limited_when_primary_is_exhausted(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 100.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 300 * 60,
+                    },
+                    "secondary_window": {
+                        "used_percent": 10.0,
+                        "reset_at": 1736208000,
+                        "limit_window_seconds": 7 * 24 * 60 * 60,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_primary_still_limited", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1736208000
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert account.status == AccountStatus.RATE_LIMITED
+    assert account.reset_at == 1735689600
+    assert account.blocked_at is None
+    assert accounts_repo.status_updates[-1] == {
+        "account_id": account.id,
+        "status": AccountStatus.RATE_LIMITED,
+        "deactivation_reason": None,
+        "reset_at": 1735689600,
+        "blocked_at": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_usage_refresh_recovers_quota_exceeded_free_weekly_account(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings
@@ -597,6 +890,30 @@ class StubAccountsRepository:
             }
         )
         return True
+
+    async def update_status_if_current(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None = None,
+        *,
+        expected_status: AccountStatus,
+        expected_deactivation_reason: str | None = None,
+        expected_reset_at: int | None = None,
+        expected_blocked_at: int | None = None,
+    ) -> bool:
+        account = self.accounts_by_id.get(account_id)
+        if (
+            account is None
+            or account.status != expected_status
+            or account.deactivation_reason != expected_deactivation_reason
+            or account.reset_at != expected_reset_at
+            or account.blocked_at != expected_blocked_at
+        ):
+            return False
+        return await self.update_status(account_id, status, deactivation_reason, reset_at, blocked_at)
 
     async def update_tokens(self, *args: Any, **kwargs: Any) -> bool:
         account_id = args[0] if args else kwargs.get("account_id")

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -401,6 +401,11 @@ async def test_usage_refresh_recovers_quota_exceeded_account_when_usage_is_avail
                         "reset_at": 1735689600,
                         "limit_window_seconds": 60,
                     },
+                    "secondary_window": {
+                        "used_percent": 10.0,
+                        "reset_at": 1736208000,
+                        "limit_window_seconds": 7 * 24 * 60 * 60,
+                    },
                 }
             }
         )
@@ -430,6 +435,51 @@ async def test_usage_refresh_recovers_quota_exceeded_account_when_usage_is_avail
             "blocked_at": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_does_not_recover_when_secondary_quota_is_missing(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 5.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 300 * 60,
+                    },
+                    "secondary_window": {
+                        "used_percent": None,
+                        "reset_at": 1736208000,
+                        "limit_window_seconds": 7 * 24 * 60 * 60,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_unknown_secondary", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1736208000
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert account.status == AccountStatus.QUOTA_EXCEEDED
+    assert account.reset_at == 1736208000
+    assert account.blocked_at == 1735600000
+    assert accounts_repo.status_updates == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -384,6 +384,91 @@ async def test_usage_updater_includes_chatgpt_account_id_even_when_shared(monkey
     assert [call["account_id"] for call in calls] == [shared, shared, "workspace_unique"]
 
 
+@pytest.mark.asyncio
+async def test_usage_refresh_recovers_quota_exceeded_account_when_usage_is_available(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 0.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 60,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_recovered", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1735689600
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert account.status == AccountStatus.ACTIVE
+    assert account.reset_at is None
+    assert account.blocked_at is None
+    assert accounts_repo.status_updates == [
+        {
+            "account_id": account.id,
+            "status": AccountStatus.ACTIVE,
+            "deactivation_reason": None,
+            "reset_at": None,
+            "blocked_at": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_recovers_quota_exceeded_free_weekly_account(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 0.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 604800,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_free_weekly_recovered", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.plan_type = "free"
+    accounts_repo.accounts_by_id[account.id] = account
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert account.status == AccountStatus.ACTIVE
+    assert usage_repo.entries[-1].window == "secondary"
+
+
 class StubAccountsRepository:
     def __init__(self) -> None:
         self.status_updates: list[dict[str, Any]] = []

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -433,6 +433,51 @@ async def test_usage_refresh_recovers_quota_exceeded_account_when_usage_is_avail
 
 
 @pytest.mark.asyncio
+async def test_usage_refresh_does_not_recover_when_secondary_quota_is_still_exhausted(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 5.0,
+                        "reset_at": 1735689600,
+                        "limit_window_seconds": 300 * 60,
+                    },
+                    "secondary_window": {
+                        "used_percent": 100.0,
+                        "reset_at": 1736208000,
+                        "limit_window_seconds": 7 * 24 * 60 * 60,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_quota_still_exhausted", "workspace_shared")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = 1736208000
+    account.blocked_at = 1735600000
+    accounts_repo.accounts_by_id[account.id] = account
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert account.status == AccountStatus.QUOTA_EXCEEDED
+    assert account.reset_at == 1736208000
+    assert account.blocked_at == 1735600000
+    assert accounts_repo.status_updates == []
+
+
+@pytest.mark.asyncio
 async def test_usage_refresh_recovers_quota_exceeded_free_weekly_account(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings


### PR DESCRIPTION
## Summary

- Recover `quota_exceeded` accounts to `active` when a successful usage refresh reports available quota.
- Clear stale `reset_at` / `blocked_at` together with the status recovery.
- Cover both ordinary primary-window recovery and free weekly-only accounts whose upstream 7d window is normalized into the secondary window.

## Why

An account can keep a stale `quota_exceeded` status even after the usage refresh has fresh upstream evidence that quota is available again. The dashboard then shows a contradictory state: 100% remaining usage but a quota-exceeded badge, and routing still treats the account as unavailable.

#529 covers a related timer-based recovery path after reset time passes. This patch handles the evidence-based path: if upstream usage refresh succeeds and reports `used_percent < 100`, the account is usable again.

## Validation

- `uv run pytest tests/unit/test_usage_updater.py -k 'recovers_quota_exceeded' -q`
- `uv run ruff check app/modules/usage/updater.py tests/unit/test_usage_updater.py`
- `uv run ty check app/modules/usage/updater.py tests/unit/test_usage_updater.py`
