### PR TITLE
fix(chat): route parallel tool-call arguments by item_id

### DIFF
--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -123,14 +123,37 @@ class ToolCallIndex:
     indexes: dict[str, int] = field(default_factory=dict)
     next_index: int = 0
 
-    def index_for(self, call_id: str | None, name: str | None) -> int:
-        key = _tool_call_key(call_id, name)
-        if key is None:
-            return 0
-        if key not in self.indexes:
-            self.indexes[key] = self.next_index
+    def index_for(
+        self,
+        call_id: str | None,
+        name: str | None,
+        item_id: str | None = None,
+    ) -> int:
+        call_key = _tool_call_key(call_id, name)
+        item_key = _tool_call_item_key(item_id)
+
+        # If either key already maps to an index, reuse it. The Responses API
+        # streams output_item.added (which carries call_id) and
+        # function_call_arguments.delta/done (which only carry item_id) for the
+        # same logical tool call; binding both keys to one slot prevents
+        # parallel tool calls from collapsing to index 0 (see issue #542).
+        existing: int | None = None
+        if call_key is not None:
+            existing = self.indexes.get(call_key)
+        if existing is None and item_key is not None:
+            existing = self.indexes.get(item_key)
+
+        if existing is None:
+            if call_key is None and item_key is None:
+                return 0
+            existing = self.next_index
             self.next_index += 1
-        return self.indexes[key]
+
+        if call_key is not None:
+            self.indexes.setdefault(call_key, existing)
+        if item_key is not None:
+            self.indexes.setdefault(item_key, existing)
+        return existing
 
 
 @dataclass
