### PR TITLE
fix(proxy): use DEFAULT_HOME_DIR for oversized response.create dumps

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from hashlib import sha256
 from ipaddress import ip_address
-from pathlib import Path
 from typing import Any, AsyncIterator, Literal, Mapping, NoReturn, TypeVar, cast, overload
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -58,7 +57,7 @@ from app.core.clients.proxy_websocket import (
     connect_responses_websocket,
     filter_inbound_websocket_headers,
 )
-from app.core.config.settings import Settings, get_settings
+from app.core.config.settings import DEFAULT_HOME_DIR, Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
@@ -174,7 +173,12 @@ logger = logging.getLogger(__name__)
 
 _UPSTREAM_RESPONSE_CREATE_MAX_BYTES = get_settings().upstream_response_create_max_bytes
 _UPSTREAM_RESPONSE_CREATE_WARN_BYTES = int(_UPSTREAM_RESPONSE_CREATE_MAX_BYTES * 0.8)
-_OVERSIZED_RESPONSE_CREATE_DUMP_DIR = Path("/var/lib/codex-lb/debug/response-create-dumps")
+# Use the deploy's resolved data directory so non-container installs
+# (notably macOS ``uv tool`` / LaunchAgent layouts that don't have
+# ``/var/lib/codex-lb`` writable) still get oversized-payload dumps.
+# The container image keeps writing to ``/var/lib/codex-lb`` because
+# ``DEFAULT_HOME_DIR`` resolves to that path inside the image.
+_OVERSIZED_RESPONSE_CREATE_DUMP_DIR = DEFAULT_HOME_DIR / "debug" / "response-create-dumps"
 _OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS = 10
 _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE = (
     "[codex-lb omitted {count} historical input items to fit upstream websocket budget]"


### PR DESCRIPTION
## Why

`#560` ([commit `e42af5e`](https://github.com/Soju06/codex-lb/commit/e42af5e), reverted in `#569` / [commit `9910e95`](https://github.com/Soju06/codex-lb/commit/9910e95)) was reverted because of layering issues with its history-slimming behavior. But it also bundled an unrelated, correct fix for [#556](https://github.com/Soju06/codex-lb/issues/556): the oversized `response.create` payload dump path was hardcoded to `/var/lib/codex-lb/debug/response-create-dumps`. That path is fine inside the container image (where `DEFAULT_HOME_DIR` resolves to `/var/lib/codex-lb`), but the `#556` reporter's macOS `uv tool` / LaunchAgent install has no writable access to `/var/lib/codex-lb`, so the proxy's guarded oversized-payload dump silently fails to write.

When `#560` was reverted, this portability fix was reverted with it, so `#556` is currently re-opened. This PR re-lands **only** that one hunk on top of current `main`, with no other change from `#560`.

## What changed

- `app/modules/proxy/service.py`: import `DEFAULT_HOME_DIR` from `app.core.config.settings` and resolve `_OVERSIZED_RESPONSE_CREATE_DUMP_DIR = DEFAULT_HOME_DIR / "debug" / "response-create-dumps"` instead of the hardcoded absolute path.
- `app/modules/proxy/service.py`: drop the now-unused `from pathlib import Path` import (it was only used by the hardcoded `Path("/var/lib/...")` literal).

That's the entire diff: **+7 / -3, 1 file**.

## What this is **not**

- Not the history-slimming behavior from `#560`. None of `_slim_response_create_payload_for_upstream`, `_omit_historical_response_input_items_to_fit`, or the omission notice items are touched.
- Not the WebSocket bridge path. The dump fires inside `_enforce_response_create_size_limit`, which only runs when the proxy is *guarding* against an oversized request that already exceeds the upstream WebSocket frame budget. The dump is a debug artefact, not part of the request flow.
- Not new functionality. The dump was always supposed to land somewhere writable; it just had the wrong absolute path baked in for non-container deploys.

## Verification

Local on the fix branch:

```
$ uv run --frozen ruff check app tests             # All checks passed!
$ uv run --frozen ruff format --check app tests    # 426 files already formatted
$ uv run --frozen ty check app tests               # All checks passed!
$ uv run --frozen pytest tests/unit -q             # 1493 passed, 3 skipped, 4 warnings
```

Empirical verification on the rebuilt dev container:

```
$ docker exec codex-lb-dev-server python -c \
    "from app.core.config.settings import DEFAULT_HOME_DIR; \
     from app.modules.proxy.service import _OVERSIZED_RESPONSE_CREATE_DUMP_DIR; \
     print(DEFAULT_HOME_DIR, _OVERSIZED_RESPONSE_CREATE_DUMP_DIR)"
/var/lib/codex-lb /var/lib/codex-lb/debug/response-create-dumps
```

The container image's resolved path matches the previous hardcoded literal, so existing operators see no behavior change. macOS `uv tool` deploys now write to `~/.codex-lb/debug/response-create-dumps` (or wherever `DEFAULT_HOME_DIR` resolves on that host) instead of failing.

## Out of scope

- The history-slimming approach from `#560` stays out (see `#568` / `#569` for the broader design discussion). This PR is intentionally minimal: only the dump-path portability slice.
