### PR TITLE
fix(proxy): trim websocket codex full-replay continuations

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -248,6 +248,9 @@ _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES = frozenset(
     }
 )
 _WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
+_WEBSOCKET_CONTINUITY_CACHE_LIMIT = 4096
+_WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS = 20
+_WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS = 0.05
 
 
 @dataclass(frozen=True, slots=True)
@@ -281,6 +284,64 @@ def _fingerprint_input_items(items: Sequence[JsonValue]) -> str:
     return sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _response_create_text(
+    payload: ResponsesRequest,
+    *,
+    include_type_field: bool,
+    client_metadata: Mapping[str, JsonValue] | None,
+) -> str:
+    upstream_payload = dict(payload.to_payload())
+    upstream_payload.pop("stream", None)
+    upstream_payload.pop("background", None)
+    if include_type_field:
+        upstream_payload["type"] = "response.create"
+    if client_metadata:
+        upstream_payload["client_metadata"] = client_metadata
+    return json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
+
+
+def _response_create_text_with_size_guard(
+    payload: ResponsesRequest,
+    *,
+    include_type_field: bool,
+    client_metadata: Mapping[str, JsonValue] | None,
+    request_state: "_WebSocketRequestState",
+    transport: str,
+) -> str:
+    upstream_payload = dict(payload.to_payload())
+    upstream_payload.pop("stream", None)
+    upstream_payload.pop("background", None)
+    if include_type_field:
+        upstream_payload["type"] = "response.create"
+    if client_metadata:
+        upstream_payload["client_metadata"] = client_metadata
+    text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
+    payload_size = len(text_data.encode("utf-8"))
+    if payload_size > _UPSTREAM_RESPONSE_CREATE_MAX_BYTES:
+        slimmed_payload, slim_summary = _slim_response_create_payload_for_upstream(
+            upstream_payload,
+            max_bytes=_UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
+        )
+        if slim_summary is not None:
+            upstream_payload = slimmed_payload
+            text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
+            logger.warning(
+                (
+                    "Slimmed response.create request_id=%s request_log_id=%s transport=%s "
+                    "original_bytes=%s slimmed_bytes=%s "
+                    "historical_tool_outputs_slimmed=%s historical_images_slimmed=%s"
+                ),
+                request_state.request_id,
+                request_state.request_log_id,
+                transport,
+                payload_size,
+                len(text_data.encode("utf-8")),
+                slim_summary["historical_tool_outputs_slimmed"],
+                slim_summary["historical_images_slimmed"],
+            )
+    return text_data
+
+
 class ProxyService:
     def __init__(self, repo_factory: ProxyRepoFactory) -> None:
         self._repo_factory = repo_factory
@@ -294,6 +355,7 @@ class ProxyService:
         self._http_bridge_turn_state_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
         self._http_bridge_previous_response_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
         self._websocket_previous_response_account_index: dict[tuple[str, str | None, str | None], str] = {}
+        self._websocket_continuity_index: dict[tuple[str, str | None], _WebSocketContinuityState] = {}
         # In-memory pin from upstream-issued file_id -> codex-lb account_id.
         # Used so ``finalize_file`` for a given ``file_id`` is routed to
         # the same account that handled ``create_file``. Cross-instance
@@ -305,6 +367,30 @@ class ProxyService:
         self._file_account_pin_lock = asyncio.Lock()
         self._http_bridge_lock = anyio.Lock()
         self._work_admission: WorkAdmissionController | None = None
+
+    def _websocket_continuity_state_for_request(
+        self,
+        headers: Mapping[str, str],
+        *,
+        api_key: ApiKeyData | None,
+        codex_session_affinity: bool,
+    ) -> "_WebSocketContinuityState":
+        if not codex_session_affinity:
+            return _WebSocketContinuityState()
+        session_id = _owner_lookup_session_id_from_headers(headers)
+        if session_id is None:
+            return _WebSocketContinuityState()
+        key = (session_id, api_key.id if api_key is not None else None)
+        continuity_state = self._websocket_continuity_index.get(key)
+        if continuity_state is None:
+            continuity_state = _WebSocketContinuityState()
+            self._websocket_continuity_index[key] = continuity_state
+        else:
+            self._websocket_continuity_index.pop(key, None)
+            self._websocket_continuity_index[key] = continuity_state
+        while len(self._websocket_continuity_index) > _WEBSOCKET_CONTINUITY_CACHE_LIMIT:
+            self._websocket_continuity_index.pop(next(iter(self._websocket_continuity_index)))
+        return continuity_state
 
     def _get_work_admission(self) -> WorkAdmissionController:
         if self._work_admission is None:
