### PR TITLE
fix(auth): deactivate account on refresh-time token_expired

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -14,6 +14,12 @@ PERMANENT_FAILURE_CODES = {
     "refresh_token_expired": "Refresh token expired - re-login required",
     "refresh_token_reused": "Refresh token was reused - re-login required",
     "refresh_token_invalidated": "Refresh token was revoked - re-login required",
+    # ``token_expired`` from the OAuth refresh endpoint means the refresh
+    # request itself failed because the refresh token (or the session it
+    # belonged to) is no longer usable -- access-token-only expiry would have
+    # returned a fresh token pair instead. Treat it as a permanent failure so
+    # the account stops being routed to until it is re-authenticated.
+    "token_expired": "Authentication token expired - re-login required",
     "account_deactivated": "Account has been deactivated",
     "account_suspended": "Account has been suspended",
     "account_deleted": "Account has been deleted",

--- a/openspec/changes/deactivate-on-token-expired/proposal.md
+++ b/openspec/changes/deactivate-on-token-expired/proposal.md
@@ -1,0 +1,22 @@
+## Why
+Issue #383 reports that accounts whose upstream session has expired keep returning `token_expired` (HTTP 401 with `{"error": {"code": "token_expired"}}`) on every request, yet codex-lb keeps the account in `ACTIVE` state. The load balancer continues to route real client traffic to it, every request fails the same way, and the only mitigation is for an operator to manually pause the account.
+
+The reporter's diagnosis is correct against the current code:
+
+- `PERMANENT_FAILURE_CODES` in `app/core/balancer/logic.py` only lists `refresh_token_expired`, `refresh_token_reused`, `refresh_token_invalidated`, `account_deactivated`, `account_suspended`, and `account_deleted`. It does **not** include `token_expired`.
+- `classify_refresh_error("token_expired")` therefore returns `False`, so `RefreshError` for this case is built with `is_permanent=False`.
+- `AuthManager.refresh_account` only deactivates the account when the error is permanent, and `usage._should_deactivate_for_usage_error` only deactivates on HTTP 402/404 or the existing permanent set, so a refresh-time `token_expired` slips through both paths.
+- Result: refresh keeps failing, the account stays `ACTIVE`, and the load balancer keeps selecting it. The reporter ran into exactly this with `email_3e2ba4c18bda` until they manually paused it.
+
+The cause is specifically that `token_expired` is reaching codex-lb on the **token refresh** endpoint. Access-token-only expiry would have caused the refresh call itself to return a fresh token pair, not to fail with `token_expired`. So a `token_expired` at the refresh boundary unambiguously means the refresh token (or the session it represents) is no longer usable, which is the same shape as `refresh_token_expired` and the other entries already classified as permanent.
+
+## What Changes
+- Add `token_expired` to `PERMANENT_FAILURE_CODES` in `app/core/balancer/logic.py` with the message `"Authentication token expired - re-login required"`. This single change flows through both the `AuthManager.refresh_account` deactivation path (via `classify_refresh_error`) and the usage-refresh deactivation path (via `_should_deactivate_for_usage_error`'s `code in PERMANENT_FAILURE_CODES` check) without further plumbing.
+- Add a unit regression in `tests/unit/test_auth_refresh.py` pinning `classify_refresh_error("token_expired") is True`.
+- Add a unit regression in `tests/unit/test_auth_manager.py` that drives `refresh_account` against a stubbed `refresh_access_token` raising `RefreshError("token_expired", ..., classify_refresh_error("token_expired"))` and asserts the account is marked `DEACTIVATED` with a re-login-required reason.
+
+## Impact
+- Accounts that the upstream session has truly invalidated stop receiving traffic and are surfaced as `DEACTIVATED` with a clear reason in the dashboard, instead of looping `token_expired` failures while staying `ACTIVE`.
+- No false positives expected: a still-valid refresh token returns a fresh token pair (HTTP 200), so `token_expired` only appears when the refresh itself has failed in a non-recoverable way.
+- Operators no longer need to pause a clearly broken account manually; the next failing refresh will surface the deactivation. Re-authentication clears the deactivation as it does today for the existing permanent codes.
+- No schema or migration changes. Behavior for the rest of the permanent codes is unchanged.

--- a/openspec/changes/deactivate-on-token-expired/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/deactivate-on-token-expired/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: token_expired at the refresh boundary deactivates the account
+
+When the OAuth refresh endpoint fails with error code `token_expired`, the system MUST treat it as a permanent authentication failure on par with `refresh_token_expired` / `refresh_token_reused` / `refresh_token_invalidated`. The affected account MUST be deactivated and removed from the routing pool until it is re-authenticated.
+
+#### Scenario: Refresh-time `token_expired` is classified as permanent
+
+- **WHEN** `classify_refresh_error("token_expired")` is evaluated
+- **THEN** it returns `True`
+
+#### Scenario: Refresh-time `token_expired` deactivates the account
+
+- **WHEN** `AuthManager.refresh_account` receives a `RefreshError("token_expired", ..., is_permanent=True)` from `refresh_access_token`
+- **THEN** the account is transitioned to `DEACTIVATED`
+- **AND** the deactivation reason references the re-login requirement so the dashboard can surface it
+- **AND** the account is no longer selected by the load balancer until it is re-authenticated
+
+#### Scenario: Usage-refresh-time `token_expired` deactivates the account
+
+- **WHEN** background usage refresh observes an upstream error whose code is `token_expired` (via `_should_deactivate_for_usage_error`'s permanent-code check)
+- **THEN** the account is transitioned to `DEACTIVATED` immediately, without entering the ambiguous-401 cooldown loop

--- a/openspec/changes/deactivate-on-token-expired/tasks.md
+++ b/openspec/changes/deactivate-on-token-expired/tasks.md
@@ -1,0 +1,4 @@
+- [x] Add `token_expired` to `PERMANENT_FAILURE_CODES` in `app/core/balancer/logic.py` with a re-login-required message, so `classify_refresh_error("token_expired")` returns `True` and both the auth-manager refresh path and the usage-refresh deactivation path treat it as permanent.
+- [x] Add a unit regression in `tests/unit/test_auth_refresh.py` pinning `classify_refresh_error("token_expired") is True`.
+- [x] Add a unit regression in `tests/unit/test_auth_manager.py` driving `AuthManager.refresh_account` against a stubbed `refresh_access_token` raising `RefreshError("token_expired", ..., is_permanent=True)` and asserting the account transitions to `DEACTIVATED` with a re-login-required reason.
+- [x] Document the new behavior under the `usage-refresh-policy` capability spec.

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -371,3 +371,58 @@ async def test_refresh_account_deactivates_when_repo_only_reencrypted_same_refre
     assert exc_info.value.is_permanent is True
     assert repo.status_payload is not None
     assert repo.status_payload["status"] == AccountStatus.DEACTIVATED
+
+
+@pytest.mark.asyncio
+async def test_refresh_account_deactivates_when_upstream_returns_token_expired(monkeypatch):
+    """Regression for #383: a ``token_expired`` code from the OAuth refresh
+    endpoint must classify as a permanent failure and deactivate the account,
+    not loop retries forever while the account stays ``ACTIVE``.
+    """
+
+    async def _fake_refresh(_: str) -> TokenRefreshResult:
+        # Real upstream-observed shape: HTTP 4xx body whose error code is
+        # ``token_expired`` and message is the user-facing "Provided
+        # authentication token is expired" wording. classify_refresh_error
+        # must surface this as ``is_permanent=True``.
+        from app.core.auth.refresh import classify_refresh_error
+
+        assert classify_refresh_error("token_expired") is True
+        raise RefreshError(
+            "token_expired",
+            "Provided authentication token is expired. Please try signing in again.",
+            classify_refresh_error("token_expired"),
+        )
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    expired_account = Account(
+        id="acc_token_expired",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    repo = _DummyRepo()
+    latest_account = Account(
+        **{column.name: getattr(expired_account, column.name) for column in Account.__table__.columns}
+    )
+    repo.accounts_by_id[expired_account.id] = latest_account
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    with pytest.raises(RefreshError) as exc_info:
+        await manager.refresh_account(expired_account)
+
+    assert exc_info.value.code == "token_expired"
+    assert exc_info.value.is_permanent is True
+    assert repo.status_payload is not None
+    assert repo.status_payload["status"] == AccountStatus.DEACTIVATED
+    reason = repo.status_payload["deactivation_reason"]
+    assert isinstance(reason, str)
+    assert "re-login" in reason.lower() or "expired" in reason.lower()

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -25,5 +25,14 @@ def test_classify_refresh_error_permanent():
     assert classify_refresh_error("account_deactivated") is True
 
 
+def test_classify_refresh_error_token_expired_is_permanent():
+    # ``token_expired`` from the OAuth refresh endpoint means the refresh
+    # request itself failed because the refresh token (or the session it
+    # belonged to) is no longer usable. Treat it as a permanent failure so
+    # the load balancer deactivates the account instead of looping retries.
+    # Regression for #383.
+    assert classify_refresh_error("token_expired") is True
+
+
 def test_classify_refresh_error_temporary():
     assert classify_refresh_error("temporary_error") is False


### PR DESCRIPTION
Fixes #383.

## Root cause

When the OAuth refresh endpoint returns error code `token_expired` (HTTP 401 body `{"error": {"code": "token_expired"}}` with message `"Provided authentication token is expired. Please try signing in again."`), the existing code path treats it as a transient failure:

- `PERMANENT_FAILURE_CODES` in `app/core/balancer/logic.py` only lists `refresh_token_expired`, `refresh_token_reused`, `refresh_token_invalidated`, `account_deactivated`, `account_suspended`, `account_deleted`. It does **not** include `token_expired`.
- `classify_refresh_error("token_expired")` therefore returns `False`, so `RefreshError` is built with `is_permanent=False`.
- `AuthManager.refresh_account` only deactivates on a permanent error.
- `usage._should_deactivate_for_usage_error` only deactivates on HTTP 402/404, on the existing permanent code set, or on the "account has been deactivated" message hint.

Net effect: refresh keeps failing, the account stays `ACTIVE`, and the load balancer keeps selecting it. The reporter ran into exactly this with `email_3e2ba4c18bda` until they manually paused it.

## Why `token_expired` at the refresh boundary is permanent

This is not a transient error in practice:

- Access-token-only expiry would have caused the refresh call itself to return a fresh token pair (HTTP 200). The refresh wouldn't fail.
- A `token_expired` arriving at the **refresh boundary** means the refresh token (or the session it represents) is no longer usable.
- That is the same shape as `refresh_token_expired` / `refresh_token_invalidated` -- just a different error code on the upstream side.

So treating it as permanent matches what is actually happening on the upstream side, and matches the reporter's observation that the account only recovers after re-authentication.

## Fix

Add `token_expired` to `PERMANENT_FAILURE_CODES` with the message `"Authentication token expired - re-login required"`. This single change flows through both deactivation paths without further plumbing:

- `AuthManager.refresh_account` -- via `classify_refresh_error("token_expired") -> True`
- usage-refresh `_should_deactivate_for_usage_error` -- via its `code in PERMANENT_FAILURE_CODES` check

So a refresh-time `token_expired` now correctly deactivates the account on both the request-driven refresh path and the background usage refresh path. The reporter's affected account would now be deactivated on the next failing refresh and stop draining client requests.

Re-authentication clears the deactivation as it does today for the other permanent codes.

## Tests

```
tests/unit/test_auth_refresh.py::test_classify_refresh_error_token_expired_is_permanent PASSED
tests/unit/test_auth_manager.py::test_refresh_account_deactivates_when_upstream_returns_token_expired PASSED
```

The auth-manager regression test drives `refresh_account` against a stubbed `refresh_access_token` raising `RefreshError("token_expired", ..., classify_refresh_error("token_expired"))`, then asserts:

- the resulting `RefreshError` has `is_permanent=True` and `code="token_expired"`
- the account row is updated to `AccountStatus.DEACTIVATED`
- the deactivation reason surfaces the re-login / expired wording

Verification on this branch:

```
uv run ruff check app/core/balancer/logic.py tests/unit/test_auth_refresh.py tests/unit/test_auth_manager.py     # clean
uv run ruff format --check app/core/balancer/logic.py tests/unit/test_auth_refresh.py tests/unit/test_auth_manager.py  # clean
uv run ty check app/core/balancer/logic.py tests/unit/test_auth_refresh.py tests/unit/test_auth_manager.py        # clean
uv run pytest tests/unit/test_auth_refresh.py tests/unit/test_auth_manager.py tests/unit/test_load_balancer.py -q   # 74 passed
npx @fission-ai/openspec validate deactivate-on-token-expired                                                       # change is valid
```

## OpenSpec

Added `openspec/changes/deactivate-on-token-expired/` capturing the new behavior under the existing `usage-refresh-policy` capability (refresh-time and usage-refresh-time `token_expired` both deactivate; classification scenario; deactivation scenario; reason wording requirement).

## Hotfix candidate for v1.17.1 / v1.17.2

Small, scoped change to the permanent-failure classification, with two unit regressions and an OpenSpec entry. No runtime/migration impact. Pairs naturally with #598 (the bcrypt 72-byte fix) for the next patch release.
