### PR TITLE
fix(proxy): classify upstream overloaded_error as retryable transient

### DIFF
--- a/app/modules/proxy/helpers.py
+++ b/app/modules/proxy/helpers.py
@@ -36,7 +36,7 @@ PLAN_TYPE_PRIORITY = (
 
 _RATE_LIMIT_CODES = frozenset({"rate_limit_exceeded", "usage_limit_reached"})
 _QUOTA_CODES = frozenset({"insufficient_quota", "usage_not_included", "quota_exceeded"})
-_TRANSIENT_CODES = frozenset({"server_error", "upstream_error", "stream_incomplete"})
+_TRANSIENT_CODES = frozenset({"server_error", "upstream_error", "stream_incomplete", "overloaded_error"})
 
 
 def classify_upstream_failure(

--- a/openspec/changes/treat-upstream-overloaded-as-retryable/proposal.md
+++ b/openspec/changes/treat-upstream-overloaded-as-retryable/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+Issue #565 reports that long-running Codex agent sessions stop mid-task when the upstream returns a transient `"Our servers are currently overloaded. Please try again later"` error. The codex-lb classifier in `app/modules/proxy/helpers.py:classify_upstream_failure` keys its retryable-transient decision on `_TRANSIENT_CODES = {"server_error", "upstream_error", "stream_incomplete"}` plus any 5xx HTTP status.
+
+OpenAI surfaces the overload condition with `error.code = "overloaded_error"`. That code is missing from `_TRANSIENT_CODES`, and the error can arrive without an accompanying 5xx HTTP status (the most common path is a streamed response where the HTTP status was already `200` before the error envelope hit the wire, or a non-stream JSON response with status `503` that some upstream variants downgrade to `200` to keep the SSE channel open). In both shapes `http_status >= 500` is false, so the failover layer ends up classifying it as `non_retryable`.
+
+`failover_decision` only retries / fails over for `failure_class in ("rate_limit", "quota", "retryable_transient")` (`app/core/balancer/logic.py:361`). With `non_retryable` the agent's request is failed back to the client and the agent stops without any account fail-over, which is exactly the symptom in #565.
+
+## What Changes
+
+- Add `"overloaded_error"` to `_TRANSIENT_CODES` in `app/modules/proxy/helpers.py` so the classifier returns `retryable_transient` regardless of whether the upstream surfaced an HTTP 5xx alongside the envelope.
+- Document the upstream-overload classification rule under the `responses-api-compat` capability so future contributors know the failover behavior is intentional and codified.
+- Add a regression test in `tests/unit/test_failover_foundation.py` covering the `code=overloaded_error`, `http_status=None` shape so accidental removal of the code from the set fails CI.
+
+## Impact
+
+- Restores account fail-over and retry behavior when one upstream account is overloaded, instead of stopping the agent mid-task on a transient condition that another account or a near-term retry would have served.
+- No effect on `rate_limit`, `quota`, or genuinely non-retryable client errors (auth, invalid request) — the change only widens the *transient* set by one code that is, by definition, transient on the upstream side.
+- No public surface change. Clients continue to see the upstream error envelope verbatim; only codex-lb's internal failover decision changes.

--- a/openspec/changes/treat-upstream-overloaded-as-retryable/specs/responses-api-compat/spec.md
+++ b/openspec/changes/treat-upstream-overloaded-as-retryable/specs/responses-api-compat/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Upstream overload envelopes are classified as retryable transient failures
+
+When `classify_upstream_failure` observes an upstream error envelope whose `code` is `overloaded_error`, the system MUST treat it as `retryable_transient` regardless of the accompanying HTTP status. Streamed Responses API traffic can deliver the overload envelope on a connection that has already returned HTTP 200, so a 5xx-only heuristic is insufficient to drive account fail-over and bounded retry.
+
+#### Scenario: `overloaded_error` without a 5xx status is retryable transient
+
+- **WHEN** `classify_upstream_failure` is called with `error_code="overloaded_error"` and `http_status` not in the 5xx range (including `None`)
+- **THEN** the returned `failure_class` is `retryable_transient`
+- **AND** the failover layer is eligible to retry the request or fail over to another account instead of returning a non-retryable error to the client
+
+#### Scenario: `overloaded_error` with a 5xx status remains retryable transient
+
+- **WHEN** `classify_upstream_failure` is called with `error_code="overloaded_error"` and `http_status` is 500, 502, 503, or 504
+- **THEN** the returned `failure_class` is `retryable_transient`
+- **AND** the result is the same as the no-status path, so the 5xx fallback heuristic is not the only signal driving the decision

--- a/openspec/changes/treat-upstream-overloaded-as-retryable/tasks.md
+++ b/openspec/changes/treat-upstream-overloaded-as-retryable/tasks.md
@@ -1,0 +1,3 @@
+- [x] Add `"overloaded_error"` to `_TRANSIENT_CODES` in `app/modules/proxy/helpers.py` so `classify_upstream_failure` returns `retryable_transient` for the upstream overload envelope even when no 5xx HTTP status accompanies it.
+- [x] Add a regression in `tests/unit/test_failover_foundation.py::TestClassifyUpstreamFailure` driving `error_code="overloaded_error"` with `http_status=None` and asserting `failure_class == "retryable_transient"`.
+- [x] Add a requirement under the `responses-api-compat` capability documenting that upstream overload envelopes are classified as retryable transient failures regardless of HTTP status, so account fail-over and bounded retry are exercised.

--- a/tests/unit/test_failover_foundation.py
+++ b/tests/unit/test_failover_foundation.py
@@ -92,6 +92,21 @@ class TestClassifyUpstreamFailure:
         )
         assert result["failure_class"] == "retryable_transient"
 
+    def test_overloaded_error(self) -> None:
+        # Regression for #565: upstream "Our servers are currently overloaded.
+        # Please try again later" is delivered with code=overloaded_error and
+        # may surface without a 5xx status (e.g. on streamed responses where
+        # the HTTP status was already 200 before the error envelope).
+        # Classifying it as non_retryable made the agent stop mid-task instead
+        # of failing over to another account or surfacing a retryable error.
+        result = classify_upstream_failure(
+            error_code="overloaded_error",
+            error=UpstreamError(message="Our servers are currently overloaded. Please try again later"),
+            http_status=None,
+            phase="first_event",
+        )
+        assert result["failure_class"] == "retryable_transient"
+
     def test_non_retryable_bad_request(self) -> None:
         result = classify_upstream_failure(
             error_code="invalid_request",


### PR DESCRIPTION
## Summary
- Fixes #565. Long-running agent sessions stop mid-task when the upstream returns `Our servers are currently overloaded. Please try again later`. OpenAI delivers that as `error.code = \"overloaded_error\"`, which is missing from `_TRANSIENT_CODES` in `app/modules/proxy/helpers.py`.
- The envelope often arrives without a 5xx HTTP status — streamed Responses traffic returns `200` before the error frame hits the wire, and some upstream variants downgrade the JSON 503 to 200 to keep the SSE channel open. With both code-set membership and the `http_status >= 500` fallback failing, the classifier returns `non_retryable`. `failover_decision` only retries / fails over for `rate_limit`, `quota`, or `retryable_transient` (`app/core/balancer/logic.py:361`), so the agent is failed back to the client without any account failover and stops.
- Add `\"overloaded_error\"` to `_TRANSIENT_CODES`, exercise the regression in `tests/unit/test_failover_foundation.py` using the `http_status=None` shape, and document the requirement under the `responses-api-compat` capability.
- No public surface change. Clients still see the upstream error envelope verbatim; only codex-lb's internal failover decision is widened by one code that is, by definition, transient.

## Validation
- `uv run pytest tests/unit/test_failover_foundation.py` — 44 passed
- `uvx ruff check app/modules/proxy/helpers.py tests/unit/test_failover_foundation.py` — clean
- `uv run ty check app/modules/proxy/helpers.py` — clean
- `openspec validate treat-upstream-overloaded-as-retryable` — valid

## Notes
- Same classifier feeds both `/v1/responses` and `/v1/chat/completions` failover, so the fix benefits both surfaces even though the documented requirement is parked under `responses-api-compat` (where the issue surfaced).
- Intentionally minimal: this PR widens the transient set by one code. It does not change retry budget, backoff, or any client-facing payload. If you'd prefer broader message-pattern matching as a defence in depth for hosts that strip the structured `code`, happy to follow up in a separate change.

Fixes #565