### PR TITLE
fix(quota): 5h quota of free acc should be 0

### DIFF
--- a/app/core/usage/__init__.py
+++ b/app/core/usage/__init__.py
@@ -16,7 +16,7 @@ from app.core.usage.types import (
 from app.db.models import Account
 
 PLAN_CAPACITY_CREDITS_PRIMARY = {
-    "free": 33.75,
+    "free": 0.0,
     "plus": 225.0,
     "business": 225.0,
     "team": 225.0,


### PR DESCRIPTION
<img width="689" height="235" alt="螢幕截圖 2026-05-10 21 59 46" src="https://github.com/user-attachments/assets/6163a13b-47b3-4576-899b-8bc6beddea27" />

now it is `33.75`, which will cause the pie chart showing a `dead` proportion of 5h quota