### PR TITLE
fix(oauth): start device polling on oauth start

### DIFF
--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -165,22 +165,10 @@ class OauthService:
                 return OauthCompleteResponse(status="success")
             if state.method != "device":
                 return OauthCompleteResponse(status="pending")
-            if state.poll_task and not state.poll_task.done():
-                return OauthCompleteResponse(status="pending")
-            if not state.device_auth_id or not state.user_code or not state.expires_at:
+            if not self._ensure_device_poll_task_locked(state):
                 state.status = "error"
                 state.error_message = "Device code flow is not initialized."
                 return OauthCompleteResponse(status="error")
-
-            interval = state.interval_seconds if state.interval_seconds is not None else 0
-            interval = max(interval, 0)
-            poll_context = DevicePollContext(
-                device_auth_id=state.device_auth_id,
-                user_code=state.user_code,
-                interval_seconds=interval,
-                expires_at=state.expires_at,
-            )
-            state.poll_task = asyncio.create_task(self._poll_device_tokens(poll_context))
             return OauthCompleteResponse(status="pending")
 
     async def _start_browser_flow(self) -> OauthStartResponse:
@@ -290,6 +278,7 @@ class OauthService:
             state.interval_seconds = device.interval_seconds
             state.expires_at = time.time() + device.expires_in_seconds
             state.error_message = None
+            self._ensure_device_poll_task_locked(state)
 
         return OauthStartResponse(
             method="device",
@@ -355,6 +344,22 @@ class OauthService:
                 current = asyncio.current_task()
                 if self._store.state.poll_task is current:
                     self._store.state.poll_task = None
+
+    def _ensure_device_poll_task_locked(self, state: OAuthState) -> bool:
+        if state.poll_task and not state.poll_task.done():
+            return True
+        if not state.device_auth_id or not state.user_code or not state.expires_at:
+            return False
+
+        interval = state.interval_seconds if state.interval_seconds is not None else 0
+        poll_context = DevicePollContext(
+            device_auth_id=state.device_auth_id,
+            user_code=state.user_code,
+            interval_seconds=max(interval, 0),
+            expires_at=state.expires_at,
+        )
+        state.poll_task = asyncio.create_task(self._poll_device_tokens(poll_context))
+        return True
 
     async def _persist_tokens(self, tokens: OAuthTokens) -> None:
         claims = extract_id_token_claims(tokens.id_token)

--- a/openspec/changes/start-device-oauth-polling/proposal.md
+++ b/openspec/changes/start-device-oauth-polling/proposal.md
@@ -1,0 +1,12 @@
+## Why
+Device Code OAuth can stay pending forever when the client misses or fails the compatibility `/api/oauth/complete` request after `/api/oauth/start` returns a `deviceAuthId` and `userCode`. The backend has enough state to poll immediately, so requiring a second client request makes account setup fragile behind remote dashboards, proxies, or flaky browser sessions.
+
+## What Changes
+- Start the Device Code token polling task as soon as `/api/oauth/start` initializes a device flow.
+- Keep `/api/oauth/complete` as an idempotent compatibility endpoint that starts polling only if no active poll task exists.
+- Cover the robust start-only device flow with an integration regression test.
+
+## Impact
+- Affects backend OAuth device-flow state management.
+- No request or response schema changes are required.
+- Fixes https://github.com/Soju06/codex-lb/issues/110.

--- a/openspec/changes/start-device-oauth-polling/specs/frontend-architecture/spec.md
+++ b/openspec/changes/start-device-oauth-polling/specs/frontend-architecture/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Accounts page
+
+The Accounts page SHALL display a two-column layout: left panel with searchable account list, import button, and add account button; right panel with selected account details including usage, token info, and actions (pause/resume/delete/re-authenticate).
+
+#### Scenario: Account selection
+
+- **WHEN** a user clicks an account in the list
+- **THEN** the right panel shows the selected account's details
+
+#### Scenario: Account import
+
+- **WHEN** a user clicks the import button and uploads an auth.json file
+- **THEN** the app calls `POST /api/accounts/import` and refreshes the account list on success
+
+#### Scenario: OAuth add account
+
+- **WHEN** a user clicks the add account button
+- **THEN** an OAuth dialog opens with browser and device code flow options
+
+#### Scenario: Device OAuth start begins polling
+
+- **WHEN** the app starts Device Code OAuth with `POST /api/oauth/start`
+- **AND** the response includes a `deviceAuthId` and `userCode`
+- **THEN** the backend starts polling for the device token without requiring a separate `/api/oauth/complete` call
+- **AND** a later `/api/oauth/complete` call remains safe and does not start a duplicate polling task
+
+#### Scenario: Account actions
+
+- **WHEN** a user clicks pause/resume/delete on an account
+- **THEN** the corresponding API is called and the account list is refreshed

--- a/openspec/changes/start-device-oauth-polling/tasks.md
+++ b/openspec/changes/start-device-oauth-polling/tasks.md
@@ -1,0 +1,12 @@
+## 1. Spec
+- [x] 1.1 Add a frontend-architecture delta for robust Device Code OAuth polling.
+
+## 2. Implementation
+- [x] 2.1 Start device token polling from `_start_device_flow()` after state is saved.
+- [x] 2.2 Keep `/api/oauth/complete` idempotent and duplicate-safe.
+
+## 3. Validation
+- [x] 3.1 Update the device OAuth integration test so it succeeds without calling `/api/oauth/complete`.
+- [x] 3.2 Run the targeted OAuth integration tests.
+- [x] 3.3 Run targeted lint and type checks for the changed files.
+- [x] 3.4 Validate OpenSpec specs locally.

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -63,10 +63,6 @@ async def test_device_oauth_flow_creates_account(async_client, monkeypatch):
     assert start.status_code == 200
     assert start.json()["method"] == "device"
 
-    complete = await async_client.post("/api/oauth/complete", json={})
-    assert complete.status_code == 200
-    assert complete.json()["status"] == "pending"
-
     await asyncio.sleep(0)
 
     payload = None


### PR DESCRIPTION
## Summary
- start Device Code OAuth token polling as soon as `/api/oauth/start` initializes the device flow
- keep `/api/oauth/complete` as a duplicate-safe compatibility endpoint
- add an OpenSpec delta and regression coverage for start-only device OAuth

Fixes https://github.com/Soju06/codex-lb/issues/110

## Validation
- `uv run python -m pytest -q -ra tests/integration/test_oauth_flow.py -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread`
- `uv run python -m ruff check app/modules/oauth/service.py tests/integration/test_oauth_flow.py`
- `uv run python -m ty check app/modules/oauth/service.py tests/integration/test_oauth_flow.py`
- `uv run openspec validate --specs`
- `git diff --check`