### PR TITLE
fix(proxy): make /v1/responses streams parseable by the OpenAI SDK

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -340,6 +340,17 @@ async def internal_bridge_responses(
         forwarded_downstream_turn_state=forwarded_request_context.context.downstream_turn_state,
         forwarded_affinity_kind=forwarded_request_context.context.original_affinity_kind,
         forwarded_affinity_key=forwarded_request_context.context.original_affinity_key,
+        # The OpenAI-SDK contract rewrites (drop ``codex.*``, backfill terminal
+        # output, synthesize ``response.created``) MUST be applied by the
+        # origin instance — the one that actually responds to the client — so
+        # they can honour the original route's ``enforce_openai_sdk_contract``
+        # decision. This handler runs on the owner instance after the origin
+        # forwarded the request via the internal bridge; if we re-applied them
+        # here, a forwarded ``/backend-api/codex/responses`` request would
+        # lose ``codex.*`` events (and gain a synthetic ``response.created``)
+        # before the origin ever sees the stream. Forward verbatim and let
+        # the origin run its own normalization.
+        enforce_openai_sdk_contract=False,
     )
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -214,6 +214,11 @@ async def responses(
         codex_session_affinity=True,
         openai_cache_affinity=True,
         prefer_http_bridge=True,
+        # The Codex CLI consumes codex.* vendor events and the upstream's
+        # native event ordering (it does not use the OpenAI Python SDK parser);
+        # forward the stream verbatim instead of enforcing the OpenAI SDK
+        # contract that /v1/responses applies.
+        enforce_openai_sdk_contract=False,
     )
 
 
@@ -1558,6 +1563,7 @@ async def _stream_responses(
     forwarded_downstream_turn_state: str | None = None,
     forwarded_affinity_kind: str | None = None,
     forwarded_affinity_key: str | None = None,
+    enforce_openai_sdk_contract: bool = True,
 ) -> Response:
     apply_api_key_enforcement(payload, api_key)
     validate_model_access(api_key, payload.model)
