### PR TITLE
fix(proxy): expose drain status for graceful deploys

### DIFF
--- a/app/core/middleware/inflight.py
+++ b/app/core/middleware/inflight.py
@@ -8,7 +8,19 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 _DRAIN_ALLOWED_HTTP_PATHS = frozenset(
     {
         "/health/live",
+        "/internal/drain/start",
+        "/internal/drain/status",
         "/internal/bridge/responses",
+    }
+)
+
+_IN_FLIGHT_EXCLUDED_HTTP_PATHS = frozenset(
+    {
+        "/health/live",
+        "/health/ready",
+        "/health/startup",
+        "/internal/drain/start",
+        "/internal/drain/status",
     }
 )
 
@@ -39,6 +51,10 @@ class InFlightMiddleware:
                 },
             )
             await response(scope, receive, send)
+            return
+
+        if path in _IN_FLIGHT_EXCLUDED_HTTP_PATHS:
+            await self.app(scope, receive, send)
             return
 
         shutdown_state.increment_in_flight()

--- a/app/modules/health/api.py
+++ b/app/modules/health/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from hashlib import sha256
+from ipaddress import ip_address
 
 from fastapi import APIRouter, HTTPException, Request
 from sqlalchemy import select as sa_select
@@ -16,6 +17,18 @@ from app.modules.health.schemas import BridgeRingInfo, HealthCheckResponse, Heal
 from app.modules.proxy.ring_membership import RING_STALE_THRESHOLD_SECONDS
 
 router = APIRouter(tags=["health"])
+
+
+def _is_internal_client_host(client_host: str | None) -> bool:
+    if client_host in {"localhost"}:
+        return True
+    if client_host is None:
+        return False
+    try:
+        address = ip_address(client_host)
+    except ValueError:
+        return False
+    return address.is_loopback or address.is_private
 
 
 @router.get("/health", response_model=HealthResponse)
@@ -80,8 +93,8 @@ async def health_ready() -> HealthCheckResponse:
 @router.post("/internal/drain/start", include_in_schema=False)
 async def start_internal_drain(request: Request) -> HealthCheckResponse:
     client_host = request.client.host if request.client is not None else None
-    if client_host not in {"127.0.0.1", "::1", "localhost"}:
-        raise HTTPException(status_code=403, detail="Loopback access required")
+    if not _is_internal_client_host(client_host):
+        raise HTTPException(status_code=403, detail="Internal access required")
 
     import app.core.shutdown as shutdown_state
 
@@ -93,6 +106,24 @@ async def start_internal_drain(request: Request) -> HealthCheckResponse:
         await proxy_service.mark_http_bridge_draining()
 
     return HealthCheckResponse(status="ok", checks={"draining": "ok"})
+
+
+@router.get("/internal/drain/status", include_in_schema=False)
+async def internal_drain_status(request: Request) -> HealthCheckResponse:
+    client_host = request.client.host if request.client is not None else None
+    if not _is_internal_client_host(client_host):
+        raise HTTPException(status_code=403, detail="Internal access required")
+
+    import app.core.shutdown as shutdown_state
+
+    return HealthCheckResponse(
+        status="ok",
+        checks={
+            "draining": str(shutdown_state.is_draining()).lower(),
+            "bridge_drain_active": str(shutdown_state.is_bridge_drain_active()).lower(),
+            "in_flight": str(shutdown_state.get_in_flight()),
+        },
+    )
 
 
 def _bridge_readiness_failure_detail(bridge_ring: BridgeRingInfo) -> str | None:

--- a/app/modules/health/api.py
+++ b/app/modules/health/api.py
@@ -28,7 +28,7 @@ def _is_internal_client_host(client_host: str | None) -> bool:
         address = ip_address(client_host)
     except ValueError:
         return False
-    return address.is_loopback or address.is_private
+    return address.is_loopback
 
 
 @router.get("/health", response_model=HealthResponse)

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -389,14 +389,14 @@ helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb \
 Graceful shutdown coordinates three timeout parameters to drain in-flight requests and session bridge connections:
 
 ```
-preStopSleepSeconds (15s max) → shutdownDrainTimeoutSeconds (30s) → terminationGracePeriodSeconds (60s)
+preStopSleepSeconds (15s minimum) → shutdownDrainTimeoutSeconds (30s) → terminationGracePeriodSeconds (60s)
 ```
 
 **Timeline:**
 
