### PR TITLE
fix(api): add back the account selection on api creation

### DIFF
--- a/app/modules/api_keys/api.py
+++ b/app/modules/api_keys/api.py
@@ -118,6 +118,7 @@ async def create_api_key(
                 enforced_reasoning_effort=payload.enforced_reasoning_effort,
                 enforced_service_tier=payload.enforced_service_tier,
                 expires_at=payload.expires_at,
+                assigned_account_ids=payload.assigned_account_ids,
                 limits=limit_inputs,
             )
         )

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -95,9 +95,10 @@ class ApiKeysRepository:
             )
         )
 
-    async def create(self, row: ApiKey) -> ApiKey:
+    async def create(self, row: ApiKey, *, commit: bool = True) -> ApiKey:
         self._session.add(row)
-        await self._session.commit()
+        if commit:
+            await self._session.commit()
         created = await self.get_by_id(row.id)
         assert created is not None
         return created

--- a/app/modules/api_keys/schemas.py
+++ b/app/modules/api_keys/schemas.py
@@ -32,6 +32,7 @@ class ApiKeyCreateRequest(DashboardModel):
     enforced_service_tier: str | None = Field(default=None, pattern=r"(?i)^(auto|default|priority|flex|fast)$")
     weekly_token_limit: int | None = Field(default=None, ge=1)
     expires_at: datetime | None = None
+    assigned_account_ids: list[str] | None = None
     limits: list[LimitRuleCreate] | None = None
 
 

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -34,7 +34,7 @@ _DETAIL_BUCKET_SECONDS = 3600
 
 
 class ApiKeysRepositoryProtocol(Protocol):
-    async def create(self, row: ApiKey) -> ApiKey: ...
+    async def create(self, row: ApiKey, *, commit: bool = True) -> ApiKey: ...
 
     async def get_by_id(self, key_id: str) -> ApiKey | None: ...
 
@@ -204,6 +204,7 @@ class ApiKeyCreateData:
     enforced_reasoning_effort: str | None = None
     enforced_service_tier: str | None = None
     expires_at: datetime | None = None
+    assigned_account_ids: list[str] | None = None
     limits: list[LimitRuleInput] = field(default_factory=list)
 
 
@@ -278,6 +279,7 @@ class ApiKeysService:
         expires_at = _normalize_expires_at(payload.expires_at)
         plain_key = _generate_plain_key()
         normalized_allowed_models = _normalize_allowed_models(payload.allowed_models)
+        assigned_account_ids = await self._resolve_assigned_account_ids(payload.assigned_account_ids)
         enforced_model = _normalize_model_slug(payload.enforced_model)
         enforced_reasoning_effort = _normalize_reasoning_effort(payload.enforced_reasoning_effort)
         enforced_service_tier = _normalize_service_tier(payload.enforced_service_tier)
@@ -291,20 +293,30 @@ class ApiKeysService:
             enforced_model=enforced_model,
             enforced_reasoning_effort=enforced_reasoning_effort,
             enforced_service_tier=enforced_service_tier,
+            account_assignment_scope_enabled=bool(assigned_account_ids),
             expires_at=expires_at,
             is_active=True,
             created_at=now,
             last_used_at=None,
         )
-        created = await self._repository.create(row)
+        try:
+            created = await self._repository.create(row, commit=False)
 
-        if payload.limits:
-            limit_rows = [_limit_input_to_row(li, created.id, now) for li in payload.limits]
-            await self._repository.replace_limits(created.id, limit_rows)
-            # Refresh to get updated limits
-            created = await self._repository.get_by_id(created.id)
-            if created is None:
-                raise ValueError("Failed to create API key")
+            if assigned_account_ids:
+                await self._repository.replace_account_assignments(created.id, assigned_account_ids, commit=False)
+
+            if payload.limits:
+                limit_rows = [_limit_input_to_row(li, created.id, now) for li in payload.limits]
+                await self._repository.upsert_limits(created.id, limit_rows, commit=False)
+
+            await self._repository.commit()
+        except Exception:
+            await self._repository.rollback()
+            raise
+
+        created = await self._repository.get_by_id(created.id)
+        if created is None:
+            raise ValueError("Failed to create API key")
 
         return _to_created_data(_to_api_key_data(created), plain_key)
 
@@ -327,15 +339,7 @@ class ApiKeysService:
         else:
             allowed_models = None
         if payload.assigned_account_ids_set:
