### PR TITLE
fix(proxy): trim durable full-resend continuations

### DIFF
--- a/app/db/alembic/versions/20260518_000000_add_http_bridge_durable_input_prefix.py
+++ b/app/db/alembic/versions/20260518_000000_add_http_bridge_durable_input_prefix.py
@@ -1,0 +1,29 @@
+"""add HTTP bridge durable input prefix metadata
+
+Revision ID: 20260518_000000_add_http_bridge_durable_input_prefix
+Revises: 20260515_000000_soft_delete_request_logs_on_account_delete
+Create Date: 2026-05-18 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260518_000000_add_http_bridge_durable_input_prefix"
+down_revision: str | Sequence[str] | None = "20260515_000000_soft_delete_request_logs_on_account_delete"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("http_bridge_sessions", sa.Column("latest_input_item_count", sa.Integer(), nullable=True))
+    op.add_column(
+        "http_bridge_sessions",
+        sa.Column("latest_input_full_fingerprint", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("http_bridge_sessions", "latest_input_full_fingerprint")
+    op.drop_column("http_bridge_sessions", "latest_input_item_count")

--- a/app/db/alembic/versions/20260518_000000_add_http_bridge_durable_input_prefix.py
+++ b/app/db/alembic/versions/20260518_000000_add_http_bridge_durable_input_prefix.py
@@ -9,6 +9,7 @@ from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.engine import Connection
 
 revision: str = "20260518_000000_add_http_bridge_durable_input_prefix"
 down_revision: str | Sequence[str] | None = "20260515_000000_soft_delete_request_logs_on_account_delete"
@@ -16,14 +17,28 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    return {str(column["name"]) for column in inspector.get_columns(table_name) if column.get("name") is not None}
+
+
 def upgrade() -> None:
-    op.add_column("http_bridge_sessions", sa.Column("latest_input_item_count", sa.Integer(), nullable=True))
-    op.add_column(
-        "http_bridge_sessions",
-        sa.Column("latest_input_full_fingerprint", sa.String(length=64), nullable=True),
-    )
+    bind = op.get_bind()
+    existing_columns = _columns(bind, "http_bridge_sessions")
+    with op.batch_alter_table("http_bridge_sessions") as batch_op:
+        if "latest_input_item_count" not in existing_columns:
+            batch_op.add_column(sa.Column("latest_input_item_count", sa.Integer(), nullable=True))
+        if "latest_input_full_fingerprint" not in existing_columns:
+            batch_op.add_column(
+                sa.Column("latest_input_full_fingerprint", sa.String(length=64), nullable=True),
+            )
 
 
 def downgrade() -> None:
-    op.drop_column("http_bridge_sessions", "latest_input_full_fingerprint")
-    op.drop_column("http_bridge_sessions", "latest_input_item_count")
+    bind = op.get_bind()
+    existing_columns = _columns(bind, "http_bridge_sessions")
+    with op.batch_alter_table("http_bridge_sessions") as batch_op:
+        if "latest_input_full_fingerprint" in existing_columns:
+            batch_op.drop_column("latest_input_full_fingerprint")
+        if "latest_input_item_count" in existing_columns:
+            batch_op.drop_column("latest_input_item_count")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -522,6 +522,8 @@ class HttpBridgeSessionRecord(Base):
     service_tier: Mapped[str | None] = mapped_column(String, nullable=True)
     latest_turn_state: Mapped[str | None] = mapped_column(Text, nullable=True)
     latest_response_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    latest_input_item_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    latest_input_full_fingerprint: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -32,6 +32,8 @@ class DurableBridgeLookup:
     state: HttpBridgeSessionState
     latest_turn_state: str | None
     latest_response_id: str | None
+    latest_input_item_count: int | None = None
+    latest_input_full_fingerprint: str | None = None
 
     def lease_is_active(self, *, now: datetime) -> bool:
         if self.owner_instance_id is None:
@@ -134,6 +136,8 @@ class DurableBridgeSessionCoordinator:
         lease_ttl_seconds: float,
         latest_turn_state: str | None = None,
         latest_response_id: str | None = None,
+        latest_input_item_count: int | None = None,
+        latest_input_full_fingerprint: str | None = None,
         state: HttpBridgeSessionState | None = None,
     ) -> DurableBridgeLookup | None:
         del api_key_id
@@ -145,6 +149,8 @@ class DurableBridgeSessionCoordinator:
                 lease_ttl_seconds=lease_ttl_seconds,
                 latest_turn_state=latest_turn_state,
                 latest_response_id=latest_response_id,
+                latest_input_item_count=latest_input_item_count,
+                latest_input_full_fingerprint=latest_input_full_fingerprint,
                 state=state,
             )
         if snapshot is None:
@@ -210,6 +216,8 @@ class DurableBridgeSessionCoordinator:
         owner_epoch: int,
         response_id: str,
         lease_ttl_seconds: float,
+        input_item_count: int | None = None,
+        input_full_fingerprint: str | None = None,
     ) -> None:
         api_key_scope = durable_bridge_api_key_scope(api_key_id)
         async with self._session() as session:
@@ -226,6 +234,8 @@ class DurableBridgeSessionCoordinator:
                 owner_epoch=owner_epoch,
                 lease_ttl_seconds=lease_ttl_seconds,
                 latest_response_id=response_id,
+                latest_input_item_count=input_item_count,
+                latest_input_full_fingerprint=input_full_fingerprint,
             )
 
     async def register_session_header(
@@ -266,4 +276,6 @@ def _to_lookup(snapshot: DurableBridgeSessionSnapshot) -> DurableBridgeLookup:
         state=snapshot.state,
         latest_turn_state=snapshot.latest_turn_state,
         latest_response_id=snapshot.latest_response_id,
+        latest_input_item_count=snapshot.latest_input_item_count,
+        latest_input_full_fingerprint=snapshot.latest_input_full_fingerprint,
     )

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -47,6 +47,8 @@ class DurableBridgeSessionSnapshot:
     service_tier: str | None
     latest_turn_state: str | None
     latest_response_id: str | None
+    latest_input_item_count: int | None
+    latest_input_full_fingerprint: str | None
     closed_at: datetime | None
 
 
@@ -228,16 +230,22 @@ class DurableBridgeRepository:
             if account_changed:
                 existing.latest_turn_state = latest_turn_state
                 existing.latest_response_id = latest_response_id
+                existing.latest_input_item_count = None
+                existing.latest_input_full_fingerprint = None
             elif owner_changed:
                 if latest_turn_state is not None or previous_state == HttpBridgeSessionState.CLOSED:
                     existing.latest_turn_state = latest_turn_state
                 if latest_response_id is not None or previous_state == HttpBridgeSessionState.CLOSED:
                     existing.latest_response_id = latest_response_id
+                    existing.latest_input_item_count = None
+                    existing.latest_input_full_fingerprint = None
             else:
                 if latest_turn_state is not None:
                     existing.latest_turn_state = latest_turn_state
                 if latest_response_id is not None:
                     existing.latest_response_id = latest_response_id
+                    existing.latest_input_item_count = None
+                    existing.latest_input_full_fingerprint = None
             existing.last_seen_at = now
             existing.closed_at = None
             await self._session.commit()
@@ -254,6 +262,8 @@ class DurableBridgeRepository:
         lease_ttl_seconds: float,
         latest_turn_state: str | None = None,
         latest_response_id: str | None = None,
+        latest_input_item_count: int | None = None,
+        latest_input_full_fingerprint: str | None = None,
         state: HttpBridgeSessionState | None = None,
     ) -> DurableBridgeSessionSnapshot | None:
         row = await self._session.get(HttpBridgeSessionRecord, session_id)
@@ -268,6 +278,12 @@ class DurableBridgeRepository:
             row.latest_turn_state = latest_turn_state
         if latest_response_id is not None:
             row.latest_response_id = latest_response_id
+            if latest_input_item_count is None or latest_input_full_fingerprint is None:
+                row.latest_input_item_count = None
+                row.latest_input_full_fingerprint = None
+        if latest_input_item_count is not None and latest_input_full_fingerprint is not None:
+            row.latest_input_item_count = latest_input_item_count
+            row.latest_input_full_fingerprint = latest_input_full_fingerprint
         if state is not None:
             row.state = state
         await self._session.commit()
@@ -413,6 +429,8 @@ def _to_snapshot(row: HttpBridgeSessionRecord | None) -> DurableBridgeSessionSna
         service_tier=row.service_tier,
         latest_turn_state=row.latest_turn_state,
         latest_response_id=row.latest_response_id,
+        latest_input_item_count=row.latest_input_item_count,
+        latest_input_full_fingerprint=row.latest_input_full_fingerprint,
         closed_at=row.closed_at,
     )
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1354,17 +1354,13 @@ class ProxyService:
                 block_event_type = _event_type_from_payload(None, block_payload)
                 if request_state.latency_first_token_ms is None and block_event_type in _TEXT_DELTA_EVENT_TYPES:
                     request_state.latency_first_token_ms = int((time.monotonic() - request_state.started_at) * 1000)
-                if (
-                    not propagate_http_errors
-                    and request_state.previous_response_id is not None
-                    and _is_previous_response_not_found_error(
-                        code=_normalize_error_code(
-                            _websocket_event_error_code(block_event_type, block_payload),
-                            _websocket_event_error_type(block_event_type, block_payload),
-                        ),
-                        param=_websocket_event_error_param(block_event_type, block_payload),
-                        message=_websocket_event_error_message(block_event_type, block_payload),
-                    )
+                if not propagate_http_errors and _is_previous_response_not_found_error(
+                    code=_normalize_error_code(
+                        _websocket_event_error_code(block_event_type, block_payload),
+                        _websocket_event_error_type(block_event_type, block_payload),
+                    ),
+                    param=_websocket_event_error_param(block_event_type, block_payload),
+                    message=_websocket_event_error_message(block_event_type, block_payload),
                 ):
                     session.upstream_control.reconnect_requested = True
                     request_state.error_http_status_override = 502
@@ -6403,6 +6399,7 @@ class ProxyService:
                     or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
+                    allow_unanchored_previous_response_error=is_previous_response_not_found_event,
                 )
                 release_create_gate = False
             else:
@@ -6434,6 +6431,7 @@ class ProxyService:
                     or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
+                    allow_unanchored_previous_response_error=is_previous_response_not_found_event,
                     allow_precreated_terminal_fallback=event_type
                     in {
                         "response.failed",
@@ -6450,6 +6448,7 @@ class ProxyService:
                             session.pending_requests,
                             previous_response_id_hint=previous_response_id_hint,
                             error_message=error_message,
+                            allow_unanchored_previous_response_error=is_previous_response_not_found_event,
                         ),
                     )
                     if not grouped_previous_response_request_states and is_missing_tool_output_event:
@@ -6557,11 +6556,7 @@ class ProxyService:
             )
             event_block = f"data: {rewritten_text}\n\n"
 
-        if (
-            status_request_state is not None
-            and status_request_state.previous_response_id is not None
-            and is_previous_response_not_found_event
-        ):
+        if status_request_state is not None and is_previous_response_not_found_event:
             status_request_state.error_http_status_override = 502
             status_request_state.previous_response_not_found_rewritten = (
                 response_id is None and not has_other_pending_requests
@@ -7259,6 +7254,7 @@ class ProxyService:
                     or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
+                    allow_unanchored_previous_response_error=is_previous_response_not_found_event,
                 )
                 release_create_gate = False
             else:
@@ -7293,6 +7289,7 @@ class ProxyService:
                     or is_missing_tool_output_event,
                     previous_response_id_hint=previous_response_id_hint,
                     error_message=error_message,
+                    allow_unanchored_previous_response_error=is_previous_response_not_found_event,
                     allow_precreated_terminal_fallback=event_type
                     in {
                         "response.failed",
@@ -7307,6 +7304,7 @@ class ProxyService:
                             pending_requests,
                             previous_response_id_hint=previous_response_id_hint,
                             error_message=error_message,
+                            allow_unanchored_previous_response_error=is_previous_response_not_found_event,
                         ),
                     )
                     if not grouped_previous_response_request_states and is_missing_tool_output_event:
@@ -10530,9 +10528,6 @@ def _maybe_rewrite_websocket_previous_response_not_found_event(
     upstream_control: _WebSocketUpstreamControl,
     original_text: str,
 ) -> tuple[OpenAIEvent | None, dict[str, JsonValue] | None, str | None, str]:
-    if request_state.previous_response_id is None:
-        return event, payload, event_type, original_text
-
     error_code = _websocket_event_error_code(event_type, payload)
     error_param = _websocket_event_error_param(event_type, payload)
     error_message = _websocket_event_error_message(event_type, payload)
@@ -10543,6 +10538,8 @@ def _maybe_rewrite_websocket_previous_response_not_found_event(
     )
     reason = "previous_response_not_found"
     if not should_rewrite:
+        if request_state.previous_response_id is None:
+            return event, payload, event_type, original_text
         should_rewrite = _is_missing_tool_output_error(
             code=error_code,
             param=error_param,
@@ -10798,12 +10795,14 @@ def _match_websocket_request_state_for_anonymous_event(
     prefer_previous_response_not_found: bool,
     previous_response_id_hint: str | None = None,
     error_message: str | None = None,
+    allow_unanchored_previous_response_error: bool = False,
 ) -> _WebSocketRequestState | None:
     if prefer_previous_response_not_found:
         return _match_websocket_request_state_for_previous_response_error(
             pending_requests,
             previous_response_id_hint=previous_response_id_hint,
             error_message=error_message,
+            allow_unanchored_previous_response_error=allow_unanchored_previous_response_error,
         )
 
     if len(pending_requests) == 1:
@@ -10833,11 +10832,13 @@ def _match_websocket_request_state_for_previous_response_error(
     *,
     previous_response_id_hint: str | None = None,
     error_message: str | None = None,
+    allow_unanchored_previous_response_error: bool = False,
 ) -> _WebSocketRequestState | None:
     matching_requests = _matching_websocket_request_states_for_previous_response_error(
         pending_requests,
         previous_response_id_hint=previous_response_id_hint,
         error_message=error_message,
+        allow_unanchored_previous_response_error=allow_unanchored_previous_response_error,
     )
     if len(matching_requests) == 1:
         return matching_requests[0]
@@ -10849,11 +10850,14 @@ def _matching_websocket_request_states_for_previous_response_error(
     *,
     previous_response_id_hint: str | None = None,
     error_message: str | None = None,
+    allow_unanchored_previous_response_error: bool = False,
 ) -> list[_WebSocketRequestState]:
     followup_requests = [
         request_state for request_state in pending_requests if request_state.previous_response_id is not None
     ]
     if not followup_requests:
+        if allow_unanchored_previous_response_error and len(pending_requests) == 1:
+            return [pending_requests[0]]
         return []
     if previous_response_id_hint is not None:
         matching_requests = [
@@ -11372,6 +11376,7 @@ def _pop_terminal_websocket_request_state(
     prefer_previous_response_not_found: bool = False,
     previous_response_id_hint: str | None = None,
     error_message: str | None = None,
+    allow_unanchored_previous_response_error: bool = False,
     allow_precreated_terminal_fallback: bool = False,
 ) -> _WebSocketRequestState | None:
     if response_id is not None:
@@ -11392,6 +11397,7 @@ def _pop_terminal_websocket_request_state(
             pending_requests,
             previous_response_id_hint=previous_response_id_hint,
             error_message=error_message,
+            allow_unanchored_previous_response_error=allow_unanchored_previous_response_error,
         )
         if request_state is not None and request_state in pending_requests:
             pending_requests.remove(request_state)
@@ -11402,6 +11408,7 @@ def _pop_terminal_websocket_request_state(
             prefer_previous_response_not_found=prefer_previous_response_not_found,
             previous_response_id_hint=previous_response_id_hint,
             error_message=error_message,
+            allow_unanchored_previous_response_error=allow_unanchored_previous_response_error,
         )
         if request_state is not None and request_state in pending_requests:
             pending_requests.remove(request_state)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -657,6 +657,8 @@ class ProxyService:
         fresh_upstream_request_text: str | None = None
         previous_response_trimmed_input_count: int | None = None
         previous_response_trimmed_input_fingerprint: str | None = None
+        durable_full_resend_anchor_count: int | None = None
+        durable_full_resend_anchor_fingerprint: str | None = None
         if durable_lookup is not None:
             bridge_session_key = _HTTPBridgeSessionKey(
                 durable_lookup.canonical_kind,
@@ -669,13 +671,18 @@ class ProxyService:
                 api_key=api_key,
             )
             forwards_to_active_owner = await self._http_bridge_can_forward_to_active_owner(durable_lookup)
+            durable_anchor_trimmable = _input_prefix_matches_stored_context(
+                payload.input,
+                stored_count=durable_lookup.latest_input_item_count or 0,
+                stored_fingerprint=durable_lookup.latest_input_full_fingerprint,
+            )
             if (
                 not live_local_session_exists
                 and not forwards_to_active_owner
                 and payload.previous_response_id is None
                 and bridge_session_key.strength == "hard"
                 and durable_lookup.latest_response_id is not None
-                and not _http_bridge_payload_looks_like_full_resend(payload)
+                and (not _http_bridge_payload_looks_like_full_resend(payload) or durable_anchor_trimmable)
             ):
                 effective_payload = payload.model_copy(
                     update={"previous_response_id": durable_lookup.latest_response_id}
@@ -698,6 +705,21 @@ class ProxyService:
                     cache_key_family=bridge_session_key.affinity_kind,
                     model_class=_extract_model_class(payload.model) if payload.model else None,
                 )
+                if _http_bridge_payload_looks_like_full_resend(payload):
+                    durable_full_resend_anchor_count = durable_lookup.latest_input_item_count
+                    durable_full_resend_anchor_fingerprint = durable_lookup.latest_input_full_fingerprint
+                    _log_http_bridge_event(
+                        "durable_full_resend_anchor_injected",
+                        bridge_session_key,
+                        account_id=None,
+                        model=payload.model,
+                        detail=(
+                            f"response_id={durable_lookup.latest_response_id} "
+                            f"stored_items={durable_full_resend_anchor_count}"
+                        ),
+                        cache_key_family=bridge_session_key.affinity_kind,
+                        model_class=_extract_model_class(payload.model) if payload.model else None,
+                    )
         if effective_payload.previous_response_id is not None and isinstance(effective_payload.input, list):
             previous_response_input_items = cast(list[JsonValue], effective_payload.input)
             trimmed_input_items = _trim_http_bridge_previous_response_input_items(previous_response_input_items)
@@ -950,6 +972,15 @@ class ProxyService:
                             session.last_used_at = time.monotonic()
                 return
         session = session_or_forward
+        if (
+            durable_full_resend_anchor_count is not None
+            and durable_full_resend_anchor_fingerprint is not None
+            and durable_lookup is not None
+            and durable_lookup.latest_response_id is not None
+        ):
+            session.last_completed_response_id = durable_lookup.latest_response_id
+            session.last_completed_input_count = durable_full_resend_anchor_count
+            session.last_completed_input_prefix_fingerprint = durable_full_resend_anchor_fingerprint
         # --- Session-level previous_response_id injection ---
         # If the client didn't send previous_response_id and the durable
         # lookup didn't inject one, but this bridge session is carrying
@@ -971,13 +1002,10 @@ class ProxyService:
         incoming_input_preview = effective_payload.input
         stored_count_preview = session.last_completed_input_count
         stored_fingerprint_preview = session.last_completed_input_prefix_fingerprint
-        session_anchor_trimmable = (
-            stored_count_preview > 0
-            and stored_fingerprint_preview is not None
-            and isinstance(incoming_input_preview, list)
-            and len(incoming_input_preview) > stored_count_preview
-            and _fingerprint_input_items(cast(list[JsonValue], incoming_input_preview)[:stored_count_preview])
-            == stored_fingerprint_preview
+        session_anchor_trimmable = _input_prefix_matches_stored_context(
+            incoming_input_preview,
+            stored_count=stored_count_preview,
+            stored_fingerprint=stored_fingerprint_preview,
         )
         if (
             session.codex_session
@@ -3184,6 +3212,31 @@ class ProxyService:
                         payload = None
                         continue
 
+                if request_state is not None and await _websocket_full_resend_conflicts_with_visible_pending(
+                    request_state,
+                    pending_requests,
+                    pending_lock=pending_lock,
+                ):
+                    logger.warning(
+                        "Rejecting websocket full resend while prior response is visible request_id=%s input_items=%s",
+                        request_state.request_log_id or request_state.request_id,
+                        request_state.input_item_count,
+                    )
+                    await self._release_websocket_reservation(request_state.api_key_reservation)
+                    await self._emit_websocket_terminal_error(
+                        websocket,
+                        client_send_lock=client_send_lock,
+                        request_state=request_state,
+                        error_code="stream_incomplete",
+                        error_message="Previous response is still streaming; retry after the terminal frame",
+                        error_type="server_error",
+                        downstream_activity=downstream_activity,
+                    )
+                    request_state = None
+                    text_data = None
+                    payload = None
+                    continue
+
                 if request_state is not None and not request_state_registered:
                     try:
                         await self._acquire_request_state_response_create_admission(
@@ -5340,6 +5393,9 @@ class ProxyService:
         self,
         session: "_HTTPBridgeSession",
         response_id: str,
+        *,
+        input_item_count: int | None = None,
+        input_full_fingerprint: str | None = None,
     ) -> None:
         stripped_response_id = response_id.strip()
         if not stripped_response_id:
@@ -5359,6 +5415,8 @@ class ProxyService:
                     owner_epoch=session.durable_owner_epoch,
                     response_id=stripped_response_id,
                     lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
+                    input_item_count=input_item_count,
+                    input_full_fingerprint=input_full_fingerprint,
                 )
             except Exception:
                 logger.warning("Failed to persist durable HTTP bridge previous_response_id alias", exc_info=True)
@@ -6592,7 +6650,20 @@ class ProxyService:
             _release_websocket_response_create_gate(created_request_state, session.response_create_gate)
 
         if response_id is not None and matched_request_state is not None:
-            await self._register_http_bridge_previous_response_id(session, response_id)
+            await self._register_http_bridge_previous_response_id(
+                session,
+                response_id,
+                input_item_count=(
+                    matched_request_state.input_item_count
+                    if event_type == "response.completed" and matched_request_state.input_item_count > 0
+                    else None
+                ),
+                input_full_fingerprint=(
+                    matched_request_state.input_full_fingerprint
+                    if event_type == "response.completed" and matched_request_state.input_item_count > 0
+                    else None
+                ),
+            )
 
         if matched_request_state is not None and matched_request_state.event_queue is not None:
             await matched_request_state.event_queue.put(event_block)
@@ -7184,6 +7255,8 @@ class ProxyService:
                     request_state.suppressed_duplicate_tool_call = True
                     upstream_control.suppress_downstream_event = True
                     return text
+                if event_type in _TEXT_DELTA_EVENT_TYPES:
+                    request_state.downstream_visible = True
                 if payload is not None:
                     text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
             if (
@@ -9675,6 +9748,7 @@ class _WebSocketRequestState:
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
+    downstream_visible: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -10316,6 +10390,24 @@ def _is_missing_tool_output_error(
         return False
     normalized = " ".join(message.lower().split())
     return normalized.startswith("no tool output found for function call call_")
+
+
+async def _websocket_full_resend_conflicts_with_visible_pending(
+    request_state: _WebSocketRequestState,
+    pending_requests: deque[_WebSocketRequestState],
+    *,
+    pending_lock: anyio.Lock,
+) -> bool:
+    if request_state.previous_response_id is not None:
+        return False
+    if request_state.input_item_count <= 1:
+        return False
+    async with pending_lock:
+        return any(
+            pending is not request_state
+            and (pending.downstream_visible or pending.response_id is not None or not pending.awaiting_response_created)
+            for pending in pending_requests
+        )
 
 
 def _is_previous_response_not_found_error(
@@ -11658,6 +11750,21 @@ def _http_bridge_payload_looks_like_full_resend(payload: ResponsesRequest) -> bo
             except TypeError:
                 return False
     return False
+
+
+def _input_prefix_matches_stored_context(
+    input_value: JsonValue,
+    *,
+    stored_count: int,
+    stored_fingerprint: str | None,
+) -> bool:
+    if stored_count <= 0 or stored_fingerprint is None:
+        return False
+    if not isinstance(input_value, list):
+        return False
+    if len(input_value) <= stored_count:
+        return False
+    return _fingerprint_input_items(cast(list[JsonValue], input_value)[:stored_count]) == stored_fingerprint
 
 
 def _truncate_identifier(value: str, *, max_length: int = 96) -> str:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3232,6 +3232,7 @@ class ProxyService:
                     request_state,
                     pending_requests,
                     pending_lock=pending_lock,
+                    codex_session_affinity=codex_session_affinity,
                 ):
                     logger.warning(
                         "Rejecting websocket full resend while prior response is visible request_id=%s input_items=%s",
@@ -10418,10 +10419,13 @@ async def _websocket_full_resend_conflicts_with_visible_pending(
     pending_requests: deque[_WebSocketRequestState],
     *,
     pending_lock: anyio.Lock,
+    codex_session_affinity: bool,
 ) -> bool:
-    if request_state.previous_response_id is not None:
-        return False
-    if request_state.input_item_count <= 1:
+    if (
+        not codex_session_affinity
+        or request_state.previous_response_id is not None
+        or request_state.input_item_count < _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS
+    ):
         return False
     async with pending_lock:
         return any(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10426,10 +10426,7 @@ async def _websocket_full_resend_conflicts_with_visible_pending(
     ):
         return False
     async with pending_lock:
-        return any(
-            pending is not request_state and pending.downstream_visible
-            for pending in pending_requests
-        )
+        return any(pending is not request_state and pending.downstream_visible for pending in pending_requests)
 
 
 def _is_previous_response_not_found_error(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1780,6 +1780,22 @@ class ProxyService:
                         log_status = "success"
                         return response
                     except ProxyResponseError as exc:
+                        compact_continuity_error = _compact_previous_response_not_found_error(exc)
+                        if compact_continuity_error is not None:
+                            await self._settle_compact_api_key_usage(
+                                api_key=api_key,
+                                api_key_reservation=api_key_reservation,
+                                response=None,
+                                request_service_tier=request_service_tier,
+                            )
+                            _record_continuity_fail_closed(
+                                surface="compact",
+                                reason="previous_response_not_found",
+                                previous_response_id=None,
+                                session_id=_owner_lookup_session_id_from_headers(headers),
+                                upstream_error_code=_proxy_response_error_code(exc),
+                            )
+                            raise compact_continuity_error from exc
                         if exc.status_code == 401:
                             if refresh_retry_used:
                                 await self._settle_compact_api_key_usage(
@@ -10421,6 +10437,39 @@ def _is_previous_response_not_found_error(
     if code != "invalid_request_error" or param != "previous_response_id":
         return False
     return _is_previous_response_not_found_message(message)
+
+
+def _compact_previous_response_not_found_error(exc: ProxyResponseError) -> ProxyResponseError | None:
+    error = _parse_openai_error(exc.payload)
+    if error is None:
+        return None
+    code = _normalize_error_code(error.code, error.type)
+    if not _is_previous_response_not_found_error(
+        code=code,
+        param=error.param,
+        message=error.message,
+    ):
+        return None
+    return ProxyResponseError(
+        502,
+        openai_error(
+            "stream_incomplete",
+            "Upstream websocket closed before response.completed",
+            error_type="server_error",
+        ),
+        failure_phase=exc.failure_phase,
+        retryable_same_contract=False,
+        failure_detail="previous_response_not_found",
+        failure_exception_type=exc.failure_exception_type,
+        upstream_status_code=exc.upstream_status_code or exc.status_code,
+    )
+
+
+def _proxy_response_error_code(exc: ProxyResponseError) -> str | None:
+    error = _parse_openai_error(exc.payload)
+    if error is None:
+        return None
+    return _normalize_error_code(error.code, error.type)
 
 
 def _refresh_websocket_request_input_fingerprint_from_text(request_state: _WebSocketRequestState) -> None:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4459,6 +4459,7 @@ class ProxyService:
             force_durable_takeover = False
             missing_turn_state_alias = False
             used_session_header_fallback = False
+            session_to_return_after_close: _HTTPBridgeSession | None = None
             preserve_durable_canonical_key = (
                 incoming_turn_state is not None
                 and forwarded_affinity is None
@@ -5006,11 +5007,12 @@ class ProxyService:
                                         if previous_session.request_model
                                         else None,
                                     )
-                                    return previous_session
+                                    session_to_return_after_close = previous_session
                             else:
                                 self._http_bridge_previous_response_index.pop(previous_alias_key, None)
                     if (
-                        previous_response_id is not None
+                        session_to_return_after_close is None
+                        and previous_response_id is not None
                         and not used_session_header_fallback
                         and not allow_previous_response_recovery_rebind
                         and durable_lookup is None
@@ -5131,6 +5133,9 @@ class ProxyService:
 
             for stale_session in sessions_to_close:
                 await self._close_http_bridge_session(stale_session)
+
+            if session_to_return_after_close is not None:
+                return session_to_return_after_close
 
             if owner_forward is not None:
                 return owner_forward

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10427,8 +10427,7 @@ async def _websocket_full_resend_conflicts_with_visible_pending(
         return False
     async with pending_lock:
         return any(
-            pending is not request_state
-            and (pending.downstream_visible or pending.response_id is not None or not pending.awaiting_response_created)
+            pending is not request_state and pending.downstream_visible
             for pending in pending_requests
         )
 

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -267,6 +267,37 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_masks_previous_response_not_found(async_client, monkeypatch):
+    email = "compact-prev-missing@example.com"
+    raw_account_id = "acc_compact_prev_missing"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        error_payload = openai_error(
+            "invalid_request_error",
+            "Previous response with id 'resp_compact_missing' not found.",
+            error_type="invalid_request_error",
+        )
+        error_payload["error"]["param"] = "previous_response_id"
+        raise ProxyResponseError(400, error_payload)
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": []}
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 502
+    body = response.json()
+    assert body["error"]["code"] == "stream_incomplete"
+    assert body["error"]["message"] == "Upstream websocket closed before response.completed"
+    assert "resp_compact_missing" not in response.text
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_headers_normalize_weekly_only_with_stale_secondary(async_client, monkeypatch):
     email = "compact-weekly@example.com"
     raw_account_id = "acc_compact_weekly"

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -325,6 +325,50 @@ async def test_durable_bridge_takeover_preserves_existing_anchor_when_replacemen
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_previous_response_records_completed_input_prefix(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-prefix",
+        api_key_id="key-1",
+        instance_id="instance-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_prefix",
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+
+    await coordinator.register_previous_response_id(
+        session_id=claimed.session_id,
+        api_key_id="key-1",
+        instance_id="instance-a",
+        owner_epoch=claimed.owner_epoch,
+        response_id="resp_prefix",
+        lease_ttl_seconds=60.0,
+        input_item_count=3,
+        input_full_fingerprint="a" * 64,
+    )
+
+    lookup = await coordinator.lookup_request_targets(
+        session_key_kind="session_header",
+        session_key_value="sid-prefix",
+        api_key_id="key-1",
+        turn_state=None,
+        session_header="sid-prefix",
+        previous_response_id=None,
+    )
+
+    assert lookup is not None
+    assert lookup.latest_response_id == "resp_prefix"
+    assert lookup.latest_input_item_count == 3
+    assert lookup.latest_input_full_fingerprint == "a" * 64
+
+
+@pytest.mark.asyncio
 async def test_durable_bridge_takeover_with_account_change_clears_stale_aliases(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5515,6 +5515,85 @@ async def test_process_http_bridge_upstream_text_masks_single_previous_response_
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_masks_previous_response_not_found_when_anchor_was_lost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-lost-anchor",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "previous_response_not_found",
+                    "message": (
+                        "Previous response with id 'resp_03ac4d75eac7c5d1016a0a619e8a688191b5267ba7ffac3111' not found."
+                    ),
+                    "param": "previous_response_id",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    event_block = await event_queue.get()
+    assert event_block is not None
+    assert await event_queue.get() is None
+    payload = proxy_service.parse_sse_data_json(event_block)
+    assert isinstance(payload, dict)
+    response = payload.get("response")
+    assert isinstance(response, dict)
+    error = response.get("error")
+    assert isinstance(error, dict)
+
+    assert payload["type"] == "response.failed"
+    assert error["code"] == "stream_incomplete"
+    assert error["message"] == "Upstream websocket closed before response.completed"
+    payload_text = json.dumps(payload)
+    assert "previous_response_not_found" not in payload_text
+    assert "resp_03ac4d75eac7c5d1016a0a619e8a688191b5267ba7ffac3111" not in payload_text
+    assert request_state.error_http_status_override == 502
+    assert request_state.previous_response_not_found_rewritten is True
+    assert session.pending_requests == deque()
+    assert session.queued_request_count == 0
+
+
+@pytest.mark.asyncio
 async def test_process_http_bridge_upstream_text_retries_precreated_usage_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -4289,6 +4289,89 @@ async def test_get_or_create_http_bridge_session_recovers_from_previous_response
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_closes_stale_session_before_previous_response_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "stale-sid", "key-1")
+    stale_session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"x-codex-session-id": "stale-sid"},
+        affinity=proxy_service._AffinityPolicy(
+            key="stale-sid",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4-mini",
+        account=cast(Any, SimpleNamespace(id="acc-stale", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    recovered_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", "key-1")
+    recovered_session = proxy_service._HTTPBridgeSession(
+        key=recovered_key,
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=2.0,
+        idle_ttl_seconds=120.0,
+        previous_response_ids={"resp_prev_1"},
+    )
+    service._http_bridge_sessions[key] = stale_session
+    service._http_bridge_sessions[recovered_key] = recovered_session
+    service._http_bridge_previous_response_index[
+        proxy_service._http_bridge_previous_response_alias_key("resp_prev_1", "key-1")
+    ] = recovered_key
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    close_session = AsyncMock(wraps=service._close_http_bridge_session)
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_session)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a", "instance-b"])),
+    )
+
+    resolved = await service._get_or_create_http_bridge_session(
+        key,
+        headers={"x-codex-session-id": "stale-sid"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=_make_api_key(
+            key_id="key-1",
+            assigned_account_ids=[],
+            account_assignment_scope_enabled=True,
+        ),
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+        previous_response_id="resp_prev_1",
+    )
+
+    assert resolved is recovered_session
+    assert stale_session.closed is True
+    assert any(call.args == (stale_session,) for call in close_session.await_args_list)
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_drops_stale_previous_response_mapping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1392,6 +1392,141 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_resend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    input_items = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+        {"role": "user", "content": "follow up"},
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": input_items,
+        },
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-full-resend-trim",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    await event_queue.put(None)
+    prepared_previous_response_ids: list[str | None] = []
+    prepared_input_lengths: list[int] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id
+        prepared_previous_response_ids.append(prepared_payload.previous_response_id)
+        inp = prepared_payload.input
+        prepared_input_lengths.append(len(inp) if isinstance(inp, list) else 1)
+        return request_state, '{"type":"response.create"}'
+
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+        headers={"x-codex-session-id": "sid-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        service._durable_bridge,
+        "lookup_request_targets",
+        AsyncMock(
+            return_value=proxy_service.DurableBridgeLookup(
+                session_id="sess-1",
+                canonical_kind="session_header",
+                canonical_key="sid-123",
+                api_key_scope="__anonymous__",
+                account_id="acc-1",
+                owner_instance_id="instance-a",
+                owner_epoch=1,
+                lease_expires_at=datetime.now(timezone.utc),
+                state=HttpBridgeSessionState.ACTIVE,
+                latest_turn_state="http_turn_1",
+                latest_response_id="resp_latest",
+                latest_input_item_count=2,
+                latest_input_full_fingerprint=proxy_service._fingerprint_input_items(
+                    cast(list[Any], payload.input)[:2]
+                ),
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=session))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"x-codex-session-id": "sid-123"},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == []
+    assert prepared_previous_response_ids == [None, "resp_latest", "resp_latest"]
+    assert prepared_input_lengths == [3, 3, 1]
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_anchor_for_explicit_prompt_cache_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6139,6 +6139,86 @@ async def test_pop_replayable_precreated_websocket_request_replays_injected_anch
     assert json.loads(pending_request.request_text) == fresh_payload
 
 
+@pytest.mark.asyncio
+async def test_websocket_full_resend_conflicts_with_visible_pending() -> None:
+    pending_lock = anyio.Lock()
+    pending = deque(
+        [
+            proxy_service._WebSocketRequestState(
+                request_id="ws_started",
+                model="gpt-5.1",
+                service_tier=None,
+                reasoning_effort=None,
+                api_key_reservation=None,
+                started_at=0.0,
+                response_id="resp_started",
+                awaiting_response_created=False,
+                downstream_visible=True,
+                input_item_count=1,
+            )
+        ]
+    )
+    full_resend = proxy_service._WebSocketRequestState(
+        request_id="ws_full_resend",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id=None,
+        input_item_count=4,
+    )
+
+    assert (
+        await proxy_service._websocket_full_resend_conflicts_with_visible_pending(
+            full_resend,
+            pending,
+            pending_lock=pending_lock,
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_websocket_full_resend_allows_explicit_previous_response_id() -> None:
+    pending_lock = anyio.Lock()
+    pending = deque(
+        [
+            proxy_service._WebSocketRequestState(
+                request_id="ws_started",
+                model="gpt-5.1",
+                service_tier=None,
+                reasoning_effort=None,
+                api_key_reservation=None,
+                started_at=0.0,
+                response_id="resp_started",
+                awaiting_response_created=False,
+                downstream_visible=True,
+                input_item_count=1,
+            )
+        ]
+    )
+    anchored_followup = proxy_service._WebSocketRequestState(
+        request_id="ws_anchored",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_started",
+        input_item_count=4,
+    )
+
+    assert (
+        await proxy_service._websocket_full_resend_conflicts_with_visible_pending(
+            anchored_followup,
+            pending,
+            pending_lock=pending_lock,
+        )
+        is False
+    )
+
+
 def test_slim_response_create_payload_rewrites_top_level_historical_input_image():
     payload: dict[str, JsonValue] = {
         "type": "response.create",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11180,6 +11180,65 @@ async def test_compact_responses_records_transient_error_for_generic_upstream_fa
 
 
 @pytest.mark.asyncio
+async def test_compact_previous_response_not_found_is_masked_without_account_penalty(monkeypatch, caplog):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_prev_missing")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    counter = _ObservedCounter()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_service, "continuity_fail_closed_total", counter, raising=False)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+
+    async def failing_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        error_payload = openai_error(
+            "invalid_request_error",
+            "Previous response with id 'resp_compact_missing' not found.",
+            error_type="invalid_request_error",
+        )
+        error_payload["error"]["param"] = "previous_response_id"
+        raise proxy_module.ProxyResponseError(400, error_payload)
+
+    monkeypatch.setattr(proxy_service, "core_compact_responses", failing_compact)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+
+    caplog.set_level(logging.WARNING, logger="app.modules.proxy.service")
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(payload, {"session_id": "sid-compact"})
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "stream_incomplete"
+    assert _proxy_error_message(exc) == "Upstream websocket closed before response.completed"
+    assert "resp_compact_missing" not in json.dumps(exc.payload)
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+    assert "continuity_fail_closed surface=compact reason=previous_response_not_found" in caplog.text
+    assert "resp_compact_missing" not in caplog.text
+    assert counter.samples == [
+        {
+            "labels": {"surface": "compact", "reason": "previous_response_not_found"},
+            "value": 1.0,
+        }
+    ]
+    record_error.assert_not_awaited()
+    record_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_compact_responses_surfaces_local_create_overload_without_penalizing_account(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.proxy_compact_response_create_limit = 1

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10225,7 +10225,7 @@ def test_http_bridge_should_rollover_after_context_overflow():
     assert proxy_service._http_bridge_should_rollover_after_context_overflow(unrelated_error) is False
 
 
-def test_maybe_rewrite_websocket_previous_response_not_found_leaves_non_previous_request_unchanged():
+def test_maybe_rewrite_websocket_previous_response_not_found_masks_lost_local_anchor():
     request_state = proxy_service._WebSocketRequestState(
         request_id="ws_req_plain",
         model="gpt-5.1",
@@ -10262,9 +10262,14 @@ def test_maybe_rewrite_websocket_previous_response_not_found_leaves_non_previous
     )
 
     assert upstream_control.reconnect_requested is False
-    assert rewritten_event_type == original_event_type
-    assert rewritten_payload == original_payload
-    assert rewritten_text == original_text
+    assert rewritten_event_type == "response.failed"
+    assert rewritten_payload is not None
+    response_payload = cast(dict[str, JsonValue], rewritten_payload.get("response"))
+    error_payload = cast(dict[str, JsonValue], response_payload.get("error"))
+    assert error_payload["code"] == "stream_incomplete"
+    assert error_payload["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in rewritten_text
+    assert "resp_any" not in rewritten_text
 
 
 def test_sanitize_websocket_connect_failure_rewrites_previous_response_not_found(monkeypatch, caplog):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6166,7 +6166,7 @@ async def test_websocket_full_resend_conflicts_with_visible_pending() -> None:
         api_key_reservation=None,
         started_at=0.0,
         previous_response_id=None,
-        input_item_count=4,
+        input_item_count=proxy_service._WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,
     )
 
     assert (
@@ -6174,8 +6174,50 @@ async def test_websocket_full_resend_conflicts_with_visible_pending() -> None:
             full_resend,
             pending,
             pending_lock=pending_lock,
+            codex_session_affinity=True,
         )
         is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_websocket_full_resend_allows_fresh_multi_item_request() -> None:
+    pending_lock = anyio.Lock()
+    pending = deque(
+        [
+            proxy_service._WebSocketRequestState(
+                request_id="ws_started",
+                model="gpt-5.1",
+                service_tier=None,
+                reasoning_effort=None,
+                api_key_reservation=None,
+                started_at=0.0,
+                response_id="resp_started",
+                awaiting_response_created=False,
+                downstream_visible=True,
+                input_item_count=1,
+            )
+        ]
+    )
+    fresh_request = proxy_service._WebSocketRequestState(
+        request_id="ws_fresh_multi_item",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id=None,
+        input_item_count=2,
+    )
+
+    assert (
+        await proxy_service._websocket_full_resend_conflicts_with_visible_pending(
+            fresh_request,
+            pending,
+            pending_lock=pending_lock,
+            codex_session_affinity=True,
+        )
+        is False
     )
 
 
@@ -6206,7 +6248,7 @@ async def test_websocket_full_resend_allows_explicit_previous_response_id() -> N
         api_key_reservation=None,
         started_at=0.0,
         previous_response_id="resp_started",
-        input_item_count=4,
+        input_item_count=proxy_service._WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,
     )
 
     assert (
@@ -6214,6 +6256,7 @@ async def test_websocket_full_resend_allows_explicit_previous_response_id() -> N
             anchored_followup,
             pending,
             pending_lock=pending_lock,
+            codex_session_affinity=True,
         )
         is False
     )

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6222,6 +6222,47 @@ async def test_websocket_full_resend_allows_fresh_multi_item_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_websocket_full_resend_allows_pending_before_downstream_visible() -> None:
+    pending_lock = anyio.Lock()
+    pending = deque(
+        [
+            proxy_service._WebSocketRequestState(
+                request_id="ws_started",
+                model="gpt-5.1",
+                service_tier=None,
+                reasoning_effort=None,
+                api_key_reservation=None,
+                started_at=0.0,
+                response_id="resp_started",
+                awaiting_response_created=False,
+                downstream_visible=False,
+                input_item_count=1,
+            )
+        ]
+    )
+    full_resend_shaped_request = proxy_service._WebSocketRequestState(
+        request_id="ws_full_resend_shaped",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id=None,
+        input_item_count=proxy_service._WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,
+    )
+
+    assert (
+        await proxy_service._websocket_full_resend_conflicts_with_visible_pending(
+            full_resend_shaped_request,
+            pending,
+            pending_lock=pending_lock,
+            codex_session_affinity=True,
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
 async def test_websocket_full_resend_allows_explicit_previous_response_id() -> None:
     pending_lock = anyio.Lock()
     pending = deque(


### PR DESCRIPTION
## Summary
- persist completed HTTP bridge input-prefix metadata beside the durable latest response id
- use that metadata to reattach a full resend only when its stored prefix fingerprint matches, then trim the resend down to the new tail
- fail closed for same-websocket full resends while an earlier response is already visible, so clients do not see the answer restart as another upstream turn
- close stale HTTP bridge sessions before returning a recovered `previous_response_id` session, so old upstream websocket state cannot leak after recovery
- limit same-websocket full-resend rejection to codex-session replay-sized requests, avoiding false positives for normal fresh multi-item turns
- mask `responses/compact` `previous_response_not_found` misses as public `stream_incomplete`, without penalizing the selected account or leaking raw `resp_*` ids
- mask raw websocket `previous_response_not_found` terminal errors even when local pending state has lost the previous-response anchor, so clients receive the public `stream_incomplete` fail-closed event instead of a leaked `resp_*` id

## Evidence
- reported websocket continuity failures could surface raw upstream `previous_response_not_found` terminal errors repeatedly before a later turn recovered without `previous_response_id`
- reported retries could resend a full `response.create` with `previous_response_id=None` after visible text had already started; codex-lb forwarded it as a fresh upstream turn
- `responses/compact` continuity failures could surface upstream `invalid_request_error` / `previous_response_id` misses as raw public errors instead of the existing terminal `stream_incomplete` contract
- `.venv/bin/python -m pytest tests/unit/test_proxy_utils.py -k 'compact_previous_response_not_found or compact_responses_records_transient_error_for_generic_upstream_failure or stream_previous_response_not_found_proxy_error_is_masked_to_stream_incomplete'`
- `.venv/bin/python -m pytest tests/integration/test_proxy_compact.py -k 'masks_previous_response_not_found or proxy_compact_success_preserves_compaction_payload'`
- `.venv/bin/python -m pytest tests/unit/test_proxy_api_websocket_auth.py -k 'previous_response'`
- `.venv/bin/python -m ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/integration/test_proxy_compact.py`
- `.venv/bin/python -m pytest tests/unit/test_db_migrate.py::test_run_upgrade_auto_remaps_legacy_revision_ids tests/integration/test_migrations.py::test_run_startup_migrations_auto_remaps_legacy_alembic_revision_ids`
- `.venv/bin/python -m ruff check app/db/alembic/versions/20260518_000000_add_http_bridge_durable_input_prefix.py`
- `uv run pytest tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_closes_stale_session_before_previous_response_recovery tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_recovers_from_previous_response_id_mapping`
- `uv run pytest tests/unit/test_proxy_utils.py::test_websocket_full_resend_conflicts_with_visible_pending tests/unit/test_proxy_utils.py::test_websocket_full_resend_allows_fresh_multi_item_request tests/unit/test_proxy_utils.py::test_websocket_full_resend_allows_explicit_previous_response_id tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_closes_stale_session_before_previous_response_recovery`
- `uvx ruff check app/modules/proxy/service.py tests/unit/test_proxy_http_bridge.py`
- `uvx ruff format --check app/modules/proxy/service.py tests/unit/test_proxy_http_bridge.py`
- `uv run pytest tests/unit/test_proxy_utils.py::test_process_upstream_websocket_text_masks_foreign_previous_response_not_found_for_only_created_followup tests/unit/test_proxy_utils.py::test_process_upstream_websocket_text_masks_anonymous_previous_response_not_found_for_created_followup tests/unit/test_proxy_utils.py::test_stream_previous_response_not_found_proxy_error_is_masked_to_stream_incomplete tests/unit/test_proxy_utils.py::test_stream_selection_budget_exhaustion_emits_timeout_event tests/unit/test_proxy_utils.py::test_stream_responses_budget_exhaustion_emits_timeout_event tests/unit/test_proxy_http_bridge.py::test_process_http_bridge_upstream_text_masks_single_previous_response_not_found tests/unit/test_proxy_http_bridge.py::test_process_http_bridge_upstream_text_masks_previous_response_not_found_when_anchor_was_lost`
- `uv run pytest tests/unit` (`1693 passed, 39 skipped`)
- `uvx ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
- `uvx ruff format --check app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
- `git diff --check`
- previous slice on this PR: HTTP bridge durable trim tests, bridge context blowup tests, durable bridge session tests, touched-file ruff, and sqlite migration check



