### PR TITLE
fix(chat-completions): drop unknown message-object keys during coercion

### DIFF
--- a/app/core/openai/message_coercion.py
+++ b/app/core/openai/message_coercion.py
@@ -223,8 +223,18 @@ def _normalize_message_content(message: OpenAIMessage) -> OpenAIMessage:
     role = message.get("role")
     role_str = role if isinstance(role, str) else "user"
     refusal = _get_assistant_refusal(message) if role_str == "assistant" else None
+
+    # The Responses API input message item only carries `role` + `content`.
+    # Build a fresh dict with exactly those keys so unknown message-object
+    # fields (the standard chat `name` field, client-internal bookkeeping
+    # keys, etc.) are never forwarded upstream — OpenAI's own
+    # `/v1/chat/completions` ignores them rather than relaying them, and
+    # the upstream Responses API rejects the whole request if it sees them.
     if content is None and refusal is None:
-        return message
+        if "content" in message:
+            return cast(OpenAIMessage, {"role": role, "content": content})
+        return cast(OpenAIMessage, {"role": role})
+
     if content is not None:
         normalized = _normalize_content_parts(content, role_str)
     else:
@@ -233,13 +243,7 @@ def _normalize_message_content(message: OpenAIMessage) -> OpenAIMessage:
         parts = _to_content_list(normalized)
         parts.append({"type": "refusal", "refusal": refusal})
         normalized = parts
-    if normalized is content and refusal is None:
-        return message
-    updated = dict(message)
-    updated["content"] = normalized
-    if refusal is not None:
-        updated.pop("refusal", None)
-    return cast(OpenAIMessage, updated)
+    return cast(OpenAIMessage, {"role": role, "content": normalized})
 
 
 def _get_assistant_refusal(message: OpenAIMessage) -> str | None:

--- a/openspec/changes/drop-unknown-message-fields/proposal.md
+++ b/openspec/changes/drop-unknown-message-fields/proposal.md
@@ -1,0 +1,55 @@
+# Drop Unknown Message Fields in Chat → Responses Coercion
+
+## Problem
+
+codex-lb's `/v1/chat/completions` accepts unknown message-object fields (the standard chat `name` field, arbitrary client-internal bookkeeping keys, etc.) and forwards them verbatim into the upstream Responses API `input` items. The upstream Responses API rejects those keys with a hard error:
+
+```
+502 invalid_request_error:
+  [ObjectParam] [input[N]._<key>] [unknown_parameter]
+  Unknown parameter: 'input[N]._<key>'
+```
+
+OpenAI's own `/v1/chat/completions` does not behave this way — it parses the documented chat-message fields and silently drops everything else. codex-lb advertises chat-completions compatibility, so client code written against the OpenAI contract (which often attaches its own message-object bookkeeping keys, or sets the documented standard `name` field) breaks against codex-lb but works against OpenAI.
+
+Concrete failure observed against `https://codex.nekos.me/v1/chat/completions` (Hermes Agent, 2026-05-15):
+
+1. Client appends two synthetic recovery messages carrying an internal marker key `_empty_recovery_synthetic` (a normal pattern: bookkeeping flags on the local message buffer that the client never expected to wire).
+2. codex-lb forwards the marker into the Responses `input` items.
+3. Upstream returns `502 unknown_parameter`.
+4. Because the marker persists in the client's session buffer, every subsequent request in that session replays the poisoned input → identical 502 → retry storm.
+
+The standard chat `name` field has the same problem: every message that carries `name` produces a 502.
+
+## Solution
+
+Treat message-object coercion as a strict translation: a Responses API input message item carries only `role` + `content`, and that's all we should emit. Everything else on the inbound chat message — known fields used elsewhere (`tool_calls`, `tool_call_id`, `refusal`), unsupported standard fields (`name`), and arbitrary client-supplied keys — is consumed during coercion or dropped.
+
+The fix is narrowly scoped to `app/core/openai/message_coercion.py::_normalize_message_content`: replace the previous "copy the message dict and overwrite `content`" pattern with explicit field selection. The function now emits `{"role": role, "content": normalized_content}` and nothing else. Refusal is folded into content as a `refusal` part (existing behavior); tool_calls flow through their existing decomposition path (existing behavior); `name` / `_*` / any other key is dropped.
+
+This matches OpenAI's chat-completions semantics: known fields are parsed, unknown fields are silently ignored.
+
+## Why this is correct as a behavior change
+
+- The chat-completions compatibility capability already promises "OpenAI Chat Completions expectations" as the contract. OpenAI ignores unknown message-object keys; codex-lb should too.
+- The Responses API input message item schema does not include `name` or arbitrary keys — forwarding them was always a violation of the upstream contract, just one that happened to work for clients that never set those fields.
+- No client could have been relying on the previous behavior in any useful way: any request that exercised it returned `502 unknown_parameter` and failed.
+
+## Changes
+
+### Spec deltas
+- `chat-completions-compat`: add one Requirement covering the silent-drop semantics for unknown message-object fields, with scenarios for `name`, client-internal bookkeeping keys, and the assistant + tool_calls case.
+
+### Code
+- `app/core/openai/message_coercion.py::_normalize_message_content` — emit `{role, content}` explicitly.
+
+### Tests
+- `tests/unit/test_chat_request_mapping.py` — three new tests:
+  - `test_chat_unknown_message_keys_are_dropped` (general unknown-key case + reproducer for the `_empty_recovery_synthetic` field that triggered the original report)
+  - `test_chat_message_name_field_is_dropped` (standard `name` field)
+  - `test_chat_assistant_tool_call_message_drops_unknown_keys` (assistant + tool_calls path)
+
+## Out of scope
+
+- Changing the OpenAI-compat status code for `unknown_parameter` errors that escape via other paths (the proxy already converts upstream `invalid_request_error` to 400 in the chat-completions adapter).
+- The proxy's tool-call message + tool message paths already select fields explicitly (`call_id` / `name` / `arguments` / `output`), so they don't carry unknown keys today.

