### PR TITLE
fix(proxy): suppress duplicate side-effect tool calls

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -935,18 +935,21 @@ def _normalize_stream_event_payload(payload: dict[str, JsonValue]) -> dict[str, 
         for key in ("plan_type", "resets_at", "resets_in_seconds"):
             if key in detail:
                 event["response"]["error"][key] = detail[key]
-        return event
+        return cast(dict[str, JsonValue], event)
     if event_type == "error":
         message = _extract_upstream_message(payload) or "Upstream websocket error"
         code = payload.get("code")
         error_type = payload.get("error_type") or payload.get("type")
-        return response_failed_event(
-            _normalize_error_code(
-                code if isinstance(code, str) else None, error_type if isinstance(error_type, str) else None
+        return cast(
+            dict[str, JsonValue],
+            response_failed_event(
+                _normalize_error_code(
+                    code if isinstance(code, str) else None, error_type if isinstance(error_type, str) else None
+                ),
+                message,
+                error_type=error_type if isinstance(error_type, str) and error_type != "error" else "server_error",
+                response_id=get_request_id(),
             ),
-            message,
-            error_type=error_type if isinstance(error_type, str) and error_type != "error" else "server_error",
-            response_id=get_request_id(),
         )
     return payload
 

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -939,15 +939,17 @@ def _normalize_stream_event_payload(payload: dict[str, JsonValue]) -> dict[str, 
     if event_type == "error":
         message = _extract_upstream_message(payload) or "Upstream websocket error"
         code = payload.get("code")
-        error_type = payload.get("error_type") or payload.get("type")
+        raw_error_type = payload.get("error_type")
+        error_type = raw_error_type if isinstance(raw_error_type, str) else None
         return cast(
             dict[str, JsonValue],
             response_failed_event(
                 _normalize_error_code(
-                    code if isinstance(code, str) else None, error_type if isinstance(error_type, str) else None
+                    code if isinstance(code, str) else None,
+                    error_type,
                 ),
                 message,
-                error_type=error_type if isinstance(error_type, str) and error_type != "error" else "server_error",
+                error_type=error_type or "server_error",
                 response_id=get_request_id(),
             ),
         )

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -84,6 +84,13 @@ _SSE_EVENT_TYPE_ALIASES = {
     "response.audio.delta": "response.output_audio.delta",
     "response.audio_transcript.delta": "response.output_audio_transcript.delta",
 }
+_RESPONSE_STREAM_TERMINAL_EVENT_TYPES = frozenset(
+    {
+        "response.completed",
+        "response.failed",
+        "response.incomplete",
+    }
+)
 
 _SSE_READ_CHUNK_SIZE = 1 * 1024
 _IMAGE_INLINE_MAX_BYTES = 8 * 1024 * 1024
@@ -915,6 +922,32 @@ def _normalize_stream_event_payload(payload: dict[str, JsonValue]) -> dict[str, 
         normalized = dict(payload)
         normalized["type"] = _SSE_EVENT_TYPE_ALIASES[event_type]
         return normalized
+    error = parse_error_payload(payload)
+    if error is not None:
+        detail = error.model_dump(exclude_none=True)
+        event = response_failed_event(
+            _normalize_error_code(detail.get("code"), detail.get("type")),
+            detail.get("message", "Upstream websocket error"),
+            error_type=detail.get("type") or "server_error",
+            response_id=get_request_id(),
+            error_param=detail.get("param"),
+        )
+        for key in ("plan_type", "resets_at", "resets_in_seconds"):
+            if key in detail:
+                event["response"]["error"][key] = detail[key]
+        return event
+    if event_type == "error":
+        message = _extract_upstream_message(payload) or "Upstream websocket error"
+        code = payload.get("code")
+        error_type = payload.get("error_type") or payload.get("type")
+        return response_failed_event(
+            _normalize_error_code(
+                code if isinstance(code, str) else None, error_type if isinstance(error_type, str) else None
+            ),
+            message,
+            error_type=error_type if isinstance(error_type, str) and error_type != "error" else "server_error",
+            response_id=get_request_id(),
+        )
     return payload
 
 
@@ -1210,13 +1243,9 @@ async def _stream_websocket_events(
         if not isinstance(payload, dict):
             continue
         normalized = _normalize_stream_event_payload(payload)
-        event_type = payload.get("type")
+        event_type = normalized.get("type")
         yield format_sse_event(normalized)
-        if isinstance(event_type, str) and event_type in (
-            "response.completed",
-            "response.failed",
-            "response.incomplete",
-        ):
+        if isinstance(event_type, str) and event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
             break
 
 
@@ -1303,7 +1332,7 @@ async def _stream_responses_via_websocket(
             max_event_bytes=max_event_bytes,
         ):
             parsed_event = parse_sse_event(event)
-            if parsed_event and parsed_event.type in ("response.completed", "response.failed", "response.incomplete"):
+            if parsed_event and parsed_event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
                 seen_terminal = True
                 await _record_lifecycle_success()
             yield event
@@ -1885,7 +1914,7 @@ async def stream_responses(
                 event = parse_sse_event(event_block)
                 if event:
                     event_type = event.type
-                    if event_type in ("response.completed", "response.failed", "response.incomplete"):
+                    if event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
                         seen_terminal = True
                 yield event_block
                 if seen_terminal:
@@ -1919,7 +1948,7 @@ async def stream_responses(
                     event = parse_sse_event(event_block)
                     if event:
                         event_type = event.type
-                        if event_type in ("response.completed", "response.failed", "response.incomplete"):
+                        if event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
                             seen_terminal = True
                     yield event_block
                     if seen_terminal:

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -135,7 +135,7 @@ class Settings(BaseSettings):
     upstream_websocket_trust_env: bool = False
     proxy_request_budget_seconds: float = Field(default=600.0, gt=0)
     compact_request_budget_seconds: float = Field(default=180.0, gt=0)
-    stream_idle_timeout_seconds: float = 120.0
+    stream_idle_timeout_seconds: float = 600.0
     sse_keepalive_interval_seconds: float = Field(default=10.0, ge=0)
     proxy_downstream_websocket_idle_timeout_seconds: float = Field(default=120.0, gt=0)
     # Applies to both upstream SSE event buffering and upstream websocket message

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -135,7 +135,7 @@ class Settings(BaseSettings):
     upstream_websocket_trust_env: bool = False
     proxy_request_budget_seconds: float = Field(default=600.0, gt=0)
     compact_request_budget_seconds: float = Field(default=180.0, gt=0)
-    stream_idle_timeout_seconds: float = 600.0
+    stream_idle_timeout_seconds: float = 120.0
     sse_keepalive_interval_seconds: float = Field(default=10.0, ge=0)
     proxy_downstream_websocket_idle_timeout_seconds: float = Field(default=120.0, gt=0)
     # Applies to both upstream SSE event buffering and upstream websocket message

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -134,8 +134,8 @@ class Settings(BaseSettings):
     upstream_compact_timeout_seconds: float | None = None
     upstream_websocket_trust_env: bool = False
     proxy_request_budget_seconds: float = Field(default=600.0, gt=0)
-    compact_request_budget_seconds: float = Field(default=75.0, gt=0)
-    stream_idle_timeout_seconds: float = 300.0
+    compact_request_budget_seconds: float = Field(default=180.0, gt=0)
+    stream_idle_timeout_seconds: float = 600.0
     sse_keepalive_interval_seconds: float = Field(default=10.0, ge=0)
     proxy_downstream_websocket_idle_timeout_seconds: float = Field(default=120.0, gt=0)
     # Applies to both upstream SSE event buffering and upstream websocket message

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1644,7 +1644,7 @@ async def _stream_responses(
         return _stream_startup_error_response(
             request,
             startup_error,
-            headers=rate_limit_headers,
+            headers={**turn_state_headers, **rate_limit_headers},
         )
     stream = _normalize_public_responses_stream(
         _stream_response_error_events(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1644,7 +1644,7 @@ async def _stream_responses(
         return _stream_startup_error_response(
             request,
             startup_error,
-            headers={**turn_state_headers, **rate_limit_headers},
+            headers=rate_limit_headers,
         )
     stream = _normalize_public_responses_stream(
         _stream_response_error_events(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1631,7 +1631,13 @@ async def _stream_responses(
             api_key_reservation=reservation,
             suppress_text_done_events=suppress_text_done_events,
         )
-    stream, startup_error = await _probe_stream_startup_error(stream)
+    stream, startup_error = await _probe_stream_startup_error(
+        stream,
+        convert_event_errors=bridge_active,
+        timeout_seconds=(
+            _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS if prefer_http_bridge else _STREAM_STARTUP_ERROR_PROBE_SECONDS
+        ),
+    )
     if startup_error is not None:
         if owns_reservation:
             await _release_reservation(reservation)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2815,12 +2815,6 @@ def _is_previous_response_not_found_public_error(error_value: OpenAIError | None
         return True
     message = error_value.message or ""
     normalized_message = " ".join(message.lower().split())
-    if (
-        error_value.code == "invalid_request_error"
-        and error_value.param == "input"
-        and normalized_message.startswith("no tool output found for function call call_")
-    ):
-        return True
     return (
         error_value.code == "invalid_request_error"
         and error_value.param == "previous_response_id"

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2814,11 +2814,18 @@ def _is_previous_response_not_found_public_error(error_value: OpenAIError | None
     if error_value.code == "previous_response_not_found":
         return True
     message = error_value.message or ""
+    normalized_message = " ".join(message.lower().split())
+    if (
+        error_value.code == "invalid_request_error"
+        and error_value.param == "input"
+        and normalized_message.startswith("no tool output found for function call call_")
+    ):
+        return True
     return (
         error_value.code == "invalid_request_error"
         and error_value.param == "previous_response_id"
-        and "previous response" in message.lower()
-        and "not found" in message.lower()
+        and "previous response" in normalized_message
+        and "not found" in normalized_message
     )
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1962,7 +1962,10 @@ async def _stream_response_error_events(
             yield line
     except ProxyResponseError as exc:
         if owns_reservation:
-            await _release_reservation(reservation)
+            try:
+                await _release_reservation(reservation)
+            except Exception:
+                logger.warning("Failed to release stream reservation after upstream proxy error", exc_info=True)
         envelope = _parse_error_envelope(exc.payload)
         _, envelope = _mask_previous_response_not_found_error(envelope, default_status=exc.status_code)
         error = envelope.error

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1638,7 +1638,7 @@ async def _stream_responses(
         return _stream_startup_error_response(
             request,
             startup_error,
-            headers={**turn_state_headers, **rate_limit_headers},
+            headers=rate_limit_headers,
         )
     stream = _normalize_public_responses_stream(
         _stream_response_error_events(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1631,19 +1631,12 @@ async def _stream_responses(
             api_key_reservation=reservation,
             suppress_text_done_events=suppress_text_done_events,
         )
-    stream, startup_error = await _probe_stream_startup_error(
-        stream,
-        convert_event_errors=bridge_active,
-        timeout_seconds=_HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS
-        if prefer_http_bridge
-        else _STREAM_STARTUP_ERROR_PROBE_SECONDS,
-    )
-    if startup_error is not None:
-        if reservation is not None and owns_reservation:
-            await _release_reservation(reservation)
-        return _stream_startup_error_response(request, startup_error, headers=rate_limit_headers)
     stream = _normalize_public_responses_stream(
-        _stream_proxy_errors_as_response_failed(stream),
+        _stream_response_error_events(
+            stream,
+            owns_reservation=owns_reservation,
+            reservation=reservation,
+        ),
         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
     )
     return StreamingResponse(
@@ -1939,10 +1932,22 @@ async def _prepend_first_task(first_task: asyncio.Task[str], stream: AsyncIterat
 
 
 async def _stream_proxy_errors_as_response_failed(stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    async for line in _stream_response_error_events(stream, owns_reservation=False, reservation=None):
+        yield line
+
+
+async def _stream_response_error_events(
+    stream: AsyncIterator[str],
+    *,
+    owns_reservation: bool,
+    reservation: ApiKeyUsageReservationData | None,
+) -> AsyncIterator[str]:
     try:
         async for line in stream:
             yield line
     except ProxyResponseError as exc:
+        if owns_reservation:
+            await _release_reservation(reservation)
         envelope = _parse_error_envelope(exc.payload)
         _, envelope = _mask_previous_response_not_found_error(envelope, default_status=exc.status_code)
         error = envelope.error

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1631,6 +1631,15 @@ async def _stream_responses(
             api_key_reservation=reservation,
             suppress_text_done_events=suppress_text_done_events,
         )
+    stream, startup_error = await _probe_stream_startup_error(stream)
+    if startup_error is not None:
+        if owns_reservation:
+            await _release_reservation(reservation)
+        return _stream_startup_error_response(
+            request,
+            startup_error,
+            headers={**turn_state_headers, **rate_limit_headers},
+        )
     stream = _normalize_public_responses_stream(
         _stream_response_error_events(
             stream,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5729,6 +5729,13 @@ class ProxyService:
                             error_message=error_message,
                         ),
                     )
+                    if not grouped_previous_response_request_states and is_missing_tool_output_event:
+                        grouped_previous_response_request_states = _pop_matching_websocket_request_states(
+                            session.pending_requests,
+                            _matching_websocket_request_states_for_missing_tool_output_error(
+                                session.pending_requests,
+                            ),
+                        )
                     if grouped_previous_response_request_states:
                         session.queued_request_count = max(
                             0,
@@ -6485,6 +6492,13 @@ class ProxyService:
                             error_message=error_message,
                         ),
                     )
+                    if not grouped_previous_response_request_states and is_missing_tool_output_event:
+                        grouped_previous_response_request_states = _pop_matching_websocket_request_states(
+                            pending_requests,
+                            _matching_websocket_request_states_for_missing_tool_output_error(
+                                pending_requests,
+                            ),
+                        )
                 elif request_state is None and event_type == "error":
                     grouped_previous_response_request_states = list(pending_requests)
                     pending_requests.clear()
@@ -9732,6 +9746,16 @@ def _matching_websocket_request_states_for_previous_response_error(
         if len(unique_previous_response_ids) == 1:
             return unresolved_followups
     return []
+
+
+def _matching_websocket_request_states_for_missing_tool_output_error(
+    pending_requests: deque[_WebSocketRequestState],
+) -> list[_WebSocketRequestState]:
+    return [
+        request_state
+        for request_state in pending_requests
+        if request_state.response_id is None and request_state.previous_response_id is not None
+    ]
 
 
 def _pop_matching_websocket_request_states(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -254,6 +254,9 @@ _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES = frozenset(
     }
 )
 _WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
+_SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE = (
+    "Suppressed duplicate side-effect tool call; upstream response cannot be continued safely."
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -8008,6 +8011,7 @@ class ProxyService:
         latency_first_token_ms: int | None = None
         response_create_lease = AdmissionLease(None)
         tool_call_dedupe = _WebSocketUpstreamControl()
+        suppressed_duplicate_tool_call = False
 
         try:
             response_create_lease = await self._get_work_admission().acquire_response_create()
@@ -8126,10 +8130,11 @@ class ProxyService:
                     seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
                     response_id=_websocket_response_id(event, first_payload) or response_id,
                 ):
-                    return
-                if latency_first_token_ms is None and event_type in _TEXT_DELTA_EVENT_TYPES:
-                    latency_first_token_ms = int((time.monotonic() - request_started_at) * 1000)
-                yield first
+                    suppressed_duplicate_tool_call = True
+                else:
+                    if latency_first_token_ms is None and event_type in _TEXT_DELTA_EVENT_TYPES:
+                        latency_first_token_ms = int((time.monotonic() - request_started_at) * 1000)
+                    yield first
             if terminal_stream_error is not None:
                 raise terminal_stream_error
 
@@ -8209,6 +8214,17 @@ class ProxyService:
                             response_id = response.id
                         if event_type == "response.incomplete":
                             status = "error"
+                    if event_type == "response.completed" and suppressed_duplicate_tool_call:
+                        line, event, event_payload, event_type = _build_rewritten_stream_response_failed_event(
+                            response_id=response_id,
+                            error_code="stream_incomplete",
+                            error_message=_SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE,
+                        )
+                        status = "error"
+                        error_code = "stream_incomplete"
+                        error_message = _SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE
+                        settlement.record_success = False
+                        settlement.account_health_error = False
                 if latency_first_token_ms is None and event_type in _TEXT_DELTA_EVENT_TYPES:
                     latency_first_token_ms = int((time.monotonic() - request_started_at) * 1000)
                 if mark_duplicate_tool_call_downstream_event(
@@ -8216,6 +8232,7 @@ class ProxyService:
                     seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
                     response_id=_websocket_response_id(event, event_payload) or response_id,
                 ):
+                    suppressed_duplicate_tool_call = True
                     continue
                 yield line
         except ProxyResponseError as exc:
@@ -9400,7 +9417,7 @@ def _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
 ) -> tuple[OpenAIEvent | None, dict[str, JsonValue] | None, str | None, str]:
     rewritten_event_payload = response_failed_event(
         "stream_incomplete",
-        "Suppressed duplicate side-effect tool call; upstream response cannot be continued safely.",
+        _SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE,
         error_type="server_error",
         response_id=request_state.response_id or request_state.request_id,
     )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5635,6 +5635,11 @@ class ProxyService:
         event_type = _event_type_from_payload(event, payload)
         response_id = _websocket_response_id(event, payload)
         error_message = _websocket_event_error_message(event_type, payload)
+        is_typeless_error_event = (
+            isinstance(payload, dict)
+            and not isinstance(payload.get("type"), str)
+            and isinstance(payload.get("error"), dict)
+        )
         is_previous_response_not_found_event = _is_previous_response_not_found_error(
             code=_normalize_error_code(
                 _websocket_event_error_code(event_type, payload),
@@ -5745,7 +5750,12 @@ class ProxyService:
                             0,
                             session.queued_request_count - len(grouped_previous_response_request_states),
                         )
-                elif event_type == "error":
+                if (
+                    terminal_request_state is None
+                    and event_type == "error"
+                    and is_typeless_error_event
+                    and not grouped_previous_response_request_states
+                ):
                     grouped_previous_response_request_states = list(session.pending_requests)
                     session.pending_requests.clear()
                     if grouped_previous_response_request_states:
@@ -6408,6 +6418,11 @@ class ProxyService:
         event_type = _event_type_from_payload(event, payload)
         response_id = _websocket_response_id(event, payload)
         error_message = _websocket_event_error_message(event_type, payload)
+        is_typeless_error_event = (
+            isinstance(payload, dict)
+            and not isinstance(payload.get("type"), str)
+            and isinstance(payload.get("error"), dict)
+        )
         is_previous_response_not_found_event = _is_previous_response_not_found_error(
             code=_normalize_error_code(
                 _websocket_event_error_code(event_type, payload),
@@ -6509,7 +6524,12 @@ class ProxyService:
                             pending_requests,
                             _all_pending_websocket_followup_requests(pending_requests),
                         )
-                elif request_state is None and event_type == "error":
+                if (
+                    request_state is None
+                    and event_type == "error"
+                    and is_typeless_error_event
+                    and not grouped_previous_response_request_states
+                ):
                     grouped_previous_response_request_states = list(pending_requests)
                     pending_requests.clear()
                 if (

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2906,6 +2906,7 @@ class ProxyService:
         except ProxyResponseError:
             await self._release_websocket_reservation(reservation)
             raise
+        had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
         if previous_response_trimmed_input_count is not None:
             request_state.input_item_count = previous_response_trimmed_input_count
             request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
@@ -2919,7 +2920,6 @@ class ProxyService:
                 else None,
                 responses_payload.previous_response_id,
             )
-        had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
         affinity_policy = _sticky_key_for_responses_request(
             responses_payload,
             headers,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5807,7 +5807,11 @@ class ProxyService:
             )
             event_block = f"data: {rewritten_text}\n\n"
 
-        if status_request_state is not None and is_missing_tool_output_event:
+        if (
+            status_request_state is not None
+            and status_request_state.previous_response_id is not None
+            and is_missing_tool_output_event
+        ):
             status_request_state.error_http_status_override = 502
             event, payload, event_type, rewritten_text = _rewrite_websocket_continuity_corruption_event(
                 request_state=status_request_state,
@@ -6497,7 +6501,11 @@ class ProxyService:
                         )
                     )
                     text = rewritten_text
-                if request_state is not None and is_missing_tool_output_event:
+                if (
+                    request_state is not None
+                    and request_state.previous_response_id is not None
+                    and is_missing_tool_output_event
+                ):
                     request_state.error_http_status_override = 502
                     event, payload, event_type, text = _rewrite_websocket_continuity_corruption_event(
                         request_state=request_state,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -282,35 +282,6 @@ def _fingerprint_input_items(items: Sequence[JsonValue]) -> str:
     return sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
-    first_output_index = next(
-        (index for index, item in enumerate(input_items) if _websocket_input_item_type(item) == "function_call_output"),
-        None,
-    )
-    if first_output_index is None or first_output_index == 0:
-        return input_items
-    prefix = input_items[:first_output_index]
-    if not all(_is_websocket_previous_response_output_item(item) for item in prefix):
-        return input_items
-    return input_items[first_output_index:]
-
-
-def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
-    item_type = _websocket_input_item_type(item)
-    if item_type in {"reasoning", "function_call", "custom_tool_call"}:
-        return True
-    if item_type != "message" or not isinstance(item, dict):
-        return False
-    return item.get("role") == "assistant"
-
-
-def _websocket_input_item_type(item: JsonValue) -> str | None:
-    if not isinstance(item, dict):
-        return None
-    item_type = item.get("type")
-    return item_type if isinstance(item_type, str) else None
-
-
 class ProxyService:
     def __init__(self, repo_factory: ProxyRepoFactory) -> None:
         self._repo_factory = repo_factory
@@ -2900,10 +2871,6 @@ class ProxyService:
         refreshed_api_key = await self._refresh_websocket_api_key_policy(api_key)
         client_metadata = _response_create_client_metadata(payload, headers=headers)
         responses_payload = normalize_responses_request_payload(payload, openai_compat=openai_cache_affinity)
-        apply_api_key_enforcement(responses_payload, refreshed_api_key)
-        validate_model_access(refreshed_api_key, responses_payload.model)
-        self._raise_for_unsupported_input_image_references(responses_payload)
-        rewritten_file_account_id = await self._resolve_file_account_for_responses(responses_payload, headers)
         previous_response_trimmed_input_count: int | None = None
         previous_response_trimmed_input_fingerprint: str | None = None
         if responses_payload.previous_response_id is not None and isinstance(responses_payload.input, list):
@@ -2913,6 +2880,10 @@ class ProxyService:
                 previous_response_trimmed_input_count = len(previous_response_input_items)
                 previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
                 responses_payload = responses_payload.model_copy(update={"input": trimmed_input_items})
+        apply_api_key_enforcement(responses_payload, refreshed_api_key)
+        validate_model_access(refreshed_api_key, responses_payload.model)
+        self._raise_for_unsupported_input_image_references(responses_payload)
+        rewritten_file_account_id = await self._resolve_file_account_for_responses(responses_payload, headers)
         reservation = await self._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -10078,6 +10049,41 @@ def _wrapped_websocket_error_event(
 
 def _serialize_websocket_error_event(payload: dict[str, JsonValue]) -> str:
     return json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+
+
+def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
+    first_output_index = next(
+        (
+            index
+            for index, item in enumerate(input_items)
+            if _websocket_input_item_type(item) in {"function_call_output", "custom_tool_call_output"}
+        ),
+        None,
+    )
+    if first_output_index is None or first_output_index == 0:
+        return input_items
+    prefix = input_items[:first_output_index]
+    if not all(_is_websocket_previous_response_output_item(item) for item in prefix):
+        return input_items
+    return input_items[first_output_index:]
+
+
+def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
+    if isinstance(item, dict) and _websocket_input_item_type(item) is None and item.get("role") == "assistant":
+        return True
+    item_type = _websocket_input_item_type(item)
+    if item_type in {"reasoning", "function_call", "custom_tool_call"}:
+        return True
+    if item_type != "message" or not isinstance(item, dict):
+        return False
+    return item.get("role") == "assistant"
+
+
+def _websocket_input_item_type(item: JsonValue) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    item_type = item.get("type")
+    return item_type if isinstance(item_type, str) else None
 
 
 def _remaining_budget_seconds(deadline: float) -> float:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -160,6 +160,7 @@ from app.modules.proxy.ring_membership import (
     RingMembershipService,
 )
 from app.modules.proxy.tool_call_dedupe import (
+    dedupe_replayed_side_effect_input_items,
     mark_duplicate_tool_call_downstream_event,
     rewrite_parallel_tool_call_sse_line,
     rewrite_parallel_tool_call_text,
@@ -3030,6 +3031,18 @@ class ProxyService:
         request_id: str | None = None,
         request_log_id: str | None = None,
     ) -> tuple[_WebSocketRequestState, str]:
+        deduped_replayed_input_count: int | None = None
+        deduped_replayed_input_fingerprint: str | None = None
+        deduped_replayed_tool_call_count = 0
+        if isinstance(payload.input, list):
+            replayed_input_items = cast(list[JsonValue], payload.input)
+            deduped_input_items, deduped_replayed_tool_call_count = dedupe_replayed_side_effect_input_items(
+                replayed_input_items
+            )
+            if deduped_replayed_tool_call_count > 0:
+                deduped_replayed_input_count = len(replayed_input_items)
+                deduped_replayed_input_fingerprint = _fingerprint_input_items(replayed_input_items)
+                payload = payload.model_copy(update={"input": deduped_input_items})
         upstream_payload = dict(payload.to_payload())
         upstream_payload.pop("stream", None)
         upstream_payload.pop("background", None)
@@ -3065,6 +3078,19 @@ class ProxyService:
             input_item_count=input_item_count,
             input_full_fingerprint=input_full_fingerprint,
         )
+        if deduped_replayed_input_count is not None:
+            request_state.input_item_count = deduped_replayed_input_count
+            request_state.input_full_fingerprint = deduped_replayed_input_fingerprint
+            logger.warning(
+                "%s_replayed_tool_call_input_deduped request_id=%s original_items=%s deduped_to=%s "
+                "removed_tool_calls=%s previous_response_id=%s",
+                transport,
+                request_state.request_id,
+                deduped_replayed_input_count,
+                input_item_count,
+                deduped_replayed_tool_call_count,
+                payload.previous_response_id,
+            )
         text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
         payload_size = len(text_data.encode("utf-8"))
         if payload_size > _UPSTREAM_RESPONSE_CREATE_MAX_BYTES:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3038,7 +3038,8 @@ class ProxyService:
         if payload.previous_response_id is not None and isinstance(payload.input, list):
             replayed_input_items = cast(list[JsonValue], payload.input)
             deduped_input_items, deduped_replayed_tool_call_count = dedupe_replayed_side_effect_input_items(
-                replayed_input_items
+                replayed_input_items,
+                sanitize_missing_outputs=True,
             )
             if deduped_replayed_tool_call_count > 0:
                 deduped_replayed_input_count = len(replayed_input_items)
@@ -5693,7 +5694,7 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
                     seen_tool_call_keys=session.seen_tool_call_keys,
-                    response_id=response_id or matched_request_state.response_id or matched_request_state.request_id,
+                    response_id=matched_request_state.request_id,
                 ):
                     matched_request_state.suppressed_duplicate_tool_call = True
                     return
@@ -5719,7 +5720,7 @@ class ProxyService:
                 )
                 if terminal_request_state is not None:
                     session.queued_request_count = max(0, session.queued_request_count - 1)
-                elif is_previous_response_not_found_event:
+                elif is_previous_response_not_found_event or is_missing_tool_output_event:
                     grouped_previous_response_request_states = _pop_matching_websocket_request_states(
                         session.pending_requests,
                         _matching_websocket_request_states_for_previous_response_error(
@@ -6444,8 +6445,8 @@ class ProxyService:
                     request_state.service_tier = actual_service_tier
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
-                    seen_tool_call_keys=upstream_control.seen_tool_call_keys,
-                    response_id=response_id or request_state.response_id or request_state.request_id,
+                    seen_tool_call_keys=request_state.seen_tool_call_keys,
+                    response_id=request_state.request_id,
                 ):
                     request_state.suppressed_duplicate_tool_call = True
                     upstream_control.suppress_downstream_event = True
@@ -6471,7 +6472,7 @@ class ProxyService:
                         "error",
                     },
                 )
-                if request_state is None and is_previous_response_not_found_event:
+                if request_state is None and (is_previous_response_not_found_event or is_missing_tool_output_event):
                     grouped_previous_response_request_states = _pop_matching_websocket_request_states(
                         pending_requests,
                         _matching_websocket_request_states_for_previous_response_error(
@@ -8907,6 +8908,7 @@ class _WebSocketRequestState:
     input_full_fingerprint: str | None = None
     suppressed_downstream_tool_call: bool = False
     suppressed_duplicate_tool_call: bool = False
+    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -162,6 +162,7 @@ from app.modules.proxy.ring_membership import (
 from app.modules.proxy.tool_call_dedupe import (
     dedupe_replayed_side_effect_input_items,
     mark_duplicate_tool_call_downstream_event,
+    response_id_from_payload,
     rewrite_parallel_tool_call_sse_line,
     rewrite_parallel_tool_call_text,
 )
@@ -254,10 +255,10 @@ _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES = frozenset(
         "quota_exceeded",
     }
 )
-_WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
 _SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE = (
     "Suppressed duplicate side-effect tool call; upstream response cannot be continued safely."
 )
+_WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
 
 
 @dataclass(frozen=True, slots=True)
@@ -3034,7 +3035,7 @@ class ProxyService:
         deduped_replayed_input_count: int | None = None
         deduped_replayed_input_fingerprint: str | None = None
         deduped_replayed_tool_call_count = 0
-        if isinstance(payload.input, list):
+        if payload.previous_response_id is not None and isinstance(payload.input, list):
             replayed_input_items = cast(list[JsonValue], payload.input)
             deduped_input_items, deduped_replayed_tool_call_count = dedupe_replayed_side_effect_input_items(
                 replayed_input_items
@@ -5691,7 +5692,7 @@ class ProxyService:
                     matched_request_state.service_tier = actual_service_tier
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
-                    seen_tool_call_keys=session.upstream_control.seen_tool_call_keys,
+                    seen_tool_call_keys=session.seen_tool_call_keys,
                     response_id=response_id or matched_request_state.response_id or matched_request_state.request_id,
                 ):
                     matched_request_state.suppressed_duplicate_tool_call = True
@@ -5783,6 +5784,28 @@ class ProxyService:
             session.upstream_control.reconnect_requested = True
             return
 
+        if (
+            event_type == "response.completed"
+            and terminal_request_state is not None
+            and terminal_request_state.suppressed_duplicate_tool_call
+        ):
+            session.upstream_control.reconnect_requested = True
+            session.closed = True
+            try:
+                await session.upstream.close()
+            except Exception:
+                logger.debug("Failed to close HTTP bridge upstream after suppressed duplicate tool call", exc_info=True)
+            terminal_request_state.error_http_status_override = 502
+            (
+                event,
+                payload,
+                event_type,
+                rewritten_text,
+            ) = _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
+                request_state=terminal_request_state,
+            )
+            event_block = f"data: {rewritten_text}\n\n"
+
         if status_request_state is not None and is_missing_tool_output_event:
             status_request_state.error_http_status_override = 502
             event, payload, event_type, rewritten_text = _rewrite_websocket_continuity_corruption_event(
@@ -5809,28 +5832,6 @@ class ProxyService:
                 event_type=event_type,
                 upstream_control=session.upstream_control,
                 original_text=text,
-            )
-            event_block = f"data: {rewritten_text}\n\n"
-
-        if (
-            event_type == "response.completed"
-            and terminal_request_state is not None
-            and terminal_request_state.suppressed_duplicate_tool_call
-        ):
-            session.upstream_control.reconnect_requested = True
-            session.closed = True
-            try:
-                await session.upstream.close()
-            except Exception:
-                logger.debug("Failed to close HTTP bridge upstream after suppressed duplicate tool call", exc_info=True)
-            terminal_request_state.error_http_status_override = 502
-            (
-                event,
-                payload,
-                event_type,
-                rewritten_text,
-            ) = _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
-                request_state=terminal_request_state,
             )
             event_block = f"data: {rewritten_text}\n\n"
 
@@ -8163,7 +8164,9 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     first_payload,
                     seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
-                    response_id=_websocket_response_id(event, first_payload) or response_id,
+                    response_id=response_id_from_payload(first_payload)
+                    or _websocket_response_id(event, first_payload)
+                    or response_id,
                 ):
                     suppressed_duplicate_tool_call = True
                 else:
@@ -8267,7 +8270,9 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     event_payload,
                     seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
-                    response_id=_websocket_response_id(event, event_payload) or response_id,
+                    response_id=response_id_from_payload(event_payload)
+                    or _websocket_response_id(event, event_payload)
+                    or response_id,
                 ):
                     suppressed_duplicate_tool_call = True
                     continue
@@ -8959,6 +8964,7 @@ class _HTTPBridgeSession:
     upstream_reader: asyncio.Task[None] | None = None
     last_upstream_close_code: int | None = None
     closed: bool = False
+    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -231,6 +231,7 @@ _TRANSIENT_RETRY_CODES = frozenset(
     {
         "server_error",
         "stream_incomplete",
+        "stream_idle_timeout",
         "upstream_request_timeout",
     }
 )
@@ -2515,6 +2516,7 @@ class ProxyService:
                     message_type = message["type"]
 
                     if message_type == "websocket.disconnect":
+                        downstream_activity.mark_disconnected()
                         break
                     if message_type != "websocket.receive":
                         continue
@@ -2830,18 +2832,29 @@ class ProxyService:
                     await upstream.close()
                 except Exception:
                     logger.debug("Failed to close upstream websocket", exc_info=True)
+            if replay_request_state is not None:
+                await self._release_websocket_reservation(replay_request_state.api_key_reservation)
+                replay_request_state.api_key_reservation = None
+                _release_websocket_response_create_gate(replay_request_state, response_create_gate)
+            client_disconnected = downstream_activity.disconnected
             await self._fail_pending_websocket_requests(
-                account=account,
+                account=None if client_disconnected else account,
                 account_id_value=account.id if account else None,
                 pending_requests=pending_requests,
                 pending_lock=pending_lock,
-                error_code="stream_incomplete",
-                error_message="Upstream websocket closed before response.completed",
+                error_code="client_disconnected" if client_disconnected else "stream_incomplete",
+                error_message=(
+                    "Downstream websocket disconnected before response.completed"
+                    if client_disconnected
+                    else "Upstream websocket closed before response.completed"
+                ),
                 api_key=api_key,
-                websocket=websocket,
-                client_send_lock=client_send_lock,
+                websocket=None if client_disconnected else websocket,
+                client_send_lock=None if client_disconnected else client_send_lock,
                 response_create_gate=response_create_gate,
                 downstream_activity=downstream_activity,
+                status="cancelled" if client_disconnected else "error",
+                penalize_account=not client_disconnected,
             )
 
     async def _prepare_websocket_response_create_request(
@@ -5974,17 +5987,58 @@ class ProxyService:
                     proxy_request_budget_seconds=proxy_request_budget_seconds,
                     stream_idle_timeout_seconds=stream_idle_timeout_seconds,
                 )
+                receive_deadline = (
+                    None if receive_timeout is None else time.monotonic() + receive_timeout.timeout_seconds
+                )
                 try:
-                    if receive_timeout is None:
-                        message = await upstream.receive()
-                    elif receive_timeout.timeout_seconds <= 0:
-                        raise asyncio.TimeoutError()
-                    else:
+                    while True:
+                        wait_timeout = None if receive_deadline is None else receive_deadline - time.monotonic()
+                        if wait_timeout is not None and wait_timeout <= 0:
+                            raise asyncio.TimeoutError()
+                        keepalive_interval = get_settings().sse_keepalive_interval_seconds
+                        if keepalive_interval > 0:
+                            wait_timeout = (
+                                keepalive_interval if wait_timeout is None else min(wait_timeout, keepalive_interval)
+                            )
                         message = await asyncio.wait_for(
                             upstream.receive(),
-                            timeout=receive_timeout.timeout_seconds,
+                            timeout=wait_timeout,
                         )
+                        break
                 except asyncio.TimeoutError:
+                    if receive_deadline is None or time.monotonic() < receive_deadline:
+                        try:
+                            await self._emit_pending_websocket_keepalive(
+                                websocket,
+                                pending_requests=pending_requests,
+                                pending_lock=pending_lock,
+                                client_send_lock=client_send_lock,
+                                downstream_activity=downstream_activity,
+                            )
+                        except Exception:
+                            downstream_activity.mark_disconnected()
+                            logger.debug("Downstream websocket disconnected during keepalive", exc_info=True)
+                            await self._fail_pending_websocket_requests(
+                                account=None,
+                                account_id_value=account_id_value,
+                                pending_requests=pending_requests,
+                                pending_lock=pending_lock,
+                                error_code="client_disconnected",
+                                error_message="Downstream websocket disconnected before response.completed",
+                                api_key=api_key,
+                                response_create_gate=response_create_gate,
+                                status="cancelled",
+                                penalize_account=False,
+                            )
+                            try:
+                                await upstream.close()
+                            except Exception:
+                                logger.debug(
+                                    "Failed to close upstream websocket after downstream keepalive failure",
+                                    exc_info=True,
+                                )
+                            break
+                        continue
                     if receive_timeout is None:
                         raise
                     if receive_timeout.fail_all_pending:
@@ -6037,19 +6091,69 @@ class ProxyService:
                     upstream_control.downstream_texts = None
                     if downstream_texts is not None:
                         for emitted_text in downstream_texts:
+                            try:
+                                await self._send_downstream_websocket_text(
+                                    websocket,
+                                    client_send_lock=client_send_lock,
+                                    text=emitted_text,
+                                    downstream_activity=downstream_activity,
+                                )
+                            except Exception:
+                                downstream_activity.mark_disconnected()
+                                logger.debug("Downstream websocket disconnected during upstream relay", exc_info=True)
+                                await self._fail_pending_websocket_requests(
+                                    account=None,
+                                    account_id_value=account_id_value,
+                                    pending_requests=pending_requests,
+                                    pending_lock=pending_lock,
+                                    error_code="client_disconnected",
+                                    error_message="Downstream websocket disconnected before response.completed",
+                                    api_key=api_key,
+                                    response_create_gate=response_create_gate,
+                                    status="cancelled",
+                                    penalize_account=False,
+                                )
+                                try:
+                                    await upstream.close()
+                                except Exception:
+                                    logger.debug(
+                                        "Failed to close upstream websocket after downstream disconnect",
+                                        exc_info=True,
+                                    )
+                                break
+                        if downstream_activity.disconnected:
+                            break
+                    elif not suppress_downstream_event:
+                        try:
                             await self._send_downstream_websocket_text(
                                 websocket,
                                 client_send_lock=client_send_lock,
-                                text=emitted_text,
+                                text=downstream_text,
                                 downstream_activity=downstream_activity,
                             )
-                    elif not suppress_downstream_event:
-                        await self._send_downstream_websocket_text(
-                            websocket,
-                            client_send_lock=client_send_lock,
-                            text=downstream_text,
-                            downstream_activity=downstream_activity,
-                        )
+                        except Exception:
+                            downstream_activity.mark_disconnected()
+                            logger.debug("Downstream websocket disconnected during upstream relay", exc_info=True)
+                            await self._fail_pending_websocket_requests(
+                                account=None,
+                                account_id_value=account_id_value,
+                                pending_requests=pending_requests,
+                                pending_lock=pending_lock,
+                                error_code="client_disconnected",
+                                error_message="Downstream websocket disconnected before response.completed",
+                                api_key=api_key,
+                                response_create_gate=response_create_gate,
+                                status="cancelled",
+                                penalize_account=False,
+                            )
+                            try:
+                                await upstream.close()
+                            except Exception:
+                                logger.debug(
+                                    "Failed to close upstream websocket after downstream disconnect",
+                                    exc_info=True,
+                                )
+                            break
                     if upstream_control.reconnect_requested:
                         should_reconnect = upstream_control.replay_request_state is not None
                         if not should_reconnect:
@@ -6064,12 +6168,36 @@ class ProxyService:
                     continue
                 if message.kind == "binary" and message.data is not None:
                     downstream_activity.mark()
-                    await self._send_downstream_websocket_bytes(
-                        websocket,
-                        client_send_lock=client_send_lock,
-                        data=message.data,
-                        downstream_activity=downstream_activity,
-                    )
+                    try:
+                        await self._send_downstream_websocket_bytes(
+                            websocket,
+                            client_send_lock=client_send_lock,
+                            data=message.data,
+                            downstream_activity=downstream_activity,
+                        )
+                    except Exception:
+                        downstream_activity.mark_disconnected()
+                        logger.debug("Downstream websocket disconnected during upstream binary relay", exc_info=True)
+                        await self._fail_pending_websocket_requests(
+                            account=None,
+                            account_id_value=account_id_value,
+                            pending_requests=pending_requests,
+                            pending_lock=pending_lock,
+                            error_code="client_disconnected",
+                            error_message="Downstream websocket disconnected before response.completed",
+                            api_key=api_key,
+                            response_create_gate=response_create_gate,
+                            status="cancelled",
+                            penalize_account=False,
+                        )
+                        try:
+                            await upstream.close()
+                        except Exception:
+                            logger.debug(
+                                "Failed to close upstream websocket after downstream disconnect",
+                                exc_info=True,
+                            )
+                        break
                     continue
                 replay_request_state = await _pop_replayable_precreated_websocket_request_state(
                     pending_requests,
@@ -6363,6 +6491,36 @@ class ProxyService:
             stream_idle_timeout_seconds=stream_idle_timeout_seconds,
         )
 
+    async def _emit_pending_websocket_keepalive(
+        self,
+        websocket: WebSocket,
+        *,
+        pending_requests: deque[_WebSocketRequestState],
+        pending_lock: anyio.Lock,
+        client_send_lock: anyio.Lock,
+        downstream_activity: _DownstreamWebSocketActivity,
+    ) -> bool:
+        async with pending_lock:
+            keepalive_ids = [
+                request_state.response_id or request_state.request_id
+                for request_state in pending_requests
+                if request_state.response_id is not None or request_state.request_id
+            ]
+        if not keepalive_ids:
+            return False
+        for response_id in keepalive_ids:
+            event = {
+                "type": "response.in_progress",
+                "response": {"id": response_id, "status": "in_progress"},
+            }
+            await self._send_downstream_websocket_text(
+                websocket,
+                client_send_lock=client_send_lock,
+                text=json.dumps(event, ensure_ascii=True, separators=(",", ":")),
+                downstream_activity=downstream_activity,
+            )
+        return True
+
     async def _downstream_websocket_is_idle(
         self,
         pending_requests: deque[_WebSocketRequestState],
@@ -6635,6 +6793,8 @@ class ProxyService:
         client_send_lock: anyio.Lock | None = None,
         response_create_gate: asyncio.Semaphore | None = None,
         downstream_activity: _DownstreamWebSocketActivity | None = None,
+        status: str = "error",
+        penalize_account: bool = True,
     ) -> None:
         async with pending_lock:
             remaining = list(pending_requests)
@@ -6642,14 +6802,21 @@ class ProxyService:
 
         penalty_code: str | None = None
         penalty_message: str | None = None
-        for request_state in remaining:
-            request_error_code = request_state.error_code_override or error_code
-            if request_error_code in _TRANSIENT_RETRY_CODES or _should_penalize_stream_error(request_error_code):
-                penalty_code = request_error_code
-                penalty_message = request_state.error_message_override or error_message
-                break
+        if penalize_account:
+            for request_state in remaining:
+                request_error_code = request_state.error_code_override or error_code
+                if request_error_code in _TRANSIENT_RETRY_CODES or _should_penalize_stream_error(request_error_code):
+                    penalty_code = request_error_code
+                    penalty_message = request_state.error_message_override or error_message
+                    break
 
-        if remaining and account is not None and isinstance(account, Account) and penalty_code is not None:
+        if (
+            remaining
+            and penalize_account
+            and account is not None
+            and isinstance(account, Account)
+            and penalty_code is not None
+        ):
             await self._handle_stream_error(account, {"message": penalty_message or error_message}, penalty_code)
 
         last_index = len(remaining) - 1
@@ -6701,7 +6868,7 @@ class ProxyService:
                 request_id=request_state.response_id or request_state.request_log_id or request_state.request_id,
                 model=request_state.model or "",
                 latency_ms=latency_ms,
-                status="error",
+                status=status,
                 error_code=request_error_code,
                 error_message=request_error_message,
                 reasoning_effort=request_state.reasoning_effort,
@@ -6710,6 +6877,7 @@ class ProxyService:
                 requested_service_tier=request_state.requested_service_tier,
                 actual_service_tier=request_state.actual_service_tier,
                 latency_first_token_ms=request_state.latency_first_token_ms,
+                session_id=request_state.session_id,
             )
 
     async def _emit_websocket_terminal_error(
@@ -8449,7 +8617,7 @@ def _stream_settlement_error_payload(settlement: _StreamSettlement) -> UpstreamE
 def _should_penalize_stream_error(code: str | None) -> bool:
     if code is None:
         return False
-    return code in _ACCOUNT_RECOVERY_RETRY_CODES
+    return code in _ACCOUNT_RECOVERY_RETRY_CODES or code in _TRANSIENT_RETRY_CODES
 
 
 def _is_account_neutral_error_code(code: str | None) -> bool:
@@ -8597,9 +8765,14 @@ class _WebSocketUpstreamControl:
 @dataclass(slots=True)
 class _DownstreamWebSocketActivity:
     last_activity_at: float = field(default_factory=time.monotonic)
+    disconnected: bool = False
 
     def mark(self) -> None:
         self.last_activity_at = time.monotonic()
+
+    def mark_disconnected(self) -> None:
+        self.disconnected = True
+        self.mark()
 
 
 @dataclass(slots=True)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -162,7 +162,6 @@ from app.modules.proxy.ring_membership import (
 from app.modules.proxy.tool_call_dedupe import (
     dedupe_replayed_side_effect_input_items,
     mark_duplicate_tool_call_downstream_event,
-    response_id_from_payload,
     rewrite_parallel_tool_call_sse_line,
     rewrite_parallel_tool_call_text,
 )
@@ -3039,7 +3038,7 @@ class ProxyService:
             replayed_input_items = cast(list[JsonValue], payload.input)
             deduped_input_items, deduped_replayed_tool_call_count = dedupe_replayed_side_effect_input_items(
                 replayed_input_items,
-                sanitize_missing_outputs=True,
+                sanitize_missing_outputs=False,
             )
             if deduped_replayed_tool_call_count > 0:
                 deduped_replayed_input_count = len(replayed_input_items)
@@ -5736,6 +5735,11 @@ class ProxyService:
                                 session.pending_requests,
                             ),
                         )
+                    if not grouped_previous_response_request_states and is_missing_tool_output_event:
+                        grouped_previous_response_request_states = _pop_matching_websocket_request_states(
+                            session.pending_requests,
+                            _all_pending_websocket_followup_requests(session.pending_requests),
+                        )
                     if grouped_previous_response_request_states:
                         session.queued_request_count = max(
                             0,
@@ -6498,6 +6502,11 @@ class ProxyService:
                             _matching_websocket_request_states_for_missing_tool_output_error(
                                 pending_requests,
                             ),
+                        )
+                    if not grouped_previous_response_request_states and is_missing_tool_output_event:
+                        grouped_previous_response_request_states = _pop_matching_websocket_request_states(
+                            pending_requests,
+                            _all_pending_websocket_followup_requests(pending_requests),
                         )
                 elif request_state is None and event_type == "error":
                     grouped_previous_response_request_states = list(pending_requests)
@@ -7679,6 +7688,7 @@ class ProxyService:
                         return
                     any_attempt_logged = True
                     settlement = _StreamSettlement()
+                    tool_call_dedupe = _WebSocketUpstreamControl()
                     effective_attempt_timeout = _remaining_budget_seconds(deadline)
                     if effective_attempt_timeout <= 0:
                         logger.warning(
@@ -7726,6 +7736,7 @@ class ProxyService:
                                 upstream_stream_transport=upstream_stream_transport,
                                 request_transport=request_transport,
                                 preferred_account_id=preferred_account_id,
+                                tool_call_dedupe=tool_call_dedupe,
                             ):
                                 yield line
                         except (_TransientStreamError, ProxyResponseError) as tex:
@@ -7933,6 +7944,7 @@ class ProxyService:
                                 suppress_text_done_events=suppress_text_done_events,
                                 upstream_stream_transport=upstream_stream_transport,
                                 request_transport=request_transport,
+                                tool_call_dedupe=tool_call_dedupe,
                             ):
                                 yield line
                         finally:
@@ -8052,6 +8064,7 @@ class ProxyService:
         upstream_stream_transport: str | None,
         request_transport: str,
         preferred_account_id: str | None = None,
+        tool_call_dedupe: _WebSocketUpstreamControl | None = None,
     ) -> AsyncIterator[str]:
         account_id_value = account.id
         access_token = self._encryptor.decrypt(account.access_token_encrypted)
@@ -8070,7 +8083,8 @@ class ProxyService:
         usage = None
         saw_text_delta = False
         latency_first_token_ms: int | None = None
-        tool_call_dedupe = _WebSocketUpstreamControl()
+        if tool_call_dedupe is None:
+            tool_call_dedupe = _WebSocketUpstreamControl()
         suppressed_duplicate_tool_call = False
         response_create_lease = AdmissionLease(None)
 
@@ -8189,9 +8203,7 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     first_payload,
                     seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
-                    response_id=response_id_from_payload(first_payload)
-                    or _websocket_response_id(event, first_payload)
-                    or response_id,
+                    response_id=request_id,
                 ):
                     suppressed_duplicate_tool_call = True
                 else:
@@ -8297,9 +8309,7 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     event_payload,
                     seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
-                    response_id=response_id_from_payload(event_payload)
-                    or _websocket_response_id(event, event_payload)
-                    or response_id,
+                    response_id=request_id,
                 ):
                     suppressed_duplicate_tool_call = True
                     continue
@@ -9770,6 +9780,12 @@ def _matching_websocket_request_states_for_missing_tool_output_error(
     if len(unique_previous_response_ids) == 1:
         return unresolved_followups
     return []
+
+
+def _all_pending_websocket_followup_requests(
+    pending_requests: deque[_WebSocketRequestState],
+) -> list[_WebSocketRequestState]:
+    return [request_state for request_state in pending_requests if request_state.previous_response_id is not None]
 
 
 def _pop_matching_websocket_request_states(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7545,8 +7545,6 @@ class ProxyService:
                                     code,
                                     http_status=tex.status_code,
                                 )
-                                if propagate_http_errors:
-                                    raise
                                 if getattr(base_settings, "deterministic_failover_enabled", True):
                                     action = failover_decision(
                                         failure_class=classified["failure_class"],

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8205,11 +8205,11 @@ class ProxyService:
                 event_payload = parse_sse_data_json(line)
                 event = parse_sse_event(line)
                 event_type = _event_type_from_payload(event, event_payload)
-                line, event_payload, event, event_type = rewrite_parallel_tool_call_sse_line(line, event_payload)
                 event_service_tier = _service_tier_from_event_payload(event_payload)
                 if event_service_tier is not None:
                     actual_service_tier = event_service_tier
                     service_tier = event_service_tier
+                line, event_payload, event, event_type = rewrite_parallel_tool_call_sse_line(line, event_payload)
                 if event_type in _TEXT_DELTA_EVENT_TYPES:
                     saw_text_delta = True
                 if _should_suppress_text_done_event(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6626,13 +6626,17 @@ class ProxyService:
             remaining = list(pending_requests)
             pending_requests.clear()
 
-        if (
-            remaining
-            and account is not None
-            and isinstance(account, Account)
-            and (error_code in _TRANSIENT_RETRY_CODES or _should_penalize_stream_error(error_code))
-        ):
-            await self._handle_stream_error(account, {"message": error_message}, error_code)
+        penalty_code: str | None = None
+        penalty_message: str | None = None
+        for request_state in remaining:
+            request_error_code = request_state.error_code_override or error_code
+            if request_error_code in _TRANSIENT_RETRY_CODES or _should_penalize_stream_error(request_error_code):
+                penalty_code = request_error_code
+                penalty_message = request_state.error_message_override or error_message
+                break
+
+        if remaining and account is not None and isinstance(account, Account) and penalty_code is not None:
+            await self._handle_stream_error(account, {"message": penalty_message or error_message}, penalty_code)
 
         last_index = len(remaining) - 1
         for index, request_state in enumerate(remaining):

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5613,6 +5613,14 @@ class ProxyService:
             param=_websocket_event_error_param(event_type, payload),
             message=error_message,
         )
+        is_missing_tool_output_event = _is_missing_tool_output_error(
+            code=_normalize_error_code(
+                _websocket_event_error_code(event_type, payload),
+                _websocket_event_error_type(event_type, payload),
+            ),
+            param=_websocket_event_error_param(event_type, payload),
+            message=error_message,
+        )
         previous_response_id_hint = _previous_response_id_from_not_found_message(error_message)
         text, payload, event, event_type, event_block = rewrite_parallel_tool_call_text(
             text,
@@ -5638,7 +5646,8 @@ class ProxyService:
             elif response_id is None:
                 matched_request_state = _match_websocket_request_state_for_anonymous_event(
                     session.pending_requests,
-                    prefer_previous_response_not_found=is_previous_response_not_found_event,
+                    prefer_previous_response_not_found=is_previous_response_not_found_event
+                    or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
                 )
@@ -5665,7 +5674,8 @@ class ProxyService:
                     session.pending_requests,
                     response_id=response_id,
                     fallback_request_state=matched_request_state,
-                    prefer_previous_response_not_found=is_previous_response_not_found_event,
+                    prefer_previous_response_not_found=is_previous_response_not_found_event
+                    or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
                     allow_precreated_terminal_fallback=event_type
@@ -5741,6 +5751,16 @@ class ProxyService:
         if status_request_state is None and is_previous_response_not_found_event:
             session.upstream_control.reconnect_requested = True
             return
+
+        if status_request_state is not None and is_missing_tool_output_event:
+            status_request_state.error_http_status_override = 502
+            event, payload, event_type, rewritten_text = _rewrite_websocket_continuity_corruption_event(
+                request_state=status_request_state,
+                upstream_control=session.upstream_control,
+                reason="missing_tool_output",
+                original_text=text,
+            )
+            event_block = f"data: {rewritten_text}\n\n"
 
         if (
             status_request_state is not None
@@ -6342,6 +6362,14 @@ class ProxyService:
             param=_websocket_event_error_param(event_type, payload),
             message=error_message,
         )
+        is_missing_tool_output_event = _is_missing_tool_output_error(
+            code=_normalize_error_code(
+                _websocket_event_error_code(event_type, payload),
+                _websocket_event_error_type(event_type, payload),
+            ),
+            param=_websocket_event_error_param(event_type, payload),
+            message=error_message,
+        )
         previous_response_id_hint = _previous_response_id_from_not_found_message(error_message)
         text, payload, event, event_type, _event_block = rewrite_parallel_tool_call_text(
             text,
@@ -6364,7 +6392,8 @@ class ProxyService:
             elif response_id is None:
                 request_state = _match_websocket_request_state_for_anonymous_event(
                     pending_requests,
-                    prefer_previous_response_not_found=is_previous_response_not_found_event,
+                    prefer_previous_response_not_found=is_previous_response_not_found_event
+                    or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
                 )
@@ -6392,7 +6421,8 @@ class ProxyService:
                     pending_requests,
                     response_id=response_id,
                     fallback_request_state=request_state,
-                    prefer_previous_response_not_found=is_previous_response_not_found_event,
+                    prefer_previous_response_not_found=is_previous_response_not_found_event
+                    or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
                     allow_precreated_terminal_fallback=event_type
@@ -6427,6 +6457,14 @@ class ProxyService:
                         )
                     )
                     text = rewritten_text
+                if request_state is not None and is_missing_tool_output_event:
+                    request_state.error_http_status_override = 502
+                    event, payload, event_type, text = _rewrite_websocket_continuity_corruption_event(
+                        request_state=request_state,
+                        upstream_control=upstream_control,
+                        reason="missing_tool_output",
+                        original_text=text,
+                    )
                 has_other_pending_requests = bool(pending_requests)
             else:
                 request_state = None
@@ -9184,6 +9222,12 @@ def _websocket_precreated_retry_error_code(
         message=error_message,
     ):
         return "stream_incomplete"
+    if _is_missing_tool_output_error(
+        code=error_code,
+        param=error_param,
+        message=error_message,
+    ):
+        return "stream_incomplete"
     if error_code not in _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
         return None
     return error_code
@@ -9226,6 +9270,18 @@ def _is_previous_response_not_found_error(
     return _is_previous_response_not_found_message(message)
 
 
+def _is_missing_tool_output_error(
+    *,
+    code: str | None,
+    param: str | None,
+    message: str | None,
+) -> bool:
+    if code != "invalid_request_error" or param != "input" or message is None:
+        return False
+    normalized = " ".join(message.lower().split())
+    return normalized.startswith("no tool output found for function call call_")
+
+
 def _websocket_event_error_payload(
     event_type: str | None,
     payload: dict[str, JsonValue] | None,
@@ -9262,17 +9318,43 @@ def _maybe_rewrite_websocket_previous_response_not_found_event(
         param=error_param,
         message=error_message,
     )
+    reason = "previous_response_not_found"
+    if not should_rewrite:
+        should_rewrite = _is_missing_tool_output_error(
+            code=error_code,
+            param=error_param,
+            message=error_message,
+        )
+        reason = "missing_tool_output"
     if not should_rewrite:
         return event, payload, event_type, original_text
 
-    if request_state.preferred_account_id is not None:
+    reconnect_requested = reason == "missing_tool_output" or request_state.preferred_account_id is not None
+    return _rewrite_websocket_continuity_corruption_event(
+        request_state=request_state,
+        upstream_control=upstream_control,
+        reason=reason,
+        reconnect_requested=reconnect_requested,
+        original_text=original_text,
+    )
+
+
+def _rewrite_websocket_continuity_corruption_event(
+    *,
+    request_state: _WebSocketRequestState,
+    upstream_control: _WebSocketUpstreamControl,
+    reason: str,
+    reconnect_requested: bool,
+    original_text: str,
+) -> tuple[OpenAIEvent | None, dict[str, JsonValue] | None, str | None, str]:
+    del original_text
+    if reconnect_requested:
         upstream_control.reconnect_requested = True
     _record_continuity_fail_closed(
         surface="websocket_stream",
-        reason="previous_response_not_found",
+        reason=reason,
         previous_response_id=request_state.previous_response_id,
         session_id=request_state.session_id,
-        upstream_error_code=error_code,
     )
     rewritten_event_payload = response_failed_event(
         "stream_incomplete",
@@ -9347,17 +9429,26 @@ def _sanitize_websocket_connect_failure(
         parsed_error.type if parsed_error else None,
     )
     normalized_message = parsed_error.message if parsed_error and parsed_error.message else error_message
-    if not _is_previous_response_not_found_error(
+    reason = "previous_response_not_found"
+    should_rewrite = _is_previous_response_not_found_error(
         code=normalized_code,
         param=parsed_error.param if parsed_error else None,
         message=normalized_message,
-    ):
+    )
+    if not should_rewrite:
+        should_rewrite = _is_missing_tool_output_error(
+            code=normalized_code,
+            param=parsed_error.param if parsed_error else None,
+            message=normalized_message,
+        )
+        reason = "missing_tool_output"
+    if not should_rewrite:
         return status_code, payload, error_code, error_message
 
     rewritten_message = "Upstream websocket closed before response.completed"
     _record_continuity_fail_closed(
         surface="websocket_connect",
-        reason="previous_response_not_found",
+        reason=reason,
         previous_response_id=request_state.previous_response_id,
         session_id=request_state.session_id,
         upstream_error_code=normalized_code,
@@ -9393,6 +9484,22 @@ def _rewrite_previous_response_stream_error(
         _record_continuity_fail_closed(
             surface="http_stream",
             reason="previous_response_not_found",
+            previous_response_id=previous_response_id,
+            upstream_error_code=error_code,
+        )
+        return (
+            "stream_incomplete",
+            "Upstream websocket closed before response.completed",
+            None,
+        )
+    if _is_missing_tool_output_error(
+        code=error_code,
+        param=error_param,
+        message=error_message,
+    ):
+        _record_continuity_fail_closed(
+            surface="http_stream",
+            reason="missing_tool_output",
             previous_response_id=previous_response_id,
             upstream_error_code=error_code,
         )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9946,6 +9946,8 @@ def _websocket_receive_timeout_for_pending_requests(
     idle_timeout_seconds = max(0.001, stream_idle_timeout_seconds)
     oldest_started_at = min(started_ats)
     remaining_budget = _remaining_budget_seconds(oldest_started_at + proxy_request_budget_seconds)
+    if remaining_budget > 1.0 and idle_timeout_seconds >= remaining_budget:
+        idle_timeout_seconds = max(0.001, min(120.0, remaining_budget / 5.0))
 
     if remaining_budget <= 0:
         return _WebSocketReceiveTimeout(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5700,7 +5700,7 @@ class ProxyService:
                     matched_request_state.service_tier = actual_service_tier
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
-                    seen_tool_call_keys=session.seen_tool_call_keys,
+                    seen_tool_call_keys=matched_request_state.seen_tool_call_keys,
                     response_id=tool_call_response_id_from_payload(payload) or matched_request_state.request_id,
                     scope_side_effects_by_response_id=False,
                 ):

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10413,7 +10413,8 @@ def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) 
         (
             index
             for index, item in enumerate(input_items)
-            if _websocket_input_item_type(item) in {"function_call_output", "custom_tool_call_output"}
+            if _websocket_input_item_type(item)
+            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
         ),
         None,
     )
@@ -10429,7 +10430,7 @@ def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
     if isinstance(item, dict) and _websocket_input_item_type(item) is None and item.get("role") == "assistant":
         return True
     item_type = _websocket_input_item_type(item)
-    if item_type in {"reasoning", "function_call", "custom_tool_call"}:
+    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call"}:
         return True
     if item_type != "message" or not isinstance(item, dict):
         return False

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9313,7 +9313,7 @@ def _websocket_precreated_retry_error_code(
         param=error_param,
         message=error_message,
     ):
-        return "stream_incomplete"
+        return None
     if error_code not in _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
         return None
     return error_code

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6634,7 +6634,6 @@ class ProxyService:
                 {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
                 retry_error_code,
             )
-            request_state.account_health_error_handled = True
             event, payload, event_type, downstream_text = _rewrite_websocket_previous_response_owner_unavailable_event(
                 request_state=request_state,
             )
@@ -6673,7 +6672,6 @@ class ProxyService:
                     {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
                     retry_error_code,
                 )
-                request_state.account_health_error_handled = True
             if retry_error_code is not None:
                 return downstream_text
 
@@ -6852,8 +6850,6 @@ class ProxyService:
         if event_type in {"response.failed", "error"}:
             settlement.account_health_error = _should_penalize_stream_error(error_code)
         if request_state.suppressed_duplicate_tool_call and error_code == "stream_incomplete":
-            settlement.account_health_error = False
-        if request_state.account_health_error_handled:
             settlement.account_health_error = False
         if (
             error_code == "stream_incomplete"
@@ -8966,7 +8962,6 @@ class _WebSocketRequestState:
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
     suppressed_downstream_tool_call: bool = False
     suppressed_duplicate_tool_call: bool = False
-    account_health_error_handled: bool = False
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -159,6 +159,11 @@ from app.modules.proxy.ring_membership import (
     RING_STALE_THRESHOLD_SECONDS,
     RingMembershipService,
 )
+from app.modules.proxy.tool_call_dedupe import (
+    mark_duplicate_tool_call_downstream_event,
+    rewrite_parallel_tool_call_sse_line,
+    rewrite_parallel_tool_call_text,
+)
 from app.modules.proxy.types import (
     AdditionalRateLimitData,
     RateLimitStatusDetailsData,
@@ -5609,6 +5614,11 @@ class ProxyService:
             message=error_message,
         )
         previous_response_id_hint = _previous_response_id_from_not_found_message(error_message)
+        text, payload, event, event_type, event_block = rewrite_parallel_tool_call_text(
+            text,
+            payload,
+            event_block=event_block,
+        )
 
         async with session.pending_lock:
             matched_request_state = None
@@ -5641,6 +5651,13 @@ class ProxyService:
                 if actual_service_tier is not None:
                     matched_request_state.actual_service_tier = actual_service_tier
                     matched_request_state.service_tier = actual_service_tier
+                if mark_duplicate_tool_call_downstream_event(
+                    payload,
+                    seen_tool_call_keys=session.upstream_control.seen_tool_call_keys,
+                    response_id=response_id or matched_request_state.response_id or matched_request_state.request_id,
+                ):
+                    matched_request_state.suppressed_duplicate_tool_call = True
+                    return
 
             terminal_request_state = None
             if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
@@ -5741,6 +5758,23 @@ class ProxyService:
                 event_type=event_type,
                 upstream_control=session.upstream_control,
                 original_text=text,
+            )
+            event_block = f"data: {rewritten_text}\n\n"
+
+        if (
+            event_type == "response.completed"
+            and terminal_request_state is not None
+            and terminal_request_state.suppressed_duplicate_tool_call
+        ):
+            session.upstream_control.reconnect_requested = True
+            terminal_request_state.error_http_status_override = 502
+            (
+                event,
+                payload,
+                event_type,
+                rewritten_text,
+            ) = _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
+                request_state=terminal_request_state,
             )
             event_block = f"data: {rewritten_text}\n\n"
 
@@ -6309,6 +6343,11 @@ class ProxyService:
             message=error_message,
         )
         previous_response_id_hint = _previous_response_id_from_not_found_message(error_message)
+        text, payload, event, event_type, _event_block = rewrite_parallel_tool_call_text(
+            text,
+            payload,
+            event_block=format_sse_event(payload) if payload is not None else f"data: {text}\n\n",
+        )
 
         async with pending_lock:
             request_state = None
@@ -6337,6 +6376,14 @@ class ProxyService:
                 if actual_service_tier is not None:
                     request_state.actual_service_tier = actual_service_tier
                     request_state.service_tier = actual_service_tier
+                if mark_duplicate_tool_call_downstream_event(
+                    payload,
+                    seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+                    response_id=response_id or request_state.response_id or request_state.request_id,
+                ):
+                    request_state.suppressed_duplicate_tool_call = True
+                    upstream_control.suppress_downstream_event = True
+                    return text
             if (
                 event_type in {"response.completed", "response.failed", "response.incomplete", "error"}
                 and pending_requests
@@ -6367,6 +6414,19 @@ class ProxyService:
                 elif request_state is None and event_type == "error":
                     grouped_previous_response_request_states = list(pending_requests)
                     pending_requests.clear()
+                if (
+                    event_type == "response.completed"
+                    and request_state is not None
+                    and request_state.suppressed_duplicate_tool_call
+                ):
+                    upstream_control.reconnect_requested = True
+                    request_state.error_http_status_override = 502
+                    event, payload, event_type, rewritten_text = (
+                        _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
+                            request_state=request_state,
+                        )
+                    )
+                    text = rewritten_text
                 has_other_pending_requests = bool(pending_requests)
             else:
                 request_state = None
@@ -7909,6 +7969,7 @@ class ProxyService:
         saw_text_delta = False
         latency_first_token_ms: int | None = None
         response_create_lease = AdmissionLease(None)
+        tool_call_dedupe = _WebSocketUpstreamControl()
 
         try:
             response_create_lease = await self._get_work_admission().acquire_response_create()
@@ -8021,6 +8082,13 @@ class ProxyService:
                 suppress_text_done_events=suppress_text_done_events,
                 saw_text_delta=saw_text_delta,
             ):
+                first, first_payload, event, event_type = rewrite_parallel_tool_call_sse_line(first, first_payload)
+                if mark_duplicate_tool_call_downstream_event(
+                    first_payload,
+                    seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
+                    response_id=_websocket_response_id(event, first_payload) or response_id,
+                ):
+                    return
                 if latency_first_token_ms is None and event_type in _TEXT_DELTA_EVENT_TYPES:
                     latency_first_token_ms = int((time.monotonic() - request_started_at) * 1000)
                 yield first
@@ -8029,8 +8097,7 @@ class ProxyService:
 
             async for line in iterator:
                 event_payload = parse_sse_data_json(line)
-                event = parse_sse_event(line)
-                event_type = _event_type_from_payload(event, event_payload)
+                line, event_payload, event, event_type = rewrite_parallel_tool_call_sse_line(line, event_payload)
                 event_service_tier = _service_tier_from_event_payload(event_payload)
                 if event_service_tier is not None:
                     actual_service_tier = event_service_tier
@@ -8106,6 +8173,12 @@ class ProxyService:
                             status = "error"
                 if latency_first_token_ms is None and event_type in _TEXT_DELTA_EVENT_TYPES:
                     latency_first_token_ms = int((time.monotonic() - request_started_at) * 1000)
+                if mark_duplicate_tool_call_downstream_event(
+                    event_payload,
+                    seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
+                    response_id=_websocket_response_id(event, event_payload) or response_id,
+                ):
+                    continue
                 yield line
         except ProxyResponseError as exc:
             response_create_lease.release()
@@ -8733,6 +8806,8 @@ class _WebSocketRequestState:
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
+    suppressed_downstream_tool_call: bool = False
+    suppressed_duplicate_tool_call: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -8798,6 +8873,7 @@ class _WebSocketUpstreamControl:
     suppress_downstream_event: bool = False
     replay_request_state: _WebSocketRequestState | None = None
     downstream_texts: list[str] | None = None
+    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -9225,6 +9301,24 @@ def _rewrite_websocket_previous_response_owner_unavailable_event(
     rewritten_event_payload = response_failed_event(
         "upstream_unavailable",
         "Previous response owner account is unavailable; retry later.",
+        error_type="server_error",
+        response_id=request_state.response_id or request_state.request_id,
+    )
+    rewritten_text = json.dumps(rewritten_event_payload, ensure_ascii=True, separators=(",", ":"))
+    rewritten_event_block = format_sse_event(rewritten_event_payload)
+    rewritten_payload = parse_sse_data_json(rewritten_event_block)
+    rewritten_event = parse_sse_event(rewritten_event_block)
+    rewritten_event_type = _event_type_from_payload(rewritten_event, rewritten_payload)
+    return rewritten_event, rewritten_payload, rewritten_event_type, rewritten_text
+
+
+def _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
+    *,
+    request_state: _WebSocketRequestState,
+) -> tuple[OpenAIEvent | None, dict[str, JsonValue] | None, str | None, str]:
+    rewritten_event_payload = response_failed_event(
+        "stream_incomplete",
+        "Suppressed duplicate side-effect tool call; upstream response cannot be continued safely.",
         error_type="server_error",
         response_id=request_state.response_id or request_state.request_id,
     )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5792,6 +5792,11 @@ class ProxyService:
             and terminal_request_state.suppressed_duplicate_tool_call
         ):
             session.upstream_control.reconnect_requested = True
+            session.closed = True
+            try:
+                await session.upstream.close()
+            except Exception:
+                logger.debug("Failed to close HTTP bridge upstream after suppressed duplicate tool call", exc_info=True)
             terminal_request_state.error_http_status_override = 502
             (
                 event,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6845,7 +6845,15 @@ class ProxyService:
             and isinstance(account, Account)
             and penalty_code is not None
         ):
-            await self._handle_stream_error(account, {"message": penalty_message or error_message}, penalty_code)
+            try:
+                await self._handle_stream_error(account, {"message": penalty_message or error_message}, penalty_code)
+            except Exception:
+                logger.warning(
+                    "Failed to record websocket pending-request health penalty account_id=%s error_code=%s",
+                    account_id_value,
+                    penalty_code,
+                    exc_info=True,
+                )
 
         last_index = len(remaining) - 1
         for index, request_state in enumerate(remaining):
@@ -9977,8 +9985,6 @@ def _websocket_receive_timeout_for_pending_requests(
     idle_timeout_seconds = max(0.001, stream_idle_timeout_seconds)
     oldest_started_at = min(started_ats)
     remaining_budget = _remaining_budget_seconds(oldest_started_at + proxy_request_budget_seconds)
-    if remaining_budget > 1.0 and idle_timeout_seconds >= remaining_budget:
-        idle_timeout_seconds = max(0.001, min(120.0, remaining_budget / 5.0))
 
     if remaining_budget <= 0:
         return _WebSocketReceiveTimeout(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -165,6 +165,9 @@ from app.modules.proxy.tool_call_dedupe import (
     rewrite_parallel_tool_call_sse_line,
     rewrite_parallel_tool_call_text,
 )
+from app.modules.proxy.tool_call_dedupe import (
+    response_id_from_payload as tool_call_response_id_from_payload,
+)
 from app.modules.proxy.types import (
     AdditionalRateLimitData,
     RateLimitStatusDetailsData,
@@ -5698,7 +5701,8 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
                     seen_tool_call_keys=session.seen_tool_call_keys,
-                    response_id=matched_request_state.request_id,
+                    response_id=tool_call_response_id_from_payload(payload) or matched_request_state.request_id,
+                    scope_side_effects_by_response_id=False,
                 ):
                     matched_request_state.suppressed_duplicate_tool_call = True
                     return
@@ -5739,11 +5743,6 @@ class ProxyService:
                             _matching_websocket_request_states_for_missing_tool_output_error(
                                 session.pending_requests,
                             ),
-                        )
-                    if not grouped_previous_response_request_states and is_missing_tool_output_event:
-                        grouped_previous_response_request_states = _pop_matching_websocket_request_states(
-                            session.pending_requests,
-                            _all_pending_websocket_followup_requests(session.pending_requests),
                         )
                     if grouped_previous_response_request_states:
                         session.queued_request_count = max(
@@ -6477,7 +6476,8 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
                     seen_tool_call_keys=request_state.seen_tool_call_keys,
-                    response_id=request_state.request_id,
+                    response_id=tool_call_response_id_from_payload(payload) or request_state.request_id,
+                    scope_side_effects_by_response_id=False,
                 ):
                     request_state.suppressed_duplicate_tool_call = True
                     upstream_control.suppress_downstream_event = True
@@ -6518,11 +6518,6 @@ class ProxyService:
                             _matching_websocket_request_states_for_missing_tool_output_error(
                                 pending_requests,
                             ),
-                        )
-                    if not grouped_previous_response_request_states and is_missing_tool_output_event:
-                        grouped_previous_response_request_states = _pop_matching_websocket_request_states(
-                            pending_requests,
-                            _all_pending_websocket_followup_requests(pending_requests),
                         )
                 if (
                     request_state is None
@@ -6598,7 +6593,7 @@ class ProxyService:
         _record_response_event(request_state, event_type)
 
         if request_state is None:
-            if is_previous_response_not_found_event:
+            if is_previous_response_not_found_event or is_missing_tool_output_event:
                 upstream_control.suppress_downstream_event = True
             return text
 
@@ -8227,7 +8222,8 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     first_payload,
                     seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
-                    response_id=request_id,
+                    response_id=tool_call_response_id_from_payload(first_payload) or request_id,
+                    scope_side_effects_by_response_id=False,
                 ):
                     suppressed_duplicate_tool_call = True
                 else:
@@ -8333,7 +8329,8 @@ class ProxyService:
                 if mark_duplicate_tool_call_downstream_event(
                     event_payload,
                     seen_tool_call_keys=tool_call_dedupe.seen_tool_call_keys,
-                    response_id=request_id,
+                    response_id=tool_call_response_id_from_payload(event_payload) or request_id,
+                    scope_side_effects_by_response_id=False,
                 ):
                     suppressed_duplicate_tool_call = True
                     continue
@@ -9804,12 +9801,6 @@ def _matching_websocket_request_states_for_missing_tool_output_error(
     if len(unique_previous_response_ids) == 1:
         return unresolved_followups
     return []
-
-
-def _all_pending_websocket_followup_requests(
-    pending_requests: deque[_WebSocketRequestState],
-) -> list[_WebSocketRequestState]:
-    return [request_state for request_state in pending_requests if request_state.previous_response_id is not None]
 
 
 def _pop_matching_websocket_request_states(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5995,7 +5995,7 @@ class ProxyService:
                         wait_timeout = None if receive_deadline is None else receive_deadline - time.monotonic()
                         if wait_timeout is not None and wait_timeout <= 0:
                             raise asyncio.TimeoutError()
-                        keepalive_interval = get_settings().sse_keepalive_interval_seconds
+                        keepalive_interval = getattr(get_settings(), "sse_keepalive_interval_seconds", 10.0)
                         if keepalive_interval > 0:
                             wait_timeout = (
                                 keepalive_interval if wait_timeout is None else min(wait_timeout, keepalive_interval)
@@ -7545,6 +7545,8 @@ class ProxyService:
                                     code,
                                     http_status=tex.status_code,
                                 )
+                                if propagate_http_errors:
+                                    raise
                                 if getattr(base_settings, "deterministic_failover_enabled", True):
                                     action = failover_decision(
                                         failure_class=classified["failure_class"],
@@ -7956,7 +7958,7 @@ class ProxyService:
                     settlement.account_health_error = _should_penalize_stream_error(code)
                     if allow_retry and _should_retry_stream_error(code):
                         raise _RetryableStreamError(code, settlement.error)
-                    if allow_transient_retry and code in _TRANSIENT_RETRY_CODES:
+                    if allow_transient_retry and code in _TRANSIENT_RETRY_CODES and code != "stream_idle_timeout":
                         raise _TransientStreamError(code, settlement.error)
                 terminal_stream_error = _TerminalStreamError(
                     error_code or code,
@@ -7977,7 +7979,7 @@ class ProxyService:
                 if event.type == "response.incomplete":
                     status = "error"
 
-            if suppress_text_done_events and event_type in _TEXT_DELTA_EVENT_TYPES:
+            if event_type in _TEXT_DELTA_EVENT_TYPES:
                 saw_text_delta = True
             if not _should_suppress_text_done_event(
                 event_type=event_type,
@@ -7999,7 +8001,7 @@ class ProxyService:
                 if event_service_tier is not None:
                     actual_service_tier = event_service_tier
                     service_tier = event_service_tier
-                if suppress_text_done_events and event_type in _TEXT_DELTA_EVENT_TYPES:
+                if event_type in _TEXT_DELTA_EVENT_TYPES:
                     saw_text_delta = True
                 if _should_suppress_text_done_event(
                     event_type=event_type,
@@ -8058,7 +8060,9 @@ class ProxyService:
                             error_message = error.message if error else None
                             settlement.error = _upstream_error_from_openai(error)
                             settlement.record_success = False
-                            settlement.account_health_error = _should_penalize_stream_error(error_code)
+                            settlement.account_health_error = (
+                                _should_penalize_stream_error(error_code) and not saw_text_delta
+                            )
                     if event_type in ("response.completed", "response.incomplete"):
                         response = event.response if event is not None else None
                         usage = response.usage if response else None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9343,6 +9343,18 @@ async def _pop_replayable_precreated_websocket_request_state(
     return request_state
 
 
+def _is_missing_tool_output_error(
+    *,
+    code: str | None,
+    param: str | None,
+    message: str | None,
+) -> bool:
+    if code != "invalid_request_error" or param != "input" or message is None:
+        return False
+    normalized = " ".join(message.lower().split())
+    return normalized.startswith("no tool output found for function call call_")
+
+
 def _is_previous_response_not_found_error(
     *,
     code: str | None,
@@ -9354,18 +9366,6 @@ def _is_previous_response_not_found_error(
     if code != "invalid_request_error" or param != "previous_response_id":
         return False
     return _is_previous_response_not_found_message(message)
-
-
-def _is_missing_tool_output_error(
-    *,
-    code: str | None,
-    param: str | None,
-    message: str | None,
-) -> bool:
-    if code != "invalid_request_error" or param != "input" or message is None:
-        return False
-    normalized = " ".join(message.lower().split())
-    return normalized.startswith("no tool output found for function call call_")
 
 
 def _websocket_event_error_payload(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8068,9 +8068,9 @@ class ProxyService:
         usage = None
         saw_text_delta = False
         latency_first_token_ms: int | None = None
-        response_create_lease = AdmissionLease(None)
         tool_call_dedupe = _WebSocketUpstreamControl()
         suppressed_duplicate_tool_call = False
+        response_create_lease = AdmissionLease(None)
 
         try:
             response_create_lease = await self._get_work_admission().acquire_response_create()
@@ -8203,6 +8203,8 @@ class ProxyService:
 
             async for line in iterator:
                 event_payload = parse_sse_data_json(line)
+                event = parse_sse_event(line)
+                event_type = _event_type_from_payload(event, event_payload)
                 line, event_payload, event, event_type = rewrite_parallel_tool_call_sse_line(line, event_payload)
                 event_service_tier = _service_tier_from_event_payload(event_payload)
                 if event_service_tier is not None:
@@ -8926,11 +8928,11 @@ class _WebSocketRequestState:
     response_create_gate: asyncio.Semaphore | None = None
     response_create_admission: AdmissionLease | None = None
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
-    input_item_count: int = 0
-    input_full_fingerprint: str | None = None
     suppressed_downstream_tool_call: bool = False
     suppressed_duplicate_tool_call: bool = False
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
+    input_item_count: int = 0
+    input_full_fingerprint: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -282,6 +282,35 @@ def _fingerprint_input_items(items: Sequence[JsonValue]) -> str:
     return sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
+    first_output_index = next(
+        (index for index, item in enumerate(input_items) if _websocket_input_item_type(item) == "function_call_output"),
+        None,
+    )
+    if first_output_index is None or first_output_index == 0:
+        return input_items
+    prefix = input_items[:first_output_index]
+    if not all(_is_websocket_previous_response_output_item(item) for item in prefix):
+        return input_items
+    return input_items[first_output_index:]
+
+
+def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
+    item_type = _websocket_input_item_type(item)
+    if item_type in {"reasoning", "function_call", "custom_tool_call"}:
+        return True
+    if item_type != "message" or not isinstance(item, dict):
+        return False
+    return item.get("role") == "assistant"
+
+
+def _websocket_input_item_type(item: JsonValue) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    item_type = item.get("type")
+    return item_type if isinstance(item_type, str) else None
+
+
 class ProxyService:
     def __init__(self, repo_factory: ProxyRepoFactory) -> None:
         self._repo_factory = repo_factory
@@ -2875,6 +2904,15 @@ class ProxyService:
         validate_model_access(refreshed_api_key, responses_payload.model)
         self._raise_for_unsupported_input_image_references(responses_payload)
         rewritten_file_account_id = await self._resolve_file_account_for_responses(responses_payload, headers)
+        previous_response_trimmed_input_count: int | None = None
+        previous_response_trimmed_input_fingerprint: str | None = None
+        if responses_payload.previous_response_id is not None and isinstance(responses_payload.input, list):
+            previous_response_input_items = cast(list[JsonValue], responses_payload.input)
+            trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
+            if len(trimmed_input_items) != len(previous_response_input_items):
+                previous_response_trimmed_input_count = len(previous_response_input_items)
+                previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
+                responses_payload = responses_payload.model_copy(update={"input": trimmed_input_items})
         reservation = await self._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -2897,6 +2935,19 @@ class ProxyService:
         except ProxyResponseError:
             await self._release_websocket_reservation(reservation)
             raise
+        if previous_response_trimmed_input_count is not None:
+            request_state.input_item_count = previous_response_trimmed_input_count
+            request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
+            logger.info(
+                "websocket_previous_response_input_trimmed request_id=%s original_items=%s trimmed_to=%s "
+                "previous_response_id=%s",
+                request_state.request_id,
+                previous_response_trimmed_input_count,
+                len(cast(list[JsonValue], responses_payload.input))
+                if isinstance(responses_payload.input, list)
+                else None,
+                responses_payload.previous_response_id,
+            )
         had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
         affinity_policy = _sticky_key_for_responses_request(
             responses_payload,
@@ -6638,6 +6689,12 @@ class ProxyService:
             settlement.record_success = False
         if event_type in {"response.failed", "error"}:
             settlement.account_health_error = _should_penalize_stream_error(error_code)
+        if (
+            error_code == "stream_incomplete"
+            and request_state.previous_response_id is not None
+            and error_message == "Upstream websocket closed before response.completed"
+        ):
+            settlement.account_health_error = False
         _release_websocket_response_create_gate(request_state, response_create_gate)
         await self._settle_stream_api_key_usage(
             api_key,
@@ -9153,7 +9210,8 @@ def _maybe_rewrite_websocket_previous_response_not_found_event(
     if not should_rewrite:
         return event, payload, event_type, original_text
 
-    upstream_control.reconnect_requested = True
+    if request_state.preferred_account_id is not None:
+        upstream_control.reconnect_requested = True
     _record_continuity_fail_closed(
         surface="websocket_stream",
         reason="previous_response_not_found",

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5670,6 +5670,8 @@ class ProxyService:
                 ):
                     matched_request_state.suppressed_duplicate_tool_call = True
                     return
+                if payload is not None:
+                    event_block = format_sse_event(payload)
 
             terminal_request_state = None
             if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
@@ -6416,6 +6418,8 @@ class ProxyService:
                     request_state.suppressed_duplicate_tool_call = True
                     upstream_control.suppress_downstream_event = True
                     return text
+                if payload is not None:
+                    text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
             if (
                 event_type in {"response.completed", "response.failed", "response.incomplete", "error"}
                 and pending_requests
@@ -8132,6 +8136,8 @@ class ProxyService:
                 ):
                     suppressed_duplicate_tool_call = True
                 else:
+                    if first_payload is not None:
+                        first = format_sse_event(first_payload)
                     if latency_first_token_ms is None and event_type in _TEXT_DELTA_EVENT_TYPES:
                         latency_first_token_ms = int((time.monotonic() - request_started_at) * 1000)
                     yield first
@@ -8234,6 +8240,8 @@ class ProxyService:
                 ):
                     suppressed_duplicate_tool_call = True
                     continue
+                if event_payload is not None:
+                    line = format_sse_event(event_payload)
                 yield line
         except ProxyResponseError as exc:
             response_create_lease.release()

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6634,6 +6634,7 @@ class ProxyService:
                 {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
                 retry_error_code,
             )
+            request_state.account_health_error_handled = True
             event, payload, event_type, downstream_text = _rewrite_websocket_previous_response_owner_unavailable_event(
                 request_state=request_state,
             )
@@ -6672,6 +6673,7 @@ class ProxyService:
                     {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
                     retry_error_code,
                 )
+                request_state.account_health_error_handled = True
             if retry_error_code is not None:
                 return downstream_text
 
@@ -6850,6 +6852,8 @@ class ProxyService:
         if event_type in {"response.failed", "error"}:
             settlement.account_health_error = _should_penalize_stream_error(error_code)
         if request_state.suppressed_duplicate_tool_call and error_code == "stream_incomplete":
+            settlement.account_health_error = False
+        if request_state.account_health_error_handled:
             settlement.account_health_error = False
         if (
             error_code == "stream_incomplete"
@@ -8962,6 +8966,7 @@ class _WebSocketRequestState:
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
     suppressed_downstream_tool_call: bool = False
     suppressed_duplicate_tool_call: bool = False
+    account_health_error_handled: bool = False
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6848,7 +6848,11 @@ class ProxyService:
         if event_type in {"response.failed", "response.incomplete", "error"}:
             settlement.record_success = False
         if event_type in {"response.failed", "error"}:
-            settlement.account_health_error = _should_penalize_stream_error(error_code)
+            settlement.account_health_error = _should_penalize_stream_error(error_code) and not getattr(
+                request_state,
+                "account_health_error_handled",
+                False,
+            )
         if request_state.suppressed_duplicate_tool_call and error_code == "stream_incomplete":
             settlement.account_health_error = False
         if (

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5828,6 +5828,7 @@ class ProxyService:
                 request_state=status_request_state,
                 upstream_control=session.upstream_control,
                 reason="missing_tool_output",
+                reconnect_requested=True,
                 original_text=text,
             )
             event_block = f"data: {rewritten_text}\n\n"
@@ -6534,6 +6535,7 @@ class ProxyService:
                         request_state=request_state,
                         upstream_control=upstream_control,
                         reason="missing_tool_output",
+                        reconnect_requested=True,
                         original_text=text,
                     )
                 has_other_pending_requests = bool(pending_requests)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6715,9 +6715,7 @@ class ProxyService:
     ) -> bool:
         async with pending_lock:
             keepalive_ids = [
-                request_state.response_id or request_state.request_id
-                for request_state in pending_requests
-                if request_state.response_id is not None or request_state.request_id
+                request_state.response_id for request_state in pending_requests if request_state.response_id is not None
             ]
         if not keepalive_ids:
             return False

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6775,8 +6775,8 @@ class ProxyService:
         response_service_tier = request_state.service_tier
 
         if event_type == "error":
-            error = event.error if event else None
             status = "error"
+            error = event.error if event else None
             error_code = _normalize_error_code(
                 error.code if error else _websocket_event_error_code(event_type, payload),
                 error.type if error else _websocket_event_error_type(event_type, payload),
@@ -6820,6 +6820,8 @@ class ProxyService:
             settlement.record_success = False
         if event_type in {"response.failed", "error"}:
             settlement.account_health_error = _should_penalize_stream_error(error_code)
+        if request_state.suppressed_duplicate_tool_call and error_code == "stream_incomplete":
+            settlement.account_health_error = False
         if (
             error_code == "stream_incomplete"
             and request_state.previous_response_id is not None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5639,6 +5639,14 @@ class ProxyService:
                             0,
                             session.queued_request_count - len(grouped_previous_response_request_states),
                         )
+                elif event_type == "error":
+                    grouped_previous_response_request_states = list(session.pending_requests)
+                    session.pending_requests.clear()
+                    if grouped_previous_response_request_states:
+                        session.queued_request_count = max(
+                            0,
+                            session.queued_request_count - len(grouped_previous_response_request_states),
+                        )
                 has_other_pending_requests = bool(session.pending_requests)
 
         if len(grouped_previous_response_request_states) > 1:
@@ -6206,6 +6214,9 @@ class ProxyService:
                             error_message=error_message,
                         ),
                     )
+                elif request_state is None and event_type == "error":
+                    grouped_previous_response_request_states = list(pending_requests)
+                    pending_requests.clear()
                 has_other_pending_requests = bool(pending_requests)
             else:
                 request_state = None
@@ -6424,10 +6435,13 @@ class ProxyService:
         response_service_tier = request_state.service_tier
 
         if event_type == "error":
-            status = "error"
             error = event.error if event else None
-            error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
-            error_message = error.message if error else None
+            status = "error"
+            error_code = _normalize_error_code(
+                error.code if error else _websocket_event_error_code(event_type, payload),
+                error.type if error else _websocket_event_error_type(event_type, payload),
+            )
+            error_message = error.message if error else _websocket_event_error_message(event_type, payload)
             error_payload = _upstream_error_from_openai(error)
         elif event_type in {"response.failed", "response.incomplete"}:
             status = "error"
@@ -8611,6 +8625,8 @@ def _event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonV
     payload_type = payload.get("type")
     if isinstance(payload_type, str):
         return payload_type
+    if isinstance(payload.get("error"), dict):
+        return "error"
     return None
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1144,6 +1144,7 @@ class ProxyService:
         async with session.pending_lock:
             session.queued_request_count = 0
         await self._fail_pending_websocket_requests(
+            account=session.account,
             account_id_value=session.account.id,
             pending_requests=session.pending_requests,
             pending_lock=session.pending_lock,
@@ -2797,6 +2798,7 @@ class ProxyService:
                         account = None
                         continue
                     await self._fail_pending_websocket_requests(
+                        account=account,
                         account_id_value=account.id if account else None,
                         pending_requests=pending_requests,
                         pending_lock=pending_lock,
@@ -2829,6 +2831,7 @@ class ProxyService:
                 except Exception:
                     logger.debug("Failed to close upstream websocket", exc_info=True)
             await self._fail_pending_websocket_requests(
+                account=account,
                 account_id_value=account.id if account else None,
                 pending_requests=pending_requests,
                 pending_lock=pending_lock,
@@ -4600,6 +4603,7 @@ class ProxyService:
             async with pending_lock:
                 session.queued_request_count = 0
             await self._fail_pending_websocket_requests(
+                account=session.account,
                 account_id_value=session.account.id,
                 pending_requests=pending_requests,
                 pending_lock=pending_lock,
@@ -5071,6 +5075,7 @@ class ProxyService:
                 request_enqueued=request_enqueued,
             )
             await self._fail_pending_websocket_requests(
+                account=session.account,
                 account_id_value=session.account.id,
                 pending_requests=deque([request_state]),
                 pending_lock=anyio.Lock(),
@@ -5255,6 +5260,7 @@ class ProxyService:
                     async with session.pending_lock:
                         session.queued_request_count = 0
                     await self._fail_pending_websocket_requests(
+                        account=session.account,
                         account_id_value=session.account.id,
                         pending_requests=session.pending_requests,
                         pending_lock=session.pending_lock,
@@ -5278,6 +5284,7 @@ class ProxyService:
                 async with session.pending_lock:
                     session.queued_request_count = 0
                 await self._fail_pending_websocket_requests(
+                    account=session.account,
                     account_id_value=session.account.id,
                     pending_requests=session.pending_requests,
                     pending_lock=session.pending_lock,
@@ -5300,6 +5307,7 @@ class ProxyService:
             async with session.pending_lock:
                 session.queued_request_count = 0
             await self._fail_pending_websocket_requests(
+                account=session.account,
                 account_id_value=session.account.id,
                 pending_requests=session.pending_requests,
                 pending_lock=session.pending_lock,
@@ -5973,6 +5981,7 @@ class ProxyService:
                         raise
                     if receive_timeout.fail_all_pending:
                         await self._fail_pending_websocket_requests(
+                            account=account,
                             account_id_value=account_id_value,
                             pending_requests=pending_requests,
                             pending_lock=pending_lock,
@@ -6072,6 +6081,7 @@ class ProxyService:
                         logger.debug("Failed to close upstream websocket for replay", exc_info=True)
                     break
                 await self._fail_pending_websocket_requests(
+                    account=account,
                     account_id_value=account_id_value,
                     pending_requests=pending_requests,
                     pending_lock=pending_lock,
@@ -6093,6 +6103,7 @@ class ProxyService:
                 exc_info=True,
             )
             await self._fail_pending_websocket_requests(
+                account=account,
                 account_id_value=account_id_value,
                 pending_requests=pending_requests,
                 pending_lock=pending_lock,
@@ -6599,6 +6610,7 @@ class ProxyService:
     async def _fail_pending_websocket_requests(
         self,
         *,
+        account: Account | None = None,
         account_id_value: str | None,
         pending_requests: deque[_WebSocketRequestState],
         pending_lock: anyio.Lock,
@@ -6613,6 +6625,14 @@ class ProxyService:
         async with pending_lock:
             remaining = list(pending_requests)
             pending_requests.clear()
+
+        if (
+            remaining
+            and account is not None
+            and isinstance(account, Account)
+            and (error_code in _TRANSIENT_RETRY_CODES or _should_penalize_stream_error(error_code))
+        ):
+            await self._handle_stream_error(account, {"message": error_message}, error_code)
 
         last_index = len(remaining) - 1
         for index, request_state in enumerate(remaining):

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9755,11 +9755,21 @@ def _matching_websocket_request_states_for_previous_response_error(
 def _matching_websocket_request_states_for_missing_tool_output_error(
     pending_requests: deque[_WebSocketRequestState],
 ) -> list[_WebSocketRequestState]:
-    return [
+    unresolved_followups = [
         request_state
         for request_state in pending_requests
         if request_state.response_id is None and request_state.previous_response_id is not None
     ]
+    if len(unresolved_followups) <= 1:
+        return unresolved_followups
+    unique_previous_response_ids = {
+        request_state.previous_response_id
+        for request_state in unresolved_followups
+        if request_state.previous_response_id
+    }
+    if len(unique_previous_response_ids) == 1:
+        return unresolved_followups
+    return []
 
 
 def _pop_matching_websocket_request_states(

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -320,6 +320,10 @@ def dedupe_replayed_side_effect_input_items(
             last_side_effect_key = None
         key = call_keys.get(index)
         if key is None:
+            if isinstance(item, dict) and replayed_tool_call_segment_boundary(item):
+                first_call_id_by_key.clear()
+                first_call_index_by_key.clear()
+                last_side_effect_key = None
             continue
         if last_side_effect_key is not None and key != last_side_effect_key:
             first_call_id_by_key.clear()
@@ -418,6 +422,11 @@ def replayed_input_segment_boundary(item: Mapping[str, JsonValue]) -> bool:
         return False
     item_type = item.get("type")
     return item_type in {None, "message"}
+
+
+def replayed_tool_call_segment_boundary(item: Mapping[str, JsonValue]) -> bool:
+    item_type = item.get("type")
+    return item_type in {"function_call", "custom_tool_call"} | _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES
 
 
 def replayed_tool_output_call_id(item: Mapping[str, JsonValue]) -> str | None:

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -101,6 +101,13 @@ def mark_duplicate_tool_call_downstream_event(
     is_side_effect_tool_call = item_type in _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES or (
         item_name in _SIDE_EFFECT_TOOL_CALL_NAMES and _tool_call_has_side_effect_arguments(item_name, argument_value)
     )
+    if item_name == _PARALLEL_TOOL_CALL_NAME and is_side_effect_tool_call:
+        return _mark_duplicate_parallel_tool_call_downstream_event(
+            cast(dict[str, JsonValue], item),
+            argument_value,
+            seen_tool_call_keys=seen_tool_call_keys,
+            response_id=response_id,
+        )
     # Same-response replays have shown distinct call_ids for byte-identical shell/edit requests.
     # For local side-effect tools, running the same payload twice is worse than dropping a duplicate-looking call_id.
     dedupe_call_id = None if is_side_effect_tool_call else call_id
@@ -120,6 +127,62 @@ def mark_duplicate_tool_call_downstream_event(
     seen_tool_call_keys[key] = None
     while len(seen_tool_call_keys) > _TOOL_CALL_DEDUPE_CACHE_LIMIT:
         seen_tool_call_keys.pop(next(iter(seen_tool_call_keys)))
+    return False
+
+
+def _mark_duplicate_parallel_tool_call_downstream_event(
+    item: dict[str, JsonValue],
+    argument_value: str,
+    *,
+    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None],
+    response_id: str | None,
+) -> bool:
+    argument = json_object_from_argument(argument_value)
+    if argument is None:
+        return False
+    tool_uses = argument.get("tool_uses")
+    if not isinstance(tool_uses, list):
+        return False
+
+    kept_tool_uses: list[JsonValue] = []
+    removed_count = 0
+    for tool_use in tool_uses:
+        if not isinstance(tool_use, dict):
+            kept_tool_uses.append(cast(JsonValue, tool_use))
+            continue
+        recipient_name = tool_use.get("recipient_name")
+        if not isinstance(recipient_name, str) or recipient_name not in _PARALLEL_TOOL_USE_DEDUPE_RECIPIENT_NAMES:
+            kept_tool_uses.append(cast(JsonValue, tool_use))
+            continue
+        key = (
+            response_id or "",
+            "parallel_tool_use",
+            recipient_name,
+            None,
+            canonical_parallel_tool_use_key(cast(dict[str, JsonValue], tool_use)),
+        )
+        if key in seen_tool_call_keys:
+            removed_count += 1
+            continue
+        seen_tool_call_keys[key] = None
+        kept_tool_uses.append(cast(JsonValue, tool_use))
+
+    while len(seen_tool_call_keys) > _TOOL_CALL_DEDUPE_CACHE_LIMIT:
+        seen_tool_call_keys.pop(next(iter(seen_tool_call_keys)))
+
+    if removed_count == 0:
+        return False
+    logger.warning(
+        "Suppressed duplicate downstream parallel tool uses response_id=%s removed=%s",
+        response_id,
+        removed_count,
+    )
+    if not kept_tool_uses:
+        return True
+
+    rewritten_argument = dict(argument)
+    rewritten_argument["tool_uses"] = kept_tool_uses
+    item["arguments"] = json.dumps(rewritten_argument, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     return False
 
 

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import cast
+
+from app.core.openai.models import OpenAIEvent
+from app.core.openai.parsing import parse_sse_event
+from app.core.types import JsonValue
+from app.core.utils.sse import format_sse_event
+
+logger = logging.getLogger(__name__)
+
+_TOOL_CALL_DEDUPE_CACHE_LIMIT = 1024
+_PARALLEL_TOOL_CALL_NAME = "multi_tool_use.parallel"
+_SIDE_EFFECT_TOOL_CALL_NAMES = frozenset(
+    {
+        "exec_command",
+        _PARALLEL_TOOL_CALL_NAME,
+        "write_stdin",
+    }
+)
+_SIDE_EFFECT_TOOL_CALL_ITEM_TYPES = frozenset({"apply_patch_call"})
+_PARALLEL_TOOL_USE_DEDUPE_RECIPIENT_NAMES = frozenset(
+    {
+        "functions.apply_patch",
+        "functions.close_agent",
+        "functions.exec_command",
+        "functions.resume_agent",
+        "functions.send_input",
+        "functions.spawn_agent",
+        "functions.wait_agent",
+        "functions.write_stdin",
+        "multi_tool_use.parallel",
+    }
+)
+_SIDE_EFFECT_VOLATILE_ARG_KEYS = frozenset({"max_output_tokens", "timeout_ms", "yield_time_ms"})
+
+
+def event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonValue] | None) -> str | None:
+    if event is not None:
+        return event.type
+    if payload is None:
+        return None
+    payload_type = payload.get("type")
+    if isinstance(payload_type, str):
+        return payload_type
+    return None
+
+
+def response_id_from_payload(payload: dict[str, JsonValue] | None) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    top_level_response_id = payload.get("response_id")
+    if isinstance(top_level_response_id, str):
+        stripped = top_level_response_id.strip()
+        if stripped:
+            return stripped
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return None
+    response_id = response.get("id")
+    if not isinstance(response_id, str):
+        return None
+    stripped = response_id.strip()
+    return stripped or None
+
+
+def mark_duplicate_tool_call_downstream_event(
+    payload: dict[str, JsonValue] | None,
+    *,
+    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None],
+    response_id: str | None,
+) -> bool:
+    if not isinstance(payload, dict) or payload.get("type") != "response.output_item.done":
+        return False
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        return False
+    item_type = item.get("type")
+    if item_type == "function_call":
+        argument_value = item.get("arguments")
+    elif item_type == "custom_tool_call":
+        argument_value = item.get("input")
+    elif item_type == "apply_patch_call":
+        operation_value = item.get("operation")
+        if isinstance(operation_value, dict):
+            argument_value = json.dumps(operation_value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        else:
+            argument_value = operation_value
+    else:
+        return False
+    if not isinstance(argument_value, str):
+        return False
+    item_name = item.get("name")
+    if item_name is not None and not isinstance(item_name, str):
+        item_name = None
+    call_id = item.get("call_id")
+    if call_id is not None and not isinstance(call_id, str):
+        call_id = None
+    is_side_effect_tool_call = (
+        item_type in _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES or item_name in _SIDE_EFFECT_TOOL_CALL_NAMES
+    )
+    # Same-response replays have shown distinct call_ids for byte-identical shell/edit requests.
+    # For local side-effect tools, running the same payload twice is worse than dropping a duplicate-looking call_id.
+    dedupe_call_id = None if is_side_effect_tool_call else call_id
+    if is_side_effect_tool_call:
+        argument_key = canonical_side_effect_argument_key(item_name, argument_value)
+    else:
+        argument_key = argument_value
+    key = (response_id or "", str(item_type), item_name, dedupe_call_id, argument_key)
+    if key in seen_tool_call_keys:
+        logger.warning(
+            "Suppressed duplicate downstream tool call response_id=%s item_type=%s name=%s",
+            response_id,
+            item_type,
+            item_name,
+        )
+        return True
+    seen_tool_call_keys[key] = None
+    while len(seen_tool_call_keys) > _TOOL_CALL_DEDUPE_CACHE_LIMIT:
+        seen_tool_call_keys.pop(next(iter(seen_tool_call_keys)))
+    return False
+
+
+def json_object_from_argument(argument_value: str) -> dict[str, JsonValue] | None:
+    try:
+        decoded_argument = json.loads(argument_value)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded_argument, dict):
+        return None
+    return cast(dict[str, JsonValue], decoded_argument)
+
+
+def canonical_json_key(value: JsonValue) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_parameters_key(recipient_name: str, parameters: dict[str, JsonValue]) -> str:
+    canonical_parameters = dict(parameters)
+    for key in _SIDE_EFFECT_VOLATILE_ARG_KEYS:
+        canonical_parameters.pop(key, None)
+    return canonical_json_key({"recipient_name": recipient_name, "parameters": canonical_parameters})
+
+
+def canonical_wait_agent_targets(targets: JsonValue | None) -> JsonValue | None:
+    if not isinstance(targets, list):
+        return targets
+    try:
+        return cast(JsonValue, sorted(targets, key=lambda target: (target.__class__.__name__, str(target))))
+    except (TypeError, ValueError):
+        return cast(JsonValue, list(targets))
+
+
+def canonical_side_effect_argument_key(item_name: str | None, argument_value: str) -> str:
+    argument = json_object_from_argument(argument_value)
+    if argument is None:
+        return argument_value
+    if item_name in {"exec_command", "write_stdin"}:
+        return canonical_parameters_key(str(item_name), argument)
+    if item_name != _PARALLEL_TOOL_CALL_NAME:
+        return canonical_json_key(cast(JsonValue, argument))
+
+    tool_uses = argument.get("tool_uses")
+    if not isinstance(tool_uses, list):
+        return canonical_json_key(cast(JsonValue, argument))
+
+    canonical_tool_uses: list[JsonValue] = []
+    for tool_use in tool_uses:
+        if isinstance(tool_use, dict):
+            canonical_tool_use = json_object_from_argument(canonical_parallel_tool_use_key(tool_use))
+            canonical_tool_uses.append(canonical_tool_use or tool_use)
+        else:
+            canonical_tool_uses.append(cast(JsonValue, tool_use))
+    canonical_argument = dict(argument)
+    canonical_argument["tool_uses"] = canonical_tool_uses
+    return canonical_json_key(cast(JsonValue, canonical_argument))
+
+
+def canonical_parallel_tool_use_key(tool_use: dict[str, JsonValue]) -> str:
+    recipient_name = tool_use.get("recipient_name")
+    parameters = tool_use.get("parameters")
+    if not isinstance(recipient_name, str):
+        return json.dumps(tool_use, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    if recipient_name == "functions.write_stdin" and isinstance(parameters, dict):
+        return json.dumps(
+            {
+                "recipient_name": recipient_name,
+                "session_id": parameters.get("session_id"),
+                "chars": parameters.get("chars"),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    if recipient_name == "functions.wait_agent" and isinstance(parameters, dict):
+        targets = parameters.get("targets")
+        return json.dumps(
+            {
+                "recipient_name": recipient_name,
+                "targets": canonical_wait_agent_targets(targets),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    if recipient_name == "functions.exec_command" and isinstance(parameters, dict):
+        return canonical_parameters_key(recipient_name, cast(dict[str, JsonValue], parameters))
+    return json.dumps(tool_use, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def dedupe_parallel_tool_uses_argument(argument_value: str) -> tuple[str, bool, int]:
+    try:
+        decoded_arguments = json.loads(argument_value)
+    except json.JSONDecodeError:
+        return argument_value, False, 0
+    if not isinstance(decoded_arguments, dict):
+        return argument_value, False, 0
+    tool_uses = decoded_arguments.get("tool_uses")
+    if not isinstance(tool_uses, list):
+        return argument_value, False, 0
+
+    seen_tool_uses: set[str] = set()
+    deduped_tool_uses: list[JsonValue] = []
+    removed_count = 0
+    for tool_use in tool_uses:
+        if not isinstance(tool_use, dict):
+            deduped_tool_uses.append(cast(JsonValue, tool_use))
+            continue
+        recipient_name = tool_use.get("recipient_name")
+        if not isinstance(recipient_name, str) or recipient_name not in _PARALLEL_TOOL_USE_DEDUPE_RECIPIENT_NAMES:
+            deduped_tool_uses.append(cast(JsonValue, tool_use))
+            continue
+        tool_use_key = canonical_parallel_tool_use_key(cast(dict[str, JsonValue], tool_use))
+        if tool_use_key in seen_tool_uses:
+            removed_count += 1
+            continue
+        seen_tool_uses.add(tool_use_key)
+        deduped_tool_uses.append(cast(JsonValue, tool_use))
+
+    if removed_count == 0:
+        return argument_value, False, 0
+
+    rewritten_arguments: dict[str, JsonValue] = dict(cast(dict[str, JsonValue], decoded_arguments))
+    rewritten_arguments["tool_uses"] = deduped_tool_uses
+    return (
+        json.dumps(rewritten_arguments, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
+        True,
+        removed_count,
+    )
+
+
+def rewrite_parallel_tool_call_payload(
+    payload: dict[str, JsonValue] | None,
+) -> tuple[dict[str, JsonValue] | None, bool, int]:
+    if not isinstance(payload, dict) or payload.get("type") != "response.output_item.done":
+        return payload, False, 0
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        return payload, False, 0
+    if item.get("type") != "function_call" or item.get("name") != _PARALLEL_TOOL_CALL_NAME:
+        return payload, False, 0
+    argument_value = item.get("arguments")
+    if not isinstance(argument_value, str):
+        return payload, False, 0
+
+    rewritten_arguments, changed, removed_count = dedupe_parallel_tool_uses_argument(argument_value)
+    if not changed:
+        return payload, False, 0
+
+    rewritten_item: dict[str, JsonValue] = dict(cast(dict[str, JsonValue], item))
+    rewritten_item["arguments"] = rewritten_arguments
+    rewritten_payload: dict[str, JsonValue] = dict(payload)
+    rewritten_payload["item"] = rewritten_item
+    logger.warning(
+        "Suppressed duplicate nested parallel tool uses response_id=%s removed=%s",
+        response_id_from_payload(rewritten_payload),
+        removed_count,
+    )
+    return rewritten_payload, True, removed_count
+
+
+def rewrite_parallel_tool_call_text(
+    text: str,
+    payload: dict[str, JsonValue] | None,
+    *,
+    event_block: str,
+) -> tuple[str, dict[str, JsonValue] | None, OpenAIEvent | None, str | None, str]:
+    rewritten_payload, changed, _removed_count = rewrite_parallel_tool_call_payload(payload)
+    if not changed:
+        event = parse_sse_event(event_block)
+        return text, payload, event, event_type_from_payload(event, payload), event_block
+    assert rewritten_payload is not None
+    rewritten_text = json.dumps(rewritten_payload, ensure_ascii=True, separators=(",", ":"))
+    rewritten_event_block = f"data: {rewritten_text}\n\n"
+    rewritten_event = parse_sse_event(rewritten_event_block)
+    return (
+        rewritten_text,
+        rewritten_payload,
+        rewritten_event,
+        event_type_from_payload(rewritten_event, rewritten_payload),
+        rewritten_event_block,
+    )
+
+
+def rewrite_parallel_tool_call_sse_line(
+    line: str,
+    payload: dict[str, JsonValue] | None,
+) -> tuple[str, dict[str, JsonValue] | None, OpenAIEvent | None, str | None]:
+    rewritten_payload, changed, _removed_count = rewrite_parallel_tool_call_payload(payload)
+    if not changed:
+        event = parse_sse_event(line)
+        return line, payload, event, event_type_from_payload(event, payload)
+    assert rewritten_payload is not None
+    rewritten_line = format_sse_event(rewritten_payload)
+    rewritten_event = parse_sse_event(rewritten_line)
+    return (
+        rewritten_line,
+        rewritten_payload,
+        rewritten_event,
+        event_type_from_payload(rewritten_event, rewritten_payload),
+    )

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Mapping
 from typing import cast
 
 from app.core.openai.models import OpenAIEvent
@@ -239,6 +240,169 @@ def canonical_side_effect_argument_key(item_name: str | None, argument_value: st
     canonical_argument = dict(argument)
     canonical_argument["tool_uses"] = canonical_tool_uses
     return canonical_json_key(cast(JsonValue, canonical_argument))
+
+
+def dedupe_replayed_side_effect_input_items(input_items: list[JsonValue]) -> tuple[list[JsonValue], int]:
+    call_keys: dict[int, tuple[str, str | None, str]] = {}
+    call_ids: dict[int, str] = {}
+    output_indices_by_call_id: dict[str, list[int]] = {}
+    for index, item in enumerate(input_items):
+        if not isinstance(item, dict):
+            continue
+        tool_call_key = replayed_side_effect_tool_call_key(item)
+        if tool_call_key is not None:
+            call_keys[index] = tool_call_key
+            call_id = item.get("call_id")
+            if isinstance(call_id, str) and call_id:
+                call_ids[index] = call_id
+            continue
+        output_call_id = replayed_tool_output_call_id(item)
+        if output_call_id is not None:
+            output_indices_by_call_id.setdefault(output_call_id, []).append(index)
+
+    if not call_keys:
+        return input_items, 0
+
+    kept = [True] * len(input_items)
+    rewritten: dict[int, JsonValue] = {}
+    first_call_id_by_key: dict[tuple[str, str | None, str], str | None] = {}
+    next_output_cursor_by_call_id: dict[str, int] = {}
+    last_side_effect_key: tuple[str, str | None, str] | None = None
+    removed_count = 0
+    for index, item in enumerate(input_items):
+        if isinstance(item, dict) and replayed_input_segment_boundary(item):
+            first_call_id_by_key.clear()
+            last_side_effect_key = None
+        key = call_keys.get(index)
+        if key is None:
+            continue
+        if last_side_effect_key is not None and key != last_side_effect_key:
+            first_call_id_by_key.clear()
+        last_side_effect_key = key
+        call_id = call_ids.get(index)
+        output_index = (
+            replayed_tool_output_index_for_call(
+                output_indices_by_call_id,
+                next_output_cursor_by_call_id,
+                call_index=index,
+                call_id=call_id,
+            )
+            if call_id is not None
+            else None
+        )
+        if key not in first_call_id_by_key:
+            first_call_id_by_key[key] = call_id
+            continue
+
+        removed_count += 1
+        kept[index] = False
+        if output_index is not None:
+            output_item = input_items[output_index]
+            if isinstance(output_item, dict):
+                rewritten[output_index] = replayed_tool_output_as_assistant_message(output_item)
+
+    if removed_count == 0:
+        return input_items, 0
+
+    deduped_items: list[JsonValue] = []
+    for index, item in enumerate(input_items):
+        if kept[index]:
+            deduped_items.append(rewritten.get(index, item))
+    return deduped_items, removed_count
+
+
+def replayed_side_effect_tool_call_key(item: Mapping[str, JsonValue]) -> tuple[str, str | None, str] | None:
+    item_type_value = item.get("type")
+    item_type = item_type_value if isinstance(item_type_value, str) else None
+    if item_type == "function_call":
+        item_name_value = item.get("name")
+        item_name = item_name_value if isinstance(item_name_value, str) else None
+        argument_value = item.get("arguments")
+        if not isinstance(argument_value, str):
+            return None
+        is_side_effect_tool_call = item_name in _SIDE_EFFECT_TOOL_CALL_NAMES and _tool_call_has_side_effect_arguments(
+            item_name,
+            argument_value,
+        )
+        if not is_side_effect_tool_call:
+            return None
+        argument_key = canonical_side_effect_argument_key(item_name, argument_value)
+    elif item_type == "custom_tool_call":
+        item_name_value = item.get("name")
+        item_name = item_name_value if isinstance(item_name_value, str) else None
+        if item_name not in _SIDE_EFFECT_TOOL_CALL_NAMES:
+            return None
+        argument_value = item.get("input")
+        if not isinstance(argument_value, str):
+            return None
+        argument_key = canonical_side_effect_argument_key(item_name, argument_value)
+    elif item_type in _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES:
+        item_name = item_type
+        operation_value = item.get("operation")
+        argument_key = canonical_json_key(operation_value)
+    else:
+        return None
+    return (cast(str, item_type), item_name, argument_key)
+
+
+def replayed_input_segment_boundary(item: Mapping[str, JsonValue]) -> bool:
+    role = item.get("role")
+    if role not in {"developer", "system", "user"}:
+        return False
+    item_type = item.get("type")
+    return item_type in {None, "message"}
+
+
+def replayed_tool_output_call_id(item: Mapping[str, JsonValue]) -> str | None:
+    if item.get("type") not in {
+        "function_call_output",
+        "custom_tool_call_output",
+        "apply_patch_call_output",
+    }:
+        return None
+    call_id = item.get("call_id")
+    if isinstance(call_id, str) and call_id:
+        return call_id
+    return None
+
+
+def replayed_tool_output_as_assistant_message(item: Mapping[str, JsonValue]) -> JsonValue:
+    output_value = item.get("output")
+    if isinstance(output_value, str):
+        output_text = output_value
+    else:
+        output_text = canonical_json_key(cast(JsonValue, output_value))
+    return {
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "output_text",
+                "text": output_text,
+            }
+        ],
+    }
+
+
+def replayed_tool_output_index_for_call(
+    output_indices_by_call_id: dict[str, list[int]],
+    next_output_cursor_by_call_id: dict[str, int],
+    *,
+    call_index: int,
+    call_id: str,
+) -> int | None:
+    output_indices = output_indices_by_call_id.get(call_id)
+    if not output_indices:
+        return None
+    cursor = next_output_cursor_by_call_id.get(call_id, 0)
+    while cursor < len(output_indices) and output_indices[cursor] < call_index:
+        cursor += 1
+    if cursor >= len(output_indices):
+        next_output_cursor_by_call_id[call_id] = cursor
+        return None
+    output_index = output_indices[cursor]
+    next_output_cursor_by_call_id[call_id] = cursor + 1
+    return output_index
 
 
 def _tool_call_has_side_effect_arguments(item_name: str | None, argument_value: str) -> bool:

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -40,14 +40,7 @@ _SIDE_EFFECT_TOOL_CALL_NAMES = frozenset(
 _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES = frozenset({"apply_patch_call"})
 _PARALLEL_TOOL_USE_DEDUPE_RECIPIENT_NAMES = frozenset(
     {
-        "functions.apply_patch",
-        "functions.close_agent",
-        "functions.exec_command",
-        "functions.resume_agent",
-        "functions.send_input",
-        "functions.spawn_agent",
-        "functions.wait_agent",
-        "functions.write_stdin",
+        *(f"functions.{name}" for name in _DIRECT_SIDE_EFFECT_TOOL_CALL_NAMES),
         "multi_tool_use.parallel",
     }
 )

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -144,8 +144,6 @@ def mark_duplicate_tool_call_downstream_event(
             item_name,
         )
         return True
-    if seen_tool_call_keys:
-        seen_tool_call_keys.clear()
     seen_tool_call_keys[key] = None
     while len(seen_tool_call_keys) > _TOOL_CALL_DEDUPE_CACHE_LIMIT:
         seen_tool_call_keys.pop(next(iter(seen_tool_call_keys)))
@@ -184,9 +182,6 @@ def _mark_duplicate_parallel_tool_call_downstream_event(
                 canonical_parallel_tool_use_key(cast(dict[str, JsonValue], tool_use)),
             )
         )
-    if candidate_keys and seen_tool_call_keys and not any(key in seen_tool_call_keys for key in candidate_keys):
-        seen_tool_call_keys.clear()
-
     kept_tool_uses: list[JsonValue] = []
     removed_count = 0
     for tool_use in tool_uses:

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -316,7 +316,17 @@ def dedupe_replayed_side_effect_input_items(
             last_side_effect_key = None
         key = call_keys.get(index)
         if key is None:
-            if isinstance(item, dict) and replayed_tool_call_segment_boundary(item):
+            output_call_id = replayed_tool_output_call_id(item) if isinstance(item, dict) else None
+            if (
+                last_side_effect_key is not None
+                and output_call_id is not None
+                and first_call_id_by_key.get(last_side_effect_key) == output_call_id
+            ):
+                continue
+            if (
+                output_call_id is not None
+                or (isinstance(item, dict) and replayed_tool_call_segment_boundary(item))
+            ):
                 first_call_id_by_key.clear()
                 first_call_index_by_key.clear()
                 last_side_effect_key = None

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -102,6 +102,7 @@ def mark_duplicate_tool_call_downstream_event(
         else:
             argument_value = operation_value
     else:
+        seen_tool_call_keys.clear()
         return False
     if not isinstance(argument_value, str):
         return False
@@ -114,6 +115,9 @@ def mark_duplicate_tool_call_downstream_event(
     is_side_effect_tool_call = item_type in _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES or (
         item_name in _SIDE_EFFECT_TOOL_CALL_NAMES and _tool_call_has_side_effect_arguments(item_name, argument_value)
     )
+    if not is_side_effect_tool_call:
+        seen_tool_call_keys.clear()
+        return False
     if item_name == _PARALLEL_TOOL_CALL_NAME and is_side_effect_tool_call:
         return _mark_duplicate_parallel_tool_call_downstream_event(
             cast(dict[str, JsonValue], item),
@@ -127,7 +131,7 @@ def mark_duplicate_tool_call_downstream_event(
     dedupe_call_id = None if is_side_effect_tool_call else call_id
     if is_side_effect_tool_call:
         item_name = normalize_tool_call_name(item_name)
-        argument_key = canonical_side_effect_argument_key(item_name, argument_value)
+        argument_key = canonical_downstream_side_effect_argument_key(item_name, argument_value)
     else:
         argument_key = argument_value
     dedupe_response_id = response_id if scope_side_effects_by_response_id or not is_side_effect_tool_call else None
@@ -140,6 +144,8 @@ def mark_duplicate_tool_call_downstream_event(
             item_name,
         )
         return True
+    if seen_tool_call_keys:
+        seen_tool_call_keys.clear()
     seen_tool_call_keys[key] = None
     while len(seen_tool_call_keys) > _TOOL_CALL_DEDUPE_CACHE_LIMIT:
         seen_tool_call_keys.pop(next(iter(seen_tool_call_keys)))
@@ -160,6 +166,26 @@ def _mark_duplicate_parallel_tool_call_downstream_event(
     tool_uses = argument.get("tool_uses")
     if not isinstance(tool_uses, list):
         return False
+
+    candidate_keys: list[tuple[str, str, str | None, str | None, str]] = []
+    for tool_use in tool_uses:
+        if not isinstance(tool_use, dict):
+            continue
+        recipient_name = tool_use.get("recipient_name")
+        if not isinstance(recipient_name, str) or recipient_name not in _PARALLEL_TOOL_USE_DEDUPE_RECIPIENT_NAMES:
+            continue
+        dedupe_response_id = response_id if scope_side_effects_by_response_id else None
+        candidate_keys.append(
+            (
+                dedupe_response_id or "",
+                "parallel_tool_use",
+                recipient_name,
+                None,
+                canonical_parallel_tool_use_key(cast(dict[str, JsonValue], tool_use)),
+            )
+        )
+    if candidate_keys and seen_tool_call_keys and not any(key in seen_tool_call_keys for key in candidate_keys):
+        seen_tool_call_keys.clear()
 
     kept_tool_uses: list[JsonValue] = []
     removed_count = 0
@@ -228,10 +254,16 @@ def canonical_parameters_key(recipient_name: str, parameters: dict[str, JsonValu
 def canonical_wait_agent_targets(targets: JsonValue | None) -> JsonValue | None:
     if not isinstance(targets, list):
         return targets
-    try:
-        return cast(JsonValue, sorted(targets, key=lambda target: (target.__class__.__name__, str(target))))
-    except (TypeError, ValueError):
-        return cast(JsonValue, list(targets))
+    return cast(
+        JsonValue,
+        sorted(
+            targets,
+            key=lambda target: (
+                target.__class__.__name__,
+                canonical_json_key(cast(JsonValue, target)),
+            ),
+        ),
+    )
 
 
 def canonical_side_effect_argument_key(item_name: str | None, argument_value: str) -> str:
@@ -274,6 +306,26 @@ def canonical_side_effect_argument_key(item_name: str | None, argument_value: st
     canonical_argument = dict(argument)
     canonical_argument["tool_uses"] = canonical_tool_uses
     return canonical_json_key(cast(JsonValue, canonical_argument))
+
+
+def canonical_downstream_side_effect_argument_key(item_name: str | None, argument_value: str) -> str:
+    argument = json_object_from_argument(argument_value)
+    if argument is None:
+        return argument_value
+    normalized_item_name = normalize_tool_call_name(item_name)
+    if normalized_item_name == "write_stdin":
+        return canonical_parameters_key(
+            normalized_item_name,
+            {
+                "session_id": argument.get("session_id"),
+                "chars": argument.get("chars"),
+                "yield_time_ms": argument.get("yield_time_ms"),
+                "max_output_tokens": argument.get("max_output_tokens"),
+            },
+        )
+    if normalized_item_name == "exec_command":
+        return canonical_parameters_key(normalized_item_name, argument)
+    return canonical_side_effect_argument_key(item_name, argument_value)
 
 
 def dedupe_replayed_side_effect_input_items(
@@ -528,16 +580,14 @@ def canonical_parallel_tool_use_key(tool_use: dict[str, JsonValue]) -> str:
         return json.dumps(tool_use, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     normalized_recipient_name = normalize_tool_call_name(recipient_name)
     if normalized_recipient_name == "write_stdin" and isinstance(parameters, dict):
-        return json.dumps(
+        return canonical_parameters_key(
+            normalized_recipient_name,
             {
-                "recipient_name": normalized_recipient_name,
                 "session_id": parameters.get("session_id"),
                 "chars": parameters.get("chars"),
                 "yield_time_ms": parameters.get("yield_time_ms"),
+                "max_output_tokens": parameters.get("max_output_tokens"),
             },
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=False,
         )
     if normalized_recipient_name == "wait_agent" and isinstance(parameters, dict):
         targets = parameters.get("targets")

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -72,6 +72,7 @@ def mark_duplicate_tool_call_downstream_event(
     *,
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None],
     response_id: str | None,
+    scope_side_effects_by_response_id: bool = True,
 ) -> bool:
     if not isinstance(payload, dict) or payload.get("type") != "response.output_item.done":
         return False
@@ -108,6 +109,7 @@ def mark_duplicate_tool_call_downstream_event(
             argument_value,
             seen_tool_call_keys=seen_tool_call_keys,
             response_id=response_id,
+            scope_side_effects_by_response_id=scope_side_effects_by_response_id,
         )
     # Same-response replays have shown distinct call_ids for byte-identical shell/edit requests.
     # For local side-effect tools, running the same payload twice is worse than dropping a duplicate-looking call_id.
@@ -116,7 +118,8 @@ def mark_duplicate_tool_call_downstream_event(
         argument_key = canonical_side_effect_argument_key(item_name, argument_value)
     else:
         argument_key = argument_value
-    key = (response_id or "", str(item_type), item_name, dedupe_call_id, argument_key)
+    dedupe_response_id = response_id if scope_side_effects_by_response_id or not is_side_effect_tool_call else None
+    key = (dedupe_response_id or "", str(item_type), item_name, dedupe_call_id, argument_key)
     if key in seen_tool_call_keys:
         logger.warning(
             "Suppressed duplicate downstream tool call response_id=%s item_type=%s name=%s",
@@ -137,6 +140,7 @@ def _mark_duplicate_parallel_tool_call_downstream_event(
     *,
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None],
     response_id: str | None,
+    scope_side_effects_by_response_id: bool,
 ) -> bool:
     argument = json_object_from_argument(argument_value)
     if argument is None:
@@ -155,8 +159,9 @@ def _mark_duplicate_parallel_tool_call_downstream_event(
         if not isinstance(recipient_name, str) or recipient_name not in _PARALLEL_TOOL_USE_DEDUPE_RECIPIENT_NAMES:
             kept_tool_uses.append(cast(JsonValue, tool_use))
             continue
+        dedupe_response_id = response_id if scope_side_effects_by_response_id else None
         key = (
-            response_id or "",
+            dedupe_response_id or "",
             "parallel_tool_use",
             recipient_name,
             None,

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -126,16 +126,13 @@ def mark_duplicate_tool_call_downstream_event(
             response_id=response_id,
             scope_side_effects_by_response_id=scope_side_effects_by_response_id,
         )
-    # Same-response replays have shown distinct call_ids for byte-identical shell/edit requests.
-    # For local side-effect tools, running the same payload twice is worse than dropping a duplicate-looking call_id.
-    dedupe_call_id = None if is_side_effect_tool_call else call_id
     if is_side_effect_tool_call:
         item_name = normalize_tool_call_name(item_name)
         argument_key = canonical_downstream_side_effect_argument_key(item_name, argument_value)
     else:
         argument_key = argument_value
-    dedupe_response_id = response_id if scope_side_effects_by_response_id or not is_side_effect_tool_call else None
-    key = (dedupe_response_id or "", str(item_type), item_name, dedupe_call_id, argument_key)
+    dedupe_response_id = response_id if response_id is not None else ""
+    key = (dedupe_response_id, str(item_type), item_name, call_id, argument_key)
     if key in seen_tool_call_keys:
         logger.warning(
             "Suppressed duplicate downstream tool call response_id=%s item_type=%s name=%s",
@@ -144,7 +141,26 @@ def mark_duplicate_tool_call_downstream_event(
             item_name,
         )
         return True
+    if is_side_effect_tool_call:
+        same_response_argument_key = (dedupe_response_id, str(item_type), item_name, None, argument_key)
+        cross_response_argument_key = ("", str(item_type), item_name, None, argument_key)
+        if (
+            not scope_side_effects_by_response_id
+            and cross_response_argument_key in seen_tool_call_keys
+            and same_response_argument_key not in seen_tool_call_keys
+        ):
+            logger.warning(
+                "Suppressed duplicate downstream side-effect replay response_id=%s item_type=%s name=%s",
+                response_id,
+                item_type,
+                item_name,
+            )
+            return True
     seen_tool_call_keys[key] = None
+    if is_side_effect_tool_call:
+        seen_tool_call_keys[same_response_argument_key] = None
+        if not scope_side_effects_by_response_id:
+            seen_tool_call_keys[cross_response_argument_key] = None
     while len(seen_tool_call_keys) > _TOOL_CALL_DEDUPE_CACHE_LIMIT:
         seen_tool_call_keys.pop(next(iter(seen_tool_call_keys)))
     return False

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -14,11 +14,27 @@ logger = logging.getLogger(__name__)
 
 _TOOL_CALL_DEDUPE_CACHE_LIMIT = 1024
 _PARALLEL_TOOL_CALL_NAME = "multi_tool_use.parallel"
+_DIRECT_SIDE_EFFECT_TOOL_CALL_NAMES = frozenset(
+    {
+        "apply_patch",
+        "close_agent",
+        "create_goal",
+        "exec_command",
+        "request_user_input",
+        "resume_agent",
+        "send_input",
+        "spawn_agent",
+        "update_goal",
+        "update_plan",
+        "wait_agent",
+        "write_stdin",
+    }
+)
 _SIDE_EFFECT_TOOL_CALL_NAMES = frozenset(
     {
-        "exec_command",
         _PARALLEL_TOOL_CALL_NAME,
-        "write_stdin",
+        *_DIRECT_SIDE_EFFECT_TOOL_CALL_NAMES,
+        *(f"functions.{name}" for name in _DIRECT_SIDE_EFFECT_TOOL_CALL_NAMES),
     }
 )
 _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES = frozenset({"apply_patch_call"})
@@ -115,6 +131,7 @@ def mark_duplicate_tool_call_downstream_event(
     # For local side-effect tools, running the same payload twice is worse than dropping a duplicate-looking call_id.
     dedupe_call_id = None if is_side_effect_tool_call else call_id
     if is_side_effect_tool_call:
+        item_name = normalize_tool_call_name(item_name)
         argument_key = canonical_side_effect_argument_key(item_name, argument_value)
     else:
         argument_key = argument_value
@@ -226,10 +243,26 @@ def canonical_side_effect_argument_key(item_name: str | None, argument_value: st
     argument = json_object_from_argument(argument_value)
     if argument is None:
         return argument_value
-    if item_name in {"exec_command", "write_stdin"}:
-        return canonical_parameters_key(str(item_name), argument)
+    normalized_item_name = normalize_tool_call_name(item_name)
+    if normalized_item_name == "write_stdin":
+        return canonical_json_key(
+            {
+                "name": normalized_item_name,
+                "session_id": argument.get("session_id"),
+                "chars": argument.get("chars"),
+            }
+        )
+    if normalized_item_name == "wait_agent":
+        return canonical_json_key(
+            {
+                "name": normalized_item_name,
+                "targets": canonical_wait_agent_targets(argument.get("targets")),
+            }
+        )
+    if normalized_item_name == "exec_command":
+        return canonical_parameters_key(normalized_item_name, argument)
     if item_name != _PARALLEL_TOOL_CALL_NAME:
-        return canonical_json_key(cast(JsonValue, argument))
+        return canonical_json_key({"name": normalized_item_name or item_name, "parameters": cast(JsonValue, argument)})
 
     tool_uses = argument.get("tool_uses")
     if not isinstance(tool_uses, list):
@@ -247,7 +280,11 @@ def canonical_side_effect_argument_key(item_name: str | None, argument_value: st
     return canonical_json_key(cast(JsonValue, canonical_argument))
 
 
-def dedupe_replayed_side_effect_input_items(input_items: list[JsonValue]) -> tuple[list[JsonValue], int]:
+def dedupe_replayed_side_effect_input_items(
+    input_items: list[JsonValue],
+    *,
+    sanitize_missing_outputs: bool = False,
+) -> tuple[list[JsonValue], int]:
     call_keys: dict[int, tuple[str, str | None, str]] = {}
     call_ids: dict[int, str] = {}
     output_indices_by_call_id: dict[str, list[int]] = {}
@@ -271,12 +308,15 @@ def dedupe_replayed_side_effect_input_items(input_items: list[JsonValue]) -> tup
     kept = [True] * len(input_items)
     rewritten: dict[int, JsonValue] = {}
     first_call_id_by_key: dict[tuple[str, str | None, str], str | None] = {}
+    first_call_index_by_key: dict[tuple[str, str | None, str], int] = {}
+    output_index_by_call_index: dict[int, int | None] = {}
     next_output_cursor_by_call_id: dict[str, int] = {}
     last_side_effect_key: tuple[str, str | None, str] | None = None
     removed_count = 0
     for index, item in enumerate(input_items):
         if isinstance(item, dict) and replayed_input_segment_boundary(item):
             first_call_id_by_key.clear()
+            first_call_index_by_key.clear()
             last_side_effect_key = None
         key = call_keys.get(index)
         if key is None:
@@ -295,10 +335,17 @@ def dedupe_replayed_side_effect_input_items(input_items: list[JsonValue]) -> tup
             if call_id is not None
             else None
         )
+        output_index_by_call_index[index] = output_index
         if key not in first_call_id_by_key:
             first_call_id_by_key[key] = call_id
+            first_call_index_by_key[key] = index
             continue
 
+        first_call_index = first_call_index_by_key.get(key)
+        if first_call_index is not None and output_index_by_call_index.get(first_call_index) is None:
+            rewritten[first_call_index] = replayed_tool_call_without_output_as_assistant_message(
+                cast(Mapping[str, JsonValue], input_items[first_call_index])
+            )
         removed_count += 1
         kept[index] = False
         if output_index is not None:
@@ -306,14 +353,29 @@ def dedupe_replayed_side_effect_input_items(input_items: list[JsonValue]) -> tup
             if isinstance(output_item, dict):
                 rewritten[output_index] = replayed_tool_output_as_assistant_message(output_item)
 
+    missing_output_rewrites = 0
+    if sanitize_missing_outputs:
+        for index, key in call_keys.items():
+            del key
+            if not kept[index] or index in rewritten:
+                continue
+            if output_index_by_call_index.get(index) is not None:
+                continue
+            item = input_items[index]
+            if not isinstance(item, dict):
+                continue
+            rewritten[index] = replayed_tool_call_without_output_as_assistant_message(item)
+            missing_output_rewrites += 1
+
     if removed_count == 0:
-        return input_items, 0
+        if missing_output_rewrites == 0:
+            return input_items, 0
 
     deduped_items: list[JsonValue] = []
     for index, item in enumerate(input_items):
         if kept[index]:
             deduped_items.append(rewritten.get(index, item))
-    return deduped_items, removed_count
+    return deduped_items, removed_count + missing_output_rewrites
 
 
 def replayed_side_effect_tool_call_key(item: Mapping[str, JsonValue]) -> tuple[str, str | None, str] | None:
@@ -389,6 +451,21 @@ def replayed_tool_output_as_assistant_message(item: Mapping[str, JsonValue]) -> 
     }
 
 
+def replayed_tool_call_without_output_as_assistant_message(item: Mapping[str, JsonValue]) -> JsonValue:
+    name_value = item.get("name")
+    name = name_value if isinstance(name_value, str) and name_value else "tool"
+    return {
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "output_text",
+                "text": f"Omitted replayed side-effect tool call without matching output: {name}.",
+            }
+        ],
+    }
+
+
 def replayed_tool_output_index_for_call(
     output_indices_by_call_id: dict[str, list[int]],
     next_output_cursor_by_call_id: dict[str, int],
@@ -434,10 +511,11 @@ def canonical_parallel_tool_use_key(tool_use: dict[str, JsonValue]) -> str:
     parameters = tool_use.get("parameters")
     if not isinstance(recipient_name, str):
         return json.dumps(tool_use, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    if recipient_name == "functions.write_stdin" and isinstance(parameters, dict):
+    normalized_recipient_name = normalize_tool_call_name(recipient_name)
+    if normalized_recipient_name == "write_stdin" and isinstance(parameters, dict):
         return json.dumps(
             {
-                "recipient_name": recipient_name,
+                "recipient_name": normalized_recipient_name,
                 "session_id": parameters.get("session_id"),
                 "chars": parameters.get("chars"),
             },
@@ -445,20 +523,28 @@ def canonical_parallel_tool_use_key(tool_use: dict[str, JsonValue]) -> str:
             separators=(",", ":"),
             ensure_ascii=False,
         )
-    if recipient_name == "functions.wait_agent" and isinstance(parameters, dict):
+    if normalized_recipient_name == "wait_agent" and isinstance(parameters, dict):
         targets = parameters.get("targets")
         return json.dumps(
             {
-                "recipient_name": recipient_name,
+                "recipient_name": normalized_recipient_name,
                 "targets": canonical_wait_agent_targets(targets),
             },
             sort_keys=True,
             separators=(",", ":"),
             ensure_ascii=False,
         )
-    if recipient_name == "functions.exec_command" and isinstance(parameters, dict):
-        return canonical_parameters_key(recipient_name, cast(dict[str, JsonValue], parameters))
+    if normalized_recipient_name == "exec_command" and isinstance(parameters, dict):
+        return canonical_parameters_key(normalized_recipient_name, cast(dict[str, JsonValue], parameters))
     return json.dumps(tool_use, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def normalize_tool_call_name(name: str | None) -> str | None:
+    if name is None:
+        return None
+    if name.startswith("functions."):
+        return name.removeprefix("functions.")
+    return name
 
 
 def dedupe_parallel_tool_uses_argument(argument_value: str) -> tuple[str, bool, int]:

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -98,8 +98,8 @@ def mark_duplicate_tool_call_downstream_event(
     call_id = item.get("call_id")
     if call_id is not None and not isinstance(call_id, str):
         call_id = None
-    is_side_effect_tool_call = (
-        item_type in _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES or item_name in _SIDE_EFFECT_TOOL_CALL_NAMES
+    is_side_effect_tool_call = item_type in _SIDE_EFFECT_TOOL_CALL_ITEM_TYPES or (
+        item_name in _SIDE_EFFECT_TOOL_CALL_NAMES and _tool_call_has_side_effect_arguments(item_name, argument_value)
     )
     # Same-response replays have shown distinct call_ids for byte-identical shell/edit requests.
     # For local side-effect tools, running the same payload twice is worse than dropping a duplicate-looking call_id.
@@ -176,6 +176,25 @@ def canonical_side_effect_argument_key(item_name: str | None, argument_value: st
     canonical_argument = dict(argument)
     canonical_argument["tool_uses"] = canonical_tool_uses
     return canonical_json_key(cast(JsonValue, canonical_argument))
+
+
+def _tool_call_has_side_effect_arguments(item_name: str | None, argument_value: str) -> bool:
+    if item_name != _PARALLEL_TOOL_CALL_NAME:
+        return item_name in _SIDE_EFFECT_TOOL_CALL_NAMES
+
+    argument = json_object_from_argument(argument_value)
+    if argument is None:
+        return False
+    tool_uses = argument.get("tool_uses")
+    if not isinstance(tool_uses, list):
+        return False
+    for tool_use in tool_uses:
+        if not isinstance(tool_use, dict):
+            continue
+        recipient_name = tool_use.get("recipient_name")
+        if isinstance(recipient_name, str) and recipient_name in _PARALLEL_TOOL_USE_DEDUPE_RECIPIENT_NAMES:
+            return True
+    return False
 
 
 def canonical_parallel_tool_use_key(tool_use: dict[str, JsonValue]) -> str:
@@ -293,7 +312,7 @@ def rewrite_parallel_tool_call_text(
         return text, payload, event, event_type_from_payload(event, payload), event_block
     assert rewritten_payload is not None
     rewritten_text = json.dumps(rewritten_payload, ensure_ascii=True, separators=(",", ":"))
-    rewritten_event_block = f"data: {rewritten_text}\n\n"
+    rewritten_event_block = format_sse_event(rewritten_payload)
     rewritten_event = parse_sse_event(rewritten_event_block)
     return (
         rewritten_text,

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -375,10 +375,7 @@ def dedupe_replayed_side_effect_input_items(
                 and first_call_id_by_key.get(last_side_effect_key) == output_call_id
             ):
                 continue
-            if (
-                output_call_id is not None
-                or (isinstance(item, dict) and replayed_tool_call_segment_boundary(item))
-            ):
+            if output_call_id is not None or (isinstance(item, dict) and replayed_tool_call_segment_boundary(item)):
                 first_call_id_by_key.clear()
                 first_call_index_by_key.clear()
                 last_side_effect_key = None

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -55,6 +55,8 @@ def event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonVa
     payload_type = payload.get("type")
     if isinstance(payload_type, str):
         return payload_type
+    if isinstance(payload.get("error"), dict):
+        return "error"
     return None
 
 
@@ -243,6 +245,7 @@ def canonical_side_effect_argument_key(item_name: str | None, argument_value: st
                 "name": normalized_item_name,
                 "session_id": argument.get("session_id"),
                 "chars": argument.get("chars"),
+                "yield_time_ms": argument.get("yield_time_ms"),
             }
         )
     if normalized_item_name == "wait_agent":
@@ -520,6 +523,7 @@ def canonical_parallel_tool_use_key(tool_use: dict[str, JsonValue]) -> str:
                 "recipient_name": normalized_recipient_name,
                 "session_id": parameters.get("session_id"),
                 "chars": parameters.get("chars"),
+                "yield_time_ms": parameters.get("yield_time_ms"),
             },
             sort_keys=True,
             separators=(",", ":"),

--- a/openspec/changes/harden-long-codex-websocket-turns/proposal.md
+++ b/openspec/changes/harden-long-codex-websocket-turns/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Long-running Codex turns can legitimately spend more than five minutes between
+observable upstream stream events while the agent is compacting context or
+executing tool-heavy work. The previous defaults treated that silence as a
+local timeout: compact budget was capped at 75 seconds and upstream stream idle
+watching at 300 seconds. That made the proxy return `upstream_unavailable` or
+surface `stream_incomplete` even while the client still expected the same turn
+to continue.
+
+The failover path also did not penalize an account when an upstream websocket
+closed before the pending streamed response reached a terminal event. The
+client saw an incomplete stream, but the next routing decision had no recent
+transient-failure signal for that account.
+
+## What Changes
+
+- Raise the default compact request budget to 180 seconds.
+- Raise the upstream stream idle timeout to 600 seconds so long Codex turns have
+  the same end-to-end budget as the general proxy request budget.
+- When an upstream websocket closes with pending streamed responses that have
+  not reached a terminal event, record a transient account error before
+  completing those pending futures with `stream_incomplete`.
+
+## Impact
+
+- Long Codex turns are less likely to be interrupted by local proxy watchdogs.
+- Account selection can temporarily avoid an upstream account that just dropped
+  in-flight websocket responses.
+- The change does not hide terminal upstream failures. Completed responses,
+  explicit upstream error frames, and normal client disconnect handling keep
+  their existing behavior.

--- a/openspec/changes/harden-long-codex-websocket-turns/tasks.md
+++ b/openspec/changes/harden-long-codex-websocket-turns/tasks.md
@@ -1,0 +1,6 @@
+- [x] Increase default compact and stream idle budgets for long Codex turns.
+- [x] Record a transient account error when an upstream websocket closes before
+      pending streamed responses complete.
+- [x] Add focused regression coverage for the new defaults and websocket drop
+      penalty behavior.
+- [x] Run focused proxy/config tests and OpenSpec validation before merge.

--- a/openspec/changes/suppress-duplicate-side-effect-tool-calls/proposal.md
+++ b/openspec/changes/suppress-duplicate-side-effect-tool-calls/proposal.md
@@ -1,0 +1,10 @@
+# Change Proposal
+
+Codex sessions can receive replayed `response.output_item.done` tool-call events with a new `call_id` but the same side-effecting operation. Passing both copies through causes duplicate local shell writes, terminal polls, or patch applications.
+
+## Changes
+
+- Suppress duplicate same-response downstream tool-call events for local side-effect tools.
+- Treat `exec_command`, `write_stdin`, and `apply_patch_call` as side-effecting operations where `call_id` changes do not make a replay safe.
+- Rewrite `multi_tool_use.parallel` arguments before forwarding so duplicate nested side-effect operations are removed from a single batch.
+- Keep distinct read-only calls and calls under later response ids visible.

--- a/openspec/changes/suppress-duplicate-side-effect-tool-calls/specs/responses-api-compat/spec.md
+++ b/openspec/changes/suppress-duplicate-side-effect-tool-calls/specs/responses-api-compat/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Same-response side-effect tool-call replays are suppressed
+
+When the proxy receives multiple downstream `response.output_item.done` events for the same response that describe the same side-effecting local tool operation, the proxy SHALL forward only the first event to the client.
+
+The proxy SHALL treat `exec_command`, `write_stdin`, `multi_tool_use.parallel`, and `apply_patch_call` events as side-effecting. For these tools, a changed `call_id` alone MUST NOT make a same-response replay distinct.
+
+When a `multi_tool_use.parallel` event contains duplicate nested side-effect operations, the proxy SHALL remove the duplicate nested operations before forwarding the event. Duplicate nested `exec_command` operations MUST ignore volatile output/wait fields such as `yield_time_ms` and `max_output_tokens`. Duplicate nested `write_stdin` operations MUST be scoped by `session_id` and `chars`. Duplicate nested `wait_agent` operations MUST be scoped by the target set.
+
+Read-only function calls and matching operations under different response ids MUST continue to pass through.
+
+#### Scenario: side-effect call replay uses a new call id
+
+- **WHEN** a streamed response emits two `exec_command` output items with the same response id and arguments but different call ids
+- **THEN** the proxy forwards the first event
+- **AND** suppresses the second event
+
+#### Scenario: read-only call ids stay distinct
+
+- **WHEN** a streamed response emits two read-only function calls with the same arguments and different call ids
+- **THEN** the proxy forwards both events
+
+#### Scenario: later response ids stay distinct
+
+- **WHEN** two responses emit the same side-effecting operation under different response ids
+- **THEN** the proxy forwards both events
+
+#### Scenario: parallel batch contains duplicate shell operations
+
+- **WHEN** a `multi_tool_use.parallel` event contains two nested `functions.exec_command` operations with the same command and only different wait/output fields
+- **THEN** the proxy forwards one nested operation inside the parallel batch
+- **AND** does not forward the duplicate nested operation to the client

--- a/openspec/changes/suppress-duplicate-side-effect-tool-calls/tasks.md
+++ b/openspec/changes/suppress-duplicate-side-effect-tool-calls/tasks.md
@@ -1,0 +1,5 @@
+- [x] Add downstream side-effect tool-call dedupe for HTTP streams, websocket streams, and the HTTP responses bridge.
+- [x] Suppress same-response `exec_command`, `write_stdin`, and `apply_patch_call` replays even when `call_id` changes.
+- [x] Remove duplicate nested side-effect operations from `multi_tool_use.parallel` batches before forwarding.
+- [x] Preserve distinct read-only calls and repeated operations under later response ids.
+- [x] Add regression tests for same-response replay suppression, read-only pass-through, response-id scoping, and cache bounds.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -49,3 +49,20 @@ When the HTTP responses bridge observes an upstream websocket close with `close_
 - **WHEN** upstream closes the HTTP responses bridge with `close_code = 1000` before any `response.*` event for the pending request
 - **THEN** the proxy returns HTTP 502 with `error.code = "upstream_rejected_input"`
 - **AND** does not transparently replay the pre-created request
+
+### Requirement: Long Codex websocket turns tolerate extended upstream silence
+The default compact request budget MUST be at least 180 seconds, and the default upstream stream idle timeout MUST be at least 600 seconds, so long-running Codex turns can survive expensive compaction or tool execution without a local proxy watchdog ending the turn prematurely.
+
+#### Scenario: compact and stream watchdog defaults leave room for long turns
+- **WHEN** the service starts with default configuration
+- **THEN** `compact_request_budget_seconds` is at least 180 seconds
+- **AND** `stream_idle_timeout_seconds` is at least 600 seconds
+
+### Requirement: Upstream websocket drops penalize affected accounts
+When an upstream websocket closes while one or more streamed response requests are pending and have not reached a terminal event, the proxy MUST record a transient upstream error for the account before surfacing `stream_incomplete` to those pending requests.
+
+#### Scenario: websocket closes before pending responses complete
+- **GIVEN** a streamed response request is pending on an upstream websocket
+- **WHEN** the websocket closes before a terminal response event is observed
+- **THEN** the pending request fails with `stream_incomplete`
+- **AND** the account receives a transient upstream failure signal for routing

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
+from types import SimpleNamespace
 
 import pytest
+from fastapi.responses import StreamingResponse
 from sqlalchemy import select
+from starlette.requests import Request
 
+import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
 from app.core.clients.proxy import ProxyResponseError
+from app.core.utils.sse import SSE_KEEPALIVE_FRAME
 from app.db.models import Account, AccountStatus, RequestLog
 from app.db.session import SessionLocal
+from app.dependencies import ProxyContext
 
 pytestmark = pytest.mark.integration
 
@@ -151,6 +158,59 @@ async def test_proxy_stream_records_cached_and_reasoning_tokens(async_client, mo
         assert log.cached_input_tokens == 3
         assert log.reasoning_tokens == 2
         assert log.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event(monkeypatch):
+    upstream_started = asyncio.Event()
+    release_upstream = asyncio.Event()
+
+    class _FakeService:
+        async def rate_limit_headers(self):
+            return {}
+
+        async def stream_responses(self, *args, **kwargs):
+            del args, kwargs
+            upstream_started.set()
+            await release_upstream.wait()
+            event = {"type": "response.completed", "response": {"id": "resp_delayed"}}
+            yield _sse_event(event)
+
+    settings = SimpleNamespace(
+        http_responses_session_bridge_enabled=False,
+        sse_keepalive_interval_seconds=0.01,
+    )
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module.proxy_service_module, "get_settings", lambda: settings)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/backend-api/codex/responses",
+            "headers": [],
+        }
+    )
+    payload = proxy_api_module.ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    )
+
+    response = await proxy_api_module._stream_responses(
+        request,
+        payload,
+        ProxyContext(service=_FakeService()),
+        api_key=None,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    assert upstream_started.is_set() is False
+    iterator = response.body_iterator.__aiter__()
+    first_chunk = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert first_chunk == SSE_KEEPALIVE_FRAME
+    assert upstream_started.is_set() is True
+    release_upstream.set()
+    chunks = [await asyncio.wait_for(iterator.__anext__(), timeout=0.2) for _ in range(2)]
+    assert any("response.completed" in chunk for chunk in chunks)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from fastapi.responses import StreamingResponse
@@ -198,7 +199,7 @@ async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event
     response = await proxy_api_module._stream_responses(
         request,
         payload,
-        ProxyContext(service=_FakeService()),
+        ProxyContext(service=cast(proxy_module.ProxyService, _FakeService())),
         api_key=None,
     )
 
@@ -209,7 +210,7 @@ async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event
     assert first_chunk == SSE_KEEPALIVE_FRAME
     assert upstream_started.is_set() is True
     release_upstream.set()
-    chunks = [await asyncio.wait_for(iterator.__anext__(), timeout=0.2) for _ in range(2)]
+    chunks = [cast(str, await asyncio.wait_for(iterator.__anext__(), timeout=0.2)) for _ in range(2)]
     assert any("response.completed" in chunk for chunk in chunks)
 
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -204,11 +204,10 @@ async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event
     )
 
     assert isinstance(response, StreamingResponse)
-    assert upstream_started.is_set() is False
+    assert upstream_started.is_set() is True
     iterator = response.body_iterator.__aiter__()
     first_chunk = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
     assert first_chunk == SSE_KEEPALIVE_FRAME
-    assert upstream_started.is_set() is True
     release_upstream.set()
     chunks = [cast(str, await asyncio.wait_for(iterator.__anext__(), timeout=0.2)) for _ in range(2)]
     assert any("response.completed" in chunk for chunk in chunks)

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -110,6 +110,7 @@ def _websocket_settings(**overrides):
         "stream_idle_timeout_seconds": 300.0,
         "proxy_downstream_websocket_idle_timeout_seconds": 120.0,
         "http_responses_session_bridge_instance_id": "test-instance",
+        "sse_keepalive_interval_seconds": 10.0,
         "log_proxy_request_shape": False,
         "log_proxy_request_shape_raw_cache_key": False,
         "proxy_token_refresh_limit": 32,
@@ -3449,6 +3450,7 @@ def test_backend_responses_websocket_emits_timeout_failure_for_stalled_upstream(
         ]
     )
     log_calls: list[dict[str, object]] = []
+    handled_error_codes: list[str] = []
     connect_attempts = {"count": 0}
 
     class _FakeSettingsCache:
@@ -3487,7 +3489,20 @@ def test_backend_responses_websocket_emits_timeout_failure_for_stalled_upstream(
         connect_attempts["count"] += 1
         if connect_attempts["count"] == 1:
             del client_send_lock, websocket, request_state
-            return SimpleNamespace(id="acct_ws_proxy"), fake_upstream
+            return (
+                proxy_module.Account(
+                    id="acct_ws_proxy",
+                    chatgpt_account_id="acct_ws_proxy",
+                    email="acct_ws_proxy@example.com",
+                    plan_type="plus",
+                    access_token_encrypted=b"access",
+                    refresh_token_encrypted=b"refresh",
+                    id_token_encrypted=b"id",
+                    last_refresh=proxy_module.utcnow(),
+                    status=proxy_module.AccountStatus.ACTIVE,
+                ),
+                fake_upstream,
+            )
         async with client_send_lock:
             await websocket.send_text(json.dumps({"type": "error", "status": 503, "error": {"code": "no_accounts"}}))
         return None, None
@@ -3496,11 +3511,16 @@ def test_backend_responses_websocket_emits_timeout_failure_for_stalled_upstream(
         del self
         log_calls.append(kwargs)
 
+    async def fake_handle_stream_error(self, account, error, code):
+        del self, account, error
+        handled_error_codes.append(code)
+
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
     monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
     monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
     monkeypatch.setattr(proxy_module, "get_settings", lambda: runtime_settings)
     monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_handle_stream_error", fake_handle_stream_error)
     monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
 
     request_payload = {
@@ -3527,6 +3547,7 @@ def test_backend_responses_websocket_emits_timeout_failure_for_stalled_upstream(
     assert failed_event["response"]["error"]["message"] == "Upstream stream idle timeout"
     assert fake_upstream.closed is True
     assert connect_attempts["count"] == 2
+    assert handled_error_codes == ["stream_idle_timeout"]
     assert followup_event["type"] == "error"
     assert followup_event["status"] == 503
     assert followup_event["error"]["code"] == "no_accounts"

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -262,7 +262,7 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     assert log["output_tokens"] == 5
 
 
-def test_backend_responses_websocket_fails_completion_after_suppressed_duplicate_tool_call(
+def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
     app_instance,
     monkeypatch,
 ):
@@ -401,18 +401,18 @@ def test_backend_responses_websocket_fails_completion_after_suppressed_duplicate
             websocket.send_text(json.dumps(request_payload))
             created_event = json.loads(websocket.receive_text())
             tool_event = json.loads(websocket.receive_text())
+            replay_tool_event = json.loads(websocket.receive_text())
             terminal_event = json.loads(websocket.receive_text())
 
     assert created_event["type"] == "response.created"
     assert tool_event["type"] == "response.output_item.done"
     assert tool_event["item"]["call_id"] == "call_first"
-    assert terminal_event["type"] == "response.failed"
+    assert replay_tool_event["type"] == "response.output_item.done"
+    assert replay_tool_event["item"]["call_id"] == "call_replay"
+    assert terminal_event["type"] == "response.completed"
     assert terminal_event["response"]["id"] == "resp_ws_duplicate_tool"
-    assert terminal_event["response"]["error"]["code"] == "stream_incomplete"
-    assert "call_replay" not in json.dumps([created_event, tool_event, terminal_event])
     assert len(log_calls) == 1
-    assert log_calls[0]["status"] == "error"
-    assert log_calls[0]["error_code"] == "stream_incomplete"
+    assert log_calls[0]["status"] == "success"
 
 
 def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app_instance, monkeypatch):

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -983,6 +983,114 @@ def test_backend_responses_websocket_forwards_previous_response_id(app_instance,
     ]
 
 
+def test_backend_responses_websocket_trims_replayed_tool_call_items_with_previous_response_id(
+    app_instance,
+    monkeypatch,
+):
+    fake_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": "resp_ws_tool_output", "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.completed", "response": {"id": "resp_ws_tool_output", "status": "completed"}},
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+    ):
+        del self, headers, sticky_key, sticky_kind, prefer_earlier_reset, routing_strategy, model
+        del request_state, api_key, client_send_lock, websocket, reallocate_sticky, sticky_max_age_seconds
+        return SimpleNamespace(id="acct_ws_tool_output"), fake_upstream
+
+    async def fake_write_request_log(self, **kwargs):
+        del self, kwargs
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "previous_response_id": "resp_prev_tool_call",
+        "input": [
+            {"type": "reasoning", "summary": []},
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "running command"}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_repeat",
+                "name": "exec_command",
+                "arguments": '{"cmd":"date"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_repeat",
+                "output": "Wed May 6 16:00:00 UTC 2026",
+            },
+        ],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            first = json.loads(websocket.receive_text())
+            second = json.loads(websocket.receive_text())
+
+    assert first["type"] == "response.created"
+    assert second["type"] == "response.completed"
+    sent_payload = json.loads(fake_upstream.sent_text[0])
+    assert sent_payload["previous_response_id"] == "resp_prev_tool_call"
+    assert sent_payload["input"] == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_repeat",
+            "output": "Wed May 6 16:00:00 UTC 2026",
+        }
+    ]
+
+
 def test_v1_responses_websocket_forwards_previous_response_id(app_instance, monkeypatch):
     fake_upstream = _FakeUpstreamWebSocket(
         [
@@ -3426,6 +3534,103 @@ def test_backend_responses_websocket_emits_timeout_failure_for_stalled_upstream(
     assert log_calls[0]["request_id"] == "resp_ws_idle"
     assert log_calls[0]["error_code"] == "stream_idle_timeout"
     assert log_calls[0]["error_message"] == "Upstream stream idle timeout"
+
+
+def test_backend_responses_websocket_treats_typeless_upstream_error_as_terminal(app_instance, monkeypatch):
+    fake_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": "resp_ws_raw_error", "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "error": {
+                            "type": "invalid_request_error",
+                            "message": "No tool output found for function call call_missing.",
+                            "param": "input",
+                        },
+                        "status": 400,
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+    log_calls: list[dict[str, object]] = []
+    connect_attempts = {"count": 0}
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del self, headers, sticky_key, sticky_kind, reallocate_sticky, sticky_max_age_seconds
+        del prefer_earlier_reset, routing_strategy, model, request_state, api_key
+        del client_send_lock, websocket
+        connect_attempts["count"] += 1
+        return SimpleNamespace(id="acct_ws_proxy"), fake_upstream
+
+    async def fake_write_request_log(self, **kwargs):
+        del self
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            created_event = json.loads(websocket.receive_text())
+            error_event = json.loads(websocket.receive_text())
+
+    assert created_event["type"] == "response.created"
+    assert error_event["status"] == 400
+    assert error_event["error"]["type"] == "invalid_request_error"
+    assert error_event["error"]["param"] == "input"
+    assert connect_attempts["count"] == 1
+    assert len(log_calls) == 1
+    assert log_calls[0]["request_id"] == "resp_ws_raw_error"
+    assert log_calls[0]["status"] == "error"
+    assert log_calls[0]["error_code"] == "invalid_request_error"
+    assert log_calls[0]["error_message"] == "No tool output found for function call call_missing."
 
 
 def test_backend_responses_websocket_emits_terminal_failure_when_upstream_send_breaks(app_instance, monkeypatch):

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -262,6 +262,159 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     assert log["output_tokens"] == 5
 
 
+def test_backend_responses_websocket_fails_completion_after_suppressed_duplicate_tool_call(
+    app_instance,
+    monkeypatch,
+):
+    duplicate_arguments = json.dumps(
+        {"session_id": 41288, "chars": "", "yield_time_ms": 30000, "max_output_tokens": 6000},
+        separators=(",", ":"),
+    )
+    upstream_messages = [
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp_ws_duplicate_tool", "status": "in_progress"},
+                },
+                separators=(",", ":"),
+            ),
+        ),
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "id": "fc_first",
+                        "type": "function_call",
+                        "status": "completed",
+                        "arguments": duplicate_arguments,
+                        "call_id": "call_first",
+                        "name": "write_stdin",
+                    },
+                    "output_index": 0,
+                },
+                separators=(",", ":"),
+            ),
+        ),
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "id": "fc_replay",
+                        "type": "function_call",
+                        "status": "completed",
+                        "arguments": duplicate_arguments,
+                        "call_id": "call_replay",
+                        "name": "write_stdin",
+                    },
+                    "output_index": 0,
+                },
+                separators=(",", ":"),
+            ),
+        ),
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_duplicate_tool",
+                        "status": "completed",
+                        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ),
+    ]
+    fake_upstream = _FakeUpstreamWebSocket(upstream_messages)
+    log_calls: list[dict[str, object]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return SimpleNamespace(id="acct_ws_duplicate_tool"), fake_upstream
+
+    async def fake_write_request_log(self, **kwargs):
+        del self
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            created_event = json.loads(websocket.receive_text())
+            tool_event = json.loads(websocket.receive_text())
+            terminal_event = json.loads(websocket.receive_text())
+
+    assert created_event["type"] == "response.created"
+    assert tool_event["type"] == "response.output_item.done"
+    assert tool_event["item"]["call_id"] == "call_first"
+    assert terminal_event["type"] == "response.failed"
+    assert terminal_event["response"]["id"] == "resp_ws_duplicate_tool"
+    assert terminal_event["response"]["error"]["code"] == "stream_incomplete"
+    assert "call_replay" not in json.dumps([created_event, tool_event, terminal_event])
+    assert len(log_calls) == 1
+    assert log_calls[0]["status"] == "error"
+    assert log_calls[0]["error_code"] == "stream_incomplete"
+
+
 def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app_instance, monkeypatch):
     upstream_messages = [
         _FakeUpstreamMessage(

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -523,7 +523,7 @@ def test_public_previous_response_top_level_error_envelope_is_parsed_for_masking
     assert "resp_missing" not in masked.model_dump_json()
 
 
-def test_public_missing_tool_output_error_is_parsed_for_masking():
+def test_public_missing_tool_output_input_error_preserves_client_status():
     payload = {
         "type": "error",
         "status": 400,
@@ -538,7 +538,8 @@ def test_public_missing_tool_output_error_is_parsed_for_masking():
     parsed = proxy_api_module._parse_error_envelope(payload)
     status_code, masked = proxy_api_module._mask_previous_response_not_found_error(parsed, default_status=400)
 
-    assert status_code == 502
+    assert status_code == 400
     error = masked.model_dump(mode="json")["error"]
-    assert error["code"] == "stream_incomplete"
-    assert "call_W3U0TC60cgB5OD7gVCyS0qIq" not in masked.model_dump_json()
+    assert error["code"] == "invalid_request_error"
+    assert error["param"] == "input"
+    assert "call_W3U0TC60cgB5OD7gVCyS0qIq" in masked.model_dump_json()

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -521,3 +521,24 @@ def test_public_previous_response_top_level_error_envelope_is_parsed_for_masking
     error = masked.model_dump(mode="json")["error"]
     assert error["code"] == "stream_incomplete"
     assert "resp_missing" not in masked.model_dump_json()
+
+
+def test_public_missing_tool_output_error_is_parsed_for_masking():
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "message": "No tool output found for function call call_W3U0TC60cgB5OD7gVCyS0qIq.",
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "param": "input",
+        },
+    }
+
+    parsed = proxy_api_module._parse_error_envelope(payload)
+    status_code, masked = proxy_api_module._mask_previous_response_not_found_error(parsed, default_status=400)
+
+    assert status_code == 502
+    error = masked.model_dump(mode="json")["error"]
+    assert error["code"] == "stream_incomplete"
+    assert "call_W3U0TC60cgB5OD7gVCyS0qIq" not in masked.model_dump_json()

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5133,7 +5133,7 @@ async def test_process_http_bridge_upstream_text_masks_unmatched_missing_tool_ou
         reasoning_effort=None,
         api_key_reservation=None,
         started_at=1.0,
-        previous_response_id="resp_missing_tool_b",
+        previous_response_id="resp_missing_tool_a",
         event_queue=asyncio.Queue(),
         transport="http",
         skip_request_log=True,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5052,6 +5052,100 @@ async def test_process_http_bridge_upstream_text_masks_single_previous_response_
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_masks_unmatched_missing_tool_output_followups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    finalize_request_state = AsyncMock()
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    request_state_a = proxy_service._WebSocketRequestState(
+        request_id="req-missing-tool-a",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_missing_tool_a",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    request_state_b = proxy_service._WebSocketRequestState(
+        request_id="req-missing-tool-b",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_missing_tool_b",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state_a, request_state_b]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(2),
+        queued_request_count=2,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "No tool output found for function call call_missing_output.",
+                    "param": "input",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    for request_state in (request_state_a, request_state_b):
+        event_queue = request_state.event_queue
+        assert event_queue is not None
+        event_block = await event_queue.get()
+        assert event_block is not None
+        assert await event_queue.get() is None
+        payload = proxy_service.parse_sse_data_json(event_block)
+        assert isinstance(payload, dict)
+        response = payload.get("response")
+        assert isinstance(response, dict)
+        error = response.get("error")
+        assert isinstance(error, dict)
+        assert payload["type"] == "response.failed"
+        assert error["code"] == "stream_incomplete"
+        assert "call_missing_output" not in json.dumps(payload)
+        assert request_state.error_http_status_override == 502
+
+    assert session.upstream_control.reconnect_requested is True
+    assert session.pending_requests == deque()
+    assert session.queued_request_count == 0
+    assert finalize_request_state.await_count == 2
+    finalized_requests = [call.args[0] for call in finalize_request_state.await_args_list]
+    assert finalized_requests == [request_state_a, request_state_b]
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_request_on_fresh_upstream_reconnects_without_resending_previous_response_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5052,6 +5052,60 @@ async def test_process_http_bridge_upstream_text_masks_single_previous_response_
 
 
 @pytest.mark.asyncio
+async def test_retry_http_bridge_request_on_fresh_upstream_reconnects_without_resending_previous_response_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-1",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_prev_1",
+        transport="http",
+    )
+    reconnect = AsyncMock()
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    recovered = await service._retry_http_bridge_request_on_fresh_upstream(
+        session=session,
+        request_state=request_state,
+        text_data='{"type":"response.create","previous_response_id":"resp_prev_1"}',
+        send_request=False,
+    )
+
+    assert recovered is True
+    assert request_state.replay_count == 1
+    reconnect.assert_awaited_once_with(
+        session,
+        request_state=request_state,
+        restart_reader=True,
+    )
+    send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_process_http_bridge_upstream_text_masks_unmatched_missing_tool_output_followups(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5143,60 +5197,6 @@ async def test_process_http_bridge_upstream_text_masks_unmatched_missing_tool_ou
     assert finalize_request_state.await_count == 2
     finalized_requests = [call.args[0] for call in finalize_request_state.await_args_list]
     assert finalized_requests == [request_state_a, request_state_b]
-
-
-@pytest.mark.asyncio
-async def test_retry_http_bridge_request_on_fresh_upstream_reconnects_without_resending_previous_response_id(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    send_text = AsyncMock()
-    session = proxy_service._HTTPBridgeSession(
-        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
-        headers={"x-codex-session-id": "sid-123"},
-        affinity=proxy_service._AffinityPolicy(
-            key="sid-123",
-            kind=proxy_service.StickySessionKind.CODEX_SESSION,
-        ),
-        request_model="gpt-5.4",
-        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
-        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
-        upstream_control=proxy_service._WebSocketUpstreamControl(),
-        pending_requests=deque(),
-        pending_lock=anyio.Lock(),
-        response_create_gate=asyncio.Semaphore(1),
-        queued_request_count=0,
-        last_used_at=1.0,
-        idle_ttl_seconds=120.0,
-    )
-    request_state = proxy_service._WebSocketRequestState(
-        request_id="req-1",
-        model="gpt-5.4",
-        service_tier=None,
-        reasoning_effort=None,
-        api_key_reservation=None,
-        started_at=1.0,
-        previous_response_id="resp_prev_1",
-        transport="http",
-    )
-    reconnect = AsyncMock()
-    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
-
-    recovered = await service._retry_http_bridge_request_on_fresh_upstream(
-        session=session,
-        request_state=request_state,
-        text_data='{"type":"response.create","previous_response_id":"resp_prev_1"}',
-        send_request=False,
-    )
-
-    assert recovered is True
-    assert request_state.replay_count == 1
-    reconnect.assert_awaited_once_with(
-        session,
-        request_state=request_state,
-        restart_reader=True,
-    )
-    send_text.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -131,7 +131,7 @@ async def test_http_bridge_stream_masks_single_top_level_previous_response_error
         )
     ]
 
-    assert session.upstream_control.reconnect_requested is True
+    assert session.upstream_control.reconnect_requested is False
     assert request_state.error_http_status_override == 502
     assert len(events) == 1
     event_block = events[0]
@@ -5046,7 +5046,7 @@ async def test_process_http_bridge_upstream_text_masks_single_previous_response_
     assert "previous_response_not_found" not in json.dumps(payload)
     assert request_state.error_http_status_override == 502
     assert request_state.previous_response_not_found_rewritten is True
-    assert session.upstream_control.reconnect_requested is True
+    assert session.upstream_control.reconnect_requested is False
     assert session.pending_requests == deque()
     assert session.queued_request_count == 0
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5200,6 +5200,84 @@ async def test_process_http_bridge_upstream_text_masks_unmatched_missing_tool_ou
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_does_not_mask_unmatched_missing_tool_output_across_chains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    finalize_request_state = AsyncMock()
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    request_state_a = proxy_service._WebSocketRequestState(
+        request_id="req-missing-tool-a",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_missing_tool_a",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    request_state_b = proxy_service._WebSocketRequestState(
+        request_id="req-missing-tool-b",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_missing_tool_b",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state_a, request_state_b]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(2),
+        queued_request_count=2,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "No tool output found for function call call_missing_output.",
+                    "param": "input",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert session.pending_requests == deque([request_state_a, request_state_b])
+    assert session.queued_request_count == 2
+    assert finalize_request_state.await_count == 0
+    for request_state in (request_state_a, request_state_b):
+        event_queue = request_state.event_queue
+        assert event_queue is not None
+        assert event_queue.empty()
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_request_on_fresh_upstream_refuses_to_resend_previous_response_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5278,6 +5278,83 @@ async def test_process_http_bridge_upstream_text_does_not_mask_unmatched_missing
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_scopes_tool_dedupe_to_request_state() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state_a = proxy_service._WebSocketRequestState(
+        request_id="req-bridge-tool-a",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        response_id="resp_bridge_tool_a",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    request_state_b = proxy_service._WebSocketRequestState(
+        request_id="req-bridge-tool-b",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=2.0,
+        response_id="resp_bridge_tool_b",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state_a, request_state_b]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(2),
+        queued_request_count=2,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    def tool_event(response_id: str, call_id: str) -> str:
+        return json.dumps(
+            {
+                "type": "response.output_item.done",
+                "response": {"id": response_id, "status": "in_progress"},
+                "response_id": response_id,
+                "item": {
+                    "type": "function_call",
+                    "name": "write_stdin",
+                    "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+                    "call_id": call_id,
+                },
+            },
+            separators=(",", ":"),
+        )
+
+    await service._process_http_bridge_upstream_text(session, tool_event("resp_bridge_tool_a", "call_a"))
+    await service._process_http_bridge_upstream_text(session, tool_event("resp_bridge_tool_b", "call_b"))
+
+    assert request_state_a.suppressed_duplicate_tool_call is False
+    assert request_state_b.suppressed_duplicate_tool_call is False
+    queue_a = request_state_a.event_queue
+    queue_b = request_state_b.event_queue
+    assert queue_a is not None
+    assert queue_b is not None
+    event_a = await asyncio.wait_for(queue_a.get(), timeout=0.1)
+    event_b = await asyncio.wait_for(queue_b.get(), timeout=0.1)
+    assert proxy_service.parse_sse_data_json(event_a)["item"]["call_id"] == "call_a"
+    assert proxy_service.parse_sse_data_json(event_b)["item"]["call_id"] == "call_b"
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_request_on_fresh_upstream_refuses_to_resend_previous_response_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5350,8 +5350,18 @@ async def test_process_http_bridge_upstream_text_scopes_tool_dedupe_to_request_s
     assert queue_b is not None
     event_a = await asyncio.wait_for(queue_a.get(), timeout=0.1)
     event_b = await asyncio.wait_for(queue_b.get(), timeout=0.1)
-    assert proxy_service.parse_sse_data_json(event_a)["item"]["call_id"] == "call_a"
-    assert proxy_service.parse_sse_data_json(event_b)["item"]["call_id"] == "call_b"
+    assert event_a is not None
+    assert event_b is not None
+    payload_a = proxy_service.parse_sse_data_json(event_a)
+    payload_b = proxy_service.parse_sse_data_json(event_b)
+    assert isinstance(payload_a, dict)
+    assert isinstance(payload_b, dict)
+    item_a = payload_a.get("item")
+    item_b = payload_b.get("item")
+    assert isinstance(item_a, dict)
+    assert isinstance(item_b, dict)
+    assert item_a["call_id"] == "call_a"
+    assert item_b["call_id"] == "call_b"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -867,7 +867,7 @@ def test_mark_duplicate_tool_call_downstream_event_resets_after_non_side_effect_
     )
 
 
-def test_mark_duplicate_tool_call_downstream_event_resets_after_intervening_side_effect():
+def test_mark_duplicate_tool_call_downstream_event_retains_intervening_side_effects():
     upstream_control = proxy_service._WebSocketUpstreamControl()
     exec_payload: dict[str, JsonValue] = {
         "type": "response.output_item.done",
@@ -921,8 +921,70 @@ def test_mark_duplicate_tool_call_downstream_event_resets_after_intervening_side
             seen_tool_call_keys=upstream_control.seen_tool_call_keys,
             response_id="resp_chain",
         )
-        is False
+        is True
     )
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_side_effect_replay_bursts_across_response_ids():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    exec_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_first",
+        "item": {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": '{"cmd":"pytest","yield_time_ms":1000}',
+            "call_id": "call_exec_a",
+        },
+    }
+    write_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_first",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+            "call_id": "call_write_a",
+        },
+    }
+    exec_replay_payload: dict[str, JsonValue] = {
+        **exec_payload,
+        "response_id": "resp_replay",
+        "item": {
+            **cast(dict[str, JsonValue], exec_payload["item"]),
+            "call_id": "call_exec_b",
+        },
+    }
+    write_replay_payload: dict[str, JsonValue] = {
+        **write_payload,
+        "response_id": "resp_replay",
+        "item": {
+            **cast(dict[str, JsonValue], write_payload["item"]),
+            "call_id": "call_write_b",
+        },
+    }
+
+    for payload in (exec_payload, write_payload):
+        assert (
+            tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+                payload,
+                seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+                response_id=tool_call_dedupe.response_id_from_payload(payload),
+                scope_side_effects_by_response_id=False,
+            )
+            is False
+        )
+
+    for payload in (exec_replay_payload, write_replay_payload):
+        assert (
+            tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+                payload,
+                seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+                response_id=tool_call_dedupe.response_id_from_payload(payload),
+                scope_side_effects_by_response_id=False,
+            )
+            is True
+        )
 
 
 def test_mark_duplicate_tool_call_downstream_event_suppresses_apply_patch_call_replay():
@@ -1044,7 +1106,7 @@ def test_mark_duplicate_tool_call_downstream_event_can_suppress_one_stream_repla
     )
 
 
-def test_mark_duplicate_tool_call_downstream_event_keeps_only_active_side_effect_block():
+def test_mark_duplicate_tool_call_downstream_event_bounds_side_effect_history():
     upstream_control = proxy_service._WebSocketUpstreamControl()
 
     for index in range(tool_call_dedupe._TOOL_CALL_DEDUPE_CACHE_LIMIT + 3):
@@ -1065,7 +1127,7 @@ def test_mark_duplicate_tool_call_downstream_event_keeps_only_active_side_effect
             is False
         )
 
-    assert len(upstream_control.seen_tool_call_keys) == 1
+    assert len(upstream_control.seen_tool_call_keys) == tool_call_dedupe._TOOL_CALL_DEDUPE_CACHE_LIMIT
 
 
 def test_dedupe_replayed_side_effect_input_items_removes_duplicate_call_but_preserves_outputs():

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -172,7 +172,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_namespaced_write_s
         "item": {
             "type": "function_call",
             "name": "write_stdin",
-            "arguments": '{"session_id":17,"chars":"","yield_time_ms":60000,"max_output_tokens":24000}',
+            "arguments": '{"session_id":17,"chars":"","yield_time_ms":1000,"max_output_tokens":24000}',
             "call_id": "call_b",
         },
     }
@@ -265,7 +265,7 @@ def test_rewrite_parallel_tool_call_payload_removes_duplicate_write_stdin_owner(
                 "parameters": {
                     "session_id": 41288,
                     "chars": "",
-                    "yield_time_ms": 1000,
+                    "yield_time_ms": 30000,
                     "max_output_tokens": 2000,
                 },
             },
@@ -895,7 +895,7 @@ def test_dedupe_replayed_side_effect_input_items_removes_duplicate_call_but_pres
             "type": "function_call",
             "name": "write_stdin",
             "arguments": json.dumps(
-                {"session_id": 75180, "chars": "", "yield_time_ms": 1000, "max_output_tokens": 4000}
+                {"session_id": 75180, "chars": "", "yield_time_ms": 30000, "max_output_tokens": 4000}
             ),
             "call_id": "call_replay",
         },
@@ -937,6 +937,28 @@ def test_dedupe_replayed_side_effect_input_items_keeps_distinct_write_payloads()
             "name": "write_stdin",
             "arguments": json.dumps({"session_id": 75180, "chars": "y", "yield_time_ms": 30000}),
             "call_id": "call_input",
+        },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
+def test_dedupe_replayed_side_effect_input_items_keeps_distinct_write_waits():
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000}),
+            "call_id": "call_long_poll",
+        },
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 1000}),
+            "call_id": "call_short_poll",
         },
     ]
 
@@ -1156,6 +1178,30 @@ def test_rewrite_parallel_tool_call_text_preserves_sse_event_name():
     assert rewritten_event_type == "response.output_item.done"
     assert rewritten_event is not None
     assert rewritten_payload is not None
+
+
+def test_rewrite_parallel_tool_call_text_preserves_raw_error_type():
+    payload: dict[str, JsonValue] = {
+        "error": {
+            "type": "invalid_request_error",
+            "message": "Upstream rejected the shared websocket request.",
+        },
+        "status": 400,
+    }
+
+    text, rewritten_payload, rewritten_event, rewritten_event_type, rewritten_event_block = (
+        tool_call_dedupe.rewrite_parallel_tool_call_text(
+            json.dumps(payload, separators=(",", ":")),
+            payload,
+            event_block=f"data: {json.dumps(payload, separators=(',', ':'))}\n\n",
+        )
+    )
+
+    assert rewritten_event_type == "error"
+    assert rewritten_event is None
+    assert rewritten_payload == payload
+    assert text == json.dumps(payload, separators=(",", ":"))
+    assert rewritten_event_block == f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
 
 
 def test_rewrite_parallel_tool_call_payload_removes_duplicate_goal_side_effects():

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -195,6 +195,47 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_namespaced_write_s
     )
 
 
+def test_mark_duplicate_tool_call_downstream_event_suppresses_write_stdin_with_volatile_differences():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_write",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":17,"chars":"","yield_time_ms":1000,"max_output_tokens":4000}',
+            "call_id": "call_a",
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_write",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":17,"chars":"","yield_time_ms":30000,"max_output_tokens":24000}',
+            "call_id": "call_b",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_write",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_write",
+        )
+        is True
+    )
+
+
 def test_rewrite_parallel_tool_call_payload_removes_duplicate_side_effect_tool_uses():
     arguments = {
         "tool_uses": [
@@ -379,6 +420,43 @@ def test_rewrite_parallel_tool_call_payload_tolerates_mixed_wait_agent_targets()
     assert changed is False
     assert removed_count == 0
     assert rewritten_payload is payload
+
+
+def test_rewrite_parallel_tool_call_payload_sorts_wait_agent_mapping_targets_canonically():
+    arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.wait_agent",
+                "parameters": {
+                    "targets": [{"agent": "b", "kind": "spark"}, {"kind": "spark", "agent": "a"}],
+                    "timeout_ms": 30000,
+                },
+            },
+            {
+                "recipient_name": "functions.wait_agent",
+                "parameters": {
+                    "targets": [{"kind": "spark", "agent": "a"}, {"kind": "spark", "agent": "b"}],
+                    "timeout_ms": 60000,
+                },
+            },
+        ]
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": json.dumps(arguments),
+            "call_id": "call_parallel",
+        },
+    }
+
+    rewritten_payload, changed, removed_count = tool_call_dedupe.rewrite_parallel_tool_call_payload(payload)
+
+    assert changed is True
+    assert removed_count == 1
+    assert isinstance(rewritten_payload, dict)
 
 
 def test_rewrite_parallel_tool_call_payload_keeps_duplicate_read_only_connector_uses():
@@ -732,6 +810,121 @@ def test_mark_duplicate_tool_call_downstream_event_keeps_distinct_read_only_call
     )
 
 
+def test_mark_duplicate_tool_call_downstream_event_resets_after_non_side_effect_item():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_chain",
+        "item": {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": '{"cmd":"echo hi","yield_time_ms":1000}',
+            "call_id": "call_a",
+        },
+    }
+    reasoning_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_chain",
+        "item": {
+            "type": "reasoning",
+            "summary": [],
+        },
+    }
+    repeated_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_chain",
+        "item": {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": '{"cmd":"echo hi","yield_time_ms":30000}',
+            "call_id": "call_b",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_chain",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            reasoning_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_chain",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            repeated_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_chain",
+        )
+        is False
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_resets_after_intervening_side_effect():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    exec_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_chain",
+        "item": {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": '{"cmd":"pytest","yield_time_ms":1000}',
+            "call_id": "call_exec_a",
+        },
+    }
+    patch_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_chain",
+        "item": {
+            "type": "apply_patch_call",
+            "operation": {"type": "update_file", "path": "app.py", "diff": "@@\n- old\n+ new\n"},
+            "call_id": "call_patch",
+        },
+    }
+    exec_repeat_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_chain",
+        "item": {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": '{"cmd":"pytest","yield_time_ms":30000}',
+            "call_id": "call_exec_b",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            exec_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_chain",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            patch_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_chain",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            exec_repeat_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_chain",
+        )
+        is False
+    )
+
+
 def test_mark_duplicate_tool_call_downstream_event_suppresses_apply_patch_call_replay():
     upstream_control = proxy_service._WebSocketUpstreamControl()
     first_payload: dict[str, JsonValue] = {
@@ -851,7 +1044,7 @@ def test_mark_duplicate_tool_call_downstream_event_can_suppress_one_stream_repla
     )
 
 
-def test_mark_duplicate_tool_call_downstream_event_bounds_seen_key_cache():
+def test_mark_duplicate_tool_call_downstream_event_keeps_only_active_side_effect_block():
     upstream_control = proxy_service._WebSocketUpstreamControl()
 
     for index in range(tool_call_dedupe._TOOL_CALL_DEDUPE_CACHE_LIMIT + 3):
@@ -861,9 +1054,9 @@ def test_mark_duplicate_tool_call_downstream_event_bounds_seen_key_cache():
                     "type": "response.output_item.done",
                     "item": {
                         "type": "function_call",
-                        "name": "shell",
+                        "name": "exec_command",
                         "call_id": f"call_{index}",
-                        "arguments": f'{{"index":{index}}}',
+                        "arguments": json.dumps({"cmd": f"echo {index}"}),
                     },
                 },
                 seen_tool_call_keys=upstream_control.seen_tool_call_keys,
@@ -872,7 +1065,7 @@ def test_mark_duplicate_tool_call_downstream_event_bounds_seen_key_cache():
             is False
         )
 
-    assert len(upstream_control.seen_tool_call_keys) == tool_call_dedupe._TOOL_CALL_DEDUPE_CACHE_LIMIT
+    assert len(upstream_control.seen_tool_call_keys) == 1
 
 
 def test_dedupe_replayed_side_effect_input_items_removes_duplicate_call_but_preserves_outputs():

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -1088,6 +1088,38 @@ def test_dedupe_replayed_side_effect_input_items_keeps_read_only_custom_tool_cal
     assert deduped_items == input_items
 
 
+def test_dedupe_replayed_side_effect_input_items_resets_across_read_only_tool_call():
+    repeated_arguments = json.dumps({"cmd": "pytest"})
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": repeated_arguments,
+            "call_id": "call_pytest_first",
+        },
+        {"type": "function_call_output", "call_id": "call_pytest_first", "output": "failed"},
+        {
+            "type": "custom_tool_call",
+            "name": "read_context",
+            "input": json.dumps({"path": "README.md"}),
+            "call_id": "call_read",
+        },
+        {"type": "custom_tool_call_output", "call_id": "call_read", "output": "context"},
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": repeated_arguments,
+            "call_id": "call_pytest_second",
+        },
+        {"type": "function_call_output", "call_id": "call_pytest_second", "output": "passed"},
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
 def test_rewrite_parallel_tool_call_text_preserves_sse_event_name():
     arguments = {
         "tool_uses": [

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 import pytest
 
@@ -665,6 +666,219 @@ def test_mark_duplicate_tool_call_downstream_event_bounds_seen_key_cache():
         )
 
     assert len(upstream_control.seen_tool_call_keys) == tool_call_dedupe._TOOL_CALL_DEDUPE_CACHE_LIMIT
+
+
+def test_dedupe_replayed_side_effect_input_items_removes_duplicate_call_but_preserves_outputs():
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps(
+                {"session_id": 75180, "chars": "", "yield_time_ms": 30000, "max_output_tokens": 22000}
+            ),
+            "call_id": "call_first",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_first",
+            "output": "Process running with session ID 75180",
+        },
+        {"type": "reasoning", "summary": []},
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps(
+                {"session_id": 75180, "chars": "", "yield_time_ms": 1000, "max_output_tokens": 4000}
+            ),
+            "call_id": "call_replay",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_replay",
+            "output": "Process exited with code 0",
+        },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 1
+    assert [item.get("type") for item in deduped_items if isinstance(item, dict)] == [
+        "function_call",
+        "function_call_output",
+        "reasoning",
+        "message",
+    ]
+    first_call = cast(dict[str, JsonValue], deduped_items[0])
+    first_output = cast(dict[str, JsonValue], deduped_items[1])
+    replay_output_message = cast(dict[str, JsonValue], deduped_items[-1])
+    assert first_call["call_id"] == "call_first"
+    assert first_output["output"] == "Process running with session ID 75180"
+    assert replay_output_message["role"] == "assistant"
+    assert replay_output_message["content"] == [{"type": "output_text", "text": "Process exited with code 0"}]
+
+
+def test_dedupe_replayed_side_effect_input_items_keeps_distinct_write_payloads():
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000}),
+            "call_id": "call_poll",
+        },
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "y", "yield_time_ms": 30000}),
+            "call_id": "call_input",
+        },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
+def test_dedupe_replayed_side_effect_input_items_resets_across_user_turns():
+    repeated_arguments = json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000})
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": repeated_arguments,
+            "call_id": "call_first",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_first",
+            "output": "first result",
+        },
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "poll again"}]},
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": repeated_arguments,
+            "call_id": "call_second_turn",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_second_turn",
+            "output": "second result",
+        },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
+def test_dedupe_replayed_side_effect_input_items_resets_across_role_only_user_turns():
+    repeated_arguments = json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000})
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": repeated_arguments,
+            "call_id": "call_first",
+        },
+        {"type": "function_call_output", "call_id": "call_first", "output": "first result"},
+        {"role": "user", "content": [{"type": "input_text", "text": "poll again"}]},
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": repeated_arguments,
+            "call_id": "call_second_turn",
+        },
+        {"type": "function_call_output", "call_id": "call_second_turn", "output": "second result"},
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
+def test_dedupe_replayed_side_effect_input_items_preserves_all_outputs_when_call_id_repeats():
+    repeated_arguments = json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000})
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": repeated_arguments,
+            "call_id": "call_same",
+        },
+        {"type": "function_call_output", "call_id": "call_same", "output": "Process running"},
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": repeated_arguments,
+            "call_id": "call_same",
+        },
+        {"type": "function_call_output", "call_id": "call_same", "output": "Process exited"},
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 1
+    assert len(deduped_items) == 3
+    first_output = cast(dict[str, JsonValue], deduped_items[1])
+    replay_output_message = cast(dict[str, JsonValue], deduped_items[-1])
+    assert first_output["output"] == "Process running"
+    assert replay_output_message["content"] == [{"type": "output_text", "text": "Process exited"}]
+
+
+def test_dedupe_replayed_side_effect_input_items_keeps_repeat_after_intervening_side_effect():
+    repeated_arguments = json.dumps({"cmd": "pytest"})
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": repeated_arguments,
+            "call_id": "call_pytest_first",
+        },
+        {"type": "function_call_output", "call_id": "call_pytest_first", "output": "failed"},
+        {
+            "type": "apply_patch_call",
+            "operation": {"type": "update", "path": "app.py"},
+            "call_id": "call_patch",
+        },
+        {"type": "apply_patch_call_output", "call_id": "call_patch", "output": "patched"},
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": repeated_arguments,
+            "call_id": "call_pytest_second",
+        },
+        {"type": "function_call_output", "call_id": "call_pytest_second", "output": "passed"},
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
+def test_dedupe_replayed_side_effect_input_items_keeps_read_only_custom_tool_calls():
+    input_items: list[JsonValue] = [
+        {
+            "type": "custom_tool_call",
+            "name": "read_context",
+            "input": json.dumps({"path": "README.md"}),
+            "call_id": "call_custom_a",
+        },
+        {
+            "type": "custom_tool_call",
+            "name": "read_context",
+            "input": json.dumps({"path": "README.md"}),
+            "call_id": "call_custom_b",
+        },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
 
 
 def test_rewrite_parallel_tool_call_text_preserves_sse_event_name():

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -387,6 +387,88 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_parallel_wrapper_r
     )
 
 
+def test_mark_duplicate_tool_call_downstream_event_trims_overlapping_parallel_replay():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_arguments = json.dumps(
+        {
+            "tool_uses": [
+                {
+                    "recipient_name": "functions.exec_command",
+                    "parameters": {"cmd": "gh pr view --repo Soju06/codex-lb"},
+                },
+                {
+                    "recipient_name": "functions.exec_command",
+                    "parameters": {"cmd": "gh pr checks --repo Soju06/codex-lb"},
+                },
+            ]
+        },
+        separators=(",", ":"),
+    )
+    replay_arguments = json.dumps(
+        {
+            "tool_uses": [
+                {
+                    "recipient_name": "functions.exec_command",
+                    "parameters": {"cmd": "gh pr view --repo Soju06/codex-lb"},
+                },
+                {
+                    "recipient_name": "github.read_file",
+                    "parameters": {"repo": "Soju06/codex-lb", "path": "README.md"},
+                },
+            ]
+        },
+        separators=(",", ":"),
+    )
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel_overlap",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": first_arguments,
+            "call_id": "call_first",
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel_overlap",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": replay_arguments,
+            "call_id": "call_replayed",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_parallel_overlap",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_parallel_overlap",
+        )
+        is False
+    )
+    replay_item = replay_payload["item"]
+    assert isinstance(replay_item, dict)
+    replay_item_arguments = replay_item["arguments"]
+    assert isinstance(replay_item_arguments, str)
+    rewritten_replay_arguments = json.loads(replay_item_arguments)
+    assert rewritten_replay_arguments["tool_uses"] == [
+        {
+            "recipient_name": "github.read_file",
+            "parameters": {"repo": "Soju06/codex-lb", "path": "README.md"},
+        }
+    ]
+
+
 def test_mark_duplicate_tool_call_downstream_event_keeps_read_only_parallel_wrapper_replay():
     upstream_control = proxy_service._WebSocketUpstreamControl()
     arguments = json.dumps(

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from app.core.types import JsonValue
+from app.core.utils.sse import format_sse_event
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy import tool_call_dedupe
 
@@ -386,6 +387,61 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_parallel_wrapper_r
     )
 
 
+def test_mark_duplicate_tool_call_downstream_event_keeps_read_only_parallel_wrapper_replay():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    arguments = json.dumps(
+        {
+            "tool_uses": [
+                {
+                    "recipient_name": "github.read_file",
+                    "parameters": {
+                        "repo": "Soju06/codex-lb",
+                        "path": "README.md",
+                    },
+                }
+            ]
+        },
+        separators=(",", ":"),
+    )
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel_read",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": arguments,
+            "call_id": "call_first",
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel_read",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": arguments,
+            "call_id": "call_replayed",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_parallel_read",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_parallel_read",
+        )
+        is False
+    )
+
+
 def test_mark_duplicate_tool_call_downstream_event_keeps_distinct_read_only_call_ids():
     upstream_control = proxy_service._WebSocketUpstreamControl()
     first_payload: dict[str, JsonValue] = {
@@ -527,3 +583,41 @@ def test_mark_duplicate_tool_call_downstream_event_bounds_seen_key_cache():
         )
 
     assert len(upstream_control.seen_tool_call_keys) == tool_call_dedupe._TOOL_CALL_DEDUPE_CACHE_LIMIT
+
+
+def test_rewrite_parallel_tool_call_text_preserves_sse_event_name():
+    arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.exec_command",
+                "parameters": {"cmd": "gh pr merge"},
+            },
+            {
+                "recipient_name": "functions.exec_command",
+                "parameters": {"cmd": "gh pr merge"},
+            },
+        ]
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": json.dumps(arguments),
+            "call_id": "call_parallel",
+        },
+    }
+
+    _text, rewritten_payload, rewritten_event, rewritten_event_type, rewritten_event_block = (
+        tool_call_dedupe.rewrite_parallel_tool_call_text(
+            json.dumps(payload),
+            payload,
+            event_block=format_sse_event(payload),
+        )
+    )
+
+    assert rewritten_event_block.startswith("event: response.output_item.done\n")
+    assert rewritten_event_type == "response.output_item.done"
+    assert rewritten_event is not None
+    assert rewritten_payload is not None

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -470,6 +470,90 @@ def test_mark_duplicate_tool_call_downstream_event_trims_overlapping_parallel_re
     ]
 
 
+def test_mark_duplicate_tool_call_downstream_event_can_trim_parallel_replay_across_response_ids():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_arguments = json.dumps(
+        {
+            "tool_uses": [
+                {
+                    "recipient_name": "functions.exec_command",
+                    "parameters": {"cmd": "gh pr view --repo Soju06/codex-lb"},
+                },
+                {
+                    "recipient_name": "functions.write_stdin",
+                    "parameters": {"session_id": 1, "chars": ""},
+                },
+            ]
+        },
+        separators=(",", ":"),
+    )
+    replay_arguments = json.dumps(
+        {
+            "tool_uses": [
+                {
+                    "recipient_name": "functions.exec_command",
+                    "parameters": {"cmd": "gh pr view --repo Soju06/codex-lb"},
+                },
+                {
+                    "recipient_name": "github.read_file",
+                    "parameters": {"repo": "Soju06/codex-lb", "path": "README.md"},
+                },
+            ]
+        },
+        separators=(",", ":"),
+    )
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel_first",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": first_arguments,
+            "call_id": "call_first",
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel_replay",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": replay_arguments,
+            "call_id": "call_replayed",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_parallel_first",
+            scope_side_effects_by_response_id=False,
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_parallel_replay",
+            scope_side_effects_by_response_id=False,
+        )
+        is False
+    )
+    replay_item = replay_payload["item"]
+    assert isinstance(replay_item, dict)
+    replay_item_arguments = replay_item["arguments"]
+    assert isinstance(replay_item_arguments, str)
+    rewritten_replay_arguments = json.loads(replay_item_arguments)
+    assert rewritten_replay_arguments["tool_uses"] == [
+        {
+            "recipient_name": "github.read_file",
+            "parameters": {"repo": "Soju06/codex-lb", "path": "README.md"},
+        }
+    ]
+
+
 def test_mark_duplicate_tool_call_downstream_event_keeps_read_only_parallel_wrapper_replay():
     upstream_control = proxy_service._WebSocketUpstreamControl()
     arguments = json.dumps(
@@ -641,6 +725,47 @@ def test_mark_duplicate_tool_call_downstream_event_scopes_by_response_id():
             response_id=tool_call_dedupe.response_id_from_payload(replay_payload),
         )
         is False
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_can_suppress_one_stream_replay_across_response_ids():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_first",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_replay",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id=tool_call_dedupe.response_id_from_payload(first_payload),
+            scope_side_effects_by_response_id=False,
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id=tool_call_dedupe.response_id_from_payload(replay_payload),
+            scope_side_effects_by_response_id=False,
+        )
+        is True
     )
 
 

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -13,7 +13,7 @@ from app.modules.proxy import tool_call_dedupe
 pytestmark = pytest.mark.unit
 
 
-def test_mark_duplicate_tool_call_downstream_event_suppresses_distinct_call_ids_with_same_arguments():
+def test_mark_duplicate_tool_call_downstream_event_keeps_distinct_call_ids_with_same_arguments():
     upstream_control = proxy_service._WebSocketUpstreamControl()
     first_payload: dict[str, JsonValue] = {
         "type": "response.output_item.done",
@@ -60,7 +60,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_distinct_call_ids_
             seen_tool_call_keys=upstream_control.seen_tool_call_keys,
             response_id="resp_dupe",
         )
-        is True
+        is False
     )
     assert (
         tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
@@ -91,7 +91,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_exec_command_with_
             "type": "function_call",
             "name": "exec_command",
             "arguments": '{"max_output_tokens":9000,"cmd":"echo hi","yield_time_ms":30000}',
-            "call_id": "call_b",
+            "call_id": "call_a",
         },
     }
 
@@ -132,7 +132,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_direct_wait_agent_
             "type": "function_call",
             "name": "wait_agent",
             "arguments": '{"targets":["agent_a","agent_b"],"timeout_ms":60000}',
-            "call_id": "call_b",
+            "call_id": "call_a",
         },
     }
 
@@ -173,7 +173,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_namespaced_write_s
             "type": "function_call",
             "name": "write_stdin",
             "arguments": '{"session_id":17,"chars":"","yield_time_ms":1000,"max_output_tokens":24000}',
-            "call_id": "call_b",
+            "call_id": "call_a",
         },
     }
 
@@ -214,7 +214,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_write_stdin_with_v
             "type": "function_call",
             "name": "write_stdin",
             "arguments": '{"session_id":17,"chars":"","yield_time_ms":30000,"max_output_tokens":24000}',
-            "call_id": "call_b",
+            "call_id": "call_a",
         },
     }
 
@@ -921,7 +921,7 @@ def test_mark_duplicate_tool_call_downstream_event_retains_intervening_side_effe
             seen_tool_call_keys=upstream_control.seen_tool_call_keys,
             response_id="resp_chain",
         )
-        is True
+        is False
     )
 
 
@@ -1022,7 +1022,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_apply_patch_call_r
             seen_tool_call_keys=upstream_control.seen_tool_call_keys,
             response_id="resp_dupe",
         )
-        is True
+        is False
     )
 
 

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -1,0 +1,529 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.core.types import JsonValue
+from app.modules.proxy import service as proxy_service
+from app.modules.proxy import tool_call_dedupe
+
+pytestmark = pytest.mark.unit
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_distinct_call_ids_with_same_arguments():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+            "call_id": "call_a",
+        },
+    }
+    second_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+            "call_id": "call_b",
+        },
+    }
+    different_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"x","yield_time_ms":1000}',
+            "call_id": "call_c",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            second_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is True
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            different_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is False
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_exec_command_with_volatile_differences():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": '{"cmd":"echo hi","yield_time_ms":1000,"max_output_tokens":2000}',
+            "call_id": "call_a",
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": '{"max_output_tokens":9000,"cmd":"echo hi","yield_time_ms":30000}',
+            "call_id": "call_b",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is True
+    )
+
+
+def test_rewrite_parallel_tool_call_payload_removes_duplicate_side_effect_tool_uses():
+    arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.exec_command",
+                "parameters": {
+                    "cmd": "gh pr create --repo Komzpa/evince",
+                    "yield_time_ms": 1000,
+                },
+            },
+            {
+                "recipient_name": "functions.exec_command",
+                "parameters": {
+                    "cmd": "gh pr create --repo Komzpa/evince",
+                    "yield_time_ms": 30000,
+                },
+            },
+            {
+                "recipient_name": "functions.exec_command",
+                "parameters": {
+                    "cmd": "gh pr view --repo Komzpa/evince",
+                    "yield_time_ms": 1000,
+                },
+            },
+        ]
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": json.dumps(arguments),
+            "call_id": "call_parallel",
+        },
+    }
+
+    rewritten_payload, changed, removed_count = tool_call_dedupe.rewrite_parallel_tool_call_payload(payload)
+
+    assert changed is True
+    assert removed_count == 1
+    assert isinstance(rewritten_payload, dict)
+    item = rewritten_payload["item"]
+    assert isinstance(item, dict)
+    rewritten_arguments = json.loads(item["arguments"])
+    assert len(rewritten_arguments["tool_uses"]) == 2
+    commands = [tool_use["parameters"]["cmd"] for tool_use in rewritten_arguments["tool_uses"]]
+    assert commands == [
+        "gh pr create --repo Komzpa/evince",
+        "gh pr view --repo Komzpa/evince",
+    ]
+
+
+def test_rewrite_parallel_tool_call_payload_removes_duplicate_write_stdin_owner():
+    arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.write_stdin",
+                "parameters": {
+                    "session_id": 41288,
+                    "chars": "",
+                    "yield_time_ms": 30000,
+                    "max_output_tokens": 6000,
+                },
+            },
+            {
+                "recipient_name": "functions.write_stdin",
+                "parameters": {
+                    "session_id": 41288,
+                    "chars": "",
+                    "yield_time_ms": 1000,
+                    "max_output_tokens": 2000,
+                },
+            },
+            {
+                "recipient_name": "functions.write_stdin",
+                "parameters": {
+                    "session_id": 41288,
+                    "chars": "y",
+                    "yield_time_ms": 1000,
+                },
+            },
+        ]
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": json.dumps(arguments),
+            "call_id": "call_parallel",
+        },
+    }
+
+    rewritten_payload, changed, removed_count = tool_call_dedupe.rewrite_parallel_tool_call_payload(payload)
+
+    assert changed is True
+    assert removed_count == 1
+    assert isinstance(rewritten_payload, dict)
+    item = rewritten_payload["item"]
+    assert isinstance(item, dict)
+    rewritten_arguments = json.loads(item["arguments"])
+    chars = [tool_use["parameters"]["chars"] for tool_use in rewritten_arguments["tool_uses"]]
+    assert chars == ["", "y"]
+
+
+def test_rewrite_parallel_tool_call_payload_removes_duplicate_wait_agent_targets():
+    arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.wait_agent",
+                "parameters": {
+                    "targets": ["agent_b", "agent_a"],
+                    "timeout_ms": 30000,
+                },
+            },
+            {
+                "recipient_name": "functions.wait_agent",
+                "parameters": {
+                    "targets": ["agent_a", "agent_b"],
+                    "timeout_ms": 60000,
+                },
+            },
+        ]
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": json.dumps(arguments),
+            "call_id": "call_parallel",
+        },
+    }
+
+    rewritten_payload, changed, removed_count = tool_call_dedupe.rewrite_parallel_tool_call_payload(payload)
+
+    assert changed is True
+    assert removed_count == 1
+    assert isinstance(rewritten_payload, dict)
+    item = rewritten_payload["item"]
+    assert isinstance(item, dict)
+    rewritten_arguments = json.loads(item["arguments"])
+    assert len(rewritten_arguments["tool_uses"]) == 1
+    assert rewritten_arguments["tool_uses"][0]["parameters"]["targets"] == ["agent_b", "agent_a"]
+
+
+def test_rewrite_parallel_tool_call_payload_tolerates_mixed_wait_agent_targets():
+    arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.wait_agent",
+                "parameters": {
+                    "targets": [1, "agent_a", {}],
+                    "timeout_ms": 30000,
+                },
+            },
+            {
+                "recipient_name": "functions.wait_agent",
+                "parameters": {
+                    "targets": ["agent_a"],
+                    "timeout_ms": 30000,
+                },
+            },
+        ]
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": json.dumps(arguments),
+            "call_id": "call_parallel",
+        },
+    }
+
+    rewritten_payload, changed, removed_count = tool_call_dedupe.rewrite_parallel_tool_call_payload(payload)
+
+    assert changed is False
+    assert removed_count == 0
+    assert rewritten_payload is payload
+
+
+def test_rewrite_parallel_tool_call_payload_keeps_duplicate_read_only_connector_uses():
+    arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "github.read_file",
+                "parameters": {
+                    "repo": "Soju06/codex-lb",
+                    "path": "README.md",
+                },
+            },
+            {
+                "recipient_name": "github.read_file",
+                "parameters": {
+                    "repo": "Soju06/codex-lb",
+                    "path": "README.md",
+                },
+            },
+        ]
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": json.dumps(arguments),
+            "call_id": "call_parallel",
+        },
+    }
+
+    rewritten_payload, changed, removed_count = tool_call_dedupe.rewrite_parallel_tool_call_payload(payload)
+
+    assert changed is False
+    assert removed_count == 0
+    assert rewritten_payload is payload
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_parallel_wrapper_replay():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    arguments = json.dumps(
+        {
+            "tool_uses": [
+                {
+                    "recipient_name": "functions.exec_command",
+                    "parameters": {"cmd": "gh pr create --repo Komzpa/evince"},
+                }
+            ]
+        },
+        separators=(",", ":"),
+    )
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": arguments,
+            "call_id": "call_first",
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": arguments,
+            "call_id": "call_replayed",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_parallel",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_parallel",
+        )
+        is True
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_keeps_distinct_read_only_call_ids():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "read",
+            "arguments": '{"path":"Intermediate/info/Heartbeat Prep Status.json","limit":200}',
+            "call_id": "call_a",
+        },
+    }
+    second_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "read",
+            "arguments": '{"path":"Intermediate/info/Heartbeat Prep Status.json","limit":200}',
+            "call_id": "call_b",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            second_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is False
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_apply_patch_call_replay():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "apply_patch_call",
+            "operation": {"type": "update_file", "path": "app.py", "diff": "@@\n- old\n+ new\n"},
+            "call_id": "call_a",
+        },
+    }
+    second_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_dupe",
+        "item": {
+            "type": "apply_patch_call",
+            "operation": {"path": "app.py", "diff": "@@\n- old\n+ new\n", "type": "update_file"},
+            "call_id": "call_b",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            second_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_dupe",
+        )
+        is True
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_scopes_by_response_id():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_first",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_replay",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id=tool_call_dedupe.response_id_from_payload(first_payload),
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id=tool_call_dedupe.response_id_from_payload(replay_payload),
+        )
+        is False
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_bounds_seen_key_cache():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+
+    for index in range(tool_call_dedupe._TOOL_CALL_DEDUPE_CACHE_LIMIT + 3):
+        assert (
+            tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+                {
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "function_call",
+                        "name": "shell",
+                        "call_id": f"call_{index}",
+                        "arguments": f'{{"index":{index}}}',
+                    },
+                },
+                seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+                response_id="resp_1",
+            )
+            is False
+        )
+
+    assert len(upstream_control.seen_tool_call_keys) == tool_call_dedupe._TOOL_CALL_DEDUPE_CACHE_LIMIT

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -113,6 +113,88 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_exec_command_with_
     )
 
 
+def test_mark_duplicate_tool_call_downstream_event_suppresses_direct_wait_agent_replay():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_wait",
+        "item": {
+            "type": "function_call",
+            "name": "wait_agent",
+            "arguments": '{"targets":["agent_b","agent_a"],"timeout_ms":30000}',
+            "call_id": "call_a",
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_wait",
+        "item": {
+            "type": "function_call",
+            "name": "wait_agent",
+            "arguments": '{"targets":["agent_a","agent_b"],"timeout_ms":60000}',
+            "call_id": "call_b",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_wait",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_wait",
+        )
+        is True
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_namespaced_write_stdin_replay():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_namespaced",
+        "item": {
+            "type": "function_call",
+            "name": "functions.write_stdin",
+            "arguments": '{"session_id":17,"chars":"","yield_time_ms":1000,"max_output_tokens":4000}',
+            "call_id": "call_a",
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_namespaced",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":17,"chars":"","yield_time_ms":60000,"max_output_tokens":24000}',
+            "call_id": "call_b",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_namespaced",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            replay_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_namespaced",
+        )
+        is True
+    )
+
+
 def test_rewrite_parallel_tool_call_payload_removes_duplicate_side_effect_tool_uses():
     arguments = {
         "tool_uses": [

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -1156,3 +1156,49 @@ def test_rewrite_parallel_tool_call_text_preserves_sse_event_name():
     assert rewritten_event_type == "response.output_item.done"
     assert rewritten_event is not None
     assert rewritten_payload is not None
+
+
+def test_rewrite_parallel_tool_call_payload_removes_duplicate_goal_side_effects():
+    arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.update_plan",
+                "parameters": {"plan": [{"step": "repair", "status": "in_progress"}]},
+            },
+            {
+                "recipient_name": "functions.update_plan",
+                "parameters": {"plan": [{"step": "repair", "status": "in_progress"}]},
+            },
+            {
+                "recipient_name": "functions.request_user_input",
+                "parameters": {"questions": [{"id": "choice", "question": "Pick one", "options": []}]},
+            },
+            {
+                "recipient_name": "functions.request_user_input",
+                "parameters": {"questions": [{"id": "choice", "question": "Pick one", "options": []}]},
+            },
+        ]
+    }
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_parallel_goal",
+        "item": {
+            "type": "function_call",
+            "name": "multi_tool_use.parallel",
+            "arguments": json.dumps(arguments),
+            "call_id": "call_parallel",
+        },
+    }
+
+    rewritten_payload, changed, removed_count = tool_call_dedupe.rewrite_parallel_tool_call_payload(payload)
+
+    assert changed is True
+    assert removed_count == 2
+    assert isinstance(rewritten_payload, dict)
+    item = rewritten_payload["item"]
+    assert isinstance(item, dict)
+    rewritten_arguments = json.loads(item["arguments"])
+    assert [tool_use["recipient_name"] for tool_use in rewritten_arguments["tool_uses"]] == [
+        "functions.update_plan",
+        "functions.request_user_input",
+    ]

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4503,7 +4503,7 @@ async def test_stream_responses_suppresses_contiguous_side_effect_replay_across_
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_suppresses_same_response_http_tool_call_replay(monkeypatch):
+async def test_stream_responses_keeps_same_response_http_tool_calls_with_distinct_call_ids(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -4554,15 +4554,11 @@ async def test_stream_responses_suppresses_same_response_http_tool_call_replay(m
         if isinstance(chunk_payload, dict) and chunk_payload.get("type") == "response.output_item.done":
             tool_chunks.append(chunk_payload)
 
-    assert tool_chunks == [tool_payload]
+    assert tool_chunks == [tool_payload, replayed_tool_payload]
     terminal_payload = parse_sse_data_json(chunks[-1])
     assert isinstance(terminal_payload, dict)
-    assert terminal_payload["type"] == "response.failed"
-    terminal_response = cast(dict[str, object], terminal_payload["response"])
-    terminal_error = cast(dict[str, object], terminal_response["error"])
-    assert terminal_error["code"] == "stream_incomplete"
-    assert request_logs.calls[0]["status"] == "error"
-    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+    assert terminal_payload["type"] == "response.completed"
+    assert request_logs.calls[0]["status"] == "success"
 
 
 @pytest.mark.asyncio
@@ -7142,7 +7138,7 @@ async def test_process_upstream_websocket_text_masks_anonymous_missing_tool_outp
 
 
 @pytest.mark.asyncio
-async def test_process_upstream_websocket_text_masks_unmatched_missing_tool_output_for_followups(
+async def test_process_upstream_websocket_text_suppresses_unmatched_missing_tool_output_for_distinct_followups(
     monkeypatch,
 ):
     request_logs = _RequestLogsRecorder()
@@ -7198,20 +7194,13 @@ async def test_process_upstream_websocket_text_masks_unmatched_missing_tool_outp
         response_create_gate=asyncio.Semaphore(2),
     )
 
-    assert "No tool output found" not in downstream_text
+    assert "No tool output found" in downstream_text
     assert upstream_control.suppress_downstream_event is True
-    assert upstream_control.reconnect_requested is True
-    assert upstream_control.downstream_texts is not None
-    assert len(upstream_control.downstream_texts) == 2
-    for emitted_text in upstream_control.downstream_texts:
-        assert '"type":"response.failed"' in emitted_text
-        assert '"code":"stream_incomplete"' in emitted_text
-        assert "call_missing_output" not in emitted_text
-    assert finalize_request_state.await_count == 2
-    finalized_requests = [call.args[0] for call in finalize_request_state.await_args_list]
-    assert finalized_requests == [followup_request_a, followup_request_b]
+    assert upstream_control.reconnect_requested is False
+    assert upstream_control.downstream_texts is None
+    finalize_request_state.assert_not_awaited()
     handle_stream_error.assert_not_awaited()
-    assert list(pending_requests) == []
+    assert list(pending_requests) == [followup_request_a, followup_request_b]
 
 
 @pytest.mark.asyncio
@@ -9193,7 +9182,7 @@ async def test_process_upstream_websocket_text_masks_previous_response_not_found
 
 
 @pytest.mark.asyncio
-async def test_process_upstream_websocket_text_preserves_tool_dedupe_cache_across_reconnect(monkeypatch):
+async def test_process_upstream_websocket_text_keeps_same_response_distinct_tool_call_ids(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     finalize_request_state = AsyncMock()
@@ -9255,8 +9244,8 @@ async def test_process_upstream_websocket_text_preserves_tool_dedupe_cache_acros
 
     assert '"call_id":"call_first"' in first_text
     assert '"call_id":"call_replayed"' in replay_text
-    assert replay_control.suppress_downstream_event is True
-    assert pending_request.suppressed_duplicate_tool_call is True
+    assert replay_control.suppress_downstream_event is False
+    assert pending_request.suppressed_duplicate_tool_call is False
     finalize_request_state.assert_not_awaited()
     assert list(pending_requests) == [pending_request]
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7056,6 +7056,60 @@ async def test_process_upstream_websocket_text_masks_anonymous_missing_tool_outp
 
 
 @pytest.mark.asyncio
+async def test_process_upstream_websocket_text_preserves_first_turn_missing_tool_output(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_first_turn_missing_tool")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    first_turn_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_first_turn_missing_tool",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text='{"type":"response.create"}',
+    )
+    pending_requests = deque([first_turn_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "No tool output found for function call call_missing_output.",
+            "param": "input",
+        },
+    }
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert "No tool output found" in downstream_text
+    assert '"code":"stream_incomplete"' not in downstream_text
+    assert upstream_control.reconnect_requested is False
+    finalize_request_state.assert_not_awaited()
+    handle_stream_error.assert_not_awaited()
+    assert list(pending_requests) == [first_turn_request]
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_transparently_retries_precreated_usage_limit_failure(
     monkeypatch,
 ):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5490,6 +5490,46 @@ async def test_fail_pending_websocket_requests_penalizes_upstream_stream_drop(mo
 
 
 @pytest.mark.asyncio
+async def test_fail_pending_websocket_requests_does_not_penalize_rejected_input_override(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_rejected")
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_rejected",
+        response_id="resp_ws_rejected",
+        model="gpt-5.5",
+        service_tier="auto",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        error_code_override="upstream_rejected_input",
+        error_message_override="Upstream rejected the request before response.created (close_code=1000)",
+    )
+    pending_requests = deque([request_state])
+
+    await service._fail_pending_websocket_requests(
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        error_code="stream_incomplete",
+        error_message="Upstream websocket closed before response.completed",
+        api_key=None,
+    )
+
+    handle_stream_error.assert_not_awaited()
+    assert list(pending_requests) == []
+    assert len(request_logs.calls) == 1
+    assert request_logs.calls[0]["request_id"] == "resp_ws_rejected"
+    assert request_logs.calls[0]["error_code"] == "upstream_rejected_input"
+
+
+@pytest.mark.asyncio
 async def test_finalize_websocket_request_state_updates_balancer_state(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7056,6 +7056,79 @@ async def test_process_upstream_websocket_text_masks_anonymous_missing_tool_outp
 
 
 @pytest.mark.asyncio
+async def test_process_upstream_websocket_text_masks_unmatched_missing_tool_output_for_followups(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_unmatched_missing_tool_followups")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    followup_request_a = proxy_service._WebSocketRequestState(
+        request_id="ws_req_missing_tool_unmatched_a",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor_a",
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor_a"}',
+    )
+    followup_request_b = proxy_service._WebSocketRequestState(
+        request_id="ws_req_missing_tool_unmatched_b",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor_b",
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor_b"}',
+    )
+    pending_requests = deque([followup_request_a, followup_request_b])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "No tool output found for function call call_missing_output.",
+            "param": "input",
+        },
+    }
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(2),
+    )
+
+    assert "No tool output found" not in downstream_text
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.downstream_texts is not None
+    assert len(upstream_control.downstream_texts) == 2
+    for emitted_text in upstream_control.downstream_texts:
+        assert '"type":"response.failed"' in emitted_text
+        assert '"code":"stream_incomplete"' in emitted_text
+        assert "call_missing_output" not in emitted_text
+    assert finalize_request_state.await_count == 2
+    finalized_requests = [call.args[0] for call in finalize_request_state.await_args_list]
+    assert finalized_requests == [followup_request_a, followup_request_b]
+    handle_stream_error.assert_not_awaited()
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_preserves_first_turn_missing_tool_output(
     monkeypatch,
 ):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5448,6 +5448,48 @@ async def test_fail_expired_pending_websocket_requests_keeps_newer_requests(monk
 
 
 @pytest.mark.asyncio
+async def test_fail_pending_websocket_requests_penalizes_upstream_stream_drop(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_drop")
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_drop",
+        response_id="resp_ws_drop",
+        model="gpt-5.5",
+        service_tier="auto",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    pending_requests = deque([request_state])
+
+    await service._fail_pending_websocket_requests(
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        error_code="stream_incomplete",
+        error_message="Upstream websocket closed before response.completed",
+        api_key=None,
+    )
+
+    handle_stream_error.assert_awaited_once_with(
+        account,
+        {"message": "Upstream websocket closed before response.completed"},
+        "stream_incomplete",
+    )
+    assert list(pending_requests) == []
+    assert len(request_logs.calls) == 1
+    assert request_logs.calls[0]["request_id"] == "resp_ws_drop"
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+
+
+@pytest.mark.asyncio
 async def test_finalize_websocket_request_state_updates_balancer_state(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from collections import deque
 from collections.abc import Sequence
 from types import SimpleNamespace
@@ -5548,11 +5549,11 @@ async def test_fail_pending_websocket_requests_penalizes_upstream_stream_drop(mo
     assert request_logs.calls[0]["error_code"] == "stream_incomplete"
 
 
-@pytest.mark.asyncio
 async def test_fail_pending_websocket_requests_does_not_penalize_rejected_input_override(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     account = _make_account("acc_ws_rejected")
+
     handle_stream_error = AsyncMock()
 
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
@@ -5586,6 +5587,49 @@ async def test_fail_pending_websocket_requests_does_not_penalize_rejected_input_
     assert len(request_logs.calls) == 1
     assert request_logs.calls[0]["request_id"] == "resp_ws_rejected"
     assert request_logs.calls[0]["error_code"] == "upstream_rejected_input"
+
+
+@pytest.mark.asyncio
+async def test_fail_pending_websocket_requests_marks_client_disconnect_without_penalty(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_client_disconnect")
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_client_disconnect",
+        response_id="resp_ws_client_disconnect",
+        model="gpt-5.5",
+        service_tier="auto",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        session_id="turn_client_disconnect",
+    )
+    pending_requests = deque([request_state])
+
+    await service._fail_pending_websocket_requests(
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        error_code="client_disconnected",
+        error_message="Downstream websocket disconnected before response.completed",
+        api_key=None,
+        status="cancelled",
+        penalize_account=False,
+    )
+
+    handle_stream_error.assert_not_awaited()
+    assert list(pending_requests) == []
+    assert len(request_logs.calls) == 1
+    assert request_logs.calls[0]["request_id"] == "resp_ws_client_disconnect"
+    assert request_logs.calls[0]["status"] == "cancelled"
+    assert request_logs.calls[0]["error_code"] == "client_disconnected"
+    assert request_logs.calls[0]["session_id"] == "turn_client_disconnect"
 
 
 @pytest.mark.asyncio
@@ -5672,6 +5716,46 @@ async def test_finalize_websocket_request_state_updates_balancer_state(monkeypat
     assert handle_args.args[0] == account
     assert handle_args.args[2] == "rate_limit_exceeded"
     assert failed_upstream_control.reconnect_requested is True
+
+    record_success.reset_mock()
+    handle_stream_error.reset_mock()
+    server_error_payload: dict[str, JsonValue] = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_ws_server_failed",
+            "error": {"code": "server_error", "message": "upstream fell over"},
+            "usage": {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+        },
+    }
+    server_error_event = parse_sse_event(f"data: {json.dumps(server_error_payload)}\n\n")
+    assert server_error_event is not None
+    server_error_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_server_failed",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    server_error_upstream_control = proxy_service._WebSocketUpstreamControl()
+
+    await service._finalize_websocket_request_state(
+        server_error_state,
+        account=account,
+        account_id_value=account.id,
+        event=server_error_event,
+        event_type="response.failed",
+        payload=server_error_payload,
+        api_key=None,
+        upstream_control=server_error_upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    handle_args = handle_stream_error.await_args
+    assert handle_args is not None
+    assert handle_args.args[0] == account
+    assert handle_args.args[2] == "server_error"
+    assert server_error_upstream_control.reconnect_requested is True
 
     record_success.reset_mock()
     handle_stream_error.reset_mock()
@@ -7143,6 +7227,301 @@ async def test_proxy_responses_websocket_transparent_replay_preserves_sticky_thr
     assert len(first_upstream.sent_text) == 1
     assert len(second_upstream.sent_text) == 1
     assert json.loads(first_upstream.sent_text[0]) == json.loads(second_upstream.sent_text[0])
+
+
+@pytest.mark.asyncio
+async def test_proxy_responses_websocket_downstream_disconnect_does_not_penalize_account(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    handle_stream_error = AsyncMock()
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.stream_idle_timeout_seconds = 300.0
+    settings.proxy_downstream_websocket_idle_timeout_seconds = 120.0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.ProxyService, "_handle_stream_error", handle_stream_error)
+
+    class _DisconnectingDownstreamWebSocket:
+        def __init__(self, request_text: str) -> None:
+            self._request_text = request_text
+            self._request_sent = False
+            self.sent_text: list[str] = []
+            self.closed = False
+
+        async def receive(self) -> dict[str, object]:
+            if not self._request_sent:
+                self._request_sent = True
+                return {"type": "websocket.receive", "text": self._request_text}
+            return {"type": "websocket.disconnect"}
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+        async def close(self, code: int = 1000, reason: str | None = None) -> None:
+            del code, reason
+            self.closed = True
+
+    class _BlockingUpstreamWebSocket:
+        def __init__(self) -> None:
+            self.sent_text: list[str] = []
+            self.closed = False
+            self._closed = asyncio.Event()
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+        async def receive(self) -> SimpleNamespace:
+            await self._closed.wait()
+            return SimpleNamespace(kind="close", text=None, data=None, close_code=1000, error=None)
+
+        async def close(self) -> None:
+            self.closed = True
+            self._closed.set()
+
+    upstream = _BlockingUpstreamWebSocket()
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return _make_account("acc_ws_client_disconnect_live"), upstream
+
+    monkeypatch.setattr(proxy_service.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "bye"}]}],
+        "stream": True,
+    }
+    downstream = _DisconnectingDownstreamWebSocket(json.dumps(request_payload, separators=(",", ":")))
+
+    await service.proxy_responses_websocket(
+        cast(WebSocket, downstream),
+        {"x-codex-turn-state": "turn_client_disconnect_live"},
+        codex_session_affinity=False,
+        openai_cache_affinity=False,
+        api_key=None,
+    )
+
+    handle_stream_error.assert_not_awaited()
+    assert upstream.closed is True
+    assert len(upstream.sent_text) == 1
+    assert downstream.sent_text == []
+    assert len(request_logs.calls) == 1
+    assert request_logs.calls[0]["status"] == "cancelled"
+    assert request_logs.calls[0]["error_code"] == "client_disconnected"
+    assert request_logs.calls[0]["session_id"] == "turn_client_disconnect_live"
+
+
+@pytest.mark.asyncio
+async def test_relay_upstream_websocket_emits_keepalive_while_upstream_is_silent(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.sse_keepalive_interval_seconds = 0.01
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", AsyncMock())
+
+    class _FakeDownstreamWebSocket:
+        def __init__(self) -> None:
+            self.sent_text: list[str] = []
+            self.closed = False
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+        async def close(self, code: int = 1000, reason: str | None = None) -> None:
+            del code, reason
+            self.closed = True
+
+    class _SilentAfterCreatedUpstream:
+        def __init__(self) -> None:
+            self._created_sent = False
+            self.closed = False
+            self._closed = asyncio.Event()
+
+        async def receive(self) -> SimpleNamespace:
+            if not self._created_sent:
+                self._created_sent = True
+                return SimpleNamespace(
+                    kind="text",
+                    text=json.dumps(
+                        {"type": "response.created", "response": {"id": "resp_ws_keepalive"}},
+                        separators=(",", ":"),
+                    ),
+                    data=None,
+                    close_code=None,
+                    error=None,
+                )
+            await self._closed.wait()
+            return SimpleNamespace(kind="close", text=None, data=None, close_code=1000, error=None)
+
+        async def close(self) -> None:
+            self.closed = True
+            self._closed.set()
+
+    downstream = _FakeDownstreamWebSocket()
+    upstream = _SilentAfterCreatedUpstream()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_keepalive",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    pending_requests = deque([request_state])
+
+    relay = asyncio.create_task(
+        service._relay_upstream_websocket_messages(
+            cast(WebSocket, downstream),
+            cast(proxy_service.UpstreamResponsesWebSocket, upstream),
+            account=_make_account("acc_ws_keepalive"),
+            account_id_value="acc_ws_keepalive",
+            pending_requests=pending_requests,
+            pending_lock=anyio.Lock(),
+            client_send_lock=anyio.Lock(),
+            api_key=None,
+            upstream_control=proxy_service._WebSocketUpstreamControl(),
+            response_create_gate=asyncio.Semaphore(1),
+            proxy_request_budget_seconds=5.0,
+            stream_idle_timeout_seconds=5.0,
+            downstream_activity=proxy_service._DownstreamWebSocketActivity(),
+        )
+    )
+
+    try:
+        for _ in range(20):
+            if len(downstream.sent_text) >= 2:
+                break
+            await asyncio.sleep(0.01)
+        assert len(downstream.sent_text) >= 2
+        emitted = [json.loads(text) for text in downstream.sent_text[:2]]
+        assert emitted[0]["type"] == "response.created"
+        assert emitted[1] == {
+            "type": "response.in_progress",
+            "response": {"id": "resp_ws_keepalive", "status": "in_progress"},
+        }
+    finally:
+        relay.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await relay
+
+
+@pytest.mark.asyncio
+async def test_relay_upstream_websocket_emits_keepalive_before_response_created(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.sse_keepalive_interval_seconds = 0.01
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    class _FakeDownstreamWebSocket:
+        def __init__(self) -> None:
+            self.sent_text: list[str] = []
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+    class _SilentBeforeCreatedUpstream:
+        def __init__(self) -> None:
+            self._closed = asyncio.Event()
+
+        async def receive(self) -> SimpleNamespace:
+            await self._closed.wait()
+            return SimpleNamespace(kind="close", text=None, data=None, close_code=1000, error=None)
+
+        async def close(self) -> None:
+            self._closed.set()
+
+    downstream = _FakeDownstreamWebSocket()
+    upstream = _SilentBeforeCreatedUpstream()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_precreated_keepalive",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    pending_requests = deque([request_state])
+
+    relay = asyncio.create_task(
+        service._relay_upstream_websocket_messages(
+            cast(WebSocket, downstream),
+            cast(proxy_service.UpstreamResponsesWebSocket, upstream),
+            account=_make_account("acc_ws_precreated_keepalive"),
+            account_id_value="acc_ws_precreated_keepalive",
+            pending_requests=pending_requests,
+            pending_lock=anyio.Lock(),
+            client_send_lock=anyio.Lock(),
+            api_key=None,
+            upstream_control=proxy_service._WebSocketUpstreamControl(),
+            response_create_gate=asyncio.Semaphore(1),
+            proxy_request_budget_seconds=5.0,
+            stream_idle_timeout_seconds=5.0,
+            downstream_activity=proxy_service._DownstreamWebSocketActivity(),
+        )
+    )
+
+    try:
+        for _ in range(20):
+            if downstream.sent_text:
+                break
+            await asyncio.sleep(0.01)
+        assert downstream.sent_text
+        assert json.loads(downstream.sent_text[0]) == {
+            "type": "response.in_progress",
+            "response": {"id": "ws_req_precreated_keepalive", "status": "in_progress"},
+        }
+    finally:
+        relay.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await relay
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11573,6 +11573,19 @@ def test_prepare_response_bridge_request_state_dedupes_replayed_previous_respons
     assert upstream_input[2]["content"] == [{"type": "output_text", "text": "Process exited with code 0"}]
 
 
+def test_trim_websocket_previous_response_input_items_handles_apply_patch_replay():
+    input_items: list[JsonValue] = [
+        {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "patching"}]},
+        {"type": "apply_patch_call", "call_id": "patch_1", "input": "*** Begin Patch\n*** End Patch\n"},
+        {"type": "apply_patch_call_output", "call_id": "patch_1", "output": "Success"},
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[2:]
+
+
 def test_prepare_response_bridge_request_state_keeps_unconfirmed_missing_tool_output_history():
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4357,6 +4357,116 @@ async def test_stream_responses_non_retryable_first_failure_does_not_retry(monke
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_keeps_distinct_http_tool_calls_across_response_ids(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_http_tool_dupe")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    tool_payload = {
+        "type": "response.output_item.done",
+        "response_id": "resp_tool_first",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+            "call_id": "call_first",
+        },
+    }
+    replayed_tool_payload = {
+        **tool_payload,
+        "response_id": "resp_tool_replayed",
+        "item": {
+            **tool_payload["item"],
+            "call_id": "call_replayed",
+        },
+    }
+
+    async def fake_stream(*_, **__):
+        yield 'data: {"type":"response.created","response":{"id":"resp_http_tool_dupe"}}\n\n'
+        yield f"data: {json.dumps(tool_payload)}\n\n"
+        yield f"data: {json.dumps(replayed_tool_payload)}\n\n"
+        yield 'data: {"type":"response.completed","response":{"id":"resp_http_tool_dupe"}}\n\n'
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+    tool_chunks: list[JsonValue] = []
+    for chunk in chunks:
+        chunk_payload = parse_sse_data_json(chunk)
+        if isinstance(chunk_payload, dict) and chunk_payload.get("type") == "response.output_item.done":
+            tool_chunks.append(chunk_payload)
+
+    assert tool_chunks == [tool_payload, replayed_tool_payload]
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_suppresses_same_response_http_tool_call_replay(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_http_tool_dupe")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    tool_payload = {
+        "type": "response.output_item.done",
+        "response_id": "resp_http_tool_dupe",
+        "item": {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": '{"cmd":"date","yield_time_ms":1000}',
+            "call_id": "call_first",
+        },
+    }
+    replayed_tool_payload = {
+        **tool_payload,
+        "item": {
+            **tool_payload["item"],
+            "id": "fc_replayed",
+            "call_id": "call_replayed",
+        },
+    }
+
+    async def fake_stream(*_, **__):
+        yield 'data: {"type":"response.created","response":{"id":"resp_http_tool_dupe"}}\n\n'
+        yield f"data: {json.dumps(tool_payload)}\n\n"
+        yield f"data: {json.dumps(replayed_tool_payload)}\n\n"
+        yield 'data: {"type":"response.completed","response":{"id":"resp_http_tool_dupe"}}\n\n'
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+    tool_chunks: list[JsonValue] = []
+    for chunk in chunks:
+        chunk_payload = parse_sse_data_json(chunk)
+        if isinstance(chunk_payload, dict) and chunk_payload.get("type") == "response.output_item.done":
+            tool_chunks.append(chunk_payload)
+
+    assert tool_chunks == [tool_payload]
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_passes_sticky_kind_to_load_balancer(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2065,6 +2065,65 @@ async def test_stream_responses_uses_websocket_transport(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_websocket_normalizes_typeless_error_as_terminal(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_stream_transport = "websocket"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 75.0
+        log_upstream_request_summary = False
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    websocket = _WsResponse(
+        [
+            _ws_text_message({"type": "response.created", "response": {"id": "resp_ws_error"}}),
+            _ws_text_message(
+                {
+                    "error": {
+                        "type": "invalid_request_error",
+                        "message": "No tool output found for function call call_missing.",
+                        "param": "input",
+                    },
+                    "status": 400,
+                }
+            ),
+            _ws_text_message({"type": "response.completed", "response": {"id": "resp_ws_error"}}),
+        ]
+    )
+    session = _WsSession(websocket)
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={"originator": "codex_cli_rs", "session_id": "sid_ws"},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    assert len(events) == 2
+    failed_payload = parse_sse_data_json(events[1])
+    assert failed_payload is not None
+    assert failed_payload["type"] == "response.failed"
+    assert failed_payload["response"]["error"]["code"] == "invalid_request_error"
+    assert failed_payload["response"]["error"]["message"] == "No tool output found for function call call_missing."
+    assert failed_payload["response"]["error"]["param"] == "input"
+    assert websocket._index == 2
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_websocket_rejects_oversized_response_create_before_connect(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
@@ -5749,6 +5808,153 @@ async def test_process_upstream_websocket_text_does_not_match_foreign_completed_
     assert downstream_text == json.dumps(payload, separators=(",", ":"))
     finalize_request_state.assert_not_awaited()
     assert list(pending_requests) == [pending_request]
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_buffers_nonterminal_events_until_response_created(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    account = _make_account("acc_ws_precreated_buffer")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_precreated_buffer",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+            },
+            separators=(",", ":"),
+        ),
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    pending_lock = anyio.Lock()
+    response_create_gate = asyncio.Semaphore(1)
+    delta_text = json.dumps(
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg_precreated",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "hello",
+        },
+        separators=(",", ":"),
+    )
+
+    downstream_text = await service._process_upstream_websocket_text(
+        delta_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=pending_lock,
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=response_create_gate,
+    )
+
+    assert downstream_text == delta_text
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.downstream_texts is None
+    assert pending_request.pre_response_created_event_texts == [delta_text]
+    finalize_request_state.assert_not_awaited()
+
+    upstream_control.suppress_downstream_event = False
+    created_text = json.dumps(
+        {
+            "type": "response.created",
+            "response": {"id": "resp_precreated_buffer", "status": "in_progress"},
+        },
+        separators=(",", ":"),
+    )
+
+    downstream_text = await service._process_upstream_websocket_text(
+        created_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=pending_lock,
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=response_create_gate,
+    )
+
+    assert downstream_text == created_text
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.downstream_texts == [created_text, delta_text]
+    assert pending_request.pre_response_created_event_texts == []
+    assert pending_request.awaiting_response_created is False
+    assert pending_request.response_id == "resp_precreated_buffer"
+    finalize_request_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_clears_ambiguous_anonymous_error(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    account = _make_account("acc_ws_ambiguous_raw_error")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+
+    pending_requests = deque(
+        [
+            proxy_service._WebSocketRequestState(
+                request_id="ws_req_raw_error_a",
+                model="gpt-5.1",
+                service_tier=None,
+                reasoning_effort=None,
+                api_key_reservation=None,
+                started_at=0.0,
+            ),
+            proxy_service._WebSocketRequestState(
+                request_id="ws_req_raw_error_b",
+                model="gpt-5.1",
+                service_tier=None,
+                reasoning_effort=None,
+                api_key_reservation=None,
+                started_at=0.0,
+            ),
+        ]
+    )
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    raw_error_text = json.dumps(
+        {
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Upstream rejected the shared websocket request.",
+            },
+            "status": 400,
+        },
+        separators=(",", ":"),
+    )
+
+    downstream_text = await service._process_upstream_websocket_text(
+        raw_error_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert not pending_requests
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.downstream_texts is not None
+    assert downstream_text == upstream_control.downstream_texts[0]
+    assert len(upstream_control.downstream_texts) == 2
+    assert finalize_request_state.await_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11168,6 +11168,56 @@ def test_classify_upstream_close_rejected_only_for_clean_close_before_any_respon
     assert proxy_service._classify_upstream_close(1011, response_events_seen=0) == "transient"
 
 
+def test_prepare_response_bridge_request_state_dedupes_replayed_tool_calls_before_serializing():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000}),
+            "call_id": "call_first",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_first",
+            "output": "Process running with session ID 75180",
+        },
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 1000}),
+            "call_id": "call_replay",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_replay",
+            "output": "Process exited with code 0",
+        },
+    ]
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "", "input": input_items})
+
+    request_state, text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=proxy_service._REQUEST_TRANSPORT_WEBSOCKET,
+        client_metadata=None,
+    )
+
+    upstream_payload = json.loads(text_data)
+    upstream_input = upstream_payload["input"]
+    assert request_state.input_item_count == 4
+    assert len(upstream_input) == 3
+    assert upstream_input[0]["call_id"] == "call_first"
+    assert upstream_input[1]["call_id"] == "call_first"
+    assert upstream_input[1]["output"] == "Process running with session ID 75180"
+    assert upstream_input[2]["role"] == "assistant"
+    assert upstream_input[2]["content"] == [{"type": "output_text", "text": "Process exited with code 0"}]
+
+
 @pytest.mark.asyncio
 async def test_retry_http_bridge_precreated_request_suppresses_retry_for_rejected_close():
     request_logs = _RequestLogsRecorder()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -47,6 +47,39 @@ from app.modules.usage.repository import AdditionalUsageRepository, UsageReposit
 pytestmark = pytest.mark.unit
 
 
+def test_websocket_precreated_retry_error_code_does_not_replay_missing_tool_output():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_missing_tool_precreated",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor",
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor","input":[]}',
+    )
+    payload: dict[str, JsonValue] = {
+        "type": "error",
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "param": "input",
+            "message": "No tool output found for function call call_missing.",
+        },
+    }
+
+    assert (
+        proxy_service._websocket_precreated_retry_error_code(
+            request_state,
+            event_type="error",
+            payload=payload,
+            has_other_pending_requests=False,
+        )
+        is None
+    )
+
+
 def _assert_proxy_response_error(exc: BaseException) -> proxy_module.ProxyResponseError:
     assert isinstance(exc, proxy_module.ProxyResponseError)
     return exc

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4390,7 +4390,7 @@ async def test_stream_responses_non_retryable_first_failure_does_not_retry(monke
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_keeps_side_effect_tool_calls_across_response_ids(monkeypatch):
+async def test_stream_responses_suppresses_contiguous_side_effect_replay_across_response_ids(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -4441,12 +4441,13 @@ async def test_stream_responses_keeps_side_effect_tool_calls_across_response_ids
         if isinstance(chunk_payload, dict) and chunk_payload.get("type") == "response.output_item.done":
             tool_chunks.append(chunk_payload)
 
-    assert tool_chunks == [tool_payload, replayed_tool_payload]
-    assert parse_sse_data_json(chunks[-1]) == {
-        "type": "response.completed",
-        "response": {"id": "resp_http_tool_dupe"},
-    }
-    assert request_logs.calls[0]["status"] == "success"
+    assert tool_chunks == [tool_payload]
+    terminal_event = parse_sse_data_json(chunks[-1])
+    assert isinstance(terminal_event, dict)
+    assert terminal_event["type"] == "response.failed"
+    assert terminal_event["response"]["error"]["code"] == "stream_incomplete"
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4357,7 +4357,7 @@ async def test_stream_responses_non_retryable_first_failure_does_not_retry(monke
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_keeps_distinct_side_effect_tool_calls_across_response_ids(monkeypatch):
+async def test_stream_responses_keeps_side_effect_tool_calls_across_response_ids(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -4409,6 +4409,11 @@ async def test_stream_responses_keeps_distinct_side_effect_tool_calls_across_res
             tool_chunks.append(chunk_payload)
 
     assert tool_chunks == [tool_payload, replayed_tool_payload]
+    assert parse_sse_data_json(chunks[-1]) == {
+        "type": "response.completed",
+        "response": {"id": "resp_http_tool_dupe"},
+    }
+    assert request_logs.calls[0]["status"] == "success"
 
 
 @pytest.mark.asyncio
@@ -6978,6 +6983,79 @@ async def test_process_upstream_websocket_text_masks_anonymous_previous_response
 
 
 @pytest.mark.asyncio
+async def test_process_upstream_websocket_text_masks_anonymous_missing_tool_output_for_same_anchor_followups(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_anonymous_missing_tool_same_anchor")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    followup_request_a = proxy_service._WebSocketRequestState(
+        request_id="ws_req_missing_tool_same_anchor_a",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor",
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor"}',
+    )
+    followup_request_b = proxy_service._WebSocketRequestState(
+        request_id="ws_req_missing_tool_same_anchor_b",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_anchor",
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor"}',
+    )
+    pending_requests = deque([followup_request_a, followup_request_b])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "No tool output found for function call call_missing_output.",
+            "param": "input",
+        },
+    }
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(2),
+    )
+
+    assert "No tool output found" not in downstream_text
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.downstream_texts is not None
+    assert len(upstream_control.downstream_texts) == 2
+    for emitted_text in upstream_control.downstream_texts:
+        assert '"type":"response.failed"' in emitted_text
+        assert '"code":"stream_incomplete"' in emitted_text
+        assert "call_missing_output" not in emitted_text
+    assert finalize_request_state.await_count == 2
+    finalized_requests = [call.args[0] for call in finalize_request_state.await_args_list]
+    assert finalized_requests == [followup_request_a, followup_request_b]
+    handle_stream_error.assert_not_awaited()
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_transparently_retries_precreated_usage_limit_failure(
     monkeypatch,
 ):
@@ -8818,6 +8896,75 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
     assert pending_request.request_text == json.dumps(fresh_request_payload, separators=(",", ":"))
     # Retry-safety flag is consumed (set back to False) so we don't loop.
     assert pending_request.fresh_upstream_request_is_retry_safe is False
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_preserves_tool_dedupe_cache_across_reconnect(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_reconnect_tool_dedupe")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_reconnect_tool_dedupe",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_reconnect_tool",
+    )
+    pending_requests = deque([pending_request])
+    tool_payload = {
+        "type": "response.output_item.done",
+        "response_id": "resp_reconnect_tool",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+            "call_id": "call_first",
+        },
+    }
+    replayed_tool_payload = {
+        **tool_payload,
+        "item": {
+            **tool_payload["item"],
+            "call_id": "call_replayed",
+        },
+    }
+
+    first_text = await service._process_upstream_websocket_text(
+        json.dumps(tool_payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        response_create_gate=asyncio.Semaphore(1),
+    )
+    replay_control = proxy_service._WebSocketUpstreamControl()
+    replay_text = await service._process_upstream_websocket_text(
+        json.dumps(replayed_tool_payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=replay_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"call_id":"call_first"' in first_text
+    assert '"call_id":"call_replayed"' in replay_text
+    assert replay_control.suppress_downstream_event is True
+    assert pending_request.suppressed_duplicate_tool_call is True
+    finalize_request_state.assert_not_awaited()
+    assert list(pending_requests) == [pending_request]
 
 
 @pytest.mark.asyncio
@@ -11220,6 +11367,88 @@ def test_prepare_response_bridge_request_state_dedupes_replayed_previous_respons
     assert upstream_input[2]["content"] == [{"type": "output_text", "text": "Process exited with code 0"}]
 
 
+def test_prepare_response_bridge_request_state_rewrites_replayed_side_effect_call_without_output():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": json.dumps({"cmd": "timeout 8s rg -n needle .", "yield_time_ms": 1000}),
+            "call_id": "call_missing",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "", "input": input_items, "previous_response_id": "resp_anchor"}
+    )
+
+    request_state, text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=proxy_service._REQUEST_TRANSPORT_WEBSOCKET,
+        client_metadata=None,
+    )
+
+    upstream_payload = json.loads(text_data)
+    upstream_input = upstream_payload["input"]
+    assert request_state.input_item_count == 2
+    assert upstream_input[0]["type"] == "message"
+    assert upstream_input[0]["role"] == "assistant"
+    assert "without matching output: exec_command" in upstream_input[0]["content"][0]["text"]
+    assert "function_call" not in json.dumps(upstream_input)
+
+
+def test_prepare_response_bridge_request_state_rewrites_first_duplicate_when_only_replay_has_output():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": json.dumps({"cmd": "timeout 8s rg -n needle .", "yield_time_ms": 1000}),
+            "call_id": "call_missing",
+        },
+        {
+            "type": "function_call",
+            "name": "exec_command",
+            "arguments": json.dumps({"cmd": "timeout 8s rg -n needle .", "yield_time_ms": 30000}),
+            "call_id": "call_replay",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_replay",
+            "output": "needle found",
+        },
+    ]
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "", "input": input_items, "previous_response_id": "resp_anchor"}
+    )
+
+    request_state, text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=proxy_service._REQUEST_TRANSPORT_WEBSOCKET,
+        client_metadata=None,
+    )
+
+    upstream_payload = json.loads(text_data)
+    upstream_input = upstream_payload["input"]
+    assert request_state.input_item_count == 3
+    assert len(upstream_input) == 2
+    assert upstream_input[0]["type"] == "message"
+    assert "without matching output: exec_command" in upstream_input[0]["content"][0]["text"]
+    assert upstream_input[1]["type"] == "message"
+    assert upstream_input[1]["content"] == [{"type": "output_text", "text": "needle found"}]
+    assert "function_call" not in json.dumps(upstream_input)
+
+
 def test_prepare_response_bridge_request_state_keeps_repeated_first_attempt_tool_calls():
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -11310,22 +11539,33 @@ async def test_http_bridge_tool_call_dedupe_survives_upstream_reconnect():
     }
     replay_payload = {
         **first_payload,
+        "response_id": "resp_bridge_tool_replay_after_reconnect",
         "item": {
             **first_payload["item"],
             "call_id": "call_replayed",
         },
     }
+    replay_created_payload = {
+        "type": "response.created",
+        "response": {"id": "resp_bridge_tool_replay_after_reconnect", "status": "in_progress"},
+    }
 
     await service._process_http_bridge_upstream_text(session, json.dumps(first_payload, separators=(",", ":")))
     session.upstream_control = proxy_service._WebSocketUpstreamControl()
+    request_state.awaiting_response_created = True
+    request_state.response_id = None
+    await service._process_http_bridge_upstream_text(session, json.dumps(replay_created_payload, separators=(",", ":")))
     await service._process_http_bridge_upstream_text(session, json.dumps(replay_payload, separators=(",", ":")))
 
     assert request_state.suppressed_duplicate_tool_call is True
     event_queue = request_state.event_queue
     assert event_queue is not None
-    forwarded = await event_queue.get()
+    forwarded = await asyncio.wait_for(event_queue.get(), timeout=1.0)
     assert forwarded is not None
     assert proxy_service.parse_sse_data_json(forwarded) == first_payload
+    forwarded_created = await asyncio.wait_for(event_queue.get(), timeout=1.0)
+    assert forwarded_created is not None
+    assert proxy_service.parse_sse_data_json(forwarded_created) == replay_created_payload
     assert event_queue.empty()
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11493,7 +11493,7 @@ def test_prepare_response_bridge_request_state_dedupes_replayed_previous_respons
         {
             "type": "function_call",
             "name": "write_stdin",
-            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 1000}),
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000}),
             "call_id": "call_replay",
         },
         {

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6121,7 +6121,7 @@ async def test_process_upstream_websocket_text_masks_foreign_previous_response_n
     assert finalize_call.args[0] is pending_request
     assert finalize_call.kwargs["event_type"] == "response.failed"
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert upstream_control.suppress_downstream_event is False
     assert list(pending_requests) == []
 
@@ -6212,7 +6212,7 @@ async def test_process_upstream_websocket_text_matches_foreign_prev_nf_to_anchor
     assert finalize_call is not None
     assert finalize_call.args[0] is followup_request_a
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert list(pending_requests) == [followup_request_b]
 
 
@@ -6302,7 +6302,7 @@ async def test_process_upstream_websocket_text_matches_foreign_prev_nf_with_over
     assert finalize_call is not None
     assert finalize_call.args[0] is followup_request_b
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert list(pending_requests) == [followup_request_a]
 
 
@@ -6462,7 +6462,7 @@ async def test_process_upstream_websocket_text_matches_anonymous_prev_nf_to_anch
     assert finalize_call is not None
     assert finalize_call.args[0] is followup_request_a
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert list(pending_requests) == [followup_request_b]
 
 
@@ -6550,7 +6550,7 @@ async def test_process_upstream_websocket_text_matches_anonymous_prev_nf_with_ov
     assert finalize_call is not None
     assert finalize_call.args[0] is followup_request_b
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert list(pending_requests) == [followup_request_a]
 
 
@@ -6638,7 +6638,7 @@ async def test_process_upstream_websocket_text_masks_anonymous_previous_response
     assert finalize_call.args[0] is followup_request
     assert finalize_call.kwargs["event_type"] == "response.failed"
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert upstream_control.suppress_downstream_event is False
     assert list(pending_requests) == [inflight_request]
 
@@ -8662,7 +8662,7 @@ async def test_process_upstream_websocket_text_masks_previous_response_not_found
     assert finalize_call is not None
     assert finalize_call.args[0] is followup_request
     assert finalize_call.kwargs["event_type"] == "response.failed"
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert upstream_control.suppress_downstream_event is False
     assert list(pending_requests) == [inflight_request]
 
@@ -8708,7 +8708,7 @@ def test_maybe_rewrite_websocket_previous_response_not_found_rewrites_response_f
         )
     )
 
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert rewritten_event_type == "response.failed"
     assert rewritten_payload is not None
     response_payload = cast(dict[str, JsonValue], rewritten_payload.get("response"))
@@ -8756,7 +8756,7 @@ def test_maybe_rewrite_websocket_previous_response_invalid_request_error_rewrite
         )
     )
 
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert rewritten_event_type == "response.failed"
     assert rewritten_payload is not None
     response_payload = cast(dict[str, JsonValue], rewritten_payload.get("response"))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4445,7 +4445,9 @@ async def test_stream_responses_suppresses_contiguous_side_effect_replay_across_
     terminal_event = parse_sse_data_json(chunks[-1])
     assert isinstance(terminal_event, dict)
     assert terminal_event["type"] == "response.failed"
-    assert terminal_event["response"]["error"]["code"] == "stream_incomplete"
+    terminal_response = cast(dict[str, JsonValue], terminal_event["response"])
+    terminal_error = cast(dict[str, JsonValue], terminal_response["error"])
+    assert terminal_error["code"] == "stream_incomplete"
     assert request_logs.calls[0]["status"] == "error"
     assert request_logs.calls[0]["error_code"] == "stream_incomplete"
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2160,6 +2160,56 @@ async def test_stream_responses_websocket_normalizes_typeless_error_as_terminal(
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_websocket_normalizes_typeless_error_code_to_upstream_error(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_stream_transport = "websocket"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 75.0
+        log_upstream_request_summary = False
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    websocket = _WsResponse(
+        [
+            _ws_text_message({"type": "response.created", "response": {"id": "resp_ws_error"}}),
+            _ws_text_message({"type": "error", "message": "generic upstream failure"}),
+        ]
+    )
+    session = _WsSession(websocket)
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={"originator": "codex_cli_rs", "session_id": "sid_ws"},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    assert len(events) == 2
+    failed_payload = parse_sse_data_json(events[1])
+    assert failed_payload is not None
+    assert failed_payload["type"] == "response.failed"
+    failed_response = cast(dict[str, JsonValue], failed_payload["response"])
+    failed_error = cast(dict[str, JsonValue], failed_response["error"])
+    assert failed_error["code"] == "upstream_error"
+    assert failed_error["type"] == "server_error"
+    assert failed_error["message"] == "generic upstream failure"
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_websocket_rejects_oversized_response_create_before_connect(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4352,7 +4352,7 @@ async def test_stream_responses_non_retryable_first_failure_does_not_retry(monke
     event = json.loads(chunks[0].split("data: ", 1)[1])
     assert event["response"]["error"]["code"] == "stream_idle_timeout"
     assert select_account.await_count == 1
-    record_error.assert_not_awaited()
+    record_error.assert_awaited_once_with(account)
     record_success.assert_not_awaited()
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4357,7 +4357,7 @@ async def test_stream_responses_non_retryable_first_failure_does_not_retry(monke
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_keeps_distinct_http_tool_calls_across_response_ids(monkeypatch):
+async def test_stream_responses_suppresses_replayed_side_effect_tool_calls_across_response_ids(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -4408,7 +4408,7 @@ async def test_stream_responses_keeps_distinct_http_tool_calls_across_response_i
         if isinstance(chunk_payload, dict) and chunk_payload.get("type") == "response.output_item.done":
             tool_chunks.append(chunk_payload)
 
-    assert tool_chunks == [tool_payload, replayed_tool_payload]
+    assert tool_chunks == [tool_payload]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7108,8 +7108,8 @@ async def test_process_upstream_websocket_text_masks_unmatched_missing_tool_outp
         reasoning_effort=None,
         api_key_reservation=None,
         started_at=0.0,
-        previous_response_id="resp_anchor_a",
-        request_text='{"type":"response.create","previous_response_id":"resp_anchor_a"}',
+        previous_response_id="resp_anchor_b",
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor_b"}',
     )
     followup_request_b = proxy_service._WebSocketRequestState(
         request_id="ws_req_missing_tool_unmatched_b",
@@ -11527,7 +11527,7 @@ def test_prepare_response_bridge_request_state_dedupes_replayed_previous_respons
     assert upstream_input[2]["content"] == [{"type": "output_text", "text": "Process exited with code 0"}]
 
 
-def test_prepare_response_bridge_request_state_rewrites_replayed_side_effect_call_without_output():
+def test_prepare_response_bridge_request_state_keeps_unconfirmed_missing_tool_output_history():
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     input_items: list[JsonValue] = [
@@ -11556,10 +11556,7 @@ def test_prepare_response_bridge_request_state_rewrites_replayed_side_effect_cal
     upstream_payload = json.loads(text_data)
     upstream_input = upstream_payload["input"]
     assert request_state.input_item_count == 2
-    assert upstream_input[0]["type"] == "message"
-    assert upstream_input[0]["role"] == "assistant"
-    assert "without matching output: exec_command" in upstream_input[0]["content"][0]["text"]
-    assert "function_call" not in json.dumps(upstream_input)
+    assert upstream_input == input_items
 
 
 def test_prepare_response_bridge_request_state_rewrites_first_duplicate_when_only_replay_has_output():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4357,7 +4357,7 @@ async def test_stream_responses_non_retryable_first_failure_does_not_retry(monke
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_suppresses_replayed_side_effect_tool_calls_across_response_ids(monkeypatch):
+async def test_stream_responses_keeps_distinct_side_effect_tool_calls_across_response_ids(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -4408,7 +4408,7 @@ async def test_stream_responses_suppresses_replayed_side_effect_tool_calls_acros
         if isinstance(chunk_payload, dict) and chunk_payload.get("type") == "response.output_item.done":
             tool_chunks.append(chunk_payload)
 
-    assert tool_chunks == [tool_payload]
+    assert tool_chunks == [tool_payload, replayed_tool_payload]
 
 
 @pytest.mark.asyncio
@@ -11168,7 +11168,7 @@ def test_classify_upstream_close_rejected_only_for_clean_close_before_any_respon
     assert proxy_service._classify_upstream_close(1011, response_events_seen=0) == "transient"
 
 
-def test_prepare_response_bridge_request_state_dedupes_replayed_tool_calls_before_serializing():
+def test_prepare_response_bridge_request_state_dedupes_replayed_previous_response_tool_calls_before_serializing():
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     input_items: list[JsonValue] = [
@@ -11195,7 +11195,9 @@ def test_prepare_response_bridge_request_state_dedupes_replayed_tool_calls_befor
             "output": "Process exited with code 0",
         },
     ]
-    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "", "input": input_items})
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "", "input": input_items, "previous_response_id": "resp_anchor"}
+    )
 
     request_state, text_data = service._prepare_response_bridge_request_state(
         payload,
@@ -11216,6 +11218,115 @@ def test_prepare_response_bridge_request_state_dedupes_replayed_tool_calls_befor
     assert upstream_input[1]["output"] == "Process running with session ID 75180"
     assert upstream_input[2]["role"] == "assistant"
     assert upstream_input[2]["content"] == [{"type": "output_text", "text": "Process exited with code 0"}]
+
+
+def test_prepare_response_bridge_request_state_keeps_repeated_first_attempt_tool_calls():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000}),
+            "call_id": "call_first",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_first",
+            "output": "Process running with session ID 75180",
+        },
+        {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 1000}),
+            "call_id": "call_repeat",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_repeat",
+            "output": "Still running",
+        },
+    ]
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "", "input": input_items})
+
+    request_state, text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=proxy_service._REQUEST_TRANSPORT_WEBSOCKET,
+        client_metadata=None,
+    )
+
+    upstream_payload = json.loads(text_data)
+    upstream_input = upstream_payload["input"]
+    assert request_state.input_item_count == 4
+    assert len(upstream_input) == 4
+    assert upstream_input[2]["call_id"] == "call_repeat"
+    assert upstream_input[3]["call_id"] == "call_repeat"
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_tool_call_dedupe_survives_upstream_reconnect():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_tool_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_bridge_tool_replay",
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_tool_replay"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    first_payload = {
+        "type": "response.output_item.done",
+        "response_id": "resp_bridge_tool_replay",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": "", "yield_time_ms": 30000}),
+            "call_id": "call_first",
+        },
+    }
+    replay_payload = {
+        **first_payload,
+        "item": {
+            **first_payload["item"],
+            "call_id": "call_replayed",
+        },
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(first_payload, separators=(",", ":")))
+    session.upstream_control = proxy_service._WebSocketUpstreamControl()
+    await service._process_http_bridge_upstream_text(session, json.dumps(replay_payload, separators=(",", ":")))
+
+    assert request_state.suppressed_duplicate_tool_call is True
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    forwarded = await event_queue.get()
+    assert forwarded is not None
+    assert proxy_service.parse_sse_data_json(forwarded) == first_payload
+    assert event_queue.empty()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6656,7 +6656,7 @@ async def test_process_upstream_websocket_text_skips_anonymous_prev_nf_for_misma
     assert downstream_text == json.dumps(payload, separators=(",", ":"))
     finalize_request_state.assert_not_awaited()
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is True
+    assert upstream_control.reconnect_requested is False
     assert list(pending_requests) == [followup_request]
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4475,6 +4475,89 @@ async def test_stream_responses_suppresses_same_response_http_tool_call_replay(m
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_trims_overlapping_parallel_http_tool_call_replay(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_http_parallel_tool_overlap")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    first_arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.exec_command",
+                "parameters": {"cmd": "gh pr view --repo Soju06/codex-lb"},
+            },
+            {
+                "recipient_name": "functions.exec_command",
+                "parameters": {"cmd": "gh pr checks --repo Soju06/codex-lb"},
+            },
+        ]
+    }
+    replay_arguments = {
+        "tool_uses": [
+            {
+                "recipient_name": "functions.exec_command",
+                "parameters": {"cmd": "gh pr view --repo Soju06/codex-lb"},
+            },
+            {
+                "recipient_name": "github.read_file",
+                "parameters": {"repo": "Soju06/codex-lb", "path": "README.md"},
+            },
+        ]
+    }
+
+    def _parallel_payload(arguments: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        return {
+            "type": "response.output_item.done",
+            "response_id": "resp_http_parallel_overlap",
+            "item": {
+                "type": "function_call",
+                "name": "multi_tool_use.parallel",
+                "arguments": json.dumps(arguments),
+                "call_id": "call_parallel",
+            },
+        }
+
+    async def fake_stream(*_, **__):
+        yield 'data: {"type":"response.created","response":{"id":"resp_http_parallel_overlap"}}\n\n'
+        yield proxy_service.format_sse_event(_parallel_payload(first_arguments))
+        yield proxy_service.format_sse_event(_parallel_payload(replay_arguments))
+        yield 'data: {"type":"response.completed","response":{"id":"resp_http_parallel_overlap"}}\n\n'
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+    tool_chunks: list[dict[str, JsonValue]] = []
+    for chunk in chunks:
+        chunk_payload = parse_sse_data_json(chunk)
+        if isinstance(chunk_payload, dict) and chunk_payload.get("type") == "response.output_item.done":
+            tool_chunks.append(chunk_payload)
+
+    assert len(tool_chunks) == 2
+    replay_item = tool_chunks[1]["item"]
+    assert isinstance(replay_item, dict)
+    replay_item_arguments = replay_item["arguments"]
+    assert isinstance(replay_item_arguments, str)
+    assert json.loads(replay_item_arguments)["tool_uses"] == [
+        {
+            "recipient_name": "github.read_file",
+            "parameters": {"repo": "Soju06/codex-lb", "path": "README.md"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_passes_sticky_kind_to_load_balancer(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2118,9 +2118,11 @@ async def test_stream_responses_websocket_normalizes_typeless_error_as_terminal(
     failed_payload = parse_sse_data_json(events[1])
     assert failed_payload is not None
     assert failed_payload["type"] == "response.failed"
-    assert failed_payload["response"]["error"]["code"] == "invalid_request_error"
-    assert failed_payload["response"]["error"]["message"] == "No tool output found for function call call_missing."
-    assert failed_payload["response"]["error"]["param"] == "input"
+    failed_response = cast(dict[str, JsonValue], failed_payload["response"])
+    failed_error = cast(dict[str, JsonValue], failed_response["error"])
+    assert failed_error["code"] == "invalid_request_error"
+    assert failed_error["message"] == "No tool output found for function call call_missing."
+    assert failed_error["param"] == "input"
     assert websocket._index == 2
 
 
@@ -5892,93 +5894,6 @@ async def test_process_upstream_websocket_text_does_not_match_foreign_completed_
     assert downstream_text == json.dumps(payload, separators=(",", ":"))
     finalize_request_state.assert_not_awaited()
     assert list(pending_requests) == [pending_request]
-
-
-@pytest.mark.asyncio
-async def test_process_upstream_websocket_text_buffers_nonterminal_events_until_response_created(monkeypatch):
-    request_logs = _RequestLogsRecorder()
-    service = proxy_service.ProxyService(_repo_factory(request_logs))
-    finalize_request_state = AsyncMock()
-    account = _make_account("acc_ws_precreated_buffer")
-
-    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
-
-    pending_request = proxy_service._WebSocketRequestState(
-        request_id="ws_req_precreated_buffer",
-        model="gpt-5.1",
-        service_tier=None,
-        reasoning_effort=None,
-        api_key_reservation=None,
-        started_at=0.0,
-        awaiting_response_created=True,
-        request_text=json.dumps(
-            {
-                "type": "response.create",
-                "model": "gpt-5.1",
-                "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
-            },
-            separators=(",", ":"),
-        ),
-    )
-    pending_requests = deque([pending_request])
-    upstream_control = proxy_service._WebSocketUpstreamControl()
-    pending_lock = anyio.Lock()
-    response_create_gate = asyncio.Semaphore(1)
-    delta_text = json.dumps(
-        {
-            "type": "response.output_text.delta",
-            "item_id": "msg_precreated",
-            "output_index": 0,
-            "content_index": 0,
-            "delta": "hello",
-        },
-        separators=(",", ":"),
-    )
-
-    downstream_text = await service._process_upstream_websocket_text(
-        delta_text,
-        account=account,
-        account_id_value=account.id,
-        pending_requests=pending_requests,
-        pending_lock=pending_lock,
-        api_key=None,
-        upstream_control=upstream_control,
-        response_create_gate=response_create_gate,
-    )
-
-    assert downstream_text == delta_text
-    assert upstream_control.suppress_downstream_event is True
-    assert upstream_control.downstream_texts is None
-    assert pending_request.pre_response_created_event_texts == [delta_text]
-    finalize_request_state.assert_not_awaited()
-
-    upstream_control.suppress_downstream_event = False
-    created_text = json.dumps(
-        {
-            "type": "response.created",
-            "response": {"id": "resp_precreated_buffer", "status": "in_progress"},
-        },
-        separators=(",", ":"),
-    )
-
-    downstream_text = await service._process_upstream_websocket_text(
-        created_text,
-        account=account,
-        account_id_value=account.id,
-        pending_requests=pending_requests,
-        pending_lock=pending_lock,
-        api_key=None,
-        upstream_control=upstream_control,
-        response_create_gate=response_create_gate,
-    )
-
-    assert downstream_text == created_text
-    assert upstream_control.suppress_downstream_event is True
-    assert upstream_control.downstream_texts == [created_text, delta_text]
-    assert pending_request.pre_response_created_event_texts == []
-    assert pending_request.awaiting_response_created is False
-    assert pending_request.response_id == "resp_precreated_buffer"
-    finalize_request_state.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9059,75 +9059,6 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
 
 
 @pytest.mark.asyncio
-async def test_process_upstream_websocket_text_preserves_tool_dedupe_cache_across_reconnect(monkeypatch):
-    request_logs = _RequestLogsRecorder()
-    service = proxy_service.ProxyService(_repo_factory(request_logs))
-    finalize_request_state = AsyncMock()
-    handle_stream_error = AsyncMock()
-    account = _make_account("acc_ws_reconnect_tool_dedupe")
-
-    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
-    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
-
-    pending_request = proxy_service._WebSocketRequestState(
-        request_id="ws_req_reconnect_tool_dedupe",
-        model="gpt-5.1",
-        service_tier=None,
-        reasoning_effort=None,
-        api_key_reservation=None,
-        started_at=0.0,
-        response_id="resp_reconnect_tool",
-    )
-    pending_requests = deque([pending_request])
-    tool_payload = {
-        "type": "response.output_item.done",
-        "response_id": "resp_reconnect_tool",
-        "item": {
-            "type": "function_call",
-            "name": "write_stdin",
-            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
-            "call_id": "call_first",
-        },
-    }
-    replayed_tool_payload = {
-        **tool_payload,
-        "item": {
-            **tool_payload["item"],
-            "call_id": "call_replayed",
-        },
-    }
-
-    first_text = await service._process_upstream_websocket_text(
-        json.dumps(tool_payload, separators=(",", ":")),
-        account=account,
-        account_id_value=account.id,
-        pending_requests=pending_requests,
-        pending_lock=anyio.Lock(),
-        api_key=None,
-        upstream_control=proxy_service._WebSocketUpstreamControl(),
-        response_create_gate=asyncio.Semaphore(1),
-    )
-    replay_control = proxy_service._WebSocketUpstreamControl()
-    replay_text = await service._process_upstream_websocket_text(
-        json.dumps(replayed_tool_payload, separators=(",", ":")),
-        account=account,
-        account_id_value=account.id,
-        pending_requests=pending_requests,
-        pending_lock=anyio.Lock(),
-        api_key=None,
-        upstream_control=replay_control,
-        response_create_gate=asyncio.Semaphore(1),
-    )
-
-    assert '"call_id":"call_first"' in first_text
-    assert '"call_id":"call_replayed"' in replay_text
-    assert replay_control.suppress_downstream_event is True
-    assert pending_request.suppressed_duplicate_tool_call is True
-    finalize_request_state.assert_not_awaited()
-    assert list(pending_requests) == [pending_request]
-
-
-@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_masks_previous_response_not_found_for_unique_followup_request(
     monkeypatch,
 ):
@@ -9213,6 +9144,75 @@ async def test_process_upstream_websocket_text_masks_previous_response_not_found
     assert upstream_control.reconnect_requested is False
     assert upstream_control.suppress_downstream_event is False
     assert list(pending_requests) == [inflight_request]
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_preserves_tool_dedupe_cache_across_reconnect(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_reconnect_tool_dedupe")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_reconnect_tool_dedupe",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_reconnect_tool",
+    )
+    pending_requests = deque([pending_request])
+    tool_payload = {
+        "type": "response.output_item.done",
+        "response_id": "resp_reconnect_tool",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": '{"session_id":1,"chars":"","yield_time_ms":1000}',
+            "call_id": "call_first",
+        },
+    }
+    replayed_tool_payload = {
+        **tool_payload,
+        "item": {
+            **tool_payload["item"],
+            "call_id": "call_replayed",
+        },
+    }
+
+    first_text = await service._process_upstream_websocket_text(
+        json.dumps(tool_payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        response_create_gate=asyncio.Semaphore(1),
+    )
+    replay_control = proxy_service._WebSocketUpstreamControl()
+    replay_text = await service._process_upstream_websocket_text(
+        json.dumps(replayed_tool_payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=replay_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"call_id":"call_first"' in first_text
+    assert '"call_id":"call_replayed"' in replay_text
+    assert replay_control.suppress_downstream_event is True
+    assert pending_request.suppressed_duplicate_tool_call is True
+    finalize_request_state.assert_not_awaited()
+    assert list(pending_requests) == [pending_request]
 
 
 def test_maybe_rewrite_websocket_previous_response_not_found_rewrites_response_failed_event():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5458,7 +5458,7 @@ def test_websocket_receive_timeout_prefers_request_budget_when_sooner(monkeypatc
     assert timeout.error_message == "Proxy request budget exhausted"
 
 
-def test_websocket_receive_timeout_clamps_idle_when_equal_to_full_budget(monkeypatch):
+def test_websocket_receive_timeout_honors_idle_when_equal_to_full_budget(monkeypatch):
     monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 100.0)
 
     timeout = proxy_service._websocket_receive_timeout_for_pending_requests(
@@ -5468,7 +5468,7 @@ def test_websocket_receive_timeout_clamps_idle_when_equal_to_full_budget(monkeyp
     )
 
     assert timeout is not None
-    assert timeout.timeout_seconds == 120.0
+    assert timeout.timeout_seconds == 600.0
     assert timeout.error_code == "stream_idle_timeout"
     assert timeout.error_message == "Upstream stream idle timeout"
 
@@ -5604,6 +5604,46 @@ async def test_fail_pending_websocket_requests_does_not_penalize_rejected_input_
     assert len(request_logs.calls) == 1
     assert request_logs.calls[0]["request_id"] == "resp_ws_rejected"
     assert request_logs.calls[0]["error_code"] == "upstream_rejected_input"
+
+
+@pytest.mark.asyncio
+async def test_fail_pending_websocket_requests_logs_even_when_penalty_fails(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_penalty_fail")
+
+    async def fail_health_penalty(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("state store down")
+
+    monkeypatch.setattr(service, "_handle_stream_error", fail_health_penalty)
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_penalty_fail",
+        response_id="resp_ws_penalty_fail",
+        model="gpt-5.5",
+        service_tier="auto",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    pending_requests = deque([request_state])
+
+    await service._fail_pending_websocket_requests(
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        error_code="stream_incomplete",
+        error_message="Upstream websocket closed before response.completed",
+        api_key=None,
+    )
+
+    assert list(pending_requests) == []
+    assert len(request_logs.calls) == 1
+    assert request_logs.calls[0]["request_id"] == "resp_ws_penalty_fail"
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7861,7 +7861,7 @@ async def test_relay_upstream_websocket_emits_keepalive_while_upstream_is_silent
 
 
 @pytest.mark.asyncio
-async def test_relay_upstream_websocket_emits_keepalive_before_response_created(monkeypatch):
+async def test_relay_upstream_websocket_omits_keepalive_before_response_created(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
@@ -7921,15 +7921,8 @@ async def test_relay_upstream_websocket_emits_keepalive_before_response_created(
     )
 
     try:
-        for _ in range(20):
-            if downstream.sent_text:
-                break
-            await asyncio.sleep(0.01)
-        assert downstream.sent_text
-        assert json.loads(downstream.sent_text[0]) == {
-            "type": "response.in_progress",
-            "response": {"id": "ws_req_precreated_keepalive", "status": "in_progress"},
-        }
+        await asyncio.sleep(0.05)
+        assert downstream.sent_text == []
     finally:
         relay.cancel()
         with pytest.raises(asyncio.CancelledError):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5458,6 +5458,21 @@ def test_websocket_receive_timeout_prefers_request_budget_when_sooner(monkeypatc
     assert timeout.error_message == "Proxy request budget exhausted"
 
 
+def test_websocket_receive_timeout_clamps_idle_when_equal_to_full_budget(monkeypatch):
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 100.0)
+
+    timeout = proxy_service._websocket_receive_timeout_for_pending_requests(
+        [100.0],
+        proxy_request_budget_seconds=600.0,
+        stream_idle_timeout_seconds=600.0,
+    )
+
+    assert timeout is not None
+    assert timeout.timeout_seconds == 120.0
+    assert timeout.error_code == "stream_idle_timeout"
+    assert timeout.error_message == "Upstream stream idle timeout"
+
+
 @pytest.mark.asyncio
 async def test_fail_expired_pending_websocket_requests_keeps_newer_requests(monkeypatch):
     request_logs = _RequestLogsRecorder()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7118,8 +7118,8 @@ async def test_process_upstream_websocket_text_masks_unmatched_missing_tool_outp
         reasoning_effort=None,
         api_key_reservation=None,
         started_at=0.0,
-        previous_response_id="resp_anchor_b",
-        request_text='{"type":"response.create","previous_response_id":"resp_anchor_b"}',
+        previous_response_id="resp_anchor_a",
+        request_text='{"type":"response.create","previous_response_id":"resp_anchor_a"}',
     )
     pending_requests = deque([followup_request_a, followup_request_b])
     upstream_control = proxy_service._WebSocketUpstreamControl()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4464,6 +4464,14 @@ async def test_stream_responses_suppresses_same_response_http_tool_call_replay(m
             tool_chunks.append(chunk_payload)
 
     assert tool_chunks == [tool_payload]
+    terminal_payload = parse_sse_data_json(chunks[-1])
+    assert isinstance(terminal_payload, dict)
+    assert terminal_payload["type"] == "response.failed"
+    terminal_response = cast(dict[str, object], terminal_payload["response"])
+    terminal_error = cast(dict[str, object], terminal_response["error"])
+    assert terminal_error["code"] == "stream_incomplete"
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6656,7 +6656,7 @@ async def test_process_upstream_websocket_text_skips_anonymous_prev_nf_for_misma
     assert downstream_text == json.dumps(payload, separators=(",", ":"))
     finalize_request_state.assert_not_awaited()
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is False
+    assert upstream_control.reconnect_requested is True
     assert list(pending_requests) == [followup_request]
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8916,6 +8916,66 @@ def test_maybe_rewrite_websocket_previous_response_invalid_request_error_rewrite
     assert "previous_response_not_found" not in rewritten_text
 
 
+def test_maybe_rewrite_websocket_missing_tool_output_rewrites_to_stream_incomplete(caplog, monkeypatch):
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_missing_tool_output",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id=None,
+        previous_response_id="resp_prev_anchor",
+    )
+    original_payload: dict[str, JsonValue] = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "No tool output found for function call call_W3U0TC60cgB5OD7gVCyS0qIq.",
+            "param": "input",
+        },
+    }
+    original_text = json.dumps(original_payload, separators=(",", ":"))
+    original_event = parse_sse_event(f"data: {original_text}\n\n")
+    assert original_event is not None
+    original_event_type = proxy_service._event_type_from_payload(original_event, original_payload)
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    counter = _ObservedCounter()
+    monkeypatch.setattr(proxy_service, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_service, "continuity_fail_closed_total", counter, raising=False)
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+
+    _, rewritten_payload, rewritten_event_type, rewritten_text = (
+        proxy_service._maybe_rewrite_websocket_previous_response_not_found_event(
+            request_state=request_state,
+            event=original_event,
+            payload=original_payload,
+            event_type=original_event_type,
+            upstream_control=upstream_control,
+            original_text=original_text,
+        )
+    )
+
+    assert upstream_control.reconnect_requested is True
+    assert rewritten_event_type == "response.failed"
+    assert rewritten_payload is not None
+    response_payload = cast(dict[str, JsonValue], rewritten_payload.get("response"))
+    error_payload = cast(dict[str, JsonValue], response_payload.get("error"))
+    assert error_payload["code"] == "stream_incomplete"
+    assert error_payload["message"] == "Upstream websocket closed before response.completed"
+    assert "No tool output found" not in rewritten_text
+    assert "call_W3U0TC60cgB5OD7gVCyS0qIq" not in rewritten_text
+    assert "continuity_fail_closed surface=websocket_stream reason=missing_tool_output" in caplog.text
+    assert counter.samples == [
+        {
+            "labels": {"surface": "websocket_stream", "reason": "missing_tool_output"},
+            "value": 1.0,
+        }
+    ]
+
+
 def test_maybe_rewrite_websocket_previous_response_invalid_request_error_does_not_rewrite_other_message():
     request_state = proxy_service._WebSocketRequestState(
         request_id="ws_req_prev_invalid_other_message",
@@ -9187,6 +9247,44 @@ def test_sanitize_websocket_connect_failure_rewrites_invalid_request_previous_re
         payload=original_payload,
         error_code="invalid_request_error",
         error_message="Previous response with id 'resp_prev_anchor' not found.",
+    )
+
+    assert rewritten_status == 502
+    assert rewritten_payload["error"]["code"] == "stream_incomplete"
+    assert rewritten_payload["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert rewritten_payload["error"]["type"] == "server_error"
+    assert rewritten_error_code == "stream_incomplete"
+    assert rewritten_error_message == "Upstream websocket closed before response.completed"
+
+
+def test_sanitize_websocket_connect_failure_rewrites_missing_tool_output():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_missing_tool_output_connect",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_prev_anchor",
+    )
+    original_payload = proxy_module.openai_error(
+        "invalid_request_error",
+        "No tool output found for function call call_qFY2plVIaGr1Qv2AIxiziz3G.",
+        error_type="invalid_request_error",
+    )
+    original_payload["error"]["param"] = "input"
+
+    (
+        rewritten_status,
+        rewritten_payload,
+        rewritten_error_code,
+        rewritten_error_message,
+    ) = proxy_service._sanitize_websocket_connect_failure(
+        request_state=request_state,
+        status_code=400,
+        payload=original_payload,
+        error_code="invalid_request_error",
+        error_message="No tool output found for function call call_qFY2plVIaGr1Qv2AIxiziz3G.",
     )
 
     assert rewritten_status == 502
@@ -9765,6 +9863,76 @@ async def test_stream_previous_response_not_found_proxy_error_is_masked_to_strea
     assert counter.samples == [
         {
             "labels": {"surface": "http_stream", "reason": "previous_response_not_found"},
+            "value": 1.0,
+        }
+    ]
+    record_error.assert_not_awaited()
+    record_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_missing_tool_output_proxy_error_is_masked_to_stream_incomplete(monkeypatch, caplog):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_missing_tool_output_stream")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    counter = _ObservedCounter()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_service, "continuity_fail_closed_total", counter, raising=False)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, kwargs
+        error_payload = openai_error(
+            "invalid_request_error",
+            "No tool output found for function call call_W3U0TC60cgB5OD7gVCyS0qIq.",
+            error_type="invalid_request_error",
+        )
+        error_payload["error"]["param"] = "input"
+        raise proxy_module.ProxyResponseError(400, error_payload)
+        if False:
+            yield ""
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_prev_anchor",
+        }
+    )
+
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+
+    event = json.loads(chunks[0].split("data: ", 1)[1])
+    assert event["type"] == "response.failed"
+    assert event["response"]["error"]["code"] == "stream_incomplete"
+    assert event["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "No tool output found" not in chunks[0]
+    assert "call_W3U0TC60cgB5OD7gVCyS0qIq" not in chunks[0]
+    assert request_logs.lookup_calls == [("resp_prev_anchor", None, "sid-stream")]
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+    assert "continuity_fail_closed surface=http_stream reason=missing_tool_output" in caplog.text
+    assert counter.samples == [
+        {
+            "labels": {"surface": "http_stream", "reason": "missing_tool_output"},
             "value": 1.0,
         }
     ]

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -27,7 +27,7 @@ def test_settings_multi_replica_defaults():
     assert settings.proxy_response_create_limit == 256
     assert settings.proxy_compact_response_create_limit == 64
     assert settings.compact_request_budget_seconds == 180.0
-    assert settings.stream_idle_timeout_seconds == 600.0
+    assert settings.stream_idle_timeout_seconds == 120.0
     assert settings.proxy_downstream_websocket_idle_timeout_seconds == 120.0
     assert settings.max_sse_event_bytes == 16 * 1024 * 1024
     assert settings.proxy_refresh_failure_cooldown_seconds == 5.0

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -26,6 +26,8 @@ def test_settings_multi_replica_defaults():
     assert settings.proxy_upstream_websocket_connect_limit == 128
     assert settings.proxy_response_create_limit == 256
     assert settings.proxy_compact_response_create_limit == 64
+    assert settings.compact_request_budget_seconds == 180.0
+    assert settings.stream_idle_timeout_seconds == 600.0
     assert settings.proxy_downstream_websocket_idle_timeout_seconds == 120.0
     assert settings.max_sse_event_bytes == 16 * 1024 * 1024
     assert settings.proxy_refresh_failure_cooldown_seconds == 5.0

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -27,7 +27,7 @@ def test_settings_multi_replica_defaults():
     assert settings.proxy_response_create_limit == 256
     assert settings.proxy_compact_response_create_limit == 64
     assert settings.compact_request_budget_seconds == 180.0
-    assert settings.stream_idle_timeout_seconds == 120.0
+    assert settings.stream_idle_timeout_seconds == 600.0
     assert settings.proxy_downstream_websocket_idle_timeout_seconds == 120.0
     assert settings.max_sse_event_bytes == 16 * 1024 * 1024
     assert settings.proxy_refresh_failure_cooldown_seconds == 5.0

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.16.0"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Draft split from #555.

## Purpose
- Suppress replayed side-effect tool-call events in the HTTP stream path, including replays that change `call_id`.
- Keep independent downstream responses scoped by `response_id` so separate turns are not suppressed as duplicates.
- Rewrite duplicate nested side-effect operations inside `multi_tool_use.parallel` before forwarding the batch to the client.
- Limit input-history side-effect dedupe to previous-response replay/continuity payloads, not first-attempt list inputs.

## Validation
- Rebased on current `main`.
- `ruff format --check`, `ruff check`, and `ty check` on touched backend/test files passed locally.
- Focused pytest for downstream tool-call dedupe, HTTP stream replay, same-response replay, and previous-response input replay passed locally.
- Exact-head GitHub CI is green for `172f032bb306a712119a29ee157a0ce5d6fd6060`.
- Fresh `@codex review` completed for `172f032bb306a712119a29ee157a0ce5d6fd6060`; no inline review comments were reported.

## Relationship
- Replaces the side-effect dedupe portion of #555.
- #555 remains Draft and should not be merged as one large PR.