-            assigned_account_ids = _normalize_assigned_account_ids(payload.assigned_account_ids)
-            existing_accounts = await self._repository.list_accounts_by_ids(assigned_account_ids)
-            existing_account_ids = {account.id for account in existing_accounts}
-            missing_account_ids = [
-                account_id for account_id in assigned_account_ids if account_id not in existing_account_ids
-            ]
-            if missing_account_ids:
-                missing = ", ".join(missing_account_ids)
-                raise ValueError(f"Unknown account ids: {missing}")
+            assigned_account_ids = await self._resolve_assigned_account_ids(payload.assigned_account_ids)
             account_assignment_scope_enabled: bool | _Unset = bool(assigned_account_ids)
         else:
             assigned_account_ids = None
@@ -435,6 +439,18 @@ class ApiKeysService:
         if poller is not None:
             await poller.bump(NAMESPACE_API_KEY)
         return _to_api_key_data(row)
+
+    async def _resolve_assigned_account_ids(self, account_ids: list[str] | None) -> list[str]:
+        normalized_account_ids = _normalize_assigned_account_ids(account_ids)
+        existing_accounts = await self._repository.list_accounts_by_ids(normalized_account_ids)
+        existing_account_ids = {account.id for account in existing_accounts}
+        missing_account_ids = [
+            account_id for account_id in normalized_account_ids if account_id not in existing_account_ids
+        ]
+        if missing_account_ids:
+            missing = ", ".join(missing_account_ids)
+            raise ValueError(f"Unknown account ids: {missing}")
+        return normalized_account_ids
 
     async def delete_key(self, key_id: str) -> None:
         row = await self._repository.get_by_id(key_id)

--- a/frontend/src/__integration__/api-keys-flow.test.tsx
+++ b/frontend/src/__integration__/api-keys-flow.test.tsx
@@ -67,6 +67,35 @@ describe("api keys flow integration", () => {
     });
   });
 
