### PR TITLE
perf(dashboard): memoize per-account depletion EWMA state

### DIFF
--- a/app/modules/usage/depletion_service.py
+++ b/app/modules/usage/depletion_service.py
@@ -14,9 +14,20 @@ from app.core.usage.depletion import (
 )
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 
+# Per-account cache key: (account_id, limit_name, window).
+_StateKey = tuple[str, str, str]
+# Signature of the history slice that produced a cached EWMAState. Includes the
+# window endpoints and length so any change in the in-window history (new row,
+# aged-out row, or replaced row) invalidates the cache and forces a rebuild.
+_HistorySignature = tuple[datetime, datetime, int]
+
 # In-memory EWMA state: keyed by (account_id, limit_name, window)
 # Persists across requests; resets on process restart.
-_ewma_states: dict[tuple[str, str, str], EWMAState] = {}
+_ewma_states: dict[_StateKey, EWMAState] = {}
+# Parallel signature map used to memoize EWMA rebuilds across dashboard polls
+# (issue #537). When the in-window history is unchanged between requests we
+# reuse the cached EWMAState instead of replaying the full history.
+_history_signatures: dict[_StateKey, _HistorySignature] = {}
 
 
 @dataclass
@@ -58,7 +69,7 @@ def compute_depletion_for_account(
         return None
 
     now = now or utcnow()
-    key = (account_id, limit_name, window)
+    key: _StateKey = (account_id, limit_name, window)
 
     if len(history) < 2:
         # Only one in-window sample — seed the EWMA but don't compute
@@ -68,12 +79,24 @@ def compute_depletion_for_account(
         _ewma_states[key] = ewma_update(
             None, entry.used_percent, naive_utc_to_epoch(entry.recorded_at), reset_at=entry.reset_at
         )
+        _history_signatures[key] = (entry.recorded_at, entry.recorded_at, 1)
         return None
 
-    state = _rebuild_ewma_state(history)
+    signature: _HistorySignature = (history[0].recorded_at, history[-1].recorded_at, len(history))
+    cached_state = _ewma_states.get(key)
+    cached_signature = _history_signatures.get(key)
 
-    if state is not None:
-        _ewma_states[key] = state
+    if cached_state is not None and cached_signature == signature:
+        # Same in-window history as the last call — reuse the cached EWMA
+        # state instead of replaying every row.  Time-dependent fields below
+        # (risk, safe_usage_percent, projected_exhaustion_at) are still
+        # recomputed from `now`, so dashboard polls remain live.
+        state: EWMAState | None = cached_state
+    else:
+        state = _rebuild_ewma_state(history)
+        if state is not None:
+            _ewma_states[key] = state
+            _history_signatures[key] = signature
 
     if state is None or state.rate is None:
         return None
@@ -153,6 +176,7 @@ def compute_aggregate_depletion(
 def reset_ewma_state() -> None:
     """Clear all in-memory EWMA state. Used for testing."""
     _ewma_states.clear()
+    _history_signatures.clear()
 
 
 def _rebuild_ewma_state(history: list) -> EWMAState | None:

--- a/app/modules/usage/depletion_service.py
+++ b/app/modules/usage/depletion_service.py
@@ -16,10 +16,16 @@ from app.core.utils.time import naive_utc_to_epoch, utcnow
 
 # Per-account cache key: (account_id, limit_name, window).
 _StateKey = tuple[str, str, str]
-# Signature of the history slice that produced a cached EWMAState. Includes the
-# window endpoints and length so any change in the in-window history (new row,
-# aged-out row, or replaced row) invalidates the cache and forces a rebuild.
-_HistorySignature = tuple[datetime, datetime, int]
+# Per-row content fingerprint: timestamp + value-bearing fields. Captured
+# row-by-row so an in-place correction to `used_percent` / `reset_at` /
+# `window_minutes` on an existing row invalidates the cache even when the
+# window endpoints and row count are unchanged.
+_RowSignature = tuple[datetime, float, float | None, int | None]
+# Signature of the history slice that produced a cached EWMAState. A tuple of
+# per-row fingerprints so any change in the in-window history (new row, aged-
+# out row, replaced row, or in-place value correction) invalidates the cache
+# and forces a rebuild.
+_HistorySignature = tuple[_RowSignature, ...]
 
 # In-memory EWMA state: keyed by (account_id, limit_name, window)
 # Persists across requests; resets on process restart.
@@ -79,10 +85,14 @@ def compute_depletion_for_account(
         _ewma_states[key] = ewma_update(
             None, entry.used_percent, naive_utc_to_epoch(entry.recorded_at), reset_at=entry.reset_at
         )
-        _history_signatures[key] = (entry.recorded_at, entry.recorded_at, 1)
+        _history_signatures[key] = (
+            (entry.recorded_at, entry.used_percent, entry.reset_at, entry.window_minutes),
+        )
         return None
 
-    signature: _HistorySignature = (history[0].recorded_at, history[-1].recorded_at, len(history))
+    signature: _HistorySignature = tuple(
+        (e.recorded_at, e.used_percent, e.reset_at, e.window_minutes) for e in history
+    )
     cached_state = _ewma_states.get(key)
     cached_signature = _history_signatures.get(key)
 

--- a/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
@@ -1,0 +1,18 @@
+## Why
+Issue #537 reports that `GET /api/dashboard/overview` is slow once `usage_history` grows because the depletion / EWMA section rebuilds depletion state from raw usage rows on every request. The reporter measured 120 accounts × 117,600 usage_history rows × 7 day timeframe:
+
+- dashboard with EWMA/depletion: median **2122.3 ms**
+- dashboard with EWMA history fetch disabled: median **197.6 ms**
+- EWMA/depletion share: **~90.7 %** of endpoint time
+
+Dashboard polls are issued much more frequently than new usage rows land, yet each poll currently re-walks the full per-account history through `ewma_update`.
+
+## What Changes
+- Memoize per-account EWMA state alongside a signature of the in-window history `(earliest_recorded_at, latest_recorded_at, len(history))` so dashboard polls reuse the cached state whenever the input is unchanged.
+- Invalidate the memoized state automatically when a new sample is appended, an older sample ages out of the window, or `reset_ewma_state()` is called.
+- Continue recomputing the time-dependent fields (`risk`, `safe_usage_percent`, `projected_exhaustion_at`, `seconds_until_exhaustion`) on every call so polls remain live.
+
+## Impact
+- Cuts the dominant cost of `GET /api/dashboard/overview` in steady state: subsequent polls within the inter-arrival time of usage_history rows skip the per-account history replay entirely.
+- No change to depletion semantics: the cache key captures the only inputs that influence EWMA rate, and any change to the in-window history forces a rebuild.
+- No schema or persistence changes; the cache lives next to the existing in-memory `_ewma_states` map and clears on process restart.

--- a/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+### Requirement: Dashboard overview memoizes per-account depletion EWMA state
+`GET /api/dashboard/overview` MUST cache per-account EWMA depletion state in memory so repeated polls do not re-walk the full in-window `usage_history` slice when its content is unchanged.
+
+#### Scenario: Repeated polls with unchanged history reuse cached EWMA state
+- **GIVEN** the dashboard service has previously computed depletion for an account
+- **AND** a subsequent request supplies the same in-window history slice for that account (same earliest `recorded_at`, same latest `recorded_at`, same row count)
+- **WHEN** depletion is recomputed for the dashboard response
+- **THEN** the service MUST reuse the cached EWMA state for that account instead of replaying every history row
+- **AND** the depletion metrics for that account MUST match the previously returned values for rate-bearing fields
+
+#### Scenario: Memoized EWMA state is invalidated when a new usage row is appended
+- **WHEN** a later dashboard request supplies the same account's in-window history with an additional row appended (a new `recorded_at` past the previous latest)
+- **THEN** the service MUST rebuild the EWMA state from the new history slice
+- **AND** the recomputed rate MUST reflect the newly observed sample
+
+#### Scenario: Memoized EWMA state is invalidated when an older row ages out of the window
+- **WHEN** a later dashboard request supplies the same account's in-window history with the earliest row dropped (because it has aged past the window cutoff)
+- **THEN** the service MUST rebuild the EWMA state from the narrowed history slice
+- **AND** the cached state from the wider window MUST NOT influence the recomputed rate

--- a/openspec/changes/memoize-dashboard-depletion-ewma/tasks.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/tasks.md
@@ -1,0 +1,4 @@
+- [x] Add a per-account history signature alongside `_ewma_states` and short-circuit `compute_depletion_for_account` when the signature matches a cached state.
+- [x] Invalidate the memoized state on appended rows, aged-out rows, and `reset_ewma_state()` calls.
+- [x] Add regression tests covering: cache hit on identical history (no rebuild), cache miss when a new row lands, cache miss when an old row ages out, and continued idempotency of the result for unchanged input.
+- [x] Document the memoization contract in the `query-caching` capability spec.

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -278,6 +278,122 @@ def test_aged_out_samples_do_not_keep_stale_ewma_influence() -> None:
     assert in_window_result.rate_per_second < full_window_result.rate_per_second
 
 
+def test_repeated_call_with_unchanged_history_skips_rebuild(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #537: dashboard polls must reuse the cached EWMA state when the
+    in-window history is unchanged, instead of replaying every usage row."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    history = [
+        _entry(10.0, BASE_TIME),
+        _entry(20.0, BASE_TIME + timedelta(minutes=1)),
+        _entry(30.0, BASE_TIME + timedelta(minutes=2)),
+    ]
+    now = BASE_TIME + timedelta(minutes=3)
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    first = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert first is not None
+    assert rebuild_calls == 1
+
+    # Subsequent polls with the exact same in-window history must not re-walk
+    # the history. The result must remain identical.
+    second = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert second is not None
+    assert rebuild_calls == 1
+    assert second.rate_per_second == pytest.approx(first.rate_per_second)
+    assert second.risk == pytest.approx(first.risk)
+
+    third = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert third is not None
+    assert rebuild_calls == 1
+
+
+def test_new_history_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a new usage row lands the cache must rebuild so the rate reflects
+    the latest observations."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    history = [
+        _entry(10.0, BASE_TIME),
+        _entry(15.0, BASE_TIME + timedelta(minutes=1)),
+    ]
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    first = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", history, now=BASE_TIME + timedelta(minutes=2)
+    )
+    assert first is not None
+    assert rebuild_calls == 1
+
+    appended_history = history + [_entry(40.0, BASE_TIME + timedelta(minutes=2))]
+    second = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", appended_history, now=BASE_TIME + timedelta(minutes=3)
+    )
+    assert second is not None
+    # Signature changed (new row appended) -> rebuild executed.
+    assert rebuild_calls == 2
+    # Rate must rise to reflect the steeper observation.
+    assert second.rate_per_second > first.rate_per_second
+
+
+def test_aged_out_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the leading row of the in-window history drops away the cache must
+    rebuild so the rate does not retain influence from samples now outside the
+    window."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    full_history = [
+        _entry(10.0, BASE_TIME),
+        _entry(70.0, BASE_TIME + timedelta(minutes=1)),
+        _entry(80.0, BASE_TIME + timedelta(minutes=2)),
+    ]
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    full_result = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", full_history, now=BASE_TIME + timedelta(minutes=3)
+    )
+    assert full_result is not None
+    assert rebuild_calls == 1
+
+    in_window_history = full_history[1:]
+    truncated_result = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", in_window_history, now=BASE_TIME + timedelta(minutes=3)
+    )
+    assert truncated_result is not None
+    assert rebuild_calls == 2
+    assert truncated_result.rate_per_second != pytest.approx(full_result.rate_per_second)
+
+
 def test_post_reset_window_returns_none() -> None:
     """R30-F1: When reset_at is in the past, depletion should be None (window expired)."""
     reset_ewma_state()

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -394,6 +394,106 @@ def test_aged_out_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch
     assert truncated_result.rate_per_second != pytest.approx(full_result.rate_per_second)
 
 
