### PR TITLE
feat(observability): add conversation archive backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,10 @@ CODEX_LB_METRICS_PORT=9090
 # Logging format
 CODEX_LB_LOG_FORMAT=text
 
+# Full upstream conversation archive (opt-in; stores request/response bodies/events as gzip JSONL)
+CODEX_LB_CONVERSATION_ARCHIVE_ENABLED=false
+# CODEX_LB_CONVERSATION_ARCHIVE_DIR=~/.codex-lb/conversation-archive
+
 # Leader election (opt-in)
 CODEX_LB_LEADER_ELECTION_ENABLED=false
 CODEX_LB_LEADER_ELECTION_TTL_SECONDS=30

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -36,6 +36,7 @@ from multidict import CIMultiDict
 
 from app.core.clients.http import get_http_client
 from app.core.config.settings import Settings, get_settings
+from app.core.conversation_archive import archive_json, archive_text
 from app.core.errors import (
     OpenAIErrorDetail,
     OpenAIErrorEnvelope,
@@ -1281,6 +1282,17 @@ async def _stream_responses_via_websocket(
             request_started_at,
             time.monotonic(),
         )
+        archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="websocket",
+            payload=request_payload,
+            account_id=account_id,
+            method="GET",
+            url=websocket_url,
+            headers=headers,
+            extra={"frame_type": "text"},
+        )
         if callable(send_json):
             await asyncio.wait_for(
                 cast(Callable[[JsonObject], Awaitable[None]], send_json)(request_payload),
@@ -1302,6 +1314,17 @@ async def _stream_responses_via_websocket(
             total_timeout_seconds=remaining_total_timeout,
             max_event_bytes=max_event_bytes,
         ):
+            archive_text(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                text=event,
+                account_id=account_id,
+                method="GET",
+                url=websocket_url,
+                headers=headers,
+                extra={"event_format": "sse"},
+            )
             parsed_event = parse_sse_event(event)
             if parsed_event and parsed_event.type in ("response.completed", "response.failed", "response.incomplete"):
                 seen_terminal = True
@@ -1870,10 +1893,34 @@ async def stream_responses(
                 if raise_for_status:
                     error_payload = await _error_payload_from_response(resp)
                     error_code, error_message = _error_details_from_envelope(error_payload)
+                    archive_json(
+                        direction="server_to_codex",
+                        kind="responses",
+                        transport="http",
+                        payload=error_payload,
+                        account_id=account_id,
+                        method="POST",
+                        url=url,
+                        status_code=status_code,
+                        headers=current_headers,
+                    )
                     raise ProxyResponseError(resp.status, error_payload)
                 event = await _error_event_from_response(resp)
                 error_code, error_message = _error_details_from_failed_event(event)
-                yield format_sse_event(event)
+                event_block = format_sse_event(event)
+                archive_text(
+                    direction="server_to_codex",
+                    kind="responses",
+                    transport="http",
+                    text=event_block,
+                    account_id=account_id,
+                    method="POST",
+                    url=url,
+                    status_code=status_code,
+                    headers=current_headers,
+                    extra={"event_format": "sse"},
+                )
+                yield event_block
                 return
 
             async for event_block in _iter_sse_events(
@@ -1887,6 +1934,18 @@ async def stream_responses(
                     event_type = event.type
                     if event_type in ("response.completed", "response.failed", "response.incomplete"):
                         seen_terminal = True
+                archive_text(
+                    direction="server_to_codex",
+                    kind="responses",
+                    transport="http",
+                    text=event_block,
+                    account_id=account_id,
+                    method="POST",
+                    url=url,
+                    status_code=status_code,
+                    headers=current_headers,
+                    extra={"event_format": "sse"},
+                )
                 yield event_block
                 if seen_terminal:
                     break
@@ -1899,6 +1958,17 @@ async def stream_responses(
         payload_summary=_summarize_json_payload(payload_dict),
         payload_json=payload_json if settings.log_upstream_request_payload else None,
     )
+    if transport == "http":
+        archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="http",
+            payload=payload_dict,
+            account_id=account_id,
+            method=method,
+            url=url,
+            headers=upstream_headers,
+        )
     try:
         if transport == "websocket":
             try:
@@ -1978,6 +2048,16 @@ async def stream_responses(
                     method=method,
                     payload_summary=_summarize_json_payload(payload_dict),
                     payload_json=payload_json if settings.log_upstream_request_payload else None,
+                )
+                archive_json(
+                    direction="codex_to_server",
+                    kind="responses",
+                    transport="http",
+                    payload=payload_dict,
+                    account_id=account_id,
+                    method=method,
+                    url=url,
+                    headers=upstream_headers,
                 )
                 async for event_block in _stream_via_http(upstream_headers, timeout):
                     yield event_block
@@ -2250,6 +2330,16 @@ class _CompactCommandTransport:
             if settings.log_upstream_request_payload
             else None,
         )
+        archive_json(
+            direction="codex_to_server",
+            kind="compact",
+            transport="http",
+            payload=payload_dict,
+            account_id=self.account_id,
+            method="POST",
+            url=url,
+            headers=upstream_headers,
+        )
         try:
             async with _service_circuit_breaker_context(
                 self.session.post(
@@ -2264,6 +2354,17 @@ class _CompactCommandTransport:
                 status_code = resp.status
                 if resp.status >= 400:
                     error_payload = await _error_payload_from_response(resp)
+                    archive_json(
+                        direction="server_to_codex",
+                        kind="compact",
+                        transport="http",
+                        payload=error_payload,
+                        account_id=self.account_id,
+                        method="POST",
+                        url=url,
+                        status_code=status_code,
+                        headers=upstream_headers,
+                    )
                     error_code, error_message = _error_details_from_envelope(error_payload)
                     failure_phase = "status"
                     failure_detail = error_message
@@ -2310,6 +2411,17 @@ class _CompactCommandTransport:
                         upstream_status_code=resp.status,
                     ) from exc
                 parsed = parse_compact_response_payload(data)
+                archive_json(
+                    direction="server_to_codex",
+                    kind="compact",
+                    transport="http",
+                    payload=data,
+                    account_id=self.account_id,
+                    method="POST",
+                    url=url,
+                    status_code=status_code,
+                    headers=upstream_headers,
+                )
                 if parsed:
                     payload_object = parsed.object
                     return parsed

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -20,6 +20,7 @@ from websockets.typing import Origin
 
 from app.core.clients.proxy import ProxyResponseError, filter_inbound_headers
 from app.core.config.settings import get_settings
+from app.core.conversation_archive import archive_bytes, archive_text
 from app.core.errors import OpenAIErrorDetail, OpenAIErrorEnvelope, openai_error
 from app.core.openai.models import OpenAIError
 from app.core.openai.parsing import parse_error_payload
@@ -100,6 +101,95 @@ class WebsocketsResponsesWebSocket:
         if value is None:
             return None
         return str(value)
+
+
+class ArchivingResponsesWebSocket:
+    def __init__(
+        self,
+        wrapped: UpstreamResponsesWebSocket,
+        *,
+        url: str,
+        headers: dict[str, str],
+        account_id: str | None,
+    ) -> None:
+        self._wrapped = wrapped
+        self._url = url
+        self._headers = headers
+        self._account_id = account_id
+
+    async def send_text(self, text: str) -> None:
+        archive_text(
+            direction="codex_to_server",
+            kind="responses",
+            transport="websocket",
+            text=text,
+            account_id=self._account_id,
+            method="GET",
+            url=self._url,
+            headers=self._headers,
+            extra={"frame_type": "text"},
+        )
+        await self._wrapped.send_text(text)
+
+    async def send_bytes(self, data: bytes) -> None:
+        archive_bytes(
+            direction="codex_to_server",
+            kind="responses",
+            transport="websocket",
+            data=data,
+            account_id=self._account_id,
+            method="GET",
+            url=self._url,
+            headers=self._headers,
+            extra={"frame_type": "binary"},
+        )
+        await self._wrapped.send_bytes(data)
+
+    async def receive(self) -> UpstreamWebSocketMessage:
+        message = await self._wrapped.receive()
+        if message.kind == "text" and message.text is not None:
+            archive_text(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                text=message.text,
+                account_id=self._account_id,
+                method="GET",
+                url=self._url,
+                headers=self._headers,
+                extra={"frame_type": "text"},
+            )
+        elif message.kind == "binary" and message.data is not None:
+            archive_bytes(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                data=message.data,
+                account_id=self._account_id,
+                method="GET",
+                url=self._url,
+                headers=self._headers,
+                extra={"frame_type": "binary"},
+            )
+        else:
+            archive_text(
+                direction="server_to_codex",
+                kind="responses",
+                transport="websocket",
+                text=message.error or "",
+                account_id=self._account_id,
+                method="GET",
+                url=self._url,
+                headers=self._headers,
+                extra={"frame_type": message.kind, "close_code": message.close_code},
+            )
+        return message
+
+    async def close(self) -> None:
+        await self._wrapped.close()
+
+    def response_header(self, name: str) -> str | None:
+        return self._wrapped.response_header(name)
 
 
 def filter_inbound_websocket_headers(headers: dict[str, str]) -> dict[str, str]:
@@ -207,7 +297,12 @@ async def connect_responses_websocket(
             openai_error("upstream_unavailable", str(exc)),
         ) from exc
 
-    return WebsocketsResponsesWebSocket(response)
+    return ArchivingResponsesWebSocket(
+        WebsocketsResponsesWebSocket(response),
+        url=url,
+        headers=upstream_headers,
+        account_id=account_id,
+    )
 
 
 def _close_code_from_exception(exc: ConnectionClosedOK | ConnectionClosedError) -> int | None:

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -181,6 +181,8 @@ class Settings(BaseSettings):
     log_proxy_service_tier_trace: bool = False
     log_upstream_request_summary: bool = False
     log_upstream_request_payload: bool = False
+    conversation_archive_enabled: bool = False
+    conversation_archive_dir: Path = DEFAULT_HOME_DIR / "conversation-archive"
     max_decompressed_body_bytes: int = Field(default=32 * 1024 * 1024, gt=0)
     image_inline_fetch_enabled: bool = True
     image_inline_allowed_hosts: Annotated[list[str], NoDecode] = Field(default_factory=list)

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -325,6 +325,7 @@ def _stop_writer() -> None:
     thread = _WRITER_THREAD
     if thread is None:
         return
+    _WRITE_QUEUE.join()
     _WRITE_QUEUE.put(None)
     thread.join(timeout=1)
 

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import atexit
+import base64
+import errno
+import gzip
+import json
+import logging
+import queue
+import threading
+import time
+import zlib
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from app.core.config.settings import get_settings
+from app.core.utils.request_id import get_request_id
+
+logger = logging.getLogger(__name__)
+
+_REDACTED = "[redacted]"
+_SENSITIVE_HEADER_NAMES = frozenset(
+    {
+        "authorization",
+        "api-key",
+        "api_key",
+        "cookie",
+        "openai-api-key",
+        "proxy-authorization",
+        "set-cookie",
+        "x-api-key",
+    }
+)
+_WRITE_LOCK = threading.Lock()
+_WRITER_LOCK = threading.Lock()
+_WRITE_QUEUE_MAX_RECORDS = 4096
+_WRITE_QUEUE: queue.Queue[tuple[Path, dict[str, Any]] | None] = queue.Queue(maxsize=_WRITE_QUEUE_MAX_RECORDS)
+_WRITER_THREAD: threading.Thread | None = None
+_RECOVERY_CHECKED_PATHS: set[Path] = set()
+_DISK_PRESSURE_PAUSE_SECONDS = 60.0
+_DISK_PRESSURE_WARNING_INTERVAL_SECONDS = 300.0
+_DISK_PRESSURE_PAUSED_UNTIL = 0.0
+_DISK_PRESSURE_LAST_WARNING_AT = -_DISK_PRESSURE_WARNING_INTERVAL_SECONDS
+_DISK_PRESSURE_LOCK = threading.Lock()
+
+
+def archive_enabled() -> bool:
+    return bool(getattr(get_settings(), "conversation_archive_enabled", False))
+
+
+def archive_json(
+    *,
+    direction: str,
+    kind: str,
+    transport: str,
+    payload: Any,
+    account_id: str | None = None,
+    method: str | None = None,
+    url: str | None = None,
+    status_code: int | None = None,
+    headers: Mapping[str, str] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> None:
+    if not archive_enabled():
+        return
+
+    record: dict[str, Any] = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "request_id": get_request_id(),
+        "direction": direction,
+        "kind": kind,
+        "transport": transport,
+        "account_id": account_id,
+        "method": method,
+        "url": url,
+        "status_code": status_code,
+        "headers": _redact_headers(headers),
+        "payload": payload,
+    }
+    if extra:
+        record["extra"] = dict(extra)
+    _enqueue_record(_archive_path(), record)
+
+
+def archive_text(
+    *,
+    direction: str,
+    kind: str,
+    transport: str,
+    text: str,
+    account_id: str | None = None,
+    method: str | None = None,
+    url: str | None = None,
+    status_code: int | None = None,
+    headers: Mapping[str, str] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> None:
+    archive_json(
+        direction=direction,
+        kind=kind,
+        transport=transport,
+        payload={"text": text},
+        account_id=account_id,
+        method=method,
+        url=url,
+        status_code=status_code,
+        headers=headers,
+        extra=extra,
+    )
+
+
+def archive_bytes(
+    *,
+    direction: str,
+    kind: str,
+    transport: str,
+    data: bytes,
+    account_id: str | None = None,
+    method: str | None = None,
+    url: str | None = None,
+    status_code: int | None = None,
+    headers: Mapping[str, str] | None = None,
+    extra: Mapping[str, Any] | None = None,
+) -> None:
+    archive_json(
+        direction=direction,
+        kind=kind,
+        transport=transport,
+        payload={
+            "encoding": "base64",
+            "data": base64.b64encode(data).decode("ascii"),
+        },
+        account_id=account_id,
+        method=method,
+        url=url,
+        status_code=status_code,
+        headers=headers,
+        extra=extra,
+    )
+
+
+def _redact_headers(headers: Mapping[str, str] | None) -> dict[str, str] | None:
+    if headers is None:
+        return None
+    redacted: dict[str, str] = {}
+    for key, value in headers.items():
+        redacted[key] = _redact_header_value(key, value)
+    return redacted
+
+
+def _archive_path() -> Path:
+    settings = get_settings()
+    directory = Path(getattr(settings, "conversation_archive_dir")).expanduser()
+    filename = f"{datetime.now(UTC).strftime('%Y-%m-%dT%H')}.jsonl.gz"
+    return directory / filename
+
+
+def flush_archive_writer() -> None:
+    _WRITE_QUEUE.join()
+
+
+def _enqueue_record(path: Path, record: dict[str, Any]) -> None:
+    if _archive_disk_pressure_active():
+        return
+    _ensure_writer_thread()
+    try:
+        _WRITE_QUEUE.put_nowait((path, record))
+    except queue.Full:
+        logger.warning(
+            "Conversation archive writer queue is full; applying synchronous archive write backpressure",
+            extra={"queue_max_records": _WRITE_QUEUE_MAX_RECORDS},
+        )
+        _append_record(path, record)
+
+
+def _ensure_writer_thread() -> None:
+    global _WRITER_THREAD
+    if _WRITER_THREAD is not None and _WRITER_THREAD.is_alive():
+        return
+    with _WRITER_LOCK:
+        if _WRITER_THREAD is not None and _WRITER_THREAD.is_alive():
+            return
+        _WRITER_THREAD = threading.Thread(
+            target=_writer_loop,
+            name="conversation-archive-writer",
+            daemon=True,
+        )
+        _WRITER_THREAD.start()
+
+
+def _writer_loop() -> None:
+    while True:
+        item = _WRITE_QUEUE.get()
+        try:
+            if item is None:
+                return
+            path, record = item
+            _append_record(path, record)
+        finally:
+            _WRITE_QUEUE.task_done()
+
+
+def _append_record(path: Path, record: Mapping[str, Any]) -> None:
+    if _archive_disk_pressure_active():
+        return
+
+    line = json.dumps(record, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    data = gzip.compress(f"{line}\n".encode("utf-8"))
+    try:
+        with _WRITE_LOCK:
+            if _archive_disk_pressure_active():
+                return
+            path.parent.mkdir(parents=True, exist_ok=True)
+            _recover_corrupt_gzip_archive(path)
+            _write_gzip_member(path, data)
+    except Exception as exc:
+        if _is_disk_pressure_error(exc):
+            _pause_archive_for_disk_pressure(path, exc)
+            return
+        logger.warning("Failed to append conversation archive record", exc_info=True)
+
+
+def _write_gzip_member(path: Path, data: bytes) -> None:
+    with path.open("ab") as fh:
+        fh.write(data)
+
+
+def _archive_disk_pressure_active() -> bool:
+    with _DISK_PRESSURE_LOCK:
+        return time.monotonic() < _DISK_PRESSURE_PAUSED_UNTIL
+
+
+def _pause_archive_for_disk_pressure(path: Path, exc: BaseException) -> None:
+    global _DISK_PRESSURE_LAST_WARNING_AT, _DISK_PRESSURE_PAUSED_UNTIL
+    now = time.monotonic()
+    with _DISK_PRESSURE_LOCK:
+        _DISK_PRESSURE_PAUSED_UNTIL = max(_DISK_PRESSURE_PAUSED_UNTIL, now + _DISK_PRESSURE_PAUSE_SECONDS)
+        should_warn = now - _DISK_PRESSURE_LAST_WARNING_AT >= _DISK_PRESSURE_WARNING_INTERVAL_SECONDS
+        if should_warn:
+            _DISK_PRESSURE_LAST_WARNING_AT = now
+
+    if should_warn:
+        logger.warning(
+            "Conversation archive disk pressure detected; pausing archive writes",
+            extra={
+                "archive_file": str(path),
+                "pause_seconds": _DISK_PRESSURE_PAUSE_SECONDS,
+                "error": str(exc),
+            },
+        )
+
+
+def _is_disk_pressure_error(exc: BaseException) -> bool:
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, OSError) and current.errno in {errno.ENOSPC, errno.EDQUOT}:
+            return True
+        message = str(current).lower()
+        if (
+            "no space left on device" in message
+            or "disk quota exceeded" in message
+            or "database or disk is full" in message
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _recover_corrupt_gzip_archive(path: Path) -> None:
+    resolved_path = path.resolve()
+    if resolved_path in _RECOVERY_CHECKED_PATHS:
+        return
+    _RECOVERY_CHECKED_PATHS.add(resolved_path)
+
+    if not path.exists() or path.stat().st_size == 0:
+        return
+    if _gzip_archive_is_readable(path):
+        return
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    backup = path.with_name(f"{path.name}.corrupt-{timestamp}")
+    recovered = path.with_name(f".{path.name}.recovered-{timestamp}")
+    recovered_count = 0
+    try:
+        with gzip.open(path, "rb") as source, recovered.open("wb") as target:
+            while True:
+                try:
+                    line = source.readline()
+                except (EOFError, gzip.BadGzipFile, zlib.error):
+                    break
+                if not line:
+                    break
+                target.write(gzip.compress(line))
+                recovered_count += 1
+        path.replace(backup)
+        recovered.replace(path)
+        logger.warning(
+            "Recovered readable conversation archive prefix from corrupt gzip file",
+            extra={
+                "archive_file": str(path),
+                "backup_file": str(backup),
+                "recovered_records": recovered_count,
+            },
+        )
+    except Exception:
+        recovered.unlink(missing_ok=True)
+        logger.warning("Failed to recover corrupt conversation archive gzip", exc_info=True)
+
+
+def _gzip_archive_is_readable(path: Path) -> bool:
+    try:
+        with gzip.open(path, "rb") as fh:
+            for _chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                pass
+    except (EOFError, gzip.BadGzipFile, zlib.error):
+        return False
+    return True
+
+
+def _stop_writer() -> None:
+    thread = _WRITER_THREAD
+    if thread is None:
+        return
+    _WRITE_QUEUE.put(None)
+    thread.join(timeout=1)
+
+
+def _redact_header_value(key: str, value: object) -> str:
+    lowered = key.lower()
+    normalized = lowered.replace("_", "-")
+    if normalized in _SENSITIVE_HEADER_NAMES or normalized.endswith("-api-key") or "token" in normalized:
+        return _REDACTED
+    return str(value)
+
+
+atexit.register(_stop_writer)

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -6,6 +6,7 @@ import errno
 import gzip
 import json
 import logging
+import os
 import queue
 import threading
 import time
@@ -47,6 +48,8 @@ _DISK_PRESSURE_WARNING_INTERVAL_SECONDS = 300.0
 _DISK_PRESSURE_PAUSED_UNTIL = 0.0
 _DISK_PRESSURE_LAST_WARNING_AT = -_DISK_PRESSURE_WARNING_INTERVAL_SECONDS
 _DISK_PRESSURE_LOCK = threading.Lock()
+_ARCHIVE_DIR_MODE = 0o700
+_ARCHIVE_FILE_MODE = 0o600
 
 
 def archive_enabled() -> bool:
@@ -239,6 +242,7 @@ def _append_record(path: Path, record: Mapping[str, Any]) -> None:
             if _archive_disk_pressure_active():
                 return
             path.parent.mkdir(parents=True, exist_ok=True)
+            path.parent.chmod(_ARCHIVE_DIR_MODE)
             _recover_corrupt_gzip_archive(path)
             _write_gzip_member(path, data)
     except Exception as exc:
@@ -270,8 +274,15 @@ def _release_archive_queue_bytes(size: int) -> None:
 
 
 def _write_gzip_member(path: Path, data: bytes) -> None:
-    with path.open("ab") as fh:
-        fh.write(data)
+    fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, _ARCHIVE_FILE_MODE)
+    try:
+        os.fchmod(fd, _ARCHIVE_FILE_MODE)
+        with os.fdopen(fd, "ab") as fh:
+            fd = -1
+            fh.write(data)
+    finally:
+        if fd >= 0:
+            os.close(fd)
 
 
 def _archive_disk_pressure_active() -> bool:

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -216,6 +216,7 @@ def _append_record(path: Path, record: Mapping[str, Any]) -> None:
             _recover_corrupt_gzip_archive(path)
             _write_gzip_member(path, data)
     except Exception as exc:
+        _RECOVERY_CHECKED_PATHS.discard(path.resolve())
         if _is_disk_pressure_error(exc):
             _pause_archive_for_disk_pressure(path, exc)
             return
@@ -274,11 +275,11 @@ def _recover_corrupt_gzip_archive(path: Path) -> None:
     resolved_path = path.resolve()
     if resolved_path in _RECOVERY_CHECKED_PATHS:
         return
-    _RECOVERY_CHECKED_PATHS.add(resolved_path)
 
     if not path.exists() or path.stat().st_size == 0:
         return
     if _gzip_archive_is_readable(path):
+        _RECOVERY_CHECKED_PATHS.add(resolved_path)
         return
 
     timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
@@ -298,6 +299,7 @@ def _recover_corrupt_gzip_archive(path: Path) -> None:
                 recovered_count += 1
         path.replace(backup)
         recovered.replace(path)
+        _RECOVERY_CHECKED_PATHS.add(resolved_path)
         logger.warning(
             "Recovered readable conversation archive prefix from corrupt gzip file",
             extra={
@@ -327,7 +329,7 @@ def _stop_writer() -> None:
         return
     _WRITE_QUEUE.join()
     _WRITE_QUEUE.put(None)
-    thread.join(timeout=1)
+    thread.join()
 
 
 def _redact_header_value(key: str, value: object) -> str:

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -181,16 +181,22 @@ def _enqueue_record(path: Path, record: dict[str, Any]) -> None:
         )
         _append_record(path, record)
         return
-    _ensure_writer_thread()
+    queued = False
     try:
+        _ensure_writer_thread()
         _WRITE_QUEUE.put_nowait((path, record, queued_bytes))
+        queued = True
     except queue.Full:
-        _release_archive_queue_bytes(queued_bytes)
         logger.warning(
             "Conversation archive writer queue is full; applying synchronous archive write backpressure",
             extra={"queue_max_records": _WRITE_QUEUE_MAX_RECORDS},
         )
         _append_record(path, record)
+    except Exception:
+        logger.warning("Failed to enqueue conversation archive record; dropping it", exc_info=True)
+    finally:
+        if not queued:
+            _release_archive_queue_bytes(queued_bytes)
 
 
 def _ensure_writer_thread() -> None:

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -124,6 +124,9 @@ def archive_bytes(
     headers: Mapping[str, str] | None = None,
     extra: Mapping[str, Any] | None = None,
 ) -> None:
+    if not archive_enabled():
+        return
+
     archive_json(
         direction=direction,
         kind=kind,

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -36,7 +36,10 @@ _SENSITIVE_HEADER_NAMES = frozenset(
 _WRITE_LOCK = threading.Lock()
 _WRITER_LOCK = threading.Lock()
 _WRITE_QUEUE_MAX_RECORDS = 4096
-_WRITE_QUEUE: queue.Queue[tuple[Path, dict[str, Any]] | None] = queue.Queue(maxsize=_WRITE_QUEUE_MAX_RECORDS)
+_WRITE_QUEUE_MAX_BYTES = 8 * 1024 * 1024
+_WRITE_QUEUE_BYTES = 0
+_WRITE_QUEUE_BYTES_LOCK = threading.Lock()
+_WRITE_QUEUE: queue.Queue[tuple[Path, dict[str, Any], int] | None] = queue.Queue(maxsize=_WRITE_QUEUE_MAX_RECORDS)
 _WRITER_THREAD: threading.Thread | None = None
 _RECOVERY_CHECKED_PATHS: set[Path] = set()
 _DISK_PRESSURE_PAUSE_SECONDS = 60.0
@@ -167,10 +170,22 @@ def flush_archive_writer() -> None:
 def _enqueue_record(path: Path, record: dict[str, Any]) -> None:
     if _archive_disk_pressure_active():
         return
+    queued_bytes = _serialized_record_size(record)
+    if not _reserve_archive_queue_bytes(queued_bytes):
+        logger.warning(
+            "Conversation archive writer queue byte budget is full; applying synchronous archive write backpressure",
+            extra={
+                "queue_max_bytes": _WRITE_QUEUE_MAX_BYTES,
+                "record_bytes": queued_bytes,
+            },
+        )
+        _append_record(path, record)
+        return
     _ensure_writer_thread()
     try:
-        _WRITE_QUEUE.put_nowait((path, record))
+        _WRITE_QUEUE.put_nowait((path, record, queued_bytes))
     except queue.Full:
+        _release_archive_queue_bytes(queued_bytes)
         logger.warning(
             "Conversation archive writer queue is full; applying synchronous archive write backpressure",
             extra={"queue_max_records": _WRITE_QUEUE_MAX_RECORDS},
@@ -199,9 +214,11 @@ def _writer_loop() -> None:
         try:
             if item is None:
                 return
-            path, record = item
+            path, record, queued_bytes = item
             _append_record(path, record)
         finally:
+            if item is not None:
+                _release_archive_queue_bytes(queued_bytes)
             _WRITE_QUEUE.task_done()
 
 
@@ -224,6 +241,26 @@ def _append_record(path: Path, record: Mapping[str, Any]) -> None:
             _pause_archive_for_disk_pressure(path, exc)
             return
         logger.warning("Failed to append conversation archive record", exc_info=True)
+
+
+def _serialized_record_size(record: Mapping[str, Any]) -> int:
+    line = json.dumps(record, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return len(line.encode("utf-8")) + 1
+
+
+def _reserve_archive_queue_bytes(size: int) -> bool:
+    global _WRITE_QUEUE_BYTES
+    with _WRITE_QUEUE_BYTES_LOCK:
+        if _WRITE_QUEUE_BYTES + size > _WRITE_QUEUE_MAX_BYTES:
+            return False
+        _WRITE_QUEUE_BYTES += size
+        return True
+
+
+def _release_archive_queue_bytes(size: int) -> None:
+    global _WRITE_QUEUE_BYTES
+    with _WRITE_QUEUE_BYTES_LOCK:
+        _WRITE_QUEUE_BYTES = max(0, _WRITE_QUEUE_BYTES - size)
 
 
 def _write_gzip_member(path: Path, data: bytes) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ from app.modules.accounts import api as accounts_api
 from app.modules.api_keys import api as api_keys_api
 from app.modules.api_keys.reset_scheduler import build_api_key_limit_reset_scheduler
 from app.modules.audit import api as audit_api
+from app.modules.conversation_archive import api as conversation_archive_api
 from app.modules.dashboard import api as dashboard_api
 from app.modules.dashboard_auth import api as dashboard_auth_api
 from app.modules.firewall import api as firewall_api
@@ -360,6 +361,7 @@ def create_app() -> FastAPI:
     app.include_router(dashboard_api.router)
     app.include_router(usage_api.router)
     app.include_router(request_logs_api.router)
+    app.include_router(conversation_archive_api.router)
     app.include_router(oauth_api.router)
     app.include_router(dashboard_auth_api.router)
     app.include_router(settings_api.router)

--- a/app/modules/conversation_archive/__init__.py
+++ b/app/modules/conversation_archive/__init__.py
@@ -1,0 +1,1 @@
+"""Conversation archive dashboard module."""

--- a/app/modules/conversation_archive/api.py
+++ b/app/modules/conversation_archive/api.py
@@ -22,8 +22,8 @@ router = APIRouter(
 
 
 @router.get("/files", response_model=list[ConversationArchiveFileResponse])
-async def list_conversation_archive_files() -> list[ConversationArchiveFileResponse]:
-    files = await run_in_threadpool(service.list_archive_files)
+def list_conversation_archive_files() -> list[ConversationArchiveFileResponse]:
+    files = service.list_archive_files()
     return [
         ConversationArchiveFileResponse(
             name=file.name,

--- a/app/modules/conversation_archive/api.py
+++ b/app/modules/conversation_archive/api.py
@@ -23,6 +23,7 @@ router = APIRouter(
 
 @router.get("/files", response_model=list[ConversationArchiveFileResponse])
 async def list_conversation_archive_files() -> list[ConversationArchiveFileResponse]:
+    files = await run_in_threadpool(service.list_archive_files)
     return [
         ConversationArchiveFileResponse(
             name=file.name,
@@ -31,7 +32,7 @@ async def list_conversation_archive_files() -> list[ConversationArchiveFileRespo
             compressed=file.compressed,
             modified_at=file.modified_at,
         )
-        for file in service.list_archive_files()
+        for file in files
     ]
 
 

--- a/app/modules/conversation_archive/api.py
+++ b/app/modules/conversation_archive/api.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.concurrency import run_in_threadpool
+
+from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.modules.conversation_archive import service
+from app.modules.conversation_archive.schemas import (
+    ConversationArchiveFileResponse,
+    ConversationArchiveRecordResponse,
+    ConversationArchiveRecordsResponse,
+)
+
+router = APIRouter(
+    prefix="/api/conversation-archive",
+    tags=["dashboard"],
+    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+)
+
+
+@router.get("/files", response_model=list[ConversationArchiveFileResponse])
+async def list_conversation_archive_files() -> list[ConversationArchiveFileResponse]:
+    return [
+        ConversationArchiveFileResponse(
+            name=file.name,
+            date=file.date,
+            size_bytes=file.size_bytes,
+            compressed=file.compressed,
+            modified_at=file.modified_at,
+        )
+        for file in service.list_archive_files()
+    ]
+
+
+@router.get("/records", response_model=ConversationArchiveRecordsResponse)
+async def list_conversation_archive_records(
+    file: str | None = Query(default=None, min_length=1),
+    limit: int = Query(default=100, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    direction: str | None = Query(default=None),
+    kind: str | None = Query(default=None),
+    transport: str | None = Query(default=None),
+    request_id: str | None = Query(default=None, alias="requestId"),
+    requested_at: datetime | None = Query(default=None, alias="requestedAt"),
+) -> ConversationArchiveRecordsResponse:
+    if file is None and not request_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="file or requestId is required",
+        )
+    try:
+        page = await run_in_threadpool(
+            service.read_archive_records,
+            filename=file,
+            limit=limit,
+            offset=offset,
+            direction=direction,
+            kind=kind,
+            transport=transport,
+            request_id=request_id,
+            requested_at=requested_at,
+        )
+    except service.ConversationArchiveInvalidFileError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except service.ConversationArchiveNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    return ConversationArchiveRecordsResponse(
+        records=[_record_response(record) for record in page.records],
+        total=page.total,
+        has_more=page.has_more,
+    )
+
+
+def _record_response(record: dict[str, Any]) -> ConversationArchiveRecordResponse:
+    return ConversationArchiveRecordResponse(
+        file_name=_optional_str(record.get("_archive_file")),
+        timestamp=_parse_timestamp(record.get("timestamp")),
+        request_id=_optional_str(record.get("request_id")),
+        direction=_optional_str(record.get("direction")),
+        kind=_optional_str(record.get("kind")),
+        transport=_optional_str(record.get("transport")),
+        account_id=_optional_str(record.get("account_id")),
+        method=_optional_str(record.get("method")),
+        url=_optional_str(record.get("url")),
+        status_code=record.get("status_code") if isinstance(record.get("status_code"), int) else None,
+        headers=_headers(record.get("headers")),
+        payload=record.get("payload"),
+        extra=record.get("extra") if isinstance(record.get("extra"), dict) else None,
+    )
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _headers(value: object) -> dict[str, str] | None:
+    if not isinstance(value, dict):
+        return None
+    return {str(key): str(item) for key, item in value.items()}

--- a/app/modules/conversation_archive/schemas.py
+++ b/app/modules/conversation_archive/schemas.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from app.modules.shared.schemas import DashboardModel
+
+
+class ConversationArchiveFileResponse(DashboardModel):
+    name: str
+    date: str | None
+    size_bytes: int
+    compressed: bool
+    modified_at: datetime
+
+
+class ConversationArchiveRecordResponse(DashboardModel):
+    file_name: str | None = None
+    timestamp: datetime | None
+    request_id: str | None
+    direction: str | None
+    kind: str | None
+    transport: str | None
+    account_id: str | None
+    method: str | None
+    url: str | None
+    status_code: int | None
+    headers: dict[str, str] | None
+    payload: Any
+    extra: dict[str, Any] | None = None
+
+
+class ConversationArchiveRecordsResponse(DashboardModel):
+    records: list[ConversationArchiveRecordResponse]
+    total: int
+    has_more: bool

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -70,7 +70,7 @@ def read_archive_records(
     request_id: str | None = None,
     requested_at: datetime | None = None,
 ) -> ConversationArchivePage:
-    paths = _archive_paths_for_lookup(filename=filename, requested_at=requested_at)
+    paths = _archive_paths_for_lookup(filename=filename, requested_at=requested_at, request_id=request_id)
     records: list[dict[str, Any]] = []
     total = 0
     end = offset + limit
@@ -96,16 +96,28 @@ def read_archive_records(
     )
 
 
-def _archive_paths_for_lookup(*, filename: str | None, requested_at: datetime | None) -> list[Path]:
+def _archive_paths_for_lookup(
+    *,
+    filename: str | None,
+    requested_at: datetime | None,
+    request_id: str | None,
+) -> list[Path]:
     if filename:
         return [_resolve_archive_file(filename)]
     directory = _archive_dir()
     if requested_at is None:
         return list(_iter_archive_paths(directory))
 
+    if request_id is not None:
+        return sorted(path for path in _iter_archive_paths(directory) if path.exists() and path.is_file())
+
     requested_at_utc = requested_at.astimezone(UTC)
     hourly_stems = [(requested_at_utc + timedelta(hours=delta)).strftime("%Y-%m-%dT%H") for delta in (-1, 0, 1)]
-    daily_stem = requested_at_utc.strftime("%Y-%m-%d")
+    daily_stems = {
+        requested_at_utc.strftime("%Y-%m-%d"),
+        (requested_at_utc.date() - timedelta(days=1)).strftime("%Y-%m-%d"),
+        (requested_at_utc.date() + timedelta(days=1)).strftime("%Y-%m-%d"),
+    }
     candidates: list[Path] = []
     for stem in hourly_stems:
         candidates.extend(
@@ -114,12 +126,13 @@ def _archive_paths_for_lookup(*, filename: str | None, requested_at: datetime | 
                 directory / f"{stem}{_JSONL_SUFFIX}",
             )
         )
-    candidates.extend(
-        (
-            directory / f"{daily_stem}{_GZIP_JSONL_SUFFIX}",
-            directory / f"{daily_stem}{_JSONL_SUFFIX}",
+    for stem in daily_stems:
+        candidates.extend(
+            (
+                directory / f"{stem}{_GZIP_JSONL_SUFFIX}",
+                directory / f"{stem}{_JSONL_SUFFIX}",
+            )
         )
-    )
     return [path for path in candidates if path.exists() and path.is_file()]
 
 

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -75,7 +75,7 @@ def read_archive_records(
     total = 0
     end = offset + limit
 
-    for path in sorted(paths, key=lambda item: item.name, reverse=True):
+    for path in sorted(paths, key=lambda item: item.name):
         for record in _iter_records(path):
             if not _record_matches(
                 record,

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import gzip
+import json
+import zlib
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from app.core.config.settings import get_settings
+
+_JSONL_SUFFIX = ".jsonl"
+_GZIP_JSONL_SUFFIX = ".jsonl.gz"
+
+
+@dataclass(frozen=True)
+class ConversationArchiveFile:
+    name: str
+    date: str | None
+    size_bytes: int
+    compressed: bool
+    modified_at: datetime
+
+
+@dataclass(frozen=True)
+class ConversationArchivePage:
+    records: list[dict[str, Any]]
+    total: int
+    has_more: bool
+
+
+class ConversationArchiveNotFoundError(ValueError):
+    pass
+
+
+class ConversationArchiveInvalidFileError(ValueError):
+    pass
+
+
+def list_archive_files() -> list[ConversationArchiveFile]:
+    directory = _archive_dir()
+    if not directory.exists():
+        return []
+
+    files: list[ConversationArchiveFile] = []
+    for path in sorted(_iter_archive_paths(directory), key=lambda item: item.name, reverse=True):
+        stat = path.stat()
+        files.append(
+            ConversationArchiveFile(
+                name=path.name,
+                date=_date_from_filename(path.name),
+                size_bytes=stat.st_size,
+                compressed=path.name.endswith(_GZIP_JSONL_SUFFIX),
+                modified_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
+            )
+        )
+    return files
+
+
+def read_archive_records(
+    *,
+    filename: str | None,
+    limit: int,
+    offset: int,
+    direction: str | None = None,
+    kind: str | None = None,
+    transport: str | None = None,
+    request_id: str | None = None,
+    requested_at: datetime | None = None,
+) -> ConversationArchivePage:
+    paths = _archive_paths_for_lookup(filename=filename, requested_at=requested_at)
+    records: list[dict[str, Any]] = []
+    total = 0
+    end = offset + limit
+
+    for path in sorted(paths, key=lambda item: item.name, reverse=True):
+        for record in _iter_records(path):
+            if not _record_matches(
+                record,
+                direction=direction,
+                kind=kind,
+                transport=transport,
+                request_id=request_id,
+            ):
+                continue
+            if offset <= total < end:
+                records.append({**record, "_archive_file": path.name})
+            total += 1
+
+    return ConversationArchivePage(
+        records=records,
+        total=total,
+        has_more=end < total,
+    )
+
+
+def _archive_paths_for_lookup(*, filename: str | None, requested_at: datetime | None) -> list[Path]:
+    if filename:
+        return [_resolve_archive_file(filename)]
+    directory = _archive_dir()
+    if requested_at is None:
+        return list(_iter_archive_paths(directory))
+
+    requested_at_utc = requested_at.astimezone(UTC)
+    hourly_stem = requested_at_utc.strftime("%Y-%m-%dT%H")
+    daily_stem = requested_at_utc.strftime("%Y-%m-%d")
+    candidates = [
+        directory / f"{hourly_stem}{_GZIP_JSONL_SUFFIX}",
+        directory / f"{hourly_stem}{_JSONL_SUFFIX}",
+        directory / f"{daily_stem}{_GZIP_JSONL_SUFFIX}",
+        directory / f"{daily_stem}{_JSONL_SUFFIX}",
+    ]
+    return [path for path in candidates if path.exists() and path.is_file()]
+
+
+def _archive_dir() -> Path:
+    return Path(getattr(get_settings(), "conversation_archive_dir")).expanduser()
+
+
+def _iter_archive_paths(directory: Path) -> Iterator[Path]:
+    yield from directory.glob(f"*{_JSONL_SUFFIX}")
+    yield from directory.glob(f"*{_GZIP_JSONL_SUFFIX}")
+
+
+def _date_from_filename(filename: str) -> str | None:
+    if filename.endswith(_GZIP_JSONL_SUFFIX):
+        stem = filename[: -len(_GZIP_JSONL_SUFFIX)]
+    elif filename.endswith(_JSONL_SUFFIX):
+        stem = filename[: -len(_JSONL_SUFFIX)]
+    else:
+        return None
+    for date_format in ("%Y-%m-%dT%H", "%Y-%m-%d"):
+        try:
+            datetime.strptime(stem, date_format)
+        except ValueError:
+            continue
+        return stem
+    return None
+
+
+def _resolve_archive_file(filename: str) -> Path:
+    if Path(filename).name != filename or not (
+        filename.endswith(_JSONL_SUFFIX) or filename.endswith(_GZIP_JSONL_SUFFIX)
+    ):
+        raise ConversationArchiveInvalidFileError("Invalid conversation archive file name")
+
+    path = _archive_dir() / filename
+    if not path.exists() or not path.is_file():
+        raise ConversationArchiveNotFoundError("Conversation archive file not found")
+    return path
+
+
+def _iter_records(path: Path) -> Iterator[dict[str, Any]]:
+    opener = gzip.open if path.name.endswith(_GZIP_JSONL_SUFFIX) else Path.open
+    try:
+        with opener(path, "rt", encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict):
+                    yield parsed
+    except (EOFError, gzip.BadGzipFile, zlib.error):
+        return
+
+
+def _record_matches(
+    record: dict[str, Any],
+    *,
+    direction: str | None,
+    kind: str | None,
+    transport: str | None,
+    request_id: str | None,
+) -> bool:
+    if direction and record.get("direction") != direction:
+        return False
+    if kind and record.get("kind") != kind:
+        return False
+    if transport and record.get("transport") != transport:
+        return False
+    if request_id and str(record.get("request_id") or "") != request_id:
+        return False
+    return True

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -5,7 +5,7 @@ import json
 import zlib
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -104,14 +104,24 @@ def _archive_paths_for_lookup(*, filename: str | None, requested_at: datetime | 
         return list(_iter_archive_paths(directory))
 
     requested_at_utc = requested_at.astimezone(UTC)
-    hourly_stem = requested_at_utc.strftime("%Y-%m-%dT%H")
-    daily_stem = requested_at_utc.strftime("%Y-%m-%d")
-    candidates = [
-        directory / f"{hourly_stem}{_GZIP_JSONL_SUFFIX}",
-        directory / f"{hourly_stem}{_JSONL_SUFFIX}",
-        directory / f"{daily_stem}{_GZIP_JSONL_SUFFIX}",
-        directory / f"{daily_stem}{_JSONL_SUFFIX}",
+    hourly_stems = [
+        (requested_at_utc + timedelta(hours=delta)).strftime("%Y-%m-%dT%H") for delta in (-1, 0, 1)
     ]
+    daily_stem = requested_at_utc.strftime("%Y-%m-%d")
+    candidates: list[Path] = []
+    for stem in hourly_stems:
+        candidates.extend(
+            (
+                directory / f"{stem}{_GZIP_JSONL_SUFFIX}",
+                directory / f"{stem}{_JSONL_SUFFIX}",
+            )
+        )
+    candidates.extend(
+        (
+            directory / f"{daily_stem}{_GZIP_JSONL_SUFFIX}",
+            directory / f"{daily_stem}{_JSONL_SUFFIX}",
+        )
+    )
     return [path for path in candidates if path.exists() and path.is_file()]
 
 

--- a/app/modules/conversation_archive/service.py
+++ b/app/modules/conversation_archive/service.py
@@ -104,9 +104,7 @@ def _archive_paths_for_lookup(*, filename: str | None, requested_at: datetime | 
         return list(_iter_archive_paths(directory))
 
     requested_at_utc = requested_at.astimezone(UTC)
-    hourly_stems = [
-        (requested_at_utc + timedelta(hours=delta)).strftime("%Y-%m-%dT%H") for delta in (-1, 0, 1)
-    ]
+    hourly_stems = [(requested_at_utc + timedelta(hours=delta)).strftime("%Y-%m-%dT%H") for delta in (-1, 0, 1)]
     daily_stem = requested_at_utc.strftime("%Y-%m-%d")
     candidates: list[Path] = []
     for stem in hourly_stems:

--- a/openspec/changes/archive-codex-upstream-dialogs/proposal.md
+++ b/openspec/changes/archive-codex-upstream-dialogs/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Operators need a durable, replayable record of Codex-to-upstream traffic for later incident audit and possible offline dataset preparation. Existing request logs and audit logs only preserve metadata, while console payload logging is transient and not structured as a training-friendly archive.
+
+## What Changes
+
+- Add an opt-in gzip JSONL conversation archive for upstream Codex Responses traffic.
+- Store upstream request payloads, streamed SSE events, compact responses, and websocket frames with request/account metadata.
+- Redact credential-bearing headers while preserving payload bodies and upstream events verbatim.
+- Add archived payload inspection to the existing dashboard request details flow.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: operators can enable a durable full-fidelity upstream conversation archive.
+
+## Impact
+
+- Affected code: `app/core/conversation_archive.py`, upstream HTTP/SSE/compact/websocket clients, dashboard archive APIs, frontend archive viewer, settings, and tests.
+- Operational impact: disabled by default; when enabled, archive files may contain private prompts, tool outputs, and model responses and must be stored as sensitive data.

--- a/openspec/changes/archive-codex-upstream-dialogs/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/archive-codex-upstream-dialogs/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Full upstream conversation archive
+The proxy MUST provide an opt-in durable archive of Codex-to-upstream conversation traffic. When enabled, the archive MUST write gzip-compressed newline-delimited JSON records for upstream request payloads, streamed Responses events, compact response payloads, and websocket text or binary frames without performing gzip file I/O in the request event loop during normal operation. The archive writer queue MUST be bounded and MUST apply synchronous write backpressure instead of growing without limit when the background writer is saturated. Archive records MUST include request id, timestamp, direction, traffic kind, transport, account id when known, upstream target metadata, redacted headers, and the full payload or frame body. Credential-bearing headers such as authorization, cookies, proxy authorization, token headers, and API key headers MUST be redacted before persistence. JSON records MUST preserve non-ASCII payload text as UTF-8 rather than Unicode escape sequences. When disabled, no archive file MUST be created by the archive writer.
+
+#### Scenario: operator enables archive for audit
+- **WHEN** `CODEX_LB_CONVERSATION_ARCHIVE_ENABLED=true`
+- **AND** a Codex Responses request is proxied upstream
+- **THEN** the archive records both the outbound upstream payload and inbound upstream events or response body as gzip JSONL
+- **AND** credential-bearing headers are stored as redacted values
+
+#### Scenario: archive remains disabled by default
+- **WHEN** the archive setting is not enabled
+- **THEN** the archive writer does not create conversation archive files
+
+#### Scenario: operator views archived traffic
+- **GIVEN** conversation archive files exist as `.jsonl.gz` or legacy `.jsonl`
+- **WHEN** an authenticated dashboard operator opens an existing request log detail
+- **THEN** the dashboard can find matching archive records by request id across archive files and display payload plus metadata for that request

--- a/openspec/changes/archive-codex-upstream-dialogs/tasks.md
+++ b/openspec/changes/archive-codex-upstream-dialogs/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] 1.1 Add opt-in settings for full conversation archival.
+- [x] 1.2 Persist upstream request/response payloads and stream events as JSONL.
+- [x] 1.3 Redact credential-bearing headers in archive records.
+- [x] 1.4 Compress new archive files as gzip JSONL and keep legacy JSONL readable.
+- [x] 1.5 Add dashboard APIs and request detail UI for browsing archived records.
+- [x] 1.6 Keep archive gzip writes and archive reads off the request event loop.
+- [x] 1.7 Bound archive writer memory and preserve non-ASCII text as readable UTF-8.
+
+## 2. Verification
+
+- [x] 2.1 Add unit tests for archive writing, disabled mode, binary frame encoding, bounded queue fallback, UTF-8 text, and archive reading.
+- [x] 2.2 Run targeted pytest, ruff, type checks, frontend build, and OpenSpec validation.

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -9,8 +9,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import cast
 
-import pytest
-
 from app.core import conversation_archive
 from app.core.utils.request_id import reset_request_id, set_request_id
 from app.modules.conversation_archive import api as conversation_archive_api
@@ -43,6 +41,11 @@ def _archive_lines(directory: Path) -> list[str]:
     assert len(files) == 1
     with gzip.open(files[0], "rt", encoding="utf-8") as fh:
         return fh.read().splitlines()
+
+
+def _write_gzip_record(path: Path, payload: dict[str, object]) -> None:
+    with gzip.open(path, "at", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload) + "\n")
 
 
 def test_archive_json_writes_redacted_jsonl_record(monkeypatch, tmp_path):
@@ -140,8 +143,7 @@ def test_archive_stop_writer_drains_queue_before_sentinel(monkeypatch):
     assert events == ["queue.join", "queue.put_sentinel", "thread.join"]
 
 
-@pytest.mark.asyncio
-async def test_archive_file_listing_runs_in_threadpool(monkeypatch):
+def test_archive_file_listing_runs_sync(monkeypatch):
     called: list[object] = []
     modified_at = datetime.fromisoformat("2026-05-16T00:00:00+00:00")
     archive_file = conversation_archive_service.ConversationArchiveFile(
@@ -152,16 +154,15 @@ async def test_archive_file_listing_runs_in_threadpool(monkeypatch):
         modified_at=modified_at,
     )
 
-    async def fake_run_in_threadpool(func, *args, **kwargs):
-        called.append(func)
-        return func(*args, **kwargs)
+    monkeypatch.setattr(
+        conversation_archive_api.service,
+        "list_archive_files",
+        lambda: called.append("service") or [archive_file],
+    )
 
-    monkeypatch.setattr(conversation_archive_api, "run_in_threadpool", fake_run_in_threadpool)
-    monkeypatch.setattr(conversation_archive_api.service, "list_archive_files", lambda: [archive_file])
+    [response] = conversation_archive_api.list_conversation_archive_files()
 
-    [response] = await conversation_archive_api.list_conversation_archive_files()
-
-    assert called == [conversation_archive_api.service.list_archive_files]
+    assert called == ["service"]
     assert response.name == "2026-05-16T00.jsonl.gz"
     assert response.modified_at == modified_at
 
@@ -454,6 +455,48 @@ def test_archive_service_reads_gzip_and_legacy_jsonl(monkeypatch, tmp_path):
         requested_at=datetime.fromisoformat("2026-04-29T10:30:00+00:00"),
     )
     assert [record["request_id"] for record in requested_at_page.records] == ["req_gzip"]
+
+
+def test_archive_service_lookup_requests_adjacent_hours(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    _write_gzip_record(
+        tmp_path / "2026-04-29T10.jsonl.gz",
+        {
+            "timestamp": "2026-04-29T10:59:45+00:00",
+            "request_id": "req_prev_hour",
+            "direction": "server_to_codex",
+            "kind": "responses",
+            "transport": "http",
+            "payload": {"input": "prev"},
+        },
+    )
+    _write_gzip_record(
+        tmp_path / "2026-04-29T11.jsonl.gz",
+        {
+            "timestamp": "2026-04-29T11:00:15+00:00",
+            "request_id": "req_next_hour",
+            "direction": "server_to_codex",
+            "kind": "responses",
+            "transport": "http",
+            "payload": {"input": "next"},
+        },
+    )
+
+    boundary_requested_at = datetime.fromisoformat("2026-04-29T11:00:00+00:00")
+    page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        requested_at=boundary_requested_at,
+    )
+
+    assert page.total == 2
+    assert sorted(record["request_id"] for record in page.records) == ["req_next_hour", "req_prev_hour"]
 
 
 def test_archive_service_expands_user_home(monkeypatch, tmp_path):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -9,8 +9,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import cast
 
+import pytest
+
 from app.core import conversation_archive
 from app.core.utils.request_id import reset_request_id, set_request_id
+from app.modules.conversation_archive import api as conversation_archive_api
 from app.modules.conversation_archive import service as conversation_archive_service
 
 
@@ -126,7 +129,7 @@ def test_archive_stop_writer_drains_queue_before_sentinel(monkeypatch):
 
     class FakeThread:
         def join(self, timeout: float | None = None) -> None:
-            assert timeout == 1
+            assert timeout is None
             events.append("thread.join")
 
     monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", FakeQueue())
@@ -135,6 +138,32 @@ def test_archive_stop_writer_drains_queue_before_sentinel(monkeypatch):
     conversation_archive._stop_writer()
 
     assert events == ["queue.join", "queue.put_sentinel", "thread.join"]
+
+
+@pytest.mark.asyncio
+async def test_archive_file_listing_runs_in_threadpool(monkeypatch):
+    called: list[object] = []
+    modified_at = datetime.fromisoformat("2026-05-16T00:00:00+00:00")
+    archive_file = conversation_archive_service.ConversationArchiveFile(
+        name="2026-05-16T00.jsonl.gz",
+        date="2026-05-16T00",
+        size_bytes=123,
+        compressed=True,
+        modified_at=modified_at,
+    )
+
+    async def fake_run_in_threadpool(func, *args, **kwargs):
+        called.append(func)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(conversation_archive_api, "run_in_threadpool", fake_run_in_threadpool)
+    monkeypatch.setattr(conversation_archive_api.service, "list_archive_files", lambda: [archive_file])
+
+    [response] = await conversation_archive_api.list_conversation_archive_files()
+
+    assert called == [conversation_archive_api.service.list_archive_files]
+    assert response.name == "2026-05-16T00.jsonl.gz"
+    assert response.modified_at == modified_at
 
 
 def test_archive_appends_complete_gzip_members(monkeypatch, tmp_path):
@@ -230,6 +259,23 @@ def test_archive_recovery_check_runs_once_per_file(monkeypatch, tmp_path):
     conversation_archive._append_record(path, {"request_id": "req_new_2"})
 
     assert calls == 1
+
+
+def test_archive_write_failure_forgets_prior_recovery_check(monkeypatch, tmp_path):
+    path = tmp_path / "2026-04-30T12.jsonl.gz"
+    path.write_bytes(gzip.compress(json.dumps({"request_id": "req_ok"}).encode("utf-8") + b"\n"))
+    conversation_archive._RECOVERY_CHECKED_PATHS.discard(path.resolve())
+
+    conversation_archive._append_record(path, {"request_id": "req_new_1"})
+    assert path.resolve() in conversation_archive._RECOVERY_CHECKED_PATHS
+
+    def fail_write(_path: Path, _data: bytes) -> None:
+        raise OSError("simulated partial archive write")
+
+    monkeypatch.setattr(conversation_archive, "_write_gzip_member", fail_write)
+    conversation_archive._append_record(path, {"request_id": "req_new_2"})
+
+    assert path.resolve() not in conversation_archive._RECOVERY_CHECKED_PATHS
 
 
 def test_archive_disk_full_pauses_writes_without_traceback_spam(monkeypatch, tmp_path, caplog):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -496,7 +496,14 @@ def test_archive_service_lookup_requests_adjacent_hours(monkeypatch, tmp_path):
     )
 
     assert page.total == 2
-    assert sorted(record["request_id"] for record in page.records) == ["req_next_hour", "req_prev_hour"]
+    assert [record["request_id"] for record in page.records] == [
+        "req_prev_hour",
+        "req_next_hour",
+    ]
+    assert [record["_archive_file"] for record in page.records] == [
+        "2026-04-29T10.jsonl.gz",
+        "2026-04-29T11.jsonl.gz",
+    ]
 
 
 def test_archive_service_expands_user_home(monkeypatch, tmp_path):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -556,6 +556,98 @@ def test_archive_service_lookup_requests_adjacent_hours(monkeypatch, tmp_path):
     ]
 
 
+def test_archive_service_lookup_request_id_searches_beyond_adjacent_hours(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    _write_gzip_record(
+        tmp_path / "2026-04-29T10.jsonl.gz",
+        {
+            "timestamp": "2026-04-29T10:59:45+00:00",
+            "request_id": "req_span",
+            "direction": "server_to_codex",
+            "kind": "responses",
+            "transport": "http",
+            "payload": {"input": "near"},
+        },
+    )
+    _write_gzip_record(
+        tmp_path / "2026-04-29T11.jsonl.gz",
+        {
+            "timestamp": "2026-04-29T11:00:15+00:00",
+            "request_id": "req_other",
+            "direction": "server_to_codex",
+            "kind": "responses",
+            "transport": "http",
+            "payload": {"input": "near"},
+        },
+    )
+    _write_gzip_record(
+        tmp_path / "2026-04-29T12.jsonl.gz",
+        {
+            "timestamp": "2026-04-29T12:01:05+00:00",
+            "request_id": "req_span",
+            "direction": "server_to_codex",
+            "kind": "responses",
+            "transport": "http",
+            "payload": {"input": "later"},
+        },
+    )
+
+    page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="req_span",
+        requested_at=datetime.fromisoformat("2026-04-29T10:30:00+00:00"),
+    )
+
+    assert page.total == 2
+    assert [record["request_id"] for record in page.records] == ["req_span", "req_span"]
+    assert [record["_archive_file"] for record in page.records] == [
+        "2026-04-29T10.jsonl.gz",
+        "2026-04-29T12.jsonl.gz",
+    ]
+
+
+def test_archive_service_lookup_request_id_includes_adjacent_day_legacy_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    (tmp_path / "2026-04-29.jsonl").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-29T23:59:58+00:00",
+                "request_id": "req_midnight",
+                "direction": "server_to_codex",
+                "kind": "responses",
+                "transport": "http",
+                "payload": {"input": "end_of_day"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="req_midnight",
+        requested_at=datetime.fromisoformat("2026-04-30T00:10:00+00:00"),
+    )
+
+    assert page.total == 1
+    assert page.records[0]["request_id"] == "req_midnight"
+    assert page.records[0]["_archive_file"] == "2026-04-29.jsonl"
+
+
 def test_archive_service_expands_user_home(monkeypatch, tmp_path):
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir()

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -4,7 +4,9 @@ import base64
 import errno
 import gzip
 import json
+import os
 import queue
+import stat
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -287,6 +289,30 @@ def test_archive_uses_hourly_gzip_files(monkeypatch, tmp_path):
     assert len(path.stem) == len("2026-04-30T12.jsonl")
     assert path.name.endswith(".jsonl.gz")
     assert "T" in path.name
+
+
+def test_archive_files_are_operator_only_even_with_permissive_umask(monkeypatch, tmp_path):
+    archive_dir = tmp_path / "archive"
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=archive_dir),
+    )
+    old_umask = os.umask(0o022)
+    try:
+        conversation_archive.archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="http",
+            payload={"text": "private"},
+        )
+        conversation_archive.flush_archive_writer()
+    finally:
+        os.umask(old_umask)
+
+    [path] = list(archive_dir.glob("*.jsonl.gz"))
+    assert stat.S_IMODE(archive_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
 
 
 def test_archive_path_expands_user_home(monkeypatch, tmp_path):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -169,6 +169,32 @@ def test_archive_queue_byte_limit_falls_back_to_sync_write(monkeypatch, tmp_path
         assert conversation_archive._WRITE_QUEUE_BYTES == 0
 
 
+def test_archive_queue_thread_start_failure_drops_record(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        conversation_archive._WRITE_QUEUE_BYTES = 0
+
+    def fail_writer_thread() -> None:
+        raise RuntimeError("thread limit reached")
+
+    monkeypatch.setattr(conversation_archive, "_ensure_writer_thread", fail_writer_thread)
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "optional archive"},
+    )
+
+    assert list(tmp_path.glob("*.jsonl.gz")) == []
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        assert conversation_archive._WRITE_QUEUE_BYTES == 0
+
+
 def test_archive_stop_writer_drains_queue_before_sentinel(monkeypatch):
     events: list[str] = []
 

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import base64
+import errno
+import gzip
+import json
+import queue
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+
+from app.core import conversation_archive
+from app.core.utils.request_id import reset_request_id, set_request_id
+from app.modules.conversation_archive import service as conversation_archive_service
+
+
+def _reset_archive_disk_pressure() -> None:
+    with conversation_archive._DISK_PRESSURE_LOCK:
+        conversation_archive._DISK_PRESSURE_PAUSED_UNTIL = 0.0
+        conversation_archive._DISK_PRESSURE_LAST_WARNING_AT = (
+            -conversation_archive._DISK_PRESSURE_WARNING_INTERVAL_SECONDS
+        )
+
+
+class _ArchiveSettings:
+    def __init__(self, *, enabled: bool, directory: Path) -> None:
+        self.conversation_archive_enabled = enabled
+        self.conversation_archive_dir = directory
+
+
+def _archive_records(directory: Path) -> list[dict[str, object]]:
+    files = sorted(directory.glob("*.jsonl.gz"))
+    assert len(files) == 1
+    with gzip.open(files[0], "rt", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh.read().splitlines()]
+
+
+def _archive_lines(directory: Path) -> list[str]:
+    files = sorted(directory.glob("*.jsonl.gz"))
+    assert len(files) == 1
+    with gzip.open(files[0], "rt", encoding="utf-8") as fh:
+        return fh.read().splitlines()
+
+
+def test_archive_json_writes_redacted_jsonl_record(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    token = set_request_id("req_archive_1")
+    try:
+        conversation_archive.archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="http",
+            account_id="acc_1",
+            method="POST",
+            url="https://chatgpt.com/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer secret",
+                "api-key": "bare-secret",
+                "api_key": "underscore-secret",
+                "session_id": "sid_1",
+                "x-session-token": "tok_1",
+            },
+            payload={"model": "gpt-5.4", "input": "привет без юникод-эскейпов"},
+        )
+    finally:
+        reset_request_id(token)
+    conversation_archive.flush_archive_writer()
+
+    [record] = _archive_records(tmp_path)
+    assert record["request_id"] == "req_archive_1"
+    assert record["direction"] == "codex_to_server"
+    assert record["kind"] == "responses"
+    assert record["transport"] == "http"
+    assert record["account_id"] == "acc_1"
+    assert record["payload"] == {"model": "gpt-5.4", "input": "привет без юникод-эскейпов"}
+    assert record["headers"] == {
+        "Authorization": "[redacted]",
+        "api-key": "[redacted]",
+        "api_key": "[redacted]",
+        "session_id": "sid_1",
+        "x-session-token": "[redacted]",
+    }
+    [line] = _archive_lines(tmp_path)
+    assert "привет без юникод-эскейпов" in line
+    assert "\\u043f" not in line
+
+
+def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    bounded_queue: queue.Queue[tuple[Path, dict[str, object]] | None] = queue.Queue(maxsize=1)
+    bounded_queue.put((tmp_path / "blocked.jsonl.gz", {"payload": "queued"}))
+    monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", bounded_queue)
+    monkeypatch.setattr(conversation_archive, "_ensure_writer_thread", lambda: None)
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "синхронный fallback"},
+    )
+
+    [line] = _archive_lines(tmp_path)
+    assert "синхронный fallback" in line
+    assert bounded_queue.qsize() == 1
+
+
+def test_archive_appends_complete_gzip_members(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "first"},
+    )
+    conversation_archive.archive_json(
+        direction="server_to_codex",
+        kind="responses",
+        transport="http",
+        payload={"text": "second"},
+    )
+    conversation_archive.flush_archive_writer()
+
+    records = _archive_records(tmp_path)
+    assert [record["payload"] for record in records] == [{"text": "first"}, {"text": "second"}]
+
+
+def test_archive_uses_hourly_gzip_files(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "hourly"},
+    )
+    conversation_archive.flush_archive_writer()
+
+    [path] = list(tmp_path.glob("*.jsonl.gz"))
+    assert len(path.stem) == len("2026-04-30T12.jsonl")
+    assert path.name.endswith(".jsonl.gz")
+    assert "T" in path.name
+
+
+def test_archive_path_expands_user_home(monkeypatch, tmp_path):
+    archive_dir = tmp_path / "archive"
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=Path("~/archive")),
+    )
+
+    assert conversation_archive._archive_path().parent == archive_dir
+
+
+def test_archive_writer_recovers_corrupt_gzip_tail_before_append(tmp_path):
+    path = tmp_path / "2026-04-30.jsonl.gz"
+    conversation_archive._RECOVERY_CHECKED_PATHS.discard(path.resolve())
+    path.write_bytes(
+        gzip.compress(json.dumps({"request_id": "req_ok", "payload": "old"}).encode("utf-8") + b"\n")
+        + b"not a complete gzip member"
+    )
+
+    conversation_archive._append_record(path, {"request_id": "req_new", "payload": "new"})
+
+    with gzip.open(path, "rt", encoding="utf-8") as fh:
+        rows = [json.loads(line) for line in fh.read().splitlines()]
+    assert [row["request_id"] for row in rows] == ["req_ok", "req_new"]
+    backups = list(tmp_path.glob("2026-04-30.jsonl.gz.corrupt-*"))
+    assert len(backups) == 1
+
+
+def test_archive_recovery_check_runs_once_per_file(monkeypatch, tmp_path):
+    path = tmp_path / "2026-04-30T12.jsonl.gz"
+    conversation_archive._RECOVERY_CHECKED_PATHS.discard(path.resolve())
+    path.write_bytes(gzip.compress(json.dumps({"request_id": "req_ok"}).encode("utf-8") + b"\n"))
+    calls = 0
+
+    def fake_readable(read_path: Path) -> bool:
+        nonlocal calls
+        assert read_path == path
+        calls += 1
+        return True
+
+    monkeypatch.setattr(conversation_archive, "_gzip_archive_is_readable", fake_readable)
+
+    conversation_archive._append_record(path, {"request_id": "req_new_1"})
+    conversation_archive._append_record(path, {"request_id": "req_new_2"})
+
+    assert calls == 1
+
+
+def test_archive_disk_full_pauses_writes_without_traceback_spam(monkeypatch, tmp_path, caplog):
+    _reset_archive_disk_pressure()
+    path = tmp_path / "2026-04-30T12.jsonl.gz"
+
+    def fail_write(_path: Path, _data: bytes) -> None:
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr(conversation_archive, "_write_gzip_member", fail_write)
+    caplog.set_level("WARNING", logger="app.core.conversation_archive")
+
+    conversation_archive._append_record(path, {"request_id": "req_full", "payload": "old"})
+
+    assert not path.exists()
+    assert "Conversation archive disk pressure detected; pausing archive writes" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert conversation_archive._archive_disk_pressure_active() is True
+
+    calls = 0
+
+    def record_write(_path: Path, _data: bytes) -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr(conversation_archive, "_write_gzip_member", record_write)
+    conversation_archive._append_record(path, {"request_id": "req_dropped", "payload": "new"})
+    assert calls == 0
+
+    with conversation_archive._DISK_PRESSURE_LOCK:
+        conversation_archive._DISK_PRESSURE_PAUSED_UNTIL = 0.0
+    conversation_archive._append_record(path, {"request_id": "req_retry", "payload": "new"})
+    assert calls == 1
+
+
+def test_archive_enqueue_drops_records_while_disk_pressure_pause_is_active(monkeypatch, tmp_path):
+    _reset_archive_disk_pressure()
+    with conversation_archive._DISK_PRESSURE_LOCK:
+        conversation_archive._DISK_PRESSURE_PAUSED_UNTIL = float(conversation_archive.time.monotonic() + 60)
+    monkeypatch.setattr(
+        conversation_archive,
+        "_ensure_writer_thread",
+        lambda: (_ for _ in ()).throw(AssertionError("writer should not start while paused")),
+    )
+
+    conversation_archive._enqueue_record(tmp_path / "paused.jsonl.gz", {"request_id": "req_paused"})
+
+    assert list(tmp_path.iterdir()) == []
+    _reset_archive_disk_pressure()
+
+
+def test_archive_disk_pressure_detection_walks_exception_causes():
+    wrapped = RuntimeError("outer")
+    wrapped.__cause__ = OSError(errno.EDQUOT, "Disk quota exceeded")
+
+    assert conversation_archive._is_disk_pressure_error(wrapped) is True
+    assert conversation_archive._is_disk_pressure_error(RuntimeError("database or disk is full")) is True
+    assert conversation_archive._is_disk_pressure_error(RuntimeError("regular archive failure")) is False
+
+
+def test_archive_disabled_does_not_create_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=False, directory=tmp_path),
+    )
+
+    conversation_archive.archive_text(
+        direction="server_to_codex",
+        kind="responses",
+        transport="websocket",
+        text='{"type":"response.completed"}',
+    )
+    conversation_archive.flush_archive_writer()
+
+    assert list(tmp_path.glob("*.jsonl*")) == []
+
+
+def test_archive_bytes_uses_base64_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    conversation_archive.archive_bytes(
+        direction="server_to_codex",
+        kind="responses",
+        transport="websocket",
+        data=b"\x00\x01binary",
+    )
+    conversation_archive.flush_archive_writer()
+
+    [record] = _archive_records(tmp_path)
+    payload = cast(dict[str, object], record["payload"])
+    assert payload["encoding"] == "base64"
+    assert payload["data"] == base64.b64encode(b"\x00\x01binary").decode("ascii")
+
+
+def test_archive_service_reads_gzip_and_legacy_jsonl(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    legacy_path = tmp_path / "2026-04-28.jsonl"
+    legacy_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-04-28T10:00:00+00:00",
+                "request_id": "req_legacy",
+                "direction": "codex_to_server",
+                "kind": "responses",
+                "transport": "http",
+                "payload": {"input": "old"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    gzip_path = tmp_path / "2026-04-29T10.jsonl.gz"
+    with gzip.open(gzip_path, "wt", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "timestamp": "2026-04-29T10:00:00+00:00",
+                    "request_id": "req_gzip",
+                    "direction": "server_to_codex",
+                    "kind": "responses",
+                    "transport": "sse",
+                    "payload": {"type": "response.completed"},
+                }
+            )
+            + "\n"
+        )
+
+    files = conversation_archive_service.list_archive_files()
+    assert [file.name for file in files] == ["2026-04-29T10.jsonl.gz", "2026-04-28.jsonl"]
+    assert [file.date for file in files] == ["2026-04-29T10", "2026-04-28"]
+    assert files[0].compressed is True
+    assert files[1].compressed is False
+
+    page = conversation_archive_service.read_archive_records(
+        filename="2026-04-29T10.jsonl.gz",
+        limit=10,
+        offset=0,
+        direction="server_to_codex",
+    )
+    assert page.total == 1
+    assert page.has_more is False
+    assert page.records[0]["request_id"] == "req_gzip"
+    assert page.records[0]["_archive_file"] == "2026-04-29T10.jsonl.gz"
+
+    legacy_page = conversation_archive_service.read_archive_records(
+        filename="2026-04-28.jsonl",
+        limit=10,
+        offset=0,
+        request_id="req_legacy",
+    )
+    assert legacy_page.total == 1
+    assert legacy_page.records[0]["payload"] == {"input": "old"}
+
+    all_files_page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="req_gzip",
+    )
+    assert [record["request_id"] for record in all_files_page.records] == ["req_gzip"]
+
+    requested_at_page = conversation_archive_service.read_archive_records(
+        filename=None,
+        limit=10,
+        offset=0,
+        request_id="req_gzip",
+        requested_at=datetime.fromisoformat("2026-04-29T10:30:00+00:00"),
+    )
+    assert [record["request_id"] for record in requested_at_page.records] == ["req_gzip"]
+
+
+def test_archive_service_expands_user_home(monkeypatch, tmp_path):
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+    archive_path = archive_dir / "2026-04-29T10.jsonl.gz"
+    with gzip.open(archive_path, "wt", encoding="utf-8") as fh:
+        fh.write(json.dumps({"timestamp": "2026-04-29T10:00:00+00:00"}) + "\n")
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=Path("~/archive")),
+    )
+
+    [file] = conversation_archive_service.list_archive_files()
+    assert file.name == archive_path.name
+
+
+def test_archive_service_keeps_readable_records_before_corrupt_gzip_tail(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    path = tmp_path / "2026-04-30.jsonl.gz"
+    path.write_bytes(
+        gzip.compress(json.dumps({"request_id": "req_ok", "direction": "codex_to_server"}).encode("utf-8") + b"\n")
+        + b"not a complete gzip member"
+    )
+
+    page = conversation_archive_service.read_archive_records(
+        filename=path.name,
+        limit=10,
+        offset=0,
+    )
+
+    assert [record["request_id"] for record in page.records] == ["req_ok"]
+
+
+def test_archive_service_rejects_path_traversal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive_service,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    try:
+        conversation_archive_service.read_archive_records(
+            filename="../2026-04-29.jsonl.gz",
+            limit=10,
+            offset=0,
+        )
+    except conversation_archive_service.ConversationArchiveInvalidFileError:
+        pass
+    else:
+        raise AssertionError("expected invalid archive file error")

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -124,8 +124,8 @@ def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_
         "get_settings",
         lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
     )
-    bounded_queue: queue.Queue[tuple[Path, dict[str, object]] | None] = queue.Queue(maxsize=1)
-    bounded_queue.put((tmp_path / "blocked.jsonl.gz", {"payload": "queued"}))
+    bounded_queue: queue.Queue[tuple[Path, dict[str, object], int] | None] = queue.Queue(maxsize=1)
+    bounded_queue.put((tmp_path / "blocked.jsonl.gz", {"payload": "queued"}, 10))
     monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", bounded_queue)
     monkeypatch.setattr(conversation_archive, "_ensure_writer_thread", lambda: None)
 
@@ -139,6 +139,34 @@ def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_
     [line] = _archive_lines(tmp_path)
     assert "синхронный fallback" in line
     assert bounded_queue.qsize() == 1
+
+
+def test_archive_queue_byte_limit_falls_back_to_sync_write(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+    monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE_MAX_BYTES", 64)
+    monkeypatch.setattr(
+        conversation_archive,
+        "_ensure_writer_thread",
+        lambda: (_ for _ in ()).throw(AssertionError("writer should not start for byte-budget fallback")),
+    )
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        conversation_archive._WRITE_QUEUE_BYTES = 0
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "x" * 256},
+    )
+
+    [record] = _archive_records(tmp_path)
+    assert record["payload"] == {"text": "x" * 256}
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        assert conversation_archive._WRITE_QUEUE_BYTES == 0
 
 
 def test_archive_stop_writer_drains_queue_before_sentinel(monkeypatch):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -113,6 +113,30 @@ def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_
     assert bounded_queue.qsize() == 1
 
 
