### PR TITLE
fix(proxy): narrow budget-safe gate to primary usage

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -260,10 +260,7 @@ def select_account(
             selected = _select_capacity_weighted(candidate_pool)
     else:
         if primary_first_usage_weighted:
-            selected = min(
-                effective_pool,
-                key=_primary_reset_first_sort_key if prefer_earlier_reset else _primary_usage_sort_key,
-            )
+            selected = min(effective_pool, key=_primary_usage_sort_key)
         else:
             selected = min(effective_pool, key=_reset_first_sort_key if prefer_earlier_reset else _usage_sort_key)
     return SelectionResult(selected, None)

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -77,6 +77,13 @@ def _usage_sort_key(state: AccountState) -> tuple[float, float, float, str]:
     return secondary_used, primary_used, last_selected, state.account_id
 
 
+def _primary_usage_sort_key(state: AccountState) -> tuple[float, float, float, str]:
+    primary_used = state.used_percent if state.used_percent is not None else 0.0
+    secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else primary_used
+    last_selected = state.last_selected_at or 0.0
+    return primary_used, secondary_used, last_selected, state.account_id
+
+
 def _reset_bucket_days(state: AccountState, current: float) -> int:
     if state.secondary_reset_at is None:
         return UNKNOWN_RESET_BUCKET_DAYS
@@ -105,6 +112,7 @@ def select_account(
     routing_strategy: RoutingStrategy = "capacity_weighted",
     allow_backoff_fallback: bool = True,
     deterministic_probe: bool = False,
+    primary_first_usage_weighted: bool = False,
 ) -> SelectionResult:
     """Select an eligible account by applying availability checks and routing strategy.
 
@@ -127,6 +135,8 @@ def select_account(
             account exists.
         deterministic_probe: Whether capacity-weighted routing should use a
             deterministic probe order instead of random weighted choice.
+        primary_first_usage_weighted: Whether usage-weighted routing should
+            rank by primary-window pressure before secondary-window pressure.
 
     Returns:
         A ``SelectionResult`` containing the selected ``AccountState`` and no
@@ -224,6 +234,11 @@ def select_account(
         secondary_used, primary_used, last_selected, account_id = _usage_sort_key(state)
         return reset_bucket_days, secondary_used, primary_used, last_selected, account_id
 
+    def _primary_reset_first_sort_key(state: AccountState) -> tuple[int, float, float, float, str]:
+        reset_bucket_days = _reset_bucket_days(state, current)
+        primary_used, secondary_used, last_selected, account_id = _primary_usage_sort_key(state)
+        return reset_bucket_days, primary_used, secondary_used, last_selected, account_id
+
     def _round_robin_sort_key(state: AccountState) -> tuple[float, str]:
         # Pick the least recently selected account, then stabilize by account_id.
         return state.last_selected_at or 0.0, state.account_id
@@ -244,7 +259,13 @@ def select_account(
         else:
             selected = _select_capacity_weighted(candidate_pool)
     else:
-        selected = min(effective_pool, key=_reset_first_sort_key if prefer_earlier_reset else _usage_sort_key)
+        if primary_first_usage_weighted:
+            selected = min(
+                effective_pool,
+                key=_primary_reset_first_sort_key if prefer_earlier_reset else _primary_usage_sort_key,
+            )
+        else:
+            selected = min(effective_pool, key=_reset_first_sort_key if prefer_earlier_reset else _usage_sort_key)
     return SelectionResult(selected, None)
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1303,10 +1303,14 @@ def _additional_usage_is_exhausted(entry: AdditionalUsageHistory) -> bool:
 
 
 def _state_above_budget_threshold(state: AccountState, budget_threshold_pct: float) -> bool:
-    return any(
-        used_percent is not None and used_percent > budget_threshold_pct
-        for used_percent in (state.used_percent, state.secondary_used_percent)
-    )
+    return state.used_percent is not None and state.used_percent > budget_threshold_pct
+
+
+def _primary_budget_pressure_sort_key(state: AccountState) -> tuple[float, float, float, str]:
+    primary_used = state.used_percent if state.used_percent is not None else 0.0
+    secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else primary_used
+    last_selected = state.last_selected_at or 0.0
+    return primary_used, secondary_used, last_selected, state.account_id
 
 
 def _select_account_preferring_budget_safe(
@@ -1330,6 +1334,21 @@ def _select_account_preferring_budget_safe(
         )
         if preferred.account is not None:
             return preferred
+    if (
+        routing_strategy == "usage_weighted"
+        and state_list
+        and all(_state_above_budget_threshold(state, budget_threshold_pct) for state in state_list)
+    ):
+        for state in sorted(state_list, key=_primary_budget_pressure_sort_key):
+            candidate = select_account(
+                [state],
+                prefer_earlier_reset=prefer_earlier_reset,
+                routing_strategy=routing_strategy,
+                allow_backoff_fallback=False,
+                deterministic_probe=deterministic_probe,
+            )
+            if candidate.account is not None:
+                return candidate
     return select_account(
         state_list,
         prefer_earlier_reset=prefer_earlier_reset,

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1312,12 +1312,8 @@ def _state_above_budget_threshold(state: AccountState, budget_threshold_pct: flo
 
 
 def _state_above_sticky_budget_threshold(state: AccountState, budget_threshold_pct: float) -> bool:
-    return (
-        (state.used_percent is not None and state.used_percent > budget_threshold_pct)
-        or (
-            state.secondary_used_percent is not None
-            and state.secondary_used_percent > budget_threshold_pct
-        )
+    return (state.used_percent is not None and state.used_percent > budget_threshold_pct) or (
+        state.secondary_used_percent is not None and state.secondary_used_percent > budget_threshold_pct
     )
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1306,13 +1306,6 @@ def _state_above_budget_threshold(state: AccountState, budget_threshold_pct: flo
     return state.used_percent is not None and state.used_percent > budget_threshold_pct
 
 
-def _primary_budget_pressure_sort_key(state: AccountState) -> tuple[float, float, float, str]:
-    primary_used = state.used_percent if state.used_percent is not None else 0.0
-    secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else primary_used
-    last_selected = state.last_selected_at or 0.0
-    return primary_used, secondary_used, last_selected, state.account_id
-
-
 def _select_account_preferring_budget_safe(
     states: Iterable[AccountState],
     *,
@@ -1339,16 +1332,14 @@ def _select_account_preferring_budget_safe(
         and state_list
         and all(_state_above_budget_threshold(state, budget_threshold_pct) for state in state_list)
     ):
-        for state in sorted(state_list, key=_primary_budget_pressure_sort_key):
-            candidate = select_account(
-                [state],
-                prefer_earlier_reset=prefer_earlier_reset,
-                routing_strategy=routing_strategy,
-                allow_backoff_fallback=False,
-                deterministic_probe=deterministic_probe,
-            )
-            if candidate.account is not None:
-                return candidate
+        return select_account(
+            state_list,
+            prefer_earlier_reset=prefer_earlier_reset,
+            routing_strategy=routing_strategy,
+            allow_backoff_fallback=allow_backoff_fallback,
+            deterministic_probe=deterministic_probe,
+            primary_first_usage_weighted=True,
+        )
     return select_account(
         state_list,
         prefer_earlier_reset=prefer_earlier_reset,

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -681,7 +681,7 @@ class LoadBalancer:
                 budget_pressured = (
                     sticky_kind in (StickySessionKind.PROMPT_CACHE, StickySessionKind.CODEX_SESSION)
                     and pinned.status != AccountStatus.RATE_LIMITED
-                    and _state_above_budget_threshold(pinned, budget_threshold_pct)
+                    and _state_above_sticky_budget_threshold(pinned, budget_threshold_pct)
                 )
                 rate_limit_far_away = (
                     sticky_kind == StickySessionKind.PROMPT_CACHE
@@ -714,9 +714,14 @@ class LoadBalancer:
                             deterministic_probe=True,
                             budget_threshold_pct=budget_threshold_pct,
                         )
+                        pool_exhausted = (
+                            _state_above_budget_threshold
+                            if _state_above_budget_threshold(pinned, budget_threshold_pct)
+                            else _state_above_sticky_budget_threshold
+                        )
                         pool_also_exhausted = pool_best.account is not None and (
                             pool_best.account.account_id == pinned.account_id
-                            or _state_above_budget_threshold(pool_best.account, budget_threshold_pct)
+                            or pool_exhausted(pool_best.account, budget_threshold_pct)
                         )
                         if pool_also_exhausted:
                             pinned_result = select_account(
@@ -1306,6 +1311,16 @@ def _state_above_budget_threshold(state: AccountState, budget_threshold_pct: flo
     return state.used_percent is not None and state.used_percent > budget_threshold_pct
 
 
+def _state_above_sticky_budget_threshold(state: AccountState, budget_threshold_pct: float) -> bool:
+    return (
+        (state.used_percent is not None and state.used_percent > budget_threshold_pct)
+        or (
+            state.secondary_used_percent is not None
+            and state.secondary_used_percent > budget_threshold_pct
+        )
+    )
+
+
 def _select_account_preferring_budget_safe(
     states: Iterable[AccountState],
     *,
@@ -1317,15 +1332,18 @@ def _select_account_preferring_budget_safe(
 ) -> SelectionResult:
     state_list = list(states)
     preferred_states = [state for state in state_list if not _state_above_budget_threshold(state, budget_threshold_pct)]
-    if preferred_states and len(preferred_states) != len(state_list):
+    if preferred_states:
+        selection_pool = preferred_states if len(preferred_states) != len(state_list) else state_list
         preferred = select_account(
-            preferred_states,
+            selection_pool,
             prefer_earlier_reset=prefer_earlier_reset,
             routing_strategy=routing_strategy,
             allow_backoff_fallback=allow_backoff_fallback,
             deterministic_probe=deterministic_probe,
         )
         if preferred.account is not None:
+            return preferred
+        if len(preferred_states) == len(state_list):
             return preferred
     if routing_strategy == "usage_weighted" and state_list:
         return select_account(

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1327,11 +1327,7 @@ def _select_account_preferring_budget_safe(
         )
         if preferred.account is not None:
             return preferred
-    if (
-        routing_strategy == "usage_weighted"
-        and state_list
-        and all(_state_above_budget_threshold(state, budget_threshold_pct) for state in state_list)
-    ):
+    if routing_strategy == "usage_weighted" and state_list:
         return select_account(
             state_list,
             prefer_earlier_reset=prefer_earlier_reset,

--- a/openspec/changes/narrow-budget-safe-primary-gate/proposal.md
+++ b/openspec/changes/narrow-budget-safe-primary-gate/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The budget-safe Responses routing gate currently treats primary and secondary
+usage windows as equivalent pressure signals. That can move traffic away from
+an account whose short-window budget is still healthy only because its weekly
+window is high, even though the short window is the one most likely to cause an
+immediate upstream `usage_limit_reached` failure.
+
+When every candidate is already above the primary threshold, the existing
+`usage_weighted` fallback can also prefer a nearly exhausted primary-window
+account if its secondary usage is lower. That spends the riskiest account first
+in the degraded path.
+
+## What Changes
+
+- narrow the budget-safe hard gate to primary-window usage only
+- keep secondary-window usage available to routing strategies as a prioritizing
+  signal instead of a hard exclusion signal
+- make the degraded all-pressured `usage_weighted` fallback choose the least
+  primary-pressured account before secondary usage
+- add regression coverage for secondary-only pressure and all-primary-pressured
+  fallback selection
+
+## Impact
+
+Accounts with high weekly usage but healthy short-window usage remain eligible
+for Responses routing. When no healthy-primary candidate exists, the fallback
+uses the account least likely to fail immediately on the short window.

--- a/openspec/changes/narrow-budget-safe-primary-gate/specs/responses-api-compat/spec.md
+++ b/openspec/changes/narrow-budget-safe-primary-gate/specs/responses-api-compat/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+### Requirement: Responses routing prefers budget-safe accounts
+When serving Responses routes, the service MUST prefer eligible accounts whose
+primary usage window is still below the configured budget threshold over
+eligible accounts already above that primary-window threshold. Secondary-window
+usage MAY be used as a routing strategy signal, but MUST NOT by itself exclude
+an account from the budget-safe candidate set. If no below-primary-threshold
+candidate exists, the service MAY fall back to pressured candidates, but the
+`usage_weighted` degraded fallback MUST prefer lower primary-window pressure
+before lower secondary-window usage.
+
+#### Scenario: Fresh Responses request keeps weekly-pressured accounts eligible
+- **WHEN** `/backend-api/codex/responses`, `/backend-api/codex/responses/compact`, `/v1/responses`, or `/v1/responses/compact` selects among multiple eligible active accounts
+- **AND** one candidate is above the secondary-window usage threshold but below the primary-window usage threshold
+- **AND** another candidate is above the primary-window usage threshold
+- **THEN** the secondary-only pressured candidate remains eligible for the budget-safe selection set
+
+#### Scenario: Fresh Responses fallback avoids the most primary-pressured account
+- **WHEN** `/backend-api/codex/responses`, `/backend-api/codex/responses/compact`, `/v1/responses`, or `/v1/responses/compact` selects among multiple eligible active accounts with `usage_weighted` routing
+- **AND** every candidate is above the configured primary-window budget threshold
+- **AND** one candidate has lower secondary-window usage but higher primary-window usage
+- **THEN** the account with lower primary-window usage is chosen first

--- a/openspec/changes/narrow-budget-safe-primary-gate/tasks.md
+++ b/openspec/changes/narrow-budget-safe-primary-gate/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+- [x] 1.1 Narrow the budget-safe hard gate to primary-window usage
+- [x] 1.2 Add primary-first fallback ordering when every usage-weighted candidate is primary-pressured
+
+## 2. Verification
+
+- [x] 2.1 Add regression coverage for secondary-only pressure
+- [x] 2.2 Add regression coverage for all-primary-pressured `usage_weighted` fallback selection

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -16,7 +16,7 @@ from app.core.balancer import (
 )
 from app.core.usage.quota import apply_usage_quota
 from app.db.models import Account, AccountStatus, UsageHistory
-from app.modules.proxy.load_balancer import RuntimeState, _state_from_account
+from app.modules.proxy.load_balancer import RuntimeState, _select_account_preferring_budget_safe, _state_from_account
 
 pytestmark = pytest.mark.unit
 
@@ -1201,6 +1201,64 @@ def test_select_account_capacity_weighted_prefers_earlier_reset_bucket():
         )
         assert result.account is not None
         assert result.account.account_id == "early"
+
+
+def test_all_primary_pressured_fallback_skips_unavailable_account():
+    now = time.time()
+    states = [
+        AccountState(
+            "blocked",
+            AccountStatus.ACTIVE,
+            used_percent=96.0,
+            secondary_used_percent=5.0,
+            cooldown_until=now + 60,
+        ),
+        AccountState(
+            "available",
+            AccountStatus.ACTIVE,
+            used_percent=98.0,
+            secondary_used_percent=90.0,
+        ),
+    ]
+
+    result = _select_account_preferring_budget_safe(
+        states,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "available"
+
+
+def test_all_primary_pressured_fallback_prefers_healthy_over_draining():
+    states = [
+        AccountState(
+            "draining",
+            AccountStatus.ACTIVE,
+            used_percent=96.0,
+            secondary_used_percent=5.0,
+            health_tier=1,
+        ),
+        AccountState(
+            "healthy",
+            AccountStatus.ACTIVE,
+            used_percent=98.0,
+            secondary_used_percent=90.0,
+            health_tier=0,
+        ),
+    ]
+
+    result = _select_account_preferring_budget_safe(
+        states,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "healthy"
 
 
 def test_select_account_capacity_weighted_prefers_capacity_within_same_reset_bucket():

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1261,6 +1261,39 @@ def test_all_primary_pressured_fallback_prefers_healthy_over_draining():
     assert result.account.account_id == "healthy"
 
 
+def test_primary_pressured_fallback_ignores_unavailable_safe_accounts():
+    states = [
+        AccountState(
+            "safe-but-exhausted",
+            AccountStatus.QUOTA_EXCEEDED,
+            used_percent=10.0,
+            secondary_used_percent=10.0,
+        ),
+        AccountState(
+            "higher-primary",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=1.0,
+        ),
+        AccountState(
+            "lower-primary",
+            AccountStatus.ACTIVE,
+            used_percent=96.0,
+            secondary_used_percent=99.0,
+        ),
+    ]
+
+    result = _select_account_preferring_budget_safe(
+        states,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "lower-primary"
+
+
 def test_select_account_capacity_weighted_prefers_capacity_within_same_reset_bucket():
     random.seed(66)
     n = 2000

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -16,7 +16,12 @@ from app.core.balancer import (
 )
 from app.core.usage.quota import apply_usage_quota
 from app.db.models import Account, AccountStatus, UsageHistory
-from app.modules.proxy.load_balancer import RuntimeState, _select_account_preferring_budget_safe, _state_from_account
+from app.modules.proxy.load_balancer import (
+    RuntimeState,
+    _select_account_preferring_budget_safe,
+    _state_above_sticky_budget_threshold,
+    _state_from_account,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -1232,6 +1237,23 @@ def test_all_primary_pressured_fallback_skips_unavailable_account():
     assert result.account.account_id == "available"
 
 
+def test_budget_safe_selection_preserves_secondary_first_when_all_primary_safe():
+    states = [
+        AccountState("secondary-high", AccountStatus.ACTIVE, used_percent=10.0, secondary_used_percent=90.0),
+        AccountState("secondary-low", AccountStatus.ACTIVE, used_percent=20.0, secondary_used_percent=1.0),
+    ]
+
+    result = _select_account_preferring_budget_safe(
+        states,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "secondary-low"
+
+
 def test_all_primary_pressured_fallback_prefers_healthy_over_draining():
     states = [
         AccountState(
@@ -1292,6 +1314,47 @@ def test_primary_pressured_fallback_ignores_unavailable_safe_accounts():
 
     assert result.account is not None
     assert result.account.account_id == "lower-primary"
+
+
+def test_primary_pressured_fallback_prioritizes_primary_usage_before_reset_bucket():
+    now = time.time()
+    states = [
+        AccountState(
+            "earlier-reset-higher-primary",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=1.0,
+            secondary_reset_at=int(now + 3600),
+        ),
+        AccountState(
+            "later-reset-lower-primary",
+            AccountStatus.ACTIVE,
+            used_percent=96.0,
+            secondary_used_percent=99.0,
+            secondary_reset_at=int(now + 7 * 24 * 3600),
+        ),
+    ]
+
+    result = _select_account_preferring_budget_safe(
+        states,
+        prefer_earlier_reset=True,
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "later-reset-lower-primary"
+
+
+def test_sticky_budget_threshold_still_counts_secondary_pressure():
+    state = AccountState(
+        "sticky",
+        AccountStatus.ACTIVE,
+        used_percent=10.0,
+        secondary_used_percent=99.0,
+    )
+
+    assert _state_above_sticky_budget_threshold(state, 95.0) is True
 
 
 def test_select_account_capacity_weighted_prefers_capacity_within_same_reset_bucket():

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -348,7 +348,7 @@ async def test_select_account_prefers_budget_safe_account_when_any_exist() -> No
             account_id=safe_account.id,
             recorded_at=now,
             window="secondary",
-            used_percent=80.0,
+            used_percent=99.0,
             reset_at=now_epoch + 3600,
             window_minutes=60,
         ),
@@ -375,6 +375,194 @@ async def test_select_account_prefers_budget_safe_account_when_any_exist() -> No
 
     assert selection.account is not None
     assert selection.account.id == safe_account.id
+
+
+@pytest.mark.asyncio
+async def test_budget_safe_filter_ignores_secondary_only_pressure_when_primary_safe() -> None:
+    weekly_pressured_account = _make_account("acc-weekly-pressured", "weekly-pressured@example.com")
+    primary_pressured_account = _make_account("acc-primary-pressured", "primary-pressured@example.com")
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    primary = {
+        weekly_pressured_account.id: UsageHistory(
+            id=1,
+            account_id=weekly_pressured_account.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=20.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+        primary_pressured_account.id: UsageHistory(
+            id=2,
+            account_id=primary_pressured_account.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=99.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+    }
+    secondary = {
+        weekly_pressured_account.id: UsageHistory(
+            id=3,
+            account_id=weekly_pressured_account.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=99.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+        primary_pressured_account.id: UsageHistory(
+            id=4,
+            account_id=primary_pressured_account.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=1.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+    }
+
+    accounts_repo = StubAccountsRepository([weekly_pressured_account, primary_pressured_account])
+    usage_repo = StubUsageRepository(primary=primary, secondary=secondary)
+    sticky_repo = StubStickySessionsRepository()
+
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    selection = await balancer.select_account(
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert selection.account is not None
+    assert selection.account.id == weekly_pressured_account.id
+
+
+@pytest.mark.asyncio
+async def test_budget_safe_fallback_does_not_pick_near_exhausted_primary_under_usage_weighted() -> None:
+    nearly_exhausted_account = _make_account("acc-nearly-exhausted", "nearly-exhausted@example.com")
+    less_pressured_account = _make_account("acc-less-pressured", "less-pressured@example.com")
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    primary = {
+        nearly_exhausted_account.id: UsageHistory(
+            id=1,
+            account_id=nearly_exhausted_account.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=99.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+        less_pressured_account.id: UsageHistory(
+            id=2,
+            account_id=less_pressured_account.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=96.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+    }
+    secondary = {
+        nearly_exhausted_account.id: UsageHistory(
+            id=3,
+            account_id=nearly_exhausted_account.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=1.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+        less_pressured_account.id: UsageHistory(
+            id=4,
+            account_id=less_pressured_account.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=99.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+    }
+
+    accounts_repo = StubAccountsRepository([nearly_exhausted_account, less_pressured_account])
+    usage_repo = StubUsageRepository(primary=primary, secondary=secondary)
+    sticky_repo = StubStickySessionsRepository()
+
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    selection = await balancer.select_account(
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert selection.account is not None
+    assert selection.account.id == less_pressured_account.id
+
+
+@pytest.mark.asyncio
+async def test_budget_safe_fallback_still_skips_unavailable_accounts() -> None:
+    blocked_account = _make_account("acc-blocked", "blocked@example.com")
+    available_account = _make_account("acc-available", "available@example.com")
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    blocked_account.status = AccountStatus.QUOTA_EXCEEDED
+    blocked_account.reset_at = now_epoch + 300
+
+    primary = {
+        blocked_account.id: UsageHistory(
+            id=1,
+            account_id=blocked_account.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=96.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+        available_account.id: UsageHistory(
+            id=2,
+            account_id=available_account.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=99.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+    }
+    secondary = {
+        blocked_account.id: UsageHistory(
+            id=3,
+            account_id=blocked_account.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=100.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+        available_account.id: UsageHistory(
+            id=4,
+            account_id=available_account.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=99.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+    }
+
+    accounts_repo = StubAccountsRepository([blocked_account, available_account])
+    usage_repo = StubUsageRepository(primary=primary, secondary=secondary)
+    sticky_repo = StubStickySessionsRepository()
+
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    selection = await balancer.select_account(
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert selection.account is not None
+    assert selection.account.id == available_account.id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_select_with_stickiness.py
+++ b/tests/unit/test_select_with_stickiness.py
@@ -21,8 +21,17 @@ from app.modules.proxy.load_balancer import LoadBalancer
 pytestmark = pytest.mark.unit
 
 
-def _active(account_id: str, used_percent: float = 10.0) -> AccountState:
-    return AccountState(account_id, AccountStatus.ACTIVE, used_percent=used_percent)
+def _active(
+    account_id: str,
+    used_percent: float = 10.0,
+    secondary_used_percent: float | None = None,
+) -> AccountState:
+    return AccountState(
+        account_id,
+        AccountStatus.ACTIVE,
+        used_percent=used_percent,
+        secondary_used_percent=secondary_used_percent,
+    )
 
 
 def _rate_limited(
@@ -758,6 +767,50 @@ async def test_budget_threshold_reallocates_codex_session_affinity():
     assert result.account.account_id == "b"
     repo.delete.assert_called_once_with("codex-session-123", kind=StickySessionKind.CODEX_SESSION)
     repo.upsert.assert_called_once_with("codex-session-123", "b", kind=StickySessionKind.CODEX_SESSION)
+
+
+@pytest.mark.asyncio
+async def test_budget_threshold_reallocates_to_primary_safe_secondary_pressured_candidate():
+    acc_a = _active("a", used_percent=99.0, secondary_used_percent=1.0)
+    acc_b = _active("b", used_percent=10.0, secondary_used_percent=99.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b],
+        "codex-session-123",
+        repo,
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+        budget_threshold_pct=95.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "b"
+    repo.delete.assert_called_once_with("codex-session-123", kind=StickySessionKind.CODEX_SESSION)
+    repo.upsert.assert_called_once_with("codex-session-123", "b", kind=StickySessionKind.CODEX_SESSION)
+
+
+@pytest.mark.asyncio
+async def test_budget_threshold_preserves_sticky_when_every_candidate_secondary_pressured():
+    acc_a = _active("a", used_percent=10.0, secondary_used_percent=99.0)
+    acc_b = _active("b", used_percent=20.0, secondary_used_percent=99.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b],
+        "codex-session-123",
+        repo,
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+        budget_threshold_pct=95.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    repo.delete.assert_not_called()
+    repo.upsert.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- narrows the budget-safe Responses routing hard gate to primary-window usage only
- keeps secondary/weekly usage as a routing strategy signal instead of a hard exclusion signal
- makes the degraded all-primary-pressured `usage_weighted` fallback prefer lower primary pressure before lower weekly usage
- adds OpenSpec coverage and regression tests for the #446 edge cases

Closes #446.

## Verification

- `openspec validate narrow-budget-safe-primary-gate --strict`
- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-fix-446 uv run pytest tests/unit/test_proxy_load_balancer_refresh.py -k 'budget_safe or reads_cached_usage_once' -q`\n- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-fix-446 uv run ruff check app/modules/proxy/load_balancer.py tests/unit/test_proxy_load_balancer_refresh.py`\n- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-fix-446 uv run ruff format --check app/modules/proxy/load_balancer.py tests/unit/test_proxy_load_balancer_refresh.py`\n- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-fix-446 uv run ty check app/modules/proxy/load_balancer.py tests/unit/test_proxy_load_balancer_refresh.py`