### PR TITLE
fix(api-keys): map enforced service_tier auto/default to outbound omission

### DIFF
--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -27,6 +27,15 @@ logger = logging.getLogger(__name__)
 _UNSUPPORTED_UPSTREAM_REASONING_EFFORTS: frozenset[str] = frozenset({"minimal"})
 _DEFAULT_REASONING_EFFORT_FALLBACK = "low"
 
+# Service tier values codex-lb accepts at the API-key surface but that the
+# ChatGPT/Codex backend rejects with ``Unsupported service_tier: <value>``.
+# Semantically both ``auto`` and ``default`` mean "let upstream pick" -- the
+# same thing as omitting the field entirely -- so when an enforced API-key
+# policy resolves to one of these, we forward the request without a
+# ``service_tier`` instead of sending a literal that fails upstream. See
+# https://github.com/Soju06/codex-lb/issues/546
+_UPSTREAM_OMIT_SERVICE_TIERS: frozenset[str] = frozenset({"auto", "default"})
+
 
 def validate_model_access(api_key: ApiKeyData | None, model: str | None) -> None:
     if api_key is None:
@@ -76,15 +85,27 @@ def apply_api_key_enforcement(
 
     if api_key.enforced_service_tier is not None:
         requested_service_tier = getattr(payload, "service_tier", None)
-        setattr(payload, "service_tier", api_key.enforced_service_tier)
+        # ``auto``/``default`` are accepted at the API-key surface but
+        # the ChatGPT/Codex backend rejects them as literal values. Map
+        # them onto the wire-level absence of ``service_tier`` (which
+        # already means "use upstream default") so the enforcement
+        # actually reaches upstream instead of failing with
+        # ``Unsupported service_tier``. See issue #546.
+        if api_key.enforced_service_tier in _UPSTREAM_OMIT_SERVICE_TIERS:
+            effective_service_tier: str | None = None
+        else:
+            effective_service_tier = api_key.enforced_service_tier
+        setattr(payload, "service_tier", effective_service_tier)
         if requested_service_tier != api_key.enforced_service_tier:
             logger.info(
                 "api_key_service_tier_enforced request_id=%s key_id=%s "
-                "requested_service_tier=%s enforced_service_tier=%s",
+                "requested_service_tier=%s enforced_service_tier=%s "
+                "outbound_service_tier=%s",
                 get_request_id(),
                 api_key.id,
                 requested_service_tier,
                 api_key.enforced_service_tier,
+                effective_service_tier,
             )
 
 

--- a/openspec/changes/fix-enforced-service-tier-default/proposal.md
+++ b/openspec/changes/fix-enforced-service-tier-default/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Issue #546 reports that setting an API key's `enforced_service_tier` to `default` (or `auto`) breaks every request through that key: the request fails upstream with `invalid_request_error Unsupported service_tier: default` (or `... auto`).
+
+The root cause is in `apply_api_key_enforcement` in `app/modules/proxy/request_policy.py`. The enforcement step writes the literal `enforced_service_tier` value onto `payload.service_tier`, and then the request is forwarded as-is. The ChatGPT/Codex backend rejects both `default` and `auto` as literal values: they are codex-lb's API-key surface conventions for "let upstream pick", not upstream-level service tiers.
+
+Today operators have no working way to enforce "no priority / no flex" — exactly the use case the issue raises ("I want to disable fast mode globally or per-key"). The API-key form accepts the value, but every request through that key fails.
+
+## What Changes
+
+- In `apply_api_key_enforcement`, when `enforced_service_tier` is `auto` or `default`, set `payload.service_tier = None` (wire-level absence) instead of writing the literal. Real upstream tiers (`priority`, `flex`) continue to propagate as the literal value.
+- Extend the existing `api_key_service_tier_enforced` log line with an `outbound_service_tier` field so operators can confirm enforcement reached upstream as expected.
+- Add unit coverage in `tests/unit/test_proxy_utils.py` for the `default` and `auto` omission paths and for the unchanged `flex`/`priority` propagation.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `api-keys`: when the persisted `enforced_service_tier` is `auto` or `default`, the proxy MUST forward the request without a `service_tier` field rather than as a literal value the upstream rejects. Enforcement of `priority` and `flex` is unchanged.
+
+## Impact
+
+- **Code**: `app/modules/proxy/request_policy.py` only.
+- **Tests**: `tests/unit/test_proxy_utils.py` (additions, no modifications to existing assertions).
+- **API surface**: no schema changes. Existing `enforced_service_tier` validator already accepts `auto`/`default`/`priority`/`flex` (plus `fast` aliased to `priority`); only the outbound mapping changes for the two "let upstream pick" sentinels.
+- **Operational**: an extra `outbound_service_tier=...` field on the existing enforcement log; no new env vars or settings.

--- a/openspec/changes/fix-enforced-service-tier-default/specs/api-keys/spec.md
+++ b/openspec/changes/fix-enforced-service-tier-default/specs/api-keys/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Map `auto`/`default` enforced service tier to outbound omission
+codex-lb accepts `auto`, `default`, `priority`, and `flex` (plus the `fast` alias for `priority`) at the API-key `enforced_service_tier` surface. The ChatGPT/Codex backend that the proxy forwards to, however, rejects `auto` and `default` as literal values (`Unsupported service_tier: <value>`); semantically both already mean "let upstream pick", which equals omitting the field.
+
+When a request is enforced under an API key whose `enforced_service_tier` is `auto` or `default`, the proxy MUST forward the request with `service_tier` absent (`None`) rather than as the literal string. Enforcement of `priority` and `flex` MUST continue to forward the literal value unchanged.
+
+#### Scenario: Enforced service tier is `default`
+- **WHEN** a request is processed under an API key with `enforced_service_tier = "default"`
+- **THEN** the outbound `service_tier` field is absent
+
+#### Scenario: Enforced service tier is `auto`
+- **WHEN** a request is processed under an API key with `enforced_service_tier = "auto"`
+- **THEN** the outbound `service_tier` field is absent
+
+#### Scenario: Enforced service tier is a real upstream tier
+- **WHEN** a request is processed under an API key with `enforced_service_tier = "priority"` or `"flex"`
+- **THEN** the outbound `service_tier` field equals the enforced value

--- a/openspec/changes/fix-enforced-service-tier-default/tasks.md
+++ b/openspec/changes/fix-enforced-service-tier-default/tasks.md
@@ -1,0 +1,16 @@
+## 1. Outbound Mapping
+
+- [x] 1.1 Introduce `_UPSTREAM_OMIT_SERVICE_TIERS = frozenset({"auto", "default"})` in `app/modules/proxy/request_policy.py`.
+- [x] 1.2 In `apply_api_key_enforcement`, when `enforced_service_tier` is in `_UPSTREAM_OMIT_SERVICE_TIERS`, set `payload.service_tier = None` instead of the literal value.
+- [x] 1.3 Extend `api_key_service_tier_enforced` log line with `outbound_service_tier=` for operator visibility.
+
+## 2. Tests
+
+- [x] 2.1 Add `test_apply_api_key_enforcement_default_service_tier_omits_outbound_field` to `tests/unit/test_proxy_utils.py`.
+- [x] 2.2 Add `test_apply_api_key_enforcement_auto_service_tier_omits_outbound_field`.
+- [x] 2.3 Add `test_apply_api_key_enforcement_priority_service_tier_still_propagates` to lock the unchanged `flex`/`priority` path.
+
+## 3. Spec Delta
+
+- [x] 3.1 Add `openspec/changes/fix-enforced-service-tier-default/specs/api-keys/spec.md` describing the outbound omission contract.
+- [x] 3.2 `openspec validate --specs` (if available).

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -144,6 +144,80 @@ def test_apply_api_key_enforcement_overrides_service_tier_aliases_to_priority():
     assert payload.service_tier == "priority"
 
 
+def _service_tier_enforcement_key(enforced: str) -> proxy_service.ApiKeyData:
+    return proxy_service.ApiKeyData(
+        id="key_default",
+        name="service-tier-default-key",
+        key_prefix="sk-clb-test",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=enforced,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+
+def test_apply_api_key_enforcement_default_service_tier_omits_outbound_field():
+    # Regression for #546: enforcing ``default`` previously forwarded
+    # the literal string upstream, which the ChatGPT/Codex backend
+    # rejects with ``Unsupported service_tier: default``. The fix maps
+    # ``default``/``auto`` to wire-level absence so enforcement
+    # actually reaches upstream.
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hello",
+            "input": [],
+            "service_tier": "priority",
+        }
+    )
+
+    proxy_request_policy.apply_api_key_enforcement(
+        payload, _service_tier_enforcement_key("default")
+    )
+
+    assert payload.service_tier is None
+
+
+def test_apply_api_key_enforcement_auto_service_tier_omits_outbound_field():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hello",
+            "input": [],
+            "service_tier": "priority",
+        }
+    )
+
+    proxy_request_policy.apply_api_key_enforcement(
+        payload, _service_tier_enforcement_key("auto")
+    )
+
+    assert payload.service_tier is None
+
+
+def test_apply_api_key_enforcement_priority_service_tier_still_propagates():
+    # Sanity: omission only applies to ``auto``/``default``. Real
+    # service tiers (``priority``, ``flex``) MUST still be forwarded
+    # as the literal value the upstream backend recognises.
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+
+    proxy_request_policy.apply_api_key_enforcement(
+        payload, _service_tier_enforcement_key("flex")
+    )
+
+    assert payload.service_tier == "flex"
+
+
 def _build_registry_with_model(slug: str, efforts: list[str]):
     from app.core.openai.model_registry import (
         ModelRegistry,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -175,9 +175,7 @@ def test_apply_api_key_enforcement_default_service_tier_omits_outbound_field():
         }
     )
 
