### PR TITLE
fix: remove unsupported `type` field from issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/account_quota.yml
+++ b/.github/ISSUE_TEMPLATE/account_quota.yml
@@ -4,7 +4,6 @@ description: |
   recovery, or the dashboard view of accounts. Use the Bug Report form instead
   if the issue is about proxy/request behavior.
 title: "bug(accounts): <one-line summary>"
-type: Bug
 labels: ["bug", "triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: 🐛 Bug Report
 description: Report a reproducible bug, crash, or unexpected behavior in codex-lb.
 title: "bug: <one-line summary of what's broken>"
-type: Bug
 labels: ["bug", "triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: ✨ Feature Request
 description: Propose a new feature, enhancement, or behavior change.
 title: "feat: <one-line summary of the proposed feature>"
-type: Feature
 labels: ["enhancement", "triage"]
 body:
   - type: markdown


### PR DESCRIPTION
## Symptom

Issue chooser at <https://github.com/Soju06/codex-lb/issues/new/choose> shows only **"Blank issue (Maintainers only)"** plus the four `contact_links`. None of the three YAML issue forms appear.

## Suspected cause (not yet confirmed)

PR #614 added a `type:` top-level key to three forms:

- `bug_report.yml` → `type: Bug`
- `feature_request.yml` → `type: Feature`
- `account_quota.yml` → `type: Bug`

`type` is GitHub's [Issue Types](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization) feature, which references a type catalog. For `codex-lb` no catalog is defined, so it's plausible the validator silently rejects the form.

**Counter-evidence**: `Soju06/python-kis` (also a user-owned repo) ships Issue Forms successfully — but it doesn't use `type:` at all. So this fix isolates the *only* difference between the working python-kis forms and the broken codex-lb forms.

I can't prove `type:` is the cause without an experiment. This PR is that experiment: if dropping the three `type:` lines restores the chooser, the diagnosis is right; if it doesn't, the cause is elsewhere and we'll dig further.

## Fix

Remove the `type:` line from the three affected forms. Existing `labels: ["bug", "triage"]` / `labels: ["enhancement", "triage"]` keep triage routing, so no observable behavior changes beyond making the forms load.

## Type of change

- [x] `fix:` — restores broken issue chooser

## OpenSpec

- [x] Not applicable — config-only fix

## Test plan

YAML still parses, `type` removed:

```
$ python3 -c "
import yaml
from pathlib import Path
for p in sorted(Path('.github/ISSUE_TEMPLATE').glob('*.yml')):
    if p.name == 'config.yml': continue
    d = yaml.safe_load(p.read_text())
    assert 'type' not in d, f'{p}: still has type key'
    print(f'OK {p}: name={d[\"name\"]!r} labels={d.get(\"labels\")}')
"
OK .github/ISSUE_TEMPLATE/account_quota.yml: name='📊 Account / Quota / Dashboard Issue' labels=['bug', 'triage']
OK .github/ISSUE_TEMPLATE/bug_report.yml: name='🐛 Bug Report' labels=['bug', 'triage']
OK .github/ISSUE_TEMPLATE/feature_request.yml: name='✨ Feature Request' labels=['enhancement', 'triage']
```

**The real test is post-merge**: open <https://github.com/Soju06/codex-lb/issues/new/choose> and confirm:

- 🐛 Bug Report
- ✨ Feature Request
- 📊 Account / Quota / Dashboard Issue

all appear, with no "Blank issue (Maintainers only)" fallback.

If they still don't appear after this merge, the diagnosis is wrong and we need to look at other diffs (e.g. whether one of the `dropdown` / `checkboxes` blocks has a subtler schema problem).

## Checklist

- [x] Title is in Conventional Commits format (`fix: ...`).
- [x] Verified YAML files parse cleanly and no longer carry the `type` key.
- [x] CHANGELOG is **not** edited by hand (release-please).
