### PR TITLE
test(proxy): pin previous response continuity masking

### DIFF
--- a/openspec/changes/close-live-websocket-previous-response-leak/.openspec.yaml
+++ b/openspec/changes/close-live-websocket-previous-response-leak/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/close-live-websocket-previous-response-leak/proposal.md
+++ b/openspec/changes/close-live-websocket-previous-response-leak/proposal.md
@@ -1,0 +1,29 @@
+# Close live WebSocket previous-response leak
+
+## Why
+
+Codex Desktop `Continue` turns are still seeing raw upstream `previous_response_not_found` errors through the direct Responses WebSocket path. Prior continuity work masks many HTTP bridge and WebSocket cases, but live evidence shows either the deployed container is stale or a direct WebSocket edge still escapes the public masking contract.
+
+Raw `previous_response_not_found` causes the client to treat the previous response anchor as permanently invalid. The desired public contract is retryable continuity failure or transparent recovery, never a raw upstream invalid-request payload.
+
+## What Changes
+
+- Add a live/parity verifier that proves the running container commit and checks recent Codex client logs for raw `previous_response_not_found`.
+- Add a regression that matches the Codex Desktop direct WebSocket `Continue` shape and fails if any raw `previous_response_not_found` text can reach the downstream client.
+- If current repo code already passes the regression, stop code changes and rebuild/redeploy the local container from the fixed commit.
+- If current repo code fails the regression, harden the direct WebSocket public boundary so all previous-response misses are rewritten or suppressed into retryable terminal events.
+- Add operator diagnostics for deployed build identity, request-log persistence failures, and continuity masking decisions.
+
+This change intentionally extends, rather than duplicates, `harden-continuity-fail-closed-edges`: that earlier change covers many fail-closed rewrite cases, while this one adds the live raw-text-never-leaks invariant plus deploy/runtime parity proof.
+
+## Non-goals
+
+- Do not change model routing or account-selection strategy unless owner lookup proves unsafe.
+- Do not weaken the existing fail-closed behavior for hard continuity.
+- Do not push, open PRs, or run live Cubic while workspace PR/CI mode is ORANGE.
+
+## Impact
+
+- Affected code: `app/modules/proxy/service.py`, possibly `app/modules/proxy/api.py`, and continuity tests.
+- Affected ops: local `codex-lb` Docker/Colima watchdog recovery.
+- User-visible outcome: Codex `Continue` either succeeds, receives a retryable masked continuity error, or starts cleanly after a verified local redeploy. It never displays raw `previous_response_not_found`.

--- a/openspec/changes/close-live-websocket-previous-response-leak/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/close-live-websocket-previous-response-leak/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Runtime continuity canary reports raw-error exposure and build parity
+Operators MUST have a local verifier that reports whether the running `codex-lb` runtime is built from the expected code and whether recent Codex client logs contain raw `previous_response_not_found` errors.
+
+#### Scenario: live runtime is checked after a continuity patch
+- **WHEN** an operator runs the verifier on the Mac host
+- **THEN** the verifier reports the repo commit, the running container image/id, local `/health` status, and recent raw `previous_response_not_found` count
+- **AND** the verifier exits nonzero if raw errors are still present after the verification window
+- **AND** the verifier redacts response ids by default unless `--show-ids` is passed
+
+### Requirement: Request-log persistence failures are operator-visible
+If request-log persistence fails for Responses WebSocket requests, the runtime MUST surface that condition in logs or verifier output so operators do not mistake HTTP `/health` success for continuity safety.
+
+#### Scenario: request-log persistence fails during WebSocket traffic
+- **WHEN** the runtime logs a request-log persistence failure
+- **THEN** the verifier reports the failure count
+- **AND** the continuity closeout cannot be marked green until persistence failures are absent or explicitly explained

--- a/openspec/changes/close-live-websocket-previous-response-leak/specs/responses-api-compat/spec.md
+++ b/openspec/changes/close-live-websocket-previous-response-leak/specs/responses-api-compat/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Direct WebSocket previous-response misses never leak raw upstream errors
+When a direct Responses WebSocket request depends on `previous_response_id`, the service MUST NOT send a raw upstream `previous_response_not_found` payload to the downstream client. This applies to `/v1/responses` and `/backend-api/codex/responses` WebSocket clients.
+
+#### Scenario: Codex Desktop continue receives upstream previous-response miss before response.created
+- **WHEN** a direct WebSocket `response.create` request includes `previous_response_id`
+- **AND** upstream emits a top-level `type=error` payload with `code=previous_response_not_found` or `param=previous_response_id`
+- **AND** no stable upstream `response.id` has been assigned yet
+- **THEN** the downstream client receives either a transparent replay result or a retryable terminal event
+- **AND** the downstream payload does not include `previous_response_not_found`
+- **AND** the downstream payload does not include the missing previous response id
+
+#### Scenario: Codex Desktop continue has only request-log owner metadata
+- **WHEN** a prior direct WebSocket turn completed and was persisted only in `request_logs`
+- **AND** a later direct WebSocket follow-up references that completed response id
+- **THEN** owner lookup uses request-log metadata or fails closed with a retryable error
+- **AND** it does not continue on an unpinned account
+- **AND** it does not expose raw `previous_response_not_found`