+def test_inplace_value_correction_invalidates_memoized_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review on #588: when a row's `used_percent` is corrected in place
+    (same timestamps, same row count) the cache must rebuild — otherwise we
+    keep returning depletion metrics derived from the stale value."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    history = [
+        _entry(10.0, BASE_TIME),
+        _entry(20.0, BASE_TIME + timedelta(minutes=1)),
+        _entry(30.0, BASE_TIME + timedelta(minutes=2)),
+    ]
+    now = BASE_TIME + timedelta(minutes=3)
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    first = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert first is not None
+    assert rebuild_calls == 1
+
+    # Same window endpoints and row count, but the middle row's used_percent is
+    # corrected upward (e.g. backfill of a previously underreported sample) so
+    # the corrected series remains monotonically non-decreasing. Window-
+    # endpoint-only signatures would treat this as unchanged and reuse the
+    # stale EWMA state.
+    corrected_history = [
+        history[0],
+        _entry(25.0, BASE_TIME + timedelta(minutes=1)),
+        history[2],
+    ]
+    second = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", corrected_history, now=now
+    )
+    assert second is not None
+    assert rebuild_calls == 2
+    # Rate must reflect the correction, not the stale cached state.
+    assert second.rate_per_second != pytest.approx(first.rate_per_second)
+
+
+def test_inplace_reset_at_correction_invalidates_memoized_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review on #588: corrections to value-bearing non-`used_percent`
+    fields (here `reset_at`) must also invalidate the cache."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    reset_epoch = int((BASE_TIME + timedelta(minutes=30)).timestamp())
+    history = [
+        _entry(10.0, BASE_TIME, reset_at=reset_epoch, window_minutes=60),
+        _entry(20.0, BASE_TIME + timedelta(minutes=1), reset_at=reset_epoch, window_minutes=60),
+        _entry(30.0, BASE_TIME + timedelta(minutes=2), reset_at=reset_epoch, window_minutes=60),
+    ]
+    now = BASE_TIME + timedelta(minutes=3)
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    first = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert first is not None
+    assert rebuild_calls == 1
+
+    # Upstream extended the window — reset_at moved later on every row
+    # (per-row consistency keeps ewma_update from treating it as a mid-stream
+    # window change and dropping the rate).
+    extended_reset = int((BASE_TIME + timedelta(minutes=90)).timestamp())
+    corrected_history = [
+        _entry(e.used_percent, e.recorded_at, reset_at=extended_reset, window_minutes=60)
+        for e in history
+    ]
+    second = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", corrected_history, now=now
+    )
+    assert second is not None
+    assert rebuild_calls == 2
+    # Extending reset_at lengthens seconds_until_reset which lowers the
+    # sustainable_rate denominator in compute_burn_rate, so burn_rate must
+    # rise; the cached pre-correction state would have produced the old,
+    # lower burn_rate.
+    assert second.burn_rate != pytest.approx(first.burn_rate)
+    assert second.burn_rate > first.burn_rate
+
+
 def test_post_reset_window_returns_none() -> None:
     """R30-F1: When reset_at is in the past, depletion should be None (window expired)."""
     reset_ewma_state()


