### PR TITLE
feat(observability): add conversation archive viewer

### DIFF
--- a/frontend/src/features/conversation-archive/api.ts
+++ b/frontend/src/features/conversation-archive/api.ts
@@ -1,0 +1,52 @@
+import { get } from "@/lib/api-client";
+
+import {
+  ConversationArchiveFileSchema,
+  ConversationArchiveRecordsResponseSchema,
+} from "@/features/conversation-archive/schemas";
+
+const CONVERSATION_ARCHIVE_PATH = "/api/conversation-archive";
+
+export type ConversationArchiveRecordParams = {
+  file?: string;
+  limit?: number;
+  offset?: number;
+  direction?: string;
+  kind?: string;
+  transport?: string;
+  requestId?: string;
+  requestedAt?: string;
+};
+
+export function listConversationArchiveFiles() {
+  return get(`${CONVERSATION_ARCHIVE_PATH}/files`, ConversationArchiveFileSchema.array());
+}
+
+export function listConversationArchiveRecords(params: ConversationArchiveRecordParams) {
+  const query = new URLSearchParams();
+  if (params.file) {
+    query.set("file", params.file);
+  }
+  if (typeof params.limit === "number") {
+    query.set("limit", String(params.limit));
+  }
+  if (typeof params.offset === "number") {
+    query.set("offset", String(params.offset));
+  }
+  if (params.direction) {
+    query.set("direction", params.direction);
+  }
+  if (params.kind) {
+    query.set("kind", params.kind);
+  }
+  if (params.transport) {
+    query.set("transport", params.transport);
+  }
+  if (params.requestId) {
+    query.set("requestId", params.requestId);
+  }
+  if (params.requestedAt) {
+    query.set("requestedAt", params.requestedAt);
+  }
+  return get(`${CONVERSATION_ARCHIVE_PATH}/records?${query.toString()}`, ConversationArchiveRecordsResponseSchema);
+}