--- a/openspec/changes/close-live-websocket-previous-response-leak/tasks.md
+++ b/openspec/changes/close-live-websocket-previous-response-leak/tasks.md
@@ -1,0 +1,23 @@
+## 1. Spec and Reproduction
+
+- [ ] 1.1 Add the live direct WebSocket continuity contract requirements.
+- [ ] 1.2 Add a focused regression for the Codex Desktop `Continue` raw-error shape.
+- [ ] 1.3 Add a live/parity verifier that reports deployed build identity and recent raw client errors.
+
+## 2. Repair Path
+
+- [ ] 2.1 If the focused regression fails on current repo code, harden the direct WebSocket public error boundary.
+- [ ] 2.2 If current repo code passes but live canary fails, rebuild/redeploy local `codex-lb` from the current commit instead of changing service logic.
+- [ ] 2.3 Make request-log persistence failures visible in health or verifier output.
+
+## 3. Watchdog Recovery
+
+- [ ] 3.1 Update the local watchdog to use Colima's Docker context/socket explicitly.
+- [ ] 3.2 Verify watchdog restart behavior against the live `codex-lb` container without pushing remote work.
+
+## 4. Verification
+
+- [ ] 4.1 Run targeted continuity pytest suites.
+- [ ] 4.2 Run `openspec validate --specs`.
+- [ ] 4.3 Run the live verifier before and after local redeploy.
+- [ ] 4.4 Record the proof boundary in the final handoff.

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -3297,6 +3297,131 @@ def test_backend_responses_websocket_masks_previous_response_not_found_when_mess
     assert connect_count == 1
 
 
+def test_backend_responses_websocket_never_exposes_raw_previous_response_not_found_to_client(
+    app_instance,
+    monkeypatch,
+):
+    upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "error",
+                            "status": 400,
+                            "error": {
+                                "type": "invalid_request_error",
+                                "code": "previous_response_not_found",
+                                "message": "Previous response with id 'resp_live_anchor' not found.",
+                                "param": "previous_response_id",
+                            },
+                        },
+                        separators=(",", ":"),
+                    ),
+                )
+            ]
+        ],
+    )
+    connect_count = 0
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
+        del request
+        return None
+
+    async def fake_resolve_previous_response_owner(
+        self,
+        *,
+        previous_response_id,
+        api_key,
+        session_id=None,
+        surface,
+    ):
+        del self, api_key, session_id, surface
+        assert previous_response_id == "resp_live_anchor"
+        return "acct_live_anchor"
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        nonlocal connect_count
+        connect_count += 1
+        return SimpleNamespace(id="acct_live_anchor"), upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_resolve_websocket_previous_response_owner",
+        fake_resolve_previous_response_owner,
+    )
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "previous_response_id": "resp_live_anchor",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "Continue."}]}],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer external-token",
+                "session_id": "thread-live-leak",
+                "openai-beta": "responses_websockets=2026-02-06",
+            },
+        ) as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            event = json.loads(websocket.receive_text())
+
+    serialized_event = json.dumps(event)
+    assert event["type"] == "response.failed"
+    _assert_codex_previous_response_stale_error(event["response"]["error"])
+    assert "previous_response_not_found" not in serialized_event
+    assert "resp_live_anchor" not in serialized_event
+    assert connect_count == 1
+
+
 def test_backend_responses_websocket_keeps_session_alive_after_foreign_previous_response_not_found(
     app_instance,
     monkeypatch,


### PR DESCRIPTION
## Summary
- add an OpenSpec change capturing the live direct WebSocket previous_response_not_found leak contract
- add a regression that proves /backend-api/codex/responses rewrites upstream previous_response_not_found into a retryable response.failed event
- assert the downstream payload does not expose the raw upstream code or missing response id

## Verification
- .venv/bin/python -m pytest tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_never_exposes_raw_previous_response_not_found_to_client -q
- .venv/bin/python -m pytest tests/integration/test_proxy_websocket_responses.py -q

## Notes
- openspec validate --specs could not be run locally because the openspec CLI is not installed in this environment.
- This PR intentionally excludes Andrew-local runtime verifier/watchdog artifacts from the upstream-facing branch.