### PR TITLE
feat(accounts): expose weekly token pace data

### DIFF
--- a/app/core/usage/types.py
+++ b/app/core/usage/types.py
@@ -105,6 +105,9 @@ class UsageTrendBucket:
     window: str
     avg_used_percent: float
     samples: int
+    reset_at: int | None = None
+    window_minutes: int | None = None
+    recorded_at: datetime | None = None
 
 
 @dataclass(frozen=True)

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -205,9 +205,21 @@ def build_account_usage_trends(
     """
     # Group buckets by (account_id, window)
     grouped: dict[tuple[str, str], dict[int, float]] = {}
-    for b in buckets:
-        key = (b.account_id, b.window)
+    secondary_schedule: dict[str, dict[int, tuple[int, int]]] = {}
+    for b in _effective_usage_trend_buckets(buckets):
+        is_weekly_primary = b.window == "primary" and usage_core.is_weekly_window_minutes(b.window_minutes)
+        window = "secondary" if is_weekly_primary else b.window
+        key = (b.account_id, window)
         grouped.setdefault(key, {})[b.bucket_epoch] = b.avg_used_percent
+        if (
+            (window == "secondary" or usage_core.is_weekly_window_minutes(b.window_minutes))
+            and b.reset_at is not None
+            and b.window_minutes
+        ):
+            secondary_schedule.setdefault(b.account_id, {})[b.bucket_epoch] = (
+                b.reset_at,
+                b.window_minutes,
+            )
 
     # Generate the full time grid, aligned to bucket boundaries (same as SQL)
     aligned_start = (since_epoch // bucket_seconds) * bucket_seconds
@@ -223,13 +235,58 @@ def build_account_usage_trends(
 
         primary_points = _fill_trend_points(time_grid, primary_data) if primary_data else []
         secondary_points = _fill_trend_points(time_grid, secondary_data) if secondary_data else []
+        secondary_scheduled_points = _fill_scheduled_secondary_points(
+            time_grid,
+            secondary_schedule.get(account_id, {}),
+        )
 
         result[account_id] = AccountUsageTrend(
             primary=primary_points,
             secondary=secondary_points,
+            secondary_scheduled=secondary_scheduled_points,
         )
 
     return result
+
+
+def _effective_usage_trend_buckets(buckets: list[UsageTrendBucket]) -> list[UsageTrendBucket]:
+    secondary_by_key = {
+        (bucket.account_id, bucket.bucket_epoch): bucket for bucket in buckets if bucket.window == "secondary"
+    }
+    weekly_primary_by_key = {
+        (bucket.account_id, bucket.bucket_epoch): bucket
+        for bucket in buckets
+        if bucket.window == "primary" and usage_core.is_weekly_window_minutes(bucket.window_minutes)
+    }
+    result: list[UsageTrendBucket] = []
+    for bucket in buckets:
+        key = (bucket.account_id, bucket.bucket_epoch)
+        weekly_primary = weekly_primary_by_key.get(key)
+        if bucket.window == "secondary" and weekly_primary is not None:
+            if usage_core.should_use_weekly_primary(
+                _trend_bucket_to_window_row(weekly_primary),
+                _trend_bucket_to_window_row(bucket),
+            ):
+                continue
+        if bucket is weekly_primary and key in secondary_by_key:
+            secondary = secondary_by_key[key]
+            if not usage_core.should_use_weekly_primary(
+                _trend_bucket_to_window_row(bucket),
+                _trend_bucket_to_window_row(secondary),
+            ):
+                continue
+        result.append(bucket)
+    return result
+
+
+def _trend_bucket_to_window_row(bucket: UsageTrendBucket) -> UsageWindowRow:
+    return UsageWindowRow(
+        account_id=bucket.account_id,
+        used_percent=bucket.avg_used_percent,
+        reset_at=bucket.reset_at,
+        window_minutes=bucket.window_minutes,
+        recorded_at=bucket.recorded_at,
+    )
 
 
 def _fill_trend_points(
@@ -251,4 +308,33 @@ def _fill_trend_points(
                 v=round(remaining, 2),
             )
         )
+    return points
+
+
+def _fill_scheduled_secondary_points(
+    time_grid: list[int],
+    schedule_data: dict[int, tuple[int, int]],
+) -> list[UsageTrendPoint]:
+    """Build the ideal weekly remaining line from each sample's own reset deadline."""
+    points: list[UsageTrendPoint] = []
+    current_reset_at: int | None = None
+    current_window_minutes: int | None = None
+
+    for epoch in time_grid:
+        if epoch in schedule_data:
+            current_reset_at, current_window_minutes = schedule_data[epoch]
+
+        if current_reset_at is None or not current_window_minutes:
+            continue
+
+        window_seconds = current_window_minutes * 60
+        remaining_seconds = max(0, min(window_seconds, current_reset_at - epoch))
+        scheduled_remaining = 100.0 * remaining_seconds / window_seconds
+        points.append(
+            UsageTrendPoint(
+                t=datetime.fromtimestamp(epoch, tz=timezone.utc),
+                v=round(scheduled_remaining, 2),
+            )
+        )
+
     return points

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -16,6 +16,7 @@ class UsageTrendPoint(DashboardModel):
 class AccountUsageTrend(DashboardModel):
     primary: list[UsageTrendPoint] = Field(default_factory=list)
     secondary: list[UsageTrendPoint] = Field(default_factory=list)
+    secondary_scheduled: list[UsageTrendPoint] = Field(default_factory=list)
 
 
 class AccountUsage(DashboardModel):
@@ -105,3 +106,4 @@ class AccountTrendsResponse(DashboardModel):
     account_id: str
     primary: list[UsageTrendPoint] = Field(default_factory=list)
     secondary: list[UsageTrendPoint] = Field(default_factory=list)
+    secondary_scheduled: list[UsageTrendPoint] = Field(default_factory=list)

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -140,6 +140,7 @@ class AccountsService:
             account_id=account_id,
             primary=trend.primary if trend else [],
             secondary=trend.secondary if trend else [],
+            secondary_scheduled=trend.secondary_scheduled if trend else [],
         )
 
     async def import_account(self, raw: bytes) -> AccountImportResponse:

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Collection
 from datetime import datetime
 
