### PR TITLE
docs(contributing): codify merge gates, collaborator rules, and bus-factor clause

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,9 +18,10 @@ that's the easiest first contribution.
 5. [Workflow: OpenSpec-first](#workflow-openspec-first)
 6. [Coding conventions](#coding-conventions)
 7. [Commit & PR conventions](#commit--pr-conventions)
-8. [Tests](#tests)
-9. [Release process](#release-process)
-10. [Security issues](#security-issues)
+8. [Merge gates and collaborator rules](#merge-gates-and-collaborator-rules)
+9. [Tests](#tests)
+10. [Release process](#release-process)
+11. [Security issues](#security-issues)
 
 ---
 
@@ -189,6 +190,89 @@ PR titles must follow the same format — that's the title release-please reads.
    pushing follow-up commits — no force-pushing during active review.
 6. Once approved and CI is green, a maintainer squash-merges with a clean
    Conventional Commits title.
+
+## Merge gates and collaborator rules
+
+These rules apply to **every PR**, regardless of author (external
+contributor, project owner, or collaborator). They formalize the review
+bar that has produced the current proxy / continuity-recovery / OpenSpec
+quality so far.
+
+### Merge gates
+
+Before a PR is squash-merged into `main`:
+
+1. **CI must be all-green** on the merge-target head. "UNSTABLE, looks
+   fine" is not a green CI; rerun, fix, or wait. The Helm / migration /
+   PostgreSQL test jobs are part of the gate, not optional.
+2. **`@codex review` must be clean — or its findings addressed — on the
+   merge-target head.** Every PR triggers `@codex review` at least once
+   against the head that's about to be merged. Local `codex review
+   --base origin/main` runs are encouraged but don't substitute for the
+   cloud review (the cloud `@codex review` reliably catches things the
+   local run misses).
+   - **P1 findings**: fix in the PR, or justify in-thread with a short
+     write-up of why the finding doesn't apply. No silent skipping.
+   - **P2 findings**: fix in the PR, or open a follow-up issue and link
+     it in the PR thread before merging.
+3. **`mergeable` must be `CLEAN`** in the GitHub API — no merge
+   conflicts, no requested-changes review still outstanding, no missing
+   required status check.
+4. **OpenSpec change folder for behavior changes** (see
+   [Workflow: OpenSpec-first](#workflow-openspec-first)). Pure
+   refactors, docs-only edits, dev-tool changes, and test stabilization
+   PRs are exempt; everything else needs an `openspec/changes/<slug>/`
+   entry.
+5. **`Fixes #N` / `Closes #N` in the PR body** for anything that
+   resolves an issue, so the issue close stays automatic and the merge
+   stays traceable. Use `Refs #N` / `Related to #N` for partial cover.
+
+### Collaborator rules
+
+Collaborators (write-access contributors) follow two additional rules on
+top of the merge gates above:
+
+1. **No self-merge by default.** A collaborator's own PR is merged by
+   another maintainer (or, until the project has more collaborators,
+   by the project owner). Review independence matters more than
+   turnaround.
+2. **Large PRs get split.** Roughly:
+   - If a PR is a stack tip pulling in unrelated commits from sibling
+     branches, split it so each merged PR is a single scoped change.
+   - If a single PR is over **~800 net lines** and spans multiple
+     concerns, split it into reviewable pieces. A single 1500-line
+     change scoped to one capability is fine; a 400-line change that
+     touches the proxy hot path *and* the dashboard *and* the OAuth
+     flow is not.
+
+### Bus factor escape hatch
+
+To keep the project unblocked if the owner is unavailable, the following
+self-merge escape hatch applies:
+
+- If a collaborator's PR has been waiting on a maintainer merge for
+  **more than 14 days** with **all merge gates met** (CI green,
+  `@codex review` clean or findings addressed, `mergeable=CLEAN`, no
+  outstanding requested-changes review, no objection from any other
+  active collaborator in the thread), the PR author may self-merge.
+- Self-merge under this clause **must** include a comment on the PR
+  explicitly invoking the clause and linking to the date the merge
+  gates first went green. Audit trail must stay clean.
+- The clause is a safety valve, not a default path. If you're tempted to
+  invoke it on a PR you opened less than two weeks ago, the merge gates
+  probably aren't actually all green yet.
+
+### What this is not
+
+These rules are intentionally lightweight. They don't require:
+
+- A second human reviewer in addition to `@codex review` for every PR.
+  Codex review + the PR author + a maintainer merge is the baseline.
+- Squash-merge commit message rewriting beyond the Conventional Commits
+  title. The PR description ends up in the body; that's enough.
+- A formal escalation process for disagreements. If a P1 finding is
+  disputed, work it out in-thread; if it can't be resolved, leave the
+  PR open and ping the owner.
 
 ## Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,27 @@ Prompting cue (use when writing docs):
 - Verify before archive: `/opsx:verify <change>`
 - Sync delta specs → main specs: `/opsx:sync <change>`
 - Archive: `/opsx:archive <change>`
+
+## Contributing & Merge Gates
+
+When authoring or merging a PR (as a human contributor, a collaborator,
+or an AI assistant acting on behalf of either), the binding workflow is
+in [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md). The sections
+an AI assistant most often needs are:
+
+- [Merge gates](.github/CONTRIBUTING.md#merge-gates) — CI green +
+  `@codex review` clean (or findings addressed) + `mergeable=CLEAN` +
+  OpenSpec change folder for behavior changes + `Fixes #N` /
+  `Closes #N` for issue cover.
+- [Collaborator rules](.github/CONTRIBUTING.md#collaborator-rules) —
+  no self-merge by default; large PRs get split (≈1-concern per PR,
+  ~800 net lines / scoped capability ceiling).
+- [Bus factor escape hatch](.github/CONTRIBUTING.md#bus-factor-escape-hatch)
+  — self-merge allowed after **14 days** with all gates met and a
+  comment invoking the clause.
+
+An assistant preparing a merge MUST verify the gates against the
+actual GitHub state (status check rollup, codex review submissions,
+`mergeable` field) rather than asserting them from local history.
+Local `uv run pytest` / `uv run ruff` / `codex review --base origin/main`
+are encouraged but not substitutes for the cloud gates.


### PR DESCRIPTION
Folds the collaborator-onboarding agreement from #554 into the binding workflow as a `.github/CONTRIBUTING.md` section and a pointer in `AGENTS.md` so AI assistants pick it up automatically.

## What's in here

Pure docs change. No code, no specs, no migrations.

### `.github/CONTRIBUTING.md`

New `Merge gates and collaborator rules` section between "Commit & PR conventions" and "Tests", covering:

- **Merge gates** that apply to every PR regardless of author:
  - CI all-green on the merge-target head (no "UNSTABLE, looks fine" merges).
  - `@codex review` clean on the merge-target head, or findings addressed (P1 fix-or-justify, P2 fix-or-follow-up-issue).
  - `mergeable=CLEAN` in the GitHub API (no conflicts / requested-changes / missing required status).
  - OpenSpec change folder for behavior changes; pure refactors / docs-only / dev-tool / test-stabilization PRs are exempt.
  - `Fixes #N` / `Closes #N` in the PR body for issue cover.
- **Collaborator rules** on top of the merge gates:
  - No self-merge by default.
  - Large PRs get split: stack tips that pull in unrelated commits are unbundled, single PRs over ~800 net lines spanning multiple concerns are split into reviewable pieces.
- **Bus factor escape hatch**: if a collaborator's PR has been waiting on a maintainer merge for more than **14 days** with all gates met (CI green, codex review clean or findings addressed, `mergeable=CLEAN`, no outstanding requested-changes review, no collaborator objection), the author may self-merge with an in-thread comment invoking the clause and linking to the date the gates first went green.
- **What this is not**: explicitly carves out what the rules *don't* require (second-human reviewer, commit-message rewriting beyond the PR title, formal escalation process). Keeps the gate cheap.

Table of contents updated to include the new section.

### `AGENTS.md`

New `Contributing & Merge Gates` section pointing at the three subsections in `.github/CONTRIBUTING.md` that an AI assistant most often needs (merge gates, collaborator rules, bus factor) and stating the gate-verification expectation: assistants verify against GitHub state (status check rollup, codex review submissions, `mergeable` field) rather than asserting from local history.

## Why now

Folds the agreement reached in <https://github.com/Soju06/codex-lb/issues/554#issuecomment-4458358196> into the binding workflow at exactly one place. Without this PR the rules live only in an issue thread, which is fragile.

@Komzpa -- happy to take edits on this, especially on the bus-factor wording (14 days, threshold for "active collaborator objection", whether the audit comment should also @-mention you). You're the one who'd actually invoke the clause, so the threshold should be comfortable for you.

## Verification

```
uv run ruff check .   # clean (CONTRIBUTING / AGENTS aren't ruff scope, but no other changes here)
```

No tests touched. No OpenSpec change folder -- this PR is the documentation pointer itself; the rules being documented are a workflow convention, not a behavior change. Adding an OpenSpec change for "we wrote down a workflow we already follow" would be the wrong shape.

Refs #554.