+def test_archive_stop_writer_drains_queue_before_sentinel(monkeypatch):
+    events: list[str] = []
+
+    class FakeQueue:
+        def join(self) -> None:
+            events.append("queue.join")
+
+        def put(self, item: object) -> None:
+            assert item is None
+            events.append("queue.put_sentinel")
+
+    class FakeThread:
+        def join(self, timeout: float | None = None) -> None:
+            assert timeout == 1
+            events.append("thread.join")
+
+    monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", FakeQueue())
+    monkeypatch.setattr(conversation_archive, "_WRITER_THREAD", FakeThread())
+
+    conversation_archive._stop_writer()
+
+    assert events == ["queue.join", "queue.put_sentinel", "thread.join"]
+
+
 def test_archive_appends_complete_gzip_members(monkeypatch, tmp_path):
     monkeypatch.setattr(
         conversation_archive,

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -96,6 +96,28 @@ def test_archive_json_writes_redacted_jsonl_record(monkeypatch, tmp_path):
     assert "\\u043f" not in line
 
 
+def test_archive_bytes_disabled_does_not_encode_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=False, directory=tmp_path),
+    )
+
+    def fail_b64encode(_data: bytes) -> bytes:
+        raise AssertionError("disabled archiving should not encode binary payloads")
+
+    monkeypatch.setattr(conversation_archive.base64, "b64encode", fail_b64encode)
+
+    conversation_archive.archive_bytes(
+        direction="server_to_codex",
+        kind="responses",
+        transport="websocket",
+        data=b"large binary frame",
+    )
+
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_path):
     monkeypatch.setattr(
         conversation_archive,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1160,7 +1160,7 @@ class _SsePostResponse:
 
 
 class _SseSession:
-    def __init__(self, response: _SsePostResponse) -> None:
+    def __init__(self, response: object) -> None:
         self._response = response
         self.calls: list[dict[str, object]] = []
 
@@ -1729,6 +1729,70 @@ async def test_stream_responses_starts_upstream_timer_after_image_inlining(monke
     assert timeout.total == pytest.approx(11.0)
     assert events == ['data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']
     assert recorded["started_at"] == 104.0
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_archives_http_error_before_raising(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 1.0
+        stream_idle_timeout_seconds = 1.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 15.0
+        upstream_stream_transport = "http"
+        log_upstream_request_summary = False
+
+    class ErrorPostResponse:
+        status = 429
+        reason = "Too Many Requests"
+        content = _DummyContent([])
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self, *, content_type=None):
+            del content_type
+            return {"error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"}}
+
+        async def text(self):
+            return "slow down"
+
+    archived: list[dict[str, object]] = []
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "archive_json", lambda **kwargs: archived.append(kwargs))
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        _ = [
+            event
+            async for event in proxy_module.stream_responses(
+                payload,
+                headers={},
+                access_token="token",
+                account_id="acc_1",
+                session=cast(proxy_module.aiohttp.ClientSession, _SseSession(ErrorPostResponse())),
+                raise_for_status=True,
+            )
+        ]
+
+    assert exc_info.value.status_code == 429
+    assert len(archived) == 2
+    assert archived[-1]["direction"] == "server_to_codex"
+    assert archived[-1]["status_code"] == 429
+    assert archived[-1]["payload"] == {
+        "error": {"code": "rate_limit_exceeded", "message": "slow down", "type": "server_error"}
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Draft split from #519.

Purpose:
- backend archive capture/storage/API for upstream conversation inspection.

Validation:
- rebased on current main
- ruff format/check on backend archive/test files
- pytest tests/unit/test_conversation_archive.py tests/unit/test_proxy_utils.py -k "archive or conversation" (17 passed, 225 deselected)

Relationship:
- replaces the backend/archive portion of #519
- companion frontend split: split/519-archive-frontend