+  it("creates an api key with assigned accounts", async () => {
+    const user = userEvent.setup();
+
+    window.history.pushState({}, "", "/settings");
+    renderWithProviders(<App />);
+
+    await user.click(await screen.findByRole("button", { name: "Create key" }));
+    await user.type(screen.getByLabelText("Name"), "Scoped Integration Key");
+    await user.click(await screen.findByRole("button", { name: "All accounts" }));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: /primary@example\.com/i }));
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    const createdDialog = await screen.findByRole("dialog", { name: "API key created" });
+    const closeCandidates = within(createdDialog).getAllByRole("button", {
+      name: "Close",
+    });
+    const closeButton =
+      closeCandidates.find((element) => element.getAttribute("data-slot") === "button") ??
+      closeCandidates[0];
+    await user.click(closeButton);
+
+    const createdRow = getParentRow(await screen.findByText("Scoped Integration Key"));
+    await openRowActions(user, createdRow);
+    await user.click(await screen.findByRole("menuitem", { name: /Edit/ }));
+
+    expect(await screen.findByRole("button", { name: "1 account selected" })).toBeInTheDocument();
+  });
+
   it("displays the current api key list on settings", async () => {
     window.history.pushState({}, "", "/settings");
     renderWithProviders(<App />);

--- a/frontend/src/features/api-keys/components/api-key-create-dialog.test.tsx
+++ b/frontend/src/features/api-keys/components/api-key-create-dialog.test.tsx
@@ -1,0 +1,99 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "@/test/utils";
+
+import { ApiKeyCreateDialog } from "./api-key-create-dialog";
+
+describe("ApiKeyCreateDialog", () => {
+  it("omits assigned accounts when left at all accounts", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <ApiKeyCreateDialog
+        open
+        busy={false}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Name"), "Scoped create");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.name).toBe("Scoped create");
+    expect("assignedAccountIds" in payload).toBe(false);
+  });
+
+  it("submits selected assigned accounts on create", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <ApiKeyCreateDialog
+        open
+        busy={false}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Name"), "Scoped create");
+    await user.click(await screen.findByRole("button", { name: "All accounts" }));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: /primary@example\.com/i }));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: /secondary@example\.com/i }));
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.assignedAccountIds).toEqual(["acc_primary", "acc_secondary"]);
+  });
+
+  it("clears selected assigned accounts when the dialog is dismissed", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    function Harness() {
+      const [open, setOpen] = useState(true);
+
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Reopen
+          </button>
+          <ApiKeyCreateDialog
+            open={open}
+            busy={false}
+            onOpenChange={setOpen}
+            onSubmit={onSubmit}
+          />
+        </>
+      );
+    }
+
+    renderWithProviders(<Harness />);
+
+    await user.click(await screen.findByRole("button", { name: "All accounts" }));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: /primary@example\.com/i }));
+    await user.keyboard("{Escape}");
+    expect(screen.getByRole("button", { name: "1 account selected" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    await user.click(screen.getByRole("button", { name: "Reopen" }));
+
+    expect(await screen.findByRole("button", { name: "All accounts" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "1 account selected" })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { AccountMultiSelect } from "@/features/api-keys/components/account-multi-select";
 import { ExpiryPicker } from "@/features/api-keys/components/expiry-picker";
 import { LimitRulesEditor } from "@/features/api-keys/components/limit-rules-editor";
 import { ModelMultiSelect } from "@/features/api-keys/components/model-multi-select";
@@ -46,17 +47,37 @@ export function ApiKeyCreateDialog({ open, busy, onOpenChange, onSubmit }: ApiKe
   });
 
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
+  const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([]);
   const [limitRules, setLimitRules] = useState<LimitRuleCreate[]>([]);
   const [expiresAt, setExpiresAt] = useState<Date | null>(null);
   const [enforcedModel, setEnforcedModel] = useState("");
   const [enforcedReasoningEffort, setEnforcedReasoningEffort] = useState("none");
   const [enforcedServiceTier, setEnforcedServiceTier] = useState("none");
 
+  const resetForm = () => {
+    form.reset();
+    setSelectedModels([]);
+    setSelectedAccountIds([]);
+    setLimitRules([]);
+    setExpiresAt(null);
+    setEnforcedModel("");
+    setEnforcedReasoningEffort("none");
+    setEnforcedServiceTier("none");
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      resetForm();
+    }
+    onOpenChange(nextOpen);
+  };
+
   const handleSubmit = async (values: FormValues) => {
     const validLimits = limitRules.filter((r) => r.maxValue > 0);
     const payload: ApiKeyCreateRequest = {
       name: values.name,
-      allowedModels: selectedModels.length > 0 ? selectedModels : undefined,
+      ...(selectedModels.length > 0 ? { allowedModels: selectedModels } : {}),
+      ...(selectedAccountIds.length > 0 ? { assignedAccountIds: selectedAccountIds } : {}),
       enforcedModel: enforcedModel.trim() ? enforcedModel.trim() : null,
       enforcedReasoningEffort: enforcedReasoningEffort === "none" ? null : enforcedReasoningEffort as "minimal" | "low" | "medium" | "high" | "xhigh",
       enforcedServiceTier: enforcedServiceTier === "none" ? null : enforcedServiceTier as ServiceTierType,
@@ -68,18 +89,12 @@ export function ApiKeyCreateDialog({ open, busy, onOpenChange, onSubmit }: ApiKe
     } catch {
       return;
     }
-    form.reset();
-    setSelectedModels([]);
-    setLimitRules([]);
-    setExpiresAt(null);
-    setEnforcedModel("");
-    setEnforcedReasoningEffort("none");
-    setEnforcedServiceTier("none");
+    resetForm();
     onOpenChange(false);
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Create API key</DialogTitle>
@@ -110,6 +125,11 @@ export function ApiKeyCreateDialog({ open, busy, onOpenChange, onSubmit }: ApiKe
                 <div className="space-y-1">
                   <label className="text-sm font-medium">Allowed models</label>
                   <ModelMultiSelect value={selectedModels} onChange={setSelectedModels} />
+                </div>
+
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Assigned accounts</label>
+                  <AccountMultiSelect value={selectedAccountIds} onChange={setSelectedAccountIds} />
                 </div>
 
                 <div className="space-y-1">

--- a/frontend/src/features/api-keys/schemas.test.ts
+++ b/frontend/src/features/api-keys/schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ApiKeyCreateRequestSchema,
   ApiKeyCreateResponseSchema,
   ApiKeySchema,
   ApiKeyUpdateRequestSchema,
@@ -71,6 +72,17 @@ describe("ApiKeyCreateResponseSchema", () => {
     });
 
     expect(parsed.key).toBe("sk-test-plaintext");
+  });
+});
+
+describe("ApiKeyCreateRequestSchema", () => {
+  it("accepts optional assigned accounts", () => {
+    const parsed = ApiKeyCreateRequestSchema.parse({
+      name: "Scoped Key",
+      assignedAccountIds: ["acc_primary"],
+    });
+
+    expect(parsed.assignedAccountIds).toEqual(["acc_primary"]);
   });
 });
 

--- a/frontend/src/features/api-keys/schemas.ts
+++ b/frontend/src/features/api-keys/schemas.ts
@@ -71,6 +71,7 @@ export const ApiKeyCreateRequestSchema = z.object({
     .optional(),
   weeklyTokenLimit: z.number().int().positive().nullable().optional(),
   expiresAt: z.string().datetime({ offset: true }).nullable().optional(),
+  assignedAccountIds: z.array(z.string()).optional(),
   limits: z.array(LimitRuleCreateSchema).optional(),
 });
 

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -41,6 +41,7 @@ const OauthStartPayloadSchema = z
 const ApiKeyCreatePayloadSchema = z
 	.object({
 		name: z.string().optional(),
+		assignedAccountIds: z.array(z.string()).optional(),
 	})
 	.passthrough();
 
@@ -755,6 +756,8 @@ export const handlers = [
 			...createApiKey({
 				id: `key_${sequence}`,
 				name: payload?.name ?? `API Key ${sequence}`,
+				accountAssignmentScopeEnabled: (payload?.assignedAccountIds?.length ?? 0) > 0,
+				assignedAccountIds: payload?.assignedAccountIds ?? [],
 			}),
 			key: `sk-test-generated-${sequence}`,
 		});

