### PR TITLE
fix(dashboard): derive quota status from usage windows

### DIFF
--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -6,9 +6,10 @@ from app.core import usage as usage_core
 from app.core.auth import DEFAULT_PLAN, extract_id_token_claims
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
+from app.core.usage.quota import apply_usage_quota
 from app.core.usage.types import UsageTrendBucket, UsageWindowRow
 from app.core.utils.time import from_epoch_seconds
-from app.db.models import Account, UsageHistory
+from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.accounts.schemas import (
     AccountAdditionalQuota,
     AccountAuthStatus,
@@ -94,12 +95,19 @@ def _account_to_summary(
         secondary_used_percent,
         capacity_secondary,
     )
+    effective_status = _effective_status_from_usage(
+        account,
+        effective_primary_usage,
+        primary_used_percent,
+        effective_secondary_usage,
+        secondary_used_percent,
+    )
     return AccountSummary(
         account_id=account.id,
         email=account.email,
         display_name=account.email,
         plan_type=plan_type,
-        status=account.status.value,
+        status=effective_status.value,
         usage=AccountUsage(
             primary_remaining_percent=primary_remaining_percent,
             secondary_remaining_percent=secondary_remaining_percent,
@@ -118,6 +126,25 @@ def _account_to_summary(
         deactivation_reason=account.deactivation_reason,
         auth=auth_status,
     )
+
+
+def _effective_status_from_usage(
+    account: Account,
+    primary_usage: UsageHistory | None,
+    primary_used_percent: float | None,
+    secondary_usage: UsageHistory | None,
+    secondary_used_percent: float | None,
+) -> AccountStatus:
+    status, _, _ = apply_usage_quota(
+        status=account.status,
+        primary_used=primary_used_percent,
+        primary_reset=primary_usage.reset_at if primary_usage is not None else None,
+        primary_window_minutes=primary_usage.window_minutes if primary_usage is not None else None,
+        runtime_reset=float(account.reset_at) if account.reset_at else None,
+        secondary_used=secondary_used_percent,
+        secondary_reset=secondary_usage.reset_at if secondary_usage is not None else None,
+    )
+    return status
 
 
 def _effective_usage_windows(

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -186,6 +186,42 @@ async def test_dashboard_overview_maps_weekly_only_primary_to_secondary(async_cl
 
 
 @pytest.mark.asyncio
+async def test_dashboard_overview_derives_quota_status_from_current_weekly_usage(async_client, db_setup):
+    now = utcnow().replace(microsecond=0)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_weekly_full", "weekly-full@example.com"))
+        await usage_repo.add_entry(
+            "acc_weekly_full",
+            5.0,
+            window="primary",
+            window_minutes=300,
+            recorded_at=now - timedelta(minutes=2),
+        )
+        await usage_repo.add_entry(
+            "acc_weekly_full",
+            100.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=int(naive_utc_to_epoch(now + timedelta(days=2))),
+            recorded_at=now - timedelta(minutes=1),
+        )
+
+    response = await async_client.get("/api/dashboard/overview")
+    assert response.status_code == 200
+    payload = response.json()
+
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+    account = accounts["acc_weekly_full"]
+    assert account["status"] == "quota_exceeded"
+    assert account["usage"]["primaryRemainingPercent"] == pytest.approx(95.0)
+    assert account["usage"]["secondaryRemainingPercent"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
 async def test_dashboard_overview_counts_prolite_capacity(async_client, db_setup):
     now = utcnow().replace(microsecond=0)
 

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.17.0"
+version = "1.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- derive account dashboard status from the current usage windows before rendering
- show `quota_exceeded` when weekly/secondary usage is exhausted even if the persisted account row still says `active`
- add regression coverage for the “5h remaining, weekly exhausted” dashboard case
- sync the editable package version in `uv.lock` with `pyproject.toml`

## Validation
```bash
uvx ruff check app/modules/accounts/mappers.py tests/integration/test_dashboard_overview.py
uv run --locked ty check app/modules/accounts/mappers.py tests/integration/test_dashboard_overview.py
uv run --locked pytest -q -ra tests/integration/test_dashboard_overview.py::test_dashboard_overview_derives_quota_status_from_current_weekly_usage tests/integration/test_dashboard_overview.py::test_dashboard_overview_maps_weekly_only_primary_to_secondary
```