--- a/openspec/changes/drop-unknown-message-fields/specs/chat-completions-compat/spec.md
+++ b/openspec/changes/drop-unknown-message-fields/specs/chat-completions-compat/spec.md
@@ -1,0 +1,31 @@
+# Drop Unknown Message Fields in Chat → Responses Coercion
+
+## ADDED Requirements
+
+### Requirement: Drop unknown message-object fields during coercion
+
+The service MUST drop unknown keys on a chat message object when coercing the message into a Responses API input message item. Specifically, when a chat message is converted into an `input` message item (role `user` / `assistant` without tool_calls, or the message-content half of an assistant message that also has tool_calls), the emitted item MUST contain exactly the keys `role` and `content`. Other fields on the inbound chat message — the documented but unsupported `name` field, any other standard chat-message field that has no Responses input-item equivalent, and any arbitrary client-supplied key (including keys starting with `_`) — MUST NOT appear on the emitted item.
+
+This matches OpenAI's own `/v1/chat/completions`, which parses the known chat-message fields and silently ignores everything else rather than forwarding it. The Responses API input message item only accepts `role` + `content`; forwarding any other key triggers an upstream `unknown_parameter` rejection.
+
+The Requirement applies only to message-item shapes. The existing tool-call decomposition (`FunctionCallInputItem`) and tool-message conversion (`FunctionCallOutputInputItem`) paths already select fields explicitly and are unaffected.
+
+#### Scenario: Standard `name` field is dropped
+
+- **WHEN** a client sends `{ "model": "...", "messages": [{ "role": "user", "content": "hi", "name": "alice" }] }`
+- **THEN** the mapped Responses payload's `input` contains exactly `[{ "role": "user", "content": [{"type": "input_text", "text": "hi"}] }]` with no `name` key on the input item
+
+#### Scenario: Arbitrary client-internal keys are dropped
+
+- **WHEN** a client sends a message carrying client-internal bookkeeping keys, e.g. `{ "role": "user", "content": "hi", "_client_marker": true, "extra": 1 }`
+- **THEN** the mapped Responses payload's `input` item for that message contains exactly `role` + `content` and no other keys
+
+#### Scenario: Assistant message with tool_calls drops unknown keys on the message half
+
+- **WHEN** a client sends an assistant message that has both `content` and `tool_calls`, with extra keys on the message object (`name`, `_client_marker`, etc.)
+- **THEN** the message-content half of the decomposed input items is `{ "role": "assistant", "content": [...] }` with no `name` / `_client_marker` keys, and the tool-call half remains a well-formed `function_call` input item
+
+#### Scenario: No regression for clean messages
+
+- **WHEN** a client sends a message that already carries only `role` and `content` (the most common case)
+- **THEN** the mapped Responses payload's `input` item for that message is byte-equivalent to the previous behavior