@@ -2411,6 +2497,11 @@ class ProxyService:
         upstream: UpstreamResponsesWebSocket | None = None
         upstream_reader: asyncio.Task[None] | None = None
         upstream_control: _WebSocketUpstreamControl | None = None
+        continuity_state = self._websocket_continuity_state_for_request(
+            headers,
+            api_key=api_key,
+            codex_session_affinity=codex_session_affinity,
+        )
         account: Account | None = None
         upstream_turn_state: str | None = _sticky_key_from_turn_state_header(headers)
         downstream_activity = _DownstreamWebSocketActivity()
@@ -2533,7 +2624,40 @@ class ProxyService:
                                     sticky_threads_enabled=sticky_threads_enabled,
                                     openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
                                     api_key=api_key,
+                                    continuity_state=continuity_state,
                                 )
+                                if await _websocket_full_replay_should_wait_for_continuity(
+                                    prepared_request.request_state,
+                                    pending_requests,
+                                    pending_lock=pending_lock,
+                                    codex_session_affinity=codex_session_affinity,
+                                ):
+                                    await self._release_websocket_reservation(
+                                        prepared_request.request_state.api_key_reservation
+                                    )
+                                    wait_started_at = time.monotonic()
+                                    waited_for_anchor = await _wait_for_websocket_continuity_gap(
+                                        pending_requests,
+                                        pending_lock=pending_lock,
+                                        timeout_seconds=runtime_settings.proxy_request_budget_seconds,
+                                    )
+                                    logger.info(
+                                        "websocket_full_replay_waited_for_continuity waited=%s elapsed_ms=%s "
+                                        "original_items=%s",
+                                        waited_for_anchor,
+                                        int((time.monotonic() - wait_started_at) * 1000),
+                                        prepared_request.request_state.input_item_count,
+                                    )
+                                    prepared_request = await self._prepare_websocket_response_create_request(
+                                        payload,
+                                        headers=headers,
+                                        codex_session_affinity=codex_session_affinity,
+                                        openai_cache_affinity=openai_cache_affinity,
+                                        sticky_threads_enabled=sticky_threads_enabled,
+                                        openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
+                                        api_key=api_key,
+                                        continuity_state=continuity_state,
+                                    )
                                 request_state = prepared_request.request_state
                                 request_affinity = prepared_request.affinity_policy
                                 text_data = prepared_request.text_data
@@ -2759,6 +2883,7 @@ class ProxyService:
                             api_key=api_key,
                             upstream_control=upstream_control,
                             response_create_gate=response_create_gate,
+                            continuity_state=continuity_state,
                             proxy_request_budget_seconds=runtime_settings.proxy_request_budget_seconds,
                             stream_idle_timeout_seconds=runtime_settings.stream_idle_timeout_seconds,
                             downstream_activity=downstream_activity,
@@ -2851,6 +2976,7 @@ class ProxyService:
         sticky_threads_enabled: bool,
         openai_cache_affinity_max_age_seconds: int,
         api_key: ApiKeyData | None,
+        continuity_state: "_WebSocketContinuityState | None" = None,
     ) -> _PreparedWebSocketRequest:
         refreshed_api_key = await self._refresh_websocket_api_key_policy(api_key)
         client_metadata = _response_create_client_metadata(payload, headers=headers)
@@ -2859,6 +2985,25 @@ class ProxyService:
         validate_model_access(refreshed_api_key, responses_payload.model)
         self._raise_for_unsupported_input_image_references(responses_payload)
         rewritten_file_account_id = await self._resolve_file_account_for_responses(responses_payload, headers)