@@ -1625,7 +1631,7 @@ async def _stream_responses(
         if reservation is not None and owns_reservation:
             await _release_reservation(reservation)
         return _stream_startup_error_response(request, startup_error, headers=rate_limit_headers)
-    stream = _normalize_public_responses_stream(_stream_proxy_errors_as_response_failed(stream))
+    stream = _normalize_public_responses_stream(_stream_proxy_errors_as_response_failed(stream), enforce_openai_sdk_contract=enforce_openai_sdk_contract)
     return StreamingResponse(
         inject_sse_keepalives(
             stream,
@@ -2278,10 +2284,47 @@ def _merge_collected_output_items(
     return merged
 
 
-async def _normalize_public_responses_stream(stream: AsyncIterator[str]) -> AsyncIterator[str]:
+async def _normalize_public_responses_stream(
+    stream: AsyncIterator[str],
+    *,
+    enforce_openai_sdk_contract: bool = True,
+) -> AsyncIterator[str]:
+    """Normalize the upstream SSE event stream for the public /v1 surface.
+
+    Args:
+        stream: the upstream SSE event blocks (post-error-conversion).
+        enforce_openai_sdk_contract: when True (the default, used for /v1),
+            apply OpenAI Responses SSE contract enforcement: drop Codex
+            vendor events (codex.*), backfill terminal output from streamed
+            item events, and synthesize a leading response.created event
+            when the upstream stream's first standard event is not
+            response.created. When False (used for /backend-api/codex/*,
+            which feeds the Codex CLI), all events including codex.* are
+            forwarded verbatim and no synthesis happens — the Codex CLI
+            relies on the upstream's native event shape.
+    """
     terminal_seen = False
     contract_violation_kind: str | None = None
     seen_text_delta_keys: set[tuple[str | None, int | None]] = set()
+    # Collect output items from streamed ``response.output_item.added`` /
+    # ``response.output_item.done`` events so the terminal
+    # ``response.completed`` / ``response.incomplete`` payload can be
+    # backfilled when the upstream Codex backend leaves ``response.output``
+    # empty. This mirrors the existing non-streaming behavior in
+    # ``_collect_responses_payload`` so OpenAI SDK consumers calling
+    # ``stream.get_final_response().output`` see the same items the
+    # non-streaming endpoint returns.
+    output_items: dict[int, dict[str, JsonValue]] = {}
+    # Track whether the first standard ``response.*`` event the public stream
+    # emits is ``response.created``. The OpenAI Responses SSE contract requires
+    # ``response.created`` to be the first event. The upstream Codex backend
+    # sometimes drops straight to a terminal event (e.g. ``response.failed``
+    # when upstream rejects the request mid-stream) without emitting
+    # ``response.created`` first, which makes the OpenAI SDK's
+    # ``_create_initial_response`` raise ``RuntimeError``. When that happens
+    # we synthesize a ``response.created`` snapshot from the terminal event's
+    # ``response`` envelope so the SDK parser can complete the stream.
+    created_emitted = False
     async for event_block in stream:
         if event_block.strip() == "data: [DONE]":
             if terminal_seen:
@@ -2292,7 +2335,28 @@ async def _normalize_public_responses_stream(stream: AsyncIterator[str]) -> Asyn
             if _looks_like_sse_data_block(event_block):
                 contract_violation_kind = contract_violation_kind or "invalid_json"
             continue
-        normalized_payload, violation_kind = _normalize_public_stream_payload(payload)
+        _collect_output_item_event(payload, output_items)
+        raw_event_type = payload.get("type")
+        if (
+            enforce_openai_sdk_contract
+            and isinstance(raw_event_type, str)
+            and raw_event_type in (
+                "response.completed",
+                "response.incomplete",
+            )
+        ):
+            response_obj = payload.get("response")
+            if is_json_mapping(response_obj):
+                existing_output = response_obj.get("output")
+                needs_backfill = not (isinstance(existing_output, list) and existing_output)
+                if needs_backfill and output_items:
+                    merged_response = _merge_collected_output_items(response_obj, output_items)
+                    payload = dict(payload)
+                    payload["response"] = merged_response
+        normalized_payload, violation_kind = _normalize_public_stream_payload(
+            payload,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+        )
         if violation_kind is not None:
             contract_violation_kind = contract_violation_kind or violation_kind
         if normalized_payload is None:
@@ -2300,6 +2364,25 @@ async def _normalize_public_responses_stream(stream: AsyncIterator[str]) -> Asyn
         event_type = normalized_payload.get("type")
         if event_type == "response.output_text.delta":
             seen_text_delta_keys.add(_text_delta_stream_key(normalized_payload))
+        # Ensure the public stream always starts with ``response.created``.
+        # When the upstream stream jumps straight to a non-created event
+        # (terminal failure, or any other ordering quirk), synthesize a
+        # ``response.created`` envelope from whatever ``response`` envelope is
+        # available on the current event so the OpenAI SDK parser can begin.
+        # Only enforced on the OpenAI SDK contract path; the Codex CLI route
+        # forwards the upstream sequence verbatim.
+        if (
+            enforce_openai_sdk_contract
+            and not created_emitted
+            and isinstance(event_type, str)
+            and event_type != "response.created"
+        ):
+            synthetic_created = _synthetic_response_created_envelope(normalized_payload)
+            if synthetic_created is not None:
+                yield format_sse_event(synthetic_created)
+                created_emitted = True
+        if event_type == "response.created":
+            created_emitted = True
         for synthetic_payload in _synthetic_text_delta_events(normalized_payload, seen_text_delta_keys):
             yield format_sse_event(synthetic_payload)
         if isinstance(event_type, str) and event_type in {
@@ -2323,8 +2406,25 @@ async def _normalize_public_responses_stream(stream: AsyncIterator[str]) -> Asyn
 
 def _normalize_public_stream_payload(
     payload: dict[str, JsonValue],
+    *,
+    enforce_openai_sdk_contract: bool = True,
 ) -> tuple[dict[str, JsonValue] | None, str | None]:
     event_type = payload.get("type")
+    # Drop Codex-internal vendor events on the public /v1 surface only. The
+    # upstream Codex backend emits non-standard events (notably
+    # ``codex.rate_limits``, which is throttled per rate-limit window and so
+    # leaks intermittently before ``response.created``). The OpenAI Responses
+    # SSE contract does not define any ``codex.*`` event type, and the OpenAI
+    # SDK's stream parser raises ``RuntimeError`` if any other event arrives
+    # first. The Codex CLI routes under ``/backend-api/codex/*`` legitimately
+    # consume these events and pass ``enforce_openai_sdk_contract=False`` so
+    # they continue to forward unchanged.
+    if (
+        enforce_openai_sdk_contract
+        and isinstance(event_type, str)
+        and event_type.startswith("codex.")
+    ):
+        return None, None
     if event_type == "error":
         parsed_error = _parse_event_error_envelope(payload)
         if _is_previous_response_not_found_public_error(parsed_error.error):
@@ -2383,6 +2483,40 @@ def _normalize_public_stream_payload(
             violation_kind = "invalid_output_item"
         return normalized_payload, violation_kind
     return payload, None
+
+
+def _synthetic_response_created_envelope(
+    payload: Mapping[str, JsonValue],
+) -> dict[str, JsonValue] | None:
+    """Synthesize a ``response.created`` SSE payload from a non-created event.
+
+    Used by ``_normalize_public_responses_stream`` when the upstream's first
+    standard event is not ``response.created`` (for example, the Codex backend
+    sometimes jumps straight to ``response.failed`` when upstream rejects the
+    request mid-stream). The OpenAI Responses SSE contract requires
+    ``response.created`` to be the first event the stream emits — the OpenAI
+    Python SDK's ``ResponseStreamState._create_initial_response`` raises
+    ``RuntimeError`` otherwise.
+
+    Returns ``None`` when no ``response`` envelope is available on the source
+    event (in that case the caller forwards the event verbatim; the SDK
+    consumer will still see a parser error, but the stream contract is at
+    least not silently violated by our synthesis logic).
+    """
+    response = payload.get("response")
+    if not is_json_mapping(response):
+        return None
+    created_envelope: dict[str, JsonValue] = dict(response)
+    created_envelope["status"] = "in_progress"
+    created_envelope["output"] = []
+    synthetic: dict[str, JsonValue] = {
+        "type": "response.created",
+        "response": created_envelope,
+    }
+    sequence_number = payload.get("sequence_number")
+    if isinstance(sequence_number, int):
+        synthetic["sequence_number"] = sequence_number
+    return synthetic
 
 
 def _synthetic_text_delta_events(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1631,7 +1631,10 @@ async def _stream_responses(
         if reservation is not None and owns_reservation:
             await _release_reservation(reservation)
         return _stream_startup_error_response(request, startup_error, headers=rate_limit_headers)
-    stream = _normalize_public_responses_stream(_stream_proxy_errors_as_response_failed(stream), enforce_openai_sdk_contract=enforce_openai_sdk_contract)
+    stream = _normalize_public_responses_stream(
+        _stream_proxy_errors_as_response_failed(stream),
+        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+    )
     return StreamingResponse(
         inject_sse_keepalives(
             stream,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2343,7 +2343,8 @@ async def _normalize_public_responses_stream(
         if (
             enforce_openai_sdk_contract
             and isinstance(raw_event_type, str)
-            and raw_event_type in (
+            and raw_event_type
+            in (
                 "response.completed",
                 "response.incomplete",
             )
@@ -2422,11 +2423,7 @@ def _normalize_public_stream_payload(
     # first. The Codex CLI routes under ``/backend-api/codex/*`` legitimately
     # consume these events and pass ``enforce_openai_sdk_contract=False`` so
     # they continue to forward unchanged.
-    if (
-        enforce_openai_sdk_contract
-        and isinstance(event_type, str)
-        and event_type.startswith("codex.")
-    ):
+    if enforce_openai_sdk_contract and isinstance(event_type, str) and event_type.startswith("codex."):
         return None, None
     if event_type == "error":
         parsed_error = _parse_event_error_envelope(payload)

--- a/openspec/changes/normalize-v1-responses-openai-sdk-stream/design.md
+++ b/openspec/changes/normalize-v1-responses-openai-sdk-stream/design.md
@@ -1,0 +1,71 @@
+## Overview
+
+`codex-lb` exposes two routers that both proxy the upstream Codex Responses API:
+
+- `/backend-api/codex/*` — for the Codex CLI itself; preserves the upstream event stream verbatim because the Codex CLI expects (and uses) `codex.rate_limits` and other vendor-specific events.
+- `/v1/*` — advertised as OpenAI-compatible (see README: Codex CLI uses `/backend-api/codex`, but OpenCode, OpenClaw, and the OpenAI Python SDK all use `/v1`).
+
+The streaming normalizer for the public `/v1` surface (`_normalize_public_responses_stream` + `_normalize_public_stream_payload`) currently does per-event normalization only. Two stream-level gaps were found by feeding live upstream traffic through the normalizer and into the OpenAI Python SDK's `ResponseStreamState` parser.
+
+## Decisions
+
+### 1. Drop Codex-internal events at the `/v1` boundary
+
+`_normalize_public_stream_payload` ends with a catch-all `return payload, None`. Any event type not explicitly handled (`error`, `response.completed`, `response.incomplete`, `response.output_item.added`, `response.output_item.done`) is forwarded verbatim. This includes `codex.rate_limits`, which the upstream emits *before* `response.created` whenever the rate-limit telemetry window hasn't expired.
+
+The OpenAI SDK parser (`ResponseStreamState._create_initial_response`) raises `RuntimeError` when the first received event is not `response.created`. Because the rate-limit event is throttled (one per window, not per request), the same request shape sometimes works and sometimes fails — the SDK never starts parsing.
+
+**Decision:** in the `/v1` normalizer, drop any event whose `type` starts with `codex.`. This is the smallest predicate that matches all current and reasonably-future Codex vendor extensions while preserving every event type defined in the public OpenAI Responses SSE contract. Add the check at the top of `_normalize_public_stream_payload` (returning `None, None` to suppress) so the outer `_normalize_public_responses_stream` skips emission.
+
+**Why not move the filter into the upstream client (`stream_responses`)?** The `/backend-api/codex/*` routes share `_stream_responses` and the same `_normalize_public_responses_stream` family, and the Codex CLI legitimately needs `codex.*` events and the upstream's native ordering. Adding a per-route `enforce_openai_sdk_contract: bool` parameter to `_stream_responses` (defaulting to `True`) and threading it into `_normalize_public_responses_stream` is the minimum surgery that keeps the two routes decoupled. The `/backend-api/codex/responses` route passes `enforce_openai_sdk_contract=False`; everything else (`/v1/responses`, `internal_bridge_responses`) keeps the default `True`.
+
+**Why not normalize to a real OpenAI event (e.g. by translating to rate-limit headers)?** `/v1/responses` already exposes upstream rate-limit information via response headers (`include_rate_limit_headers=True` in `_stream_responses`). Re-emitting the same information as a stream event would be additional surface that the public OpenAI contract does not specify. Drop is the minimal correct action.
+
+### 2. Backfill terminal `output` from streamed item events
+
+The Codex backend emits `response.completed` with `output: []`, relying on intermediate `response.output_item.done` events to carry the real output items (messages, function calls, reasoning items, etc.).
+
+The non-streaming path in `_collect_responses_payload` already handles this correctly: it collects `output_item.done` payloads into a dict keyed by `output_index`, then `_merge_collected_output_items` overlays them onto the terminal `response.output` when it is empty.
+
+The streaming path does not. The OpenAI SDK's `accumulate_event` for `response.completed` calls `parse_response(response=event.response, ...)` with the raw `event.response`, so `get_final_response().output` reflects exactly what `response.completed` carried — `[]`.
+
+**Decision:** introduce the same collect-and-merge behavior in `_normalize_public_responses_stream`. Track `response.output_item.done` events as the stream is iterated; when a `response.completed` or `response.incomplete` event arrives, if its `response.output` is empty/missing, rewrite the payload's `response.output` from the collected items before yielding the SSE block. Reuse the existing `_merge_collected_output_items` helper to keep the merge rule identical to the non-streaming path.
+
+**Why not let the client (OpenAI SDK) accumulate from item events itself?** The SDK does accumulate items in its `accumulate_event` path via `response.output_item.added`. But the `final_response` returned by `get_final_response()` comes from `parse_response(response=event.response, ...)`, not from the internal snapshot — so even though the SDK *internally* sees the items during the stream, the user-facing `final_response.output` reflects the terminal event's `response.output`. Backfilling at the proxy is the only way to make `get_final_response().output` correct for the documented public contract.
+
+### 3. Synthesize `response.created` when the upstream stream starts with a non-created event
+
+This gap was discovered during Phase 0 audit *after* fix (1) landed: with `codex.rate_limits` dropped, the error-stream case (an upstream-rejection scenario that produces only `response.failed`) became the new first event. The OpenAI SDK parser raises the same `RuntimeError` for *any* first event that is not `response.created`.
+
+**Decision:** in `_normalize_public_responses_stream`, track whether the public stream has emitted `response.created`. Before emitting any other standard `response.*` event for the first time, synthesize a `response.created` envelope from whatever `response` payload is on the current event (`response.failed` carries one; so do `response.completed` and `response.incomplete`). Set `status: "in_progress"` and `output: []` on the synthesized envelope so the SDK's accumulator starts cleanly. The original event is then forwarded unchanged.
+
+**Why not promote the upstream rejection to an HTTP 4xx?** Upstream rejection mid-stream goes through `_probe_stream_startup_error` first, which already converts certain pre-stream rejections to HTTP responses. The class we're fixing here is *post-stream-startup* failures where the upstream connection succeeded and started sending SSE but the very first event is terminal. Treating those as HTTP errors would require unwinding an already-active stream and breaking the existing `_probe_stream_startup_error` contract; synthesizing `response.created` is the minimum that makes the SDK-parser path correct without touching transport.
+
+**Why not drop the leading non-created event and emit only `response.created`?** Then consumers would see no terminal event and the stream would hang from the SDK's perspective until the keepalive shutdown.
+
+**Why is the synthesized envelope safe?** `response.created` from real OpenAI carries `id`, `object`, `created_at`, `model`, `status="in_progress"`, `output=[]`. The Codex backend's `response.failed.response` payload carries the same envelope shape (verified in audit2: `body.status="completed"` for non-streaming, and `response.failed.response` carries the same fields). We copy the envelope and set `status="in_progress"`, `output=[]` — the only two fields whose values must reflect the synthesized event's contract.
+
+### 4. Scope: streaming `/v1/responses` only
+
+- `/backend-api/codex/*` — out of scope. Codex CLI uses these events. Confirmed in the existing image-adapter comment in `images_service.py` that mentions `codex.rate_limits` as a known passthrough event for the Codex surface.
+- Non-streaming `/v1/responses` — out of scope. Audit confirmed `_collect_responses_payload` + `_merge_collected_output_items` already produce a SDK-parseable `Response` object (`output_len=2`, all items present).
+- The upstream transport layer (WebSocket vs HTTP bridge) — out of scope. The gap is in the public-stream emission layer, not the upstream transport.
+
+### 5. Test strategy
+
+- **Unit tests** (`tests/unit/test_proxy_api_responses_contract.py`): direct exercise of `_normalize_public_responses_stream` with hand-crafted upstream blocks, asserting (a) `codex.rate_limits` does not appear in the normalized output, (b) `response.created` is the first emitted event, (c) when upstream sends `response.completed` with `output: []`, the normalized terminal event has `output` reconstructed from prior `output_item.done` events.
+- **E2E tests** (`tests/e2e/test_v1_responses_openai_sdk.py`, new): drive the real `openai` Python SDK against the in-process ASGI app via `httpx.ASGITransport`, mocking `core_stream_responses` (the same pattern `tests/e2e/test_proxy_flow.py` already uses) to inject a leading `codex.rate_limits` block and an empty `response.completed.output`. Verify:
+  - `client.responses.stream(...)` `with` block completes without `RuntimeError`
+  - `stream.get_final_response().output` is non-empty across plain-text, tool-call, and structured-output shapes
+  - `client.responses.create(...)` (non-streaming) returns a populated `Response` object
+  - Error-stream case (upstream `response.failed` after `response.created`) surfaces as the SDK's `error` / failed-response path, not as a parser exception
+
+## Risks
+
+- **Future Codex vendor events.** Hardcoding the `codex.` prefix drop catches the known event and any future Codex-prefixed extensions. If OpenAI ever ships a real upstream event whose type happens to start with `codex.`, the drop will hide it; this is acceptable given OpenAI's existing event naming convention (all standard events use `response.*` or `error`).
+- **Upstream contract drift.** If Codex starts emitting `output` directly in `response.completed`, the backfill becomes a no-op (it only fires when `output` is empty/missing), so there is no regression risk.
+
+## Out of scope (deferred)
+
+- Translating `codex.rate_limits` into response headers on the `/v1` surface. The data is already exposed via the same response headers used by the non-streaming path (`include_rate_limit_headers=True`); duplicating it in stream form is unnecessary.
+- WebSocket transport (`/v1/responses/websocket`). Audit was HTTP-only because the gaps observed are in `_normalize_public_*`, which runs after the transport. The WebSocket path goes through the same normalizer family — a follow-up audit can confirm, but no separate fix is anticipated.

--- a/openspec/changes/normalize-v1-responses-openai-sdk-stream/proposal.md
+++ b/openspec/changes/normalize-v1-responses-openai-sdk-stream/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`codex-lb`'s public `/v1/responses` endpoint is advertised as OpenAI-compatible (README: "OpenAI Python SDK", "OpenCode", "OpenClaw" all point at `/v1`). But the streaming path forwards the upstream Codex backend's SSE event stream with only per-event normalization — it never reconciles the *stream-level shape* the OpenAI SDK parser requires. An audit against the OpenAI Python SDK (`openai>=2.16`) `ResponseStreamState` parser found two stream-level contract gaps:
+
+1. **Codex-internal events leak as the first SSE event.** The Codex backend emits a non-standard `codex.rate_limits` event, and the backend frequently (not always — it is throttled per rate-limit window) places it *before* `response.created`. `_normalize_public_stream_payload` has a catch-all `return payload, None` that passes through any event type it does not explicitly handle, so `codex.rate_limits` reaches the client verbatim. The OpenAI SDK's `_create_initial_response` raises `RuntimeError: Expected to have received 'response.created' before 'codex.rate_limits'` on the very first event — the stream never starts. Because the upstream throttles the event, the same request intermittently works or fails, which is the hardest failure mode to diagnose. Verified against `codex.nekos.me`: 4/5 streaming request shapes (plain text, tool call, structured output, error) fail; the 5th passed only because the rate-limit window had already been consumed.
+
+2. **Streamed `response.completed` carries an empty `output` array.** The Codex backend sends `response.completed` with `output: []` and relies on the intermediate `response.output_item.done` events to carry the real items. The non-streaming path already reconstructs output via `_collect_responses_payload` / `_merge_collected_output_items`, but the streaming normalizer (`_normalize_public_responses_stream`) has no equivalent backfill. The OpenAI SDK's `get_final_response()` reads `event.response` directly from `response.completed`, so SDK consumers of the streaming endpoint get `final_response.output == []` even on a fully successful turn.
+
+These are not Codex-client problems — the `/backend-api/codex/*` routes legitimately need `codex.rate_limits` and the Codex CLI's own stream handling. They are specifically `/v1` public-surface gaps: the `/v1` normalizer must produce a stream that conforms to the documented OpenAI Responses SSE contract.
+
+## What Changes
+
+- **Drop Codex-internal stream events on the `/v1` public surface.** `_normalize_public_stream_payload` MUST drop event types that are not part of the public OpenAI Responses SSE contract — specifically the `codex.`-prefixed vendor events (`codex.rate_limits`, and any future `codex.*`). The `/backend-api/codex/*` routes are unaffected and continue to forward these events.
+- **Backfill streamed `response.completed` / `response.incomplete` output from item events.** `_normalize_public_responses_stream` MUST track `response.output_item.done` events and, when the terminal `response.completed` / `response.incomplete` payload carries an empty or missing `output`, reconstruct `output` from the collected item events — mirroring the existing non-streaming `_collect_responses_payload` behavior.
+- **Synthesize `response.created` when the upstream stream starts with a non-created event.** When the first standard event the public stream would emit is not `response.created` (e.g. the Codex backend jumps directly to `response.failed` on upstream rejection mid-stream), `_normalize_public_responses_stream` MUST synthesize a `response.created` envelope from whatever `response` payload is available so the OpenAI SDK parser can begin processing the stream. The OpenAI Python SDK's `_create_initial_response` raises `RuntimeError` when the first event is anything other than `response.created`, breaking even legitimate error-stream consumers.
+- **Add regression coverage** in `tests/unit/test_proxy_api_responses_contract.py` for all three gaps, plus an end-to-end test in `tests/e2e/` that drives the real `openai` Python SDK (`client.responses.stream(...)` and `client.responses.create(...)`) through the in-process ASGI app across plain-text, tool-call, structured-output, and error-stream shapes, asserting the SDK parser survives and `get_final_response().output` is populated.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: the public `/v1/responses` streaming surface MUST emit only OpenAI Responses SSE contract events (no Codex-internal events) and MUST backfill terminal `output` from streamed item events.
+
+## Impact
+
+- **Code**: `app/modules/proxy/api.py` (`_normalize_public_stream_payload`, `_normalize_public_responses_stream`)
+- **Tests**: `tests/unit/test_proxy_api_responses_contract.py`, `tests/e2e/test_v1_responses_openai_sdk.py` (new)
+- **Behavior**: `/v1/responses` streaming responses become parseable by the stock OpenAI Python SDK in all request shapes; `/backend-api/codex/*` is unchanged.
+- **Non-goals**: No change to upstream transport selection (WebSocket / HTTP bridge), no change to `/backend-api/codex/*` event forwarding, no change to non-streaming `/v1/responses` (already correct per audit).

--- a/openspec/changes/normalize-v1-responses-openai-sdk-stream/specs/responses-api-compat/spec.md
+++ b/openspec/changes/normalize-v1-responses-openai-sdk-stream/specs/responses-api-compat/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Public /v1 responses SSE stream emits only OpenAI Responses contract events
+When serving streaming `POST /v1/responses`, the service MUST emit only event types defined by the OpenAI Responses SSE contract (the `response.*` and `error` families) on the public stream. The service MUST drop any vendor-internal event types — specifically, any event whose `type` begins with `codex.` (for example `codex.rate_limits`) — before they reach the public stream. The `/backend-api/codex/*` routes are NOT subject to this requirement and MUST continue forwarding these events unchanged.
+
+#### Scenario: Codex-internal rate-limit event is dropped before response.created
+- **WHEN** the upstream Codex backend emits `codex.rate_limits` before `response.created` for a streaming `/v1/responses` request
+- **THEN** the public stream MUST NOT contain the `codex.rate_limits` event
+- **AND** the first event the public stream emits MUST be `response.created`
+
+#### Scenario: Codex-internal events on the Codex CLI route are preserved
+- **WHEN** the upstream emits `codex.rate_limits` for a `POST /backend-api/codex/responses` request
+- **THEN** the response stream forwards the `codex.rate_limits` event to the Codex CLI client unchanged
+
+### Requirement: Streamed /v1 responses terminal output is backfilled from item events
+When serving streaming `POST /v1/responses`, if the upstream's terminal `response.completed` or `response.incomplete` event carries `output` as missing or as an empty list, the service MUST reconstruct `output` from the `response.output_item.done` events emitted earlier in the same stream before yielding the terminal SSE event. The reconstructed `output` MUST preserve the `output_index` ordering and the raw item payloads. When the terminal `response.completed` / `response.incomplete` already carries a non-empty `output`, the service MUST forward it unchanged.
+
+#### Scenario: Terminal response.completed with empty output is backfilled from streamed items
+- **GIVEN** the upstream emits `response.output_item.done` events with valid message or function-call items
+- **WHEN** the upstream's terminal `response.completed` event carries `output: []`
+- **THEN** the public stream's terminal `response.completed` event MUST carry the reconstructed `output` array, populated from the streamed `output_item.done` items in `output_index` order
+- **AND** an OpenAI Python SDK consumer calling `stream.get_final_response().output` MUST receive the same populated list
+
+#### Scenario: Terminal response.completed already carries output
+- **WHEN** the upstream's terminal `response.completed` event already includes a non-empty `output` array
+- **THEN** the public stream's terminal event MUST carry that `output` array unchanged
+
+### Requirement: Public /v1 responses SSE stream starts with response.created
+When serving streaming `POST /v1/responses`, the first OpenAI-contract event the public stream emits MUST be `response.created`. When the upstream's first standard `response.*` event is not `response.created` (for example when the Codex backend jumps directly to `response.failed` on upstream rejection mid-stream), the service MUST synthesize a `response.created` SSE event from the source event's `response` envelope and emit it before forwarding the source event, so that consumers using the OpenAI Python SDK's `responses.stream(...)` parser do not raise `RuntimeError`.
+
+#### Scenario: Upstream error stream that skips response.created is repaired
+- **WHEN** the upstream's first standard event is `response.failed` (no preceding `response.created`)
+- **THEN** the public stream MUST emit a synthesized `response.created` event derived from the failed event's `response` envelope before forwarding the `response.failed` event
+- **AND** an OpenAI Python SDK consumer iterating the stream MUST NOT raise `RuntimeError` from the parser's initial-response check
+
+#### Scenario: Normal stream is not double-emitted
+- **WHEN** the upstream's first standard event is already `response.created`
+- **THEN** the public stream MUST emit exactly one `response.created` event (no synthesized duplicate)

--- a/openspec/changes/normalize-v1-responses-openai-sdk-stream/tasks.md
+++ b/openspec/changes/normalize-v1-responses-openai-sdk-stream/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [x] 1.1 Drop Codex-internal (`codex.`-prefixed) events in `_normalize_public_stream_payload` so they never reach the `/v1` public stream; leave `/backend-api/codex/*` forwarding untouched
+- [x] 1.2 Track `response.output_item.done` events in `_normalize_public_responses_stream` and backfill `response.completed` / `response.incomplete` `output` from collected items when the terminal payload's `output` is empty or missing, reusing the existing `_merge_collected_output_items` / `_normalize_public_response_mapping` helpers
+- [x] 1.3 Synthesize a `response.created` SSE event from the current event's `response` envelope when the first standard event the public stream would emit is not `response.created` (e.g. upstream-rejection error streams that jump straight to `response.failed`)
+
+## 2. Tests
+
+- [ ] 2.1 Unit: extend `tests/unit/test_proxy_api_responses_contract.py` — `_normalize_public_responses_stream` drops a leading `codex.rate_limits` event and yields `response.created` as the first event
+- [ ] 2.2 Unit: `_normalize_public_responses_stream` backfills terminal `output` from streamed `response.output_item.done` events when `response.completed` carries `output: []`
+- [ ] 2.3 Unit: `_normalize_public_responses_stream` synthesizes `response.created` when the upstream stream's first standard event is `response.failed` (or any other non-created event)
+- [ ] 2.4 E2E: add `tests/e2e/test_v1_responses_openai_sdk.py` driving the real `openai` SDK (`responses.stream` + `responses.create`) through the in-process ASGI app for plain-text, tool-call, structured-output, and error-stream shapes; assert the SDK stream parser does not raise and `get_final_response().output` is populated
+
+## 3. Spec Delta
+
+- [ ] 3.1 Add a `responses-api-compat` spec delta for the public `/v1` streaming SSE contract (drop Codex-internal events, backfill terminal output, synthesize leading `response.created`)
+- [ ] 3.2 Validate specs locally with `openspec validate normalize-v1-responses-openai-sdk-stream --strict`

--- a/scripts/verify_v1_responses_openai_sdk.py
+++ b/scripts/verify_v1_responses_openai_sdk.py
@@ -82,17 +82,30 @@ async def case_plain_streaming(client: openai.AsyncOpenAI, model: str) -> CaseRe
 async def case_tool_call_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResult:
     """Tool-call streaming. Asserts get_final_response() carries a
     function_call output item with parseable arguments."""
+    # ``Iterable[FunctionToolParam]`` is a ``TypedDict`` union; build the
+    # dict explicitly typed so ty/pyright accept the overload.
+    from openai.types.responses import FunctionToolParam
+
+    tools: list[FunctionToolParam] = [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+            "strict": True,
+        }
+    ]
     try:
         events: list[str] = []
         async with client.responses.stream(
             model=model,
             input=[{"role": "user",
                      "content": "What is the weather in Seoul? Use the get_weather tool."}],
-            tools=[{"type": "function", "name": "get_weather",
-                     "description": "Get current weather for a city",
-                     "parameters": {"type": "object",
-                                      "properties": {"city": {"type": "string"}},
-                                      "required": ["city"]}}],
+            tools=tools,
             max_output_tokens=200,
         ) as stream:
             async for event in stream:
@@ -106,13 +119,18 @@ async def case_tool_call_streaming(client: openai.AsyncOpenAI, model: str) -> Ca
                               f"no function_call in output: "
                               f"{[it.type for it in final.output]}")
         fc = fc_items[0]
+        fc_args = getattr(fc, "arguments", None)
+        fc_name = getattr(fc, "name", None)
+        if not isinstance(fc_args, str) or not isinstance(fc_name, str):
+            return CaseResult("tool_call_streaming", False,
+                              f"function_call missing name/arguments: {fc!r}")
         try:
-            args = json.loads(fc.arguments)
+            args = json.loads(fc_args)
         except Exception as e:
             return CaseResult("tool_call_streaming", False,
                               f"function_call.arguments not JSON: {e}")
         return CaseResult("tool_call_streaming", True,
-                          f"name={fc.name} args={args}")
+                          f"name={fc_name} args={args}")
     except Exception as e:
         return CaseResult("tool_call_streaming", False,
                           f"{type(e).__name__}: {e}")
@@ -137,7 +155,16 @@ async def case_structured_output_streaming(client: openai.AsyncOpenAI, model: st
         if not msg_items:
             return CaseResult("structured_output_streaming", False,
                               f"no message in output: {[it.type for it in final.output]}")
-        text = msg_items[0].content[0].text
+        msg = msg_items[0]
+        content = getattr(msg, "content", None)
+        if not content:
+            return CaseResult("structured_output_streaming", False,
+                              f"message has no content: {msg!r}")
+        first_part = content[0]
+        text = getattr(first_part, "text", None)
+        if not isinstance(text, str):
+            return CaseResult("structured_output_streaming", False,
+                              f"first content part has no text: {first_part!r}")
         try:
             json.loads(text)
         except Exception as e:

--- a/scripts/verify_v1_responses_openai_sdk.py
+++ b/scripts/verify_v1_responses_openai_sdk.py
@@ -179,9 +179,18 @@ async def case_error_stream(client: openai.AsyncOpenAI, model: str) -> CaseResul
             ) as stream:
                 async for event in stream:
                     events.append(event.type)
-        except openai.APIError:
-            # Acceptable: upstream may reject pre-stream as HTTP error.
-            return CaseResult("error_stream", True, "pre-stream HTTP error (acceptable)")
+        except openai.APIStatusError as e:
+            # Acceptable: upstream may reject pre-stream as an HTTP 4xx (the
+            # invalid schema is a client error). 5xx / auth / config errors
+            # are NOT a pass — those mean the proxy or upstream is broken,
+            # not that we successfully surfaced a client validation failure.
+            status = getattr(e, "status_code", None)
+            if isinstance(status, int) and 400 <= status < 500 and status not in (401, 403):
+                return CaseResult("error_stream", True, f"pre-stream HTTP {status} (acceptable client error)")
+            return CaseResult("error_stream", False, f"unexpected HTTP {status}: {type(e).__name__}: {e}")
+        except openai.APIConnectionError as e:
+            # Transport-level failure — never a pass.
+            return CaseResult("error_stream", False, f"connection error: {e}")
         codex_events = [e for e in events if e.startswith("codex.")]
         if codex_events:
             return CaseResult("error_stream", False, f"codex.* leaked: {codex_events}")

--- a/scripts/verify_v1_responses_openai_sdk.py
+++ b/scripts/verify_v1_responses_openai_sdk.py
@@ -26,6 +26,7 @@ Or against the public deployment after the fix is deployed:
 Exits 0 on full pass, non-zero on any failure (with a per-case PASS/FAIL
 summary printed before exit).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -47,10 +48,10 @@ class CaseResult:
 
 async def case_plain_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResult:
     """Plain text streaming. Asserts:
-      - SDK parser does NOT raise
-      - response.created is the first event
-      - codex.* events do NOT appear
-      - get_final_response().output is non-empty
+    - SDK parser does NOT raise
+    - response.created is the first event
+    - codex.* events do NOT appear
+    - get_final_response().output is non-empty
     """
     try:
         events: list[str] = []
@@ -64,19 +65,14 @@ async def case_plain_streaming(client: openai.AsyncOpenAI, model: str) -> CaseRe
             final = await stream.get_final_response()
         codex_events = [e for e in events if e.startswith("codex.")]
         if codex_events:
-            return CaseResult("plain_streaming", False,
-                              f"codex.* events leaked: {codex_events}")
+            return CaseResult("plain_streaming", False, f"codex.* events leaked: {codex_events}")
         if "response.created" not in events:
-            return CaseResult("plain_streaming", False,
-                              f"response.created missing; events={events[:5]}")
+            return CaseResult("plain_streaming", False, f"response.created missing; events={events[:5]}")
         if not final.output:
-            return CaseResult("plain_streaming", False,
-                              "get_final_response().output is empty")
-        return CaseResult("plain_streaming", True,
-                          f"output_len={len(final.output)} events={len(events)}")
+            return CaseResult("plain_streaming", False, "get_final_response().output is empty")
+        return CaseResult("plain_streaming", True, f"output_len={len(final.output)} events={len(events)}")
     except Exception as e:
-        return CaseResult("plain_streaming", False,
-                          f"{type(e).__name__}: {e}")
+        return CaseResult("plain_streaming", False, f"{type(e).__name__}: {e}")
 
 
 async def case_tool_call_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResult:
@@ -103,8 +99,7 @@ async def case_tool_call_streaming(client: openai.AsyncOpenAI, model: str) -> Ca
         events: list[str] = []
         async with client.responses.stream(
             model=model,
-            input=[{"role": "user",
-                     "content": "What is the weather in Seoul? Use the get_weather tool."}],
+            input=[{"role": "user", "content": "What is the weather in Seoul? Use the get_weather tool."}],
             tools=tools,
             max_output_tokens=200,
         ) as stream:
@@ -115,25 +110,21 @@ async def case_tool_call_streaming(client: openai.AsyncOpenAI, model: str) -> Ca
             return CaseResult("tool_call_streaming", False, "output empty")
         fc_items = [it for it in final.output if it.type == "function_call"]
         if not fc_items:
-            return CaseResult("tool_call_streaming", False,
-                              f"no function_call in output: "
-                              f"{[it.type for it in final.output]}")
+            return CaseResult(
+                "tool_call_streaming", False, f"no function_call in output: {[it.type for it in final.output]}"
+            )
         fc = fc_items[0]
         fc_args = getattr(fc, "arguments", None)
         fc_name = getattr(fc, "name", None)
         if not isinstance(fc_args, str) or not isinstance(fc_name, str):
-            return CaseResult("tool_call_streaming", False,
-                              f"function_call missing name/arguments: {fc!r}")
+            return CaseResult("tool_call_streaming", False, f"function_call missing name/arguments: {fc!r}")
         try:
             args = json.loads(fc_args)
         except Exception as e:
-            return CaseResult("tool_call_streaming", False,
-                              f"function_call.arguments not JSON: {e}")
-        return CaseResult("tool_call_streaming", True,
-                          f"name={fc_name} args={args}")
+            return CaseResult("tool_call_streaming", False, f"function_call.arguments not JSON: {e}")
+        return CaseResult("tool_call_streaming", True, f"name={fc_name} args={args}")
     except Exception as e:
-        return CaseResult("tool_call_streaming", False,
-                          f"{type(e).__name__}: {e}")
+        return CaseResult("tool_call_streaming", False, f"{type(e).__name__}: {e}")
 
 
 async def case_structured_output_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResult:
@@ -141,8 +132,7 @@ async def case_structured_output_streaming(client: openai.AsyncOpenAI, model: st
     try:
         async with client.responses.stream(
             model=model,
-            input=[{"role": "user",
-                     "content": "Return json with a 'city' field set to Seoul."}],
+            input=[{"role": "user", "content": "Return json with a 'city' field set to Seoul."}],
             text={"format": {"type": "json_object"}},
             max_output_tokens=100,
         ) as stream:
@@ -153,28 +143,24 @@ async def case_structured_output_streaming(client: openai.AsyncOpenAI, model: st
             return CaseResult("structured_output_streaming", False, "output empty")
         msg_items = [it for it in final.output if it.type == "message"]
         if not msg_items:
-            return CaseResult("structured_output_streaming", False,
-                              f"no message in output: {[it.type for it in final.output]}")
+            return CaseResult(
+                "structured_output_streaming", False, f"no message in output: {[it.type for it in final.output]}"
+            )
         msg = msg_items[0]
         content = getattr(msg, "content", None)
         if not content:
-            return CaseResult("structured_output_streaming", False,
-                              f"message has no content: {msg!r}")
+            return CaseResult("structured_output_streaming", False, f"message has no content: {msg!r}")
         first_part = content[0]
         text = getattr(first_part, "text", None)
         if not isinstance(text, str):
-            return CaseResult("structured_output_streaming", False,
-                              f"first content part has no text: {first_part!r}")
+            return CaseResult("structured_output_streaming", False, f"first content part has no text: {first_part!r}")
         try:
             json.loads(text)
         except Exception as e:
-            return CaseResult("structured_output_streaming", False,
-                              f"output text not JSON: {e}: {text[:80]}")
-        return CaseResult("structured_output_streaming", True,
-                          f"text={text[:60]}")
+            return CaseResult("structured_output_streaming", False, f"output text not JSON: {e}: {text[:80]}")
+        return CaseResult("structured_output_streaming", True, f"text={text[:60]}")
     except Exception as e:
-        return CaseResult("structured_output_streaming", False,
-                          f"{type(e).__name__}: {e}")
+        return CaseResult("structured_output_streaming", False, f"{type(e).__name__}: {e}")
 
 
 async def case_error_stream(client: openai.AsyncOpenAI, model: str) -> CaseResult:
@@ -188,8 +174,7 @@ async def case_error_stream(client: openai.AsyncOpenAI, model: str) -> CaseResul
             async with client.responses.stream(
                 model=model,
                 input=[{"role": "user", "content": "hi"}],
-                text={"format": {"type": "json_schema", "name": "x",
-                                    "schema": {"type": "INVALID_TYPE"}}},
+                text={"format": {"type": "json_schema", "name": "x", "schema": {"type": "INVALID_TYPE"}}},
                 max_output_tokens=50,
             ) as stream:
                 async for event in stream:
@@ -199,11 +184,9 @@ async def case_error_stream(client: openai.AsyncOpenAI, model: str) -> CaseResul
             return CaseResult("error_stream", True, "pre-stream HTTP error (acceptable)")
         codex_events = [e for e in events if e.startswith("codex.")]
         if codex_events:
-            return CaseResult("error_stream", False,
-                              f"codex.* leaked: {codex_events}")
+            return CaseResult("error_stream", False, f"codex.* leaked: {codex_events}")
         if events and events[0] != "response.created":
-            return CaseResult("error_stream", False,
-                              f"first event was {events[0]!r}, expected response.created")
+            return CaseResult("error_stream", False, f"first event was {events[0]!r}, expected response.created")
         return CaseResult("error_stream", True, f"events={events}")
     except RuntimeError as e:
         return CaseResult("error_stream", False, f"SDK parser raised: {e}")
@@ -223,23 +206,17 @@ async def case_non_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResu
         )
         if not response.output:
             return CaseResult("non_streaming", False, "output empty")
-        return CaseResult("non_streaming", True,
-                          f"output_len={len(response.output)} "
-                          f"status={response.status}")
+        return CaseResult("non_streaming", True, f"output_len={len(response.output)} status={response.status}")
     except Exception as e:
-        return CaseResult("non_streaming", False,
-                          f"{type(e).__name__}: {e}")
+        return CaseResult("non_streaming", False, f"{type(e).__name__}: {e}")
 
 
 async def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--base-url", required=True,
-                        help="codex-lb /v1 base URL (e.g. http://127.0.0.1:2455/v1)")
-    parser.add_argument("--api-key", required=True,
-                        help="codex-lb API key (sk-clb-...)")
+    parser.add_argument("--base-url", required=True, help="codex-lb /v1 base URL (e.g. http://127.0.0.1:2455/v1)")
+    parser.add_argument("--api-key", required=True, help="codex-lb API key (sk-clb-...)")
     parser.add_argument("--model", default="gpt-5.5")
-    parser.add_argument("--skip", default="",
-                        help="comma-separated case names to skip")
+    parser.add_argument("--skip", default="", help="comma-separated case names to skip")
     args = parser.parse_args()
 
     client = openai.AsyncOpenAI(api_key=args.api_key, base_url=args.base_url)
@@ -267,7 +244,7 @@ async def main() -> int:
     await client.close()
     failed = [r for r in results if not r.passed]
     print()
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     print(f"Summary: {len(results) - len(failed)}/{len(results)} passed")
     if failed:
         print("Failures:")

--- a/scripts/verify_v1_responses_openai_sdk.py
+++ b/scripts/verify_v1_responses_openai_sdk.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Live verification of /v1/responses OpenAI SDK compatibility.
+
+Drives the official `openai` Python SDK against a running codex-lb instance
+and asserts the public /v1 surface is parseable across all request shapes:
+plain text, tool call, structured output, error stream, non-streaming.
+
+Usage:
+    # 1. Boot codex-lb locally (with the fix branch checked out)
+    cd ~/projects/codex-lb
+    .venv/bin/python -m app.main &
+    sleep 3
+
+    # 2. Run this script
+    .venv/bin/python scripts/verify_v1_responses_openai_sdk.py \\
+        --base-url http://127.0.0.1:2455/v1 \\
+        --api-key <codex-lb dashboard key> \\
+        --model gpt-5.5
+
+Or against the public deployment after the fix is deployed:
+    .venv/bin/python scripts/verify_v1_responses_openai_sdk.py \\
+        --base-url https://codex.nekos.me/v1 \\
+        --api-key $CODEX_NEKOS_API_KEY \\
+        --model gpt-5.5
+
+Exits 0 on full pass, non-zero on any failure (with a per-case PASS/FAIL
+summary printed before exit).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from dataclasses import dataclass
+
+import openai
+
+
+@dataclass
+class CaseResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+async def case_plain_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResult:
+    """Plain text streaming. Asserts:
+      - SDK parser does NOT raise
+      - response.created is the first event
+      - codex.* events do NOT appear
+      - get_final_response().output is non-empty
+    """
+    try:
+        events: list[str] = []
+        async with client.responses.stream(
+            model=model,
+            input=[{"role": "user", "content": "Reply with exactly: hello"}],
+            max_output_tokens=50,
+        ) as stream:
+            async for event in stream:
+                events.append(event.type)
+            final = await stream.get_final_response()
+        codex_events = [e for e in events if e.startswith("codex.")]
+        if codex_events:
+            return CaseResult("plain_streaming", False,
+                              f"codex.* events leaked: {codex_events}")
+        if "response.created" not in events:
+            return CaseResult("plain_streaming", False,
+                              f"response.created missing; events={events[:5]}")
+        if not final.output:
+            return CaseResult("plain_streaming", False,
+                              "get_final_response().output is empty")
+        return CaseResult("plain_streaming", True,
+                          f"output_len={len(final.output)} events={len(events)}")
+    except Exception as e:
+        return CaseResult("plain_streaming", False,
+                          f"{type(e).__name__}: {e}")
+
+
+async def case_tool_call_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResult:
+    """Tool-call streaming. Asserts get_final_response() carries a
+    function_call output item with parseable arguments."""
+    try:
+        events: list[str] = []
+        async with client.responses.stream(
+            model=model,
+            input=[{"role": "user",
+                     "content": "What is the weather in Seoul? Use the get_weather tool."}],
+            tools=[{"type": "function", "name": "get_weather",
+                     "description": "Get current weather for a city",
+                     "parameters": {"type": "object",
+                                      "properties": {"city": {"type": "string"}},
+                                      "required": ["city"]}}],
+            max_output_tokens=200,
+        ) as stream:
+            async for event in stream:
+                events.append(event.type)
+            final = await stream.get_final_response()
+        if not final.output:
+            return CaseResult("tool_call_streaming", False, "output empty")
+        fc_items = [it for it in final.output if it.type == "function_call"]
+        if not fc_items:
+            return CaseResult("tool_call_streaming", False,
+                              f"no function_call in output: "
+                              f"{[it.type for it in final.output]}")
+        fc = fc_items[0]
+        try:
+            args = json.loads(fc.arguments)
+        except Exception as e:
+            return CaseResult("tool_call_streaming", False,
+                              f"function_call.arguments not JSON: {e}")
+        return CaseResult("tool_call_streaming", True,
+                          f"name={fc.name} args={args}")
+    except Exception as e:
+        return CaseResult("tool_call_streaming", False,
+                          f"{type(e).__name__}: {e}")
+
+
+async def case_structured_output_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResult:
+    """JSON-format streaming. Asserts the final text parses as JSON."""
+    try:
+        async with client.responses.stream(
+            model=model,
+            input=[{"role": "user",
+                     "content": "Return json with a 'city' field set to Seoul."}],
+            text={"format": {"type": "json_object"}},
+            max_output_tokens=100,
+        ) as stream:
+            async for _ in stream:
+                pass
+            final = await stream.get_final_response()
+        if not final.output:
+            return CaseResult("structured_output_streaming", False, "output empty")
+        msg_items = [it for it in final.output if it.type == "message"]
+        if not msg_items:
+            return CaseResult("structured_output_streaming", False,
+                              f"no message in output: {[it.type for it in final.output]}")
+        text = msg_items[0].content[0].text
+        try:
+            json.loads(text)
+        except Exception as e:
+            return CaseResult("structured_output_streaming", False,
+                              f"output text not JSON: {e}: {text[:80]}")
+        return CaseResult("structured_output_streaming", True,
+                          f"text={text[:60]}")
+    except Exception as e:
+        return CaseResult("structured_output_streaming", False,
+                          f"{type(e).__name__}: {e}")
+
+
+async def case_error_stream(client: openai.AsyncOpenAI, model: str) -> CaseResult:
+    """Error-stream case: send an invalid json_schema and expect the SDK to
+    iterate the stream WITHOUT raising RuntimeError. Whether the stream
+    surfaces as response.failed or HTTP 4xx depends on the upstream, but the
+    parser MUST NOT crash on the leading event."""
+    try:
+        events: list[str] = []
+        try:
+            async with client.responses.stream(
+                model=model,
+                input=[{"role": "user", "content": "hi"}],
+                text={"format": {"type": "json_schema", "name": "x",
+                                    "schema": {"type": "INVALID_TYPE"}}},
+                max_output_tokens=50,
+            ) as stream:
+                async for event in stream:
+                    events.append(event.type)
+        except openai.APIError:
+            # Acceptable: upstream may reject pre-stream as HTTP error.
+            return CaseResult("error_stream", True, "pre-stream HTTP error (acceptable)")
+        codex_events = [e for e in events if e.startswith("codex.")]
+        if codex_events:
+            return CaseResult("error_stream", False,
+                              f"codex.* leaked: {codex_events}")
+        if events and events[0] != "response.created":
+            return CaseResult("error_stream", False,
+                              f"first event was {events[0]!r}, expected response.created")
+        return CaseResult("error_stream", True, f"events={events}")
+    except RuntimeError as e:
+        return CaseResult("error_stream", False, f"SDK parser raised: {e}")
+    except Exception as e:
+        return CaseResult("error_stream", False, f"{type(e).__name__}: {e}")
+
+
+async def case_non_streaming(client: openai.AsyncOpenAI, model: str) -> CaseResult:
+    """Non-streaming /v1/responses. Asserts SDK parses the response into a
+    valid Response object with populated output."""
+    try:
+        response = await client.responses.create(
+            model=model,
+            input=[{"role": "user", "content": "Reply with exactly: hello"}],
+            max_output_tokens=50,
+            stream=False,
+        )
+        if not response.output:
+            return CaseResult("non_streaming", False, "output empty")
+        return CaseResult("non_streaming", True,
+                          f"output_len={len(response.output)} "
+                          f"status={response.status}")
+    except Exception as e:
+        return CaseResult("non_streaming", False,
+                          f"{type(e).__name__}: {e}")
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", required=True,
+                        help="codex-lb /v1 base URL (e.g. http://127.0.0.1:2455/v1)")
+    parser.add_argument("--api-key", required=True,
+                        help="codex-lb API key (sk-clb-...)")
+    parser.add_argument("--model", default="gpt-5.5")
+    parser.add_argument("--skip", default="",
+                        help="comma-separated case names to skip")
+    args = parser.parse_args()
+
+    client = openai.AsyncOpenAI(api_key=args.api_key, base_url=args.base_url)
+    cases = [
+        ("plain_streaming", case_plain_streaming),
+        ("tool_call_streaming", case_tool_call_streaming),
+        ("structured_output_streaming", case_structured_output_streaming),
+        ("error_stream", case_error_stream),
+        ("non_streaming", case_non_streaming),
+    ]
+    skip = {s.strip() for s in args.skip.split(",") if s.strip()}
+
+    results: list[CaseResult] = []
+    for name, fn in cases:
+        if name in skip:
+            print(f"  ~ {name:30s} SKIP")
+            continue
+        t0 = time.time()
+        result = await fn(client, args.model)
+        elapsed = time.time() - t0
+        marker = "✓ PASS" if result.passed else "✗ FAIL"
+        print(f"  {marker} {result.name:30s} [{elapsed:5.1f}s]  {result.detail}")
+        results.append(result)
+
+    await client.close()
+    failed = [r for r in results if not r.passed]
+    print()
+    print(f"{'='*60}")
+    print(f"Summary: {len(results) - len(failed)}/{len(results)} passed")
+    if failed:
+        print("Failures:")
+        for r in failed:
+            print(f"  - {r.name}: {r.detail}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/e2e/test_openai_sdk_compat.py
+++ b/tests/e2e/test_openai_sdk_compat.py
@@ -27,6 +27,7 @@ Surfaces covered:
 All upstream interactions are mocked via ``monkeypatch`` on the proxy
 service so these tests run hermetically (no network).
 """
+
 from __future__ import annotations
 
 import base64
@@ -60,95 +61,172 @@ IMAGE_MODEL = "gpt-image-2"
 # SSE helpers (mirror test_v1_responses_openai_sdk.py to stay independent)
 # ---------------------------------------------------------------------------
 
+
 def _sse(payload: dict) -> str:
     return f"data: {json.dumps(payload)}\n\n"
 
 
 def _codex_rate_limits_event() -> str:
-    return _sse({
-        "type": "codex.rate_limits",
-        "plan_type": "pro",
-        "rate_limits": {"allowed": True, "limit_reached": False},
-    })
+    return _sse(
+        {
+            "type": "codex.rate_limits",
+            "plan_type": "pro",
+            "rate_limits": {"allowed": True, "limit_reached": False},
+        }
+    )
 
 
 def _response_created(resp_id: str, seq: int = 0) -> str:
-    return _sse({
-        "type": "response.created", "sequence_number": seq,
-        "response": {"id": resp_id, "object": "response",
-                     "status": "in_progress", "output": []},
-    })
+    return _sse(
+        {
+            "type": "response.created",
+            "sequence_number": seq,
+            "response": {"id": resp_id, "object": "response", "status": "in_progress", "output": []},
+        }
+    )
 
 
-def _response_completed_empty(resp_id: str, seq: int,
-                              *, usage: dict | None = None) -> str:
+def _response_completed_empty(resp_id: str, seq: int, *, usage: dict | None = None) -> str:
     body: dict[str, Any] = {
-        "id": resp_id, "object": "response",
-        "status": "completed", "output": [],
+        "id": resp_id,
+        "object": "response",
+        "status": "completed",
+        "output": [],
     }
     body["usage"] = usage or {
-        "input_tokens": 4, "output_tokens": 7, "total_tokens": 11,
+        "input_tokens": 4,
+        "output_tokens": 7,
+        "total_tokens": 11,
     }
-    return _sse({
-        "type": "response.completed", "sequence_number": seq,
-        "response": body,
-    })
+    return _sse(
+        {
+            "type": "response.completed",
+            "sequence_number": seq,
+            "response": body,
+        }
+    )
 
 
-def _message_output_block(item_id: str, text: str, output_index: int,
-                          start_seq: int) -> list[str]:
+def _message_output_block(item_id: str, text: str, output_index: int, start_seq: int) -> list[str]:
     return [
-        _sse({"type": "response.output_item.added",
-              "sequence_number": start_seq, "output_index": output_index,
-              "item": {"id": item_id, "type": "message", "role": "assistant",
-                       "status": "in_progress", "content": []}}),
-        _sse({"type": "response.content_part.added",
-              "sequence_number": start_seq + 1,
-              "output_index": output_index, "content_index": 0,
-              "item_id": item_id,
-              "part": {"type": "output_text", "text": ""}}),
-        _sse({"type": "response.output_text.delta",
-              "sequence_number": start_seq + 2,
-              "output_index": output_index, "content_index": 0,
-              "item_id": item_id, "delta": text, "logprobs": []}),
-        _sse({"type": "response.output_text.done",
-              "sequence_number": start_seq + 3,
-              "output_index": output_index, "content_index": 0,
-              "item_id": item_id, "text": text, "logprobs": []}),
-        _sse({"type": "response.content_part.done",
-              "sequence_number": start_seq + 4,
-              "output_index": output_index, "content_index": 0,
-              "item_id": item_id,
-              "part": {"type": "output_text", "text": text}}),
-        _sse({"type": "response.output_item.done",
-              "sequence_number": start_seq + 5, "output_index": output_index,
-              "item": {"id": item_id, "type": "message", "role": "assistant",
-                       "status": "completed",
-                       "content": [{"type": "output_text", "text": text}]}}),
+        _sse(
+            {
+                "type": "response.output_item.added",
+                "sequence_number": start_seq,
+                "output_index": output_index,
+                "item": {"id": item_id, "type": "message", "role": "assistant", "status": "in_progress", "content": []},
+            }
+        ),
+        _sse(
+            {
+                "type": "response.content_part.added",
+                "sequence_number": start_seq + 1,
+                "output_index": output_index,
+                "content_index": 0,
+                "item_id": item_id,
+                "part": {"type": "output_text", "text": ""},
+            }
+        ),
+        _sse(
+            {
+                "type": "response.output_text.delta",
+                "sequence_number": start_seq + 2,
+                "output_index": output_index,
+                "content_index": 0,
+                "item_id": item_id,
+                "delta": text,
+                "logprobs": [],
+            }
+        ),
+        _sse(
+            {
+                "type": "response.output_text.done",
+                "sequence_number": start_seq + 3,
+                "output_index": output_index,
+                "content_index": 0,
+                "item_id": item_id,
+                "text": text,
+                "logprobs": [],
+            }
+        ),
+        _sse(
+            {
+                "type": "response.content_part.done",
+                "sequence_number": start_seq + 4,
+                "output_index": output_index,
+                "content_index": 0,
+                "item_id": item_id,
+                "part": {"type": "output_text", "text": text},
+            }
+        ),
+        _sse(
+            {
+                "type": "response.output_item.done",
+                "sequence_number": start_seq + 5,
+                "output_index": output_index,
+                "item": {
+                    "id": item_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": text}],
+                },
+            }
+        ),
     ]
 
 
-def _function_call_output_block(call_id: str, name: str, args: str,
-                                output_index: int, start_seq: int) -> list[str]:
+def _function_call_output_block(call_id: str, name: str, args: str, output_index: int, start_seq: int) -> list[str]:
     fc_id = f"fc_{call_id}"
     return [
-        _sse({"type": "response.output_item.added",
-              "sequence_number": start_seq, "output_index": output_index,
-              "item": {"id": fc_id, "type": "function_call",
-                       "status": "in_progress", "call_id": call_id,
-                       "name": name, "arguments": ""}}),
-        _sse({"type": "response.function_call_arguments.delta",
-              "sequence_number": start_seq + 1,
-              "output_index": output_index, "item_id": fc_id, "delta": args}),
-        _sse({"type": "response.function_call_arguments.done",
-              "sequence_number": start_seq + 2,
-              "output_index": output_index, "item_id": fc_id,
-              "arguments": args}),
-        _sse({"type": "response.output_item.done",
-              "sequence_number": start_seq + 3, "output_index": output_index,
-              "item": {"id": fc_id, "type": "function_call",
-                       "status": "completed", "call_id": call_id,
-                       "name": name, "arguments": args}}),
+        _sse(
+            {
+                "type": "response.output_item.added",
+                "sequence_number": start_seq,
+                "output_index": output_index,
+                "item": {
+                    "id": fc_id,
+                    "type": "function_call",
+                    "status": "in_progress",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": "",
+                },
+            }
+        ),
+        _sse(
+            {
+                "type": "response.function_call_arguments.delta",
+                "sequence_number": start_seq + 1,
+                "output_index": output_index,
+                "item_id": fc_id,
+                "delta": args,
+            }
+        ),
+        _sse(
+            {
+                "type": "response.function_call_arguments.done",
+                "sequence_number": start_seq + 2,
+                "output_index": output_index,
+                "item_id": fc_id,
+                "arguments": args,
+            }
+        ),
+        _sse(
+            {
+                "type": "response.output_item.done",
+                "sequence_number": start_seq + 3,
+                "output_index": output_index,
+                "item": {
+                    "id": fc_id,
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": args,
+                },
+            }
+        ),
     ]
 
 
@@ -156,22 +234,25 @@ def _function_call_output_block(call_id: str, name: str, args: str,
 # Fixtures: openai.AsyncOpenAI bound to the ASGI app
 # ---------------------------------------------------------------------------
 
-def _make_upstream_model(
-    slug: str, *, modalities: tuple[str, ...] = ("text",)
-) -> UpstreamModel:
+
+def _make_upstream_model(slug: str, *, modalities: tuple[str, ...] = ("text",)) -> UpstreamModel:
     return UpstreamModel(
-        slug=slug, display_name=slug, description=f"Test model {slug}",
-        context_window=272000, input_modalities=modalities,
-        supported_reasoning_levels=(
-            ReasoningLevel(effort="medium", description="default"),
-        ),
+        slug=slug,
+        display_name=slug,
+        description=f"Test model {slug}",
+        context_window=272000,
+        input_modalities=modalities,
+        supported_reasoning_levels=(ReasoningLevel(effort="medium", description="default"),),
         default_reasoning_level="medium",
         supports_reasoning_summaries=False,
-        support_verbosity=False, default_verbosity=None,
+        support_verbosity=False,
+        default_verbosity=None,
         prefer_websockets=False,
         supports_parallel_tool_calls=True,
-        supported_in_api=True, minimal_client_version=None,
-        priority=0, available_in_plans=frozenset({"plus", "pro"}),
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"plus", "pro"}),
         raw={},
     )
 
@@ -194,7 +275,8 @@ async def sdk_client(
     await enable_api_key_auth(e2e_client)
     created = await create_api_key(e2e_client, name="e2e-sdk-compat")
     await import_test_account(
-        e2e_client, account_id="acc_e2e_compat",
+        e2e_client,
+        account_id="acc_e2e_compat",
         email="e2e-compat@example.com",
     )
 
@@ -204,20 +286,24 @@ async def sdk_client(
             _make_upstream_model(DEFAULT_MODEL),
             _make_upstream_model(TRANSCRIPTION_MODEL),
             _make_upstream_model(
-                IMAGE_MODEL, modalities=("text", "image"),
+                IMAGE_MODEL,
+                modalities=("text", "image"),
             ),
             _make_upstream_model(
-                "gpt-image-1", modalities=("text", "image"),
+                "gpt-image-1",
+                modalities=("text", "image"),
             ),
         ],
         "pro": [
             _make_upstream_model(DEFAULT_MODEL),
             _make_upstream_model(TRANSCRIPTION_MODEL),
             _make_upstream_model(
-                IMAGE_MODEL, modalities=("text", "image"),
+                IMAGE_MODEL,
+                modalities=("text", "image"),
             ),
             _make_upstream_model(
-                "gpt-image-1", modalities=("text", "image"),
+                "gpt-image-1",
+                modalities=("text", "image"),
             ),
         ],
     }
@@ -227,11 +313,13 @@ async def sdk_client(
 
     transport = e2e_client._transport  # noqa: SLF001
     import httpx
+
     client = openai.AsyncOpenAI(
         api_key=created["key"],
         base_url="http://testserver/v1",
         http_client=httpx.AsyncClient(
-            transport=transport, base_url="http://testserver",
+            transport=transport,
+            base_url="http://testserver",
         ),
     )
     yield client
@@ -239,8 +327,7 @@ async def sdk_client(
 
 
 def _patch_upstream_stream(monkeypatch, blocks: list[str]) -> None:
-    async def fake_stream(payload, headers, access_token, account_id,
-                          base_url=None, raise_for_status=False):
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         for block in blocks:
             yield block
 
@@ -251,16 +338,20 @@ def _patch_upstream_stream(monkeypatch, blocks: list[str]) -> None:
 # chat.completions
 # ---------------------------------------------------------------------------
 
+
 class TestChatCompletions:
     @pytest.mark.asyncio
     async def test_non_streaming_plain_text(self, sdk_client, monkeypatch):
         resp_id = "resp_chat_nonstream"
-        _patch_upstream_stream(monkeypatch, [
-            _codex_rate_limits_event(),
-            _response_created(resp_id, 0),
-            *_message_output_block("msg_a", "hi there", 0, 1),
-            _response_completed_empty(resp_id, 7),
-        ])
+        _patch_upstream_stream(
+            monkeypatch,
+            [
+                _codex_rate_limits_event(),
+                _response_created(resp_id, 0),
+                *_message_output_block("msg_a", "hi there", 0, 1),
+                _response_completed_empty(resp_id, 7),
+            ],
+        )
 
         result = await sdk_client.chat.completions.create(
             model=DEFAULT_MODEL,
@@ -275,12 +366,15 @@ class TestChatCompletions:
     @pytest.mark.asyncio
     async def test_streaming_plain_text(self, sdk_client, monkeypatch):
         resp_id = "resp_chat_stream"
-        _patch_upstream_stream(monkeypatch, [
-            _codex_rate_limits_event(),
-            _response_created(resp_id, 0),
-            *_message_output_block("msg_b", "streamed content", 0, 1),
-            _response_completed_empty(resp_id, 7),
-        ])
+        _patch_upstream_stream(
+            monkeypatch,
+            [
+                _codex_rate_limits_event(),
+                _response_created(resp_id, 0),
+                *_message_output_block("msg_b", "streamed content", 0, 1),
+                _response_completed_empty(resp_id, 7),
+            ],
+        )
 
         chunks: list[str] = []
         roles_seen: list[str | None] = []
@@ -305,30 +399,39 @@ class TestChatCompletions:
     @pytest.mark.asyncio
     async def test_tool_call_non_streaming(self, sdk_client, monkeypatch):
         resp_id = "resp_chat_tool"
-        _patch_upstream_stream(monkeypatch, [
-            _codex_rate_limits_event(),
-            _response_created(resp_id, 0),
-            *_function_call_output_block(
-                "call_w", "get_weather", '{"city":"Seoul"}', 0, 1,
-            ),
-            _response_completed_empty(resp_id, 5),
-        ])
+        _patch_upstream_stream(
+            monkeypatch,
+            [
+                _codex_rate_limits_event(),
+                _response_created(resp_id, 0),
+                *_function_call_output_block(
+                    "call_w",
+                    "get_weather",
+                    '{"city":"Seoul"}',
+                    0,
+                    1,
+                ),
+                _response_completed_empty(resp_id, 5),
+            ],
+        )
 
         result = await sdk_client.chat.completions.create(
             model=DEFAULT_MODEL,
             messages=[{"role": "user", "content": "weather?"}],
-            tools=[{
-                "type": "function",
-                "function": {
-                    "name": "get_weather",
-                    "description": "get weather",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"city": {"type": "string"}},
-                        "required": ["city"],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
                     },
-                },
-            }],
+                }
+            ],
         )
 
         message = result.choices[0].message
@@ -345,8 +448,7 @@ class TestChatCompletions:
         resp_id = "resp_chat_multi"
         seen_payload: dict[str, Any] = {}
 
-        async def fake_stream(payload, headers, access_token, account_id,
-                              base_url=None, raise_for_status=False):
+        async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
             seen_payload["payload"] = payload
             for block in [
                 _codex_rate_limits_event(),
@@ -372,14 +474,13 @@ class TestChatCompletions:
         # The chat.completions endpoint translates to a Responses payload
         # before forwarding. Verify the multi-turn history survived.
         forwarded = seen_payload["payload"]
-        assert hasattr(forwarded, "input") or "input" in (
-            forwarded if isinstance(forwarded, dict) else {}
-        )
+        assert hasattr(forwarded, "input") or "input" in (forwarded if isinstance(forwarded, dict) else {})
 
 
 # ---------------------------------------------------------------------------
 # responses.parse (Pydantic structured output)
 # ---------------------------------------------------------------------------
+
 
 class _CityForecast(BaseModel):
     city: str
@@ -395,12 +496,15 @@ class TestResponsesParse:
         ``output_text`` is valid JSON that the SDK can hydrate."""
         resp_id = "resp_parse_struct"
         payload = json.dumps({"city": "Seoul", "temperature_c": 21})
-        _patch_upstream_stream(monkeypatch, [
-            _codex_rate_limits_event(),
-            _response_created(resp_id, 0),
-            *_message_output_block("msg_parse", payload, 0, 1),
-            _response_completed_empty(resp_id, 7),
-        ])
+        _patch_upstream_stream(
+            monkeypatch,
+            [
+                _codex_rate_limits_event(),
+                _response_created(resp_id, 0),
+                *_message_output_block("msg_parse", payload, 0, 1),
+                _response_completed_empty(resp_id, 7),
+            ],
+        )
 
         result = await sdk_client.responses.parse(
             model=DEFAULT_MODEL,
@@ -410,13 +514,15 @@ class TestResponsesParse:
 
         # ``output_parsed`` is the SDK-hydrated Pydantic instance.
         assert result.output_parsed == _CityForecast(
-            city="Seoul", temperature_c=21,
+            city="Seoul",
+            temperature_c=21,
         )
 
 
 # ---------------------------------------------------------------------------
 # models.list
 # ---------------------------------------------------------------------------
+
 
 class TestModels:
     @pytest.mark.asyncio
@@ -429,6 +535,7 @@ class TestModels:
 # ---------------------------------------------------------------------------
 # audio.transcriptions
 # ---------------------------------------------------------------------------
+
 
 def _make_wav_bytes(*, seconds: float = 0.05, sample_rate: int = 16_000) -> bytes:
     buf = io.BytesIO()
@@ -444,7 +551,9 @@ def _make_wav_bytes(*, seconds: float = 0.05, sample_rate: int = 16_000) -> byte
 class TestAudioTranscriptions:
     @pytest.mark.asyncio
     async def test_create_returns_transcription_text(
-        self, sdk_client, monkeypatch,
+        self,
+        sdk_client,
+        monkeypatch,
     ):
         """``client.audio.transcriptions.create`` must reach the
         ``/v1/audio/transcriptions`` route and return the SDK's
@@ -453,8 +562,7 @@ class TestAudioTranscriptions:
         # the upstream Codex transcription endpoint.
         captured: dict[str, Any] = {}
 
-        async def fake_transcribe(self, *, audio_bytes, filename,
-                                  content_type, prompt, headers, api_key):
+        async def fake_transcribe(self, *, audio_bytes, filename, content_type, prompt, headers, api_key):
             captured["filename"] = filename
             captured["bytes_len"] = len(audio_bytes)
             return {"text": "hello transcription"}
@@ -479,9 +587,7 @@ class TestAudioTranscriptions:
 
 # A 1x1 transparent PNG, base64-decoded. Small enough to embed inline and large
 # enough that ``UploadFile`` round-trips it as a real binary payload.
-_PNG_1X1_B64 = (
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII="
-)
+_PNG_1X1_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII="
 _PNG_1X1_BYTES = base64.b64decode(_PNG_1X1_B64)
 
 
@@ -507,40 +613,45 @@ def _patch_images_upstream(
     upstream account refresh (which would otherwise hit a real network).
     """
 
-    async def fake_stream(payload, headers, access_token, account_id,
-                          base_url=None, raise_for_status=False, **kwargs):
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
         del headers, access_token, base_url, raise_for_status, kwargs
         if captured is not None:
             captured["model"] = payload.model
             captured["account_id"] = account_id
             captured["tools"] = list(payload.tools)
-        yield _sse({
-            "type": "response.output_item.done",
-            "output_index": 0,
-            "item": {
-                "type": "image_generation_call",
-                "id": "ig_e2e",
-                "status": "completed",
-                "result": result_b64,
-                "revised_prompt": revised_prompt,
-                "size": size,
-                "quality": "low",
-                "background": "auto",
-                "output_format": output_format,
-            },
-        })
-        yield _sse({
-            "type": "response.completed",
-            "response": {
-                "id": resp_id, "object": "response", "status": "completed",
-                "tool_usage": {
-                    "image_gen": {
-                        "input_tokens": input_tokens,
-                        "output_tokens": output_tokens,
+        yield _sse(
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "image_generation_call",
+                    "id": "ig_e2e",
+                    "status": "completed",
+                    "result": result_b64,
+                    "revised_prompt": revised_prompt,
+                    "size": size,
+                    "quality": "low",
+                    "background": "auto",
+                    "output_format": output_format,
+                },
+            }
+        )
+        yield _sse(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": resp_id,
+                    "object": "response",
+                    "status": "completed",
+                    "tool_usage": {
+                        "image_gen": {
+                            "input_tokens": input_tokens,
+                            "output_tokens": output_tokens,
+                        },
                     },
                 },
-            },
-        })
+            }
+        )
 
     async def fake_ensure_fresh(self, account, **kwargs):
         del self, kwargs
@@ -548,7 +659,9 @@ def _patch_images_upstream(
 
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
     monkeypatch.setattr(
-        proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh,
+        proxy_module.ProxyService,
+        "_ensure_fresh_with_budget",
+        fake_ensure_fresh,
     )
 
 
@@ -597,7 +710,9 @@ class TestImages:
         # gpt-image-2 does not accept image edits; switch model for this
         # case to one that does.
         _patch_images_upstream(
-            monkeypatch, result_b64="EDITED_B64", revised_prompt="edited",
+            monkeypatch,
+            result_b64="EDITED_B64",
+            revised_prompt="edited",
         )
 
         result = await sdk_client.images.edit(
@@ -623,14 +738,13 @@ class TestImages:
                 n=1,
                 size="1024x1024",
             )
-        assert 400 <= ei.value.status_code < 500, (
-            f"images.variation returned non-4xx: {ei.value.status_code}"
-        )
+        assert 400 <= ei.value.status_code < 500, f"images.variation returned non-4xx: {ei.value.status_code}"
 
 
 # ---------------------------------------------------------------------------
 # Unsupported routes — SDK must receive a clean 4xx (NotFoundError)
 # ---------------------------------------------------------------------------
+
 
 class TestUnsupportedSurfaces:
     """The proxy intentionally does not expose these OpenAI surfaces.
@@ -642,15 +756,14 @@ class TestUnsupportedSurfaces:
 
     @staticmethod
     def _assert_clean_4xx(exc: openai.APIStatusError) -> None:
-        assert 400 <= exc.status_code < 500, (
-            f"Unsupported route returned non-4xx status: {exc.status_code}"
-        )
+        assert 400 <= exc.status_code < 500, f"Unsupported route returned non-4xx status: {exc.status_code}"
 
     @pytest.mark.asyncio
     async def test_embeddings_is_clean_4xx(self, sdk_client):
         with pytest.raises(openai.APIStatusError) as ei:
             await sdk_client.embeddings.create(
-                model=DEFAULT_MODEL, input="hello",
+                model=DEFAULT_MODEL,
+                input="hello",
             )
         self._assert_clean_4xx(ei.value)
 

--- a/tests/e2e/test_openai_sdk_compat.py
+++ b/tests/e2e/test_openai_sdk_compat.py
@@ -1,0 +1,521 @@
+"""E2E tests: real OpenAI Python SDK across all supported codex-lb /v1 surfaces.
+
+The companion file ``test_v1_responses_openai_sdk.py`` already covers
+``client.responses.stream(...)`` in detail (G1/G3/G4 normalisation). This
+file widens the surface to **every other** OpenAI SDK method that maps to
+a codex-lb route, plus a parametrised audit of routes the proxy does NOT
+expose — so that a regression to either layer (codex-lb routing or
+``app.modules.proxy.service``) shows up in CI without standing up a real
+upstream account.
+
+Surfaces covered:
+
+- ``client.chat.completions.create(...)`` — streaming, non-streaming,
+  tool-call, multi-turn
+- ``client.responses.parse(text_format=PydanticModel)`` — structured
+  output through the real SDK parser
+- ``client.responses.create(...)`` non-streaming (extra coverage on top
+  of ``test_v1_responses_openai_sdk.py``)
+- ``client.models.list()``
+- ``client.audio.transcriptions.create(file=..., model=...)``
+- ``client.images.generate(...)`` (best-effort against the
+  ``tool_usage.image_gen`` translation path)
+- Unsupported surfaces (embeddings, moderations, files, batches,
+  fine_tuning, ``responses.retrieve/cancel/delete``) — assert the SDK
+  receives a clean 4xx, not a 500.
+
+All upstream interactions are mocked via ``monkeypatch`` on the proxy
+service so these tests run hermetically (no network).
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import struct
+import wave
+from collections.abc import AsyncIterator
+from typing import Any
+
+import openai
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel
+
+import app.modules.proxy.service as proxy_module
+import app.modules.proxy.api as proxy_api_module
+from app.core.openai.model_registry import (
+    ReasoningLevel,
+    UpstreamModel,
+    get_model_registry,
+)
+
+
+pytestmark = pytest.mark.e2e
+
+DEFAULT_MODEL = "gpt-5.5"
+TRANSCRIPTION_MODEL = "gpt-4o-transcribe"
+IMAGE_MODEL = "gpt-image-1"
+
+
+# ---------------------------------------------------------------------------
+# SSE helpers (mirror test_v1_responses_openai_sdk.py to stay independent)
+# ---------------------------------------------------------------------------
+
+def _sse(payload: dict) -> str:
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def _codex_rate_limits_event() -> str:
+    return _sse({
+        "type": "codex.rate_limits",
+        "plan_type": "pro",
+        "rate_limits": {"allowed": True, "limit_reached": False},
+    })
+
+
+def _response_created(resp_id: str, seq: int = 0) -> str:
+    return _sse({
+        "type": "response.created", "sequence_number": seq,
+        "response": {"id": resp_id, "object": "response",
+                     "status": "in_progress", "output": []},
+    })
+
+
+def _response_completed_empty(resp_id: str, seq: int,
+                              *, usage: dict | None = None) -> str:
+    body: dict[str, Any] = {
+        "id": resp_id, "object": "response",
+        "status": "completed", "output": [],
+    }
+    body["usage"] = usage or {
+        "input_tokens": 4, "output_tokens": 7, "total_tokens": 11,
+    }
+    return _sse({
+        "type": "response.completed", "sequence_number": seq,
+        "response": body,
+    })
+
+
+def _message_output_block(item_id: str, text: str, output_index: int,
+                          start_seq: int) -> list[str]:
+    return [
+        _sse({"type": "response.output_item.added",
+              "sequence_number": start_seq, "output_index": output_index,
+              "item": {"id": item_id, "type": "message", "role": "assistant",
+                       "status": "in_progress", "content": []}}),
+        _sse({"type": "response.content_part.added",
+              "sequence_number": start_seq + 1,
+              "output_index": output_index, "content_index": 0,
+              "item_id": item_id,
+              "part": {"type": "output_text", "text": ""}}),
+        _sse({"type": "response.output_text.delta",
+              "sequence_number": start_seq + 2,
+              "output_index": output_index, "content_index": 0,
+              "item_id": item_id, "delta": text, "logprobs": []}),
+        _sse({"type": "response.output_text.done",
+              "sequence_number": start_seq + 3,
+              "output_index": output_index, "content_index": 0,
+              "item_id": item_id, "text": text, "logprobs": []}),
+        _sse({"type": "response.content_part.done",
+              "sequence_number": start_seq + 4,
+              "output_index": output_index, "content_index": 0,
+              "item_id": item_id,
+              "part": {"type": "output_text", "text": text}}),
+        _sse({"type": "response.output_item.done",
+              "sequence_number": start_seq + 5, "output_index": output_index,
+              "item": {"id": item_id, "type": "message", "role": "assistant",
+                       "status": "completed",
+                       "content": [{"type": "output_text", "text": text}]}}),
+    ]
+
+
+def _function_call_output_block(call_id: str, name: str, args: str,
+                                output_index: int, start_seq: int) -> list[str]:
+    fc_id = f"fc_{call_id}"
+    return [
+        _sse({"type": "response.output_item.added",
+              "sequence_number": start_seq, "output_index": output_index,
+              "item": {"id": fc_id, "type": "function_call",
+                       "status": "in_progress", "call_id": call_id,
+                       "name": name, "arguments": ""}}),
+        _sse({"type": "response.function_call_arguments.delta",
+              "sequence_number": start_seq + 1,
+              "output_index": output_index, "item_id": fc_id, "delta": args}),
+        _sse({"type": "response.function_call_arguments.done",
+              "sequence_number": start_seq + 2,
+              "output_index": output_index, "item_id": fc_id,
+              "arguments": args}),
+        _sse({"type": "response.output_item.done",
+              "sequence_number": start_seq + 3, "output_index": output_index,
+              "item": {"id": fc_id, "type": "function_call",
+                       "status": "completed", "call_id": call_id,
+                       "name": name, "arguments": args}}),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: openai.AsyncOpenAI bound to the ASGI app
+# ---------------------------------------------------------------------------
+
+def _make_upstream_model(
+    slug: str, *, modalities: tuple[str, ...] = ("text",)
+) -> UpstreamModel:
+    return UpstreamModel(
+        slug=slug, display_name=slug, description=f"Test model {slug}",
+        context_window=272000, input_modalities=modalities,
+        supported_reasoning_levels=(
+            ReasoningLevel(effort="medium", description="default"),
+        ),
+        default_reasoning_level="medium",
+        supports_reasoning_summaries=False,
+        support_verbosity=False, default_verbosity=None,
+        prefer_websockets=False,
+        supports_parallel_tool_calls=True,
+        supported_in_api=True, minimal_client_version=None,
+        priority=0, available_in_plans=frozenset({"plus", "pro"}),
+        raw={},
+    )
+
+
+@pytest_asyncio.fixture
+async def sdk_client(
+    e2e_client: AsyncClient,
+    setup_dashboard_password,
+    enable_api_key_auth,
+    create_api_key,
+    import_test_account,
+):
+    """Real ``openai.AsyncOpenAI`` bound to the in-process FastAPI app.
+
+    The client uses the same ASGI transport that ``e2e_client`` already
+    set up, so the SDK's HTTP traffic exercises the real codex-lb routing
+    layer end-to-end.
+    """
+    await setup_dashboard_password(e2e_client)
+    await enable_api_key_auth(e2e_client)
+    created = await create_api_key(e2e_client, name="e2e-sdk-compat")
+    await import_test_account(
+        e2e_client, account_id="acc_e2e_compat",
+        email="e2e-compat@example.com",
+    )
+
+    registry = get_model_registry()
+    snapshot = {
+        "plus": [
+            _make_upstream_model(DEFAULT_MODEL),
+            _make_upstream_model(TRANSCRIPTION_MODEL),
+            _make_upstream_model(
+                IMAGE_MODEL, modalities=("text", "image"),
+            ),
+        ],
+        "pro": [
+            _make_upstream_model(DEFAULT_MODEL),
+            _make_upstream_model(TRANSCRIPTION_MODEL),
+            _make_upstream_model(
+                IMAGE_MODEL, modalities=("text", "image"),
+            ),
+        ],
+    }
+    result = registry.update(snapshot)
+    if hasattr(result, "__await__"):
+        await result
+
+    transport = e2e_client._transport  # noqa: SLF001
+    import httpx
+    client = openai.AsyncOpenAI(
+        api_key=created["key"],
+        base_url="http://testserver/v1",
+        http_client=httpx.AsyncClient(
+            transport=transport, base_url="http://testserver",
+        ),
+    )
+    yield client
+    await client.close()
+
+
+def _patch_upstream_stream(monkeypatch, blocks: list[str]) -> None:
+    async def fake_stream(payload, headers, access_token, account_id,
+                          base_url=None, raise_for_status=False):
+        for block in blocks:
+            yield block
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+
+# ---------------------------------------------------------------------------
+# chat.completions
+# ---------------------------------------------------------------------------
+
+class TestChatCompletions:
+    @pytest.mark.asyncio
+    async def test_non_streaming_plain_text(self, sdk_client, monkeypatch):
+        resp_id = "resp_chat_nonstream"
+        _patch_upstream_stream(monkeypatch, [
+            _codex_rate_limits_event(),
+            _response_created(resp_id, 0),
+            *_message_output_block("msg_a", "hi there", 0, 1),
+            _response_completed_empty(resp_id, 7),
+        ])
+
+        result = await sdk_client.chat.completions.create(
+            model=DEFAULT_MODEL,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        assert result.choices
+        assert result.choices[0].message.role == "assistant"
+        assert result.choices[0].message.content == "hi there"
+        assert result.choices[0].finish_reason in {"stop", "length"}
+
+    @pytest.mark.asyncio
+    async def test_streaming_plain_text(self, sdk_client, monkeypatch):
+        resp_id = "resp_chat_stream"
+        _patch_upstream_stream(monkeypatch, [
+            _codex_rate_limits_event(),
+            _response_created(resp_id, 0),
+            *_message_output_block("msg_b", "streamed content", 0, 1),
+            _response_completed_empty(resp_id, 7),
+        ])
+
+        chunks: list[str] = []
+        roles_seen: list[str | None] = []
+        async with await sdk_client.chat.completions.create(
+            model=DEFAULT_MODEL,
+            messages=[{"role": "user", "content": "stream"}],
+            stream=True,
+        ) as stream:
+            async for chunk in stream:
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                if delta.role:
+                    roles_seen.append(delta.role)
+                if delta.content:
+                    chunks.append(delta.content)
+
+        joined = "".join(chunks)
+        assert "streamed content" in joined
+        assert "assistant" in roles_seen
+
+    @pytest.mark.asyncio
+    async def test_tool_call_non_streaming(self, sdk_client, monkeypatch):
+        resp_id = "resp_chat_tool"
+        _patch_upstream_stream(monkeypatch, [
+            _codex_rate_limits_event(),
+            _response_created(resp_id, 0),
+            *_function_call_output_block(
+                "call_w", "get_weather", '{"city":"Seoul"}', 0, 1,
+            ),
+            _response_completed_empty(resp_id, 5),
+        ])
+
+        result = await sdk_client.chat.completions.create(
+            model=DEFAULT_MODEL,
+            messages=[{"role": "user", "content": "weather?"}],
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }],
+        )
+
+        message = result.choices[0].message
+        assert message.tool_calls
+        tc = message.tool_calls[0]
+        assert tc.function.name == "get_weather"
+        assert json.loads(tc.function.arguments) == {"city": "Seoul"}
+        assert result.choices[0].finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_payload_round_trip(self, sdk_client, monkeypatch):
+        """Multi-turn input must reach the proxy untouched and the SDK
+        must parse the reply normally."""
+        resp_id = "resp_chat_multi"
+        seen_payload: dict[str, Any] = {}
+
+        async def fake_stream(payload, headers, access_token, account_id,
+                              base_url=None, raise_for_status=False):
+            seen_payload["payload"] = payload
+            for block in [
+                _codex_rate_limits_event(),
+                _response_created(resp_id, 0),
+                *_message_output_block("msg_m", "ack", 0, 1),
+                _response_completed_empty(resp_id, 7),
+            ]:
+                yield block
+
+        monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+        result = await sdk_client.chat.completions.create(
+            model=DEFAULT_MODEL,
+            messages=[
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "again?"},
+            ],
+        )
+
+        assert result.choices[0].message.content == "ack"
+        # The chat.completions endpoint translates to a Responses payload
+        # before forwarding. Verify the multi-turn history survived.
+        forwarded = seen_payload["payload"]
+        assert hasattr(forwarded, "input") or "input" in (
+            forwarded if isinstance(forwarded, dict) else {}
+        )
+
+
+# ---------------------------------------------------------------------------
+# responses.parse (Pydantic structured output)
+# ---------------------------------------------------------------------------
+
+class _CityForecast(BaseModel):
+    city: str
+    temperature_c: int
+
+
+class TestResponsesParse:
+    @pytest.mark.asyncio
+    async def test_parse_with_pydantic_text_format(self, sdk_client, monkeypatch):
+        """The SDK's ``responses.parse(text_format=Model)`` issues a normal
+        ``responses.create`` then parses the returned ``output_text`` into the
+        Pydantic model. The proxy must produce a stream whose final
+        ``output_text`` is valid JSON that the SDK can hydrate."""
+        resp_id = "resp_parse_struct"
+        payload = json.dumps({"city": "Seoul", "temperature_c": 21})
+        _patch_upstream_stream(monkeypatch, [
+            _codex_rate_limits_event(),
+            _response_created(resp_id, 0),
+            *_message_output_block("msg_parse", payload, 0, 1),
+            _response_completed_empty(resp_id, 7),
+        ])
+
+        result = await sdk_client.responses.parse(
+            model=DEFAULT_MODEL,
+            input=[{"role": "user", "content": "forecast for Seoul"}],
+            text_format=_CityForecast,
+        )
+
+        # ``output_parsed`` is the SDK-hydrated Pydantic instance.
+        assert result.output_parsed == _CityForecast(
+            city="Seoul", temperature_c=21,
+        )
+
+
+# ---------------------------------------------------------------------------
+# models.list
+# ---------------------------------------------------------------------------
+
+class TestModels:
+    @pytest.mark.asyncio
+    async def test_list_returns_registered_models(self, sdk_client):
+        result = await sdk_client.models.list()
+        ids = {model.id for model in result.data}
+        assert DEFAULT_MODEL in ids
+
+
+# ---------------------------------------------------------------------------
+# audio.transcriptions
+# ---------------------------------------------------------------------------
+
+def _make_wav_bytes(*, seconds: float = 0.05, sample_rate: int = 16_000) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        n_samples = int(seconds * sample_rate)
+        w.writeframes(struct.pack("<" + "h" * n_samples, *([0] * n_samples)))
+    return buf.getvalue()
+
+
+class TestAudioTranscriptions:
+    @pytest.mark.asyncio
+    async def test_create_returns_transcription_text(
+        self, sdk_client, monkeypatch,
+    ):
+        """``client.audio.transcriptions.create`` must reach the
+        ``/v1/audio/transcriptions`` route and return the SDK's
+        ``Transcription`` object with ``.text``."""
+        # Patch the proxy service's transcribe method so we don't hit
+        # the upstream Codex transcription endpoint.
+        captured: dict[str, Any] = {}
+
+        async def fake_transcribe(self, *, audio_bytes, filename,
+                                  content_type, prompt, headers, api_key):
+            captured["filename"] = filename
+            captured["bytes_len"] = len(audio_bytes)
+            return {"text": "hello transcription"}
+
+        from app.modules.proxy.service import ProxyService
+
+        monkeypatch.setattr(ProxyService, "transcribe", fake_transcribe)
+
+        wav = _make_wav_bytes()
+        result = await sdk_client.audio.transcriptions.create(
+            model=TRANSCRIPTION_MODEL,
+            file=("sample.wav", wav, "audio/wav"),
+        )
+
+        assert result.text == "hello transcription"
+        assert captured["bytes_len"] == len(wav)
+
+
+# ---------------------------------------------------------------------------
+# Unsupported routes — SDK must receive a clean 4xx (NotFoundError)
+# ---------------------------------------------------------------------------
+
+class TestUnsupportedSurfaces:
+    """The proxy intentionally does not expose these OpenAI surfaces.
+    Calling them through the SDK must yield a clean 4xx
+    (``NotFoundError`` / 405 ``APIStatusError``) rather than a 500 or
+    hang. Accepting any 4xx (and asserting ``< 500``) keeps the test
+    robust to FastAPI's choice of 404 vs 405 depending on whether a
+    different HTTP verb is registered on the same path."""
+
+    @staticmethod
+    def _assert_clean_4xx(exc: openai.APIStatusError) -> None:
+        assert 400 <= exc.status_code < 500, (
+            f"Unsupported route returned non-4xx status: {exc.status_code}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_embeddings_is_clean_4xx(self, sdk_client):
+        with pytest.raises(openai.APIStatusError) as ei:
+            await sdk_client.embeddings.create(
+                model=DEFAULT_MODEL, input="hello",
+            )
+        self._assert_clean_4xx(ei.value)
+
+    @pytest.mark.asyncio
+    async def test_moderations_is_clean_4xx(self, sdk_client):
+        with pytest.raises(openai.APIStatusError) as ei:
+            await sdk_client.moderations.create(input="hello")
+        self._assert_clean_4xx(ei.value)
+
+    @pytest.mark.asyncio
+    async def test_files_list_is_clean_4xx(self, sdk_client):
+        with pytest.raises(openai.APIStatusError) as ei:
+            await sdk_client.files.list()
+        self._assert_clean_4xx(ei.value)
+
+    @pytest.mark.asyncio
+    async def test_batches_list_is_clean_4xx(self, sdk_client):
+        with pytest.raises(openai.APIStatusError) as ei:
+            await sdk_client.batches.list()
+        self._assert_clean_4xx(ei.value)
+
+    @pytest.mark.asyncio
+    async def test_responses_retrieve_is_clean_4xx(self, sdk_client):
+        with pytest.raises(openai.APIStatusError) as ei:
+            await sdk_client.responses.retrieve("resp_does_not_exist")
+        self._assert_clean_4xx(ei.value)

--- a/tests/e2e/test_openai_sdk_compat.py
+++ b/tests/e2e/test_openai_sdk_compat.py
@@ -56,7 +56,7 @@ pytestmark = pytest.mark.e2e
 
 DEFAULT_MODEL = "gpt-5.5"
 TRANSCRIPTION_MODEL = "gpt-4o-transcribe"
-IMAGE_MODEL = "gpt-image-1"
+IMAGE_MODEL = "gpt-image-2"
 
 
 # ---------------------------------------------------------------------------
@@ -209,12 +209,18 @@ async def sdk_client(
             _make_upstream_model(
                 IMAGE_MODEL, modalities=("text", "image"),
             ),
+            _make_upstream_model(
+                "gpt-image-1", modalities=("text", "image"),
+            ),
         ],
         "pro": [
             _make_upstream_model(DEFAULT_MODEL),
             _make_upstream_model(TRANSCRIPTION_MODEL),
             _make_upstream_model(
                 IMAGE_MODEL, modalities=("text", "image"),
+            ),
+            _make_upstream_model(
+                "gpt-image-1", modalities=("text", "image"),
             ),
         ],
     }
@@ -468,6 +474,161 @@ class TestAudioTranscriptions:
 
         assert result.text == "hello transcription"
         assert captured["bytes_len"] == len(wav)
+
+
+# ---------------------------------------------------------------------------
+# images.generate / edit / variation
+# ---------------------------------------------------------------------------
+
+# A 1x1 transparent PNG, base64-decoded. Small enough to embed inline and large
+# enough that ``UploadFile`` round-trips it as a real binary payload.
+_PNG_1X1_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII="
+)
+_PNG_1X1_BYTES = base64.b64decode(_PNG_1X1_B64)
+
+
+def _patch_images_upstream(
+    monkeypatch,
+    *,
+    result_b64: str = "FAKE_IMAGE_B64",
+    revised_prompt: str = "neat",
+    resp_id: str = "resp_img",
+    size: str = "1024x1024",
+    output_format: str = "png",
+    input_tokens: int = 11,
+    output_tokens: int = 17,
+    captured: dict[str, Any] | None = None,
+) -> None:
+    """Patch the upstream Codex stream to emit the minimum SSE sequence the
+    images service needs to translate to a successful images.generate /
+    images.edit / images.variation response: an ``image_generation_call``
+    ``output_item.done`` followed by ``response.completed`` carrying
+    ``tool_usage.image_gen`` tokens.
+
+    Also patches ``_ensure_fresh_with_budget`` so the call path skips
+    upstream account refresh (which would otherwise hit a real network).
+    """
+
+    async def fake_stream(payload, headers, access_token, account_id,
+                          base_url=None, raise_for_status=False, **kwargs):
+        del headers, access_token, base_url, raise_for_status, kwargs
+        if captured is not None:
+            captured["model"] = payload.model
+            captured["account_id"] = account_id
+            captured["tools"] = list(payload.tools)
+        yield _sse({
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "type": "image_generation_call",
+                "id": "ig_e2e",
+                "status": "completed",
+                "result": result_b64,
+                "revised_prompt": revised_prompt,
+                "size": size,
+                "quality": "low",
+                "background": "auto",
+                "output_format": output_format,
+            },
+        })
+        yield _sse({
+            "type": "response.completed",
+            "response": {
+                "id": resp_id, "object": "response", "status": "completed",
+                "tool_usage": {
+                    "image_gen": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                    },
+                },
+            },
+        })
+
+    async def fake_ensure_fresh(self, account, **kwargs):
+        del self, kwargs
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(
+        proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh,
+    )
+
+
+class TestImages:
+    @pytest.mark.asyncio
+    async def test_generate_returns_b64_image(self, sdk_client, monkeypatch):
+        """``client.images.generate(...)`` must reach
+        ``/v1/images/generations`` and return an ``ImagesResponse`` whose
+        ``data[0].b64_json`` matches the upstream tool result. By default
+        the OpenAI SDK requests ``response_format='b64_json'`` for
+        ``gpt-image-*`` models, which is what the proxy emits."""
+        captured: dict[str, Any] = {}
+        _patch_images_upstream(
+            monkeypatch,
+            result_b64="GENERATED_B64",
+            revised_prompt="a clean red circle",
+            captured=captured,
+        )
+
+        result = await sdk_client.images.generate(
+            model=IMAGE_MODEL,
+            prompt="a red circle",
+            n=1,
+            size="1024x1024",
+            quality="low",
+        )
+
+        assert result.data
+        assert result.data[0].b64_json == "GENERATED_B64"
+        # ``revised_prompt`` survives the translation layer.
+        assert result.data[0].revised_prompt == "a clean red circle"
+        # Image routes hide the host model behind ``images_host_model``;
+        # ensure the upstream call really used the configured host model.
+        assert captured["model"] not in {None, ""}
+        tools = captured["tools"]
+        assert tools, "image_generation tool must be forwarded to upstream"
+        assert tools[0]["type"] == "image_generation"
+        assert tools[0]["model"] == IMAGE_MODEL
+
+    @pytest.mark.asyncio
+    async def test_edit_returns_b64_image(self, sdk_client, monkeypatch):
+        """``client.images.edit(image=..., prompt=...)`` posts multipart
+        form-data to ``/v1/images/edits``. The proxy must accept the
+        single ``image`` field, forward the bytes upstream, and return
+        the translated b64 image."""
+        # gpt-image-2 does not accept image edits; switch model for this
+        # case to one that does.
+        _patch_images_upstream(
+            monkeypatch, result_b64="EDITED_B64", revised_prompt="edited",
+        )
+
+        result = await sdk_client.images.edit(
+            model="gpt-image-1",
+            image=("input.png", _PNG_1X1_BYTES, "image/png"),
+            prompt="add a yellow border",
+            n=1,
+            size="1024x1024",
+        )
+
+        assert result.data
+        assert result.data[0].b64_json == "EDITED_B64"
+
+    @pytest.mark.asyncio
+    async def test_variation_is_clean_4xx(self, sdk_client):
+        """The proxy does not implement an image-variation translation
+        path; ``client.images.create_variation(...)`` should yield a
+        clean 4xx through the SDK."""
+        with pytest.raises(openai.APIStatusError) as ei:
+            await sdk_client.images.create_variation(
+                model="gpt-image-1",
+                image=("input.png", _PNG_1X1_BYTES, "image/png"),
+                n=1,
+                size="1024x1024",
+            )
+        assert 400 <= ei.value.status_code < 500, (
+            f"images.variation returned non-4xx: {ei.value.status_code}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_openai_sdk_compat.py
+++ b/tests/e2e/test_openai_sdk_compat.py
@@ -34,23 +34,20 @@ import io
 import json
 import struct
 import wave
-from collections.abc import AsyncIterator
 from typing import Any
 
 import openai
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from pydantic import BaseModel
 
 import app.modules.proxy.service as proxy_module
-import app.modules.proxy.api as proxy_api_module
 from app.core.openai.model_registry import (
     ReasoningLevel,
     UpstreamModel,
     get_model_registry,
 )
-
 
 pytestmark = pytest.mark.e2e
 

--- a/tests/e2e/test_v1_responses_openai_sdk.py
+++ b/tests/e2e/test_v1_responses_openai_sdk.py
@@ -23,18 +23,14 @@ See change ``normalize-v1-responses-openai-sdk-stream`` for the audit and design
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
 
 import openai
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 
 import app.modules.proxy.service as proxy_module
-import app.modules.proxy.api as proxy_api_module
-from app.main import create_app
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
-
 
 pytestmark = pytest.mark.e2e
 

--- a/tests/e2e/test_v1_responses_openai_sdk.py
+++ b/tests/e2e/test_v1_responses_openai_sdk.py
@@ -1,0 +1,409 @@
+"""E2E tests: real OpenAI Python SDK against codex-lb /v1/responses via ASGI.
+
+These tests drive the actual ``openai`` package (``client.responses.stream(...)``
+and ``client.responses.create(...)``) through the in-process FastAPI app via
+``httpx.ASGITransport``. The upstream Codex stream is mocked via
+``core_stream_responses`` (same pattern as ``test_proxy_flow.py``) so the tests
+cover the entire ``codex-lb`` request/response path — including
+``_normalize_public_responses_stream`` — without requiring a real Codex
+account.
+
+The goal is to assert that the public ``/v1`` surface is parseable by the
+stock OpenAI SDK in all request shapes:
+
+- plain text streaming with an upstream ``codex.rate_limits`` leading event
+- tool-call streaming
+- structured output (JSON) streaming
+- error stream where upstream emits ``response.failed`` without ``response.created``
+- terminal ``response.completed`` with empty ``output`` (backfill required)
+- non-streaming ``/v1/responses``
+
+See change ``normalize-v1-responses-openai-sdk-stream`` for the audit and design.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import openai
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+import app.modules.proxy.service as proxy_module
+import app.modules.proxy.api as proxy_api_module
+from app.main import create_app
+from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
+
+
+pytestmark = pytest.mark.e2e
+
+
+# ---------------------------------------------------------------------------
+# Stream payload helpers (build upstream SSE shapes the Codex backend emits)
+# ---------------------------------------------------------------------------
+
+def _sse(payload: dict) -> str:
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+def _codex_rate_limits_event() -> str:
+    """The vendor event the upstream Codex backend emits before response.created
+    (intermittently — throttled per rate-limit window). This event causes the
+    OpenAI SDK parser to raise RuntimeError if it leaks onto the public stream.
+    """
+    return _sse({
+        "type": "codex.rate_limits",
+        "plan_type": "pro",
+        "rate_limits": {"allowed": True, "limit_reached": False},
+    })
+
+
+def _response_created(resp_id: str, seq: int = 0) -> str:
+    return _sse({
+        "type": "response.created", "sequence_number": seq,
+        "response": {"id": resp_id, "object": "response",
+                      "status": "in_progress", "output": []},
+    })
+
+
+def _response_completed_empty(resp_id: str, seq: int) -> str:
+    """The Codex shape: terminal event with output=[]. Real items come via
+    intermediate output_item.done events (which codex-lb must backfill)."""
+    return _sse({
+        "type": "response.completed", "sequence_number": seq,
+        "response": {"id": resp_id, "object": "response",
+                      "status": "completed", "output": [],
+                      "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}},
+    })
+
+
+def _message_output_block(item_id: str, text: str, output_index: int,
+                            start_seq: int) -> list[str]:
+    """Emit the full message-item SSE sequence the Codex backend produces
+    for a message output: output_item.added -> content_part.added ->
+    output_text.delta -> output_text.done -> content_part.done ->
+    output_item.done. Returns the list of SSE blocks and the next sequence
+    number to use (start_seq + 6).
+    """
+    blocks = [
+        _sse({"type": "response.output_item.added",
+               "sequence_number": start_seq, "output_index": output_index,
+               "item": {"id": item_id, "type": "message", "role": "assistant",
+                          "status": "in_progress", "content": []}}),
+        _sse({"type": "response.content_part.added",
+               "sequence_number": start_seq + 1,
+               "output_index": output_index, "content_index": 0,
+               "item_id": item_id,
+               "part": {"type": "output_text", "text": ""}}),
+        _sse({"type": "response.output_text.delta",
+               "sequence_number": start_seq + 2,
+               "output_index": output_index, "content_index": 0,
+               "item_id": item_id, "delta": text, "logprobs": []}),
+        _sse({"type": "response.output_text.done",
+               "sequence_number": start_seq + 3,
+               "output_index": output_index, "content_index": 0,
+               "item_id": item_id, "text": text, "logprobs": []}),
+        _sse({"type": "response.content_part.done",
+               "sequence_number": start_seq + 4,
+               "output_index": output_index, "content_index": 0,
+               "item_id": item_id,
+               "part": {"type": "output_text", "text": text}}),
+        _sse({"type": "response.output_item.done",
+               "sequence_number": start_seq + 5, "output_index": output_index,
+               "item": {"id": item_id, "type": "message", "role": "assistant",
+                          "status": "completed",
+                          "content": [{"type": "output_text", "text": text}]}}),
+    ]
+    return blocks
+
+
+def _function_call_output_block(call_id: str, name: str, args: str,
+                                  output_index: int, start_seq: int) -> list[str]:
+    """Emit the full function-call SSE sequence: output_item.added ->
+    function_call_arguments.delta -> function_call_arguments.done ->
+    output_item.done. (No content_part for function_call items.)"""
+    fc_id = f"fc_{call_id}"
+    return [
+        _sse({"type": "response.output_item.added",
+               "sequence_number": start_seq, "output_index": output_index,
+               "item": {"id": fc_id, "type": "function_call",
+                          "status": "in_progress", "call_id": call_id,
+                          "name": name, "arguments": ""}}),
+        _sse({"type": "response.function_call_arguments.delta",
+               "sequence_number": start_seq + 1,
+               "output_index": output_index, "item_id": fc_id, "delta": args}),
+        _sse({"type": "response.function_call_arguments.done",
+               "sequence_number": start_seq + 2,
+               "output_index": output_index, "item_id": fc_id,
+               "arguments": args}),
+        _sse({"type": "response.output_item.done",
+               "sequence_number": start_seq + 3, "output_index": output_index,
+               "item": {"id": fc_id, "type": "function_call",
+                          "status": "completed", "call_id": call_id,
+                          "name": name, "arguments": args}}),
+    ]
+
+
+def _message_output_item_done(item_id: str, text: str, output_index: int, seq: int) -> str:
+    """Single-event helper retained for tests that only need the terminal
+    item event (e.g. backfill correctness checks)."""
+    return _sse({
+        "type": "response.output_item.done", "sequence_number": seq,
+        "output_index": output_index,
+        "item": {"id": item_id, "type": "message", "role": "assistant",
+                  "status": "completed",
+                  "content": [{"type": "output_text", "text": text}]},
+    })
+
+
+def _function_call_output_item_done(call_id: str, name: str, args: str,
+                                      output_index: int, seq: int) -> str:
+    return _sse({
+        "type": "response.output_item.done", "sequence_number": seq,
+        "output_index": output_index,
+        "item": {"id": f"fc_{call_id}", "type": "function_call",
+                  "status": "completed", "call_id": call_id,
+                  "name": name, "arguments": args},
+    })
+
+
+def _response_failed_only(resp_id: str) -> str:
+    """Upstream rejection mid-stream — response.failed without response.created.
+    The /v1 normalizer must synthesize response.created before forwarding."""
+    return _sse({
+        "type": "response.failed", "sequence_number": 0,
+        "response": {"id": resp_id, "object": "response", "status": "failed",
+                      "output": [],
+                      "error": {"code": "invalid_request_error",
+                                  "message": "bad schema"}},
+    })
+
+
+# ---------------------------------------------------------------------------
+# ASGI client fixture + auth setup (reuses e2e conftest fixtures)
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "gpt-5.5"
+
+
+def _make_upstream_model(slug: str) -> UpstreamModel:
+    return UpstreamModel(
+        slug=slug, display_name=slug, description=f"Test model {slug}",
+        context_window=272000, input_modalities=("text",),
+        supported_reasoning_levels=(ReasoningLevel(effort="medium", description="default"),),
+        default_reasoning_level="medium",
+        supports_reasoning_summaries=False,
+        support_verbosity=False, default_verbosity=None,
+        prefer_websockets=False,
+        supports_parallel_tool_calls=True,
+        supported_in_api=True, minimal_client_version=None,
+        priority=0, available_in_plans=frozenset({"plus", "pro"}),
+        raw={},
+    )
+
+
+@pytest_asyncio.fixture
+async def sdk_client(
+    e2e_client: AsyncClient,
+    setup_dashboard_password,
+    enable_api_key_auth,
+    create_api_key,
+    import_test_account,
+):
+    """Build a real openai.AsyncOpenAI client that talks to the in-process
+    ASGI app via httpx.ASGITransport. Returns (openai_client, api_key)."""
+    await setup_dashboard_password(e2e_client)
+    await enable_api_key_auth(e2e_client)
+    created = await create_api_key(e2e_client, name="e2e-sdk-key")
+    await import_test_account(e2e_client, account_id="acc_e2e_sdk",
+                               email="e2e-sdk@example.com")
+    # Populate the model registry so the proxy accepts the model name.
+    registry = get_model_registry()
+    snapshot = {
+        "plus": [_make_upstream_model(DEFAULT_MODEL)],
+        "pro": [_make_upstream_model(DEFAULT_MODEL)],
+    }
+    result = registry.update(snapshot)
+    if hasattr(result, "__await__"):
+        await result
+    # Reuse the same ASGITransport that e2e_client built.
+    transport = e2e_client._transport  # noqa: SLF001
+    client = openai.AsyncOpenAI(
+        api_key=created["key"],
+        base_url="http://testserver/v1",
+        http_client=__import__("httpx").AsyncClient(transport=transport,
+                                                    base_url="http://testserver"),
+    )
+    yield client
+    await client.close()
+
+
+def _patch_upstream_stream(monkeypatch, blocks: list[str]) -> None:
+    """Replace ``proxy_module.core_stream_responses`` with a stub that yields
+    the given pre-built SSE blocks."""
+
+    async def fake_stream(payload, headers, access_token, account_id,
+                          base_url=None, raise_for_status=False):
+        for block in blocks:
+            yield block
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sdk_responses_stream_plain_text_with_leading_codex_rate_limits(
+    sdk_client, monkeypatch,
+) -> None:
+    """G1 + G3 combined: upstream emits codex.rate_limits before
+    response.created, and response.completed carries output=[]. The OpenAI
+    SDK stream parser must complete the stream and get_final_response().output
+    must contain the message item."""
+    resp_id = "resp_plain"
+    blocks = [
+        _codex_rate_limits_event(),  # MUST be dropped
+        _response_created(resp_id, 0),
+        *_message_output_block("msg_plain", "hello from stream", 0, 1),
+        _response_completed_empty(resp_id, 7),  # MUST be backfilled
+    ]
+    _patch_upstream_stream(monkeypatch, blocks)
+
+    async with sdk_client.responses.stream(
+        model=DEFAULT_MODEL,
+        input=[{"role": "user", "content": "hi"}],
+    ) as stream:
+        events_seen: list[str] = []
+        async for event in stream:
+            events_seen.append(event.type)
+        final = await stream.get_final_response()
+
+    assert "response.created" in events_seen
+    # codex.rate_limits MUST NOT reach the SDK
+    assert not any(t.startswith("codex.") for t in events_seen)
+    assert final.id == resp_id
+    assert len(final.output) == 1
+    assert final.output[0].type == "message"
+    msg = final.output[0]
+    assert msg.content[0].text == "hello from stream"
+
+
+@pytest.mark.asyncio
+async def test_sdk_responses_stream_tool_call(sdk_client, monkeypatch) -> None:
+    """Streaming tool-call response: function_call output item must survive
+    the backfill path and arrive in get_final_response().output."""
+    resp_id = "resp_tool"
+    blocks = [
+        _codex_rate_limits_event(),
+        _response_created(resp_id, 0),
+        *_function_call_output_block("call_1", "get_weather",
+                                       '{"city":"Seoul"}', 0, 1),
+        _response_completed_empty(resp_id, 5),
+    ]
+    _patch_upstream_stream(monkeypatch, blocks)
+
+    async with sdk_client.responses.stream(
+        model=DEFAULT_MODEL,
+        input=[{"role": "user", "content": "weather?"}],
+        tools=[{"type": "function", "name": "get_weather",
+                 "description": "get weather",
+                 "parameters": {"type": "object",
+                                  "properties": {"city": {"type": "string"}},
+                                  "required": ["city"]}}],
+    ) as stream:
+        async for _ in stream:
+            pass
+        final = await stream.get_final_response()
+
+    assert final.id == resp_id
+    assert len(final.output) == 1
+    item = final.output[0]
+    assert item.type == "function_call"
+    assert item.name == "get_weather"
+    assert json.loads(item.arguments) == {"city": "Seoul"}
+
+
+@pytest.mark.asyncio
+async def test_sdk_responses_stream_structured_output(
+    sdk_client, monkeypatch,
+) -> None:
+    """Streaming JSON-formatted response. SDK must parse it as a normal
+    message output_text item; the proxy is not responsible for JSON validation
+    here (that is the model's job), only for SDK-parseable framing."""
+    resp_id = "resp_json"
+    blocks = [
+        _codex_rate_limits_event(),
+        _response_created(resp_id, 0),
+        *_message_output_block("msg_json", '{"city":"Seoul"}', 0, 1),
+        _response_completed_empty(resp_id, 7),
+    ]
+    _patch_upstream_stream(monkeypatch, blocks)
+
+    async with sdk_client.responses.stream(
+        model=DEFAULT_MODEL,
+        input=[{"role": "user", "content": "respond as json"}],
+        text={"format": {"type": "json_object"}},
+    ) as stream:
+        async for _ in stream:
+            pass
+        final = await stream.get_final_response()
+
+    assert len(final.output) == 1
+    text = final.output[0].content[0].text
+    assert json.loads(text) == {"city": "Seoul"}
+
+
+@pytest.mark.asyncio
+async def test_sdk_responses_stream_upstream_rejection_synthesizes_created(
+    sdk_client, monkeypatch,
+) -> None:
+    """G4: upstream rejects without emitting response.created. The /v1
+    normalizer must synthesize response.created so the SDK parser does NOT
+    raise RuntimeError; the SDK then observes response.failed cleanly."""
+    resp_id = "resp_err"
+    _patch_upstream_stream(monkeypatch, [
+        _codex_rate_limits_event(),  # dropped
+        _response_failed_only(resp_id),  # only standard event
+    ])
+
+    events_seen: list[str] = []
+    async with sdk_client.responses.stream(
+        model=DEFAULT_MODEL,
+        input=[{"role": "user", "content": "trigger error"}],
+    ) as stream:
+        async for event in stream:
+            events_seen.append(event.type)
+        # get_final_response() raises on failed streams (no response.completed),
+        # which is the SDK's normal contract — the test asserts the stream
+        # PARSER didn't raise mid-iteration.
+    assert "response.created" in events_seen
+    assert "response.failed" in events_seen
+    assert not any(t.startswith("codex.") for t in events_seen)
+
+
+@pytest.mark.asyncio
+async def test_sdk_responses_non_streaming(sdk_client, monkeypatch) -> None:
+    """Non-streaming /v1/responses: SDK must parse the returned JSON into a
+    valid Response object with populated output. The non-streaming path already
+    has _collect_responses_payload backfill; this test pins the behavior."""
+    resp_id = "resp_nonstream"
+    _patch_upstream_stream(monkeypatch, [
+        _codex_rate_limits_event(),
+        _response_created(resp_id, 0),
+        _message_output_item_done("msg_n", "non-stream output", 0, 1),
+        _response_completed_empty(resp_id, 2),
+    ])
+
+    response = await sdk_client.responses.create(
+        model=DEFAULT_MODEL,
+        input=[{"role": "user", "content": "hi"}],
+        stream=False,
+    )
+
+    assert response.id == resp_id
+    assert response.status == "completed"
+    assert len(response.output) == 1
+    assert response.output[0].content[0].text == "non-stream output"

--- a/tests/e2e/test_v1_responses_openai_sdk.py
+++ b/tests/e2e/test_v1_responses_openai_sdk.py
@@ -20,6 +20,7 @@ stock OpenAI SDK in all request shapes:
 
 See change ``normalize-v1-responses-openai-sdk-stream`` for the audit and design.
 """
+
 from __future__ import annotations
 
 import json
@@ -39,6 +40,7 @@ pytestmark = pytest.mark.e2e
 # Stream payload helpers (build upstream SSE shapes the Codex backend emits)
 # ---------------------------------------------------------------------------
 
+
 def _sse(payload: dict) -> str:
     return f"data: {json.dumps(payload)}\n\n"
 
@@ -48,34 +50,44 @@ def _codex_rate_limits_event() -> str:
     (intermittently — throttled per rate-limit window). This event causes the
     OpenAI SDK parser to raise RuntimeError if it leaks onto the public stream.
     """
-    return _sse({
-        "type": "codex.rate_limits",
-        "plan_type": "pro",
-        "rate_limits": {"allowed": True, "limit_reached": False},
-    })
+    return _sse(
+        {
+            "type": "codex.rate_limits",
+            "plan_type": "pro",
+            "rate_limits": {"allowed": True, "limit_reached": False},
+        }
+    )
 
 
 def _response_created(resp_id: str, seq: int = 0) -> str:
-    return _sse({
-        "type": "response.created", "sequence_number": seq,
-        "response": {"id": resp_id, "object": "response",
-                      "status": "in_progress", "output": []},
-    })
+    return _sse(
+        {
+            "type": "response.created",
+            "sequence_number": seq,
+            "response": {"id": resp_id, "object": "response", "status": "in_progress", "output": []},
+        }
+    )
 
 
 def _response_completed_empty(resp_id: str, seq: int) -> str:
     """The Codex shape: terminal event with output=[]. Real items come via
     intermediate output_item.done events (which codex-lb must backfill)."""
-    return _sse({
-        "type": "response.completed", "sequence_number": seq,
-        "response": {"id": resp_id, "object": "response",
-                      "status": "completed", "output": [],
-                      "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5}},
-    })
+    return _sse(
+        {
+            "type": "response.completed",
+            "sequence_number": seq,
+            "response": {
+                "id": resp_id,
+                "object": "response",
+                "status": "completed",
+                "output": [],
+                "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5},
+            },
+        }
+    )
 
 
-def _message_output_block(item_id: str, text: str, output_index: int,
-                            start_seq: int) -> list[str]:
+def _message_output_block(item_id: str, text: str, output_index: int, start_seq: int) -> list[str]:
     """Emit the full message-item SSE sequence the Codex backend produces
     for a message output: output_item.added -> content_part.added ->
     output_text.delta -> output_text.done -> content_part.done ->
@@ -83,97 +95,184 @@ def _message_output_block(item_id: str, text: str, output_index: int,
     number to use (start_seq + 6).
     """
     blocks = [
-        _sse({"type": "response.output_item.added",
-               "sequence_number": start_seq, "output_index": output_index,
-               "item": {"id": item_id, "type": "message", "role": "assistant",
-                          "status": "in_progress", "content": []}}),
-        _sse({"type": "response.content_part.added",
-               "sequence_number": start_seq + 1,
-               "output_index": output_index, "content_index": 0,
-               "item_id": item_id,
-               "part": {"type": "output_text", "text": ""}}),
-        _sse({"type": "response.output_text.delta",
-               "sequence_number": start_seq + 2,
-               "output_index": output_index, "content_index": 0,
-               "item_id": item_id, "delta": text, "logprobs": []}),
-        _sse({"type": "response.output_text.done",
-               "sequence_number": start_seq + 3,
-               "output_index": output_index, "content_index": 0,
-               "item_id": item_id, "text": text, "logprobs": []}),
-        _sse({"type": "response.content_part.done",
-               "sequence_number": start_seq + 4,
-               "output_index": output_index, "content_index": 0,
-               "item_id": item_id,
-               "part": {"type": "output_text", "text": text}}),
-        _sse({"type": "response.output_item.done",
-               "sequence_number": start_seq + 5, "output_index": output_index,
-               "item": {"id": item_id, "type": "message", "role": "assistant",
-                          "status": "completed",
-                          "content": [{"type": "output_text", "text": text}]}}),
+        _sse(
+            {
+                "type": "response.output_item.added",
+                "sequence_number": start_seq,
+                "output_index": output_index,
+                "item": {"id": item_id, "type": "message", "role": "assistant", "status": "in_progress", "content": []},
+            }
+        ),
+        _sse(
+            {
+                "type": "response.content_part.added",
+                "sequence_number": start_seq + 1,
+                "output_index": output_index,
+                "content_index": 0,
+                "item_id": item_id,
+                "part": {"type": "output_text", "text": ""},
+            }
+        ),
+        _sse(
+            {
+                "type": "response.output_text.delta",
+                "sequence_number": start_seq + 2,
+                "output_index": output_index,
+                "content_index": 0,
+                "item_id": item_id,
+                "delta": text,
+                "logprobs": [],
+            }
+        ),
+        _sse(
+            {
+                "type": "response.output_text.done",
+                "sequence_number": start_seq + 3,
+                "output_index": output_index,
+                "content_index": 0,
+                "item_id": item_id,
+                "text": text,
+                "logprobs": [],
+            }
+        ),
+        _sse(
+            {
+                "type": "response.content_part.done",
+                "sequence_number": start_seq + 4,
+                "output_index": output_index,
+                "content_index": 0,
+                "item_id": item_id,
+                "part": {"type": "output_text", "text": text},
+            }
+        ),
+        _sse(
+            {
+                "type": "response.output_item.done",
+                "sequence_number": start_seq + 5,
+                "output_index": output_index,
+                "item": {
+                    "id": item_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": text}],
+                },
+            }
+        ),
     ]
     return blocks
 
 
-def _function_call_output_block(call_id: str, name: str, args: str,
-                                  output_index: int, start_seq: int) -> list[str]:
+def _function_call_output_block(call_id: str, name: str, args: str, output_index: int, start_seq: int) -> list[str]:
     """Emit the full function-call SSE sequence: output_item.added ->
     function_call_arguments.delta -> function_call_arguments.done ->
     output_item.done. (No content_part for function_call items.)"""
     fc_id = f"fc_{call_id}"
     return [
-        _sse({"type": "response.output_item.added",
-               "sequence_number": start_seq, "output_index": output_index,
-               "item": {"id": fc_id, "type": "function_call",
-                          "status": "in_progress", "call_id": call_id,
-                          "name": name, "arguments": ""}}),
-        _sse({"type": "response.function_call_arguments.delta",
-               "sequence_number": start_seq + 1,
-               "output_index": output_index, "item_id": fc_id, "delta": args}),
-        _sse({"type": "response.function_call_arguments.done",
-               "sequence_number": start_seq + 2,
-               "output_index": output_index, "item_id": fc_id,
-               "arguments": args}),
-        _sse({"type": "response.output_item.done",
-               "sequence_number": start_seq + 3, "output_index": output_index,
-               "item": {"id": fc_id, "type": "function_call",
-                          "status": "completed", "call_id": call_id,
-                          "name": name, "arguments": args}}),
+        _sse(
+            {
+                "type": "response.output_item.added",
+                "sequence_number": start_seq,
+                "output_index": output_index,
+                "item": {
+                    "id": fc_id,
+                    "type": "function_call",
+                    "status": "in_progress",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": "",
+                },
+            }
+        ),
+        _sse(
+            {
+                "type": "response.function_call_arguments.delta",
+                "sequence_number": start_seq + 1,
+                "output_index": output_index,
+                "item_id": fc_id,
+                "delta": args,
+            }
+        ),
+        _sse(
+            {
+                "type": "response.function_call_arguments.done",
+                "sequence_number": start_seq + 2,
+                "output_index": output_index,
+                "item_id": fc_id,
+                "arguments": args,
+            }
+        ),
+        _sse(
+            {
+                "type": "response.output_item.done",
+                "sequence_number": start_seq + 3,
+                "output_index": output_index,
+                "item": {
+                    "id": fc_id,
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": call_id,
+                    "name": name,
+                    "arguments": args,
+                },
+            }
+        ),
     ]
 
 
 def _message_output_item_done(item_id: str, text: str, output_index: int, seq: int) -> str:
     """Single-event helper retained for tests that only need the terminal
     item event (e.g. backfill correctness checks)."""
-    return _sse({
-        "type": "response.output_item.done", "sequence_number": seq,
-        "output_index": output_index,
-        "item": {"id": item_id, "type": "message", "role": "assistant",
-                  "status": "completed",
-                  "content": [{"type": "output_text", "text": text}]},
-    })
+    return _sse(
+        {
+            "type": "response.output_item.done",
+            "sequence_number": seq,
+            "output_index": output_index,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": text}],
+            },
+        }
+    )
 
 
-def _function_call_output_item_done(call_id: str, name: str, args: str,
-                                      output_index: int, seq: int) -> str:
-    return _sse({
-        "type": "response.output_item.done", "sequence_number": seq,
-        "output_index": output_index,
-        "item": {"id": f"fc_{call_id}", "type": "function_call",
-                  "status": "completed", "call_id": call_id,
-                  "name": name, "arguments": args},
-    })
+def _function_call_output_item_done(call_id: str, name: str, args: str, output_index: int, seq: int) -> str:
+    return _sse(
+        {
+            "type": "response.output_item.done",
+            "sequence_number": seq,
+            "output_index": output_index,
+            "item": {
+                "id": f"fc_{call_id}",
+                "type": "function_call",
+                "status": "completed",
+                "call_id": call_id,
+                "name": name,
+                "arguments": args,
+            },
+        }
+    )
 
 
 def _response_failed_only(resp_id: str) -> str:
     """Upstream rejection mid-stream — response.failed without response.created.
     The /v1 normalizer must synthesize response.created before forwarding."""
-    return _sse({
-        "type": "response.failed", "sequence_number": 0,
-        "response": {"id": resp_id, "object": "response", "status": "failed",
-                      "output": [],
-                      "error": {"code": "invalid_request_error",
-                                  "message": "bad schema"}},
-    })
+    return _sse(
+        {
+            "type": "response.failed",
+            "sequence_number": 0,
+            "response": {
+                "id": resp_id,
+                "object": "response",
+                "status": "failed",
+                "output": [],
+                "error": {"code": "invalid_request_error", "message": "bad schema"},
+            },
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -185,16 +284,22 @@ DEFAULT_MODEL = "gpt-5.5"
 
 def _make_upstream_model(slug: str) -> UpstreamModel:
     return UpstreamModel(
-        slug=slug, display_name=slug, description=f"Test model {slug}",
-        context_window=272000, input_modalities=("text",),
+        slug=slug,
+        display_name=slug,
+        description=f"Test model {slug}",
+        context_window=272000,
+        input_modalities=("text",),
         supported_reasoning_levels=(ReasoningLevel(effort="medium", description="default"),),
         default_reasoning_level="medium",
         supports_reasoning_summaries=False,
-        support_verbosity=False, default_verbosity=None,
+        support_verbosity=False,
+        default_verbosity=None,
         prefer_websockets=False,
         supports_parallel_tool_calls=True,
-        supported_in_api=True, minimal_client_version=None,
-        priority=0, available_in_plans=frozenset({"plus", "pro"}),
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"plus", "pro"}),
         raw={},
     )
 
@@ -212,8 +317,7 @@ async def sdk_client(
     await setup_dashboard_password(e2e_client)
     await enable_api_key_auth(e2e_client)
     created = await create_api_key(e2e_client, name="e2e-sdk-key")
-    await import_test_account(e2e_client, account_id="acc_e2e_sdk",
-                               email="e2e-sdk@example.com")
+    await import_test_account(e2e_client, account_id="acc_e2e_sdk", email="e2e-sdk@example.com")
     # Populate the model registry so the proxy accepts the model name.
     registry = get_model_registry()
     snapshot = {
@@ -228,8 +332,7 @@ async def sdk_client(
     client = openai.AsyncOpenAI(
         api_key=created["key"],
         base_url="http://testserver/v1",
-        http_client=__import__("httpx").AsyncClient(transport=transport,
-                                                    base_url="http://testserver"),
+        http_client=__import__("httpx").AsyncClient(transport=transport, base_url="http://testserver"),
     )
     yield client
     await client.close()
@@ -239,8 +342,7 @@ def _patch_upstream_stream(monkeypatch, blocks: list[str]) -> None:
     """Replace ``proxy_module.core_stream_responses`` with a stub that yields
     the given pre-built SSE blocks."""
 
-    async def fake_stream(payload, headers, access_token, account_id,
-                          base_url=None, raise_for_status=False):
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         for block in blocks:
             yield block
 
@@ -251,9 +353,11 @@ def _patch_upstream_stream(monkeypatch, blocks: list[str]) -> None:
 # Test cases
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_sdk_responses_stream_plain_text_with_leading_codex_rate_limits(
-    sdk_client, monkeypatch,
+    sdk_client,
+    monkeypatch,
 ) -> None:
     """G1 + G3 combined: upstream emits codex.rate_limits before
     response.created, and response.completed carries output=[]. The OpenAI
@@ -295,8 +399,7 @@ async def test_sdk_responses_stream_tool_call(sdk_client, monkeypatch) -> None:
     blocks = [
         _codex_rate_limits_event(),
         _response_created(resp_id, 0),
-        *_function_call_output_block("call_1", "get_weather",
-                                       '{"city":"Seoul"}', 0, 1),
+        *_function_call_output_block("call_1", "get_weather", '{"city":"Seoul"}', 0, 1),
         _response_completed_empty(resp_id, 5),
     ]
     _patch_upstream_stream(monkeypatch, blocks)
@@ -304,11 +407,14 @@ async def test_sdk_responses_stream_tool_call(sdk_client, monkeypatch) -> None:
     async with sdk_client.responses.stream(
         model=DEFAULT_MODEL,
         input=[{"role": "user", "content": "weather?"}],
-        tools=[{"type": "function", "name": "get_weather",
-                 "description": "get weather",
-                 "parameters": {"type": "object",
-                                  "properties": {"city": {"type": "string"}},
-                                  "required": ["city"]}}],
+        tools=[
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "get weather",
+                "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]},
+            }
+        ],
     ) as stream:
         async for _ in stream:
             pass
@@ -324,7 +430,8 @@ async def test_sdk_responses_stream_tool_call(sdk_client, monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_sdk_responses_stream_structured_output(
-    sdk_client, monkeypatch,
+    sdk_client,
+    monkeypatch,
 ) -> None:
     """Streaming JSON-formatted response. SDK must parse it as a normal
     message output_text item; the proxy is not responsible for JSON validation
@@ -354,16 +461,20 @@ async def test_sdk_responses_stream_structured_output(
 
 @pytest.mark.asyncio
 async def test_sdk_responses_stream_upstream_rejection_synthesizes_created(
-    sdk_client, monkeypatch,
+    sdk_client,
+    monkeypatch,
 ) -> None:
     """G4: upstream rejects without emitting response.created. The /v1
     normalizer must synthesize response.created so the SDK parser does NOT
     raise RuntimeError; the SDK then observes response.failed cleanly."""
     resp_id = "resp_err"
-    _patch_upstream_stream(monkeypatch, [
-        _codex_rate_limits_event(),  # dropped
-        _response_failed_only(resp_id),  # only standard event
-    ])
+    _patch_upstream_stream(
+        monkeypatch,
+        [
+            _codex_rate_limits_event(),  # dropped
+            _response_failed_only(resp_id),  # only standard event
+        ],
+    )
 
     events_seen: list[str] = []
     async with sdk_client.responses.stream(
@@ -386,12 +497,15 @@ async def test_sdk_responses_non_streaming(sdk_client, monkeypatch) -> None:
     valid Response object with populated output. The non-streaming path already
     has _collect_responses_payload backfill; this test pins the behavior."""
     resp_id = "resp_nonstream"
-    _patch_upstream_stream(monkeypatch, [
-        _codex_rate_limits_event(),
-        _response_created(resp_id, 0),
-        _message_output_item_done("msg_n", "non-stream output", 0, 1),
-        _response_completed_empty(resp_id, 2),
-    ])
+    _patch_upstream_stream(
+        monkeypatch,
+        [
+            _codex_rate_limits_event(),
+            _response_created(resp_id, 0),
+            _message_output_item_done("msg_n", "non-stream output", 0, 1),
+            _response_completed_empty(resp_id, 2),
+        ],
+    )
 
     response = await sdk_client.responses.create(
         model=DEFAULT_MODEL,

--- a/tests/integration/test_codex_client_compat.py
+++ b/tests/integration/test_codex_client_compat.py
@@ -48,12 +48,12 @@ async def test_codex_style_responses_payload_is_accepted(async_client):
     assert event["type"] == "response.created"
     # The terminal event (somewhere after response.created) should be one of
     # the known terminal types.
-    terminal_types = {"response.completed", "response.incomplete",
-                       "response.failed", "error"}
+    terminal_types = {"response.completed", "response.incomplete", "response.failed", "error"}
     terminal_events = [
         json.loads(line[6:])
         for line in lines
-        if line.startswith("data: ") and not line.startswith("data: [DONE]")
+        if line.startswith("data: ")
+        and not line.startswith("data: [DONE]")
         and json.loads(line[6:]).get("type") in terminal_types
     ]
     assert terminal_events, "Expected at least one terminal event in the stream"

--- a/tests/integration/test_codex_client_compat.py
+++ b/tests/integration/test_codex_client_compat.py
@@ -36,5 +36,24 @@ async def test_codex_style_responses_payload_is_accepted(async_client):
         assert resp.status_code == 200
         lines = [line async for line in resp.aiter_lines() if line]
 
+    # Public /v1/responses stream MUST start with `response.created` per the
+    # OpenAI Responses SSE contract; the proxy synthesizes one when the
+    # upstream stream skips it (e.g. when no accounts are available and
+    # upstream emits only `response.failed`). The original intent of this
+    # test is to verify the Codex-style payload (input_text, tool_choice,
+    # parallel_tool_calls, include) is accepted and a stream begins —
+    # whether the stream then completes, fails, or terminates depends on
+    # upstream availability and is asserted elsewhere.
     event = _extract_first_event(lines)
-    assert event["type"] in ("response.failed", "response.completed", "response.incomplete")
+    assert event["type"] == "response.created"
+    # The terminal event (somewhere after response.created) should be one of
+    # the known terminal types.
+    terminal_types = {"response.completed", "response.incomplete",
+                       "response.failed", "error"}
+    terminal_events = [
+        json.loads(line[6:])
+        for line in lines
+        if line.startswith("data: ") and not line.startswith("data: [DONE]")
+        and json.loads(line[6:]).get("type") in terminal_types
+    ]
+    assert terminal_events, "Expected at least one terminal event in the stream"

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -52,9 +52,21 @@ def _sse_event(payload: dict) -> str:
 
 
 def _extract_first_event(lines: list[str]) -> dict:
+    """Return the first non-synthesized SSE event payload. Skips the
+    synthesized ``response.created`` envelope that the public-stream
+    normalizer prepends when the upstream stream's first standard event is
+    not ``response.created`` (see change
+    ``normalize-v1-responses-openai-sdk-stream``)."""
     for line in lines:
-        if line.startswith("data: "):
-            return json.loads(line[6:])
+        if not line.startswith("data: ") or line.startswith("data: [DONE]"):
+            continue
+        event = json.loads(line[6:])
+        if event.get("type") == "response.created":
+            response = event.get("response")
+            if isinstance(response, dict) and response.get("status") == "in_progress" \
+                    and response.get("output") == []:
+                continue
+        return event
     raise AssertionError("No SSE data event found")
 
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -63,8 +63,7 @@ def _extract_first_event(lines: list[str]) -> dict:
         event = json.loads(line[6:])
         if event.get("type") == "response.created":
             response = event.get("response")
-            if isinstance(response, dict) and response.get("status") == "in_progress" \
-                    and response.get("output") == []:
+            if isinstance(response, dict) and response.get("status") == "in_progress" and response.get("output") == []:
                 continue
         return event
     raise AssertionError("No SSE data event found")

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -55,8 +55,7 @@ def _extract_first_event(lines: list[str]) -> dict:
     for event in _iter_sse_events(lines):
         if event.get("type") == "response.created":
             response = event.get("response")
-            if isinstance(response, dict) and response.get("status") == "in_progress" \
-                    and response.get("output") == []:
+            if isinstance(response, dict) and response.get("status") == "in_progress" and response.get("output") == []:
                 # Likely the synthesized created envelope — skip and return
                 # whatever the upstream actually started with.
                 continue

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -43,10 +43,39 @@ def _make_auth_json(account_id: str, email: str) -> dict:
 
 
 def _extract_first_event(lines: list[str]) -> dict:
-    for line in lines:
-        if line.startswith("data: "):
-            return json.loads(line[6:])
+    """Return the first standard SSE event payload, ignoring the synthetic
+    ``response.created`` that ``_normalize_public_responses_stream`` may
+    prepend when the upstream stream's first standard event is not
+    ``response.created`` (see change
+    ``normalize-v1-responses-openai-sdk-stream``). Callers that want to
+    assert on the *original* first upstream event (e.g. ``response.failed``)
+    should keep using this helper unchanged; callers that want to assert on
+    the new synthetic created should use ``_extract_first_raw_event`` below.
+    """
+    for event in _iter_sse_events(lines):
+        if event.get("type") == "response.created":
+            response = event.get("response")
+            if isinstance(response, dict) and response.get("status") == "in_progress" \
+                    and response.get("output") == []:
+                # Likely the synthesized created envelope — skip and return
+                # whatever the upstream actually started with.
+                continue
+        return event
     raise AssertionError("No SSE data event found")
+
+
+def _extract_first_raw_event(lines: list[str]) -> dict:
+    """Return the literal first SSE data event, including any synthesized
+    ``response.created`` the public-stream normalizer prepended."""
+    for event in _iter_sse_events(lines):
+        return event
+    raise AssertionError("No SSE data event found")
+
+
+def _iter_sse_events(lines: list[str]):
+    for line in lines:
+        if line.startswith("data: ") and not line.startswith("data: [DONE]"):
+            yield json.loads(line[6:])
 
 
 class _FakeUpstreamWebSocket:

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from typing import Any, cast
 
 import pytest
 
@@ -560,3 +561,83 @@ async def test_normalize_public_responses_stream_codex_route_does_not_backfill_o
     completed = next(p for p in payloads if p and p.get("type") == "response.completed")
     # Output stays empty — Codex CLI handles its own assembly.
     assert completed["response"]["output"] == []
+
+
+# ----------------------------------------------------------------------------
+# internal_bridge_responses must opt out of OpenAI SDK contract enforcement.
+# (Regression guard: a forwarded /backend-api/codex/responses request that
+# travels through the internal bridge MUST NOT drop codex.* events or
+# synthesize a response.created envelope on the owner instance — the origin
+# instance is responsible for honouring the original route's policy.)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_internal_bridge_responses_disables_openai_sdk_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import AsyncMock
+
+    from app.modules.proxy import http_bridge_forwarding as bridge_module
+
+    captured: dict[str, object] = {}
+
+    async def fake_stream_responses(*args: object, **kwargs: object) -> object:
+        captured["kwargs"] = kwargs
+        return object()  # any non-None response; the handler returns it directly
+
+    monkeypatch.setattr(proxy_api_module, "_stream_responses", fake_stream_responses)
+
+    # Bypass HMAC verification + header parsing — we only care about the flag
+    # that internal_bridge_responses passes to _stream_responses.
+    fake_context = bridge_module.HTTPBridgeForwardContext(
+        origin_instance="origin-a",
+        target_instance="owner-b",
+        codex_session_affinity=True,
+        downstream_turn_state=None,
+        original_affinity_kind="session",
+        original_affinity_key="sid-abc",
+        reservation=None,
+    )
+    fake_forwarded = bridge_module.HTTPBridgeForwardedRequest(context=fake_context)
+
+    def fake_parse(headers, *, payload, current_instance):
+        return fake_forwarded, None
+
+    monkeypatch.setattr(proxy_api_module, "parse_forwarded_request", fake_parse)
+    # The API-key validation hits the DB by default; short-circuit it.
+    monkeypatch.setattr(
+        proxy_api_module,
+        "_validate_internal_bridge_api_key",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(proxy_api_module, "_strip_internal_bridge_headers", lambda h: dict(h))
+
+    # Minimal payload + request stubs.
+    from app.core.openai.requests import ResponsesRequest
+
+    payload = ResponsesRequest(model="gpt-5.5", input="hi", instructions="")
+
+    class _StubRequest:
+        @property
+        def headers(self) -> dict[str, str]:
+            return {}
+
+    response = await proxy_api_module.internal_bridge_responses(
+        request=cast(Any, _StubRequest()),
+        payload=payload,
+        context=cast(Any, object()),
+    )
+
+    assert response is not None
+    kwargs_obj = captured["kwargs"]
+    assert isinstance(kwargs_obj, dict)
+    # cast for the type-checker — isinstance narrows at runtime, ty doesn't track it here.
+    kwargs = cast(dict[str, object], kwargs_obj)
+    # The regression we are guarding against: enforce_openai_sdk_contract must
+    # be passed AS False so the owner instance forwards the upstream stream
+    # verbatim. The origin instance reapplies normalization based on the
+    # original route's policy.
+    assert kwargs.get("enforce_openai_sdk_contract") is False, (
+        f"internal_bridge_responses must pass enforce_openai_sdk_contract=False; got kwargs={kwargs!r}"
+    )

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -81,7 +81,8 @@ async def test_normalize_public_responses_stream_normalizes_unknown_terminal_out
                     '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
                 ),
                 (
-                    'data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1","object":"response",'
+                    'data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1",'
+                    '"object":"response",'
                     '"status":"completed","output":[{"id":"fa_1","type":"final_answer","text":"normalized"}]}}\n\n'
                 )
             )
@@ -131,7 +132,8 @@ async def test_normalize_public_responses_stream_synthesizes_delta_from_done_mes
                     '"content":[{"type":"output_text","text":"visible text"}]}}\n\n'
                 ),
                 (
-                    'data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_1","object":"response",'
+                    'data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_1",'
+                    '"object":"response",'
                     '"status":"completed","output":[]}}\n\n'
                 ),
             )
@@ -164,7 +166,8 @@ async def test_normalize_public_responses_stream_synthesizes_delta_from_complete
                     '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
                 ),
                 (
-                    'data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1","object":"response",'
+                    'data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1",'
+                    '"object":"response",'
                     '"status":"completed","output":[{"id":"msg_1","type":"message",'
                     '"content":[{"type":"output_text","text":"terminal text"}]}]}}\n\n'
                 )
@@ -195,14 +198,16 @@ async def test_normalize_public_responses_stream_does_not_duplicate_existing_del
                     'data: {"type":"response.created","sequence_number":0,'
                     '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
                 ),
-                'data: {"type":"response.output_text.delta","sequence_number":1,"item_id":"msg_1","delta":"already visible"}\n\n',
+                'data: {"type":"response.output_text.delta","sequence_number":1,"item_id":"msg_1",'
+                '"delta":"already visible"}\n\n',
                 (
                     'data: {"type":"response.output_item.done","sequence_number":2,"output_index":0,'
                     '"item":{"id":"msg_1","type":"message","role":"assistant",'
                     '"content":[{"type":"output_text","text":"already visible"}]}}\n\n'
                 ),
                 (
-                    'data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response",'
+                    'data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_1",'
+                    '"object":"response",'
                     '"status":"completed","output":[]}}\n\n'
                 ),
             )

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -84,7 +84,7 @@ async def test_normalize_public_responses_stream_normalizes_unknown_terminal_out
                     'data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1",'
                     '"object":"response",'
                     '"status":"completed","output":[{"id":"fa_1","type":"final_answer","text":"normalized"}]}}\n\n'
-                )
+                ),
             )
         )
     ]
@@ -170,7 +170,7 @@ async def test_normalize_public_responses_stream_synthesizes_delta_from_complete
                     '"object":"response",'
                     '"status":"completed","output":[{"id":"msg_1","type":"message",'
                     '"content":[{"type":"output_text","text":"terminal text"}]}]}}\n\n'
-                )
+                ),
             )
         )
     ]

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -77,19 +77,27 @@ async def test_normalize_public_responses_stream_normalizes_unknown_terminal_out
         async for block in proxy_api_module._normalize_public_responses_stream(
             _iter_blocks(
                 (
-                    'data: {"type":"response.completed","response":{"id":"resp_1","object":"response",'
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1","object":"response",'
                     '"status":"completed","output":[{"id":"fa_1","type":"final_answer","text":"normalized"}]}}\n\n'
                 )
             )
         )
     ]
 
-    assert len(blocks) == 2
-    delta_payload = proxy_api_module._parse_sse_payload(blocks[0])
+    # Now: response.created, synthetic delta, response.completed
+    assert len(blocks) == 3
+    created_payload = proxy_api_module._parse_sse_payload(blocks[0])
+    assert created_payload is not None
+    assert created_payload["type"] == "response.created"
+    delta_payload = proxy_api_module._parse_sse_payload(blocks[1])
     assert delta_payload is not None
     assert delta_payload["type"] == "response.output_text.delta"
     assert delta_payload["delta"] == "normalized"
-    payload = proxy_api_module._parse_sse_payload(blocks[1])
+    payload = proxy_api_module._parse_sse_payload(blocks[2])
     assert payload is not None
     assert payload["type"] == "response.completed"
     response = payload["response"]
@@ -114,12 +122,16 @@ async def test_normalize_public_responses_stream_synthesizes_delta_from_done_mes
         async for block in proxy_api_module._normalize_public_responses_stream(
             _iter_blocks(
                 (
-                    'data: {"type":"response.output_item.done","output_index":0,'
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,'
                     '"item":{"id":"msg_1","type":"message","role":"assistant",'
                     '"content":[{"type":"output_text","text":"visible text"}]}}\n\n'
                 ),
                 (
-                    'data: {"type":"response.completed","response":{"id":"resp_1","object":"response",'
+                    'data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_1","object":"response",'
                     '"status":"completed","output":[]}}\n\n'
                 ),
             )
@@ -127,17 +139,18 @@ async def test_normalize_public_responses_stream_synthesizes_delta_from_done_mes
     ]
 
     payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
-    assert payloads[0] == {
+    assert payloads[0] is not None and payloads[0]["type"] == "response.created"
+    assert payloads[1] == {
         "type": "response.output_text.delta",
         "output_index": 0,
         "content_index": 0,
         "delta": "visible text",
         "item_id": "msg_1",
     }
-    assert payloads[1] is not None
-    assert payloads[1]["type"] == "response.output_item.done"
     assert payloads[2] is not None
-    assert payloads[2]["type"] == "response.completed"
+    assert payloads[2]["type"] == "response.output_item.done"
+    assert payloads[3] is not None
+    assert payloads[3]["type"] == "response.completed"
 
 
 @pytest.mark.asyncio
@@ -147,7 +160,11 @@ async def test_normalize_public_responses_stream_synthesizes_delta_from_complete
         async for block in proxy_api_module._normalize_public_responses_stream(
             _iter_blocks(
                 (
-                    'data: {"type":"response.completed","response":{"id":"resp_1","object":"response",'
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp_1","object":"response",'
                     '"status":"completed","output":[{"id":"msg_1","type":"message",'
                     '"content":[{"type":"output_text","text":"terminal text"}]}]}}\n\n'
                 )
@@ -156,15 +173,16 @@ async def test_normalize_public_responses_stream_synthesizes_delta_from_complete
     ]
 
     payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
-    assert payloads[0] == {
+    assert payloads[0] is not None and payloads[0]["type"] == "response.created"
+    assert payloads[1] == {
         "type": "response.output_text.delta",
         "output_index": 0,
         "content_index": 0,
         "delta": "terminal text",
         "item_id": "msg_1",
     }
-    assert payloads[1] is not None
-    assert payloads[1]["type"] == "response.completed"
+    assert payloads[2] is not None
+    assert payloads[2]["type"] == "response.completed"
 
 
 @pytest.mark.asyncio
@@ -173,14 +191,18 @@ async def test_normalize_public_responses_stream_does_not_duplicate_existing_del
         block
         async for block in proxy_api_module._normalize_public_responses_stream(
             _iter_blocks(
-                'data: {"type":"response.output_text.delta","item_id":"msg_1","delta":"already visible"}\n\n',
                 (
-                    'data: {"type":"response.output_item.done","output_index":0,'
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                'data: {"type":"response.output_text.delta","sequence_number":1,"item_id":"msg_1","delta":"already visible"}\n\n',
+                (
+                    'data: {"type":"response.output_item.done","sequence_number":2,"output_index":0,'
                     '"item":{"id":"msg_1","type":"message","role":"assistant",'
                     '"content":[{"type":"output_text","text":"already visible"}]}}\n\n'
                 ),
                 (
-                    'data: {"type":"response.completed","response":{"id":"resp_1","object":"response",'
+                    'data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response",'
                     '"status":"completed","output":[]}}\n\n'
                 ),
             )
@@ -190,6 +212,7 @@ async def test_normalize_public_responses_stream_does_not_duplicate_existing_del
     payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
     event_types = [payload["type"] for payload in payloads if payload is not None]
     assert event_types == [
+        "response.created",
         "response.output_text.delta",
         "response.output_item.done",
         "response.completed",
@@ -279,3 +302,256 @@ async def test_collect_responses_payload_preserves_output_image_item() -> None:
             "image_url": "https://example.com/a.png",
         }
     ]
+
+
+# --- OpenAI SDK stream contract regressions ---
+# These tests cover the public /v1/responses streaming SSE contract gaps found
+# during the OpenAI Python SDK compatibility audit. See change
+# `normalize-v1-responses-openai-sdk-stream` in openspec/changes/ for the
+# full audit, design rationale, and spec delta.
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_drops_codex_rate_limits_prefix() -> None:
+    """G1: Codex-internal vendor events MUST NOT leak onto the public /v1 stream.
+
+    The upstream Codex backend emits `codex.rate_limits` (throttled per window)
+    before `response.created`. The OpenAI SDK's ResponseStreamState raises
+    `RuntimeError: Expected to have received 'response.created' before
+    'codex.rate_limits'` on the first event. The /v1 normalizer must drop any
+    `codex.*` event so the first event the public stream emits is
+    `response.created`.
+    """
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n',
+                (
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","sequence_number":1,'
+                    '"response":{"id":"resp_1","object":"response","status":"completed",'
+                    '"output":[{"id":"msg_1","type":"message","role":"assistant","status":"completed",'
+                    '"content":[{"type":"output_text","text":"hi"}]}]}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(b) for b in blocks]
+    event_types = [p["type"] for p in payloads if p is not None]
+    assert "codex.rate_limits" not in event_types
+    # First event MUST be response.created (OpenAI SDK contract A)
+    standard_events = [t for t in event_types if t not in ("[DONE]",)]
+    assert standard_events[0] == "response.created"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_backfills_terminal_output_from_items() -> None:
+    """G3: terminal `response.completed.output` MUST be backfilled from
+    `response.output_item.done` events when upstream sends empty output.
+
+    The Codex backend emits items via `output_item.done` and then sends
+    `response.completed` with `output: []`. The non-streaming path
+    (`_collect_responses_payload`) already merges these; the streaming path
+    must do the same so OpenAI SDK consumers calling
+    `stream.get_final_response().output` see the items.
+    """
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,'
+                    '"item":{"id":"msg_1","type":"message","role":"assistant","status":"completed",'
+                    '"content":[{"type":"output_text","text":"backfilled"}]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","sequence_number":2,'
+                    '"response":{"id":"resp_1","object":"response","status":"completed","output":[]}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(b) for b in blocks]
+    completed = next(p for p in payloads if p and p.get("type") == "response.completed")
+    response_obj = completed["response"]
+    assert isinstance(response_obj, dict)
+    output = response_obj["output"]
+    assert isinstance(output, list)
+    assert len(output) == 1
+    assert output[0]["id"] == "msg_1"
+    assert output[0]["type"] == "message"
+    assert output[0]["content"] == [{"type": "output_text", "text": "backfilled"}]
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_preserves_existing_terminal_output() -> None:
+    """G3 inverse: when upstream already includes terminal `output`,
+    the normalizer MUST NOT overwrite it from collected items."""
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,'
+                    '"item":{"id":"msg_stream","type":"message","role":"assistant","status":"completed",'
+                    '"content":[{"type":"output_text","text":"from-stream-events"}]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","sequence_number":2,'
+                    '"response":{"id":"resp_1","object":"response","status":"completed",'
+                    '"output":[{"id":"msg_terminal","type":"message","role":"assistant","status":"completed",'
+                    '"content":[{"type":"output_text","text":"from-terminal"}]}]}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(b) for b in blocks]
+    completed = next(p for p in payloads if p and p.get("type") == "response.completed")
+    response_obj = completed["response"]
+    assert isinstance(response_obj, dict)
+    output = response_obj["output"]
+    assert isinstance(output, list)
+    assert len(output) == 1
+    assert output[0]["id"] == "msg_terminal"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_synthesizes_response_created_on_leading_failure() -> None:
+    """G4: when the upstream stream's first standard event is not
+    `response.created` (e.g. upstream rejects and emits only
+    `response.failed`), the normalizer MUST synthesize a `response.created`
+    event from the failed event's envelope so the OpenAI SDK parser can begin.
+    """
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.failed","sequence_number":0,'
+                    '"response":{"id":"resp_err","object":"response","status":"failed","output":[],'
+                    '"error":{"code":"invalid_request_error","message":"bad schema"}}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(b) for b in blocks]
+    event_types = [p["type"] for p in payloads if p is not None]
+    # response.created must be synthesized FIRST, then response.failed forwarded
+    assert event_types[:2] == ["response.created", "response.failed"]
+    created = payloads[0]
+    assert created is not None
+    created_response = created["response"]
+    assert isinstance(created_response, dict)
+    # Synthesized envelope must use in_progress + empty output (the contract
+    # values for response.created), not copy "failed" from the source.
+    assert created_response["status"] == "in_progress"
+    assert created_response["output"] == []
+    # But the upstream id is preserved so downstream consumers can correlate.
+    assert created_response["id"] == "resp_err"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_does_not_double_emit_response_created() -> None:
+    """G4 inverse: when the upstream stream already starts with
+    `response.created`, the normalizer MUST NOT emit a second synthesized one."""
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","sequence_number":1,'
+                    '"response":{"id":"resp_1","object":"response","status":"completed",'
+                    '"output":[{"id":"msg_1","type":"message","role":"assistant","status":"completed",'
+                    '"content":[{"type":"output_text","text":"ok"}]}]}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(b) for b in blocks]
+    event_types = [p["type"] for p in payloads if p is not None]
+    assert event_types.count("response.created") == 1
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_codex_route_preserves_codex_events() -> None:
+    """`enforce_openai_sdk_contract=False` (used by /backend-api/codex/*) MUST
+    forward `codex.*` vendor events verbatim, MUST NOT backfill terminal
+    output, and MUST NOT synthesize a leading `response.created`. The Codex
+    CLI consumes the upstream stream natively."""
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n',
+                (
+                    'data: {"type":"response.failed","sequence_number":0,'
+                    '"response":{"id":"resp_err","object":"response","status":"failed","output":[],'
+                    '"error":{"code":"x","message":"y"}}}\n\n'
+                ),
+            ),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(b) for b in blocks]
+    event_types = [p["type"] for p in payloads if p is not None]
+    # codex.rate_limits MUST be preserved
+    assert "codex.rate_limits" in event_types
+    # response.created MUST NOT be synthesized
+    assert "response.created" not in event_types
+    # Original sequence order preserved
+    assert event_types == ["codex.rate_limits", "response.failed"]
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_codex_route_does_not_backfill_output() -> None:
+    """`enforce_openai_sdk_contract=False` MUST NOT backfill terminal
+    `response.completed.output` from streamed item events. The Codex CLI
+    expects upstream's exact shape."""
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.output_item.done","sequence_number":1,"output_index":0,'
+                    '"item":{"id":"msg_1","type":"message","role":"assistant","status":"completed",'
+                    '"content":[{"type":"output_text","text":"hi"}]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","sequence_number":2,'
+                    '"response":{"id":"resp_1","object":"response","status":"completed","output":[]}}\n\n'
+                ),
+            ),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(b) for b in blocks]
+    completed = next(p for p in payloads if p and p.get("type") == "response.completed")
+    # Output stays empty — Codex CLI handles its own assembly.
+    assert completed["response"]["output"] == []


### PR DESCRIPTION
## Summary

The official OpenAI Python SDK's `ResponseStreamState` parser raises `RuntimeError`s when fed the `/v1/responses` stream this proxy emits today. This PR:

1. **Audits** the SDK parser contract end-to-end and lands the minimum normalisation needed to satisfy it on the public `/v1/responses` route, keeping the Codex CLI route (`/backend-api/codex/responses`) byte-for-byte unchanged.
2. **Adds full E2E SDK coverage** across every other supported `/v1` surface (`chat.completions`, `responses.parse`, `models.list`, `audio.transcriptions`, structured output, multi-turn), plus an audit of the unsupported surfaces (embeddings, moderations, files, batches, `responses.retrieve`) that asserts the SDK receives a clean 4xx — not a 500.

Driven by an OpenSpec change: `openspec/changes/normalize-v1-responses-openai-sdk-stream/`.

## Gaps (audit-driven)

| ID | Symptom | Root cause |
|----|---------|------------|
| **G1** | `RuntimeError` on the very first event when `client.responses.stream(...)` is used. | `codex.rate_limits` (and other `codex.*`) events stream **before** `response.created`. The SDK requires `response.created` first. |
| **G3** | `final_response.output == []` even though the model produced output. | Streaming `response.completed` carries `output: []`; the items were only delivered via prior `response.output_item.done` events. |
| **G4** | After G1 fix, error streams still `RuntimeError`. | Upstream rejections (quota, etc.) emit `response.failed` without any preceding `response.created`. |

## Fix

`_normalize_public_stream_payload` / `_normalize_public_responses_stream` in `app/modules/proxy/api.py`:

- **G1** — Drop any `codex.*` events that arrive before standard events on the public stream.
- **G3** — Collect `response.output_item.done` items; if the terminal `response.completed.response.output` is empty, backfill it from the collected items.
- **G4** — If the first standard event is **not** `response.created`, synthesize a minimal `response.created` envelope from the terminal event so the SDK's preconditions are met.

### Dual-route isolation

A new `enforce_openai_sdk_contract: bool` parameter gates all three rewrites:

- `/v1/responses` → `True` (public OpenAI compatibility)
- `/backend-api/codex/responses` → `False` (Codex CLI keeps the original `codex.*` event sequence)

## Tests

### Unit (15 new + 4 existing fixtures updated)
Direct coverage for G1 / G3 / G4 plus dual-route isolation tests verifying `codex.*` survives on the Codex CLI route.

### E2E SDK contract — `tests/e2e/test_v1_responses_openai_sdk.py` (5 new)
Real `openai.AsyncOpenAI` against the ASGI app in-process — plain / tool-call / reasoning / structured / multi-turn — each exercising `client.responses.stream(...)` so `ResponseStreamState` itself is the assertion.

### E2E full SDK surface — `tests/e2e/test_openai_sdk_compat.py` (12 new)
Widens the matrix beyond `responses.stream`:

| Class | SDK call | Route |
|-------|----------|-------|
| `TestChatCompletions` | `chat.completions.create()` — non-streaming, streaming, tool-call, multi-turn | `POST /v1/chat/completions` |
| `TestResponsesParse` | `responses.parse(text_format=PydanticModel)` | `POST /v1/responses` |
| `TestModels` | `models.list()` | `GET /v1/models` |
| `TestAudioTranscriptions` | `audio.transcriptions.create(file=..., model=...)` (real WAV) | `POST /v1/audio/transcriptions` |
| `TestImages` | `images.generate` (b64 + revised_prompt), `images.edit` (multipart, gpt-image-1), `images.create_variation` (clean 4xx) | `POST /v1/images/{generations,edits,variations}` |
| `TestUnsupportedSurfaces` | `embeddings.create`, `moderations.create`, `files.list`, `batches.list`, `responses.retrieve` | (no route) — asserts clean 4xx, not 5xx |

All tests run hermetically (no upstream Codex account needed): `core_stream_responses` and `ProxyService.transcribe` are monkey-patched, the SDK talks to the FastAPI app via `httpx.ASGITransport`.

### Integration
`_extract_first_event` helpers in three test modules updated to skip the synthetic `response.created` so legacy assertions target the first semantically meaningful event.

### Full suite

```
pytest tests/unit tests/integration tests/e2e
2158 passed, 7 skipped, 0 failed in 245.91s
```

(7 skips are pre-existing: 3 T21 per-account locking, 4 PostgreSQL-only.)

## Live verification

`scripts/verify_v1_responses_openai_sdk.py` runs the five `responses.stream` cases against any deployed base URL with the installed `openai` SDK and prints a PASS/FAIL summary — usable as a smoke-test before/after deploy.

```bash
.venv/bin/python scripts/verify_v1_responses_openai_sdk.py \
  --base-url https://codex.nekos.me --api-key "$KEY" --model gpt-5.5
```

## Compatibility

- **Public `/v1/responses`** — now SDK-parseable. Existing non-SDK consumers that ignored `codex.*` events are unaffected; those that relied on receiving them must move to `/backend-api/codex/responses`.
- **`/backend-api/codex/responses`** — no change in wire format.
- **No config/schema changes.**

## Spec

- `openspec validate --strict` passes for `normalize-v1-responses-openai-sdk-stream`.
- Tasks file is fully checked off pending merge (then archive per AGENTS.md workflow).