--- a/frontend/src/features/conversation-archive/components/request-archive-panel.tsx
+++ b/frontend/src/features/conversation-archive/components/request-archive-panel.tsx
@@ -1,0 +1,162 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useConversationArchiveRecords } from "@/features/conversation-archive/hooks/use-conversation-archive";
+import type { ConversationArchiveRecord } from "@/features/conversation-archive/schemas";
+
+const REQUEST_ARCHIVE_LIMIT = 200;
+
+export function RequestArchivePanel({
+  requestId,
+  requestedAt,
+}: {
+  requestId: string | null | undefined;
+  requestedAt?: string | null | undefined;
+}) {
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(0);
+  const recordsQuery = useConversationArchiveRecords(
+    requestId
+      ? {
+          requestId,
+          requestedAt: requestedAt ?? undefined,
+          limit: REQUEST_ARCHIVE_LIMIT,
+          offset: 0,
+        }
+      : null,
+  );
+
+  if (!requestId) {
+    return null;
+  }
+
+  if (recordsQuery.isPending) {
+    return (
+      <section className="space-y-2">
+        <h3 className="text-sm font-medium">Archive</h3>
+        <Skeleton className="h-20 w-full" />
+      </section>
+    );
+  }
+
+  if (recordsQuery.isError) {
+    return (
+      <section className="space-y-2">
+        <h3 className="text-sm font-medium">Archive</h3>
+        <div className="rounded-md border border-destructive/25 bg-destructive/10 p-3 text-xs text-destructive">
+          {recordsQuery.error instanceof Error ? recordsQuery.error.message : "Failed to load archive records"}
+        </div>
+      </section>
+    );
+  }
+
+  const records = recordsQuery.data?.records ?? [];
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-medium">Archive</h3>
+        <span className="text-xs text-muted-foreground">{recordsQuery.data?.total ?? 0} records</span>
+      </div>
+      {records.length === 0 ? (
+        <div className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+          No archived payloads for this request.
+        </div>
+      ) : (
+        <div className="max-h-[42vh] overflow-y-auto rounded-md border">
+          {records.map((record, index) => {
+            const expanded = expandedIndex === index;
+            return (
+              <div key={`${record.fileName ?? "archive"}-${record.timestamp ?? index}-${index}`} className="border-b last:border-b-0">
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-muted/60"
+                  onClick={() => setExpandedIndex(expanded ? null : index)}
+                >
+                  {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                  <ArchiveRecordSummary record={record} />
+                </button>
+                {expanded ? (
+                  <div className="grid gap-2 border-t bg-muted/20 p-3 md:grid-cols-2">
+                    <JsonBlock title="Payload" value={record.payload} />
+                    <JsonBlock title="Metadata" value={metadataForRecord(record)} />
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {recordsQuery.data?.hasMore ? (
+        <div className="text-xs text-muted-foreground">Showing first {REQUEST_ARCHIVE_LIMIT} records.</div>
+      ) : null}
+    </section>
+  );
+}
+
+function ArchiveRecordSummary({ record }: { record: ConversationArchiveRecord }) {
+  return (
+    <span className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+      <Badge variant="secondary">{record.direction ?? "-"}</Badge>
+      <span className="font-mono text-xs">{record.kind ?? "-"}</span>
+      <span className="text-xs text-muted-foreground">{record.transport ?? "-"}</span>
+      <span className="truncate text-xs text-muted-foreground">{record.fileName ?? formatDateTime(record.timestamp)}</span>
+    </span>
+  );
+}
+
+function JsonBlock({ title, value }: { title: string; value: unknown }) {
+  return (
+    <div className="min-w-0 rounded-md border bg-background">
+      <div className="border-b px-3 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {title}
+      </div>
+      <pre className="max-h-72 overflow-auto p-3 text-xs leading-relaxed whitespace-pre-wrap">
+        {stringifyJson(value)}
+      </pre>
+    </div>
+  );
+}
+
+function metadataForRecord(record: ConversationArchiveRecord) {
+  return {
+    fileName: record.fileName,
+    timestamp: record.timestamp,
+    requestId: record.requestId,
+    direction: record.direction,
+    kind: record.kind,
+    transport: record.transport,
+    accountId: record.accountId,
+    method: record.method,
+    url: record.url,
+    statusCode: record.statusCode,
+    headers: record.headers,
+    extra: record.extra,
+  };
+}
+
+function stringifyJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+}

--- a/frontend/src/features/conversation-archive/hooks/use-conversation-archive.ts
+++ b/frontend/src/features/conversation-archive/hooks/use-conversation-archive.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  listConversationArchiveFiles,
+  listConversationArchiveRecords,
+  type ConversationArchiveRecordParams,
+} from "@/features/conversation-archive/api";
+
+export function useConversationArchiveFiles() {
+  return useQuery({
+    queryKey: ["conversation-archive", "files"],
+    queryFn: listConversationArchiveFiles,
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+  });
+}
+
+export function useConversationArchiveRecords(params: ConversationArchiveRecordParams | null) {
+  return useQuery({
+    queryKey: ["conversation-archive", "records", params],
+    queryFn: () => listConversationArchiveRecords(params!),
+    enabled: params !== null,
+  });
+}

--- a/frontend/src/features/conversation-archive/schemas.test.ts
+++ b/frontend/src/features/conversation-archive/schemas.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ConversationArchiveFileSchema,
+  ConversationArchiveRecordsResponseSchema,
+} from "@/features/conversation-archive/schemas";
+
+describe("conversation archive schemas", () => {
+  it("parses archive file metadata", () => {
+    const parsed = ConversationArchiveFileSchema.parse({
+      name: "2026-04-29.jsonl.gz",
+      date: "2026-04-29",
+      sizeBytes: 1234,
+      compressed: true,
+      modifiedAt: "2026-04-29T10:00:00Z",
+    });
+
+    expect(parsed.compressed).toBe(true);
+  });
+
+  it("parses records with arbitrary payloads", () => {
+    const parsed = ConversationArchiveRecordsResponseSchema.parse({
+      records: [
+        {
+          timestamp: "2026-04-29T10:00:00Z",
+          fileName: "2026-04-29.jsonl.gz",
+          requestId: "req_1",
+          direction: "server_to_codex",
+          kind: "responses",
+          transport: "sse",
+          accountId: "acc_1",
+          method: "POST",
+          url: "https://chatgpt.com/backend-api/codex/responses",
+          statusCode: 200,
+          headers: { authorization: "[redacted]" },
+          payload: { type: "response.completed" },
+          extra: null,
+        },
+      ],
+      total: 1,
+      hasMore: false,
+    });
+
+    expect(parsed.records[0]?.payload).toEqual({ type: "response.completed" });
+  });
+});

--- a/frontend/src/features/conversation-archive/schemas.ts
+++ b/frontend/src/features/conversation-archive/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+export const ConversationArchiveFileSchema = z.object({
+  name: z.string(),
+  date: z.string().nullable(),
+  sizeBytes: z.number().int().nonnegative(),
+  compressed: z.boolean(),
+  modifiedAt: z.string().datetime({ offset: true }),
+});
+
+export const ConversationArchiveRecordSchema = z.object({
+  fileName: z.string().nullable().default(null),
+  timestamp: z.string().datetime({ offset: true }).nullable(),
+  requestId: z.string().nullable(),
+  direction: z.string().nullable(),
+  kind: z.string().nullable(),
+  transport: z.string().nullable(),
+  accountId: z.string().nullable(),
+  method: z.string().nullable(),
+  url: z.string().nullable(),
+  statusCode: z.number().int().nullable(),
+  headers: z.record(z.string(), z.string()).nullable(),
+  payload: z.unknown(),
+  extra: z.record(z.string(), z.unknown()).nullable().default(null),
+});
+
+export const ConversationArchiveRecordsResponseSchema = z.object({
+  records: z.array(ConversationArchiveRecordSchema),
+  total: z.number().int().nonnegative(),
+  hasMore: z.boolean(),
+});
+
+export type ConversationArchiveFile = z.infer<typeof ConversationArchiveFileSchema>;
+export type ConversationArchiveRecord = z.infer<typeof ConversationArchiveRecordSchema>;
+export type ConversationArchiveRecordsResponse = z.infer<typeof ConversationArchiveRecordsResponseSchema>;

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -17,6 +17,12 @@ vi.mock("sonner", () => ({
   },
 }));
 
+vi.mock("@/features/conversation-archive/components/request-archive-panel", () => ({
+  RequestArchivePanel: ({ requestId }: { requestId: string }) => (
+    <div data-testid="request-archive-panel">Archive for {requestId}</div>
+  ),
+}));
+
 const PAGINATION_PROPS = {
   total: 1,
   limit: 25,
@@ -95,6 +101,7 @@ describe("RecentRequestsTable", () => {
     expect(dialog).toBeInTheDocument();
     expect(screen.getByText("Request Details")).toBeInTheDocument();
     expect(screen.getByText("req-1")).toBeInTheDocument();
+    expect(screen.getByTestId("request-archive-panel")).toHaveTextContent("Archive for req-1");
     expect(screen.getAllByText("rate_limit_exceeded")[0]).toBeInTheDocument();
     expect(dialog.textContent).toContain("Rate limit reached while processing this request");
 

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -24,6 +24,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { PaginationControls } from "@/features/dashboard/components/filters/pagination-controls";
+import { RequestArchivePanel } from "@/features/conversation-archive/components/request-archive-panel";
 import type { AccountSummary, RequestLog } from "@/features/dashboard/schemas";
 import { REQUEST_STATUS_LABELS } from "@/utils/constants";
 import {
@@ -129,7 +130,7 @@ export function RecentRequestsTable({
               <TableHead className="w-24 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Status</TableHead>
               <TableHead className="w-24 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Tokens</TableHead>
               <TableHead className="w-16 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Cost</TableHead>
-              <TableHead className="w-72 pr-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Error</TableHead>
+              <TableHead className="w-72 pr-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">Details</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -244,7 +245,15 @@ export function RecentRequestsTable({
                         </Button>
                       </div>
                     ) : (
-                      <span className="text-xs text-muted-foreground">-</span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 px-2 text-[11px]"
+                        onClick={() => setSelectedRequest(request)}
+                      >
+                        View Details
+                      </Button>
                     )}
                   </TableCell>
                 </TableRow>
@@ -291,6 +300,8 @@ export function RecentRequestsTable({
                 <RequestDetailField label="Error Code" value={selectedRequest?.errorCode ?? "—"} mono />
               </div>
             </div>
+
+            <RequestArchivePanel requestId={selectedRequest?.requestId} requestedAt={selectedRequest?.requestedAt} />
 
             <div className="space-y-2">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
Draft split from #519.

Purpose:
- frontend request archive panel, schemas, and dashboard table wiring.

Validation:
- rebased on current main
- frontend lint/typecheck
- vitest: conversation archive schemas and recent requests table (6 passed)

Relationship:
- replaces the frontend viewer portion of #519
- companion backend split: split/519-archive-backend