### PR TITLE
fix(models): report full context in v1 metadata

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -185,6 +185,18 @@ _STREAM_STARTUP_ERROR_PROBE_SECONDS = 0.05
 # Keep bridge startup probing above tiny event-loop scheduling jitter:
 # PostgreSQL-backed failures may need a DB round trip before the first item.
 _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS = 0.5
+_V1_FULL_CONTEXT_WINDOW_OVERRIDES: Final[dict[str, int]] = {
+    "gpt-5.4": 1_000_000,
+    "gpt-5.5": 400_000,
+    "gpt-5.4-mini": 400_000,
+    "gpt-5.3-codex": 400_000,
+}
+_V1_MAX_OUTPUT_TOKEN_OVERRIDES: Final[dict[str, int]] = {
+    "gpt-5.4": 128_000,
+    "gpt-5.5": 128_000,
+    "gpt-5.4-mini": 128_000,
+    "gpt-5.3-codex": 128_000,
+}
 
 # OpenAI error ``type`` -> HTTP status for the /v1/images/* non-streaming
 # error path. The /v1/responses path has its own ``_status_for_error``
@@ -1615,6 +1627,40 @@ def _effective_context_window(model: UpstreamModel) -> int:
     return overrides.get(model.slug, model.context_window)
 
 
+def _raw_positive_int(raw: Mapping[str, JsonValue], key: str) -> int | None:
+    value = raw.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
+def _v1_full_context_window(model: UpstreamModel) -> int:
+    overrides = get_settings().model_context_window_overrides
+    explicit_override = overrides.get(model.slug)
+    if explicit_override is not None:
+        return explicit_override
+
+    known_context_window = _V1_FULL_CONTEXT_WINDOW_OVERRIDES.get(model.slug)
+    if known_context_window is not None:
+        return known_context_window
+
+    upstream_context_window = model.context_window
+    raw_max_context_window = _raw_positive_int(model.raw, "max_context_window")
+    if raw_max_context_window is not None and raw_max_context_window > upstream_context_window:
+        return raw_max_context_window
+
+    return upstream_context_window
+
+
+def _v1_input_context_window(model: UpstreamModel) -> int | None:
+    input_context_window = _effective_context_window(model)
+    return input_context_window if input_context_window != _v1_full_context_window(model) else None
+
+
+def _v1_max_output_tokens(model: UpstreamModel) -> int | None:
+    return _V1_MAX_OUTPUT_TOKEN_OVERRIDES.get(model.slug)
+
+
 def _model_visibility(model: UpstreamModel) -> str:
     visibility = model.raw.get("visibility")
     return visibility if isinstance(visibility, str) else "list"
