### PR TITLE
fix(proxy): mask partial previous-response stream errors

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -398,6 +398,7 @@ class ProxyService:
         self._file_account_pin_lock = asyncio.Lock()
         self._http_bridge_lock = anyio.Lock()
         self._work_admission: WorkAdmissionController | None = None
+        self._request_log_tasks: set[asyncio.Task[None]] = set()
 
     def _websocket_continuity_state_for_request(
         self,
@@ -9156,37 +9157,117 @@ class ProxyService:
         actual_service_tier: str | None = None,
         session_id: str | None = None,
     ) -> None:
-        with anyio.CancelScope(shield=True):
+        task = asyncio.create_task(
+            self._persist_request_log(
+                account_id=account_id,
+                api_key_id=api_key.id if api_key else None,
+                request_id=request_id,
+                model=model,
+                latency_ms=latency_ms,
+                status=status,
+                latency_first_token_ms=latency_first_token_ms,
+                error_code=error_code,
+                error_message=error_message,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_input_tokens=cached_input_tokens,
+                reasoning_tokens=reasoning_tokens,
+                reasoning_effort=reasoning_effort,
+                transport=transport,
+                service_tier=service_tier,
+                requested_service_tier=requested_service_tier,
+                actual_service_tier=actual_service_tier,
+                session_id=session_id,
+            ),
+            name=f"proxy-request-log-{request_id}",
+        )
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            self._track_request_log_task(task, account_id=account_id, request_id=request_id)
+
+    def _track_request_log_task(
+        self,
+        task: asyncio.Task[None],
+        *,
+        account_id: str | None,
+        request_id: str,
+    ) -> None:
+        self._request_log_tasks.add(task)
+
+        def _request_log_done(done_task: asyncio.Task[None]) -> None:
+            self._request_log_tasks.discard(done_task)
             try:
-                async with self._repo_factory() as repos:
-                    await repos.request_logs.add_log(
-                        account_id=account_id,
-                        api_key_id=api_key.id if api_key else None,
-                        session_id=_normalize_session_id(session_id),
-                        request_id=request_id,
-                        model=model or "",
-                        input_tokens=input_tokens,
-                        output_tokens=output_tokens,
-                        cached_input_tokens=cached_input_tokens,
-                        reasoning_tokens=reasoning_tokens,
-                        reasoning_effort=reasoning_effort,
-                        transport=transport,
-                        service_tier=service_tier,
-                        requested_service_tier=requested_service_tier,
-                        actual_service_tier=actual_service_tier,
-                        latency_ms=latency_ms,
-                        latency_first_token_ms=latency_first_token_ms,
-                        status=status,
-                        error_code=error_code,
-                        error_message=error_message,
-                    )
-            except Exception:
+                done_task.result()
+            except asyncio.CancelledError:
                 logger.warning(
-                    "Failed to persist request log account_id=%s request_id=%s",
+                    "Request log persistence task cancelled account_id=%s request_id=%s",
                     account_id,
                     request_id,
-                    exc_info=True,
                 )
