### PR TITLE
perf(db-index): add index to db

### DIFF
--- a/app/db/alembic/versions/20260514_000000_add_request_logs_api_key_time_index.py
+++ b/app/db/alembic/versions/20260514_000000_add_request_logs_api_key_time_index.py
@@ -1,0 +1,43 @@
+"""add request_logs api_key time index
+
+Revision ID: 20260514_000000_add_request_logs_api_key_time_index
+Revises: 20260424_000000_merge_dashboard_session_ttl_and_request_log_heads
+Create Date: 2026-05-14
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260514_000000_add_request_logs_api_key_time_index"
+down_revision = "20260424_000000_merge_dashboard_session_ttl_and_request_log_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("request_logs"):
+        return
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes("request_logs")}
+    if "idx_logs_api_key_time" not in existing_indexes:
+        op.create_index(
+            "idx_logs_api_key_time",
+            "request_logs",
+            ["api_key_id", sa.text("requested_at DESC"), sa.text("id DESC")],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("request_logs"):
+        return
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes("request_logs")}
+    if "idx_logs_api_key_time" in existing_indexes:
+        op.drop_index("idx_logs_api_key_time", table_name="request_logs")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -616,6 +616,7 @@ Index(
 Index("idx_accounts_email", Account.email)
 Index("idx_api_keys_name", ApiKey.name)
 Index("idx_logs_account_time", RequestLog.account_id, RequestLog.requested_at)
+Index("idx_logs_api_key_time", RequestLog.api_key_id, RequestLog.requested_at.desc(), RequestLog.id.desc())
 Index("idx_logs_requested_at", RequestLog.requested_at)
 Index("idx_logs_requested_at_id", RequestLog.requested_at.desc(), RequestLog.id.desc())
 Index(

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -571,6 +571,7 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
             assert "idx_logs_requested_at_model_tier" in request_log_index_names
             assert "idx_logs_model_effort_time" in request_log_index_names
             assert "idx_logs_status_error_time" in request_log_index_names
+            assert "idx_logs_api_key_time" in request_log_index_names
             api_key_index_rows = (await session.execute(text("PRAGMA index_list(api_keys)"))).fetchall()
             api_key_index_names = {str(row[1]) for row in api_key_index_rows if len(row) > 1}
             assert "idx_api_keys_name" in api_key_index_names


### PR DESCRIPTION
Done a pass on the database index checking and found 1 index is missing for api query

  Recommended first index:
```
  Index(
      "idx_logs_api_key_time",
      RequestLog.api_key_id,
      RequestLog.requested_at.desc(),
      RequestLog.id.desc(),
  )
```
  Evidence:
  app/db/models.py:124 defines request_logs.api_key_id.
  app/db/models.py:618 has request-log indexes, but none with api_key_id first.
  app/modules/api_keys/repository.py:123 groups all request logs by api_key_id.
  app/modules/api_keys/repository.py:164 filters a single API key.
  app/modules/api_keys/repository.py:622 filters by api_key_id plus requested_at range.