### PR TITLE
fix(proxy): cap selector "Try again in" hint at 300s

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -228,11 +228,11 @@ def select_account(
                 reset_candidates = [s.reset_at for s in quota_exceeded if s.reset_at]
                 if reset_candidates:
                     wait_seconds = max(0, min(reset_candidates) - int(current))
-                    return SelectionResult(None, f"Rate limit exceeded. Try again in {wait_seconds:.0f}s")
+                    return SelectionResult(None, _format_retry_hint(wait_seconds))
             cooldowns = [s.cooldown_until for s in all_states if s.cooldown_until and s.cooldown_until > current]
             if cooldowns:
                 wait_seconds = max(0.0, min(cooldowns) - current)
-                return SelectionResult(None, f"Rate limit exceeded. Try again in {wait_seconds:.0f}s")
+                return SelectionResult(None, _format_retry_hint(wait_seconds))
             return SelectionResult(None, "No available accounts")
 
     def _reset_first_sort_key(state: AccountState) -> tuple[int, float, float, float, str]:
@@ -321,6 +321,22 @@ def handle_rate_limit(state: AccountState, error: UpstreamError) -> None:
 
 
 QUOTA_EXCEEDED_COOLDOWN_SECONDS = 120.0
+
+# Upper bound for the user-visible "Try again in {N}s" hint that
+# ``select_account`` surfaces when zero candidates are selectable. The clamp
+# protects clients from waiting the worst-case persisted ``reset_at`` after
+# OpenAI-side reset events that propagate lazily through ``/wham/usage`` (see
+# https://github.com/Soju06/codex-lb/issues/676). codex-lb's background usage
+# refresh runs every ``usage_refresh_interval_seconds`` (default 60s) and the
+# per-status cooldowns are 120s, so a 300s ceiling lets clients reattempt
+# inside the auto-recovery window. The underlying ``AccountState.reset_at``
+# and ``AccountState.cooldown_until`` fields are not clamped.
+SELECTOR_RETRY_HINT_MAX_SECONDS = 300
+
+
+def _format_retry_hint(wait_seconds: float) -> str:
+    capped = min(max(0.0, wait_seconds), float(SELECTOR_RETRY_HINT_MAX_SECONDS))
+    return f"Rate limit exceeded. Try again in {capped:.0f}s"
 
 
 def handle_quota_exceeded(state: AccountState, error: UpstreamError) -> None:

--- a/openspec/changes/clamp-selector-retry-hint/proposal.md
+++ b/openspec/changes/clamp-selector-retry-hint/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+When the balancer cannot select any account, `select_account` in `app/core/balancer/logic.py:227-235` surfaces `"Rate limit exceeded. Try again in {wait_seconds:.0f}s"`. The `wait_seconds` is derived directly from `min(reset_at)` across the quota-exceeded pool (or `min(cooldown_until)` for the cooldown branch). When upstream `reset_at` points many hours into the future — common after OpenAI-side "team reset events" where `/wham/usage` propagates lazily, see https://github.com/Soju06/codex-lb/issues/676 and https://github.com/Soju06/codex-lb/issues/678 — clients see panic-inducing retry hints like `"Try again in 89872s"` (~25h) and back off accordingly.
+
+In practice, codex-lb's background usage refresh runs every `usage_refresh_interval_seconds` (default 60s), and the per-status cooldowns (`QUOTA_EXCEEDED_COOLDOWN_SECONDS`, `RATE_LIMITED_COOLDOWN_SECONDS`) are 120s. Recovery typically completes well inside a 5-minute window when the upstream limiter catches up or the primary window rolls over. The current hint dishonestly suggests clients must wait the worst-case `reset_at`, which causes Codex CLI and other clients to sleep for hours when they should reattempt much sooner.
+
+Observed 2026-05-17 during the May 16 OpenAI paid-plan reset event: all three accounts surfaced `Try again in 89872s` despite `/wham/usage` reporting `allowed=true, limit_reached=false` within minutes of the screenshot.
+
+## What Changes
+
+- Add `SELECTOR_RETRY_HINT_MAX_SECONDS` constant (default `300`) to `app/core/balancer/logic.py`, sitting alongside the existing cooldown constants.
+- Add a private `_format_retry_hint(wait_seconds: float) -> str` helper that clamps the surfaced wait to `SELECTOR_RETRY_HINT_MAX_SECONDS` and emits `"Rate limit exceeded. Try again in {capped:.0f}s"`. The clamp only affects the user-visible string; the underlying `AccountState.reset_at` and `cooldown_until` fields are unchanged and continue to drive selection logic, telemetry, and dashboard reads.
+- Replace both `f"Rate limit exceeded. Try again in {wait_seconds:.0f}s"` formatters in `select_account` with calls to `_format_retry_hint`.
+- Add regression tests in `tests/unit/test_load_balancer.py` covering the clamp behavior for the `quota_exceeded` branch and the `cooldown_until` branch.
+
+## Impact
+
+- Clients (Codex CLI, OpenCode, OpenClaw) now see a retry hint bounded by 300s when codex-lb has zero selectable accounts. Their next retry will land inside codex-lb's auto-recovery window (60s refresh + 120s cooldown buffer + margin), so transient `/wham/usage` divergence after OpenAI reset events resolves on the next attempt instead of stalling the client for hours.
+- True hard caps (multi-day weekly resets where `/wham/usage` correctly reports `limit_reached=true`) still produce repeated rejections — clients will retry, see the same 503, and back off via their own exponential backoff. Net behavior is no worse than today's repeated requests against a hard-capped account, and substantially better when the upstream state has actually recovered.
+- No change to selector decision logic, account state transitions, persistence, or upstream HTTP behavior. The clamp lives entirely in the user-visible string returned alongside `SelectionResult(account=None, ...)`.
+- No public API or schema change. The error envelope shape is preserved.

--- a/openspec/changes/clamp-selector-retry-hint/specs/query-caching/spec.md
+++ b/openspec/changes/clamp-selector-retry-hint/specs/query-caching/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Selector retry hint is bounded by the auto-recovery window
+
+When `select_account` cannot return a candidate, the surfaced `"Try again in {N}s"` value MUST be clamped to at most `SELECTOR_RETRY_HINT_MAX_SECONDS` (default 300). Clients reattempt within codex-lb's auto-recovery window (background `/wham/usage` refresh + per-status cooldown threshold) instead of waiting the worst-case persisted `reset_at`. The clamp affects only the user-visible string; `AccountState.reset_at` and `AccountState.cooldown_until` remain unchanged and continue to drive selection, telemetry, and dashboard reads.
+
+#### Scenario: Quota-exceeded reset far in the future is clamped
+- **GIVEN** every selectable account has `status = QUOTA_EXCEEDED`
+- **AND** the soonest `reset_at` is more than `SELECTOR_RETRY_HINT_MAX_SECONDS` from now
+- **WHEN** `select_account` returns `account = None`
+- **THEN** the surfaced message ends with `Try again in 300s`
+- **AND** the underlying `AccountState.reset_at` values are unchanged
+
+#### Scenario: Quota-exceeded reset inside the cap surfaces the actual value
+- **GIVEN** every selectable account has `status = QUOTA_EXCEEDED`
+- **AND** the soonest `reset_at` is at most `SELECTOR_RETRY_HINT_MAX_SECONDS` from now
+- **WHEN** `select_account` returns `account = None`
+- **THEN** the surfaced message ends with `Try again in {soonest_reset_seconds}s`
+
+#### Scenario: Cooldown_until far in the future is clamped
+- **GIVEN** every account has a `cooldown_until` further than `SELECTOR_RETRY_HINT_MAX_SECONDS` from now and no `quota_exceeded` candidates exist
+- **WHEN** `select_account` returns `account = None`
+- **THEN** the surfaced message ends with `Try again in 300s`

--- a/openspec/changes/clamp-selector-retry-hint/tasks.md
+++ b/openspec/changes/clamp-selector-retry-hint/tasks.md
@@ -1,0 +1,20 @@
+## 1. Implement clamp helper
+
+- [ ] 1.1 Add `SELECTOR_RETRY_HINT_MAX_SECONDS = 300` constant in `app/core/balancer/logic.py`, near `QUOTA_EXCEEDED_COOLDOWN_SECONDS` / `RATE_LIMITED_COOLDOWN_SECONDS`.
+- [ ] 1.2 Add a private `_format_retry_hint(wait_seconds: float) -> str` helper that returns `f"Rate limit exceeded. Try again in {min(max(0.0, wait_seconds), float(SELECTOR_RETRY_HINT_MAX_SECONDS)):.0f}s"`.
+- [ ] 1.3 Replace both `f"Rate limit exceeded. Try again in {wait_seconds:.0f}s"` formatters in `select_account` (currently at the `quota_exceeded` branch and the `cooldown_until` branch) with calls to `_format_retry_hint(wait_seconds)`.
+- [ ] 1.4 Leave `AccountState.reset_at` / `AccountState.cooldown_until` and all selector decision logic untouched.
+
+## 2. Tests
+
+- [ ] 2.1 Add `tests/unit/test_load_balancer.py::test_select_account_caps_quota_exceeded_retry_hint`: build two `quota_exceeded` states with `reset_at = now + 89_872` and assert the surfaced message ends with `Try again in 300s`, not `Try again in 89872s`.
+- [ ] 2.2 Add `tests/unit/test_load_balancer.py::test_select_account_preserves_short_quota_exceeded_retry_hint`: build a `quota_exceeded` state with `reset_at = now + 60` and assert the surfaced message ends with `Try again in 60s` (no clamp applied).
+- [ ] 2.3 Add `tests/unit/test_load_balancer.py::test_select_account_caps_cooldown_retry_hint`: build a state with `cooldown_until = now + 86_400` and assert the surfaced message ends with `Try again in 300s`.
+- [ ] 2.4 Confirm the existing `test_select_account_reports_cooldown_wait_time` still passes (its 30s/60s cooldowns are below the cap).
+
+## 3. Spec + validation
+
+- [ ] 3.1 Add the new requirement under the `query-caching` capability spec (delta at `openspec/changes/clamp-selector-retry-hint/specs/query-caching/spec.md`) covering the clamp scenarios.
+- [ ] 3.2 Run `uv run pytest tests/unit/test_load_balancer.py -k 'select_account or retry_hint'` and confirm clean.
+- [ ] 3.3 Run `openspec validate --specs` and confirm clean.
+- [ ] 3.4 Run `uv run ruff check app/core/balancer/logic.py tests/unit/test_load_balancer.py` and confirm clean.

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -246,6 +246,62 @@ def test_select_account_reports_cooldown_wait_time():
     assert "Try again in" in result.error_message
 
 
+def test_select_account_caps_quota_exceeded_retry_hint():
+    now = 1_700_000_000.0
+    far_future_reset = int(now + 89_872)
+    states = [
+        AccountState(
+            "a",
+            AccountStatus.QUOTA_EXCEEDED,
+            used_percent=100.0,
+            reset_at=far_future_reset,
+        ),
+        AccountState(
+            "b",
+            AccountStatus.QUOTA_EXCEEDED,
+            used_percent=100.0,
+            reset_at=int(now + 271_819),
+        ),
+    ]
+    result = select_account(states, now=now)
+    assert result.account is None
+    assert result.error_message == "Rate limit exceeded. Try again in 300s"
+    # The underlying state values are intentionally not clamped — only the
+    # surfaced hint is.
+    assert states[0].reset_at == far_future_reset
+
+
+def test_select_account_preserves_short_quota_exceeded_retry_hint():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "a",
+            AccountStatus.QUOTA_EXCEEDED,
+            used_percent=100.0,
+            reset_at=int(now + 60),
+        ),
+    ]
+    result = select_account(states, now=now)
+    assert result.account is None
+    assert result.error_message == "Rate limit exceeded. Try again in 60s"
+
+
+def test_select_account_caps_cooldown_retry_hint():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "a",
+            AccountStatus.ACTIVE,
+            used_percent=5.0,
+            cooldown_until=now + 86_400,
+        ),
+    ]
+    result = select_account(states, now=now)
+    assert result.account is None
+    assert result.error_message == "Rate limit exceeded. Try again in 300s"
+    assert states[0].cooldown_until == now + 86_400
+
+
 def test_apply_usage_quota_sets_fallback_reset_for_primary_window(monkeypatch):
     now = 1_700_000_000.0
     monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)


