### PR TITLE
fix(proxy): accept /backend-api/codex/v1/<rest> as alias for /backend-api/codex/<rest>

### DIFF
--- a/app/core/middleware/__init__.py
+++ b/app/core/middleware/__init__.py
@@ -1,10 +1,12 @@
 from app.core.middleware.api_firewall import add_api_firewall_middleware
 from app.core.middleware.dashboard_auth_proxy import add_dashboard_auth_proxy_middleware
+from app.core.middleware.path_rewrite import add_backend_api_codex_v1_alias_middleware
 from app.core.middleware.request_decompression import add_request_decompression_middleware
 from app.core.middleware.request_id import add_request_id_middleware
 
 __all__ = [
     "add_api_firewall_middleware",
+    "add_backend_api_codex_v1_alias_middleware",
     "add_dashboard_auth_proxy_middleware",
     "add_request_decompression_middleware",
     "add_request_id_middleware",

--- a/app/core/middleware/path_rewrite.py
+++ b/app/core/middleware/path_rewrite.py
@@ -1,0 +1,78 @@
+"""Path-rewrite middleware for backwards-compatible `/v1/` URL handling.
+
+Some OpenAI-compatible clients unconditionally append ``/v1/`` to
+whatever base URL the operator configured. When the configured base URL
+already terminates at ``/backend-api/codex`` (codex-lb's Codex-style
+entry point), those clients end up hitting
+``/backend-api/codex/v1/<rest>`` -- a shape codex-lb does not register
+because the OpenAI-style endpoints are mounted at the top-level
+``/v1/<rest>`` and the Codex-style endpoints at
+``/backend-api/codex/<rest>``.
+
+This middleware collapses the duplicated ``/v1`` segment in-place by
+mutating ``scope["path"]`` (and ``scope["raw_path"]``) before routing,
+so the canonical handler picks the request up unchanged. See
+``openspec/changes/strip-codex-v1-prefix/`` for the spec delta.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI, Request
+from starlette.responses import Response
+
+# The middleware is intentionally scoped to the duplicated Codex prefix
+# only. The top-level ``/v1/`` namespace is the canonical OpenAI-style
+# route surface and must be left alone.
+_CODEX_V1_PREFIX = "/backend-api/codex/v1/"
+_CODEX_V1_PREFIX_BYTES = _CODEX_V1_PREFIX.encode("ascii")
+_CODEX_CANONICAL_PREFIX = "/backend-api/codex/"
+_CODEX_CANONICAL_PREFIX_BYTES = _CODEX_CANONICAL_PREFIX.encode("ascii")
+
+
+def _canonicalize_backend_api_codex_path(path: str) -> str:
+    """Collapse ``/backend-api/codex/v1/<rest>`` -> ``/backend-api/codex/<rest>``.
+
+    Returns the input unchanged for any path that is not the duplicated
+    Codex ``/v1/`` shape. In particular, ``/backend-api/codex`` (no
+    rest) and ``/backend-api/codex/v1`` (no further rest) are left
+    alone -- those are legal request paths a future contributor might
+    register, and collapsing them would silently change routing
+    semantics.
+    """
+    if not path.startswith(_CODEX_V1_PREFIX):
+        return path
+    return _CODEX_CANONICAL_PREFIX + path[len(_CODEX_V1_PREFIX) :]
+
+
+def _canonicalize_raw_path(raw_path: bytes) -> bytes:
+    if not raw_path.startswith(_CODEX_V1_PREFIX_BYTES):
+        return raw_path
+    return _CODEX_CANONICAL_PREFIX_BYTES + raw_path[len(_CODEX_V1_PREFIX_BYTES) :]
+
+
+def add_backend_api_codex_v1_alias_middleware(app: FastAPI) -> None:
+    """Register a path-rewrite middleware for the duplicated prefix.
+
+    Implemented as a standard FastAPI HTTP middleware so it runs before
+    Starlette's router matches a route. Both ``scope["path"]`` and
+    ``scope["raw_path"]`` are kept in sync so downstream middleware that
+    re-derive the request URL from either field see the canonical form.
+    """
+
+    @app.middleware("http")
+    async def alias_middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        scope = request.scope
+        path = scope.get("path")
+        if isinstance(path, str) and path.startswith(_CODEX_V1_PREFIX):
+            rewritten = _canonicalize_backend_api_codex_path(path)
+            if rewritten != path:
+                scope["path"] = rewritten
+                raw_path = scope.get("raw_path")
+                if isinstance(raw_path, bytes):
+                    scope["raw_path"] = _canonicalize_raw_path(raw_path)
+        return await call_next(request)

--- a/app/core/middleware/path_rewrite.py
+++ b/app/core/middleware/path_rewrite.py
@@ -11,16 +11,20 @@ because the OpenAI-style endpoints are mounted at the top-level
 
 This middleware collapses the duplicated ``/v1`` segment in-place by
 mutating ``scope["path"]`` (and ``scope["raw_path"]``) before routing,
-so the canonical handler picks the request up unchanged. See
+so the canonical handler picks the request up unchanged. Implemented as
+a pure ASGI middleware so the rewrite covers both HTTP and WebSocket
+scopes -- ``app/modules/proxy/api.py`` exposes websocket endpoints under
+``/backend-api/codex`` (and ``/v1``), so a client that appends ``/v1``
+to its ``/backend-api/codex`` base URL needs the alias for handshakes
+just as much as it does for HTTP requests. See
 ``openspec/changes/strip-codex-v1-prefix/`` for the spec delta.
 """
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from typing import Any
 
-from fastapi import FastAPI, Request
-from starlette.responses import Response
+from fastapi import FastAPI
 
 # The middleware is intentionally scoped to the duplicated Codex prefix
 # only. The top-level ``/v1/`` namespace is the canonical OpenAI-style
@@ -52,27 +56,39 @@ def _canonicalize_raw_path(raw_path: bytes) -> bytes:
     return _CODEX_CANONICAL_PREFIX_BYTES + raw_path[len(_CODEX_V1_PREFIX_BYTES) :]
 
 
-def add_backend_api_codex_v1_alias_middleware(app: FastAPI) -> None:
-    """Register a path-rewrite middleware for the duplicated prefix.
+class BackendApiCodexV1AliasMiddleware:
+    """ASGI middleware that canonicalises the duplicated Codex prefix.
 
-    Implemented as a standard FastAPI HTTP middleware so it runs before
-    Starlette's router matches a route. Both ``scope["path"]`` and
-    ``scope["raw_path"]`` are kept in sync so downstream middleware that
-    re-derive the request URL from either field see the canonical form.
+    Runs before Starlette's router matches a route. Both ``scope["path"]``
+    and ``scope["raw_path"]`` are kept in sync so downstream middleware
+    that re-derive the request URL from either field see the canonical
+    form.
+
+    Handles both ``http`` and ``websocket`` scopes -- HTTP-only middleware
+    misses websocket handshakes, which is the bug Codex flagged on #610.
+    Lifespan and other scope types pass through untouched.
     """
 
-    @app.middleware("http")
-    async def alias_middleware(
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        scope = request.scope
-        path = scope.get("path")
-        if isinstance(path, str) and path.startswith(_CODEX_V1_PREFIX):
-            rewritten = _canonicalize_backend_api_codex_path(path)
-            if rewritten != path:
-                scope["path"] = rewritten
-                raw_path = scope.get("raw_path")
-                if isinstance(raw_path, bytes):
-                    scope["raw_path"] = _canonicalize_raw_path(raw_path)
-        return await call_next(request)
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
+        if scope.get("type") in ("http", "websocket"):
+            path = scope.get("path")
+            if isinstance(path, str) and path.startswith(_CODEX_V1_PREFIX):
+                rewritten = _canonicalize_backend_api_codex_path(path)
+                if rewritten != path:
+                    # Copy the scope so we don't mutate the caller's dict;
+                    # ASGI servers may reuse scope instances across calls.
+                    scope = dict(scope)
+                    scope["path"] = rewritten
+                    raw_path = scope.get("raw_path")
+                    if isinstance(raw_path, bytes):
+                        scope["raw_path"] = _canonicalize_raw_path(raw_path)
+        await self.app(scope, receive, send)
+
+
+def add_backend_api_codex_v1_alias_middleware(app: FastAPI) -> None:
+    """Register the path-rewrite ASGI middleware for the duplicated prefix."""
+
+    app.add_middleware(BackendApiCodexV1AliasMiddleware)

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.core.metrics.middleware import MetricsMiddleware
 from app.core.metrics.prometheus import MULTIPROCESS_MODE, PROMETHEUS_AVAILABLE, make_scrape_registry, mark_process_dead
 from app.core.middleware import (
     add_api_firewall_middleware,
+    add_backend_api_codex_v1_alias_middleware,
     add_dashboard_auth_proxy_middleware,
     add_request_decompression_middleware,
     add_request_id_middleware,
@@ -345,6 +346,7 @@ def create_app() -> FastAPI:
             dashboard_limit=settings.bulkhead_dashboard_limit,
         ),
     )
+    add_backend_api_codex_v1_alias_middleware(app)
     add_exception_handlers(app)
 
     app.include_router(proxy_api.router)

--- a/openspec/changes/strip-codex-v1-prefix/proposal.md
+++ b/openspec/changes/strip-codex-v1-prefix/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Issue #267 reports that some OpenAI-compatible clients append `/v1/` to whatever the operator configured as the base URL. With codex-lb's natural base of `https://example.com/backend-api/codex`, those clients end up hitting `https://example.com/backend-api/codex/v1/models`, `…/v1/responses`, etc. None of those routes exist — codex-lb registers the OpenAI-style endpoints at `/v1/<rest>` (top-level) and the Codex backend endpoints at `/backend-api/codex/<rest>`, but not at the combined `/backend-api/codex/v1/<rest>` shape.
+
+Because the registered routes are otherwise symmetrical (`router.get("/models")` + `v1_router.get("/models")`, `router.post("/responses")` + `v1_router.post("/responses")`, etc.), every `/backend-api/codex/v1/<rest>` request has a working counterpart at `/backend-api/codex/<rest>`. Today those requests 404 with no operator-facing signal as to why.
+
+## What Changes
+
+- Add a small ASGI path-rewrite middleware that, on every request whose path starts with `/backend-api/codex/v1/`, strips the redundant `/v1` segment in-place by mutating `scope["path"]` and `scope["raw_path"]` before routing. The exact `/backend-api/codex/v1` and `/backend-api/codex` paths (no trailing rest) are left alone — only the duplicated prefix on subpaths is collapsed.
+- Register the middleware in the FastAPI lifespan so it runs before the existing API firewall and the proxy router. Idempotent: subsequent middleware / route handlers see the canonical `/backend-api/codex/<rest>` path the rest of the stack already understands.
+- Add unit coverage for the rewrite helper (canonical/no-op/idempotent/edge cases) and integration coverage that issues a request to the duplicated path and asserts the canonical handler runs.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: routing surface now accepts the `/backend-api/codex/v1/<rest>` prefix as a transparent alias for `/backend-api/codex/<rest>`, so misbehaving clients that append `/v1/` to the configured base URL stop hitting 404s.
+
+## Impact
+
+- **Code**: `app/core/middleware/path_rewrite.py` (new), `app/core/middleware/__init__.py`, `app/main.py`.
+- **Tests**: `tests/unit/test_path_rewrite_middleware.py` (new), `tests/integration/test_proxy_api_extended.py` (new aliasing case).
+- **API surface**: no new endpoints; `/backend-api/codex/v1/<rest>` becomes a transparent alias for `/backend-api/codex/<rest>`. Top-level `/v1/<rest>` is unchanged.
+- **Operational**: no migration. No new configuration. The middleware is unconditional and cheap (string prefix check).

--- a/openspec/changes/strip-codex-v1-prefix/specs/responses-api-compat/spec.md
+++ b/openspec/changes/strip-codex-v1-prefix/specs/responses-api-compat/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Accept duplicated /v1/ prefix under /backend-api/codex
+Some OpenAI-compatible clients append `/v1/` to whatever the operator configured as the base URL. When the operator's base URL already terminates at `/backend-api/codex`, those clients end up requesting `/backend-api/codex/v1/<rest>` (for example `/backend-api/codex/v1/models`, `/backend-api/codex/v1/responses`, `/backend-api/codex/v1/responses/compact`).
+
+The service MUST treat any inbound request whose path begins with `/backend-api/codex/v1/` followed by a non-empty rest as a transparent alias for the same path with the `/v1` segment removed. The aliasing MUST be applied before routing so the canonical handler runs unchanged.
+
+The aliasing MUST NOT trigger for `/backend-api/codex/v1` or `/backend-api/codex` with no further path. The top-level OpenAI-style `/v1/<rest>` routes are unaffected.
+
+#### Scenario: Misbehaving client requests duplicated prefix
+- **WHEN** a client requests `GET /backend-api/codex/v1/models`
+- **THEN** the response is identical to `GET /backend-api/codex/models`
+
+#### Scenario: Canonical paths are unchanged
+- **WHEN** a client requests `GET /backend-api/codex/models` or `GET /v1/models`
+- **THEN** the request is routed to its existing handler without modification

--- a/openspec/changes/strip-codex-v1-prefix/tasks.md
+++ b/openspec/changes/strip-codex-v1-prefix/tasks.md
@@ -1,0 +1,16 @@
+## 1. Path-Rewrite Middleware
+
+- [x] 1.1 Add `app/core/middleware/path_rewrite.py` with an `add_backend_api_codex_v1_alias_middleware(app)` registrar and an internal `_canonicalize_backend_api_codex_path(path)` helper.
+- [x] 1.2 Mutate `scope["path"]` and `scope["raw_path"]` together so downstream middleware/routers see the canonical path.
+- [x] 1.3 Leave `/backend-api/codex/v1` (no rest) and `/backend-api/codex` alone; only collapse the `/backend-api/codex/v1/<rest>` prefix where `<rest>` is non-empty.
+- [x] 1.4 Export the registrar from `app/core/middleware/__init__.py` and call it from `app/main.py` ahead of the existing api-firewall middleware.
+
+## 2. Tests
+
+- [x] 2.1 Unit tests for `_canonicalize_backend_api_codex_path`: canonical no-op, alias rewrite, idempotent re-application, edge paths (`/backend-api/codex`, `/backend-api/codex/v1`, trailing slash, `/v1/...` top-level).
+- [x] 2.2 Integration test: `GET /backend-api/codex/v1/models` returns the same payload as `GET /backend-api/codex/models`.
+
+## 3. Spec Delta
+
+- [x] 3.1 Add `openspec/changes/strip-codex-v1-prefix/specs/responses-api-compat/spec.md` describing the alias requirement.
+- [x] 3.2 `openspec validate --specs` (if available).

--- a/tests/integration/test_path_rewrite_alias.py
+++ b/tests/integration/test_path_rewrite_alias.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_backend_api_codex_v1_models_aliases_canonical(async_client) -> None:
+    """/backend-api/codex/v1/models must return the same payload as
+    /backend-api/codex/models -- the alias middleware should strip the
+    duplicated /v1/ segment before routing so the canonical handler
+    runs unchanged.
+    """
+    canonical = await async_client.get("/backend-api/codex/models")
+    aliased = await async_client.get("/backend-api/codex/v1/models")
+
+    assert canonical.status_code == aliased.status_code == 200
+    assert canonical.json() == aliased.json()
+
+
+@pytest.mark.asyncio
+async def test_top_level_v1_models_is_unaffected(async_client) -> None:
+    """/v1/models is the canonical OpenAI-style namespace; the alias
+    middleware must not interfere with it.
+    """
+    response = await async_client.get("/v1/models")
+    assert response.status_code == 200

--- a/tests/unit/test_path_rewrite_middleware.py
+++ b/tests/unit/test_path_rewrite_middleware.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.middleware.path_rewrite import (
+    _canonicalize_backend_api_codex_path,
+    _canonicalize_raw_path,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # Aliased prefix collapses.
+        ("/backend-api/codex/v1/models", "/backend-api/codex/models"),
+        ("/backend-api/codex/v1/responses", "/backend-api/codex/responses"),
+        (
+            "/backend-api/codex/v1/responses/compact",
+            "/backend-api/codex/responses/compact",
+        ),
+        # Canonical paths are left alone.
+        ("/backend-api/codex/models", "/backend-api/codex/models"),
+        ("/backend-api/codex/responses", "/backend-api/codex/responses"),
+        # No-rest sentinels MUST NOT be rewritten -- they are legal
+        # paths a future contributor could register, and collapsing
+        # them would silently change routing semantics.
+        ("/backend-api/codex", "/backend-api/codex"),
+        ("/backend-api/codex/v1", "/backend-api/codex/v1"),
+        # Top-level /v1 is the canonical OpenAI-style namespace and is
+        # explicitly out of scope.
+        ("/v1/models", "/v1/models"),
+        ("/v1/responses", "/v1/responses"),
+        # Unrelated paths.
+        ("/api/settings", "/api/settings"),
+        ("/", "/"),
+    ],
+)
+def test_canonicalize_backend_api_codex_path(raw: str, expected: str) -> None:
+    assert _canonicalize_backend_api_codex_path(raw) == expected
+
+
+def test_canonicalize_backend_api_codex_path_is_idempotent() -> None:
+    once = _canonicalize_backend_api_codex_path("/backend-api/codex/v1/responses")
+    twice = _canonicalize_backend_api_codex_path(once)
+    assert once == twice == "/backend-api/codex/responses"
+
+
+def test_canonicalize_raw_path_preserves_query_segment() -> None:
+    # raw_path in ASGI includes only the path; query lives in
+    # scope["query_string"]. The rewrite must therefore not split on
+    # "?", but it should still byte-equal the canonical form.
+    raw = b"/backend-api/codex/v1/models"
+    assert _canonicalize_raw_path(raw) == b"/backend-api/codex/models"
+
+
+def test_canonicalize_raw_path_noop_for_canonical() -> None:
+    raw = b"/backend-api/codex/models"
+    assert _canonicalize_raw_path(raw) is raw or _canonicalize_raw_path(raw) == raw

--- a/tests/unit/test_path_rewrite_middleware.py
+++ b/tests/unit/test_path_rewrite_middleware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from app.core.middleware.path_rewrite import (
+    BackendApiCodexV1AliasMiddleware,
     _canonicalize_backend_api_codex_path,
     _canonicalize_raw_path,
 )
@@ -58,3 +59,122 @@ def test_canonicalize_raw_path_preserves_query_segment() -> None:
 def test_canonicalize_raw_path_noop_for_canonical() -> None:
     raw = b"/backend-api/codex/models"
     assert _canonicalize_raw_path(raw) is raw or _canonicalize_raw_path(raw) == raw
+
+
+# ---- middleware scope-level tests --------------------------------------------
+# Codex review on #610: the alias must rewrite websocket handshake scopes,
+# not just HTTP scopes. The ASGI middleware below is invoked directly so we
+# can assert exactly which `scope["path"]` reaches the downstream app.
+
+
+class _RecordingApp:
+    """Minimal downstream ASGI app that captures the scope it receives."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def __call__(self, scope: dict, receive, send) -> None:  # type: ignore[no-untyped-def]
+        self.calls.append(scope)
+
+
+@pytest.mark.asyncio
+async def test_middleware_rewrites_http_scope() -> None:
+    inner = _RecordingApp()
+    middleware = BackendApiCodexV1AliasMiddleware(inner)
+
+    scope = {
+        "type": "http",
+        "path": "/backend-api/codex/v1/responses",
+        "raw_path": b"/backend-api/codex/v1/responses",
+    }
+
+    async def _receive():
+        return {"type": "http.request"}
+
+    async def _send(message):
+        pass
+
+    await middleware(scope, _receive, _send)
+
+    assert len(inner.calls) == 1
+    seen = inner.calls[0]
+    assert seen["path"] == "/backend-api/codex/responses"
+    assert seen["raw_path"] == b"/backend-api/codex/responses"
+
+
+@pytest.mark.asyncio
+async def test_middleware_rewrites_websocket_scope() -> None:
+    """The websocket handshake scope must be rewritten too.
+
+    Without this the alias only covers HTTP and clients that append `/v1`
+    to a `/backend-api/codex` base URL get a 404 on websocket handshakes
+    while the equivalent HTTP request succeeds.
+    """
+    inner = _RecordingApp()
+    middleware = BackendApiCodexV1AliasMiddleware(inner)
+
+    scope = {
+        "type": "websocket",
+        "path": "/backend-api/codex/v1/responses",
+        "raw_path": b"/backend-api/codex/v1/responses",
+    }
+
+    async def _receive():
+        return {"type": "websocket.connect"}
+
+    async def _send(message):
+        pass
+
+    await middleware(scope, _receive, _send)
+
+    assert len(inner.calls) == 1
+    seen = inner.calls[0]
+    assert seen["path"] == "/backend-api/codex/responses"
+    assert seen["raw_path"] == b"/backend-api/codex/responses"
+
+
+@pytest.mark.asyncio
+async def test_middleware_leaves_lifespan_scope_untouched() -> None:
+    """Lifespan and other non-http/non-websocket scopes must pass through
+    unchanged so we never accidentally mutate ASGI server state."""
+    inner = _RecordingApp()
+    middleware = BackendApiCodexV1AliasMiddleware(inner)
+
+    scope = {"type": "lifespan"}
+
+    async def _receive():
+        return {"type": "lifespan.startup"}
+
+    async def _send(message):
+        pass
+
+    await middleware(scope, _receive, _send)
+
+    assert len(inner.calls) == 1
+    assert inner.calls[0] is scope
+
+
+@pytest.mark.asyncio
+async def test_middleware_does_not_mutate_caller_scope_on_rewrite() -> None:
+    """ASGI servers can reuse scope dicts across calls. The rewrite must
+    happen on a copy so the caller's dict survives unchanged."""
+    inner = _RecordingApp()
+    middleware = BackendApiCodexV1AliasMiddleware(inner)
+
+    original_scope = {
+        "type": "websocket",
+        "path": "/backend-api/codex/v1/responses",
+        "raw_path": b"/backend-api/codex/v1/responses",
+    }
+    snapshot = dict(original_scope)
+
+    async def _receive():
+        return {"type": "websocket.connect"}
+
+    async def _send(message):
+        pass
+
+    await middleware(original_scope, _receive, _send)
+
+    assert original_scope == snapshot
+    assert inner.calls[0]["path"] == "/backend-api/codex/responses"


### PR DESCRIPTION
## Summary

Resolves #267.

Some OpenAI-compatible clients unconditionally append `/v1/` to whatever base URL the operator configured. When the configured base already terminates at `/backend-api/codex`, those clients end up hitting `/backend-api/codex/v1/models`, `/backend-api/codex/v1/responses`, etc. codex-lb does not register that shape (OpenAI-style routes live at top-level `/v1/<rest>`, Codex-style at `/backend-api/codex/<rest>`), so the request 404s with no operator-facing signal.

## What changes

- New small path-rewrite middleware (`app/core/middleware/path_rewrite.py`) collapses `/backend-api/codex/v1/<rest>` to `/backend-api/codex/<rest>` by mutating `scope["path"]` and `scope["raw_path"]` together before routing.
- The aliasing only triggers when `<rest>` is non-empty — the exact `/backend-api/codex/v1` and `/backend-api/codex` paths are left alone, and the canonical top-level `/v1/<rest>` namespace is unaffected.
- Registered as the outermost HTTP middleware in `app/main.py` so the firewall, metrics, request-id, etc. all see the canonical path the rest of the stack already understands.
- OpenSpec change folder under `openspec/changes/strip-codex-v1-prefix/` adds the contract under `responses-api-compat`.

## Test plan

- [x] `pytest tests/unit/test_path_rewrite_middleware.py` — canonical no-op, alias rewrite, idempotent re-application, edge sentinels (`/backend-api/codex`, `/backend-api/codex/v1`, top-level `/v1/...`)
- [x] `pytest tests/integration/test_path_rewrite_alias.py` — `GET /backend-api/codex/v1/models` returns the same payload as `GET /backend-api/codex/models`
- [x] `pytest tests/integration/test_api_firewall_middleware.py tests/integration/test_health_and_errors.py` — existing middleware/firewall tests unaffected
- [x] `ruff check`, `ty check` clean on the new files