--- a/openspec/changes/allow-api-key-account-assignment-on-create/.openspec.yaml
+++ b/openspec/changes/allow-api-key-account-assignment-on-create/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/allow-api-key-account-assignment-on-create/proposal.md
+++ b/openspec/changes/allow-api-key-account-assignment-on-create/proposal.md
@@ -1,0 +1,9 @@
+# Change Proposal
+
+API keys can currently be scoped to assigned accounts only after creation. That forces operators into a two-step workflow even when they already know the target accounts at create time.
+
+## Changes
+
+- Allow `POST /api/api-keys` to accept an optional assigned-account list during creation.
+- Add the Assigned accounts picker to the API key create dialog, reusing the existing account selection UI.
+- Preserve the current default behavior: when no accounts are selected, the new key applies to all accounts.

--- a/openspec/changes/allow-api-key-account-assignment-on-create/specs/api-keys/spec.md
+++ b/openspec/changes/allow-api-key-account-assignment-on-create/specs/api-keys/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: API Key creation
+
+The system SHALL allow the admin to create API keys via `POST /api/api-keys` with a `name` (required), `allowed_models` (optional list), `weekly_token_limit` (optional integer), `expires_at` (optional ISO 8601 datetime), and `assigned_account_ids` (optional list). The system MUST generate a key in the format `sk-clb-{48 hex chars}`, store only the `sha256` hash in the database, and return the plain key exactly once in the creation response. The system MUST accept timezone-aware ISO 8601 datetimes for `expiresAt`, normalize them to UTC naive for persistence, and return the expiration as UTC in API responses.
+
+When `assigned_account_ids` is omitted or empty, the created key SHALL remain unscoped and apply to all accounts. When `assigned_account_ids` is provided with one or more valid account IDs, the created key SHALL enable account-assignment scope and persist those assignments.
+
+#### Scenario: Create unscoped key without assigned accounts
+
+- **WHEN** admin submits `POST /api/api-keys` without `assignedAccountIds`
+- **THEN** the created key returns `accountAssignmentScopeEnabled = false`
+- **AND** `assignedAccountIds = []`
+
+#### Scenario: Create scoped key with assigned accounts
+
+- **WHEN** admin submits `POST /api/api-keys` with `assignedAccountIds` containing valid account IDs
+- **THEN** the created key returns `accountAssignmentScopeEnabled = true`
+- **AND** `assignedAccountIds` matches the supplied accounts
+
+#### Scenario: Reject unknown assigned account IDs on create
+
+- **WHEN** admin submits `POST /api/api-keys` with an unknown account ID in `assignedAccountIds`
+- **THEN** the system returns 400
+
+### Requirement: Frontend API Key management
+
+The SPA settings page SHALL include an API Key management section with: a toggle for `apiKeyAuthEnabled`, a key list table showing prefix/name/models/limit/usage/expiry/status, a create dialog (name, model selection, assigned-account selection, weekly limit, expiry date), and key actions (edit, delete, regenerate). On key creation, the SPA MUST display the plain key in a copy-able dialog with a warning that it will not be shown again.
+
+#### Scenario: Create key with optional account scoping
+
+- **WHEN** an admin opens the create API key dialog
+- **THEN** the dialog shows the Assigned accounts picker
+- **AND** leaving the picker at `All accounts` creates an unscoped key
+- **AND** selecting one or more accounts creates a scoped key for only those accounts