### PR DESCRIPTION
## Summary

When \`select_account\` cannot return a candidate, the surfaced \`Rate limit exceeded. Try again in {N}s\` value is currently driven directly by \`min(reset_at)\` of the quota-exceeded pool (or \`min(cooldown_until)\` of all states) — see \`app/core/balancer/logic.py:227-235\`. After OpenAI-side reset events where \`/wham/usage\` propagates lazily (the same pattern documented in #676 / #677 / #678), \`N\` can reach ~89,872s (~25h). Clients (Codex CLI, OpenCode, OpenClaw) then back off for hours when codex-lb's own 60s \`/wham/usage\` refresh + 120s per-status cooldown threshold would have recovered the account inside a 5-minute window.

This change caps the user-visible retry hint at \`SELECTOR_RETRY_HINT_MAX_SECONDS = 300\`. \`AccountState.reset_at\` and \`AccountState.cooldown_until\` are unchanged and continue to drive selection, telemetry, and dashboard reads — only the string returned alongside \`SelectionResult(account=None, ...)\` is clamped.

This is the operator-facing UX gap that fed several of the reports in #676 / #678: operators see a \"wait 25 hours\" message and assume they are hard-blocked, when in reality codex-lb will auto-recover on the next refresh tick. With the clamp, clients reattempt inside the auto-recovery window and the symptom resolves naturally.

## Test plan

- [x] \`uv run pytest tests/unit/test_load_balancer.py -k 'select_account or retry_hint'\` — 27 passed, 37 deselected
- [x] \`uv run ruff check app/core/balancer/logic.py tests/unit/test_load_balancer.py\` — clean
- [x] 3 new regression tests in \`tests/unit/test_load_balancer.py\`:
  - \`test_select_account_caps_quota_exceeded_retry_hint\` — \`reset_at = now + 89_872\` clamps to 300s
  - \`test_select_account_preserves_short_quota_exceeded_retry_hint\` — \`reset_at = now + 60\` surfaces as 60s (no clamp)
  - \`test_select_account_caps_cooldown_retry_hint\` — \`cooldown_until = now + 86_400\` clamps to 300s
- [x] Existing \`test_select_account_reports_cooldown_wait_time\` still passes

OpenSpec change folder: \`openspec/changes/clamp-selector-retry-hint/\` (modifies the \`query-caching\` capability spec to add the clamp scenarios).

## Notes

- The clamp is a UX-only change. Hard upstream caps (legitimate multi-day weekly resets) still produce repeated rejections; clients retry, see the same 503, and back off via their own exponential backoff. Net behavior is no worse than today's repeated requests against a hard-capped account, and substantially better when the upstream state has actually recovered.
- No public API or schema change. The error envelope shape is preserved.
- Refs #676 / #678.

🤖 Generated with [Claude Code](https://claude.com/claude-code)