### PR TITLE
fix(proxy): persist request logs outside cancellation

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -398,6 +398,7 @@ class ProxyService:
         self._file_account_pin_lock = asyncio.Lock()
         self._http_bridge_lock = anyio.Lock()
         self._work_admission: WorkAdmissionController | None = None
+        self._request_log_tasks: set[asyncio.Task[None]] = set()
 
     def _websocket_continuity_state_for_request(
         self,
@@ -9156,37 +9157,117 @@ class ProxyService:
         actual_service_tier: str | None = None,
         session_id: str | None = None,
     ) -> None:
-        with anyio.CancelScope(shield=True):
+        task = asyncio.create_task(
+            self._persist_request_log(
+                account_id=account_id,
+                api_key_id=api_key.id if api_key else None,
+                request_id=request_id,
+                model=model,
+                latency_ms=latency_ms,
+                status=status,
+                latency_first_token_ms=latency_first_token_ms,
+                error_code=error_code,
+                error_message=error_message,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_input_tokens=cached_input_tokens,
+                reasoning_tokens=reasoning_tokens,
+                reasoning_effort=reasoning_effort,
+                transport=transport,
+                service_tier=service_tier,
+                requested_service_tier=requested_service_tier,
+                actual_service_tier=actual_service_tier,
+                session_id=session_id,
+            ),
+            name=f"proxy-request-log-{request_id}",
+        )
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            self._track_request_log_task(task, account_id=account_id, request_id=request_id)
+
+    def _track_request_log_task(
+        self,
+        task: asyncio.Task[None],
+        *,
+        account_id: str | None,
+        request_id: str,
+    ) -> None:
+        self._request_log_tasks.add(task)
+
+        def _request_log_done(done_task: asyncio.Task[None]) -> None:
+            self._request_log_tasks.discard(done_task)
             try:
-                async with self._repo_factory() as repos:
-                    await repos.request_logs.add_log(
-                        account_id=account_id,
-                        api_key_id=api_key.id if api_key else None,
-                        session_id=_normalize_session_id(session_id),
-                        request_id=request_id,
-                        model=model or "",
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        cached_input_tokens=cached_input_tokens,
-                        reasoning_tokens=reasoning_tokens,
-                        reasoning_effort=reasoning_effort,
-                        transport=transport,
-                        service_tier=service_tier,
-                        requested_service_tier=requested_service_tier,
-                        actual_service_tier=actual_service_tier,
-                        latency_ms=latency_ms,
-                        latency_first_token_ms=latency_first_token_ms,
-                        status=status,
-                        error_code=error_code,
-                        error_message=error_message,
-                    )
-            except Exception:
+                done_task.result()
+            except asyncio.CancelledError:
                 logger.warning(
-                    "Failed to persist request log account_id=%s request_id=%s",
+                    "Request log persistence task cancelled account_id=%s request_id=%s",
                     account_id,
                     request_id,
-                    exc_info=True,
                 )
+            except Exception as exc:
+                logger.warning(
+                    "Request log persistence task failed account_id=%s request_id=%s",
+                    account_id,
+                    request_id,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+
+        task.add_done_callback(_request_log_done)
+
+    async def _persist_request_log(
+        self,
+        *,
+        account_id: str | None,
+        api_key_id: str | None,
+        request_id: str,
+        model: str | None,
+        latency_ms: int,
+        status: str,
+        latency_first_token_ms: int | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        cached_input_tokens: int | None = None,
+        reasoning_tokens: int | None = None,
+        reasoning_effort: str | None = None,
+        transport: str | None = None,
+        service_tier: str | None = None,
+        requested_service_tier: str | None = None,
+        actual_service_tier: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        try:
+            async with self._repo_factory() as repos:
+                await repos.request_logs.add_log(
+                    account_id=account_id,
+                    api_key_id=api_key_id,
+                    session_id=_normalize_session_id(session_id),
+                    request_id=request_id,
+                    model=model or "",
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cached_input_tokens=cached_input_tokens,
+                    reasoning_tokens=reasoning_tokens,
+                    reasoning_effort=reasoning_effort,
+                    transport=transport,
+                    service_tier=service_tier,
+                    requested_service_tier=requested_service_tier,
+                    actual_service_tier=actual_service_tier,
+                    latency_ms=latency_ms,
+                    latency_first_token_ms=latency_first_token_ms,
+                    status=status,
+                    error_code=error_code,
+                    error_message=error_message,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to persist request log account_id=%s request_id=%s",
+                account_id,
+                request_id,
+                exc_info=True,
+            )
 
     async def _write_stream_preflight_error(
         self,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9185,6 +9185,7 @@ class ProxyService:
             await asyncio.shield(task)
         except asyncio.CancelledError:
             self._track_request_log_task(task, account_id=account_id, request_id=request_id)
+            raise
 
     def _track_request_log_task(
         self,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1106,6 +1106,44 @@ def _repo_factory(request_logs: _RequestLogsRecorder) -> proxy_service.ProxyRepo
     return factory
 
 
+@pytest.mark.asyncio
+async def test_write_request_log_continues_after_caller_cancellation() -> None:
+    request_logs = _RequestLogsRecorder()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_add_log(**kwargs: object) -> None:
+        started.set()
+        await release.wait()
+        request_logs.calls.append(dict(kwargs))
+
+    request_logs.add_log = blocking_add_log  # type: ignore[method-assign]
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+
+    task = asyncio.create_task(
+        service._write_request_log(
+            account_id="acc_request_log_cancel",
+            api_key=None,
+            request_id="resp_request_log_cancel",
+            model="gpt-5.4",
+            latency_ms=1,
+            status="error",
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    task.cancel()
+    await asyncio.wait_for(task, timeout=1)
+    release.set()
+
+    for _ in range(20):
+        if request_logs.calls:
+            break
+        await asyncio.sleep(0.01)
+
+    assert request_logs.calls[0]["request_id"] == "resp_request_log_cancel"
+
+
 def _make_proxy_settings(*, log_proxy_service_tier_trace: bool) -> SimpleNamespace:
     return SimpleNamespace(
         prefer_earlier_reset_accounts=False,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1133,7 +1133,8 @@ async def test_write_request_log_continues_after_caller_cancellation() -> None:
     await asyncio.wait_for(started.wait(), timeout=1)
 
     task.cancel()
-    await asyncio.wait_for(task, timeout=1)
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1)
     release.set()
 
     for _ in range(20):


### PR DESCRIPTION
## Summary
- persist proxy request logs in a separate shielded task so request-scope cancellation does not cancel the database write mid-flight
- preserve caller `CancelledError` semantics after scheduling the background persistence task
- keep tracking background request-log tasks until they finish, with explicit warning logs if the task itself is cancelled or fails
- add a regression test that cancels the caller while `add_log` is blocked and verifies the request log still gets written

## Validation
- `uv run pytest tests/unit/test_proxy_utils.py::test_write_request_log_continues_after_caller_cancellation`
- `uv run pytest tests/unit/test_proxy_utils.py -k 'write_request_log_continues_after_caller_cancellation or stream_responses_logs_actual_service_tier_and_requested_tier_trace'`
- `uvx ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `uvx ruff format --check app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `git diff --check`

