### PR TITLE
feat(acc): preserve metrics when the account is deleted

### DIFF
--- a/app/db/alembic/versions/20260515_000000_soft_delete_request_logs_on_account_delete.py
+++ b/app/db/alembic/versions/20260515_000000_soft_delete_request_logs_on_account_delete.py
@@ -1,0 +1,59 @@
+"""soft delete request_logs on account delete
+
+Revision ID: 20260515_000000_soft_delete_request_logs_on_account_delete
+Revises: 20260514_000000_add_request_logs_api_key_time_index
+Create Date: 2026-05-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260515_000000_soft_delete_request_logs_on_account_delete"
+down_revision = "20260514_000000_add_request_logs_api_key_time_index"
+branch_labels = None
+depends_on = None
+
+_FK_NAMING = {"fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s"}
+_REQUEST_LOG_ACCOUNT_FK = "fk_request_logs_account_id_accounts"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_columns = {column["name"] for column in inspector.get_columns("request_logs")}
+
+    with op.batch_alter_table("request_logs", naming_convention=_FK_NAMING) as batch_op:
+        if "deleted_at" not in existing_columns:
+            batch_op.add_column(sa.Column("deleted_at", sa.DateTime(), nullable=True))
+        batch_op.drop_constraint(_REQUEST_LOG_ACCOUNT_FK, type_="foreignkey")
+        batch_op.create_foreign_key(
+            _REQUEST_LOG_ACCOUNT_FK,
+            "accounts",
+            ["account_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    op.create_index(
+        "idx_logs_deleted_at_requested_at_id",
+        "request_logs",
+        ["deleted_at", sa.text("requested_at DESC"), sa.text("id DESC")],
+        unique=False,
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_logs_deleted_at_requested_at_id", table_name="request_logs", if_exists=True)
+    with op.batch_alter_table("request_logs", naming_convention=_FK_NAMING) as batch_op:
+        batch_op.drop_constraint(_REQUEST_LOG_ACCOUNT_FK, type_="foreignkey")
+        batch_op.create_foreign_key(
+            _REQUEST_LOG_ACCOUNT_FK,
+            "accounts",
+            ["account_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        batch_op.drop_column("deleted_at")

--- a/app/db/alembic/versions/20260515_000000_soft_delete_request_logs_on_account_delete.py
+++ b/app/db/alembic/versions/20260515_000000_soft_delete_request_logs_on_account_delete.py
@@ -19,15 +19,34 @@ _FK_NAMING = {"fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s
 _REQUEST_LOG_ACCOUNT_FK = "fk_request_logs_account_id_accounts"
 
 
+def _request_log_account_fk_names(inspector: sa.Inspector) -> list[str]:
+    names: list[str] = []
+    for foreign_key in inspector.get_foreign_keys("request_logs"):
+        if foreign_key.get("referred_table") != "accounts":
+            continue
+        if foreign_key.get("constrained_columns") != ["account_id"]:
+            continue
+        if foreign_key.get("referred_columns") != ["id"]:
+            continue
+        name = foreign_key.get("name")
+        if name:
+            names.append(str(name))
+            continue
+        names.append(_REQUEST_LOG_ACCOUNT_FK)
+    return names
+
+
 def upgrade() -> None:
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     existing_columns = {column["name"] for column in inspector.get_columns("request_logs")}
+    existing_fk_names = _request_log_account_fk_names(inspector)
 
     with op.batch_alter_table("request_logs", naming_convention=_FK_NAMING) as batch_op:
         if "deleted_at" not in existing_columns:
             batch_op.add_column(sa.Column("deleted_at", sa.DateTime(), nullable=True))
-        batch_op.drop_constraint(_REQUEST_LOG_ACCOUNT_FK, type_="foreignkey")
+        for fk_name in existing_fk_names:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
         batch_op.create_foreign_key(
             _REQUEST_LOG_ACCOUNT_FK,
             "accounts",
@@ -46,9 +65,14 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_fk_names = _request_log_account_fk_names(inspector)
+
     op.drop_index("idx_logs_deleted_at_requested_at_id", table_name="request_logs", if_exists=True)
     with op.batch_alter_table("request_logs", naming_convention=_FK_NAMING) as batch_op:
-        batch_op.drop_constraint(_REQUEST_LOG_ACCOUNT_FK, type_="foreignkey")
+        for fk_name in existing_fk_names:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
         batch_op.create_foreign_key(
             _REQUEST_LOG_ACCOUNT_FK,
             "accounts",

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -71,6 +71,7 @@ _MANUAL_DRIFT_INDEX_REQUIREMENTS: dict[str, frozenset[str]] = {
     "request_logs": frozenset(
         {
             "idx_logs_requested_at_id",
+            "idx_logs_deleted_at_requested_at_id",
             "idx_logs_requested_at_model_tier",
             "idx_logs_model_effort_time",
             "idx_logs_status_error_time",

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -124,11 +124,16 @@ class RequestLog(Base):
     __tablename__ = "request_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    account_id: Mapped[str | None] = mapped_column(String, ForeignKey("accounts.id", ondelete="CASCADE"), nullable=True)
+    account_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("accounts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     api_key_id: Mapped[str | None] = mapped_column(String, nullable=True)
     session_id: Mapped[str | None] = mapped_column(String, nullable=True)
     request_id: Mapped[str] = mapped_column(String, nullable=False)
     requested_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     model: Mapped[str] = mapped_column(String, nullable=False)
     plan_type: Mapped[str | None] = mapped_column(String, nullable=True)
     transport: Mapped[str | None] = mapped_column(String, nullable=True)
@@ -619,6 +624,12 @@ Index("idx_logs_account_time", RequestLog.account_id, RequestLog.requested_at)
 Index("idx_logs_api_key_time", RequestLog.api_key_id, RequestLog.requested_at.desc(), RequestLog.id.desc())
 Index("idx_logs_requested_at", RequestLog.requested_at)
 Index("idx_logs_requested_at_id", RequestLog.requested_at.desc(), RequestLog.id.desc())
+Index(
+    "idx_logs_deleted_at_requested_at_id",
+    RequestLog.deleted_at,
+    RequestLog.requested_at.desc(),
+    RequestLog.id.desc(),
+)
 Index(
     "idx_logs_requested_at_model_tier",
     RequestLog.requested_at.desc(),

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -205,9 +205,7 @@ class AccountsRepository:
     async def delete(self, account_id: str) -> bool:
         await self._session.execute(delete(UsageHistory).where(UsageHistory.account_id == account_id))
         await self._session.execute(
-            update(RequestLog)
-            .where(RequestLog.account_id == account_id)
-            .values(account_id=None, deleted_at=utcnow())
+            update(RequestLog).where(RequestLog.account_id == account_id).values(account_id=None, deleted_at=utcnow())
         )
         await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
         result = await self._session.execute(delete(Account).where(Account.id == account_id).returning(Account.id))

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -8,6 +8,7 @@ from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, DashboardSettings, RequestLog, StickySession, UsageHistory
 
 _SETTINGS_ROW_ID = 1
@@ -203,7 +204,11 @@ class AccountsRepository:
 
     async def delete(self, account_id: str) -> bool:
         await self._session.execute(delete(UsageHistory).where(UsageHistory.account_id == account_id))
-        await self._session.execute(delete(RequestLog).where(RequestLog.account_id == account_id))
+        await self._session.execute(
+            update(RequestLog)
+            .where(RequestLog.account_id == account_id)
+            .values(account_id=None, deleted_at=utcnow())
+        )
         await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
         result = await self._session.execute(delete(Account).where(Account.id == account_id).returning(Account.id))
         await self._session.commit()

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -288,6 +288,7 @@ class RequestLogsRepository:
             include_error_other=include_error_other,
             error_codes_in=error_codes_in,
             error_codes_excluding=error_codes_excluding,
+            exclude_soft_deleted=True,
         )
 
         total_col = func.count().over().label("_total")
@@ -341,6 +342,7 @@ class RequestLogsRepository:
             include_error_other=True,
             error_codes_in=None,
             error_codes_excluding=None,
+            exclude_soft_deleted=True,
         )
         api_key_facet_filters = self._build_filters(
             since=since,
@@ -354,6 +356,7 @@ class RequestLogsRepository:
             include_error_other=True,
             error_codes_in=None,
             error_codes_excluding=None,
+            exclude_soft_deleted=True,
         )
 
         account_stmt = select(RequestLog.account_id).distinct().order_by(RequestLog.account_id.asc())
@@ -418,8 +421,11 @@ class RequestLogsRepository:
         include_error_other: bool = True,
         error_codes_in: list[str] | None = None,
         error_codes_excluding: list[str] | None = None,
+        exclude_soft_deleted: bool = False,
     ) -> _RequestLogFilters:
         conditions = []
+        if exclude_soft_deleted:
+            conditions.append(RequestLog.deleted_at.is_(None))
         if since is not None:
             conditions.append(RequestLog.requested_at >= since)
         if until is not None:

--- a/openspec/changes/soft-delete-request-logs-on-account-delete/.openspec.yaml
+++ b/openspec/changes/soft-delete-request-logs-on-account-delete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/soft-delete-request-logs-on-account-delete/proposal.md
+++ b/openspec/changes/soft-delete-request-logs-on-account-delete/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+Deleting an account currently hard-deletes its `request_logs` twice: the application explicitly deletes matching rows and the `request_logs.account_id` foreign key still cascades on account removal. That breaks historical request metrics and removes request-log evidence operators may still need for aggregate dashboards.
+
+## What Changes
+
+- Soft-delete `request_logs` when an account is deleted by marking a nullable `deleted_at` timestamp and detaching the row from the deleted account.
+- Hide soft-deleted request-log rows from the dashboard request-log list and filter options.
+- Preserve existing dashboard overview metrics and request-log aggregates so soft-deleted rows still contribute to historical counts, token totals, costs, and error summaries.
+- Replace the `request_logs.account_id -> accounts.id` cascade path with `ON DELETE SET NULL` so database-level account deletion does not erase historical request logs.
+- Add an index for the dashboard request-log list path that now filters on `deleted_at IS NULL`.
+
+## Impact
+
+- Code: `app/db/models.py`, `app/modules/accounts/repository.py`, `app/modules/request_logs/repository.py`
+- Migrations: add `request_logs.deleted_at`, replace the request-log account FK delete action, add a dashboard list index
+- Tests: account deletion, request-log API visibility, dashboard overview metrics, migration schema/index/FK coverage
+- Specs: `openspec/specs/frontend-architecture/spec.md`, `openspec/specs/database-migrations/spec.md`

--- a/openspec/changes/soft-delete-request-logs-on-account-delete/specs/database-migrations/spec.md
+++ b/openspec/changes/soft-delete-request-logs-on-account-delete/specs/database-migrations/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Request-log account deletion preserves historical rows
+
+The database schema SHALL preserve historical `request_logs` rows when their parent account is deleted. The schema MUST support a nullable request-log soft-delete marker and MUST NOT use a cascading account foreign key that deletes request-log history.
+
+#### Scenario: Request-log soft-delete schema exists after migration
+
+- **WHEN** migrations run to head
+- **THEN** `request_logs` contains a nullable `deleted_at` column
+- **AND** the dashboard request-log list path has an index that supports filtering non-deleted rows latest-first
+
+#### Scenario: Request-log account foreign key no longer cascades
+
+- **WHEN** migrations run to head
+- **THEN** the `request_logs.account_id -> accounts.id` foreign key uses `ON DELETE SET NULL`
+- **AND** deleting an account at the database level does not delete matching request-log rows

--- a/openspec/changes/soft-delete-request-logs-on-account-delete/specs/frontend-architecture/spec.md
+++ b/openspec/changes/soft-delete-request-logs-on-account-delete/specs/frontend-architecture/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Dashboard request-log list excludes deleted-account rows
+
+When an account is deleted, request-log rows that were soft-deleted as part of that account removal MUST NOT appear in the dashboard request-log list or request-log filter-option facets.
+
+#### Scenario: Deleted account log hidden from recent request rows
+
+- **GIVEN** a request log row was previously associated with an account
+- **AND** deleting that account soft-deleted the row
+- **WHEN** a user loads `GET /api/request-logs`
+- **THEN** the soft-deleted row is not included in the `requests` payload
+
+#### Scenario: Deleted account log hidden from request-log facets
+
+- **GIVEN** a request log row was previously associated with an account
+- **AND** deleting that account soft-deleted the row
+- **WHEN** a user loads `GET /api/request-logs/options`
+- **THEN** the soft-deleted row does not contribute account, model, API-key, or status facet options
+
+### Requirement: Dashboard overview metrics keep soft-deleted request logs
+
+Dashboard overview request metrics and trends MUST continue to aggregate soft-deleted request-log rows so account deletion does not rewrite historical request activity.
+
+#### Scenario: Deleted account log still counted in overview metrics
+
+- **GIVEN** an account has request-log activity within the active overview timeframe
+- **AND** the account is deleted afterward
+- **WHEN** a user loads `GET /api/dashboard/overview`
+- **THEN** request-derived metrics and trends still include that historical request-log activity

--- a/openspec/changes/soft-delete-request-logs-on-account-delete/tasks.md
+++ b/openspec/changes/soft-delete-request-logs-on-account-delete/tasks.md
@@ -1,0 +1,18 @@
+## 1. Spec
+
+- [x] 1.1 Add frontend-architecture requirements for hidden soft-deleted request-log rows and unchanged overview metrics.
+- [x] 1.2 Add database-migrations requirements for the non-cascading request-log FK and soft-delete column/index.
+- [x] 1.3 Validate OpenSpec changes.
+
+## 2. Implementation
+
+- [x] 2.1 Add nullable `request_logs.deleted_at` storage and replace the account FK cascade path with `ON DELETE SET NULL`.
+- [x] 2.2 Update account deletion to soft-delete matching request-log rows instead of removing them.
+- [x] 2.3 Exclude soft-deleted rows from the dashboard request-log list and filter options only.
+- [x] 2.4 Add or adjust indexes needed for the new dashboard request-log filter path.
+
+## 3. Validation
+
+- [x] 3.1 Add backend coverage for account deletion preserving request-log metrics while hiding deleted rows from `/api/request-logs`.
+- [x] 3.2 Add migration coverage for the request-log soft-delete column, index, and `SET NULL` FK behavior.
+- [x] 3.3 Run targeted backend validation plus `openspec validate --specs`.

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -5,12 +5,12 @@ import json
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import update
+from sqlalchemy import select, update
 
 from app.core.auth import fallback_account_id, generate_unique_account_id
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountStatus, RequestLog
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -293,6 +293,43 @@ async def test_delete_account_removes_from_list(async_client):
     assert accounts.status_code == 200
     data = accounts.json()["accounts"]
     assert all(account["accountId"] != actual_account_id for account in data)
+
+
+@pytest.mark.asyncio
+async def test_delete_account_soft_deletes_request_logs(async_client, db_setup):
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_delete_logs", "delete-logs@example.com"))
+        await logs_repo.add_log(
+            account_id="acc_delete_logs",
+            request_id="req_delete_logs_1",
+            model="gpt-5.1",
+            input_tokens=10,
+            output_tokens=5,
+            latency_ms=25,
+            status="success",
+            error_code=None,
+            requested_at=utcnow(),
+        )
+
+    delete = await async_client.delete("/api/accounts/acc_delete_logs")
+    assert delete.status_code == 200
+
+    async with SessionLocal() as session:
+        row = (
+            await session.execute(select(RequestLog).where(RequestLog.request_id == "req_delete_logs_1"))
+        ).scalar_one()
+        assert row.account_id is None
+        assert row.deleted_at is not None
+
+    request_logs = await async_client.get("/api/request-logs?limit=10")
+    assert request_logs.status_code == 200
+    assert request_logs.json()["total"] == 0
+
+    options = await async_client.get("/api/request-logs/options")
+    assert options.status_code == 200
+    assert options.json()["accountIds"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -103,6 +103,40 @@ async def test_dashboard_overview_combines_data(async_client, db_setup):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_overview_metrics_keep_soft_deleted_request_logs(async_client, db_setup):
+    now = utcnow().replace(microsecond=0)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_dash_deleted", "dash-deleted@example.com"))
+        await logs_repo.add_log(
+            account_id="acc_dash_deleted",
+            request_id="req_dash_deleted_1",
+            model="gpt-5.1",
+            input_tokens=40,
+            output_tokens=10,
+            latency_ms=40,
+            status="success",
+            error_code=None,
+            requested_at=now - timedelta(minutes=2),
+        )
+
+    delete_response = await async_client.delete("/api/accounts/acc_dash_deleted")
+    assert delete_response.status_code == 200
+
+    overview = await async_client.get("/api/dashboard/overview")
+    assert overview.status_code == 200
+    payload = overview.json()
+
+    assert payload["accounts"] == []
+    assert payload["summary"]["metrics"]["requests"] == 1
+    assert payload["summary"]["metrics"]["tokens"] == 50
+    request_values = [point["v"] for point in payload["trends"]["requests"]]
+    assert any(value > 0 for value in request_values)
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_maps_weekly_only_primary_to_secondary(async_client, db_setup):
     now = utcnow().replace(microsecond=0)
 

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -486,6 +486,7 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
             dashboard_columns = {str(row[1]) for row in dashboard_columns_rows if len(row) > 1}
             request_log_columns_rows = (await session.execute(text("PRAGMA table_info(request_logs)"))).fetchall()
             request_log_columns = {str(row[1]) for row in request_log_columns_rows if len(row) > 1}
+            assert "deleted_at" in request_log_columns
             assert "transport" in request_log_columns
             assert "plan_type" in request_log_columns
             legacy_plan_type = (
@@ -568,10 +569,18 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
             request_log_index_rows = (await session.execute(text("PRAGMA index_list(request_logs)"))).fetchall()
             request_log_index_names = {str(row[1]) for row in request_log_index_rows if len(row) > 1}
             assert "idx_logs_requested_at_id" in request_log_index_names
+            assert "idx_logs_deleted_at_requested_at_id" in request_log_index_names
             assert "idx_logs_requested_at_model_tier" in request_log_index_names
             assert "idx_logs_model_effort_time" in request_log_index_names
             assert "idx_logs_status_error_time" in request_log_index_names
             assert "idx_logs_api_key_time" in request_log_index_names
+            request_log_fk_rows = (await session.execute(text("PRAGMA foreign_key_list(request_logs)"))).fetchall()
+            request_log_fk_actions = {
+                (str(row[2]).lower(), str(row[3]).lower(), str(row[4]).lower(), str(row[6]).lower())
+                for row in request_log_fk_rows
+                if len(row) > 6
+            }
+            assert ("accounts", "account_id", "id", "set null") in request_log_fk_actions
             api_key_index_rows = (await session.execute(text("PRAGMA index_list(api_keys)"))).fetchall()
             api_key_index_names = {str(row[1]) for row in api_key_index_rows if len(row) > 1}
             assert "idx_api_keys_name" in api_key_index_names
@@ -606,6 +615,19 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
             assert usage_count == 1
             assert logs_count == 1
             assert sticky_count == 2
+
+            await session.execute(text("DELETE FROM usage_history WHERE account_id='acc_legacy'"))
+            await session.execute(text("DELETE FROM sticky_sessions WHERE account_id='acc_legacy'"))
+            await session.execute(text("DELETE FROM accounts WHERE id='acc_legacy'"))
+            await session.commit()
+
+            remaining_log = (
+                await session.execute(
+                    text("SELECT account_id, deleted_at FROM request_logs WHERE id=1")
+                )
+            ).one()
+            assert remaining_log[0] is None
+            assert remaining_log[1] is None
     finally:
         await engine.dispose()
 

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -370,7 +370,7 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
                     """
                     CREATE TABLE request_logs (
                         id INTEGER PRIMARY KEY,
-                        account_id VARCHAR NOT NULL REFERENCES accounts(id),
+                        account_id VARCHAR NOT NULL,
                         request_id VARCHAR NOT NULL,
                         requested_at DATETIME NOT NULL,
                         model VARCHAR NOT NULL,
@@ -382,7 +382,9 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
                         latency_ms INTEGER,
                         status VARCHAR NOT NULL,
                         error_code VARCHAR,
-                        error_message TEXT
+                        error_message TEXT,
+                        CONSTRAINT request_logs_account_id_fkey
+                            FOREIGN KEY(account_id) REFERENCES accounts(id)
                     )
                     """
                 )
@@ -622,9 +624,7 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
             await session.commit()
 
             remaining_log = (
-                await session.execute(
-                    text("SELECT account_id, deleted_at FROM request_logs WHERE id=1")
-                )
+                await session.execute(text("SELECT account_id, deleted_at FROM request_logs WHERE id=1"))
             ).one()
             assert remaining_log[0] is None
             assert remaining_log[1] is None


### PR DESCRIPTION
## Summary
To preserve metrics `request_logs` data when the user account is deleted

## Type of change


- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: <!-- e.g. Closes #123, Fixes #456 -->
Closes #525 

## OpenSpec

<!--
codex-lb is OpenSpec-first. If this PR changes observable behavior, requirements,
contracts, or schema, it needs an OpenSpec change under openspec/changes/<change>/.

If this PR touches an upstream-mimicking code path (Codex CLI / ChatGPT request
shape, image pipeline, response.create framing, etc.), it must stay
**codex-faithful** — i.e. preserve the exact wire format the real upstream
emits. Call out anything that intentionally diverges, and link the spec section
that records the divergence.
-->

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: <!-- openspec/changes/<change>/ -->

## Changes
- `request_logs` are no longer `CASCADE` delete after an account is deleted
- `deleted_at` is added to the `request_logs`

## Test plan

<!--
How did you verify this works? Paste the commands you ran and the relevant outputs.
Required: unit tests for new logic, integration tests for new endpoints.
-->

```
uv run pytest tests/integration/test_accounts_api_extended.py -q
uv run pytest tests/integration/test_dashboard_overview.py -q
uv run pytest tests/integration/test_migrations.py -q
```

## Screenshots / output (optional)

<!-- For dashboard / UI changes: before/after screenshots. For proxy behavior: example request + response, or a log excerpt. -->

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run ruff check .` and `uv run ruff format .` (or pre-commit) locally.
- [x] Ran `uv run pytest` and all tests pass.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