-from sqlalchemy import Integer, cast, delete, func, literal_column, or_, select, true
+from sqlalchemy import Integer, and_, cast, delete, func, literal_column, or_, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.usage.types import UsageAggregateRow, UsageTrendBucket
@@ -263,24 +263,73 @@ class UsageRepository:
             conditions.append(UsageHistory.account_id == account_id)
 
         window_expr = _normalized_window_expr()
-        stmt = (
+        base_rows = (
             select(
                 bucket_col,
-                UsageHistory.account_id,
+                UsageHistory.id.label("usage_id"),
+                UsageHistory.account_id.label("account_id"),
                 window_expr.label("window"),
-                func.avg(UsageHistory.used_percent).label("avg_used_percent"),
-                func.count(UsageHistory.id).label("samples"),
-                func.max(UsageHistory.reset_at).label("reset_at"),
-                func.max(UsageHistory.window_minutes).label("window_minutes"),
-                func.max(UsageHistory.recorded_at).label("recorded_at"),
+                UsageHistory.used_percent.label("used_percent"),
+                UsageHistory.reset_at.label("reset_at"),
+                UsageHistory.window_minutes.label("window_minutes"),
+                UsageHistory.recorded_at.label("recorded_at"),
             )
             .where(*conditions)
-            .group_by(
-                bucket_col,
-                UsageHistory.account_id,
-                window_expr,
+            .subquery()
+        )
+
+        aggregate_rows = (
+            select(
+                base_rows.c.bucket_epoch,
+                base_rows.c.account_id,
+                base_rows.c.window,
+                func.avg(base_rows.c.used_percent).label("avg_used_percent"),
+                func.count(base_rows.c.usage_id).label("samples"),
             )
-            .order_by(bucket_col)
+            .group_by(
+                base_rows.c.bucket_epoch,
+                base_rows.c.account_id,
+                base_rows.c.window,
+            )
+            .subquery()
+        )
+
+        latest_rows = select(
+            base_rows.c.bucket_epoch,
+            base_rows.c.account_id,
+            base_rows.c.window,
+            base_rows.c.reset_at,
+            base_rows.c.window_minutes,
+            base_rows.c.recorded_at,
+            func.row_number()
+            .over(
+                partition_by=(base_rows.c.bucket_epoch, base_rows.c.account_id, base_rows.c.window),
+                order_by=(base_rows.c.recorded_at.desc(), base_rows.c.usage_id.desc()),
+            )
+            .label("row_number"),
+        ).subquery()
+
+        stmt = (
+            select(
+                aggregate_rows.c.bucket_epoch,
+                aggregate_rows.c.account_id,
+                aggregate_rows.c.window,
+                aggregate_rows.c.avg_used_percent,
+                aggregate_rows.c.samples,
+                latest_rows.c.reset_at,
+                latest_rows.c.window_minutes,
+                latest_rows.c.recorded_at,
+            )
+            .join(
+                latest_rows,
+                and_(
+                    latest_rows.c.bucket_epoch == aggregate_rows.c.bucket_epoch,
+                    latest_rows.c.account_id == aggregate_rows.c.account_id,
+                    latest_rows.c.window == aggregate_rows.c.window,
+                    latest_rows.c.row_number == 1,
+                ),
+            )
+            .order_by(aggregate_rows.c.bucket_epoch)
         )
         result = await self._session.execute(stmt)
         return [

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -270,6 +270,9 @@ class UsageRepository:
                 window_expr.label("window"),
                 func.avg(UsageHistory.used_percent).label("avg_used_percent"),
                 func.count(UsageHistory.id).label("samples"),
+                func.max(UsageHistory.reset_at).label("reset_at"),
+                func.max(UsageHistory.window_minutes).label("window_minutes"),
+                func.max(UsageHistory.recorded_at).label("recorded_at"),
             )
             .where(*conditions)
             .group_by(
@@ -287,6 +290,9 @@ class UsageRepository:
                 window=row.window,
                 avg_used_percent=float(row.avg_used_percent) if row.avg_used_percent is not None else 0.0,
                 samples=int(row.samples),
+                reset_at=int(row.reset_at) if row.reset_at is not None else None,
+                window_minutes=int(row.window_minutes) if row.window_minutes is not None else None,
+                recorded_at=row.recorded_at,
             )
             for row in result.all()
         ]

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -71,6 +71,8 @@ async def test_dashboard_overview_combines_data(async_client, db_setup):
     payload = response.json()
 
     assert payload["accounts"][0]["accountId"] == "acc_dash"
+    assert payload["accounts"][0]["capacityCreditsSecondary"] == pytest.approx(7560.0)
+    assert payload["accounts"][0]["remainingCreditsSecondary"] == pytest.approx(4536.0)
     assert payload["timeframe"] == {
         "key": "7d",
         "windowMinutes": 10080,

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytest
 from sqlalchemy import text
@@ -191,3 +191,42 @@ async def test_latest_by_account_primary_query_plan_uses_normalized_window_index
     plan_json = json.dumps(plan)
     assert "idx_usage_window_account_latest" in plan_json or "idx_usage_window_account_time" in plan_json
     assert "Seq Scan" not in plan_json
+
+
+@pytest.mark.asyncio
+async def test_trends_by_bucket_uses_latest_sample_window_metadata(db_setup):
+    recorded_at = datetime(2026, 1, 1, 12, 0, 0)
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        repo = UsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc1"))
+
+        await repo.add_entry(
+            "acc1",
+            10.0,
+            window="secondary",
+            reset_at=9999,
+            window_minutes=10080,
+            recorded_at=recorded_at,
+        )
+        await repo.add_entry(
+            "acc1",
+            30.0,
+            window="secondary",
+            reset_at=1111,
+            window_minutes=300,
+            recorded_at=recorded_at + timedelta(minutes=5),
+        )
+
+        trends = await repo.trends_by_bucket(
+            since=recorded_at - timedelta(minutes=1),
+            bucket_seconds=86400,
+            window="secondary",
+        )
+
+    assert len(trends) == 1
+    assert trends[0].samples == 2
+    assert trends[0].avg_used_percent == pytest.approx(20.0)
+    assert trends[0].reset_at == 1111
+    assert trends[0].window_minutes == 300
+    assert trends[0].recorded_at == recorded_at + timedelta(minutes=5)

--- a/tests/unit/test_account_usage_trends.py
+++ b/tests/unit/test_account_usage_trends.py
@@ -1,16 +1,30 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from app.core.usage.types import UsageTrendBucket
 from app.modules.accounts.mappers import build_account_usage_trends
 
 
-def _bucket(epoch: int, account_id: str, window: str, avg_used: float, samples: int = 1) -> UsageTrendBucket:
+def _bucket(
+    epoch: int,
+    account_id: str,
+    window: str,
+    avg_used: float,
+    samples: int = 1,
+    reset_at: int | None = None,
+    window_minutes: int | None = None,
+    recorded_at: datetime | None = None,
+) -> UsageTrendBucket:
     return UsageTrendBucket(
         bucket_epoch=epoch,
         account_id=account_id,
         window=window,
         avg_used_percent=avg_used,
         samples=samples,
+        reset_at=reset_at,
+        window_minutes=window_minutes,
+        recorded_at=recorded_at,
     )
 
 
@@ -89,6 +103,158 @@ class TestBuildAccountUsageTrends:
         result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
         # secondary was not in any bucket → empty list
         assert result["a1"].secondary == []
+
+    def test_secondary_scheduled_line_uses_bucket_reset_deadline(self):
+        reset_at = SINCE_EPOCH + 4 * BUCKET_SECONDS
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                30.0,
+                reset_at=reset_at,
+                window_minutes=(4 * BUCKET_SECONDS) // 60,
+            ),
+        ]
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        scheduled = result["a1"].secondary_scheduled
+        assert [point.v for point in scheduled] == [100.0, 75.0, 50.0, 25.0]
+
+    def test_secondary_scheduled_line_uses_weekly_primary_bucket(self):
+        reset_at = SINCE_EPOCH + 10080 * 60
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "primary",
+                30.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+            ),
+        ]
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        assert result["a1"].primary == []
+        assert [point.v for point in result["a1"].secondary] == [70.0, 70.0, 70.0, 70.0]
+        scheduled = result["a1"].secondary_scheduled
+        assert [point.v for point in scheduled] == [100.0, 96.43, 92.86, 89.29]
+
+    def test_secondary_trend_prefers_real_secondary_over_weekly_primary_bucket(self):
+        reset_at = SINCE_EPOCH + 10080 * 60
+        stale_recorded_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        fresh_recorded_at = datetime(2026, 5, 2, tzinfo=timezone.utc)
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "primary",
+                90.0,
+                reset_at=reset_at + BUCKET_SECONDS,
+                window_minutes=10080,
+                recorded_at=stale_recorded_at,
+            ),
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                20.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=fresh_recorded_at,
+            ),
+        ]
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        assert result["a1"].primary == []
+        assert [point.v for point in result["a1"].secondary] == [80.0, 80.0, 80.0, 80.0]
+        assert result["a1"].secondary_scheduled[1].v == 96.43
+
+    def test_secondary_trend_prefers_fresher_weekly_primary_over_stale_secondary(self):
+        reset_at = SINCE_EPOCH + 10080 * 60
+        stale_recorded_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        fresh_recorded_at = datetime(2026, 5, 2, tzinfo=timezone.utc)
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "primary",
+                10.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=fresh_recorded_at,
+            ),
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                80.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=stale_recorded_at,
+            ),
+        ]
+
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        assert result["a1"].primary == []
+        assert [point.v for point in result["a1"].secondary] == [90.0, 90.0, 90.0, 90.0]
+
+    def test_secondary_trend_prefers_fresher_secondary_over_stale_weekly_primary(self):
+        reset_at = SINCE_EPOCH + 10080 * 60
+        stale_recorded_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        fresh_recorded_at = datetime(2026, 5, 2, tzinfo=timezone.utc)
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "primary",
+                10.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=stale_recorded_at,
+            ),
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                80.0,
+                reset_at=reset_at,
+                window_minutes=10080,
+                recorded_at=fresh_recorded_at,
+            ),
+        ]
+
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        assert result["a1"].primary == []
+        assert [point.v for point in result["a1"].secondary] == [20.0, 20.0, 20.0, 20.0]
+
+    def test_secondary_scheduled_line_jumps_after_weekly_reset(self):
+        first_reset = SINCE_EPOCH + BUCKET_SECONDS
+        second_reset = SINCE_EPOCH + 5 * BUCKET_SECONDS
+        buckets = [
+            _bucket(
+                SINCE_EPOCH,
+                "a1",
+                "secondary",
+                95.0,
+                reset_at=first_reset,
+                window_minutes=(4 * BUCKET_SECONDS) // 60,
+            ),
+            _bucket(
+                SINCE_EPOCH + 2 * BUCKET_SECONDS,
+                "a1",
+                "secondary",
+                5.0,
+                reset_at=second_reset,
+                window_minutes=(4 * BUCKET_SECONDS) // 60,
+            ),
+        ]
+        result = build_account_usage_trends(buckets, SINCE_EPOCH, BUCKET_SECONDS, BUCKET_COUNT)
+
+        scheduled = result["a1"].secondary_scheduled
+        assert [point.v for point in scheduled] == [25.0, 0.0, 75.0, 50.0]
 
     def test_timestamps_are_utc(self):
         buckets = [_bucket(SINCE_EPOCH, "a1", "primary", 0.0)]


### PR DESCRIPTION
Draft split from #534.

Purpose:
- backend/account usage data needed for weekly token pace display.

Validation:
- rebased on current main
- ruff format/check on touched backend/test files
- pytest tests/unit/test_account_usage_trends.py tests/integration/test_dashboard_overview.py -k "weekly or pace or usage" (17 passed, 7 deselected)

Relationship:
- replaces the backend data portion of #534
- companion frontend split: split/534-weekly-frontend