--- a/openspec/changes/allow-api-key-account-assignment-on-create/tasks.md
+++ b/openspec/changes/allow-api-key-account-assignment-on-create/tasks.md
@@ -1,0 +1,5 @@
+- [x] 1. Update the API key create request contracts in frontend and backend to accept optional assigned account IDs.
+- [x] 2. Persist assigned account IDs and `account_assignment_scope_enabled` during API key creation when scoped accounts are supplied.
+- [x] 3. Add the Assigned accounts picker to the API key create dialog while keeping the unscoped default when no accounts are selected.
+- [x] 4. Add or update backend and frontend tests covering create-time account assignment and the unscoped default.
+- [x] 5. Run `openspec validate --specs` and the relevant backend/frontend test suites.

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -183,6 +183,29 @@ async def test_api_key_update_persists_assigned_account_ids(async_client):
 
 
 @pytest.mark.asyncio
+async def test_api_key_create_persists_assigned_account_ids(async_client):
+    first_account_id = await _import_account(async_client, "acc-create-a", "create-a@example.com")
+    second_account_id = await _import_account(async_client, "acc-create-b", "create-b@example.com")
+
+    create = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "assigned-create-key",
+            "assignedAccountIds": [first_account_id, second_account_id],
+        },
+    )
+    assert create.status_code == 200
+    payload = create.json()
+    assert payload["accountAssignmentScopeEnabled"] is True
+    assert payload["assignedAccountIds"] == [first_account_id, second_account_id]
+
+    listed = await async_client.get("/api/api-keys/")
+    assert listed.status_code == 200
+    assert listed.json()[0]["accountAssignmentScopeEnabled"] is True
+    assert listed.json()[0]["assignedAccountIds"] == [first_account_id, second_account_id]
+
+
+@pytest.mark.asyncio
 async def test_deleted_assigned_accounts_do_not_fall_back_to_other_accounts(async_client, monkeypatch):
     await _populate_test_registry()
     monkeypatch.setattr(load_balancer_module, "_filter_accounts_for_model", lambda accounts, model: accounts)
@@ -257,6 +280,16 @@ async def test_api_key_update_rejects_unknown_assigned_account_ids(async_client)
     )
     assert update.status_code == 400
     assert update.json()["error"]["code"] == "invalid_api_key_payload"
+
+
+@pytest.mark.asyncio
+async def test_api_key_create_rejects_unknown_assigned_account_ids(async_client):
+    create = await async_client.post(
+        "/api/api-keys/",
+        json={"name": "invalid-create-assignment-key", "assignedAccountIds": ["missing-account"]},
+    )
+    assert create.status_code == 400
+    assert create.json()["error"]["code"] == "invalid_api_key_payload"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -37,8 +37,11 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
         self._accounts: dict[str, Account] = {}
         self._limit_id_seq = 0
         self._reservations: dict[str, UsageReservationData] = {}
+        self.commit_calls = 0
+        self.rollback_calls = 0
 
-    async def create(self, row: ApiKey) -> ApiKey:
+    async def create(self, row: ApiKey, *, commit: bool = True) -> ApiKey:
+        del commit
         self.rows[row.id] = row
         row.limits = []
         row.account_assignments = []
@@ -123,9 +126,11 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
             row.last_used_at = utcnow()
 
     async def commit(self) -> None:
+        self.commit_calls += 1
         return None
 
     async def rollback(self) -> None:
+        self.rollback_calls += 1
         return None
 
     async def get_limits_by_key(self, key_id: str) -> list[ApiKeyLimit]:
@@ -369,6 +374,44 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
         )
 
 