+        original_full_resend_payload: ResponsesRequest | None = None
+        original_input_item_count: int | None = None
+        original_input_fingerprint: str | None = None
+        session_anchor = _websocket_continuity_anchor_for_payload(
+            continuity_state,
+            responses_payload=responses_payload,
+            codex_session_affinity=codex_session_affinity,
+        )
+        if session_anchor is not None:
+            original_input_items = cast(list[JsonValue], responses_payload.input)
+            original_input_item_count = len(original_input_items)
+            original_input_fingerprint = _fingerprint_input_items(original_input_items)
+            original_full_resend_payload = responses_payload
+            responses_payload = responses_payload.model_copy(
+                update={
+                    "previous_response_id": session_anchor.previous_response_id,
+                    "input": original_input_items[session_anchor.stored_input_item_count :],
+                }
+            )
         reservation = await self._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -2881,6 +3026,28 @@ class ProxyService:
         except ProxyResponseError:
             await self._release_websocket_reservation(reservation)
             raise
+        if session_anchor is not None:
+            request_state.proxy_injected_previous_response_id = True
+            request_state.input_item_count = original_input_item_count or request_state.input_item_count
+            request_state.input_full_fingerprint = original_input_fingerprint
+            if original_full_resend_payload is not None:
+                request_state.fresh_upstream_request_text = _response_create_text_with_size_guard(
+                    original_full_resend_payload,
+                    include_type_field=True,
+                    client_metadata=client_metadata,
+                    request_state=request_state,
+                    transport=_REQUEST_TRANSPORT_WEBSOCKET,
+                )
+            request_state.fresh_upstream_request_is_retry_safe = request_state.fresh_upstream_request_text is not None
+            logger.info(
+                "websocket_session_anchor_injected request_id=%s response_id=%s original_items=%s trimmed_to=%s",
+                request_state.request_id,
+                session_anchor.previous_response_id,
+                original_input_item_count,
+                len(cast(list[JsonValue], responses_payload.input))
+                if isinstance(responses_payload.input, list)
+                else None,
+            )
         had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
         affinity_policy = _sticky_key_for_responses_request(
             responses_payload,
@@ -5949,6 +6116,7 @@ class ProxyService:
         proxy_request_budget_seconds: float,
         stream_idle_timeout_seconds: float,
         downstream_activity: _DownstreamWebSocketActivity,
+        continuity_state: "_WebSocketContinuityState | None" = None,
     ) -> None:
         try:
             while True:
@@ -6013,6 +6181,7 @@ class ProxyService:
                         api_key=api_key,
                         upstream_control=upstream_control,
                         response_create_gate=response_create_gate,
+                        continuity_state=continuity_state,
                     )
                     suppress_downstream_event = upstream_control.suppress_downstream_event
                     downstream_texts = upstream_control.downstream_texts
@@ -6124,6 +6293,7 @@ class ProxyService:
         api_key: ApiKeyData | None,
         upstream_control: _WebSocketUpstreamControl,
         response_create_gate: asyncio.Semaphore,
+        continuity_state: "_WebSocketContinuityState | None" = None,
     ) -> str:
         event_block = f"data: {text}\n\n"
         payload = parse_sse_data_json(event_block)
@@ -6311,6 +6481,13 @@ class ProxyService:
                 )
             if retry_error_code is not None:
                 return downstream_text
