### PR TITLE
fix(frontend/auth): cap dashboard password at 72 UTF-8 bytes

### DIFF
--- a/frontend/src/features/auth/schemas.test.ts
+++ b/frontend/src/features/auth/schemas.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { AuthSessionSchema, LoginRequestSchema } from "@/features/auth/schemas";
+import {
+  AuthSessionSchema,
+  LoginRequestSchema,
+  PasswordChangeRequestSchema,
+  PasswordSetupRequestSchema,
+} from "@/features/auth/schemas";
 
 describe("AuthSessionSchema", () => {
   it("parses valid auth session payload", () => {
@@ -66,5 +71,75 @@ describe("LoginRequestSchema", () => {
         password: "",
       }).success,
     ).toBe(false);
+  });
+});
+
+describe("dashboard password length cap (#615)", () => {
+  // Mirrors `_MAX_PASSWORD_BYTES = 72` in the backend
+  // `app/modules/dashboard_auth/api.py`. Without these guards the form would
+  // still post and the user would only learn about the failure when the
+  // server returns HTTP 422 `password_too_long`.
+
+  it("PasswordSetupRequestSchema accepts a password whose UTF-8 length is exactly 72 bytes", () => {
+    const exact = "a".repeat(72);
+    expect(new TextEncoder().encode(exact)).toHaveLength(72);
+    expect(
+      PasswordSetupRequestSchema.safeParse({
+        password: exact,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("PasswordSetupRequestSchema rejects an ASCII password whose UTF-8 length exceeds 72 bytes", () => {
+    const tooLong = "a".repeat(73);
+    expect(new TextEncoder().encode(tooLong)).toHaveLength(73);
+    const result = PasswordSetupRequestSchema.safeParse({
+      password: tooLong,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/72 bytes/);
+    }
+  });
+
+  it("PasswordSetupRequestSchema rejects a multi-byte password whose UTF-8 length exceeds 72 bytes", () => {
+    // Each `🔒` is 4 UTF-8 bytes; 19 of them = 76 bytes.
+    const emojiPassword = "🔒".repeat(19);
+    expect(new TextEncoder().encode(emojiPassword).length).toBe(76);
+    const result = PasswordSetupRequestSchema.safeParse({
+      password: emojiPassword,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("PasswordSetupRequestSchema still rejects passwords below the 8-character minimum", () => {
+    expect(
+      PasswordSetupRequestSchema.safeParse({
+        password: "short",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("PasswordChangeRequestSchema enforces the 72-byte cap on newPassword", () => {
+    const tooLong = "z".repeat(73);
+    const result = PasswordChangeRequestSchema.safeParse({
+      currentPassword: "current-password-x",
+      newPassword: tooLong,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Error must point at newPassword (not currentPassword) so the form
+      // surfaces the violation on the right field.
+      expect(result.error.issues[0]?.path).toContain("newPassword");
+    }
+  });
+
+  it("PasswordChangeRequestSchema accepts a 72-byte newPassword", () => {
+    expect(
+      PasswordChangeRequestSchema.safeParse({
+        currentPassword: "current-password-x",
+        newPassword: "b".repeat(72),
+      }).success,
+    ).toBe(true);
   });
 });

--- a/frontend/src/features/auth/schemas.ts
+++ b/frontend/src/features/auth/schemas.ts
@@ -1,5 +1,22 @@
 import { z } from "zod";
 
+// Mirrors backend `_MAX_PASSWORD_BYTES` in `app/modules/dashboard_auth/api.py`.
+// bcrypt only hashes the first 72 bytes of input; the backend rejects
+// anything longer with HTTP 422 `password_too_long`. Validate the same
+// budget on the client so users see the failure inline instead of after a
+// round-trip. Multi-byte characters (e.g. emoji) consume their UTF-8 byte
+// count, not the visible character count.
+export const MAX_DASHBOARD_PASSWORD_BYTES = 72;
+
+const dashboardPasswordByteLength = (value: string): number => new TextEncoder().encode(value).length;
+
+const dashboardPasswordSchema = z
+  .string()
+  .min(8)
+  .refine((value) => dashboardPasswordByteLength(value) <= MAX_DASHBOARD_PASSWORD_BYTES, {
+    message: `Password must be at most ${MAX_DASHBOARD_PASSWORD_BYTES} bytes when encoded as UTF-8.`,
+  });
+
 export const DashboardAuthModeSchema = z.enum(["standard", "trusted_header", "disabled"]);
 
 export const AuthSessionSchema = z.object({
@@ -19,13 +36,13 @@ export const LoginRequestSchema = z.object({
 });
 
 export const PasswordSetupRequestSchema = z.object({
-  password: z.string().min(8),
+  password: dashboardPasswordSchema,
   bootstrapToken: z.string().optional(),
 });
 
 export const PasswordChangeRequestSchema = z.object({
   currentPassword: z.string().min(1),
-  newPassword: z.string().min(8),
+  newPassword: dashboardPasswordSchema,
 });
 
 export const PasswordRemoveRequestSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes #615.

The backend caps dashboard passwords at 72 UTF-8 bytes — bcrypt's input ceiling — and returns HTTP 422 `password_too_long` when callers exceed it (`app/modules/dashboard_auth/api.py:159`). The OpenSpec `validate-password-length` admin-auth change locks that contract in (`openspec/changes/validate-password-length/specs/admin-auth/spec.md:5`). Until now `PasswordSetupRequestSchema` and `PasswordChangeRequestSchema` only enforced the 8-character minimum, so a user typing a 73-byte (or longer-than-72-bytes-after-emoji-expansion) password would only learn the rule after the form had already round-tripped.

This change adds a shared `dashboardPasswordSchema` that mirrors the backend rule by measuring `new TextEncoder().encode(value).length` — so emoji and other multi-byte glyphs are weighed by their UTF-8 byte count, not by visible character count — and rejects anything past 72 bytes with the same wording the backend uses. Wires the schema into the setup and change request schemas without altering the 8-character minimum or other fields.

## Tests

`frontend/src/features/auth/schemas.test.ts` (`bun test src/features/auth/schemas.test.ts` → 11 pass / 0 fail):

- 72-byte ASCII password is accepted on `PasswordSetupRequestSchema`.
- 73-byte ASCII password fails with the "72 bytes" message.
- 19-emoji password (76 UTF-8 bytes) fails.
- 8-character minimum is still enforced.
- `PasswordChangeRequestSchema` rejects a 73-byte `newPassword` and points the validation issue at the `newPassword` path.
- 72-byte `newPassword` is accepted on `PasswordChangeRequestSchema`.

## OpenSpec

Per the issue: behavior-preserving on the backend; the frontend is mirroring an already-specified backend contract. No new OpenSpec change folder. Existing `validate-password-length` admin-auth spec already requires the 72-byte cap.

Closes #615