+class _TransactionalAssignmentFailureRepo(_FakeApiKeysRepository):
+    def __init__(self) -> None:
+        super().__init__()
+        self._pending_rows: dict[str, ApiKey] = {}
+        self._pending_account_assignments: dict[str, list[ApiKeyAccountAssignment]] = {}
+
+    async def create(self, row: ApiKey, *, commit: bool = True) -> ApiKey:
+        row.limits = []
+        row.account_assignments = []
+        if commit:
+            return await super().create(row, commit=commit)
+        self._pending_rows[row.id] = row
+        return row
+
+    async def get_by_id(self, key_id: str) -> ApiKey | None:
+        row = self.rows.get(key_id)
+        if row is not None:
+            row.limits = self._limits.get(key_id, [])
+            row.account_assignments = self._account_assignments.get(key_id, [])
+        return row
+
+    async def replace_account_assignments(self, key_id: str, account_ids: list[str], *, commit: bool = True) -> None:
+        del account_ids, commit
+        raise RuntimeError("assignment insert failed")
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+        self.rows.update(self._pending_rows)
+        self._account_assignments.update(self._pending_account_assignments)
+        self._pending_rows = {}
+        self._pending_account_assignments = {}
+
+    async def rollback(self) -> None:
+        self.rollback_calls += 1
+        self._pending_rows = {}
+        self._pending_account_assignments = {}
+
+
 def _compute_increment(limit: ApiKeyLimit, input_tokens: int, output_tokens: int, cost_microdollars: int) -> int:
     if limit.limit_type == LimitType.TOTAL_TOKENS:
         return input_tokens + output_tokens
@@ -554,6 +597,86 @@ async def test_update_key_tracks_assignment_scope_after_clear() -> None:
     )
     assert cleared.account_assignment_scope_enabled is False
     assert cleared.assigned_account_ids == []
+
+
+@pytest.mark.asyncio
+async def test_create_key_persists_assigned_accounts() -> None:
+    repo = _FakeApiKeysRepository()
+    service = ApiKeysService(repo)
+    repo._accounts = {
+        "acc-a": Account(
+            id="acc-a",
+            chatgpt_account_id=None,
+            email="a@example.com",
+            plan_type="plus",
+            access_token_encrypted=b"access",
+            refresh_token_encrypted=b"refresh",
+            id_token_encrypted=b"id",
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        ),
+    }
+
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="assignment-scope",
+            allowed_models=None,
+            expires_at=None,
+            assigned_account_ids=["acc-a"],
+        )
+    )
+
+    assert created.account_assignment_scope_enabled is True
+    assert created.assigned_account_ids == ["acc-a"]
+
+
+@pytest.mark.asyncio
+async def test_create_key_rolls_back_when_account_assignment_write_fails() -> None:
+    repo = _TransactionalAssignmentFailureRepo()
+    service = ApiKeysService(repo)
+    repo._accounts = {
+        "acc-a": Account(
+            id="acc-a",
+            chatgpt_account_id=None,
+            email="a@example.com",
+            plan_type="plus",
+            access_token_encrypted=b"access",
+            refresh_token_encrypted=b"refresh",
+            id_token_encrypted=b"id",
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        ),
+    }
+
+    with pytest.raises(RuntimeError, match="assignment insert failed"):
+        await service.create_key(
+            ApiKeyCreateData(
+                name="assignment-scope",
+                allowed_models=None,
+                expires_at=None,
+                assigned_account_ids=["acc-a"],
+            )
+        )
+
+    assert repo.commit_calls == 0
+    assert repo.rollback_calls == 1
+    assert repo.rows == {}
+
+
+@pytest.mark.asyncio
+async def test_create_key_rejects_unknown_assigned_accounts() -> None:
+    repo = _FakeApiKeysRepository()
+    service = ApiKeysService(repo)
+
+    with pytest.raises(ValueError, match="Unknown account ids: missing-account"):
+        await service.create_key(
+            ApiKeyCreateData(
+                name="assignment-scope",
+                allowed_models=None,
+                expires_at=None,
+                assigned_account_ids=["missing-account"],
+            )
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Currently only edit API could configure account pool
This PR is going to add back the ability to configure the account pool while creating the API key

<img width="751" height="625" alt="螢幕截圖 2026-05-12 23 34 40" src="https://github.com/user-attachments/assets/4fb332dd-ed82-45e9-bcc8-c861dffe0d88" />