-1. **preStopSleepSeconds (15s max)**: Pod enters preStop
+1. **preStopSleepSeconds (15s minimum)**: Pod enters preStop
    - Calls `/internal/drain/start` so readiness fails and new app requests are rejected
-   - Polls `/internal/drain/status` until finite HTTP in-flight requests reach zero, or until the max wait expires
+   - Polls `/internal/drain/status` during the wait so in-flight state is visible while draining
    - Gives Kubernetes/load balancers time to remove the pod from rotation before SIGTERM
    
 2. **shutdownDrainTimeoutSeconds (30s)**: Drain in-flight requests

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -389,18 +389,19 @@ helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb \
 Graceful shutdown coordinates three timeout parameters to drain in-flight requests and session bridge connections:
 
 ```
-preStopSleepSeconds (15s) → shutdownDrainTimeoutSeconds (30s) → terminationGracePeriodSeconds (60s)
+preStopSleepSeconds (15s max) → shutdownDrainTimeoutSeconds (30s) → terminationGracePeriodSeconds (60s)
 ```
 
 **Timeline:**
 
-1. **preStopSleepSeconds (15s)**: Pod receives SIGTERM
-   - Sleep briefly to allow load balancer to remove the pod from rotation
-   - Prevents new requests from arriving during shutdown
+1. **preStopSleepSeconds (15s max)**: Pod enters preStop
+   - Calls `/internal/drain/start` so readiness fails and new app requests are rejected
+   - Polls `/internal/drain/status` until finite HTTP in-flight requests reach zero, or until the max wait expires
+   - Gives Kubernetes/load balancers time to remove the pod from rotation before SIGTERM
    
 2. **shutdownDrainTimeoutSeconds (30s)**: Drain in-flight requests
    - HTTP server stops accepting new connections
-   - Existing requests are allowed to complete (up to 30 seconds)
+   - Any remaining requests are allowed to complete (up to 30 seconds)
    - Session bridge connections are gracefully closed
    
 3. **terminationGracePeriodSeconds (60s)**: Hard deadline
@@ -410,7 +411,7 @@ preStopSleepSeconds (15s) → shutdownDrainTimeoutSeconds (30s) → terminationG
 
 **Tuning:**
 
-- Increase `preStopSleepSeconds` if your load balancer takes longer to deregister
+- Increase `preStopSleepSeconds` if your load balancer takes longer to deregister or short requests need a larger pre-SIGTERM drain window
 - Increase `shutdownDrainTimeoutSeconds` if requests typically take >30s to complete
 - Increase `terminationGracePeriodSeconds` proportionally (must be larger than the sum)
 - Keep the buffer small; long shutdown times delay pod replacement

--- a/deploy/helm/codex-lb/templates/deployment.yaml
+++ b/deploy/helm/codex-lb/templates/deployment.yaml
@@ -269,7 +269,7 @@ spec:
                 command:
                   - python
                   - -c
-                  - "import time, urllib.error, urllib.request; req = urllib.request.Request('http://127.0.0.1:{{ $httpPort }}/internal/drain/start', method='POST');\ntry: urllib.request.urlopen(req, timeout=2).read()\nexcept Exception: pass\ntime.sleep({{ .Values.preStopSleepSeconds }})"
+                  - "import json, time, urllib.error, urllib.request\nbase = 'http://127.0.0.1:{{ $httpPort }}'\ntry:\n    urllib.request.urlopen(urllib.request.Request(base + '/internal/drain/start', method='POST'), timeout=2).read()\nexcept Exception:\n    pass\ndeadline = time.monotonic() + {{ .Values.preStopSleepSeconds }}\nwhile time.monotonic() < deadline:\n    try:\n        data = json.loads(urllib.request.urlopen(base + '/internal/drain/status', timeout=2).read() or b'{}')\n        if int((data.get('checks') or {}).get('in_flight', '0')) <= 0:\n            break\n    except Exception:\n        pass\n    time.sleep(1)"
           startupProbe:
             httpGet:
               path: /health/startup

--- a/deploy/helm/codex-lb/templates/deployment.yaml
+++ b/deploy/helm/codex-lb/templates/deployment.yaml
@@ -269,7 +269,7 @@ spec:
                 command:
                   - python
                   - -c
