### PR TITLE
fix(proxy): trim replayed websocket tool inputs

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2855,6 +2855,15 @@ class ProxyService:
         refreshed_api_key = await self._refresh_websocket_api_key_policy(api_key)
         client_metadata = _response_create_client_metadata(payload, headers=headers)
         responses_payload = normalize_responses_request_payload(payload, openai_compat=openai_cache_affinity)
+        previous_response_trimmed_input_count: int | None = None
+        previous_response_trimmed_input_fingerprint: str | None = None
+        if responses_payload.previous_response_id is not None and isinstance(responses_payload.input, list):
+            previous_response_input_items = cast(list[JsonValue], responses_payload.input)
+            trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
+            if len(trimmed_input_items) != len(previous_response_input_items):
+                previous_response_trimmed_input_count = len(previous_response_input_items)
+                previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
+                responses_payload = responses_payload.model_copy(update={"input": trimmed_input_items})
         apply_api_key_enforcement(responses_payload, refreshed_api_key)
         validate_model_access(refreshed_api_key, responses_payload.model)
         self._raise_for_unsupported_input_image_references(responses_payload)
@@ -2882,6 +2891,19 @@ class ProxyService:
             await self._release_websocket_reservation(reservation)
             raise
         had_prompt_cache_key = _prompt_cache_key_from_request_model(responses_payload) is not None
+        if previous_response_trimmed_input_count is not None:
+            request_state.input_item_count = previous_response_trimmed_input_count
+            request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
+            logger.info(
+                "websocket_previous_response_input_trimmed request_id=%s original_items=%s trimmed_to=%s "
+                "previous_response_id=%s",
+                request_state.request_id,
+                previous_response_trimmed_input_count,
+                len(cast(list[JsonValue], responses_payload.input))
+                if isinstance(responses_payload.input, list)
+                else None,
+                responses_payload.previous_response_id,
+            )
         affinity_policy = _sticky_key_for_responses_request(
             responses_payload,
             headers,
@@ -8597,6 +8619,36 @@ def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int
     if isinstance(status, int):
         return status
     return None
+
+
+def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
+    first_output_index = next(
+        (index for index, item in enumerate(input_items) if _websocket_input_item_type(item) == "function_call_output"),
+        None,
+    )
+    if first_output_index is None or first_output_index == 0:
+        return input_items
+    prefix = input_items[:first_output_index]
+    if not all(_is_websocket_previous_response_output_item(item) for item in prefix):
+        return input_items
+    return input_items[first_output_index:]
+
+
+def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
+    item_type = _websocket_input_item_type(item)
+    if item_type in {"reasoning", "function_call", "custom_tool_call"}:
+        return True
+    if item_type != "message" or not isinstance(item, dict):
+        return False
+    role = item.get("role")
+    return role == "assistant"
+
+
+def _websocket_input_item_type(item: JsonValue) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    item_type = item.get("type")
+    return item_type if isinstance(item_type, str) else None
 
 
 def _openai_error_envelope_from_response_failed_payload(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8623,7 +8623,11 @@ def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int
 
 def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
     first_output_index = next(
-        (index for index, item in enumerate(input_items) if _websocket_input_item_type(item) == "function_call_output"),
+        (
+            index
+            for index, item in enumerate(input_items)
+            if _websocket_input_item_type(item) in {"function_call_output", "custom_tool_call_output"}
+        ),
         None,
     )
     if first_output_index is None or first_output_index == 0:
@@ -8635,6 +8639,8 @@ def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) 
 
 
 def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
+    if isinstance(item, dict) and _websocket_input_item_type(item) is None and item.get("role") == "assistant":
+        return True
     item_type = _websocket_input_item_type(item)
     if item_type in {"reasoning", "function_call", "custom_tool_call"}:
         return True

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -983,6 +983,114 @@ def test_backend_responses_websocket_forwards_previous_response_id(app_instance,
     ]
 
 
+def test_backend_responses_websocket_trims_replayed_tool_call_items_with_previous_response_id(
+    app_instance,
+    monkeypatch,
+):
+    fake_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": "resp_ws_tool_output", "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.completed", "response": {"id": "resp_ws_tool_output", "status": "completed"}},
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+    ):
+        del self, headers, sticky_key, sticky_kind, prefer_earlier_reset, routing_strategy, model
+        del request_state, api_key, client_send_lock, websocket, reallocate_sticky, sticky_max_age_seconds
+        return SimpleNamespace(id="acct_ws_tool_output"), fake_upstream
+
+    async def fake_write_request_log(self, **kwargs):
+        del self, kwargs
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "previous_response_id": "resp_prev_tool_call",
+        "input": [
+            {"type": "reasoning", "summary": []},
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "running command"}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "call_repeat",
+                "name": "exec_command",
+                "arguments": '{"cmd":"date"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_repeat",
+                "output": "Wed May 6 16:00:00 UTC 2026",
+            },
+        ],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            first = json.loads(websocket.receive_text())
+            second = json.loads(websocket.receive_text())
+
+    assert first["type"] == "response.created"
+    assert second["type"] == "response.completed"
+    sent_payload = json.loads(fake_upstream.sent_text[0])
+    assert sent_payload["previous_response_id"] == "resp_prev_tool_call"
+    assert sent_payload["input"] == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_repeat",
+            "output": "Wed May 6 16:00:00 UTC 2026",
+        }
+    ]
+
+
 def test_v1_responses_websocket_forwards_previous_response_id(app_instance, monkeypatch):
     fake_upstream = _FakeUpstreamWebSocket(
         [

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -59,6 +59,26 @@ def _proxy_error_message(exc: proxy_module.ProxyResponseError) -> str | None:
     return exc.payload["error"].get("message")
 
 
+def test_trim_websocket_previous_response_input_items_accepts_untyped_assistant_replay() -> None:
+    items: list[JsonValue] = [
+        {"role": "assistant", "content": [{"type": "output_text", "text": "done"}]},
+        {"type": "custom_tool_call", "call_id": "call_custom", "name": "shell", "input": "pwd"},
+        {"type": "custom_tool_call_output", "call_id": "call_custom", "output": "/tmp"},
+        {"role": "user", "content": [{"type": "input_text", "text": "next"}]},
+    ]
+
+    assert proxy_service._trim_websocket_previous_response_input_items(items) == items[2:]
+
+
+def test_trim_websocket_previous_response_input_items_keeps_non_replay_prefix() -> None:
+    items: list[JsonValue] = [
+        {"role": "system", "content": [{"type": "input_text", "text": "local context"}]},
+        {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+    ]
+
+    assert proxy_service._trim_websocket_previous_response_input_items(items) == items
+
+
 def test_filter_inbound_headers_strips_auth_and_account():
     headers = {
         "Authorization": "Bearer x",


### PR DESCRIPTION
Draft split from #555.

Scope:
- direct websocket response.create requests with previous_response_id trim replayed assistant/tool-call output items down to the first tool output needed by upstream

Validation run locally on the aggregate stack:
- ruff format/check on touched files
- focused websocket trim test

Kept draft until the replacement stack is fully validated/deployed and the tracker is updated.