### PR TITLE
fix(proxy): slim oversized response.create history

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1430,27 +1430,36 @@ def _omit_historical_response_input_items_to_fit(
     if not slimmed_historical:
         return payload, 0
 
-    omitted_count = 0
-    remaining_historical = list(slimmed_historical)
-    candidate_payload = payload
-    while remaining_historical:
-        omitted_count += 1
-        remaining_historical = remaining_historical[1:]
+    def candidate_with_omitted_count(omitted_count: int) -> JsonObject:
         candidate_payload = dict(payload)
         candidate_payload["input"] = [
             _response_create_history_omission_notice_item(omitted_count),
-            *remaining_historical,
+            *slimmed_historical[omitted_count:],
             *recent,
         ]
+        return candidate_payload
+
+    low = 1
+    high = len(slimmed_historical)
+    best: tuple[JsonObject, int] | None = None
+    while low <= high:
+        omitted_count = (low + high) // 2
+        candidate_payload = candidate_with_omitted_count(omitted_count)
         if _serialized_json_size(candidate_payload) <= max_bytes:
-            return candidate_payload, omitted_count
+            best = (candidate_payload, omitted_count)
+            high = omitted_count - 1
+        else:
+            low = omitted_count + 1
+
+    if best is not None:
+        return best
 
     recent_only_payload = dict(payload)
     recent_only_payload["input"] = list(recent)
     if _serialized_json_size(recent_only_payload) <= max_bytes:
-        return recent_only_payload, omitted_count
+        return recent_only_payload, len(slimmed_historical)
 
-    return candidate_payload, omitted_count
+    return candidate_with_omitted_count(len(slimmed_historical)), len(slimmed_historical)
 
 
 def _serialized_json_size(payload: JsonObject) -> int:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1430,26 +1430,31 @@ def _omit_historical_response_input_items_to_fit(
     if not slimmed_historical:
         return payload, 0
 
-    def candidate_with_omitted_count(omitted_count: int) -> JsonObject:
+    def candidate_with_omitted_count(prefix_omitted_count: int) -> tuple[JsonObject, int]:
+        remaining_historical, orphaned_outputs = _drop_orphaned_function_call_outputs(
+            slimmed_historical[prefix_omitted_count:],
+            recent,
+        )
+        omitted_count = prefix_omitted_count + orphaned_outputs
         candidate_payload = dict(payload)
         candidate_payload["input"] = [
             _response_create_history_omission_notice_item(omitted_count),
-            *slimmed_historical[omitted_count:],
+            *remaining_historical,
             *recent,
         ]
-        return candidate_payload
+        return candidate_payload, omitted_count
 
     low = 1
     high = len(slimmed_historical)
     best: tuple[JsonObject, int] | None = None
     while low <= high:
-        omitted_count = (low + high) // 2
-        candidate_payload = candidate_with_omitted_count(omitted_count)
+        prefix_omitted_count = (low + high) // 2
+        candidate_payload, omitted_count = candidate_with_omitted_count(prefix_omitted_count)
         if _serialized_json_size(candidate_payload) <= max_bytes:
             best = (candidate_payload, omitted_count)
-            high = omitted_count - 1
+            high = prefix_omitted_count - 1
         else:
-            low = omitted_count + 1
+            low = prefix_omitted_count + 1
 
     if best is not None:
         return best
@@ -1459,7 +1464,41 @@ def _omit_historical_response_input_items_to_fit(
     if _serialized_json_size(recent_only_payload) <= max_bytes:
         return recent_only_payload, len(slimmed_historical)
 
-    return candidate_with_omitted_count(len(slimmed_historical)), len(slimmed_historical)
+    return candidate_with_omitted_count(len(slimmed_historical))
+
+
+def _drop_orphaned_function_call_outputs(
+    historical: list[JsonValue],
+    recent: list[JsonValue],
+) -> tuple[list[JsonValue], int]:
+    kept_call_ids = {
+        item.get("call_id")
+        for item in [*historical, *recent]
+        if is_json_mapping(item) and item.get("type") == "function_call" and isinstance(item.get("call_id"), str)
+    }
+    if not kept_call_ids:
+        filtered = [
+            item
+            for item in historical
+            if not (
+                is_json_mapping(item)
+                and item.get("type") == "function_call_output"
+                and isinstance(item.get("call_id"), str)
+            )
+        ]
+        return filtered, len(historical) - len(filtered)
+
+    filtered = [
+        item
+        for item in historical
+        if not (
+            is_json_mapping(item)
+            and item.get("type") == "function_call_output"
+            and isinstance(item.get("call_id"), str)
+            and item.get("call_id") not in kept_call_ids
+        )
+    ]
+    return filtered, len(historical) - len(filtered)
 
 
 def _serialized_json_size(payload: JsonObject) -> int:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -95,6 +95,9 @@ _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE = (
     "[codex-lb omitted historical tool output ({bytes} bytes) to fit upstream websocket budget]"
 )
 _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline image to fit upstream websocket budget]"
+_RESPONSE_CREATE_HISTORY_OMISSION_NOTICE = (
+    "[codex-lb omitted {count} historical input items to fit upstream websocket budget]"
+)
 _UPSTREAM_TRACE_HEADER_ALLOWLIST = frozenset(
     {
         "accept",
@@ -1328,13 +1331,14 @@ def _prepare_websocket_response_create_payload(payload_dict: JsonObject) -> Json
                 (
                     "Slimmed response.create before upstream websocket connect request_id=%s "
                     "original_bytes=%s slimmed_bytes=%s historical_tool_outputs_slimmed=%s "
-                    "historical_images_slimmed=%s"
+                    "historical_images_slimmed=%s historical_items_omitted=%s"
                 ),
                 get_request_id(),
                 payload_size,
                 len(slimmed_text.encode("utf-8")),
                 slim_summary["historical_tool_outputs_slimmed"],
                 slim_summary["historical_images_slimmed"],
+                slim_summary["historical_items_omitted"],
             )
             payload_text = slimmed_text
             payload_size = len(payload_text.encode("utf-8"))
@@ -1375,7 +1379,6 @@ def _slim_response_create_payload_for_upstream(
     *,
     max_bytes: int,
 ) -> tuple[JsonObject, dict[str, int] | None]:
-    del max_bytes
     input_value = payload.get("input")
     if not isinstance(input_value, list) or not input_value:
         return payload, None
@@ -1395,15 +1398,63 @@ def _slim_response_create_payload_for_upstream(
         images_slimmed += item_images_slimmed
         slimmed_historical.append(slimmed_item)
 
-    if tool_outputs_slimmed == 0 and images_slimmed == 0:
-        return payload, None
-
     candidate_payload = dict(payload)
     candidate_payload["input"] = slimmed_historical + recent
+
+    items_omitted = 0
+    if _serialized_json_size(candidate_payload) > max_bytes:
+        candidate_payload, items_omitted = _omit_historical_response_input_items_to_fit(
+            candidate_payload,
+            slimmed_historical=slimmed_historical,
+            recent=recent,
+            max_bytes=max_bytes,
+        )
+
+    if tool_outputs_slimmed == 0 and images_slimmed == 0 and items_omitted == 0:
+        return payload, None
+
     return candidate_payload, {
         "historical_tool_outputs_slimmed": tool_outputs_slimmed,
         "historical_images_slimmed": images_slimmed,
+        "historical_items_omitted": items_omitted,
     }
+
+
+def _omit_historical_response_input_items_to_fit(
+    payload: JsonObject,
+    *,
+    slimmed_historical: list[JsonValue],
+    recent: list[JsonValue],
+    max_bytes: int,
+) -> tuple[JsonObject, int]:
+    if not slimmed_historical:
+        return payload, 0
+
+    omitted_count = 0
+    remaining_historical = list(slimmed_historical)
+    candidate_payload = payload
+    while remaining_historical:
+        omitted_count += 1
+        remaining_historical = remaining_historical[1:]
+        candidate_payload = dict(payload)
+        candidate_payload["input"] = [
+            _response_create_history_omission_notice_item(omitted_count),
+            *remaining_historical,
+            *recent,
+        ]
+        if _serialized_json_size(candidate_payload) <= max_bytes:
+            return candidate_payload, omitted_count
+
+    recent_only_payload = dict(payload)
+    recent_only_payload["input"] = list(recent)
+    if _serialized_json_size(recent_only_payload) <= max_bytes:
+        return recent_only_payload, omitted_count
+
+    return candidate_payload, omitted_count
+
+
+def _serialized_json_size(payload: JsonObject) -> int:
+    return len(json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8"))
 
 
 def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:
@@ -1489,6 +1540,18 @@ def _response_create_inline_image_notice_part() -> JsonObject:
 
 def _response_create_inline_image_notice_item() -> JsonObject:
     return {"role": "user", "content": [_response_create_inline_image_notice_part()]}
+
+
+def _response_create_history_omission_notice_item(count: int) -> JsonObject:
+    return {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "output_text",
+                "text": _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE.format(count=count),
+            }
+        ],
+    }
 
 
 def _is_inline_image_reference(value: JsonValue) -> bool:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9152,6 +9152,11 @@ def _omit_historical_response_input_items_to_fit(
         if _serialized_json_size(candidate_payload) <= max_bytes:
             return candidate_payload, omitted_count
 
+    recent_only_payload = dict(payload)
+    recent_only_payload["input"] = list(recent)
+    if _serialized_json_size(recent_only_payload) <= max_bytes:
+        return recent_only_payload, omitted_count
+
     return candidate_payload, omitted_count
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from hashlib import sha256
 from ipaddress import ip_address
-from pathlib import Path
 from typing import Any, AsyncIterator, Literal, Mapping, NoReturn, TypeVar, cast, overload
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -60,7 +59,7 @@ from app.core.clients.proxy_websocket import (
     connect_responses_websocket,
     filter_inbound_websocket_headers,
 )
-from app.core.config.settings import Settings, get_settings
+from app.core.config.settings import DEFAULT_HOME_DIR, Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
@@ -171,7 +170,7 @@ logger = logging.getLogger(__name__)
 
 _UPSTREAM_RESPONSE_CREATE_MAX_BYTES = get_settings().upstream_response_create_max_bytes
 _UPSTREAM_RESPONSE_CREATE_WARN_BYTES = int(_UPSTREAM_RESPONSE_CREATE_MAX_BYTES * 0.8)
-_OVERSIZED_RESPONSE_CREATE_DUMP_DIR = Path("/var/lib/codex-lb/debug/response-create-dumps")
+_OVERSIZED_RESPONSE_CREATE_DUMP_DIR = DEFAULT_HOME_DIR / "debug" / "response-create-dumps"
 _OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS = 10
 _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE = (
     "[codex-lb omitted {count} historical input items to fit upstream websocket budget]"
@@ -9109,13 +9108,55 @@ def _slim_response_create_payload_for_upstream(
     candidate_payload = dict(payload)
     candidate_payload["input"] = slimmed_historical + recent
 
-    if tool_outputs_slimmed == 0 and images_slimmed == 0:
+    items_omitted = 0
+    if _serialized_json_size(candidate_payload) > max_bytes:
+        candidate_payload, items_omitted = _omit_historical_response_input_items_to_fit(
+            candidate_payload,
+            slimmed_historical=slimmed_historical,
+            recent=recent,
+            max_bytes=max_bytes,
+        )
+
+    if tool_outputs_slimmed == 0 and images_slimmed == 0 and items_omitted == 0:
         return payload, None
 
     return candidate_payload, {
         "historical_tool_outputs_slimmed": tool_outputs_slimmed,
         "historical_images_slimmed": images_slimmed,
+        "historical_items_omitted": items_omitted,
     }
+
+
+def _omit_historical_response_input_items_to_fit(
+    payload: dict[str, JsonValue],
+    *,
+    slimmed_historical: list[JsonValue],
+    recent: list[JsonValue],
+    max_bytes: int,
+) -> tuple[dict[str, JsonValue], int]:
+    if not slimmed_historical:
+        return payload, 0
+
+    omitted_count = 0
+    remaining_historical = list(slimmed_historical)
+    candidate_payload = payload
+    while remaining_historical:
+        omitted_count += 1
+        remaining_historical = remaining_historical[1:]
+        candidate_payload = dict(payload)
+        candidate_payload["input"] = [
+            _response_create_history_omission_notice_item(omitted_count),
+            *remaining_historical,
+            *recent,
+        ]
+        if _serialized_json_size(candidate_payload) <= max_bytes:
+            return candidate_payload, omitted_count
+
+    return candidate_payload, omitted_count
+
+
+def _serialized_json_size(payload: dict[str, JsonValue]) -> int:
+    return len(json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8"))
 
 
 def _response_create_recent_suffix_start(input_items: list[JsonValue]) -> int:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9137,27 +9137,36 @@ def _omit_historical_response_input_items_to_fit(
     if not slimmed_historical:
         return payload, 0
 
-    omitted_count = 0
-    remaining_historical = list(slimmed_historical)
-    candidate_payload = payload
-    while remaining_historical:
-        omitted_count += 1
-        remaining_historical = remaining_historical[1:]
+    def candidate_with_omitted_count(omitted_count: int) -> dict[str, JsonValue]:
         candidate_payload = dict(payload)
         candidate_payload["input"] = [
             _response_create_history_omission_notice_item(omitted_count),
-            *remaining_historical,
+            *slimmed_historical[omitted_count:],
             *recent,
         ]
+        return candidate_payload
+
+    low = 1
+    high = len(slimmed_historical)
+    best: tuple[dict[str, JsonValue], int] | None = None
+    while low <= high:
+        omitted_count = (low + high) // 2
+        candidate_payload = candidate_with_omitted_count(omitted_count)
         if _serialized_json_size(candidate_payload) <= max_bytes:
-            return candidate_payload, omitted_count
+            best = (candidate_payload, omitted_count)
+            high = omitted_count - 1
+        else:
+            low = omitted_count + 1
+
+    if best is not None:
+        return best
 
     recent_only_payload = dict(payload)
     recent_only_payload["input"] = list(recent)
     if _serialized_json_size(recent_only_payload) <= max_bytes:
-        return recent_only_payload, omitted_count
+        return recent_only_payload, len(slimmed_historical)
 
-    return candidate_payload, omitted_count
+    return candidate_with_omitted_count(len(slimmed_historical)), len(slimmed_historical)
 
 
 def _serialized_json_size(payload: dict[str, JsonValue]) -> int:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9137,26 +9137,31 @@ def _omit_historical_response_input_items_to_fit(
     if not slimmed_historical:
         return payload, 0
 
-    def candidate_with_omitted_count(omitted_count: int) -> dict[str, JsonValue]:
+    def candidate_with_omitted_count(prefix_omitted_count: int) -> tuple[dict[str, JsonValue], int]:
+        remaining_historical, orphaned_outputs = _drop_orphaned_function_call_outputs(
+            slimmed_historical[prefix_omitted_count:],
+            recent,
+        )
+        omitted_count = prefix_omitted_count + orphaned_outputs
         candidate_payload = dict(payload)
         candidate_payload["input"] = [
             _response_create_history_omission_notice_item(omitted_count),
-            *slimmed_historical[omitted_count:],
+            *remaining_historical,
             *recent,
         ]
-        return candidate_payload
+        return candidate_payload, omitted_count
 
     low = 1
     high = len(slimmed_historical)
     best: tuple[dict[str, JsonValue], int] | None = None
     while low <= high:
-        omitted_count = (low + high) // 2
-        candidate_payload = candidate_with_omitted_count(omitted_count)
+        prefix_omitted_count = (low + high) // 2
+        candidate_payload, omitted_count = candidate_with_omitted_count(prefix_omitted_count)
         if _serialized_json_size(candidate_payload) <= max_bytes:
             best = (candidate_payload, omitted_count)
-            high = omitted_count - 1
+            high = prefix_omitted_count - 1
         else:
-            low = omitted_count + 1
+            low = prefix_omitted_count + 1
 
     if best is not None:
         return best
@@ -9166,7 +9171,41 @@ def _omit_historical_response_input_items_to_fit(
     if _serialized_json_size(recent_only_payload) <= max_bytes:
         return recent_only_payload, len(slimmed_historical)
 
-    return candidate_with_omitted_count(len(slimmed_historical)), len(slimmed_historical)
+    return candidate_with_omitted_count(len(slimmed_historical))
+
+
+def _drop_orphaned_function_call_outputs(
+    historical: list[JsonValue],
+    recent: list[JsonValue],
+) -> tuple[list[JsonValue], int]:
+    kept_call_ids = {
+        item.get("call_id")
+        for item in [*historical, *recent]
+        if is_json_mapping(item) and item.get("type") == "function_call" and isinstance(item.get("call_id"), str)
+    }
+    if not kept_call_ids:
+        filtered = [
+            item
+            for item in historical
+            if not (
+                is_json_mapping(item)
+                and item.get("type") == "function_call_output"
+                and isinstance(item.get("call_id"), str)
+            )
+        ]
+        return filtered, len(historical) - len(filtered)
+
+    filtered = [
+        item
+        for item in historical
+        if not (
+            is_json_mapping(item)
+            and item.get("type") == "function_call_output"
+            and isinstance(item.get("call_id"), str)
+            and item.get("call_id") not in kept_call_ids
+        )
+    ]
+    return filtered, len(historical) - len(filtered)
 
 
 def _serialized_json_size(payload: dict[str, JsonValue]) -> int:

--- a/openspec/changes/slim-oversized-response-create-history/proposal.md
+++ b/openspec/changes/slim-oversized-response-create-history/proposal.md
@@ -1,0 +1,29 @@
+# Proposal: slim-oversized-response-create-history
+
+## Why
+
+Large Codex `response.create` requests can still exceed the upstream websocket
+budget after the existing inline-image and tool-output slimming pass. In that
+case the proxy returns `413 payload_too_large` even when the oversized content is
+old conversation history and the current user turn could be preserved.
+
+The oversized debug dump path also used a Docker-only data directory. Local
+`uv tool` or LaunchAgent installs may not be allowed to create `/var/lib/codex-lb`,
+so the diagnostic dump can fail exactly when it is needed.
+
+## What Changes
+
+- After existing historical image/tool-output slimming, omit the oldest
+  historical input items until the serialized `response.create` fits the
+  upstream websocket budget.
+- Preserve the recent user-turn suffix and insert a single assistant notice that
+  says how many historical input items were omitted.
+- Use the configured default app home directory for oversized response-create
+  dumps, preserving `/var/lib/codex-lb` in containers while using
+  `~/.codex-lb` for local installs.
+
+## Impact
+
+- Fewer oversized Codex websocket requests fail with `413` when old history can
+  be safely summarized away.
+- Debug dumps remain writable in both Docker and local user installs.

--- a/openspec/changes/slim-oversized-response-create-history/specs/responses-api-compat/spec.md
+++ b/openspec/changes/slim-oversized-response-create-history/specs/responses-api-compat/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Upstream Responses request size budget
+The service SHALL enforce the configured upstream `response.create` websocket
+request size budget before sending a request upstream. When a request exceeds
+the budget, the service SHALL first slim historical inline images and historical
+tool outputs. If the request is still too large and contains historical input
+items before the recent user-turn suffix, the service SHALL omit the oldest
+historical input items until the serialized request fits the budget or no
+historical items remain. The service SHALL preserve the recent user-turn suffix
+and SHALL include an assistant notice describing the number of omitted
+historical input items.
+
+#### Scenario: oversized historical text can be omitted
+- **WHEN** a Codex `response.create` request remains over the websocket request
+  size budget after image and tool-output slimming
+- **AND** the request has historical input items before the recent user-turn
+  suffix
+- **THEN** the proxy omits the oldest historical input items until the request
+  fits the budget
+- **AND** the recent user-turn suffix remains in the upstream request
+- **AND** the upstream request includes an assistant notice with the omitted
+  item count
+
+### Requirement: Oversized Responses request diagnostics
+The service SHALL write oversized `response.create` debug dumps under the
+configured app home directory by default. Container installs SHALL keep using
+the container data directory, while local user installs SHALL use the user app
+data directory.
+
+#### Scenario: local install dump directory is writable by the user
+- **WHEN** codex-lb runs outside a container
+- **THEN** oversized `response.create` debug dumps default under the user's
+  app data directory instead of `/var/lib/codex-lb`

--- a/openspec/changes/slim-oversized-response-create-history/tasks.md
+++ b/openspec/changes/slim-oversized-response-create-history/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [x] 1.1 Add a second slimming pass that omits oldest historical input items
+      after image/tool-output slimming if the request is still over budget.
+- [x] 1.2 Preserve the recent user-turn suffix and insert an omission notice.
+- [x] 1.3 Move oversized response-create dumps under the default app home
+      directory.
+
+## 2. Verification
+
+- [x] 2.1 Add unit coverage for historical item omission.
+- [x] 2.2 Add unit coverage for the portable dump directory default.
+- [x] 2.3 Run targeted pytest, ruff, ty, and OpenSpec validation.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5127,6 +5127,35 @@ def test_slim_response_create_omits_oldest_historical_items_to_fit_budget():
     assert proxy_service._serialized_json_size(slimmed_payload) <= 360
 
 
+def test_slim_response_create_drops_omission_notice_when_only_recent_fits():
+    recent_item: dict[str, JsonValue] = {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "please continue"}],
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {"role": "assistant", "content": [{"type": "output_text", "text": "old context"}]},
+            recent_item,
+        ],
+    }
+    max_bytes = proxy_service._serialized_json_size({**payload, "input": [recent_item]})
+    notice_payload = {
+        **payload,
+        "input": [proxy_service._response_create_history_omission_notice_item(1), recent_item],
+    }
+
+    assert proxy_service._serialized_json_size(notice_payload) > max_bytes
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=max_bytes)
+
+    assert summary is not None
+    assert summary["historical_items_omitted"] == 1
+    assert slimmed_payload["input"] == [recent_item]
+    assert proxy_service._serialized_json_size(slimmed_payload) <= max_bytes
+
+
 def test_oversized_response_create_dump_dir_uses_default_home_dir():
     assert proxy_service._OVERSIZED_RESPONSE_CREATE_DUMP_DIR == (DEFAULT_HOME_DIR / "debug" / "response-create-dumps")
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -24,7 +24,7 @@ from app.core.openai.models import OpenAIResponsePayload
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
 from app.core.resilience.circuit_breaker import CircuitState
-from app.core.types import JsonValue
+from app.core.types import JsonObject, JsonValue
 from app.core.utils.request_id import get_request_id, reset_request_id, set_request_id
 from app.core.utils.sse import parse_sse_data_json
 from app.core.utils.time import utcnow
@@ -1781,7 +1781,7 @@ async def test_stream_responses_uses_websocket_transport(monkeypatch):
     ]
 
     assert session.ws_calls[0]["url"] == "wss://chatgpt.com/backend-api/codex/responses"
-    request_payload = websocket.sent_json[0]
+    request_payload = cast(JsonObject, websocket.sent_json[0])
     expected_request_payload = {
         "type": "response.create",
         **{k: v for k, v in payload.to_payload().items() if k != "stream"},
@@ -1916,7 +1916,7 @@ async def test_stream_responses_websocket_slims_historical_inline_artifacts_and_
 
     assert len(events) == 2
     assert len(session.ws_calls) == 1
-    request_payload = websocket.sent_json[0]
+    request_payload = cast(JsonObject, websocket.sent_json[0])
     request_input = cast(list[dict[str, object]], request_payload["input"])
     assert request_input[1]["output"] == proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
         bytes=len(("data:image/png;base64," + ("A" * 1200)).encode("utf-8"))
@@ -1984,7 +1984,7 @@ async def test_stream_responses_websocket_omits_oldest_historical_items_to_fit_b
 
     assert len(events) == 2
     assert len(session.ws_calls) == 1
-    request_payload = websocket.sent_json[0]
+    request_payload = cast(JsonObject, websocket.sent_json[0])
     request_input = cast(list[dict[str, object]], request_payload["input"])
     assert request_input[0] == proxy_module._response_create_history_omission_notice_item(2)
     assert request_input[-1] == {"role": "user", "content": [{"type": "input_text", "text": "please continue"}]}

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -17,7 +17,7 @@ from starlette.requests import Request
 
 import app.core.clients.proxy as proxy_module
 from app.core.clients.proxy import _build_upstream_headers, filter_inbound_headers
-from app.core.config.settings import Settings
+from app.core.config.settings import DEFAULT_HOME_DIR, Settings
 from app.core.crypto import TokenEncryptor
 from app.core.errors import openai_error
 from app.core.openai.models import OpenAIResponsePayload
@@ -5101,6 +5101,34 @@ def test_slim_response_create_handles_object_valued_content_image():
     first_content = first_item["content"]
     assert isinstance(first_content, dict)
     assert first_content["type"] == "input_text"
+
+
+def test_slim_response_create_omits_oldest_historical_items_to_fit_budget():
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {"role": "assistant", "content": [{"type": "output_text", "text": "old-a" * 200}]},
+            {"role": "assistant", "content": [{"type": "output_text", "text": "old-b" * 200}]},
+            {"role": "user", "content": [{"type": "input_text", "text": "please continue"}]},
+        ],
+    }
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=360)
+    slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
+
+    assert summary is not None
+    assert summary["historical_items_omitted"] == 2
+    notice = slimmed_input[0]
+    assert isinstance(notice, dict)
+    assert notice["role"] == "assistant"
+    assert "omitted 2 historical input items" in json.dumps(notice)
+    assert slimmed_input[-1] == {"role": "user", "content": [{"type": "input_text", "text": "please continue"}]}
+    assert proxy_service._serialized_json_size(slimmed_payload) <= 360
+
+
+def test_oversized_response_create_dump_dir_uses_default_home_dir():
+    assert proxy_service._OVERSIZED_RESPONSE_CREATE_DUMP_DIR == (DEFAULT_HOME_DIR / "debug" / "response-create-dumps")
 
 
 def test_websocket_receive_timeout_prefers_idle_timeout_when_budget_allows(monkeypatch):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5219,6 +5219,46 @@ def test_slim_response_create_drops_omission_notice_when_only_recent_fits():
     assert proxy_service._serialized_json_size(slimmed_payload) <= max_bytes
 
 
+def test_slim_response_create_omits_history_with_bounded_serialization(monkeypatch):
+    recent_item: dict[str, JsonValue] = {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "please continue"}],
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            *[
+                {"role": "assistant", "content": [{"type": "output_text", "text": f"old-{index}"}]}
+                for index in range(1024)
+            ],
+            recent_item,
+        ],
+    }
+    original_serialized_json_size = proxy_service._serialized_json_size
+    max_bytes = original_serialized_json_size(
+        {
+            **payload,
+            "input": [proxy_service._response_create_history_omission_notice_item(1024), recent_item],
+        }
+    )
+    calls = 0
+
+    def counted_serialized_json_size(payload: dict[str, JsonValue]) -> int:
+        nonlocal calls
+        calls += 1
+        return original_serialized_json_size(payload)
+
+    monkeypatch.setattr(proxy_service, "_serialized_json_size", counted_serialized_json_size)
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=max_bytes)
+
+    assert summary is not None
+    assert summary["historical_items_omitted"] == 1024
+    assert slimmed_payload["input"] == [proxy_service._response_create_history_omission_notice_item(1024), recent_item]
+    assert calls <= 16
+
+
 def test_oversized_response_create_dump_dir_uses_default_home_dir():
     assert proxy_service._OVERSIZED_RESPONSE_CREATE_DUMP_DIR == (DEFAULT_HOME_DIR / "debug" / "response-create-dumps")
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5259,6 +5259,34 @@ def test_slim_response_create_omits_history_with_bounded_serialization(monkeypat
     assert calls <= 16
 
 
+def test_slim_response_create_drops_orphaned_function_call_outputs():
+    recent_item: dict[str, JsonValue] = {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "please continue"}],
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {"type": "function_call", "call_id": "call_1", "name": "tool", "arguments": "x" * 600},
+            {"type": "function_call_output", "call_id": "call_1", "output": "small output"},
+            recent_item,
+        ],
+    }
+    max_bytes = proxy_service._serialized_json_size(
+        {
+            **payload,
+            "input": [proxy_service._response_create_history_omission_notice_item(2), recent_item],
+        }
+    )
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=max_bytes)
+
+    assert summary is not None
+    assert summary["historical_items_omitted"] == 2
+    assert slimmed_payload["input"] == [proxy_service._response_create_history_omission_notice_item(2), recent_item]
+
+
 def test_oversized_response_create_dump_dir_uses_default_home_dir():
     assert proxy_service._OVERSIZED_RESPONSE_CREATE_DUMP_DIR == (DEFAULT_HOME_DIR / "debug" / "response-create-dumps")
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1929,6 +1929,69 @@ async def test_stream_responses_websocket_slims_historical_inline_artifacts_and_
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_websocket_omits_oldest_historical_items_to_fit_budget(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_stream_transport = "websocket"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 75.0
+        log_upstream_request_summary = False
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64, raising=False)
+    monkeypatch.setattr(proxy_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 360, raising=False)
+
+    messages = [
+        SimpleNamespace(
+            type=proxy_module.aiohttp.WSMsgType.TEXT,
+            data='{"type":"response.created","response":{"id":"resp_ws_omit","service_tier":"auto"}}',
+        ),
+        SimpleNamespace(
+            type=proxy_module.aiohttp.WSMsgType.TEXT,
+            data='{"type":"response.completed","response":{"id":"resp_ws_omit","service_tier":"default"}}',
+        ),
+    ]
+    websocket = _WsResponse(messages)
+    session = _WsSession(websocket)
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "assistant", "content": [{"type": "output_text", "text": "old-a" * 200}]},
+                {"role": "assistant", "content": [{"type": "output_text", "text": "old-b" * 200}]},
+                {"role": "user", "content": [{"type": "input_text", "text": "please continue"}]},
+            ],
+        }
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    assert len(events) == 2
+    assert len(session.ws_calls) == 1
+    request_payload = websocket.sent_json[0]
+    request_input = cast(list[dict[str, object]], request_payload["input"])
+    assert request_input[0] == proxy_module._response_create_history_omission_notice_item(2)
+    assert request_input[-1] == {"role": "user", "content": [{"type": "input_text", "text": "please continue"}]}
+    assert proxy_module._serialized_json_size(request_payload) <= 360
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_websocket_forces_response_create_event_type(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"


### PR DESCRIPTION
## Summary

- Continue `response.create` slimming by omitting the oldest historical input items when image/tool-output slimming is still over the websocket budget.
- Preserve the recent user-turn suffix and add a single assistant notice with the omitted item count.
- Move oversized `response.create` debug dumps under the default app home directory so local user installs use `~/.codex-lb` while containers keep `/var/lib/codex-lb`.

Fixes #556.

## Validation

- `openspec validate --specs`
- `uv run pytest tests/unit/test_proxy_utils.py -k 'slim_response_create or oversized_response_create_dump_dir' -q`
- `uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `uv run ty check app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