-    proxy_request_policy.apply_api_key_enforcement(
-        payload, _service_tier_enforcement_key("default")
-    )
+    proxy_request_policy.apply_api_key_enforcement(payload, _service_tier_enforcement_key("default"))
 
     assert payload.service_tier is None
 
@@ -192,9 +190,7 @@ def test_apply_api_key_enforcement_auto_service_tier_omits_outbound_field():
         }
     )
 
-    proxy_request_policy.apply_api_key_enforcement(
-        payload, _service_tier_enforcement_key("auto")
-    )
+    proxy_request_policy.apply_api_key_enforcement(payload, _service_tier_enforcement_key("auto"))
 
     assert payload.service_tier is None
 
@@ -211,9 +207,7 @@ def test_apply_api_key_enforcement_priority_service_tier_still_propagates():
         }
     )
 
-    proxy_request_policy.apply_api_key_enforcement(
-        payload, _service_tier_enforcement_key("flex")
-    )
+    proxy_request_policy.apply_api_key_enforcement(payload, _service_tier_enforcement_key("flex"))
 
     assert payload.service_tier == "flex"
 


### PR DESCRIPTION
## Summary

Resolves #546.

Setting an API key's `enforced_service_tier` to `default` or `auto` previously broke every request through that key: the request failed upstream with `invalid_request_error Unsupported service_tier: default` (or `... auto`). codex-lb accepts both values at the API-key surface as conventions for "let upstream pick", but the wire-level equivalent of "let upstream pick" is the **absence** of the `service_tier` field, not the literal string.

## What changes

- In `apply_api_key_enforcement` (`app/modules/proxy/request_policy.py`), when `enforced_service_tier` resolves to `auto` or `default`, set `payload.service_tier = None` instead of the literal value. Real upstream tiers (`priority`, `flex`) keep propagating as the literal value unchanged.
- Extend the existing `api_key_service_tier_enforced` log line with `outbound_service_tier=` so operators can confirm enforcement reached upstream as expected.
- OpenSpec change folder under `openspec/changes/fix-enforced-service-tier-default/` adds the contract under `api-keys`.

## Test plan

- [x] `pytest tests/unit/test_proxy_utils.py` (228 tests pass; 3 new assertions: `default`/`auto` omission paths, plus a `flex` propagation regression guard)
- [x] Existing `test_apply_api_key_enforcement_overrides_service_tier_aliases_to_priority` continues to pass — the alias-to-`priority` rewrite path is unchanged.
- [x] `ruff check`, `ty check` clean on the touched files.