@@ -1624,7 +1670,9 @@ def _to_model_metadata(model: UpstreamModel) -> ModelMetadata:
     return ModelMetadata(
         display_name=model.display_name,
         description=model.description,
-        context_window=_effective_context_window(model),
+        context_window=_v1_full_context_window(model),
+        input_context_window=_v1_input_context_window(model),
+        max_output_tokens=_v1_max_output_tokens(model),
         input_modalities=list(model.input_modalities),
         supported_reasoning_levels=[
             ReasoningLevelSchema(effort=rl.effort, description=rl.description)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1653,7 +1653,7 @@ def _v1_full_context_window(model: UpstreamModel) -> int:
 
 
 def _v1_input_context_window(model: UpstreamModel) -> int | None:
-    input_context_window = _effective_context_window(model)
+    input_context_window = model.context_window
     return input_context_window if input_context_window != _v1_full_context_window(model) else None
 
 

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -165,6 +165,8 @@ class ModelMetadata(BaseModel):
     display_name: str
     description: str
     context_window: int
+    input_context_window: int | None = None
+    max_output_tokens: int | None = None
     input_modalities: list[str]
     supported_reasoning_levels: list[ReasoningLevelSchema]
     default_reasoning_level: str | None = None

--- a/openspec/changes/report-v1-model-full-context/proposal.md
+++ b/openspec/changes/report-v1-model-full-context/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`codex-lb` exposes `/v1/models` as the OpenAI-compatible model catalog for generic SDKs and client frameworks. That endpoint currently copies the upstream Codex `context_window` value into `metadata.context_window`.
+
+The upstream Codex catalog's `context_window` is not the same semantic as the context-window value generic OpenAI-compatible clients expect. For the GPT-5 Codex family, upstream reports `context_window=272000` even when the full model window is larger. The value matches the conservative Codex input / auto-compaction budget: for 400k-class models, `400000 - 128000 = 272000`, leaving room for output and hidden reasoning. `gpt-5.4` separately advertises `max_context_window=1000000` while still reporting the same `context_window=272000` compact budget.
+
+Passing the conservative input budget through `/v1/models` makes generic clients believe models such as `gpt-5.5`, `gpt-5.4-mini`, and `gpt-5.3-codex` are 272k-context models rather than 400k-context models, and hides that `gpt-5.4` is a 1M-context model. Native Codex clients still need the conservative compact budget, so changing `/backend-api/codex/models` would be the wrong fix. The OpenAI-compatible `/v1/models` metadata needs its own full-context normalization while preserving the Codex-native fields on the Codex route.
+
+## What Changes
+
+- Normalize `/v1/models` `metadata.context_window` to the full model context for known GPT-5 Codex models:
+  - `gpt-5.4` → `1_000_000`
+  - `gpt-5.5` → `400_000`
+  - `gpt-5.4-mini` → `400_000`
+  - `gpt-5.3-codex` → `400_000`
+- Add `/v1/models` metadata fields that preserve the split semantics:
+  - `input_context_window` carries the Codex-native conservative input / compact budget (`272000` for these models).
+  - `max_output_tokens` carries the output/reasoning reserve (`128000` for these GPT-5 Codex models).
+- Keep `/backend-api/codex/models` behavior unchanged so Codex-native clients continue to receive the upstream compact-budget semantics.
+- Preserve the existing `model_context_window_overrides` escape hatch as the highest-priority reported-context override.
+
+## Capabilities
+
+### Added Capabilities
+
+- `model-catalog-compat`: `/v1/models` exposes OpenAI-compatible full-context metadata without conflating it with Codex-native compact-budget metadata.
+
+## Impact
+
+- **Code**: `app/modules/proxy/schemas.py`, `app/modules/proxy/api.py`
+- **Tests**: `tests/integration/test_v1_models.py`
+- **Behavior**: generic OpenAI-compatible clients reading `/v1/models` see the intended full context windows; native Codex endpoint semantics remain unchanged.
+- **Non-goals**: no live probing or dynamic measurement of model limits, no change to account routing, and no change to request truncation/compaction behavior.

--- a/openspec/changes/report-v1-model-full-context/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/report-v1-model-full-context/specs/model-catalog-compat/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: OpenAI-compatible model metadata uses full context windows
+
+When serving `GET /v1/models`, the system SHALL expose `metadata.context_window` as the model's full context window for generic OpenAI-compatible clients, not the Codex-native compact-budget window. The system MUST report these full-context values for known GPT-5 Codex models:
+
+| model | `metadata.context_window` |
+| --- | ---: |
+| `gpt-5.4` | `1000000` |
+| `gpt-5.5` | `400000` |
+| `gpt-5.4-mini` | `400000` |
+| `gpt-5.3-codex` | `400000` |
+
+For models without a known full-context override, the system SHOULD use an upstream `max_context_window` value when it is a positive integer larger than the Codex-native `context_window`; otherwise it MAY fall back to the Codex-native `context_window`. Explicit operator context-window overrides remain the highest-priority reported-context value.
+
+#### Scenario: GPT-5.4 is reported as a 1M context model on /v1/models
+
+- **WHEN** the upstream model catalog contains `gpt-5.4` with `context_window=272000` and `max_context_window=1000000`
+- **THEN** `GET /v1/models` returns the `gpt-5.4` entry with `metadata.context_window=1000000`
+
+#### Scenario: 400k GPT-5 Codex models are reported with full context on /v1/models
+
+- **WHEN** the upstream model catalog contains `gpt-5.5`, `gpt-5.4-mini`, or `gpt-5.3-codex` with `context_window=272000`
+- **THEN** `GET /v1/models` returns each entry with `metadata.context_window=400000`
+
+### Requirement: OpenAI-compatible model metadata preserves Codex input-budget semantics separately
+
+When serving `GET /v1/models`, the system SHALL preserve the Codex-native compact/input budget in `metadata.input_context_window` when that budget differs from `metadata.context_window`. The system SHOULD expose `metadata.max_output_tokens` for known GPT-5 Codex models whose full-context window is derived by reserving output/reasoning budget from the full context; for `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex`, that value is `128000`.
+
+#### Scenario: /v1/models exposes the 272k Codex input budget separately
+
+- **WHEN** the upstream model catalog contains a known GPT-5 Codex model with `context_window=272000`
+- **THEN** `GET /v1/models` returns that model with `metadata.input_context_window=272000`
+- **AND** `metadata.context_window` remains the model's full context window
+
+#### Scenario: /v1/models exposes max output budget for known GPT-5 Codex models
+
+- **WHEN** `GET /v1/models` returns `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, or `gpt-5.3-codex`
+- **THEN** the entry's metadata includes `max_output_tokens=128000`
+
+### Requirement: Codex-native model catalog keeps upstream compact-budget fields
+
+When serving `GET /backend-api/codex/models`, the system MUST keep Codex-native model catalog semantics unchanged: the top-level `context_window` field remains the upstream Codex compact/input budget, and upstream raw fields such as `max_context_window` remain available when upstream provides them. The `/v1/models` full-context normalization MUST NOT change this native Codex endpoint.
+
+#### Scenario: Native Codex route preserves compact budget
+
+- **WHEN** the upstream model catalog contains `gpt-5.5` with `context_window=272000`
+- **THEN** `GET /backend-api/codex/models` returns `gpt-5.5.context_window=272000`
+- **AND** it does not replace that field with `400000`

--- a/openspec/changes/report-v1-model-full-context/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/report-v1-model-full-context/specs/model-catalog-compat/spec.md
@@ -33,6 +33,13 @@ When serving `GET /v1/models`, the system SHALL preserve the Codex-native compac
 - **THEN** `GET /v1/models` returns that model with `metadata.input_context_window=272000`
 - **AND** `metadata.context_window` remains the model's full context window
 
+#### Scenario: Explicit reported-context overrides do not hide the Codex input budget
+
+- **WHEN** an operator override sets a known GPT-5 Codex model's reported `metadata.context_window` to `515000`
+- **AND** the upstream model catalog contains that model with `context_window=272000`
+- **THEN** `GET /v1/models` returns that model with `metadata.context_window=515000`
+- **AND** `metadata.input_context_window=272000`
+
 #### Scenario: /v1/models exposes max output budget for known GPT-5 Codex models
 
 - **WHEN** `GET /v1/models` returns `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, or `gpt-5.3-codex`

--- a/openspec/changes/report-v1-model-full-context/tasks.md
+++ b/openspec/changes/report-v1-model-full-context/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add `/v1/models` metadata fields for full-context semantics: `context_window`, `input_context_window`, and `max_output_tokens`
+- [x] 1.2 Normalize known GPT-5 Codex full context windows (`gpt-5.4` = 1M; `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex` = 400k)
+- [x] 1.3 Keep `/backend-api/codex/models` Codex-native `context_window` semantics unchanged
+
+## 2. Tests
+
+- [x] 2.1 Integration: `/v1/models` reports full context windows for `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, and `gpt-5.3-codex`
+- [x] 2.2 Integration: `/v1/models` preserves the Codex input budget in `metadata.input_context_window` and exposes `metadata.max_output_tokens`
+- [x] 2.3 Integration: `/backend-api/codex/models` still reports the upstream Codex compact-budget `context_window`
+
+## 3. Spec Delta
+
+- [x] 3.1 Add `model-catalog-compat` spec delta covering full-context `/v1/models` metadata and native Codex route preservation
+- [x] 3.2 Validate specs locally with `openspec validate report-v1-model-full-context --strict`

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -292,7 +292,9 @@ async def test_model_context_window_override(async_client, monkeypatch):
     resp_v1 = await async_client.get("/v1/models")
     assert resp_v1.status_code == 200
     v1_entry = next(m for m in resp_v1.json()["data"] if m["id"] == "gpt-5.4")
-    assert v1_entry["metadata"]["context_window"] == 515000
+    metadata = v1_entry["metadata"]
+    assert metadata["context_window"] == 515000
+    assert metadata["input_context_window"] == 272000
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -305,3 +305,63 @@ async def test_model_context_window_no_override(async_client):
     assert resp.status_code == 200
     entry = next(m for m in resp.json()["models"] if m["slug"] == "gpt-5.4")
     assert entry["context_window"] == 272000
+
+
+def _raw_with_max_context_window(max_context_window: int) -> dict[str, JsonValue]:
+    return {
+        "shell_type": "shell_command",
+        "visibility": "list",
+        "max_context_window": max_context_window,
+        "auto_compact_token_limit": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_v1_models_reports_full_context_and_preserves_codex_budget(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model("gpt-5.4", raw=_raw_with_max_context_window(1_000_000)),
+        _make_upstream_model("gpt-5.5", raw=_raw_with_max_context_window(272_000)),
+        _make_upstream_model("gpt-5.4-mini", raw=_raw_with_max_context_window(272_000)),
+        _make_upstream_model("gpt-5.3-codex", raw=_raw_with_max_context_window(272_000)),
+    ]
+    await registry.update({"pro": models})
+
+    resp_v1 = await async_client.get("/v1/models")
+    assert resp_v1.status_code == 200
+    metadata_by_id = {item["id"]: item["metadata"] for item in resp_v1.json()["data"]}
+
+    expected_context_windows = {
+        "gpt-5.4": 1_000_000,
+        "gpt-5.5": 400_000,
+        "gpt-5.4-mini": 400_000,
+        "gpt-5.3-codex": 400_000,
+    }
+    for slug, full_context_window in expected_context_windows.items():
+        metadata = metadata_by_id[slug]
+        assert metadata["context_window"] == full_context_window
+        assert metadata["input_context_window"] == 272_000
+        assert metadata["max_output_tokens"] == 128_000
+
+    resp_codex = await async_client.get("/backend-api/codex/models")
+    assert resp_codex.status_code == 200
+    codex_by_slug = {item["slug"]: item for item in resp_codex.json()["models"]}
+    assert codex_by_slug["gpt-5.4"]["context_window"] == 272_000
+    assert codex_by_slug["gpt-5.4"]["max_context_window"] == 1_000_000
+    assert codex_by_slug["gpt-5.5"]["context_window"] == 272_000
+    assert codex_by_slug["gpt-5.5"]["max_context_window"] == 272_000
+
+
+@pytest.mark.asyncio
+async def test_v1_models_uses_raw_max_context_window_for_unknown_models(async_client):
+    registry = get_model_registry()
+    models = [_make_upstream_model("gpt-custom", raw=_raw_with_max_context_window(900_000))]
+    await registry.update({"pro": models})
+
+    resp = await async_client.get("/v1/models")
+    assert resp.status_code == 200
+    entry = next(item for item in resp.json()["data"] if item["id"] == "gpt-custom")
+
+    assert entry["metadata"]["context_window"] == 900_000
+    assert entry["metadata"]["input_context_window"] == 272_000
+    assert entry["metadata"].get("max_output_tokens") is None


### PR DESCRIPTION
## Summary
- normalize `/v1/models` `metadata.context_window` to full-context semantics for GPT-5 Codex models (`gpt-5.4` = 1M; `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex` = 400k)
- add `metadata.input_context_window` and `metadata.max_output_tokens` so generic clients can distinguish full context from Codex's 272k compact/input budget
- keep `/backend-api/codex/models` Codex-native `context_window` behavior unchanged
- add OpenSpec change `report-v1-model-full-context`

## Test Plan
- [x] `openspec validate report-v1-model-full-context --strict`
- [x] `openspec validate --specs`
- [x] `uv run pytest tests/unit/test_model_registry.py tests/integration/test_v1_models.py -q`
- [x] `uvx ruff check . && uvx ruff format --check .`
- [x] `uv run ty check`

## Notes
- Existing `CODEX_LB_MODEL_CONTEXT_WINDOW_OVERRIDES` remains the highest-priority reported context-window override.
- `/backend-api/codex/models` still reports upstream compact-budget values for native Codex clients, so native auto-compaction semantics are not changed.
