### PR TITLE
fix(db): size background pool for burst traffic

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -120,6 +120,8 @@ class Settings(BaseSettings):
     database_url: str = f"sqlite+aiosqlite:///{DEFAULT_DB_PATH}"
     database_pool_size: int = Field(default=15, gt=0)
     database_max_overflow: int = Field(default=10, ge=0)
+    database_background_pool_size: int | None = Field(default=None, gt=0)
+    database_background_max_overflow: int | None = Field(default=None, ge=0)
     database_pool_timeout_seconds: float = Field(default=30.0, gt=0)
     database_migrate_on_startup: bool = True
     database_sqlite_pre_migrate_backup_enabled: bool = True

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -50,10 +50,24 @@ def _postgres_async_engine_kwargs(url: str, *, background: bool) -> dict[str, ob
     if os.environ.get("CODEX_LB_TEST_DATABASE_URL") and url.startswith("postgresql+asyncpg://"):
         kwargs["poolclass"] = NullPool
     else:
-        kwargs["pool_size"] = 3 if background else _settings.database_pool_size
-        kwargs["max_overflow"] = 2 if background else _settings.database_max_overflow
+        kwargs["pool_size"] = _database_pool_size(background=background)
+        kwargs["max_overflow"] = _database_max_overflow(background=background)
         kwargs["pool_timeout"] = _settings.database_pool_timeout_seconds
     return kwargs
+
+
+def _database_pool_size(*, background: bool) -> int:
+    if background:
+        return _settings.database_background_pool_size or _settings.database_pool_size
+    return _settings.database_pool_size
+
+
+def _database_max_overflow(*, background: bool) -> int:
+    if background:
+        if _settings.database_background_max_overflow is not None:
+            return _settings.database_background_max_overflow
+        return _settings.database_max_overflow
+    return _settings.database_max_overflow
 
 
 def _configure_sqlite_engine(engine: Engine, *, enable_wal: bool) -> None:
@@ -192,8 +206,8 @@ def init_background_db(url: str | None = None) -> None:
         _background_engine = create_async_engine(
             db_url,
             echo=False,
-            pool_size=3,
-            max_overflow=2,
+            pool_size=_database_pool_size(background=True),
+            max_overflow=_database_max_overflow(background=True),
             pool_timeout=_settings.database_pool_timeout_seconds,
             connect_args={"timeout": _SQLITE_BUSY_TIMEOUT_SECONDS},
         )

--- a/openspec/changes/configure-background-db-pool/proposal.md
+++ b/openspec/changes/configure-background-db-pool/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The main database pool is configurable and defaults to a higher burst capacity,
+but the separate background/request-adjacent pool is hard-coded to
+`pool_size=3` and `max_overflow=2`. Some request paths, including auth and proxy
+helpers, use that pool during client traffic. Under bursty `/v1/chat/completions`
+load this can still surface as SQLAlchemy QueuePool timeout errors even when
+the main pool settings are larger.
+
+## What Changes
+
+- add explicit `database_background_pool_size` and `database_background_max_overflow` settings
+- default the background pool to the main pool size and overflow values
+- keep operators able to lower the background pool separately when they want a smaller auxiliary pool
+- document the background pool controls
+
+## Impact
+
+Default SQLite/PostgreSQL deployments get the same burst capacity for
+request-adjacent background sessions as the main request pool. Existing
+deployments that intentionally want the old smaller pool can configure
+`CODEX_LB_DATABASE_BACKGROUND_POOL_SIZE=3` and
+`CODEX_LB_DATABASE_BACKGROUND_MAX_OVERFLOW=2`.

--- a/openspec/changes/configure-background-db-pool/specs/database-backends/spec.md
+++ b/openspec/changes/configure-background-db-pool/specs/database-backends/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: Database pool controls cover request-adjacent background sessions
+The service SHALL expose database pool settings for both the main request pool
+and the background/request-adjacent session pool. The background pool SHALL
+default to the main pool size and overflow settings, and operators MAY override
+the background pool size and overflow separately.
+
+#### Scenario: Background pool inherits main pool capacity
+- **WHEN** `database_background_pool_size` and `database_background_max_overflow` are unset
+- **THEN** the background/request-adjacent DB pool uses `database_pool_size` and `database_max_overflow`
+
+#### Scenario: Background pool has explicit lower capacity
+- **WHEN** `database_background_pool_size` and `database_background_max_overflow` are configured
+- **THEN** the background/request-adjacent DB pool uses those explicit values

--- a/openspec/changes/configure-background-db-pool/tasks.md
+++ b/openspec/changes/configure-background-db-pool/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+- [x] 1.1 Add explicit background database pool settings
+- [x] 1.2 Default background pool sizing to the main pool settings
+- [x] 1.3 Document the new controls
+
+## 2. Verification
+
+- [x] 2.1 Add unit coverage for default and overridden background pool sizing

--- a/openspec/specs/database-backends/context.md
+++ b/openspec/specs/database-backends/context.md
@@ -17,6 +17,7 @@ For higher concurrency or infrastructure-managed deployments, PostgreSQL support
 - SQLite startup check mode: `CODEX_LB_DATABASE_SQLITE_STARTUP_CHECK_MODE=quick|full|off` (default `quick`)
 - PostgreSQL example URL: `postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb`
 - Pool controls (`database_pool_size`, `database_max_overflow`, `database_pool_timeout_seconds`) apply to non-memory SQLite and PostgreSQL engine creation.
+- Background/request-adjacent DB pool controls (`database_background_pool_size`, `database_background_max_overflow`) default to the main pool settings, and can be lowered explicitly for deployments that want a smaller auxiliary pool.
 
 ## Example
 

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -18,6 +18,11 @@ from app.db.sqlite_utils import IntegrityCheck, SqliteIntegrityCheckMode
 @dataclass(slots=True)
 class _FakeSettings:
     database_url: str
+    database_pool_size: int = 15
+    database_max_overflow: int = 10
+    database_background_pool_size: int | None = None
+    database_background_max_overflow: int | None = None
+    database_pool_timeout_seconds: float = 30.0
     database_migrate_on_startup: bool = True
     database_sqlite_pre_migrate_backup_enabled: bool = False
     database_sqlite_pre_migrate_backup_max_files: int = 5
@@ -78,6 +83,40 @@ def test_import_session_with_postgres_url_does_not_error() -> None:
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_background_pool_defaults_to_main_pool_settings(monkeypatch) -> None:
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url="sqlite+aiosqlite:///:memory:",
+            database_pool_size=15,
+            database_max_overflow=10,
+        ),
+    )
+
+    assert session_module._database_pool_size(background=True) == 15
+    assert session_module._database_max_overflow(background=True) == 10
+
+
+def test_background_pool_settings_can_override_main_pool(monkeypatch) -> None:
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url="sqlite+aiosqlite:///:memory:",
+            database_pool_size=15,
+            database_max_overflow=10,
+            database_background_pool_size=4,
+            database_background_max_overflow=1,
+        ),
+    )
+
+    assert session_module._database_pool_size(background=True) == 4
+    assert session_module._database_max_overflow(background=True) == 1
+    assert session_module._database_pool_size(background=False) == 15
+    assert session_module._database_max_overflow(background=False) == 10
 
 
 @pytest.mark.asyncio