--- a/openspec/changes/drop-unknown-message-fields/tasks.md
+++ b/openspec/changes/drop-unknown-message-fields/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+## Implementation
+
+- [x] T1: Rewrite `_normalize_message_content` in `app/core/openai/message_coercion.py` to emit `{role, content}` explicitly instead of copying the inbound message dict.
+- [x] T2: Add unit test `test_chat_unknown_message_keys_are_dropped` covering the original `_empty_recovery_synthetic` reproducer.
+- [x] T3: Add unit test `test_chat_message_name_field_is_dropped` covering the standard `name` field.
+- [x] T4: Add unit test `test_chat_assistant_tool_call_message_drops_unknown_keys` covering the assistant + tool_calls path.
+
+## Spec
+
+- [x] T5: Update `openspec/specs/chat-completions-compat/spec.md` with the new "Drop unknown message-object fields" Requirement and scenarios (applied via the delta in `openspec/changes/drop-unknown-message-fields/specs/chat-completions-compat/spec.md`).
+
+## Validation
+
+- [x] T6: Run targeted suites — `tests/unit/test_chat_request_mapping.py`, `tests/unit/test_openai_requests.py`, `tests/integration/test_proxy_chat_completions.py`, `tests/integration/test_openai_client_compat.py`, `tests/integration/test_openai_compat_features.py` — all green (187 passed).
+- [x] T7: Run broader related sweep — `tests/unit/`, `tests/integration/test_proxy_responses.py`, `tests/e2e/test_proxy_flow.py` filtered to coercion/chat/responses/proxy — 633 passed, 0 failures introduced.
+- [x] T8: Re-run the original reproducer (the exact payload that produced `502 unknown_parameter 'input[N]._empty_recovery_synthetic'`) and confirm coerced `input` items now carry only `role` + `content`.

--- a/tests/unit/test_chat_request_mapping.py
+++ b/tests/unit/test_chat_request_mapping.py
@@ -30,6 +30,104 @@ def test_chat_messages_require_objects():
         ChatCompletionsRequest.model_validate(payload)
 
 
