### PR TITLE
fix(proxy): preserve websocket stream error statuses

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import time
@@ -160,6 +161,7 @@ _UNAVAILABLE_SELECTION_ERROR_CODES = {
     "additional_quota_data_unavailable",
     "no_additional_quota_eligible_accounts",
 }
+_STREAM_STARTUP_ERROR_PROBE_SECONDS = 0.05
 
 # OpenAI error ``type`` -> HTTP status for the /v1/images/* non-streaming
 # error path. The /v1/responses path has its own ``_status_for_error``
@@ -1490,6 +1492,14 @@ async def v1_chat_completions(
         api_key_reservation=reservation,
         suppress_text_done_events=True,
     )
+    stream, startup_error = await _probe_stream_startup_error(stream)
+    if startup_error is not None:
+        return _logged_error_json_response(
+            request,
+            startup_error.status_code,
+            startup_error.payload,
+            headers=rate_limit_headers,
+        )
     if payload.stream:
         stream_options = payload.stream_options
         include_usage = bool(stream_options and stream_options.include_usage)
@@ -1606,7 +1616,16 @@ async def _stream_responses(
             api_key_reservation=reservation,
             suppress_text_done_events=suppress_text_done_events,
         )
-    del owns_reservation
+    stream, startup_error = await _probe_stream_startup_error(stream)
+    if startup_error is not None:
+        if reservation is not None and owns_reservation:
+            await _release_reservation(reservation)
+        return _logged_error_json_response(
+            request,
+            startup_error.status_code,
+            startup_error.payload,
+            headers=rate_limit_headers,
+        )
     stream = _normalize_public_responses_stream(_stream_proxy_errors_as_response_failed(stream))
     return StreamingResponse(
         inject_sse_keepalives(
@@ -1857,6 +1876,33 @@ async def codex_usage(
 async def _prepend_first(first: str | None, stream: AsyncIterator[str]) -> AsyncIterator[str]:
     if first is not None:
         yield first
+    async for line in stream:
+        yield line
+
+
+async def _probe_stream_startup_error(
+    stream: AsyncIterator[str],
+) -> tuple[AsyncIterator[str], ProxyResponseError | None]:
+    first_task = asyncio.create_task(anext(stream))
+    try:
+        first = await asyncio.wait_for(
+            asyncio.shield(first_task),
+            timeout=_STREAM_STARTUP_ERROR_PROBE_SECONDS,
+        )
+    except TimeoutError:
+        return _prepend_first_task(first_task, stream), None
+    except StopAsyncIteration:
+        return _prepend_first(None, stream), None
+    except ProxyResponseError as exc:
+        return _prepend_first(None, stream), exc
+    return _prepend_first(first, stream), None
+
+
+async def _prepend_first_task(first_task: asyncio.Task[str], stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    try:
+        yield await first_task
+    except StopAsyncIteration:
+        return
     async for line in stream:
         yield line
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2509,7 +2509,7 @@ def _parse_error_envelope(payload: JsonValue | OpenAIErrorEnvelope) -> OpenAIErr
     if not isinstance(payload, dict):
         return _default_error_envelope()
     if payload.get("type") == "error":
-        return _parse_event_error_envelope(payload)
+        return _parse_event_error_envelope(cast(dict[str, JsonValue], payload))
     try:
         return OpenAIErrorEnvelopeModel.model_validate(payload)
     except ValidationError:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2516,9 +2516,42 @@ def _error_envelope_from_response(error_value: OpenAIError | None) -> OpenAIErro
     return OpenAIErrorEnvelopeModel(error=error_value)
 
 
+def _is_previous_response_not_found_public_error(error_value: OpenAIError | None) -> bool:
+    if error_value is None:
+        return False
+    if error_value.code == "previous_response_not_found":
+        return True
+    message = error_value.message or ""
+    return (
+        error_value.code == "invalid_request_error"
+        and error_value.param == "previous_response_id"
+        and "previous response" in message.lower()
+        and "not found" in message.lower()
+    )
+
+
+def _mask_previous_response_not_found_error(
+    envelope: OpenAIErrorEnvelopeModel,
+    *,
+    default_status: int | None = None,
+) -> tuple[int, OpenAIErrorEnvelopeModel]:
+    if not _is_previous_response_not_found_public_error(envelope.error):
+        return default_status if default_status is not None else _status_for_error(envelope.error), envelope
+    return (
+        502,
+        OpenAIErrorEnvelopeModel(
+            error=OpenAIError(
+                message="Upstream websocket closed before response.completed",
+                type="server_error",
+                code="stream_incomplete",
+            )
+        ),
+    )
+
+
 def _status_for_error(error_value: OpenAIError | None) -> int:
     if error_value and error_value.code == "previous_response_not_found":
-        return 400
+        return 502
     if error_value and error_value.code in _UNAVAILABLE_SELECTION_ERROR_CODES:
         return 503
     return 502

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1611,7 +1611,10 @@ async def _stream_responses(
             api_key_reservation=reservation,
             suppress_text_done_events=suppress_text_done_events,
         )
-    stream, startup_error = await _probe_stream_startup_error(stream)
+    stream, startup_error = await _probe_stream_startup_error(
+        stream,
+        convert_event_errors=bridge_active,
+    )
     if startup_error is not None:
         if reservation is not None and owns_reservation:
             await _release_reservation(reservation)
@@ -1872,6 +1875,8 @@ async def _prepend_first(first: str | None, stream: AsyncIterator[str]) -> Async
 
 async def _probe_stream_startup_error(
     stream: AsyncIterator[str],
+    *,
+    convert_event_errors: bool = False,
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     first_task = asyncio.create_task(anext(stream))
     try:
@@ -1885,9 +1890,10 @@ async def _probe_stream_startup_error(
         return _prepend_first(None, stream), None
     except ProxyResponseError as exc:
         return _prepend_first(None, stream), exc
-    first_error = _stream_event_error_envelope(first)
-    if first_error is not None:
-        return _prepend_first(None, stream), first_error
+    if convert_event_errors:
+        first_error = _stream_event_error_envelope(first)
+        if first_error is not None:
+            return _prepend_first(None, stream), first_error
     return _prepend_first(first, stream), None
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1494,12 +1494,7 @@ async def v1_chat_completions(
     )
     stream, startup_error = await _probe_stream_startup_error(stream)
     if startup_error is not None:
-        return _logged_error_json_response(
-            request,
-            startup_error.status_code,
-            startup_error.payload,
-            headers=rate_limit_headers,
-        )
+        return _stream_startup_error_response(request, startup_error, headers=rate_limit_headers)
     if payload.stream:
         stream_options = payload.stream_options
         include_usage = bool(stream_options and stream_options.include_usage)
@@ -1620,12 +1615,7 @@ async def _stream_responses(
     if startup_error is not None:
         if reservation is not None and owns_reservation:
             await _release_reservation(reservation)
-        return _logged_error_json_response(
-            request,
-            startup_error.status_code,
-            startup_error.payload,
-            headers=rate_limit_headers,
-        )
+        return _stream_startup_error_response(request, startup_error, headers=rate_limit_headers)
     stream = _normalize_public_responses_stream(_stream_proxy_errors_as_response_failed(stream))
     return StreamingResponse(
         inject_sse_keepalives(
@@ -1882,7 +1872,7 @@ async def _prepend_first(first: str | None, stream: AsyncIterator[str]) -> Async
 
 async def _probe_stream_startup_error(
     stream: AsyncIterator[str],
-) -> tuple[AsyncIterator[str], ProxyResponseError | None]:
+) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     first_task = asyncio.create_task(anext(stream))
     try:
         first = await asyncio.wait_for(
@@ -1895,6 +1885,9 @@ async def _probe_stream_startup_error(
         return _prepend_first(None, stream), None
     except ProxyResponseError as exc:
         return _prepend_first(None, stream), exc
+    first_error = _stream_event_error_envelope(first)
+    if first_error is not None:
+        return _prepend_first(None, stream), first_error
     return _prepend_first(first, stream), None
 
 
@@ -1923,6 +1916,47 @@ async def _stream_proxy_errors_as_response_failed(stream: AsyncIterator[str]) ->
                 error_param=error.param if error else None,
             )
         )
+
+
+def _stream_startup_error_response(
+    request: Request,
+    error: ProxyResponseError | OpenAIErrorEnvelopeModel,
+    *,
+    headers: Mapping[str, str],
+) -> JSONResponse:
+    if isinstance(error, ProxyResponseError):
+        return _logged_error_json_response(request, error.status_code, error.payload, headers=headers)
+    status_code, envelope = _mask_previous_response_not_found_error(error)
+    return _logged_error_json_response(
+        request,
+        status_code,
+        envelope.model_dump(mode="json", exclude_none=True),
+        headers=headers,
+    )
+
+
+def _stream_event_error_envelope(event_block: str) -> OpenAIErrorEnvelopeModel | None:
+    payload = _parse_sse_payload(event_block)
+    if payload is None:
+        return None
+    event_type = payload.get("type")
+    if event_type == "error":
+        return _parse_event_error_envelope(payload)
+    if event_type != "response.failed":
+        return None
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return _default_error_envelope()
+    error_value = response.get("error")
+    if isinstance(error_value, dict):
+        try:
+            return OpenAIErrorEnvelopeModel.model_validate({"error": error_value})
+        except ValidationError:
+            return _default_error_envelope()
+    parsed = parse_response_payload(response)
+    if parsed is not None and parsed.error is not None:
+        return _error_envelope_from_response(parsed.error)
+    return _default_error_envelope()
 
 
 def _parse_sse_payload(line: str) -> dict[str, JsonValue] | None:
@@ -2619,6 +2653,18 @@ def _status_for_error(error_value: OpenAIError | None) -> int:
         return 502
     if error_value and error_value.code in _UNAVAILABLE_SELECTION_ERROR_CODES:
         return 503
+    if error_value and error_value.code in {"rate_limit_exceeded", "usage_limit_reached", "insufficient_quota"}:
+        return 429
+    if error_value and error_value.code in {"invalid_api_key", "invalid_authentication"}:
+        return 401
+    if error_value and error_value.code == "invalid_request_error":
+        return 400
+    if error_value and error_value.type == "authentication_error":
+        return 401
+    if error_value and error_value.type == "invalid_request_error":
+        return 400
+    if error_value and error_value.type in {"rate_limit_error", "usage_limit_reached", "insufficient_quota"}:
+        return 429
     return 502
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2217,6 +2217,20 @@ def _normalize_public_stream_payload(
     payload: dict[str, JsonValue],
 ) -> tuple[dict[str, JsonValue] | None, str | None]:
     event_type = payload.get("type")
+    if event_type == "error":
+        parsed_error = _parse_event_error_envelope(payload)
+        if _is_previous_response_not_found_public_error(parsed_error.error):
+            return (
+                cast(
+                    dict[str, JsonValue],
+                    response_failed_event(
+                        "stream_incomplete",
+                        "Upstream websocket closed before response.completed",
+                    ),
+                ),
+                None,
+            )
+        return payload, None
     if event_type in ("response.completed", "response.incomplete"):
         response = payload.get("response")
         if not is_json_mapping(response):
@@ -2494,6 +2508,8 @@ def _default_error_envelope() -> OpenAIErrorEnvelopeModel:
 def _parse_error_envelope(payload: JsonValue | OpenAIErrorEnvelope) -> OpenAIErrorEnvelopeModel:
     if not isinstance(payload, dict):
         return _default_error_envelope()
+    if payload.get("type") == "error":
+        return _parse_event_error_envelope(payload)
     try:
         return OpenAIErrorEnvelopeModel.model_validate(payload)
     except ValidationError:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -162,6 +162,9 @@ _UNAVAILABLE_SELECTION_ERROR_CODES = {
     "no_additional_quota_eligible_accounts",
 }
 _STREAM_STARTUP_ERROR_PROBE_SECONDS = 0.05
+# Keep bridge startup probing above tiny event-loop scheduling jitter:
+# PostgreSQL-backed failures may need a DB round trip before the first item.
+_HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS = 0.5
 
 # OpenAI error ``type`` -> HTTP status for the /v1/images/* non-streaming
 # error path. The /v1/responses path has its own ``_status_for_error``
@@ -1614,6 +1617,9 @@ async def _stream_responses(
     stream, startup_error = await _probe_stream_startup_error(
         stream,
         convert_event_errors=bridge_active,
+        timeout_seconds=_HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS
+        if prefer_http_bridge
+        else _STREAM_STARTUP_ERROR_PROBE_SECONDS,
     )
     if startup_error is not None:
         if reservation is not None and owns_reservation:
@@ -1877,12 +1883,13 @@ async def _probe_stream_startup_error(
     stream: AsyncIterator[str],
     *,
     convert_event_errors: bool = False,
+    timeout_seconds: float = _STREAM_STARTUP_ERROR_PROBE_SECONDS,
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     first_task = asyncio.create_task(anext(stream))
     try:
         first = await asyncio.wait_for(
             asyncio.shield(first_task),
-            timeout=_STREAM_STARTUP_ERROR_PROBE_SECONDS,
+            timeout=timeout_seconds,
         )
     except TimeoutError:
         return _prepend_first_task(first_task, stream), None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1490,6 +1490,22 @@ async def v1_chat_completions(
         api_key_reservation=reservation,
         suppress_text_done_events=True,
     )
+    if payload.stream:
+        stream_options = payload.stream_options
+        include_usage = bool(stream_options and stream_options.include_usage)
+        return StreamingResponse(
+            inject_sse_keepalives(
+                stream_chat_chunks(
+                    _stream_proxy_errors_as_response_failed(stream),
+                    model=responses_payload.model,
+                    include_usage=include_usage,
+                ),
+                get_settings().sse_keepalive_interval_seconds,
+            ),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", **rate_limit_headers},
+        )
+
     try:
         first = await stream.__anext__()
     except StopAsyncIteration:
@@ -1498,18 +1514,6 @@ async def v1_chat_completions(
         return _logged_error_json_response(request, exc.status_code, exc.payload, headers=rate_limit_headers)
 
     stream_with_first = _prepend_first(first, stream)
-    if payload.stream:
-        stream_options = payload.stream_options
-        include_usage = bool(stream_options and stream_options.include_usage)
-        return StreamingResponse(
-            inject_sse_keepalives(
-                stream_chat_chunks(stream_with_first, model=responses_payload.model, include_usage=include_usage),
-                get_settings().sse_keepalive_interval_seconds,
-            ),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", **rate_limit_headers},
-        )
-
     result = await collect_chat_completion(stream_with_first, model=responses_payload.model)
     if isinstance(result, OpenAIErrorEnvelopeModel):
         error = result.error
@@ -1602,30 +1606,11 @@ async def _stream_responses(
             api_key_reservation=reservation,
             suppress_text_done_events=suppress_text_done_events,
         )
-    stream = _normalize_public_responses_stream(stream)
-    try:
-        first = await stream.__anext__()
-    except StopAsyncIteration:
-        return StreamingResponse(
-            inject_sse_keepalives(
-                _prepend_first(None, stream),
-                get_settings().sse_keepalive_interval_seconds,
-            ),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", **rate_limit_headers},
-        )
-    except ProxyResponseError as exc:
-        if owns_reservation:
-            await _release_reservation(reservation)
-        return _logged_error_json_response(
-            request,
-            exc.status_code,
-            exc.payload,
-            headers=rate_limit_headers,
-        )
+    del owns_reservation
+    stream = _normalize_public_responses_stream(_stream_proxy_errors_as_response_failed(stream))
     return StreamingResponse(
         inject_sse_keepalives(
-            _prepend_first(first, stream),
+            stream,
             get_settings().sse_keepalive_interval_seconds,
         ),
         media_type="text/event-stream",
@@ -1874,6 +1859,24 @@ async def _prepend_first(first: str | None, stream: AsyncIterator[str]) -> Async
         yield first
     async for line in stream:
         yield line
+
+
+async def _stream_proxy_errors_as_response_failed(stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    try:
+        async for line in stream:
+            yield line
+    except ProxyResponseError as exc:
+        envelope = _parse_error_envelope(exc.payload)
+        _, envelope = _mask_previous_response_not_found_error(envelope, default_status=exc.status_code)
+        error = envelope.error
+        yield format_sse_event(
+            response_failed_event(
+                error.code if error and error.code else "upstream_error",
+                error.message if error and error.message else "Upstream error",
+                error.type if error and error.type else "server_error",
+                error_param=error.param if error else None,
+            )
+        )
 
 
 def _parse_sse_payload(line: str) -> dict[str, JsonValue] | None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1934,7 +1934,14 @@ def _stream_startup_error_response(
     headers: Mapping[str, str],
 ) -> JSONResponse:
     if isinstance(error, ProxyResponseError):
-        return _logged_error_json_response(request, error.status_code, error.payload, headers=headers)
+        envelope = _parse_error_envelope(error.payload)
+        status_code, envelope = _mask_previous_response_not_found_error(envelope, default_status=error.status_code)
+        return _logged_error_json_response(
+            request,
+            status_code,
+            envelope.model_dump(mode="json", exclude_none=True),
+            headers=headers,
+        )
     status_code, envelope = _mask_previous_response_not_found_error(error)
     return _logged_error_json_response(
         request,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1893,6 +1893,9 @@ async def _probe_stream_startup_error(
     if convert_event_errors:
         first_error = _stream_event_error_envelope(first)
         if first_error is not None:
+            aclose = getattr(stream, "aclose", None)
+            if callable(aclose):
+                await aclose()
             return _prepend_first(None, stream), first_error
     return _prepend_first(first, stream), None
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1186,6 +1186,30 @@ class ProxyService:
                 if request_state.latency_first_token_ms is None and block_event_type in _TEXT_DELTA_EVENT_TYPES:
                     request_state.latency_first_token_ms = int((time.monotonic() - request_state.started_at) * 1000)
                 if (
+                    not propagate_http_errors
+                    and request_state.previous_response_id is not None
+                    and _is_previous_response_not_found_error(
+                        code=_normalize_error_code(
+                            _websocket_event_error_code(block_event_type, block_payload),
+                            _websocket_event_error_type(block_event_type, block_payload),
+                        ),
+                        param=_websocket_event_error_param(block_event_type, block_payload),
+                        message=_websocket_event_error_message(block_event_type, block_payload),
+                    )
+                ):
+                    session.upstream_control.reconnect_requested = True
+                    request_state.error_http_status_override = 502
+                    (
+                        event_block,
+                        _event,
+                        block_payload,
+                        block_event_type,
+                    ) = _build_rewritten_stream_response_failed_event(
+                        response_id=request_state.response_id or request_state.request_id,
+                        error_code="stream_incomplete",
+                        error_message="Upstream websocket closed before response.completed",
+                    )
+                if (
                     not yielded_any
                     and propagate_http_errors
                     and block_event_type == "response.failed"

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -13,6 +13,7 @@ from starlette.requests import Request
 
 import app.core.auth.dependencies as auth_dependencies
 import app.modules.proxy.api as proxy_api_module
+from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
 from app.core.exceptions import ProxyAuthError
 from app.core.openai.requests import ResponsesRequest
@@ -459,6 +460,29 @@ async def test_probe_stream_startup_error_closes_consumed_bridge_error_stream():
 
     assert startup_error is not None
     assert closed is True
+
+
+def test_stream_startup_error_response_masks_proxy_previous_response_error():
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    error = ProxyResponseError(
+        400,
+        {
+            "error": {
+                "message": "Previous response with id 'resp_missing' not found.",
+                "type": "invalid_request_error",
+                "code": "previous_response_not_found",
+                "param": "previous_response_id",
+            }
+        },
+    )
+
+    response = proxy_api_module._stream_startup_error_response(request, error, headers={})
+
+    assert response.status_code == 502
+    response_body = bytes(response.body)
+    body = json.loads(response_body)
+    assert body["error"]["code"] == "stream_incomplete"
+    assert "resp_missing" not in response_body.decode()
 
 
 def test_public_stream_incomplete_error_event_is_not_rewritten_when_already_public():

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -366,3 +366,105 @@ async def test_stream_responses_does_not_release_forwarded_reservation_on_intern
 
     assert response.status_code == 503
     release_reservation.assert_not_awaited()
+
+
+def test_public_previous_response_not_found_error_is_masked_to_stream_incomplete():
+    envelope = proxy_api_module.OpenAIErrorEnvelopeModel(
+        error=proxy_api_module.OpenAIError(
+            message="Previous response with id 'resp_missing' not found.",
+            type="invalid_request_error",
+            code="previous_response_not_found",
+            param="previous_response_id",
+        )
+    )
+
+    status_code, masked = proxy_api_module._mask_previous_response_not_found_error(
+        envelope,
+        default_status=400,
+    )
+
+    assert status_code == 502
+    assert masked.error.code == "stream_incomplete"
+    assert masked.error.type == "server_error"
+    assert masked.error.message == "Upstream websocket closed before response.completed"
+    assert "resp_missing" not in masked.model_dump_json()
+
+
+def test_public_previous_response_invalid_request_param_is_masked_to_stream_incomplete():
+    envelope = proxy_api_module.OpenAIErrorEnvelopeModel(
+        error=proxy_api_module.OpenAIError(
+            message="Previous response with id 'resp_missing' not found.",
+            type="invalid_request_error",
+            code="invalid_request_error",
+            param="previous_response_id",
+        )
+    )
+
+    status_code, masked = proxy_api_module._mask_previous_response_not_found_error(
+        envelope,
+        default_status=400,
+    )
+
+    assert status_code == 502
+    assert masked.error.code == "stream_incomplete"
+
+
+def test_public_previous_response_error_event_is_masked_to_response_failed():
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "message": "Previous response with id 'resp_missing' not found.",
+            "type": "invalid_request_error",
+            "code": "previous_response_not_found",
+            "param": "previous_response_id",
+        },
+    }
+
+    normalized, violation_kind = proxy_api_module._normalize_public_stream_payload(payload)
+
+    assert violation_kind is None
+    assert normalized is not None
+    assert normalized["type"] == "response.failed"
+    response = cast(dict[str, object], normalized["response"])
+    error = cast(dict[str, object], response["error"])
+    assert error["code"] == "stream_incomplete"
+    assert error["type"] == "server_error"
+    assert "resp_missing" not in json.dumps(normalized)
+
+
+def test_public_stream_incomplete_error_event_is_not_rewritten_when_already_public():
+    payload = {
+        "type": "error",
+        "status": 502,
+        "error": {
+            "message": "Custom upstream stream detail",
+            "type": "server_error",
+            "code": "stream_incomplete",
+        },
+    }
+
+    normalized, violation_kind = proxy_api_module._normalize_public_stream_payload(payload)
+
+    assert violation_kind is None
+    assert normalized == payload
+
+
+def test_public_previous_response_top_level_error_envelope_is_parsed_for_masking():
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "message": "Previous response with id 'resp_missing' not found.",
+            "type": "invalid_request_error",
+            "code": "previous_response_not_found",
+            "param": "previous_response_id",
+        },
+    }
+
+    parsed = proxy_api_module._parse_error_envelope(payload)
+    status_code, masked = proxy_api_module._mask_previous_response_not_found_error(parsed, default_status=400)
+
+    assert status_code == 502
+    assert masked.error.code == "stream_incomplete"
+    assert "resp_missing" not in masked.model_dump_json()

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -435,6 +435,32 @@ def test_public_previous_response_error_event_is_masked_to_response_failed():
     assert "resp_missing" not in json.dumps(normalized)
 
 
+@pytest.mark.asyncio
+async def test_probe_stream_startup_error_closes_consumed_bridge_error_stream():
+    closed = False
+
+    async def stream():
+        nonlocal closed
+        try:
+            yield (
+                'data: {"type":"response.failed","response":{"error":{'
+                "\"message\":\"Previous response with id 'resp_missing' not found.\","
+                '"type":"invalid_request_error","code":"previous_response_not_found",'
+                '"param":"previous_response_id"}}}\n\n'
+            )
+            yield 'data: {"type":"response.completed","response":{"id":"resp_after"}}\n\n'
+        finally:
+            closed = True
+
+    _probed, startup_error = await proxy_api_module._probe_stream_startup_error(
+        stream(),
+        convert_event_errors=True,
+    )
+
+    assert startup_error is not None
+    assert closed is True
+
+
 def test_public_stream_incomplete_error_event_is_not_rewritten_when_already_public():
     payload = {
         "type": "error",

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -384,9 +384,10 @@ def test_public_previous_response_not_found_error_is_masked_to_stream_incomplete
     )
 
     assert status_code == 502
-    assert masked.error.code == "stream_incomplete"
-    assert masked.error.type == "server_error"
-    assert masked.error.message == "Upstream websocket closed before response.completed"
+    error = masked.model_dump(mode="json")["error"]
+    assert error["code"] == "stream_incomplete"
+    assert error["type"] == "server_error"
+    assert error["message"] == "Upstream websocket closed before response.completed"
     assert "resp_missing" not in masked.model_dump_json()
 
 
@@ -406,7 +407,8 @@ def test_public_previous_response_invalid_request_param_is_masked_to_stream_inco
     )
 
     assert status_code == 502
-    assert masked.error.code == "stream_incomplete"
+    error = masked.model_dump(mode="json")["error"]
+    assert error["code"] == "stream_incomplete"
 
 
 def test_public_previous_response_error_event_is_masked_to_response_failed():
@@ -466,5 +468,6 @@ def test_public_previous_response_top_level_error_envelope_is_parsed_for_masking
     status_code, masked = proxy_api_module._mask_previous_response_not_found_error(parsed, default_status=400)
 
     assert status_code == 502
-    assert masked.error.code == "stream_incomplete"
+    error = masked.model_dump(mode="json")["error"]
+    assert error["code"] == "stream_incomplete"
     assert "resp_missing" not in masked.model_dump_json()

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -445,7 +445,7 @@ async def test_probe_stream_startup_error_closes_consumed_bridge_error_stream():
         try:
             yield (
                 'data: {"type":"response.failed","response":{"error":{'
-                "\"message\":\"Previous response with id 'resp_missing' not found.\","
+                '"message":"Previous response with id \'resp_missing\' not found.",'
                 '"type":"invalid_request_error","code":"previous_response_not_found",'
                 '"param":"previous_response_id"}}}\n\n'
             )

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from collections import deque
@@ -52,6 +53,97 @@ def _make_api_key(
         ),
         assigned_account_ids=assigned_account_ids,
     )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_stream_masks_single_top_level_previous_response_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-single-prev", None),
+        headers={"session_id": "sid-single-prev"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-single-prev",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.1",
+        account=cast(Any, SimpleNamespace(id="acc-single-prev", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-single-prev",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        previous_response_id="resp_missing_single",
+    )
+    upstream_text = json.dumps(
+        {
+            "type": "error",
+            "status": 400,
+            "error": {
+                "type": "invalid_request_error",
+                "code": "previous_response_not_found",
+                "message": "Previous response with id 'resp_missing_single' not found.",
+                "param": "previous_response_id",
+            },
+        },
+        separators=(",", ":"),
+    )
+
+    async def fake_submit_http_bridge_request(
+        target_session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+    ) -> None:
+        del text_data, queue_limit
+        target_session.pending_requests.append(request_state)
+        await service._process_http_bridge_upstream_text(target_session, upstream_text)
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", fake_submit_http_bridge_request)
+
+    events = [
+        event
+        async for event in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data="{}",
+            queue_limit=8,
+            propagate_http_errors=False,
+            downstream_turn_state=None,
+        )
+    ]
+
+    assert session.upstream_control.reconnect_requested is True
+    assert request_state.error_http_status_override == 502
+    assert len(events) == 1
+    event_block = events[0]
+    assert "previous_response_not_found" not in event_block
+    payload = proxy_service.parse_sse_data_json(event_block)
+    assert isinstance(payload, dict)
+    assert payload["type"] == "response.failed"
+    response = payload["response"]
+    assert isinstance(response, dict)
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "stream_incomplete"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14,6 +14,7 @@ import pytest
 from aiohttp.client_reqrep import RequestInfo
 from fastapi import WebSocket
 from starlette.requests import Request
+from starlette.responses import StreamingResponse
 
 import app.core.clients.proxy as proxy_module
 from app.core.clients.proxy import _build_upstream_headers, filter_inbound_headers
@@ -444,6 +445,82 @@ def test_build_upstream_websocket_headers_strip_hop_by_hop_headers_and_connectio
     assert headers["Authorization"] == "Bearer token"
     assert headers["chatgpt-account-id"] == "acc_2"
     assert headers["User-Agent"] == "codex-test"
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_returns_before_first_upstream_event(monkeypatch):
+    async def skip_limits(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", skip_limits)
+
+    async def stream_responses(*args, **kwargs):
+        del args, kwargs
+        await asyncio.sleep(10.0)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_slow","status":"completed"}}\n\n'
+
+    context = SimpleNamespace(
+        service=SimpleNamespace(
+            rate_limit_headers=AsyncMock(return_value={}),
+            stream_responses=stream_responses,
+        )
+    )
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    payload = ResponsesRequest(model="gpt-5.1", instructions="test", input="hello")
+
+    response = await asyncio.wait_for(
+        proxy_api._stream_responses(
+            request,
+            payload,
+            context=cast(proxy_api.ProxyContext, context),
+            api_key=None,
+        ),
+        timeout=0.2,
+    )
+
+    assert isinstance(response, StreamingResponse)
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_streams_initial_proxy_error_as_sse(monkeypatch):
+    async def skip_limits(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", skip_limits)
+
+    async def stream_responses(*args, **kwargs):
+        del args, kwargs
+        raise proxy_module.ProxyResponseError(
+            429,
+            openai_error("rate_limit_exceeded", "opportunistic burn window closed"),
+        )
+        yield ""
+
+    context = SimpleNamespace(
+        service=SimpleNamespace(
+            rate_limit_headers=AsyncMock(return_value={"X-RateLimit-Limit": "1"}),
+            stream_responses=stream_responses,
+        )
+    )
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    payload = ResponsesRequest(model="gpt-5.1", instructions="test", input="hello")
+
+    response = await proxy_api._stream_responses(
+        request,
+        payload,
+        context=cast(proxy_api.ProxyContext, context),
+        api_key=None,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    assert response.status_code == 200
+    assert response.headers["X-RateLimit-Limit"] == "1"
+    chunks = [chunk async for chunk in response.body_iterator]
+    body = "".join(chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in chunks)
+    assert "response.failed" in body
+    assert "rate_limit_exceeded" in body
 
 
 def test_has_native_codex_transport_headers_requires_allowlisted_originator():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -483,7 +483,7 @@ async def test_stream_responses_returns_before_first_upstream_event(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_streams_initial_proxy_error_as_sse(monkeypatch):
+async def test_stream_responses_streams_post_startup_proxy_error_as_sse(monkeypatch):
     async def skip_limits(*args, **kwargs):
         del args, kwargs
         return None
@@ -492,6 +492,7 @@ async def test_stream_responses_streams_initial_proxy_error_as_sse(monkeypatch):
 
     async def stream_responses(*args, **kwargs):
         del args, kwargs
+        await asyncio.sleep(0.1)
         raise proxy_module.ProxyResponseError(
             429,
             openai_error("rate_limit_exceeded", "opportunistic burn window closed"),

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- keep previous-response masking and startup SSE error status promotion in a small PR split out of #555
- preserve immediate stream error statuses instead of hiding them behind replay trimming scope
- keep the branch cut directly from main for review

## Validation
- `uv run ruff check app/modules/proxy/api.py app/modules/proxy/service.py tests/unit/test_proxy_api_websocket_auth.py tests/unit/test_proxy_utils.py`
- `uv run ty check app/modules/proxy/api.py app/modules/proxy/service.py tests/unit/test_proxy_api_websocket_auth.py tests/unit/test_proxy_utils.py`
- `uv run pytest tests/unit/test_proxy_api_websocket_auth.py tests/unit/test_proxy_utils.py -q -k 'previous_response or stream_startup or stream_responses or startup'`\n\nSplit from #555.