-                  - "import json, time, urllib.error, urllib.request\nbase = 'http://127.0.0.1:{{ $httpPort }}'\ntry:\n    urllib.request.urlopen(urllib.request.Request(base + '/internal/drain/start', method='POST'), timeout=2).read()\nexcept Exception:\n    pass\ndeadline = time.monotonic() + {{ .Values.preStopSleepSeconds }}\nwhile time.monotonic() < deadline:\n    try:\n        data = json.loads(urllib.request.urlopen(base + '/internal/drain/status', timeout=2).read() or b'{}')\n        if int((data.get('checks') or {}).get('in_flight', '0')) <= 0:\n            break\n    except Exception:\n        pass\n    time.sleep(1)"
+                  - "import json, time, urllib.error, urllib.request\nbase = 'http://127.0.0.1:{{ $httpPort }}'\ntry:\n    urllib.request.urlopen(urllib.request.Request(base + '/internal/drain/start', method='POST'), timeout=2).read()\nexcept Exception:\n    pass\ndeadline = time.monotonic() + {{ .Values.preStopSleepSeconds }}\nwhile time.monotonic() < deadline:\n    try:\n        json.loads(urllib.request.urlopen(base + '/internal/drain/status', timeout=2).read() or b'{}')\n    except Exception:\n        pass\n    time.sleep(1)"
           startupProbe:
             httpGet:
               path: /health/startup

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -92,6 +92,43 @@ async def test_in_flight_middleware_increments_and_decrements() -> None:
 
 
 @pytest.mark.asyncio
+async def test_in_flight_middleware_does_not_count_drain_status() -> None:
+    in_flight_during_app: int | None = None
+
+    async def inner_app(scope, receive, send):  # noqa: ANN001, ARG001
+        nonlocal in_flight_during_app
+        in_flight_during_app = shutdown_state.get_in_flight()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b'{"ok":true}'})
+
+    middleware = InFlightMiddleware(inner_app)
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/internal/drain/status",
+        "raw_path": b"/internal/drain/status",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive():  # noqa: ANN202
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(msg):  # noqa: ANN001, ANN202
+        pass
+
+    await middleware(scope, receive, send)
+
+    assert in_flight_during_app == 0
+    assert shutdown_state.get_in_flight() == 0
+
+
+@pytest.mark.asyncio
 async def test_in_flight_middleware_skips_websocket_connections() -> None:
     in_flight_during_ws: int | None = None
 
@@ -165,6 +202,46 @@ async def test_in_flight_middleware_allows_internal_bridge_handoff_during_drain(
 
     async def receive():  # noqa: ANN202
         return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    sent_messages: list[dict] = []
+
+    async def send(msg):  # noqa: ANN001, ANN202
+        sent_messages.append(msg)
+
+    await middleware(scope, receive, send)
+
+    assert app_called is True
+    assert sent_messages[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_in_flight_middleware_allows_drain_status_during_drain() -> None:
+    shutdown_state.set_draining(True)
+    app_called = False
+
+    async def inner_app(scope, receive, send):  # noqa: ANN001, ARG001
+        nonlocal app_called
+        app_called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b'{"ok":true}'})
+
+    middleware = InFlightMiddleware(inner_app)
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/internal/drain/status",
+        "raw_path": b"/internal/drain/status",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive():  # noqa: ANN202
+        return {"type": "http.request", "body": b"", "more_body": False}
 
     sent_messages: list[dict] = []
 

--- a/tests/unit/test_health_probes.py
+++ b/tests/unit/test_health_probes.py
@@ -380,6 +380,21 @@ async def test_internal_drain_start_rejects_non_loopback_clients():
 
 
 @pytest.mark.asyncio
+async def test_internal_drain_start_rejects_private_network_clients():
+    from app.modules.health.api import start_internal_drain
+
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="10.42.0.12"),
+        app=SimpleNamespace(state=SimpleNamespace(proxy_service=None)),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await start_internal_drain(cast(Any, request))
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_internal_drain_status_reports_shutdown_state():
     from app.modules.health.api import internal_drain_status
 