@@ -393,7 +432,7 @@ async def test_init_background_db_creates_separate_engine() -> None:
 
 
 @pytest.mark.asyncio
-async def test_init_background_db_uses_smaller_pool_for_postgres() -> None:
+async def test_init_background_db_uses_main_pool_size_for_postgres_by_default() -> None:
     session_module.init_background_db("postgresql+asyncpg://user:pass@localhost/db")
 
     assert session_module._background_engine is not None
@@ -403,7 +442,7 @@ async def test_init_background_db_uses_smaller_pool_for_postgres() -> None:
     if os.environ.get("CODEX_LB_TEST_DATABASE_URL"):
         assert isinstance(pool, NullPool)
     else:
-        assert cast(Any, pool).size() == 3
+        assert cast(Any, pool).size() == 15
 
     if session_module._background_engine is not None:
         await session_module._background_engine.dispose()


### PR DESCRIPTION
## Summary

- adds explicit `database_background_pool_size` and `database_background_max_overflow` settings
- defaults the background/request-adjacent DB pool to the main pool size and overflow instead of the hard-coded `3 + 2` capacity
- keeps operators able to restore a smaller auxiliary pool explicitly
- documents the background pool controls and adds OpenSpec coverage

Closes #521.

## Verification

- `openspec validate configure-background-db-pool --strict`
- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-fix-521 uv run pytest tests/unit/test_db_session.py -q`
- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-fix-521 uv run ruff check app/db/session.py app/core/config/settings.py tests/unit/test_db_session.py`
- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-fix-521 uv run ty check app/db/session.py app/core/config/settings.py tests/unit/test_db_session.py`
- `git diff --check`