+def test_chat_unknown_message_keys_are_dropped():
+    """Unknown keys on a message object must not reach the Responses input.
+
+    OpenAI's own /v1/chat/completions parses the known chat-message fields
+    and ignores everything else on the message object — it never forwards
+    arbitrary client-supplied keys. codex-lb must match that: a Responses
+    API input message item only has `role` + `content`, and forwarding any
+    other key makes the upstream Responses API reject the whole request
+    with an `unknown_parameter` error (which then poisons every later
+    request that replays the same message history).
+    """
+    payload = {
+        "model": "gpt-5.2",
+        "messages": [
+            {"role": "user", "content": "hi", "_client_marker": True, "extra": 1},
+            {"role": "assistant", "content": "(empty)", "_client_marker": True},
+            {"role": "user", "content": "continue", "_client_marker": True},
+        ],
+    }
+    req = ChatCompletionsRequest.model_validate(payload)
+    responses = req.to_responses_request()
+    assert responses.input == [
+        {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "(empty)"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+    items = responses.input
+    assert isinstance(items, list)
+    for item in items:
+        assert isinstance(item, dict)
+        assert set(item.keys()) == {"role", "content"}
+
+
+def test_chat_message_name_field_is_dropped():
+    """The standard chat `name` field has no Responses input-item equivalent.
+
+    `name` is a documented optional field on OpenAI chat messages, but the
+    Responses API input message item does not accept it. It must be dropped
+    during coercion rather than forwarded (forwarding it triggers an
+    upstream `unknown_parameter` rejection).
+    """
+    payload = {
+        "model": "gpt-5.2",
+        "messages": [
+            {"role": "user", "content": "hi", "name": "alice"},
+            {"role": "assistant", "content": "hello", "name": "bot"},
+        ],
+    }
+    req = ChatCompletionsRequest.model_validate(payload)
+    responses = req.to_responses_request()
+    assert responses.input == [
+        {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "hello"}]},
+    ]
+
+
+def test_chat_assistant_tool_call_message_drops_unknown_keys():
+    """The message item emitted alongside decomposed tool calls is also clean.
+
+    When an assistant message carries both content and tool_calls, the
+    content half is emitted as a separate input message item. That item
+    must carry only `role` + `content`, same as any other message item.
+    """
+    payload = {
+        "model": "gpt-5.2",
+        "messages": [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": "Let me check",
+                "name": "bot",
+                "_client_marker": True,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+        ],
+    }
+    req = ChatCompletionsRequest.model_validate(payload)
+    responses = req.to_responses_request()
+    items = responses.input
+    assert isinstance(items, list)
+    assert items[1] == {
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "Let me check"}],
+    }
+    assert items[2] == {
+        "type": "function_call",
+        "call_id": "call_1",
+        "name": "get_weather",
+        "arguments": "{}",
+    }
+
+
 def test_chat_system_message_rejects_non_text_content():
     payload = {
         "model": "gpt-5.2",


### PR DESCRIPTION
## Summary

Match OpenAI's `/v1/chat/completions` behavior on unknown message-object fields. OpenAI parses the documented chat-message fields and silently ignores everything else on the message object. codex-lb's chat→Responses coercion was instead copying the inbound message dict wholesale, so any extra key (the standard `name` field, client-internal bookkeeping keys, etc.) leaked into the Responses `input` items and was forwarded upstream verbatim. The upstream Responses API only accepts `role` + `content` on an input message item — any other key trips an `unknown_parameter` hard error, which surfaces as a deterministic 502 and poisons every subsequent request that replays the same message buffer.

OpenSpec change: [`drop-unknown-message-fields`](https://github.com/Soju06/codex-lb/tree/fix/chat-completions-drop-unknown-message-fields/openspec/changes/drop-unknown-message-fields).

## Reproducer

Verified against `https://codex.nekos.me/v1/chat/completions` on 2026-05-15, captured from a real Hermes Agent session:

```
502 invalid_request_error:
[ObjectParam] [input[617]._empty_recovery_synthetic]
[unknown_parameter] Unknown parameter: 'input[617]._empty_recovery_synthetic'
```

The client's empty-response recovery path had appended synthetic messages tagged with `_empty_recovery_synthetic` — a normal client pattern (bookkeeping flags on the local message buffer). codex-lb relayed the flag into `input[N]`, upstream returned 502, and the client's session buffer replayed the poisoned input on every subsequent turn. The standard chat `name` field reproduces the same 502 the same way.

Direct probe before the fix:

```bash
curl -s -X POST https://codex.nekos.me/v1/chat/completions -H 'Authorization: Bearer …' \
  -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"hi","name":"alice"}],"max_tokens":5}'
# → 502 {"error":{"message":"[ObjectParam] [input[0].name] [unknown_parameter] Unknown parameter: 'input[0].name'."}}
```

Same with any other extra key on a message object.

## Root cause

`app/core/openai/message_coercion.py::_normalize_message_content` was building the output message via `updated = dict(message); updated["content"] = normalized`, which copies every key. Result:

```python
# Before the fix
input items:
  [0] {"role":"user","content":[…],"name":"alice","_empty_recovery_synthetic":true}
  [1] {"role":"assistant","content":[…],"_empty_recovery_synthetic":true}
  [2] {"role":"user","content":[…],"_empty_recovery_synthetic":true}
```

## Fix

Replace the copy-and-overwrite pattern with explicit field selection — emit `{"role": role, "content": normalized_content}` and nothing else. Refusal still folds into content as a `refusal` part (unchanged); tool_calls still flow through `_decompose_assistant_tool_calls` (unchanged); the message-item path now matches OpenAI's lenient-input, strict-output contract.

```python
# After the fix
input items:
  [0] {"role":"user","content":[{"type":"input_text","text":"hi"}]}
  [1] {"role":"assistant","content":[{"type":"output_text","text":"(empty)"}]}
  [2] {"role":"user","content":[{"type":"input_text","text":"continue"}]}
```

## Tests

`tests/unit/test_chat_request_mapping.py` gains three tests:

- `test_chat_unknown_message_keys_are_dropped` — general unknown-key case and the `_empty_recovery_synthetic` reproducer
- `test_chat_message_name_field_is_dropped` — standard `name` field
- `test_chat_assistant_tool_call_message_drops_unknown_keys` — assistant + tool_calls path (the message half emitted alongside the decomposed tool call must also be clean)

Results:

- Targeted: `tests/unit/test_chat_request_mapping.py` + `tests/unit/test_openai_requests.py` + `tests/integration/test_proxy_chat_completions.py` + `tests/integration/test_openai_client_compat.py` + `tests/integration/test_openai_compat_features.py` — **187 passed**.
- Broader sweep: unit + integration + e2e proxy filtered to coercion/chat/responses/proxy — **633 passed, 0 new failures**.
- `openspec validate drop-unknown-message-fields` → valid.

## Out of scope

- Status-code mapping for upstream `unknown_parameter` errors that escape via other paths. The chat-completions adapter already converts upstream `invalid_request_error` to 400 for non-streaming responses; this PR keeps that behavior unchanged.
- Other compatibility gaps (e.g. logprobs handling). Tracked separately if needed.