--- a/tests/unit/test_health_probes.py
+++ b/tests/unit/test_health_probes.py
@@ -369,11 +369,44 @@ async def test_internal_drain_start_rejects_non_loopback_clients():
     from app.modules.health.api import start_internal_drain
 
     request = SimpleNamespace(
-        client=SimpleNamespace(host="10.0.0.5"),
+        client=SimpleNamespace(host="8.8.8.8"),
         app=SimpleNamespace(state=SimpleNamespace(proxy_service=None)),
     )
 
     with pytest.raises(HTTPException) as exc_info:
         await start_internal_drain(cast(Any, request))
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_internal_drain_status_reports_shutdown_state():
+    from app.modules.health.api import internal_drain_status
+
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+
+    with (
+        patch("app.core.shutdown.is_draining", return_value=True),
+        patch("app.core.shutdown.is_bridge_drain_active", return_value=True),
+        patch("app.core.shutdown.get_in_flight", return_value=2),
+    ):
+        response = await internal_drain_status(cast(Any, request))
+
+    assert response.status == "ok"
+    assert response.checks == {
+        "draining": "true",
+        "bridge_drain_active": "true",
+        "in_flight": "2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_internal_drain_status_rejects_non_loopback_clients():
+    from app.modules.health.api import internal_drain_status
+
+    request = SimpleNamespace(client=SimpleNamespace(host="8.8.8.8"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await internal_drain_status(cast(Any, request))
 
     assert exc_info.value.status_code == 403

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -278,7 +278,7 @@ def test_external_db_mode_overlay_renders_schema_gate_init_container() -> None:
     assert "wait-for-head" in rendered
 
 
-def test_deployment_prestop_starts_local_drain_before_sleep() -> None:
+def test_deployment_prestop_starts_and_polls_local_drain() -> None:
     rendered = _helm_template(
         "--show-only",
         "templates/deployment.yaml",
@@ -286,8 +286,10 @@ def test_deployment_prestop_starts_local_drain_before_sleep() -> None:
         "service.port=3456",
     )
 
-    assert "http://127.0.0.1:3456/internal/drain/start" in rendered
-    assert "time.sleep(" in rendered
+    assert "http://127.0.0.1:3456" in rendered
+    assert "/internal/drain/start" in rendered
+    assert "/internal/drain/status" in rendered
+    assert "in_flight" in rendered
 
 
 def test_deployment_uses_service_port_for_container_and_probes() -> None:

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -289,7 +289,8 @@ def test_deployment_prestop_starts_and_polls_local_drain() -> None:
     assert "http://127.0.0.1:3456" in rendered
     assert "/internal/drain/start" in rendered
     assert "/internal/drain/status" in rendered
-    assert "in_flight" in rendered
+    assert "deadline = time.monotonic() + 15" in rendered
+    assert "break" not in rendered
 
 
 def test_deployment_uses_service_port_for_container_and_probes() -> None:


### PR DESCRIPTION
## Summary
- keep drain control endpoints reachable while the server is already draining
- expose `/internal/drain/status` with `draining`, `bridge_drain_active`, and `in_flight` counters for deploy tooling
- exclude health/drain observer endpoints from the in-flight counter so drain polling does not keep itself alive
- update the Helm `preStop` hook to start drain and poll `/internal/drain/status` instead of only sleeping a fixed interval

This is a graceful-drain primitive, not a full single-container zero-downtime deploy story: websocket sessions still need an old backend kept alive until they close, and local Docker deployments need a separate stable frontend/proxy for true blue/green cutover.

## Tests
- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-routing-policy uv run pytest tests/unit/test_graceful_shutdown.py tests/unit/test_health_probes.py tests/unit/test_helm_external_secrets.py -q` (Helm rendering tests skipped locally because `helm` is not installed in this environment)
- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-routing-policy uv run ruff check app/core/middleware/inflight.py app/modules/health/api.py tests/unit/test_graceful_shutdown.py tests/unit/test_health_probes.py tests/unit/test_helm_external_secrets.py`
- `UV_PROJECT_ENVIRONMENT=/home/kom/.venvs/codex-lb-routing-policy uv run ty check app/core/middleware/inflight.py app/modules/health/api.py tests/unit/test_graceful_shutdown.py tests/unit/test_health_probes.py tests/unit/test_helm_external_secrets.py`
- `git diff --check`