+            except Exception as exc:
+                logger.warning(
+                    "Request log persistence task failed account_id=%s request_id=%s",
+                    account_id,
+                    request_id,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+
+        task.add_done_callback(_request_log_done)
+
+    async def _persist_request_log(
+        self,
+        *,
+        account_id: str | None,
+        api_key_id: str | None,
+        request_id: str,
+        model: str | None,
+        latency_ms: int,
+        status: str,
+        latency_first_token_ms: int | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        cached_input_tokens: int | None = None,
+        reasoning_tokens: int | None = None,
+        reasoning_effort: str | None = None,
+        transport: str | None = None,
+        service_tier: str | None = None,
+        requested_service_tier: str | None = None,
+        actual_service_tier: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        try:
+            async with self._repo_factory() as repos:
+                await repos.request_logs.add_log(
+                    account_id=account_id,
+                    api_key_id=api_key_id,
+                    session_id=_normalize_session_id(session_id),
+                    request_id=request_id,
+                    model=model or "",
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cached_input_tokens=cached_input_tokens,
+                    reasoning_tokens=reasoning_tokens,
+                    reasoning_effort=reasoning_effort,
+                    transport=transport,
+                    service_tier=service_tier,
+                    requested_service_tier=requested_service_tier,
+                    actual_service_tier=actual_service_tier,
+                    latency_ms=latency_ms,
+                    latency_first_token_ms=latency_first_token_ms,
+                    status=status,
+                    error_code=error_code,
+                    error_message=error_message,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to persist request log account_id=%s request_id=%s",
+                account_id,
+                request_id,
+                exc_info=True,
+            )
 
     async def _write_stream_preflight_error(
         self,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9185,6 +9185,7 @@ class ProxyService:
             await asyncio.shield(task)
         except asyncio.CancelledError:
             self._track_request_log_task(task, account_id=account_id, request_id=request_id)
+            raise
 
     def _track_request_log_task(
         self,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -827,7 +827,15 @@ class ProxyService:
                 return
             except ProxyResponseError as exc:
                 if forwarded_any:
-                    raise
+                    yield _partial_output_proxy_error_event_block(
+                        exc,
+                        response_id=request_state.response_id or request_id,
+                        previous_response_id=request_state.previous_response_id,
+                        preferred_account_id=request_state.preferred_account_id,
+                        default_code="bridge_owner_unreachable",
+                        default_message="HTTP bridge owner request failed",
+                    )
+                    return
                 should_attempt_previous_response_recovery = (
                     effective_payload.previous_response_id is not None
                     and _http_bridge_should_attempt_local_previous_response_recovery(exc)
@@ -1095,9 +1103,21 @@ class ProxyService:
             downstream_turn_state=downstream_turn_state,
         )
         try:
+            yielded_any = False
             async for event_block in session_events:
                 yield event_block
+                yielded_any = True
         except ProxyResponseError as exc:
+            if yielded_any:
+                yield _partial_output_proxy_error_event_block(
+                    exc,
+                    response_id=request_state.response_id or request_id,
+                    previous_response_id=request_state.previous_response_id,
+                    preferred_account_id=request_state.preferred_account_id,
+                    default_code="upstream_error",
+                    default_message="Upstream error",
+                )
+                return
             is_context_overflow = _http_bridge_is_context_overflow_error(exc)
             should_rollover_after_context_overflow = _http_bridge_should_rollover_after_context_overflow(
                 exc,
@@ -1327,17 +1347,13 @@ class ProxyService:
                 block_event_type = _event_type_from_payload(None, block_payload)
                 if request_state.latency_first_token_ms is None and block_event_type in _TEXT_DELTA_EVENT_TYPES:
                     request_state.latency_first_token_ms = int((time.monotonic() - request_state.started_at) * 1000)
-                if (
-                    not propagate_http_errors
-                    and request_state.previous_response_id is not None
-                    and _is_previous_response_not_found_error(
-                        code=_normalize_error_code(
-                            _websocket_event_error_code(block_event_type, block_payload),
-                            _websocket_event_error_type(block_event_type, block_payload),
-                        ),
-                        param=_websocket_event_error_param(block_event_type, block_payload),
-                        message=_websocket_event_error_message(block_event_type, block_payload),
-                    )
+                if not propagate_http_errors and _is_previous_response_not_found_error(
+                    code=_normalize_error_code(
+                        _websocket_event_error_code(block_event_type, block_payload),
+                        _websocket_event_error_type(block_event_type, block_payload),
+                    ),
+                    param=_websocket_event_error_param(block_event_type, block_payload),
+                    message=_websocket_event_error_message(block_event_type, block_payload),
                 ):
                     session.upstream_control.reconnect_requested = True
                     request_state.error_http_status_override = 502
@@ -1511,6 +1527,7 @@ class ProxyService:
         )
 
         forwarded_any = False
+        forwarded_response_id: str | None = None
         try:
             async for event_block in self._http_bridge_owner_client.stream_responses(
                 owner_endpoint=owner_forward.owner_endpoint,
@@ -1520,6 +1537,11 @@ class ProxyService:
                 request_started_at=request_started_at,
             ):
                 forwarded_any = True
+                event_payload = parse_sse_data_json(event_block)
+                event_type = _event_type_from_payload(None, event_payload)
+                forwarded_response_id = _websocket_response_id(None, event_payload) or forwarded_response_id
+                if event_type == "response.failed" and forwarded_response_id is None:
+                    forwarded_response_id = get_request_id()
                 yield event_block
         except OwnerForwardRelayFailure as exc:
             if PROMETHEUS_AVAILABLE and bridge_owner_forward_total is not None:
@@ -1548,7 +1570,7 @@ class ProxyService:
                     error_type="server_error",
                 ),
             ) from exc
-        except ProxyResponseError:
+        except ProxyResponseError as exc:
             if PROMETHEUS_AVAILABLE and bridge_owner_forward_total is not None:
                 bridge_owner_forward_total.labels(outcome="fail").inc()
             _log_http_bridge_event(
@@ -1561,6 +1583,17 @@ class ProxyService:
                 model_class=_extract_model_class(payload.model) if payload.model else None,
                 owner_check_applied=True,
             )
+            if forwarded_any:
+                terminal_response_id = forwarded_response_id or get_request_id() or "unknown"
+                yield _partial_output_proxy_error_event_block(
+                    exc,
+                    response_id=terminal_response_id,
+                    previous_response_id=payload.previous_response_id,
+                    preferred_account_id=None,
+                    default_code="bridge_owner_unreachable",
+                    default_message="HTTP bridge owner request failed",
+                )
+                return
             raise
         except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
             if PROMETHEUS_AVAILABLE and bridge_owner_forward_total is not None:
@@ -1577,6 +1610,16 @@ class ProxyService:
                 model_class=_extract_model_class(payload.model) if payload.model else None,
                 owner_check_applied=True,
             )
+            if forwarded_any:
+                terminal_response_id = forwarded_response_id or get_request_id() or "unknown"
+                yield format_sse_event(
+                    response_failed_event(
+                        "bridge_owner_unreachable",
+                        "HTTP bridge owner request failed",
+                        response_id=terminal_response_id,
+                    )
+                )
+                return
             raise ProxyResponseError(
                 503,
                 openai_error(
@@ -7296,7 +7339,23 @@ class ProxyService:
         _record_response_event(request_state, event_type)
 
         if request_state is None:
-            if is_previous_response_not_found_event or is_missing_tool_output_event:
+            if is_previous_response_not_found_event and not pending_requests:
+                upstream_control.reconnect_requested = True
+                downstream_text = json.dumps(
+                    cast(
+                        dict[str, JsonValue],
+                        response_failed_event(
+                            "stream_incomplete",
+                            "Upstream websocket closed before response.completed",
+                            error_type="server_error",
+                            response_id=get_request_id(),
+                        ),
+                    ),
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                )
+                return downstream_text
+            if is_missing_tool_output_event:
                 upstream_control.suppress_downstream_event = True
             return text
 
@@ -10677,6 +10736,53 @@ def _rewrite_previous_response_stream_error(
             normalized_code,
         )
     return None
+
+
+def _partial_output_proxy_error_event_block(
+    exc: ProxyResponseError,
+    *,
+    response_id: str,
+    previous_response_id: str | None,
+    preferred_account_id: str | None,
+    default_code: str,
+    default_message: str,
+) -> str:
+    error = _parse_openai_error(exc.payload)
+    error_code = _normalize_error_code(
+        error.code if error else None,
+        error.type if error else None,
+    )
+    error_message = error.message if error else None
+    effective_previous_response_id = previous_response_id or _previous_response_id_from_not_found_message(
+        error_message,
+    )
+    rewritten_error = _rewrite_previous_response_stream_error(
+        previous_response_id=effective_previous_response_id,
+        preferred_account_id=preferred_account_id,
+        error_code=error_code,
+        error_type=error.type if error else None,
+        error_message=error_message,
+        error_param=error.param if error else None,
+    )
+    if rewritten_error is not None:
+        rewritten_code, rewritten_message, upstream_error_code = rewritten_error
+        if upstream_error_code is None:
+            event = response_failed_event(
+                rewritten_code,
+                rewritten_message,
+                error_type="server_error",
+                response_id=response_id,
+            )
+            return format_sse_event(event)
+    event = response_failed_event(
+        error_code or default_code,
+        error_message or default_message,
+        error_type=(error.type if error and error.type else "server_error"),
+        response_id=response_id,
+        error_param=error.param if error else None,
+    )
+    _apply_error_metadata(event["response"]["error"], error)
+    return format_sse_event(event)
 
 
 def _build_rewritten_stream_response_failed_event(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2759,26 +2759,98 @@ async def test_stream_via_http_bridge_does_not_rebind_after_forwarded_bytes(
     monkeypatch.setattr(service, "_forward_http_bridge_request_to_owner", fake_forward)
 
     seen: list[str] = []
-    with pytest.raises(ProxyResponseError):
-        async for chunk in service._stream_via_http_bridge(
-            payload,
-            {"x-codex-session-id": "sid-123"},
-            codex_session_affinity=True,
-            openai_cache_affinity=False,
-            api_key=None,
-            api_key_reservation=None,
-            propagate_http_errors=False,
-            suppress_text_done_events=False,
-            idle_ttl_seconds=120.0,
-            codex_idle_ttl_seconds=900.0,
-            max_sessions=8,
-            queue_limit=4,
-        ):
-            seen.append(chunk)
+    async for chunk in service._stream_via_http_bridge(
+        payload,
+        {"x-codex-session-id": "sid-123"},
+        codex_session_affinity=True,
+        openai_cache_affinity=False,
+        api_key=None,
+        api_key_reservation=None,
+        propagate_http_errors=False,
+        suppress_text_done_events=False,
+        idle_ttl_seconds=120.0,
+        codex_idle_ttl_seconds=900.0,
+        max_sessions=8,
+        queue_limit=4,
+    ):
+        seen.append(chunk)
 
-    assert seen == ["data: first\n\n"]
+    assert len(seen) == 2
+    assert seen[0] == "data: first\n\n"
+    terminal_payload = proxy_service.parse_sse_data_json(seen[1])
+    assert isinstance(terminal_payload, dict)
+    terminal_response = terminal_payload["response"]
+    assert isinstance(terminal_response, dict)
+    terminal_error = terminal_response["error"]
+    assert isinstance(terminal_error, dict)
+    assert terminal_error["code"] == "bridge_owner_unreachable"
     assert forward_calls["count"] == 1
     service._get_or_create_http_bridge_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forward_http_bridge_request_to_owner_masks_partial_previous_response_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_forward = proxy_service._HTTPBridgeOwnerForward(
+        owner_instance="instance-b",
+        owner_endpoint="http://instance-b",
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": "hi",
+            "previous_response_id": "resp_partial_anchor",
+        }
+    )
+
+    async def fake_stream_responses(**kwargs: object):
+        del kwargs
+        yield "data: first\n\n"
+        error_payload = proxy_service.openai_error(
+            "previous_response_not_found",
+            "Previous response with id 'resp_partial_anchor' not found.",
+            error_type="invalid_request_error",
+        )
+        error_payload["error"]["param"] = "previous_response_id"
+        raise ProxyResponseError(400, error_payload)
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        service,
+        "_http_bridge_owner_client",
+        cast(Any, SimpleNamespace(stream_responses=fake_stream_responses)),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._forward_http_bridge_request_to_owner(
+            owner_forward=owner_forward,
+            payload=payload,
+            headers={"x-codex-session-id": "sid-123"},
+            api_key_reservation=None,
+            codex_session_affinity=True,
+            downstream_turn_state="http_turn_generated",
+            request_started_at=10.0,
+            proxy_api_authorization=None,
+        )
+    ]
+
+    assert chunks[0] == "data: first\n\n"
+    terminal_payload = proxy_service.parse_sse_data_json(chunks[1])
+    assert isinstance(terminal_payload, dict)
+    terminal_response = terminal_payload["response"]
+    assert isinstance(terminal_response, dict)
+    terminal_error = terminal_response["error"]
+    assert isinstance(terminal_error, dict)
+    assert terminal_payload["type"] == "response.failed"
+    assert terminal_error["code"] == "stream_incomplete"
+    assert terminal_error["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in chunks[1]
+    assert "resp_partial_anchor" not in chunks[1]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1106,6 +1106,44 @@ def _repo_factory(request_logs: _RequestLogsRecorder) -> proxy_service.ProxyRepo
     return factory
 
 
+@pytest.mark.asyncio
+async def test_write_request_log_continues_after_caller_cancellation() -> None:
+    request_logs = _RequestLogsRecorder()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_add_log(**kwargs: object) -> None:
+        started.set()
+        await release.wait()
+        request_logs.calls.append(dict(kwargs))
+
+    request_logs.add_log = blocking_add_log  # type: ignore[method-assign]
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+
+    task = asyncio.create_task(
+        service._write_request_log(
+            account_id="acc_request_log_cancel",
+            api_key=None,
+            request_id="resp_request_log_cancel",
+            model="gpt-5.4",
+            latency_ms=1,
+            status="error",
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    task.cancel()
+    await asyncio.wait_for(task, timeout=1)
+    release.set()
+
+    for _ in range(20):
+        if request_logs.calls:
+            break
+        await asyncio.sleep(0.01)
+
+    assert request_logs.calls[0]["request_id"] == "resp_request_log_cancel"
+
+
 def _make_proxy_settings(*, log_proxy_service_tier_trace: bool) -> SimpleNamespace:
     return SimpleNamespace(
         prefer_earlier_reset_accounts=False,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7735,6 +7735,53 @@ async def test_process_upstream_websocket_text_suppresses_unmatched_missing_tool
 
 
 @pytest.mark.asyncio
+async def test_process_upstream_websocket_text_masks_unmatched_previous_response_not_found(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_unmatched_previous_response_not_found")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    pending_requests: deque[proxy_service._WebSocketRequestState] = deque()
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "previous_response_not_found",
+            "message": "Previous response with id 'resp_unmatched_anchor' not found.",
+            "param": "previous_response_id",
+        },
+    }
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"type":"response.failed"' in downstream_text
+    assert '"code":"stream_incomplete"' in downstream_text
+    assert "previous_response_not_found" not in downstream_text
+    assert "resp_unmatched_anchor" not in downstream_text
+    assert upstream_control.suppress_downstream_event is False
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.downstream_texts is None
+    finalize_request_state.assert_not_awaited()
+    handle_stream_error.assert_not_awaited()
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_preserves_first_turn_missing_tool_output(
     monkeypatch,
 ):
@@ -9880,6 +9927,35 @@ def test_maybe_rewrite_websocket_previous_response_not_found_rewrites_response_f
     assert error_payload["code"] == "stream_incomplete"
     assert error_payload["message"] == "Upstream websocket closed before response.completed"
     assert "previous_response_not_found" not in rewritten_text
+
+
+def test_partial_output_proxy_error_event_masks_previous_response_not_found_from_message():
+    error_payload = proxy_module.openai_error(
+        "previous_response_not_found",
+        "Previous response with id 'resp_partial_anchor' not found.",
+        error_type="invalid_request_error",
+    )
+    error_payload["error"]["param"] = "previous_response_id"
+    exc = proxy_module.ProxyResponseError(400, error_payload)
+
+    event_block = proxy_service._partial_output_proxy_error_event_block(
+        exc,
+        response_id="resp_visible",
+        previous_response_id=None,
+        preferred_account_id=None,
+        default_code="upstream_error",
+        default_message="Upstream error",
+    )
+
+    payload = parse_sse_data_json(event_block)
+    assert isinstance(payload, dict)
+    response = cast(dict[str, JsonValue], payload["response"])
+    error = cast(dict[str, JsonValue], response["error"])
+    assert payload["type"] == "response.failed"
+    assert error["code"] == "stream_incomplete"
+    assert error["message"] == "Upstream websocket closed before response.completed"
+    assert "previous_response_not_found" not in event_block
+    assert "resp_partial_anchor" not in event_block
 
 
 def test_maybe_rewrite_websocket_previous_response_invalid_request_error_rewrites_when_message_is_not_found():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1133,7 +1133,8 @@ async def test_write_request_log_continues_after_caller_cancellation() -> None:
     await asyncio.wait_for(started.wait(), timeout=1)
 
     task.cancel()
-    await asyncio.wait_for(task, timeout=1)
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=1)
     release.set()
 
     for _ in range(20):


### PR DESCRIPTION
## Summary

- mask `previous_response_not_found` errors that arrive after downstream-visible streaming output
- emit a sanitized terminal `response.failed` instead of leaking raw upstream error payloads or leaving the client waiting
- keep unmatched websocket `previous_response_not_found` terminal and retry-safe, while preserving the existing missing-tool-output and foreign-anchor invariants

## Stack

Stacked after #688. The live aggregate already runs this fix as `b86e2163`; this PR publishes the same runtime invariant as a reviewable top-of-stack change.

## Tests

- `uv run ty check`
- `uv run pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_proxy_utils.py` (`370 passed`)
- `uv run pytest tests/unit/test_proxy_utils.py -k 'previous_response_not_found or missing_tool_output or partial_output_proxy_error' tests/unit/test_proxy_http_bridge.py -k 'previous_response_not_found or masks_single_previous_response_not_found or anchor_was_lost or downstream_visible or forwarded_proxy_error or partial_previous_response_not_found or forwarded_bytes'` (`19 passed`)
- `uvx ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
- `uvx ruff format --check app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
- `git diff --check`
