### PR TITLE
fix(dashboard-auth): reject passwords longer than bcrypt's 72-byte limit

### DIFF
--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -153,6 +153,23 @@ def _ensure_password_management_enabled(request: Request) -> None:
         )
 
 
+# bcrypt enforces a hard 72-byte limit on the input password; anything longer
+# raises ``ValueError`` from ``bcrypt.hashpw`` and surfaces as a 500 to the
+# client. Validate the encoded length here so the API returns a clear 400.
+_MAX_PASSWORD_BYTES = 72
+
+
+def _validate_password_length(password: str) -> None:
+    if len(password) < 8:
+        raise DashboardValidationError("Password must be at least 8 characters")
+    if len(password.encode("utf-8")) > _MAX_PASSWORD_BYTES:
+        raise DashboardValidationError(
+            f"Password must be at most {_MAX_PASSWORD_BYTES} bytes when encoded as UTF-8. "
+            "Note that multi-byte characters (e.g. emoji, non-ASCII letters) count for more than one byte.",
+            code="password_too_long",
+        )
+
+
 @router.get("/session", response_model=DashboardAuthSessionResponse)
 async def get_dashboard_auth_session(
     request: Request,
@@ -212,8 +229,7 @@ async def setup_password(
         if validation_status != "valid":
             raise DashboardAuthError("Invalid dashboard bootstrap token.", code="invalid_bootstrap_token")
     password = payload.password.strip()
-    if len(password) < 8:
-        raise DashboardValidationError("Password must be at least 8 characters")
+    _validate_password_length(password)
     try:
         await context.service.setup_password(password)
     except PasswordAlreadyConfiguredError as exc:
@@ -290,8 +306,7 @@ async def change_password(
     await _validate_password_management_session(request)
 
     new_password = payload.new_password.strip()
-    if len(new_password) < 8:
-        raise DashboardValidationError("Password must be at least 8 characters")
+    _validate_password_length(new_password)
 
     try:
         await context.service.change_password(payload.current_password, new_password)

--- a/openspec/changes/validate-password-length/proposal.md
+++ b/openspec/changes/validate-password-length/proposal.md
@@ -1,0 +1,21 @@
+## Why
+Issue #597 reports a 500 with a server-side log of `password cannot be longer than 72 bytes` while setting a dashboard password. The frontend then surfaces a generic "Unexpected error" with no actionable detail.
+
+Root cause: `bcrypt.hashpw` enforces a hard 72-byte input limit on the encoded password (`bcrypt 5.x` raises `ValueError("password cannot be longer than 72 bytes ...")`). `_hash_password` in `app/modules/dashboard_auth/service.py` calls `bcrypt.hashpw` directly, and the two API entry points that lead there (`POST /api/dashboard-auth/password/setup`, `POST /api/dashboard-auth/password/change`) only validate `len(password) < 8` before hashing. There is no upper-bound validation, so the `ValueError` propagates out as an unhandled exception and surfaces as a 500.
+
+## What Changes
+- Add an explicit upper-bound check for password length at the API layer, alongside the existing 8-character minimum, before the password reaches `bcrypt.hashpw`.
+- The check measures **UTF-8 encoded byte length**, not codepoint count, so multi-byte characters (emoji, non-ASCII letters) count for as many bytes as bcrypt itself counts. The limit constant `_MAX_PASSWORD_BYTES = 72` matches bcrypt's own ceiling exactly.
+- Surface the failure as a structured `DashboardValidationError` (`HTTP 422`) with code `password_too_long`, so the dashboard frontend can show a clear "password must be at most 72 bytes" message instead of "Unexpected error".
+- Apply identical validation to both endpoints (`/password/setup` and `/password/change`) by introducing a shared `_validate_password_length` helper that also handles the existing 8-character minimum, eliminating divergence between the two paths.
+- Add regression tests covering:
+  - rejection of 73-byte ASCII passwords with `password_too_long`
+  - acceptance of exactly 72-byte passwords
+  - rejection of strings whose codepoint count is small but whose UTF-8 byte length exceeds 72 (e.g. an emoji-only password)
+  - identical behavior on `/password/change`'s `new_password`
+
+## Impact
+- Restores a clear, actionable 422 response for the documented failure case instead of a 500 with a confusing "Unexpected error" on the client.
+- No change to bcrypt's own behavior or to how passwords are stored.
+- No migration required.
+- Existing valid passwords are unaffected; the new check matches bcrypt's existing ceiling, so any password that could already be set is still accepted.

--- a/openspec/changes/validate-password-length/specs/admin-auth/spec.md
+++ b/openspec/changes/validate-password-length/specs/admin-auth/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Password length is bounded by bcrypt's input limit
+
+The system SHALL enforce both a minimum and a maximum length on dashboard passwords submitted to `POST /api/dashboard-auth/password/setup` and to the `new_password` field of `POST /api/dashboard-auth/password/change`. The maximum length MUST be measured against the UTF-8 encoded byte length of the password (matching bcrypt's internal limit), not against the codepoint count, and MUST be set to exactly 72 bytes.
+
+#### Scenario: Setup rejects passwords longer than 72 bytes
+
+- **WHEN** `POST /api/dashboard-auth/password/setup` receives a password whose UTF-8 encoded length exceeds 72 bytes
+- **THEN** the system returns HTTP 422 with error code `password_too_long`
+- **AND** the response message references the 72-byte limit so the client can render it
+
+#### Scenario: Setup accepts passwords up to 72 bytes inclusive
+
+- **WHEN** `POST /api/dashboard-auth/password/setup` receives a password whose UTF-8 encoded length is exactly 72 bytes
+- **THEN** the system accepts the password and configures it
+
+#### Scenario: Length is measured in UTF-8 bytes, not codepoints
+
+- **WHEN** `POST /api/dashboard-auth/password/setup` receives a password whose codepoint count is below 72 but whose UTF-8 encoded length exceeds 72 bytes (e.g. an emoji-only string)
+- **THEN** the system returns HTTP 422 with error code `password_too_long`
+
+#### Scenario: Change applies the same upper bound to the new password
+
+- **WHEN** `POST /api/dashboard-auth/password/change` receives a `new_password` whose UTF-8 encoded length exceeds 72 bytes
+- **THEN** the system returns HTTP 422 with error code `password_too_long` before attempting to hash the password

--- a/openspec/changes/validate-password-length/tasks.md
+++ b/openspec/changes/validate-password-length/tasks.md
@@ -1,0 +1,4 @@
+- [x] Add a `_validate_password_length` helper in `app/modules/dashboard_auth/api.py` that enforces the existing 8-character minimum and a new 72-UTF-8-byte maximum, raising `DashboardValidationError` with code `password_too_long` on the new failure case.
+- [x] Replace the inline `len(password) < 8` checks in `setup_password` and `change_password` with calls to the shared helper, so both endpoints validate identically before hashing.
+- [x] Add regression tests in `tests/integration/test_dashboard_password_auth.py` covering 73-byte ASCII rejection, exact 72-byte acceptance, emoji-only multi-byte rejection, and `/password/change` `new_password` rejection.
+- [x] Document the new behavior under the `admin-auth` capability spec.

--- a/tests/integration/test_dashboard_password_auth.py
+++ b/tests/integration/test_dashboard_password_auth.py
@@ -161,3 +161,61 @@ async def test_password_not_configured_requests_do_not_spend_login_budget(async_
         json={"password": "password123"},
     )
     assert login.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_password_setup_rejects_overlong_password(async_client):
+    # bcrypt enforces a hard 72-byte input limit and raises ValueError otherwise.
+    # The API must surface this as a 422 validation error, not a 500.
+    long_password = "a" * 73  # 73 ASCII bytes -> over the bcrypt limit
+    response = await async_client.post(
+        "/api/dashboard-auth/password/setup",
+        json={"password": long_password},
+    )
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "password_too_long"
+    assert "72 bytes" in body["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_password_setup_accepts_72_byte_password(async_client):
+    # Exactly 72 bytes must still be accepted.
+    setup = await async_client.post(
+        "/api/dashboard-auth/password/setup",
+        json={"password": "a" * 72},
+    )
+    assert setup.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_password_setup_counts_utf8_bytes_not_codepoints(async_client):
+    # 25 emoji code points = 100 UTF-8 bytes (each emoji is 4 bytes).
+    # Even though len() reports 25 characters, the encoded length exceeds 72
+    # bytes and must be rejected with the same clear error.
+    long_emoji = "🦞" * 25  # 100 bytes when encoded
+    response = await async_client.post(
+        "/api/dashboard-auth/password/setup",
+        json={"password": long_emoji},
+    )
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "password_too_long"
+
+
+@pytest.mark.asyncio
+async def test_password_change_rejects_overlong_new_password(async_client):
+    # Establish a valid password so we can authenticate the change request.
+    setup = await async_client.post(
+        "/api/dashboard-auth/password/setup",
+        json={"password": "password123"},
+    )
+    assert setup.status_code == 200
+
+    change = await async_client.post(
+        "/api/dashboard-auth/password/change",
+        json={"current_password": "password123", "new_password": "a" * 73},
+    )
+    assert change.status_code == 422
+    body = change.json()
+    assert body["error"]["code"] == "password_too_long"


### PR DESCRIPTION
Fixes #597.

## Root cause

`bcrypt.hashpw` enforces a hard 72-byte input limit on the encoded password (bcrypt 5.x raises `ValueError("password cannot be longer than 72 bytes ...")`). `_hash_password` in `app/modules/dashboard_auth/service.py` calls `bcrypt.hashpw` directly, and the two API entry points that lead there only validate `len(password) < 8` before hashing.

So a password whose UTF-8 encoded length exceeds 72 bytes propagated as an unhandled `ValueError` and surfaced as a 500 with a generic "Unexpected error" on the dashboard frontend (the symptom reported in #597).

## Fix

- Add a shared `_validate_password_length` helper in `app/modules/dashboard_auth/api.py` that enforces both the existing 8-character minimum and a new 72-UTF-8-byte maximum.
- Route both `POST /api/dashboard-auth/password/setup` and `POST /api/dashboard-auth/password/change` through it, so the two endpoints validate identically before hashing.
- On the new failure case, return `DashboardValidationError` (HTTP 422) with code `password_too_long` and a message that references the 72-byte limit, so the dashboard can render a clear, actionable error.

The limit is measured against the **UTF-8 encoded byte length**, not codepoint count, so multi-byte characters (emoji, non-ASCII letters) count for as many bytes as bcrypt itself counts. This matches bcrypt's own ceiling exactly.

## Why 72 bytes specifically

`bcrypt` (the underlying password hashing primitive used by all major language bindings) silently truncates input after 72 bytes when hashing on most platforms, but the Python `bcrypt` 5.x package explicitly rejects oversize inputs with `ValueError` instead of silently truncating. Anything that exceeds bcrypt's 72-byte ceiling cannot be hashed at all, so the right place to surface that is at the API layer, not as an unhandled `ValueError`.

## Tests

Added four integration tests in `tests/integration/test_dashboard_password_auth.py`:

```
tests/integration/test_dashboard_password_auth.py::test_password_setup_rejects_overlong_password PASSED
tests/integration/test_dashboard_password_auth.py::test_password_setup_accepts_72_byte_password PASSED
tests/integration/test_dashboard_password_auth.py::test_password_setup_counts_utf8_bytes_not_codepoints PASSED
tests/integration/test_dashboard_password_auth.py::test_password_change_rejects_overlong_new_password PASSED
```

Verification on this branch:

```
uv run ruff check app/modules/dashboard_auth/api.py tests/integration/test_dashboard_password_auth.py     # clean
uv run ruff format --check app/modules/dashboard_auth/api.py tests/integration/test_dashboard_password_auth.py  # clean
uv run ty check app/modules/dashboard_auth/api.py tests/integration/test_dashboard_password_auth.py        # clean
uv run pytest tests/integration/test_dashboard_password_auth.py tests/unit/test_dashboard_auth_api.py tests/unit/test_dashboard_auth_password_service.py -q   # 16 passed
npx @fission-ai/openspec validate validate-password-length                                                 # change is valid
```

## OpenSpec

Added an OpenSpec change folder `openspec/changes/validate-password-length/` capturing the new requirement under the `admin-auth` capability (length is bounded by bcrypt's input limit, measured in UTF-8 bytes, applied to both `setup` and `change`).

## Migration / Compatibility

- No schema or runtime migration.
- No change to bcrypt behavior or to how passwords are stored.
- Existing valid passwords are unaffected; the new check matches bcrypt's existing ceiling, so any password that could already be set is still accepted.

## Hotfix candidate for v1.17.1

This is a small, scoped fix on the dashboard-auth API surface with no runtime impact. It is a good candidate for the next patch release.
