### PR TITLE
feat(ui): sort the pie in decending order for better graphing.

### DIFF
--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -105,10 +105,12 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
   const legendRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const consumedColor = isDark ? "#404040" : "#d3d3d3";
   const palette = buildDonutPalette(items.length, isDark);
-  const normalizedItems = items.map((item, index) => ({
-    ...item,
-    color: item.color ?? palette[index % palette.length],
-  }));
+  const normalizedItems = items
+    .map((item, index) => ({
+      ...item,
+      color: item.color ?? palette[index % palette.length],
+    }))
+    .sort((a, b) => b.value - a.value);
 
   const usedSum = normalizedItems.reduce((acc, item) => acc + Math.max(0, item.value), 0);
   const safeCapacity = Math.max(0, total);


### PR DESCRIPTION
<img width="688" height="231" alt="螢幕截圖 2026-05-10 22 50 12" src="https://github.com/user-attachments/assets/5ff09184-a958-4e2f-b701-9dcdf2929a8c" />
Before

<img width="690" height="222" alt="螢幕截圖 2026-05-10 23 03 23" src="https://github.com/user-attachments/assets/d1c2f7a6-d9d3-461e-915a-b61c2221b40d" />
After

The pie will sort with remaining credit, in descending order, to avoid random pie distribution