### PR TITLE
fix(proxy): trim anchored http bridge replay inputs

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -537,6 +537,8 @@ class ProxyService:
         effective_payload = payload
         proxy_injected_previous_response_id = False
         fresh_upstream_request_text: str | None = None
+        previous_response_trimmed_input_count: int | None = None
+        previous_response_trimmed_input_fingerprint: str | None = None
         if durable_lookup is not None:
             bridge_session_key = _HTTPBridgeSessionKey(
                 durable_lookup.canonical_kind,
@@ -578,6 +580,13 @@ class ProxyService:
                     cache_key_family=bridge_session_key.affinity_kind,
                     model_class=_extract_model_class(payload.model) if payload.model else None,
                 )
+        if effective_payload.previous_response_id is not None and isinstance(effective_payload.input, list):
+            previous_response_input_items = cast(list[JsonValue], effective_payload.input)
+            trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
+            if len(trimmed_input_items) != len(previous_response_input_items):
+                previous_response_trimmed_input_count = len(previous_response_input_items)
+                previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
+                effective_payload = effective_payload.model_copy(update={"input": trimmed_input_items})
         request_state, text_data = self._prepare_http_bridge_request(
             effective_payload,
             headers,
@@ -587,6 +596,19 @@ class ProxyService:
         )
         if downstream_turn_state is not None:
             request_state.session_id = _normalize_session_id(downstream_turn_state)
+        if previous_response_trimmed_input_count is not None:
+            request_state.input_item_count = previous_response_trimmed_input_count
+            request_state.input_full_fingerprint = previous_response_trimmed_input_fingerprint
+            logger.info(
+                "http_bridge_previous_response_input_trimmed request_id=%s original_items=%s trimmed_to=%s "
+                "previous_response_id=%s",
+                request_state.request_id,
+                previous_response_trimmed_input_count,
+                len(cast(list[JsonValue], effective_payload.input))
+                if isinstance(effective_payload.input, list)
+                else None,
+                effective_payload.previous_response_id,
+            )
         request_state.transport = _REQUEST_TRANSPORT_HTTP
         request_state.request_stage = _http_bridge_request_stage(
             headers=headers,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -582,7 +582,7 @@ class ProxyService:
                 )
         if effective_payload.previous_response_id is not None and isinstance(effective_payload.input, list):
             previous_response_input_items = cast(list[JsonValue], effective_payload.input)
-            trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
+            trimmed_input_items = _trim_http_bridge_previous_response_input_items(previous_response_input_items)
             if len(trimmed_input_items) != len(previous_response_input_items):
                 previous_response_trimmed_input_count = len(previous_response_input_items)
                 previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