### PR DESCRIPTION
## Summary
- Fixes #537. `GET /api/dashboard/overview` rebuilt depletion EWMA state from the full per-account `usage_history` slice on every request. The reporter measured the EWMA/depletion path as ~90.7% of endpoint time (median 2122 ms → 198 ms with EWMA disabled) on a 120-account / 117,600-row dataset.
- Dashboard polls fire much more frequently than new usage rows land. Cache the per-account `EWMAState` alongside a history signature `(earliest recorded_at, latest recorded_at, len(history))`. On a cache hit, the cached state is reused instead of replaying every row through `ewma_update`.
- Any change to the in-window slice (appended row, aged-out row, or `reset_ewma_state()`) invalidates the signature and forces a rebuild, preserving existing semantics (aged-out, idempotency, window-reset).
- Time-dependent fields (`risk`, `safe_usage_percent`, `projected_exhaustion_at`, `seconds_until_exhaustion`) are still recomputed on every call so polls remain live.
- New OpenSpec change `memoize-dashboard-depletion-ewma` documents the requirement under the `query-caching` capability.

## Validation
- `uv run pytest tests/unit/test_depletion_service.py tests/unit/test_depletion.py tests/integration/test_dashboard_overview.py tests/integration/test_additional_usage_flow.py` — 60 passed
- `uv run pytest tests/unit tests/test_request_logs_options_api.py` — 1509 passed, 39 skipped
- `uv run pytest tests/integration --ignore=tests/integration/test_http_responses_bridge.py --ignore=tests/integration/test_proxy_websocket_responses.py` — 474 passed, 4 skipped
- `uv run pytest tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_websocket_responses.py tests/e2e` — 117 passed
- `uvx ruff check .` — clean
- `uvx ruff format --check .` — 435 files formatted
- `uv run ty check` — clean
- Added regression tests: `test_repeated_call_with_unchanged_history_skips_rebuild` (cache hit, monkeypatches `_rebuild_ewma_state` and asserts it is called exactly once across three identical polls), `test_new_history_row_invalidates_memoized_state` (append invalidates), `test_aged_out_row_invalidates_memoized_state` (window narrowing invalidates).

Fixes #537