@@ -596,7 +619,8 @@ def _tool_call_delta_from_payload(payload: Mapping[str, JsonValue], indexer: Too
     if fields is None:
         return None
     call_id, name, arguments, tool_type = fields
-    index = indexer.index_for(call_id, name)
+    item_id = _extract_item_id(payload)
+    index = indexer.index_for(call_id, name, item_id=item_id)
     return ToolCallDelta(
         index=index,
         call_id=call_id,
@@ -701,6 +725,28 @@ def _tool_call_key(call_id: str | None, name: str | None) -> str | None:
         return f"id:{call_id}"
     if name:
         return f"name:{name}"
+    return None
+
+
+def _tool_call_item_key(item_id: str | None) -> str | None:
+    if item_id:
+        return f"item:{item_id}"
+    return None
+
+
+def _extract_item_id(payload: Mapping[str, JsonValue]) -> str | None:
+    # response.function_call_arguments.delta/.done carry the owning item
+    # identifier at the top level as `item_id`.
+    raw = payload.get("item_id")
+    if isinstance(raw, str) and raw:
+        return raw
+    # response.output_item.added/.done nest the item; its `id` matches the
+    # `item_id` emitted by the argument events for the same call.
+    item = _as_mapping(payload.get("item"))
+    if item is not None:
+        raw = item.get("id")
+        if isinstance(raw, str) and raw:
+            return raw
     return None
 
 

--- a/openspec/changes/fix-parallel-tool-call-arguments-routing/proposal.md
+++ b/openspec/changes/fix-parallel-tool-call-arguments-routing/proposal.md
@@ -1,0 +1,12 @@
+## Why
+Issue #542 reports that `/v1/chat/completions` corrupts parallel tool-call arguments. The Responses API emits `response.function_call_arguments.delta` / `.done` events that identify their owning call only via `item_id` (e.g. `"fc_..."`). The current `ToolCallIndex.index_for` keys on `call_id`/`name` only, so argument events for the second and subsequent parallel calls fall back to index `0` and overwrite the first call's payload. Downstream agents then silently execute the wrong actions.
+
+## What Changes
+- Route Responses tool-call events through a `ToolCallIndex` that also recognises `item_id` as an indexing key.
+- Establish an alias between the `output_item` `call_id` and the corresponding `item_id` the first time both are seen, so subsequent argument-only events resolve to the same slot.
+- Preserve the existing behaviour for Chat-Completions-style events that carry `call_id` directly with no `item_id`.
+- Add regression coverage for parallel tool-call routing in both the streaming and non-streaming `/v1/chat/completions` adapters.
+
+## Impact
+- Restores correct `tool_calls[].function.arguments` per call when upstream emits multiple parallel function calls.
+- No effect on single-tool-call paths, raw `/v1/responses` forwarding, or non-tool text handling.

--- a/openspec/changes/fix-parallel-tool-call-arguments-routing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-parallel-tool-call-arguments-routing/specs/responses-api-compat/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+### Requirement: Tool call events and output items are preserved
+If the upstream model emits tool call deltas or output items, the service MUST forward those events in streaming mode and MUST include tool call items in the final response output for non-streaming mode.
+
+#### Scenario: Tool call emitted
+- **WHEN** the upstream emits a tool call delta event
+- **THEN** the service forwards the delta event and includes the finalized tool call in the completed response output
+
+#### Scenario: Chat Completions tool arguments avoid snapshot duplication
+- **WHEN** `/v1/chat/completions` maps Responses tool-call events that include incremental deltas and later finalized snapshots for the same tool call
+- **THEN** the final `tool_calls[].function.arguments` value is exactly one valid JSON string for that tool call
+- **AND** the adapter MUST NOT append full snapshot payloads on top of already-collected incremental argument deltas
+
+#### Scenario: Parallel tool calls route arguments by item_id
+- **WHEN** `/v1/chat/completions` maps Responses events for two or more parallel function calls whose `response.function_call_arguments.delta` / `.done` events identify the owning call only via `item_id`
+- **THEN** each call's arguments are routed to its own `tool_calls[]` slot using `item_id` as the indexing key
+- **AND** the adapter MUST alias the `item_id` to the same slot as the `call_id` once both identifiers have been observed, so subsequent argument-only events for that call do not collapse to index `0`

--- a/openspec/changes/fix-parallel-tool-call-arguments-routing/tasks.md
+++ b/openspec/changes/fix-parallel-tool-call-arguments-routing/tasks.md
@@ -1,0 +1,4 @@
+- [x] Add regression tests covering parallel tool-call routing for both `collect_chat_completion` and `stream_chat_chunks` using realistic `output_item` + `function_call_arguments` event sequences.
+- [x] Extend `ToolCallIndex.index_for` to accept an `item_id`, aliasing it to the `call_id`-keyed slot when both are present.
+- [x] Thread `item_id` extraction through `_tool_call_delta_from_payload` so argument-only events resolve to the correct slot.
+- [x] Document the parallel tool-call routing requirement in the Responses compatibility spec.

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -365,6 +365,149 @@ async def test_collect_completion_prefers_final_tool_call_snapshot_without_dupli
 
 
 @pytest.mark.asyncio
+async def test_collect_completion_routes_parallel_tool_calls_by_item_id():
+    """Regression test for #542.
+
+    The Responses API streams `response.function_call_arguments.delta` / `.done`
+    events that identify their owning call only via `item_id` (the `fc_...`
+    identifier from `response.output_item.added`). When two parallel tool calls
+    were in flight, the indexer routed all argument events to slot 0 because
+    `item_id` was not used as a routing key, overwriting the first call's
+    arguments with the second call's payload.
+    """
+
+    lines = [
+        # First tool call - output_item.added carries both call_id and item.id.
+        (
+            'data: {"type":"response.output_item.added","output_index":0,"item":'
+            '{"id":"fc_first","type":"function_call","call_id":"call_first",'
+            '"name":"record_observation","arguments":""}}\n\n'
+        ),
+        # First tool call - arguments are streamed using only item_id.
+        (
+            'data: {"type":"response.function_call_arguments.delta","item_id":"fc_first",'
+            '"output_index":0,"delta":"{\\"category\\":\\"activity\\",\\"content\\":'
+            '\\"Biked 20km today\\",\\"confidence\\":0.95}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","item_id":"fc_first",'
+            '"output_index":0,"arguments":"{\\"category\\":\\"activity\\",\\"content\\":'
+            '\\"Biked 20km today\\",\\"confidence\\":0.95}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":0,"item":'
+            '{"id":"fc_first","type":"function_call","call_id":"call_first",'
+            '"name":"record_observation","arguments":"{\\"category\\":\\"activity\\",'
+            '\\"content\\":\\"Biked 20km today\\",\\"confidence\\":0.95}"}}\n\n'
+        ),
+        # Second tool call - same shape, distinct identifiers and payload.
+        (
+            'data: {"type":"response.output_item.added","output_index":1,"item":'
+            '{"id":"fc_second","type":"function_call","call_id":"call_second",'
+            '"name":"record_observation","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.delta","item_id":"fc_second",'
+            '"output_index":1,"delta":"{\\"category\\":\\"food\\",\\"content\\":'
+            '\\"Pasta for dinner\\",\\"confidence\\":0.9}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","item_id":"fc_second",'
+            '"output_index":1,"arguments":"{\\"category\\":\\"food\\",\\"content\\":'
+            '\\"Pasta for dinner\\",\\"confidence\\":0.9}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.done","output_index":1,"item":'
+            '{"id":"fc_second","type":"function_call","call_id":"call_second",'
+            '"name":"record_observation","arguments":"{\\"category\\":\\"food\\",'
+            '\\"content\\":\\"Pasta for dinner\\",\\"confidence\\":0.9}"}}\n\n'
+        ),
+        'data: {"type":"response.completed","response":{"id":"r1"}}\n\n',
+    ]
+
+    async def _stream():
+        for line in lines:
+            yield line
+
+    result = await collect_chat_completion(_stream(), model="gpt-5.4-mini")
+    assert isinstance(result, ChatCompletion)
+    tool_calls = result.choices[0].message.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+
+    first, second = tool_calls
+    assert first.id == "call_first"
+    assert second.id == "call_second"
+
+    assert first.function is not None
+    assert second.function is not None
+    first_args = json.loads(first.function.arguments or "")
+    second_args = json.loads(second.function.arguments or "")
+    assert first_args["content"] == "Biked 20km today"
+    assert second_args["content"] == "Pasta for dinner"
+    assert first_args != second_args
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_chunks_routes_parallel_tool_calls_by_item_id():
+    """Streaming counterpart to the parallel-tool-call regression for #542."""
+
+    lines = [
+        (
+            'data: {"type":"response.output_item.added","output_index":0,"item":'
+            '{"id":"fc_first","type":"function_call","call_id":"call_first",'
+            '"name":"do_a","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.delta","item_id":"fc_first",'
+            '"output_index":0,"delta":"{\\"x\\":1}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","item_id":"fc_first",'
+            '"output_index":0,"arguments":"{\\"x\\":1}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.output_item.added","output_index":1,"item":'
+            '{"id":"fc_second","type":"function_call","call_id":"call_second",'
+            '"name":"do_b","arguments":""}}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.delta","item_id":"fc_second",'
+            '"output_index":1,"delta":"{\\"y\\":2}"}\n\n'
+        ),
+        (
+            'data: {"type":"response.function_call_arguments.done","item_id":"fc_second",'
+            '"output_index":1,"arguments":"{\\"y\\":2}"}\n\n'
+        ),
+        'data: {"type":"response.completed","response":{"id":"r1"}}\n\n',
+    ]
+
+    async def _stream():
+        for line in lines:
+            yield line
+
+    chunks = [
+        json.loads(chunk[5:].strip())
+        for chunk in [c async for c in stream_chat_chunks(_stream(), model="gpt-5.4-mini")]
+        if chunk.startswith("data: ") and chunk.strip() != "data: [DONE]"
+    ]
+
+    args_by_index: dict[int, str] = {}
+    for chunk in chunks:
+        tool_calls = chunk["choices"][0]["delta"].get("tool_calls")
+        if not tool_calls:
+            continue
+        for call in tool_calls:
+            function = call.get("function") or {}
+            arguments = function.get("arguments")
+            if arguments:
+                args_by_index[call["index"]] = args_by_index.get(call["index"], "") + arguments
+
+    assert args_by_index[0] == '{"x":1}'
+    assert args_by_index[1] == '{"y":2}'
+
+
+@pytest.mark.asyncio
 async def test_collect_completion_uses_snapshot_only_tool_call_arguments():
     lines = [
         (


### PR DESCRIPTION
## Summary
- Fixes #542. When upstream emits two or more parallel `function_call` items, the Responses API streams `response.function_call_arguments.delta` / `.done` events that identify their owning call only via `item_id` (e.g. `fc_...`). The previous `ToolCallIndex.index_for` keyed on `call_id` / `name` only, so all argument events for the 2nd+ parallel calls fell back to index `0` and overwrote the first call's arguments. Downstream agents silently executed the wrong actions with corrupted parameters.
- Extend `ToolCallIndex.index_for` to accept an `item_id` and alias it to the same slot as the `call_id` / `name` key the first time both are seen on an `output_item.added` / `.done` event. Argument-only events then resolve to the correct slot via the `item_id` alias.
- Single-tool-call paths, Chat-Completions-style events (which carry `call_id` directly), and raw `/v1/responses` forwarding are unchanged.
- OpenSpec change `fix-parallel-tool-call-arguments-routing` documents the new requirement and mirrors the structure of the prior accepted PR #287 change.

## Validation
- `uv run pytest tests/unit/test_chat_response_mapping.py tests/integration/test_proxy_chat_completions.py tests/integration/test_openai_compat_features.py tests/integration/test_proxy_responses.py` — 102 passed
- `uv run ruff check app/core/openai/chat_responses.py tests/unit/test_chat_response_mapping.py` — clean
- `uv run ty check app/core/openai/chat_responses.py` — clean
- Added regression tests `test_collect_completion_routes_parallel_tool_calls_by_item_id` and `test_stream_chat_chunks_routes_parallel_tool_calls_by_item_id` exercising realistic `output_item.added` + `function_call_arguments.delta/.done` + `output_item.done` sequences for two parallel calls

Fixes #542