@@ -8661,6 +8661,33 @@ def _openai_error_envelope_from_response_failed_payload(
     if isinstance(resets_in, int | float):
         error_detail["resets_in_seconds"] = resets_in
     return envelope
+
+
+def _trim_http_bridge_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
+    first_non_output_index = next(
+        (index for index, item in enumerate(input_items) if not _is_http_bridge_previous_response_output_item(item)),
+        len(input_items),
+    )
+    if first_non_output_index == 0:
+        return input_items
+    return input_items[first_non_output_index:]
+
+
+def _is_http_bridge_previous_response_output_item(item: JsonValue) -> bool:
+    item_type = _http_bridge_input_item_type(item)
+    if item_type in {"reasoning", "function_call", "custom_tool_call"}:
+        return True
+    if item_type != "message" or not isinstance(item, dict):
+        return False
+    role = item.get("role")
+    return role == "assistant"
+
+
+def _http_bridge_input_item_type(item: JsonValue) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    item_type = item.get("type")
+    return item_type if isinstance(item_type, str) else None
 
 
 def _normalize_http_bridge_error_event(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -535,6 +535,7 @@ class ProxyService:
             logger.warning("Durable bridge lookup failed; falling back to non-durable request handling", exc_info=True)
             durable_lookup = None
         effective_payload = payload
+        untrimmed_effective_payload = payload
         proxy_injected_previous_response_id = False
         fresh_upstream_request_text: str | None = None
         previous_response_trimmed_input_count: int | None = None
@@ -1030,7 +1031,7 @@ class ProxyService:
                     error_message="Upstream websocket closed before response.completed",
                 )
                 recovery_path = "context_overflow_fresh_turn"
-                retry_payload = _http_bridge_payload_without_previous_response_id(effective_payload)
+                retry_payload = _http_bridge_payload_without_previous_response_id(untrimmed_effective_payload)
                 retry_previous_response_id = None
                 retry_request_stage = "context_overflow_recover"
                 retry_preferred_account_id = None
@@ -8683,11 +8684,21 @@ def _trim_http_bridge_previous_response_input_items(input_items: list[JsonValue]
 def _is_http_bridge_previous_response_output_item(item: JsonValue) -> bool:
     item_type = _http_bridge_input_item_type(item)
     if item_type in {"reasoning", "function_call", "custom_tool_call"}:
-        return True
+        return _has_http_bridge_response_output_marker(item)
     if item_type != "message" or not isinstance(item, dict):
         return False
     role = item.get("role")
-    return role == "assistant"
+    return role == "assistant" and _has_http_bridge_response_output_marker(item)
+
+
+def _has_http_bridge_response_output_marker(item: JsonValue) -> bool:
+    if not isinstance(item, dict):
+        return False
+    item_id = item.get("id")
+    if isinstance(item_id, str) and item_id.strip():
+        return True
+    status = item.get("status")
+    return status in {"completed", "in_progress"}
 
 
 def _http_bridge_input_item_type(item: JsonValue) -> str | None:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8664,13 +8664,20 @@ def _openai_error_envelope_from_response_failed_payload(
 
 
 def _trim_http_bridge_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
-    first_non_output_index = next(
-        (index for index, item in enumerate(input_items) if not _is_http_bridge_previous_response_output_item(item)),
-        len(input_items),
+    first_output_index = next(
+        (
+            index
+            for index, item in enumerate(input_items)
+            if _http_bridge_input_item_type(item) in {"function_call_output", "custom_tool_call_output"}
+        ),
+        None,
     )
-    if first_non_output_index == 0:
+    if first_output_index is None or first_output_index == 0:
         return input_items
-    return input_items[first_non_output_index:]
+    prefix = input_items[:first_output_index]
+    if not all(_is_http_bridge_previous_response_output_item(item) for item in prefix):
+        return input_items
+    return input_items[first_output_index:]
 
 
 def _is_http_bridge_previous_response_output_item(item: JsonValue) -> bool:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -66,6 +66,7 @@ def test_trim_http_bridge_previous_response_input_items_preserves_context_assist
 
 def test_trim_http_bridge_previous_response_input_items_trims_marked_replay_outputs() -> None:
     items: list[proxy_service.JsonValue] = [
+        {"id": "rs_replay", "type": "reasoning", "summary": []},
         {
             "id": "msg_replay",
             "type": "message",
@@ -73,12 +74,29 @@ def test_trim_http_bridge_previous_response_input_items_trims_marked_replay_outp
             "status": "completed",
             "content": [{"type": "output_text", "text": "prior"}],
         },
+        {
+            "id": "fc_replay",
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+        {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+        {"role": "user", "content": [{"type": "input_text", "text": "next"}]},
+    ]
+
+    assert proxy_service._trim_http_bridge_previous_response_input_items(items) == items[3:]
+
+
+def test_trim_http_bridge_previous_response_input_items_preserves_unmarked_call_context() -> None:
+    items: list[proxy_service.JsonValue] = [
+        {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "local context"}]},
         {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"},
         {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
         {"role": "user", "content": [{"type": "input_text", "text": "next"}]},
     ]
 
-    assert proxy_service._trim_http_bridge_previous_response_input_items(items) == items[2:]
+    assert proxy_service._trim_http_bridge_previous_response_input_items(items) == items
 
 
 @pytest.mark.asyncio
@@ -887,13 +905,16 @@ async def test_stream_via_http_bridge_trims_replayed_tool_call_items_with_previo
             "instructions": "hi",
             "previous_response_id": "resp_prev_tool_call",
             "input": [
-                {"type": "reasoning", "summary": []},
+                {"id": "rs_repeat", "type": "reasoning", "summary": []},
                 {
+                    "id": "msg_repeat",
                     "type": "message",
                     "role": "assistant",
+                    "status": "completed",
                     "content": [{"type": "output_text", "text": "running command"}],
                 },
                 {
+                    "id": "fc_repeat",
                     "type": "function_call",
                     "call_id": "call_repeat",
                     "name": "exec_command",

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -851,6 +851,138 @@ async def test_stream_via_http_bridge_injects_durable_previous_response_anchor(
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_trims_replayed_tool_call_items_with_previous_response_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "previous_response_id": "resp_prev_tool_call",
+            "input": [
+                {"type": "reasoning", "summary": []},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "running command"}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_repeat",
+                    "name": "exec_command",
+                    "arguments": "{\"cmd\":\"date\"}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_repeat",
+                    "output": "Wed May 6 16:00:00 UTC 2026",
+                },
+            ],
+        }
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-trim-tool-call",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    await event_queue.put(None)
+    captured_input: list[proxy_service.JsonValue] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id
+        assert isinstance(prepared_payload.input, list)
+        captured_input[:] = cast(list[proxy_service.JsonValue], prepared_payload.input)
+        request_state.previous_response_id = prepared_payload.previous_response_id
+        return request_state, json.dumps({"type": "response.create", "input": prepared_payload.input})
+
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=session))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"x-codex-session-id": "sid-123"},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == []
+    assert captured_input == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_repeat",
+            "output": "Wed May 6 16:00:00 UTC 2026",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_does_not_inject_session_anchor_for_soft_reuse(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -871,7 +871,7 @@ async def test_stream_via_http_bridge_trims_replayed_tool_call_items_with_previo
                     "type": "function_call",
                     "call_id": "call_repeat",
                     "name": "exec_command",
-                    "arguments": "{\"cmd\":\"date\"}",
+                    "arguments": '{"cmd":"date"}',
                 },
                 {
                     "type": "function_call_output",

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -55,6 +55,32 @@ def _make_api_key(
     )
 
 
+def test_trim_http_bridge_previous_response_input_items_preserves_context_assistant_message() -> None:
+    items: list[proxy_service.JsonValue] = [
+        {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "local context"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "next"}]},
+    ]
+
+    assert proxy_service._trim_http_bridge_previous_response_input_items(items) == items
+
+
+def test_trim_http_bridge_previous_response_input_items_trims_marked_replay_outputs() -> None:
+    items: list[proxy_service.JsonValue] = [
+        {
+            "id": "msg_replay",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "prior"}],
+        },
+        {"type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+        {"role": "user", "content": [{"type": "input_text", "text": "next"}]},
+    ]
+
+    assert proxy_service._trim_http_bridge_previous_response_input_items(items) == items[2:]
+
+
 @pytest.mark.asyncio
 async def test_http_bridge_stream_masks_single_top_level_previous_response_error(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Draft split from #555.

Scope:
- HTTP bridge anchored previous_response_id replay trim helpers and regression coverage

Validation run locally on the aggregate stack:
- ruff format/check on touched files
- focused HTTP bridge trim tests

Kept draft until the replacement stack is fully validated/deployed and the tracker is updated.