### PR TITLE
spec(proxy): define images API fan-out behavior

### DIFF
--- a/openspec/changes/add-images-api-compat/specs/images-api-compat/spec.md
+++ b/openspec/changes/add-images-api-compat/specs/images-api-compat/spec.md
@@ -24,10 +24,29 @@ The system SHALL expose `POST /v1/images/generations` and accept the OpenAI Imag
 - **WHEN** a client sends `gpt-image-1.5`, `gpt-image-1`, or `gpt-image-1-mini` with `size` outside `{1024x1024, 1536x1024, 1024x1536, auto}`
 - **THEN** the service returns 400 with OpenAI `invalid_request_error` and `param: size`
 
-#### Scenario: Multi-image requests are rejected until upstream support arrives
+#### Scenario: Non-streaming multi-image generation fans out internally
 
-- **WHEN** a client sends `/v1/images/generations` or `/v1/images/edits` with `n > 1`
-- **THEN** the service returns 400 with OpenAI `invalid_request_error` and `param: n`, with a message that explains the upstream `image_generation` tool does not yet support multi-image responses. Operators may raise the cap by overriding `images_max_n`.
+- **WHEN** a client sends non-streaming `POST /v1/images/generations` with `n > 1` and `n <= images_max_n`
+- **THEN** the service performs `n` internal Responses requests using the `image_generation` tool
+- **AND** returns 200 with a JSON body of shape `{created, data: [{b64_json, revised_prompt}], usage}` containing exactly `n` entries
+- **AND** the `data` entries preserve the deterministic fan-out order
+
+#### Scenario: Non-streaming multi-image edits fan out internally
+
+- **WHEN** a client sends non-streaming `POST /v1/images/edits` with `n > 1` and `n <= images_max_n`
+- **THEN** the service performs `n` internal Responses requests using the same uploaded image and mask inputs for each fan-out attempt
+- **AND** returns 200 with a JSON body of shape `{created, data: [{b64_json, revised_prompt}], usage}` containing exactly `n` entries
+- **AND** the `data` entries preserve the deterministic fan-out order
+
+#### Scenario: Multi-image requests above the configured cap are rejected
+
+- **WHEN** a client sends `/v1/images/generations` or `/v1/images/edits` with `n > images_max_n`
+- **THEN** the service returns 400 with OpenAI `invalid_request_error` and `param: n`, with a message that references the configured cap
+
+#### Scenario: Streaming multi-image requests remain unsupported until streaming fan-out is specified
+
+- **WHEN** a client sends `/v1/images/generations` or `/v1/images/edits` with `stream=true` and `n > 1`
+- **THEN** the service returns 400 with OpenAI `invalid_request_error` and `param: n`, with a message that explains streaming multi-image fan-out is not yet supported
 
 #### Scenario: Missing model defaults to images_default_model
 
@@ -50,7 +69,7 @@ The system SHALL expose `POST /v1/images/edits` and accept the OpenAI Images Edi
 
 ### Requirement: Image generation is implemented as a Responses tool adapter
 
-The system SHALL implement `/v1/images/generations` and `/v1/images/edits` by issuing an internal `/v1/responses` request whose `tools` array includes `{"type": "image_generation", ...}` and whose `input` is constructed to deterministically force a single `image_generation` tool call. The system MUST route that internal request through the existing proxy account-selection, sticky session, retry, and authentication pipeline. The system MUST NOT introduce a new `chatgpt-token → openai-api-key` token-exchange path solely to support these endpoints.
+The system SHALL implement `/v1/images/generations` and `/v1/images/edits` by issuing internal `/v1/responses` request(s) whose `tools` array includes `{"type": "image_generation", ...}` and whose `input` is constructed to deterministically force a single `image_generation` tool call per internal request. For non-streaming requests with `n > 1`, the system MUST fan out into one internal Responses request per requested image because the upstream `image_generation` tool accepts only one image per call. The system MUST route every internal request through the existing proxy account-selection, sticky session, retry, and authentication pipeline. The system MUST NOT introduce a new `chatgpt-token → openai-api-key` token-exchange path solely to support these endpoints.
 
 #### Scenario: Internal Responses call uses existing routing
 