+
+        if event_type == "response.completed" and continuity_state is not None:
+            _record_websocket_continuity_completion(
+                continuity_state,
+                request_state=request_state,
+                response_id=response_id,
+            )
 
         await self._finalize_websocket_request_state(
             request_state,
@@ -8549,6 +8726,19 @@ class _HTTPBridgeSession:
 
 
 @dataclass(slots=True)
+class _WebSocketContinuityState:
+    last_completed_input_count: int = 0
+    last_completed_response_id: str | None = None
+    last_completed_input_prefix_fingerprint: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _WebSocketContinuityAnchor:
+    previous_response_id: str
+    stored_input_item_count: int
+
+
+@dataclass(slots=True)
 class _WebSocketUpstreamControl:
     reconnect_requested: bool = False
     suppress_downstream_event: bool = False
@@ -8588,6 +8778,85 @@ def _event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonV
     if isinstance(payload_type, str):
         return payload_type
     return None
+
+
+def _websocket_continuity_anchor_for_payload(
+    continuity_state: _WebSocketContinuityState | None,
+    *,
+    responses_payload: ResponsesRequest,
+    codex_session_affinity: bool,
+) -> _WebSocketContinuityAnchor | None:
+    if not codex_session_affinity or continuity_state is None:
+        return None
+    if responses_payload.previous_response_id is not None:
+        return None
+    previous_response_id = continuity_state.last_completed_response_id
+    stored_count = continuity_state.last_completed_input_count
+    stored_fingerprint = continuity_state.last_completed_input_prefix_fingerprint
+    incoming_input = responses_payload.input
+    if (
+        previous_response_id is None
+        or stored_count <= 0
+        or stored_fingerprint is None
+        or not isinstance(incoming_input, list)
+        or len(incoming_input) <= stored_count
+    ):
+        return None
+    incoming_input_list = cast(list[JsonValue], incoming_input)
+    incoming_prefix_fingerprint = _fingerprint_input_items(incoming_input_list[:stored_count])
+    if incoming_prefix_fingerprint != stored_fingerprint:
+        return None
+    return _WebSocketContinuityAnchor(
+        previous_response_id=previous_response_id,
+        stored_input_item_count=stored_count,
+    )
+
+
+def _record_websocket_continuity_completion(
+    continuity_state: _WebSocketContinuityState,
+    *,
+    request_state: _WebSocketRequestState,
+    response_id: str | None,
+) -> None:
+    if response_id is not None:
+        continuity_state.last_completed_response_id = response_id
+    if request_state.input_item_count > 0:
+        continuity_state.last_completed_input_count = request_state.input_item_count
+        continuity_state.last_completed_input_prefix_fingerprint = request_state.input_full_fingerprint
+
+
+async def _wait_for_websocket_continuity_gap(
+    pending_requests: deque[_WebSocketRequestState],
+    *,
+    pending_lock: anyio.Lock,
+    timeout_seconds: float,
+) -> bool:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    while True:
+        async with pending_lock:
+            if not pending_requests:
+                return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        await asyncio.sleep(min(_WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS, remaining))
+
+
+async def _websocket_full_replay_should_wait_for_continuity(
+    request_state: _WebSocketRequestState,
+    pending_requests: deque[_WebSocketRequestState],
+    *,
+    pending_lock: anyio.Lock,
+    codex_session_affinity: bool,
+) -> bool:
+    if (
+        not codex_session_affinity
+        or request_state.previous_response_id is not None
+        or request_state.input_item_count < _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS
+    ):
+        return False
+    async with pending_lock:
+        return bool(pending_requests)
 
 
 def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
@@ -8723,6 +8992,11 @@ def _websocket_response_id(event: OpenAIEvent | None, payload: dict[str, JsonVal
         return event.response.id
     if not isinstance(payload, dict):
         return None
+    direct_response_id = payload.get("response_id")
+    if isinstance(direct_response_id, str):
+        stripped_direct_response_id = direct_response_id.strip()
+        if stripped_direct_response_id:
+            return stripped_direct_response_id
     response = payload.get("response")
     if not isinstance(response, dict):
         return None
@@ -8880,6 +9154,15 @@ async def _pop_replayable_precreated_websocket_request_state(
         if request_state.replay_count >= 1:
             return None
         pending_requests.popleft()
+    if (
+        request_state.proxy_injected_previous_response_id
+        and request_state.fresh_upstream_request_is_retry_safe
+        and request_state.fresh_upstream_request_text
+    ):
+        request_state.request_text = request_state.fresh_upstream_request_text
+        request_state.previous_response_id = None
+        request_state.proxy_injected_previous_response_id = False
+        request_state.fresh_upstream_request_is_retry_safe = False
     request_state.replay_count += 1
     request_state.awaiting_response_created = True
     request_state.response_id = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -307,7 +307,7 @@ def _response_create_text_with_size_guard(
     client_metadata: Mapping[str, JsonValue] | None,
     request_state: "_WebSocketRequestState",
     transport: str,
-) -> str:
+) -> str | None:
     upstream_payload = dict(payload.to_payload())
     upstream_payload.pop("stream", None)
     upstream_payload.pop("background", None)
@@ -318,6 +318,7 @@ def _response_create_text_with_size_guard(
     text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
     payload_size = len(text_data.encode("utf-8"))
     if payload_size > _UPSTREAM_RESPONSE_CREATE_MAX_BYTES:
+        original_payload_size = payload_size
         slimmed_payload, slim_summary = _slim_response_create_payload_for_upstream(
             upstream_payload,
             max_bytes=_UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
@@ -325,6 +326,7 @@ def _response_create_text_with_size_guard(
         if slim_summary is not None:
             upstream_payload = slimmed_payload
             text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
+            payload_size = len(text_data.encode("utf-8"))
             logger.warning(
                 (
                     "Slimmed response.create request_id=%s request_log_id=%s transport=%s "
@@ -334,11 +336,24 @@ def _response_create_text_with_size_guard(
                 request_state.request_id,
                 request_state.request_log_id,
                 transport,
+                original_payload_size,
                 payload_size,
-                len(text_data.encode("utf-8")),
                 slim_summary["historical_tool_outputs_slimmed"],
                 slim_summary["historical_images_slimmed"],
             )
+        if payload_size > _UPSTREAM_RESPONSE_CREATE_MAX_BYTES:
+            logger.warning(
+                (
+                    "Skipping oversized response.create retry body request_id=%s request_log_id=%s "
+                    "transport=%s bytes=%s max_bytes=%s"
+                ),
+                request_state.request_id,
+                request_state.request_log_id,
+                transport,
+                payload_size,
+                _UPSTREAM_RESPONSE_CREATE_MAX_BYTES,
+            )
+            return None
     return text_data
 
 
@@ -4270,6 +4285,24 @@ class ProxyService:
                                                 owner_check_applied=True,
                                             )
                                             force_durable_takeover = True
+                                    elif _http_bridge_endpoint_matches_current_instance(owner_endpoint, settings):
+                                        if PROMETHEUS_AVAILABLE and bridge_durable_recover_total is not None:
+                                            bridge_durable_recover_total.labels(path="restart_takeover").inc()
+                                        _log_http_bridge_event(
+                                            "owner_mismatch_local_recover",
+                                            key,
+                                            account_id=None,
+                                            model=request_model,
+                                            detail=(
+                                                "expected_instance="
+                                                f"{owner_instance}, current_instance={current_instance}, "
+                                                "outcome=local_recover_same_endpoint"
+                                            ),
+                                            cache_key_family=key.affinity_kind,
+                                            model_class=_extract_model_class(request_model) if request_model else None,
+                                            owner_check_applied=True,
+                                        )
+                                        force_durable_takeover = True
                                     else:
                                         owner_forward = _HTTPBridgeOwnerForward(
                                             owner_instance=owner_instance,
@@ -8818,11 +8851,14 @@ def _record_websocket_continuity_completion(
     request_state: _WebSocketRequestState,
     response_id: str | None,
 ) -> None:
-    if response_id is not None:
-        continuity_state.last_completed_response_id = response_id
-    if request_state.input_item_count > 0:
-        continuity_state.last_completed_input_count = request_state.input_item_count
-        continuity_state.last_completed_input_prefix_fingerprint = request_state.input_full_fingerprint
+    if response_id is None or request_state.input_item_count <= 0 or request_state.input_full_fingerprint is None:
+        continuity_state.last_completed_response_id = None
+        continuity_state.last_completed_input_count = 0
+        continuity_state.last_completed_input_prefix_fingerprint = None
+        return
+    continuity_state.last_completed_response_id = response_id
+    continuity_state.last_completed_input_count = request_state.input_item_count
+    continuity_state.last_completed_input_prefix_fingerprint = request_state.input_full_fingerprint
 
 
 async def _wait_for_websocket_continuity_gap(
@@ -10888,6 +10924,13 @@ def _http_bridge_can_single_instance_prompt_cache_takeover_without_anchor(
     if ring[0] != current_instance:
         return False
     return owner_instance not in ring
+
+
+def _http_bridge_endpoint_matches_current_instance(owner_endpoint: str, settings: Settings) -> bool:
+    current_endpoint = settings.http_responses_session_bridge_advertise_base_url
+    if current_endpoint is None:
+        return False
+    return owner_endpoint.strip().rstrip("/") == current_endpoint.strip().rstrip("/")
 
 
 def _http_bridge_can_recover_during_drain(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9199,6 +9199,7 @@ async def _pop_replayable_precreated_websocket_request_state(
         request_state.previous_response_id = None
         request_state.proxy_injected_previous_response_id = False
         request_state.fresh_upstream_request_is_retry_safe = False
+        _refresh_websocket_request_input_fingerprint_from_text(request_state)
     request_state.replay_count += 1
     request_state.awaiting_response_created = True
     request_state.response_id = None
@@ -9216,6 +9217,30 @@ def _is_previous_response_not_found_error(
     if code != "invalid_request_error" or param != "previous_response_id":
         return False
     return _is_previous_response_not_found_message(message)
+
+
+def _refresh_websocket_request_input_fingerprint_from_text(request_state: _WebSocketRequestState) -> None:
+    if not request_state.request_text:
+        request_state.input_item_count = 0
+        request_state.input_full_fingerprint = None
+        return
+    try:
+        payload = json.loads(request_state.request_text)
+    except json.JSONDecodeError:
+        request_state.input_item_count = 0
+        request_state.input_full_fingerprint = None
+        return
+    if not isinstance(payload, dict):
+        request_state.input_item_count = 0
+        request_state.input_full_fingerprint = None
+        return
+    input_items = payload.get("input")
+    if not isinstance(input_items, list):
+        request_state.input_item_count = 0
+        request_state.input_full_fingerprint = None
+        return
+    request_state.input_item_count = len(input_items)
+    request_state.input_full_fingerprint = _fingerprint_input_items(cast(list[JsonValue], input_items))
 
 
 def _websocket_event_error_payload(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -4247,6 +4247,72 @@ async def test_get_or_create_http_bridge_session_recovers_locally_when_owner_end
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_recovers_locally_when_stale_owner_endpoint_is_current(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None)
+    created_session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(key="sid-123", kind=proxy_service.StickySessionKind.CODEX_SESSION),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=2.0,
+        idle_ttl_seconds=120.0,
+    )
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
+    claim_durable = AsyncMock()
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: Settings(
+            http_responses_session_bridge_instance_id="instance-a",
+            http_responses_session_bridge_advertise_base_url="http://127.0.0.1:2455",
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-old"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a", "instance-old"])),
+    )
+    forward_to_owner = AsyncMock()
+    monkeypatch.setattr(service, "_forward_http_bridge_request_to_owner", forward_to_owner)
+    service._ring_membership = cast(
+        Any,
+        SimpleNamespace(resolve_endpoint=AsyncMock(return_value="http://127.0.0.1:2455/")),
+    )
+
+    resolved = await service._get_or_create_http_bridge_session(
+        key,
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(key="sid-123", kind=proxy_service.StickySessionKind.CODEX_SESSION),
+        api_key=None,
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+        allow_forward_to_owner=True,
+    )
+
+    assert resolved is created_session
+    claim_durable.assert_awaited_once()
+    await_args = claim_durable.await_args
+    assert await_args is not None
+    assert await_args.kwargs["allow_takeover"] is True
+    forward_to_owner.assert_not_awaited()
+    service._ring_membership.resolve_endpoint.assert_awaited_once_with("instance-old")
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_recovers_locally_when_owner_endpoint_missing_but_replay_anchor_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5297,6 +5297,273 @@ async def test_prepare_websocket_response_create_request_does_not_infer_previous
     assert request_logs.session_lookup_calls == []
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_trims_codex_session_full_replay(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_trim_replay",
+        name="ws-trim-replay",
+        key_prefix="sk-ws-trim",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    historical_input: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
+        {"type": "function_call_output", "call_id": "call_old", "output": "old output"},
+    ]
+    new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=len(historical_input),
+        last_completed_response_id="resp_completed_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [*historical_input, new_input],
+            },
+        ),
+        headers={"session_id": "turn_ws_trim"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_completed_anchor"
+    assert upstream_payload["input"] == [new_input]
+    assert prepared.request_state.previous_response_id == "resp_completed_anchor"
+    assert prepared.request_state.proxy_injected_previous_response_id is True
+    assert prepared.request_state.input_item_count == 3
+    assert prepared.request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
+        [*historical_input, new_input]
+    )
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is True
+    assert prepared.request_state.fresh_upstream_request_text is not None
+    fresh_payload = json.loads(prepared.request_state.fresh_upstream_request_text)
+    assert "previous_response_id" not in fresh_payload
+    assert fresh_payload["input"] == [*historical_input, new_input]
+
+
+@pytest.mark.asyncio
+async def test_prepare_websocket_full_replay_retry_text_uses_size_guard(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_trim_replay_size",
+        name="ws-trim-replay-size",
+        key_prefix="sk-ws-trim-size",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    historical_input: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
+        {"type": "function_call_output", "call_id": "call_large", "output": "A" * 40000},
+    ]
+    new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=len(historical_input),
+        last_completed_response_id="resp_completed_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+    )
+
+    monkeypatch.setattr(proxy_service, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 2048)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [*historical_input, new_input],
+            },
+        ),
+        headers={"session_id": "turn_ws_trim_size"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    assert prepared.request_state.fresh_upstream_request_text is not None
+    fresh_payload = json.loads(prepared.request_state.fresh_upstream_request_text)
+    fresh_input = cast(list[JsonValue], fresh_payload["input"])
+    assert len(prepared.request_state.fresh_upstream_request_text.encode("utf-8")) <= 2048
+    assert fresh_input[1] == {
+        "type": "function_call_output",
+        "call_id": "call_large",
+        "output": proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(bytes=40000),
+    }
+    assert fresh_input[-1] == new_input
+
+
+def test_websocket_continuity_state_reuses_codex_session_scope():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+
+    first = service._websocket_continuity_state_for_request(
+        {"session_id": "codex-session-shared"},
+        api_key=None,
+        codex_session_affinity=True,
+    )
+    first.last_completed_response_id = "resp_cached"
+
+    second = service._websocket_continuity_state_for_request(
+        {"session_id": "codex-session-shared"},
+        api_key=None,
+        codex_session_affinity=True,
+    )
+    unscoped = service._websocket_continuity_state_for_request(
+        {"session_id": "codex-session-shared"},
+        api_key=None,
+        codex_session_affinity=False,
+    )
+
+    assert second is first
+    assert second.last_completed_response_id == "resp_cached"
+    assert unscoped is not first
+
+
+@pytest.mark.asyncio
+async def test_websocket_full_replay_waits_for_pending_continuity_gap():
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_pending_full_replay_anchor",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    next_request = proxy_service._WebSocketRequestState(
+        request_id="ws_next_full_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=proxy_service._WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,
+    )
+    pending_requests = deque([pending_request])
+    pending_lock = anyio.Lock()
+
+    assert await proxy_service._websocket_full_replay_should_wait_for_continuity(
+        next_request,
+        pending_requests,
+        pending_lock=pending_lock,
+        codex_session_affinity=True,
+    )
+
+    async def clear_pending() -> None:
+        await asyncio.sleep(0.01)
+        async with pending_lock:
+            pending_requests.clear()
+
+    clear_task = asyncio.create_task(clear_pending())
+    try:
+        assert await proxy_service._wait_for_websocket_continuity_gap(
+            pending_requests,
+            pending_lock=pending_lock,
+            timeout_seconds=1.0,
+        )
+    finally:
+        await clear_task
+
+
+def test_websocket_response_id_reads_output_item_done_response_id():
+    payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": " resp_output_item ",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": "{}",
+        },
+    }
+
+    assert proxy_service._websocket_response_id(None, payload) == "resp_output_item"
+
+
+@pytest.mark.asyncio
+async def test_pop_replayable_precreated_websocket_request_replays_injected_anchor_as_fresh_payload():
+    anchored_payload = {"type": "response.create", "previous_response_id": "resp_anchor", "input": ["tail"]}
+    fresh_payload = {"type": "response.create", "input": ["old", "tail"]}
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_injected_anchor_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        previous_response_id="resp_anchor",
+        request_text=json.dumps(anchored_payload, separators=(",", ":")),
+        fresh_upstream_request_text=json.dumps(fresh_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=True,
+        proxy_injected_previous_response_id=True,
+    )
+    pending_requests = deque([pending_request])
+
+    replay_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replay_request is pending_request
+    assert pending_requests == deque()
+    assert pending_request.replay_count == 1
+    assert pending_request.previous_response_id is None
+    assert pending_request.proxy_injected_previous_response_id is False
+    assert pending_request.fresh_upstream_request_is_retry_safe is False
+    assert pending_request.request_text is not None
+    assert json.loads(pending_request.request_text) == fresh_payload
+
+
 def test_slim_response_create_payload_rewrites_top_level_historical_input_image():
     payload: dict[str, JsonValue] = {
         "type": "response.create",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5444,6 +5444,69 @@ async def test_prepare_websocket_full_replay_retry_text_uses_size_guard(monkeypa
     assert fresh_input[-1] == new_input
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_full_replay_retry_text_disables_oversized_unslimmable_retry(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_trim_replay_too_large",
+        name="ws-trim-replay-too-large",
+        key_prefix="sk-ws-trim-large",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    historical_input: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "H" * 5000}]},
+    ]
+    new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=len(historical_input),
+        last_completed_response_id="resp_completed_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+    )
+
+    monkeypatch.setattr(proxy_service, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 2048)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [*historical_input, new_input],
+            },
+        ),
+        headers={"session_id": "turn_ws_trim_too_large"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    assert prepared.request_state.fresh_upstream_request_text is None
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
+
+
 def test_websocket_continuity_state_reuses_codex_session_scope():
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
 
@@ -5468,6 +5531,55 @@ def test_websocket_continuity_state_reuses_codex_session_scope():
     assert second is first
     assert second.last_completed_response_id == "resp_cached"
     assert unscoped is not first
+
+
+def test_record_websocket_continuity_completion_keeps_anchor_fields_in_sync():
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=2,
+        last_completed_response_id="resp_old",
+        last_completed_input_prefix_fingerprint="old-fingerprint",
+    )
+    incomplete_state = proxy_service._WebSocketRequestState(
+        request_id="ws_incomplete_continuity",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=3,
+        input_full_fingerprint=None,
+    )
+
+    proxy_service._record_websocket_continuity_completion(
+        continuity_state,
+        request_state=incomplete_state,
+        response_id="resp_new_without_fingerprint",
+    )
+
+    assert continuity_state.last_completed_response_id is None
+    assert continuity_state.last_completed_input_count == 0
+    assert continuity_state.last_completed_input_prefix_fingerprint is None
+
+    complete_state = proxy_service._WebSocketRequestState(
+        request_id="ws_complete_continuity",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        input_item_count=3,
+        input_full_fingerprint="new-fingerprint",
+    )
+
+    proxy_service._record_websocket_continuity_completion(
+        continuity_state,
+        request_state=complete_state,
+        response_id="resp_new",
+    )
+
+    assert continuity_state.last_completed_response_id == "resp_new"
+    assert continuity_state.last_completed_input_count == 3
+    assert continuity_state.last_completed_input_prefix_fingerprint == "new-fingerprint"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8362,6 +8362,56 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
 
 
 @pytest.mark.asyncio
+async def test_pop_replayable_precreated_request_refreshes_fresh_replay_fingerprint():
+    original_input: list[JsonValue] = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+    ]
+    fresh_input: list[JsonValue] = [{"role": "user", "content": "fresh"}]
+    fresh_request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": fresh_input,
+    }
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_refresh_fingerprint",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_anchor",
+                "input": original_input,
+            },
+            separators=(",", ":"),
+        ),
+        previous_response_id="resp_anchor",
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_text=json.dumps(fresh_request_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=True,
+        input_item_count=len(original_input),
+        input_full_fingerprint=proxy_service._fingerprint_input_items(original_input),
+    )
+    pending_requests = deque([pending_request])
+
+    replayed_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replayed_request is pending_request
+    assert pending_request.previous_response_id is None
+    assert pending_request.input_item_count == len(fresh_input)
+    assert pending_request.input_full_fingerprint == proxy_service._fingerprint_input_items(fresh_input)
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_masks_previous_response_not_found_for_unique_followup_request(
     monkeypatch,
 ):


### PR DESCRIPTION
Draft split from #555.

Scope:
- remember completed websocket response anchors per codex session
- convert safe full-history resend turns into previous_response_id continuations
- preserve retry safety by keeping a size-guarded fresh resend payload

Validation run locally on the aggregate stack:
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- focused pytest slices for websocket continuity/replay/security/dedupe

Kept draft until the replacement stack is fully validated/deployed and the tracker is updated.