@@ -61,6 +80,12 @@ The system SHALL implement `/v1/images/generations` and `/v1/images/edits` by is
 
 - **WHEN** an edit request includes `image` and optional `mask` multipart parts
 - **THEN** each binary part is encoded as a `data:` URL and inserted as `input_image` content in the internal Responses input
+
+#### Scenario: Fan-out failure returns one public error envelope
+
+- **WHEN** any internal Responses request in a non-streaming multi-image fan-out fails before producing a valid image result
+- **THEN** the public `/v1/images/*` request fails as a single OpenAI error envelope
+- **AND** the service does not return a partial-success image list
 
 ### Requirement: Image generation streaming uses canonical OpenAI Images events
 
@@ -83,7 +108,7 @@ When a client requests `stream=true` on `/v1/images/generations` or `/v1/images/
 
 ### Requirement: Image routes participate in usage accounting and policy
 
-The system SHALL apply API-key allowed-model policy and model-scoped usage limits to `/v1/images/*` using the publicly-requested `gpt-image-*` value as the effective model. The system SHALL record the publicly-requested `gpt-image-*` value (not the internal host model) in the request log's `model` column once the upstream response id becomes known.
+The system SHALL apply API-key allowed-model policy and model-scoped usage limits to `/v1/images/*` using the publicly-requested `gpt-image-*` value as the effective model. The system SHALL record the publicly-requested `gpt-image-*` value (not the internal host model) in request-log rows once upstream response ids become known. For non-streaming multi-image fan-out, the system SHALL aggregate image usage from all successful internal Responses calls into the single public response's `usage` block and SHALL finalize API-key usage against the same public `gpt-image-*` model.
 
 #### Scenario: API key allowed-model policy blocks gpt-image-2
 
@@ -93,4 +118,9 @@ The system SHALL apply API-key allowed-model policy and model-scoped usage limit
 #### Scenario: Request log surfaces the publicly requested image model
 
 - **WHEN** an `/v1/images/*` request completes successfully against an internal host Responses model (for example `gpt-5.5`)
-- **THEN** the resulting `request_logs` row has `model` equal to the publicly requested value (for example `gpt-image-2`) so dashboards and usage views surface the user-visible model rather than the internal host model
+- **THEN** every resulting `request_logs` row has `model` equal to the publicly requested value (for example `gpt-image-2`) so dashboards and usage views surface the user-visible model rather than the internal host model
+
+#### Scenario: Fan-out usage is aggregated in the public response
+
+- **WHEN** a non-streaming `/v1/images/*` request fans out into multiple internal Responses calls
+- **THEN** the public response `usage` block sums `input_tokens`, `output_tokens`, `total_tokens`, and token-detail fields across all successful internal calls

--- a/openspec/changes/add-images-api-compat/tasks.md
+++ b/openspec/changes/add-images-api-compat/tasks.md
@@ -8,6 +8,7 @@
   - [x] 1.3.1 `gpt-image-2`: quality, size constraints, reject `input_fidelity`, reject `background=transparent`.
   - [x] 1.3.2 `gpt-image-1.5` / `gpt-image-1` / `gpt-image-1-mini`: fixed sizes; `input_fidelity` only on edits.
   - [x] 1.3.3 Non-`gpt-image-*` model rejected with `invalid_request_error` / `param: model`.
+  - [ ] 1.3.4 Relax non-streaming `n > 1` validation up to `images_max_n` while keeping `stream=true && n > 1` rejected until streaming fan-out is specified.
 
 ## 2. API Routes
 
@@ -24,6 +25,7 @@
 - [x] 3.4 Non-streaming responses: drain the upstream stream via `collect_responses_stream_for_images`, then `images_response_from_responses` extracts `image_generation_call` items and `tool_usage.image_gen`.
 - [x] 3.5 Streaming responses: `translate_responses_stream_to_images_stream` maps upstream events per §6.
 - [x] 3.6 Upstream errors / `image_generation_call.status == "failed"` map to OpenAI error envelopes (`content_policy_violation` / `image_generation_failed` / `rate_limit_exceeded` / `server_error`).
+- [ ] 3.7 Add non-streaming fan-out orchestration for `/v1/images/generations` and `/v1/images/edits`: one internal Responses request per requested image, deterministic output ordering, and single public error envelope on the first failed internal call.
 
 ## 4. Usage and Limits
 
@@ -31,6 +33,7 @@
 - [x] 4.2 `tool_usage.image_gen.input_tokens` and `output_tokens` are surfaced verbatim on the public `usage` block. No size×quality fallback estimate is implemented (and it isn't required: upstream consistently emits the block).
 - [x] 4.3 `validate_model_access` runs against the public `gpt-image-*` value before the host-model swap, so API-key allowed-models policy works correctly.
 - [ ] 4.4 Surface image usage in `/v1/usage` and the dashboard usage views — not required as a separate code path because usage already groups by `model`. Dashboard model breakdown will display `gpt-image-2` automatically.
+- [ ] 4.5 Aggregate `tool_usage.image_gen` token counts across non-streaming fan-out calls and finalize API-key usage once against the public `gpt-image-*` model.
 
 ## 5. Configuration and Observability
 
@@ -52,6 +55,8 @@
 - [x] 7.3 `tests/unit/test_images_translation.py::TestTranslateResponsesStreamToImagesStream` (success, multi-partial, failed, truncated, error event passthrough) plus integration streaming test.
 - [x] 7.4 `tests/unit/test_images_schemas.py` covers the validation matrix with rejection assertions.
 - [x] 7.5 `tests/integration/test_proxy_images.py` exercises the route end-to-end with a fake upstream Responses stream (mirrors the existing `core_stream_responses` monkeypatch pattern). Live-account marker not added — follow the same opt-in pattern as `tests/integration/test_proxy_responses.py` if/when the team wants a full live-call assertion.
+- [ ] 7.6 Add schema tests for `n > images_max_n`, non-streaming `n > 1`, and streaming `n > 1` rejection.
+- [ ] 7.7 Add unit/integration tests proving non-streaming generation/edit fan-out preserves order, aggregates usage, rewrites request-log models for all internal calls, and fails as one public error envelope on internal-call failure.
 
 ## 8. Verification
 
@@ -59,3 +64,4 @@
 - [x] 8.2 `ruff check app tests` — clean.
 - [ ] 8.3 `openspec validate --strict --specs` — CLI not available in the workspace; deferred.
 - [ ] 8.4 Empirical dev-container hit — pending (the dev container requires an API key the worker did not have access to). The mocked integration stream matches the empirical event sequence the parent agent verified.
+- [ ] 8.5 Fan-out verification: `uv run pytest tests/unit/test_images_schemas.py tests/unit/test_images_translation.py tests/integration/test_proxy_images.py -q`.


### PR DESCRIPTION
## Summary
- Define non-streaming `/v1/images/*` fan-out semantics for `n > 1` in the existing Images API OpenSpec change.
- Keep streaming `n > 1` explicitly rejected until streaming fan-out is specified separately.
- Add implementation tasks for validation, fan-out orchestration, usage aggregation, and tests.

## Stack
- Part 1 of 2 for #620.
- Follow-up implementation PR will branch from this PR after spec/design feedback.

## Verification
- `git diff --check`
- `uv run openspec validate --specs` could not run locally because the `openspec` executable is not available in this environment.

Closes no issue yet; this is the spec/design slice for #620.