### PR TITLE
fix(dashboard): make weekly credit pace backend-driven

### DIFF
--- a/app/modules/dashboard/schemas.py
+++ b/app/modules/dashboard/schemas.py
@@ -54,6 +54,38 @@ class DepletionResponse(DashboardModel):
     seconds_until_exhaustion: float | None = None
 
 
+WeeklyCreditPaceStatus = Literal["behind", "on_track", "ahead", "danger"]
+WeeklyCreditPaceConfidence = Literal["high", "medium", "low"]
+
+
+class WeeklyCreditPaceResponse(DashboardModel):
+    total_full_credits: float
+    total_actual_remaining_credits: float
+    total_expected_remaining_credits: float
+    actual_used_percent: float
+    scheduled_used_percent: float
+    delta_percent: float
+    schedule_gap_credits: float
+    # Legacy frontend field name kept as an alias-compatible value for one release.
+    over_plan_credits: float
+    projected_shortfall_credits: float
+    pause_for_break_even_hours: float | None = None
+    pace_multiplier: float | None = None
+    throttle_to_percent: float | None = None
+    reduce_by_percent: float | None = None
+    pro_account_equivalent_to_cover_over_plan: float | None = None
+    pro_accounts_to_cover_over_plan: int | None = None
+    projected_depletion_hours: float | None = None
+    projected_minimum_remaining_credits: float | None = None
+    forecast_burn_rate_credits_per_hour: float | None = None
+    scheduled_burn_rate_credits_per_hour: float
+    status: WeeklyCreditPaceStatus
+    account_count: int
+    stale_account_count: int = 0
+    inactive_account_count: int = 0
+    confidence: WeeklyCreditPaceConfidence = "low"
+
+
 class DashboardOverviewResponse(DashboardModel):
     last_sync_at: datetime | None = None
     timeframe: DashboardOverviewTimeframe
@@ -63,3 +95,4 @@ class DashboardOverviewResponse(DashboardModel):
     trends: MetricsTrends
     depletion_primary: DepletionResponse | None = None
     depletion_secondary: DepletionResponse | None = None
+    weekly_credit_pace: WeeklyCreditPaceResponse | None = None

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 
 from app.core import usage as usage_core
+from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.usage.types import UsageWindowRow
 from app.core.utils.time import utcnow
@@ -20,6 +21,7 @@ from app.modules.dashboard.schemas import (
     DashboardUsageWindows,
     DepletionResponse,
 )
+from app.modules.dashboard.weekly_pace import build_weekly_credit_pace
 from app.modules.usage.builders import (
     align_bucket_window_start,
     build_activity_summaries,
@@ -214,6 +216,14 @@ class DashboardService:
                     secondary_history[account_id] = rows
 
         pri_depletion, sec_depletion = _build_depletion_by_window(primary_history, secondary_history, now)
+        settings = get_settings()
+        weekly_credit_pace = build_weekly_credit_pace(
+            accounts=accounts,
+            account_summaries=account_summaries,
+            secondary_history=secondary_history,
+            now=now,
+            usage_refresh_interval_seconds=settings.usage_refresh_interval_seconds,
+        )
 
         additional_ts = await self._repo.latest_additional_recorded_at()
         return DashboardOverviewResponse(
@@ -225,6 +235,7 @@ class DashboardService:
             trends=trends,
             depletion_primary=pri_depletion,
             depletion_secondary=sec_depletion,
+            weekly_credit_pace=weekly_credit_pace,
         )
 
 

--- a/app/modules/dashboard/weekly_pace.py
+++ b/app/modules/dashboard/weekly_pace.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from math import ceil, isfinite
+from typing import Literal
+
+from app.core.usage.depletion import EWMAState, ewma_update
+from app.core.utils.time import naive_utc_to_epoch
+from app.db.models import Account, AccountStatus, UsageHistory
+from app.modules.accounts.schemas import AccountSummary
+from app.modules.dashboard.schemas import WeeklyCreditPaceResponse, WeeklyCreditPaceStatus
+
+PRO_WEEKLY_CAPACITY_CREDITS = 50_400.0
+RECENT_BURN_WINDOW = timedelta(hours=6)
+MIN_FRESHNESS_SECONDS = 300.0
+FRESHNESS_MISSED_REFRESH_CYCLES = 3.0
+
+
+@dataclass
+class _PaceAccount:
+    account_id: str
+    full_credits: float
+    remaining_credits: float
+    reset_at_ms: float
+    window_ms: float
+    forecast_burn_rate_credits_per_hour: float | None
+
+
+@dataclass
+class _SimulationAccount:
+    full_credits: float
+    balance_credits: float
+    reset_at_ms: float
+    window_ms: float
+
+
+@dataclass
+class _Projection:
+    projected_shortfall_credits: float
+    projected_depletion_hours: float | None
+    projected_minimum_remaining_credits: float
+
+
+def build_weekly_credit_pace(
+    *,
+    accounts: list[Account],
+    account_summaries: list[AccountSummary],
+    secondary_history: dict[str, list[UsageHistory]],
+    now: datetime,
+    usage_refresh_interval_seconds: int,
+) -> WeeklyCreditPaceResponse | None:
+    """Build server-side weekly quota pace from active, fresh weekly usage rows.
+
+    The dashboard card needs two separate signals:
+    - current schedule gap: actual remaining vs. linear expected remaining now
+    - forecast shortfall: whether recent burn will deplete the pool before resets
+
+    Computing this in the backend keeps status/freshness filters aligned with the
+    routing pool and lets the forecast use usage_history instead of a full-window
+    cumulative average.
+    """
+
+    now_ms = naive_utc_to_epoch(now) * 1000.0
+    if not _is_finite_positive(now_ms):
+        return None
+
+    accounts_by_id = {account.id: account for account in accounts}
+    freshness_cutoff = now - timedelta(seconds=_freshness_seconds(usage_refresh_interval_seconds))
+
+    pace_accounts: list[_PaceAccount] = []
+    stale_account_count = 0
+    inactive_account_count = 0
+    rate_sample_count = 0
+    total_full_credits = 0.0
+    total_actual_remaining_credits = 0.0
+    total_expected_remaining_credits = 0.0
+    scheduled_burn_rate_credits_per_hour = 0.0
+    forecast_burn_rate_credits_per_hour = 0.0
+
+    for summary in account_summaries:
+        timing = _weekly_timing(summary, now_ms)
+        if timing is None:
+            continue
+
+        account = accounts_by_id.get(summary.account_id)
+        if account is None or account.status != AccountStatus.ACTIVE:
+            inactive_account_count += 1
+            continue
+
+        rows = sorted(secondary_history.get(summary.account_id, []), key=lambda row: row.recorded_at)
+        latest = rows[-1] if rows else None
+        if latest is None or latest.recorded_at < freshness_cutoff:
+            stale_account_count += 1
+            continue
+
+        full_credits, actual_remaining_credits, effective_reset_at_ms, window_ms = timing
+        time_left_ms = _clamp(effective_reset_at_ms - now_ms, 0.0, window_ms)
+        expected_remaining_credits = full_credits * (time_left_ms / window_ms)
+        account_rate = _recent_burn_rate_credits_per_hour(rows, full_credits, now)
+
+        total_full_credits += full_credits
+        total_actual_remaining_credits += actual_remaining_credits
+        total_expected_remaining_credits += expected_remaining_credits
+        scheduled_burn_rate_credits_per_hour += (full_credits / window_ms) * 3_600_000.0
+        if account_rate is not None:
+            rate_sample_count += 1
+            forecast_burn_rate_credits_per_hour += account_rate
+
+        pace_accounts.append(
+            _PaceAccount(
+                account_id=summary.account_id,
+                full_credits=full_credits,
+                remaining_credits=actual_remaining_credits,
+                reset_at_ms=effective_reset_at_ms,
+                window_ms=window_ms,
+                forecast_burn_rate_credits_per_hour=account_rate,
+            )
+        )
+
+    if not pace_accounts or total_full_credits <= 0:
+        return None
+
+    actual_used_percent = 100.0 * (total_full_credits - total_actual_remaining_credits) / total_full_credits
+    scheduled_used_percent = 100.0 * (total_full_credits - total_expected_remaining_credits) / total_full_credits
+    delta_percent = actual_used_percent - scheduled_used_percent
+    schedule_gap_credits = max(0.0, total_expected_remaining_credits - total_actual_remaining_credits)
+
+    forecast_rate = forecast_burn_rate_credits_per_hour if rate_sample_count > 0 else None
+    projection = _project_weekly_pool(pace_accounts, now_ms, forecast_rate)
+    projected_shortfall_credits = projection.projected_shortfall_credits
+    pace_multiplier = (
+        forecast_rate / scheduled_burn_rate_credits_per_hour
+        if forecast_rate is not None and scheduled_burn_rate_credits_per_hour > 0
+        else None
+    )
+    pause_for_break_even_hours = (
+        projected_shortfall_credits / forecast_rate
+        if forecast_rate is not None and forecast_rate > 0 and projected_shortfall_credits > 0
+        else None
+    )
+    throttle_to_percent = (
+        _clamp((scheduled_burn_rate_credits_per_hour / forecast_rate) * 100.0, 0.0, 100.0)
+        if forecast_rate is not None
+        and forecast_rate > 0
+        and scheduled_burn_rate_credits_per_hour > 0
+        and projected_shortfall_credits > 0
+        else None
+    )
+    reduce_by_percent = 100.0 - throttle_to_percent if throttle_to_percent is not None else None
+    pro_equivalent = (
+        projected_shortfall_credits / PRO_WEEKLY_CAPACITY_CREDITS if projected_shortfall_credits > 0 else None
+    )
+    pro_accounts = ceil(pro_equivalent) if pro_equivalent is not None else None
+
+    return WeeklyCreditPaceResponse(
+        total_full_credits=total_full_credits,
+        total_actual_remaining_credits=total_actual_remaining_credits,
+        total_expected_remaining_credits=total_expected_remaining_credits,
+        actual_used_percent=actual_used_percent,
+        scheduled_used_percent=scheduled_used_percent,
+        delta_percent=delta_percent,
+        schedule_gap_credits=schedule_gap_credits,
+        over_plan_credits=schedule_gap_credits,
+        projected_shortfall_credits=projected_shortfall_credits,
+        pause_for_break_even_hours=pause_for_break_even_hours,
+        pace_multiplier=pace_multiplier,
+        throttle_to_percent=throttle_to_percent,
+        reduce_by_percent=reduce_by_percent,
+        pro_account_equivalent_to_cover_over_plan=pro_equivalent,
+        pro_accounts_to_cover_over_plan=pro_accounts,
+        projected_depletion_hours=projection.projected_depletion_hours,
+        projected_minimum_remaining_credits=projection.projected_minimum_remaining_credits,
+        forecast_burn_rate_credits_per_hour=forecast_rate,
+        scheduled_burn_rate_credits_per_hour=scheduled_burn_rate_credits_per_hour,
+        status=_weekly_pace_status(delta_percent, projected_shortfall_credits),
+        account_count=len(pace_accounts),
+        stale_account_count=stale_account_count,
+        inactive_account_count=inactive_account_count,
+        confidence=_confidence(len(pace_accounts), rate_sample_count, stale_account_count),
+    )
+
+
+def _weekly_timing(summary: AccountSummary, now_ms: float) -> tuple[float, float, float, float] | None:
+    raw_full_credits = summary.capacity_credits_secondary
+    raw_remaining_credits = summary.remaining_credits_secondary
+    reset_at = summary.reset_at_secondary
+    raw_window_minutes = summary.window_minutes_secondary
+    if (
+        not isinstance(raw_full_credits, int | float)
+        or raw_full_credits <= 0
+        or not isinstance(raw_remaining_credits, int | float)
+        or raw_remaining_credits < 0
+        or reset_at is None
+        or not isinstance(raw_window_minutes, int | float)
+        or raw_window_minutes <= 0
+    ):
+        return None
+
+    full_credits = float(raw_full_credits)
+    remaining_credits = float(raw_remaining_credits)
+    window_minutes = float(raw_window_minutes)
+    reset_at_ms = reset_at.timestamp() * 1000.0
+    window_ms = window_minutes * 60_000.0
+    if not _is_finite_positive(reset_at_ms) or not _is_finite_positive(window_ms):
+        return None
+
+    effective_reset_at_ms = _advance_reset_at(reset_at_ms, window_ms, now_ms)
+    return (
+        full_credits,
+        _clamp(remaining_credits, 0.0, full_credits),
+        effective_reset_at_ms,
+        window_ms,
+    )
+
+
+def _recent_burn_rate_credits_per_hour(
+    rows: list[UsageHistory],
+    full_credits: float,
+    now: datetime,
+) -> float | None:
+    recent_start = now - RECENT_BURN_WINDOW
+    recent_rows = [row for row in rows if row.recorded_at >= recent_start and row.recorded_at <= now]
+    if len(recent_rows) < 2:
+        return None
+
+    state: EWMAState | None = None
+    for row in recent_rows:
+        state = ewma_update(
+            state,
+            row.used_percent,
+            float(naive_utc_to_epoch(row.recorded_at)),
+            reset_at=row.reset_at,
+        )
+    if state is None or state.rate is None:
+        return None
+    return max(0.0, state.rate * full_credits * 36.0)
+
+
+def _project_weekly_pool(
+    accounts: list[_PaceAccount],
+    now_ms: float,
+    forecast_burn_rate_credits_per_hour: float | None,
+) -> _Projection:
+    total_remaining = sum(account.remaining_credits for account in accounts)
+    if forecast_burn_rate_credits_per_hour is None or forecast_burn_rate_credits_per_hour <= 0:
+        return _Projection(
+            projected_shortfall_credits=0.0,
+            projected_depletion_hours=None,
+            projected_minimum_remaining_credits=total_remaining,
+        )
+
+    burn_rate_credits_per_ms = forecast_burn_rate_credits_per_hour / 3_600_000.0
+    simulation_accounts = [
+        _SimulationAccount(
+            full_credits=account.full_credits,
+            balance_credits=account.remaining_credits,
+            reset_at_ms=account.reset_at_ms,
+            window_ms=account.window_ms,
+        )
+        for account in accounts
+    ]
+    horizon_ms = now_ms + (max(account.window_ms for account in accounts) * 2.0)
+    cursor_ms = now_ms
+    minimum_remaining = total_remaining
+
+    while cursor_ms < horizon_ms:
+        simulation_accounts.sort(key=lambda account: account.reset_at_ms)
+        next_reset = simulation_accounts[0]
+        next_event_at_ms = min(next_reset.reset_at_ms, horizon_ms)
+        interval_ms = max(0.0, next_event_at_ms - cursor_ms)
+        interval_burn = burn_rate_credits_per_ms * interval_ms
+        total_balance = _total_balance(simulation_accounts)
+
+        if interval_burn > total_balance:
+            depletion_wait_ms = total_balance / burn_rate_credits_per_ms if burn_rate_credits_per_ms > 0 else 0.0
+            return _Projection(
+                projected_shortfall_credits=interval_burn - total_balance,
+                projected_depletion_hours=(cursor_ms - now_ms + depletion_wait_ms) / 3_600_000.0,
+                projected_minimum_remaining_credits=0.0,
+            )
+
+        _consume_balance(simulation_accounts, interval_burn)
+        minimum_remaining = min(minimum_remaining, _total_balance(simulation_accounts))
+        cursor_ms = next_event_at_ms
+        if cursor_ms >= horizon_ms:
+            break
+
+        next_reset.balance_credits = next_reset.full_credits
+        next_reset.reset_at_ms += next_reset.window_ms
+        minimum_remaining = min(minimum_remaining, _total_balance(simulation_accounts))
+
+    return _Projection(
+        projected_shortfall_credits=0.0,
+        projected_depletion_hours=None,
+        projected_minimum_remaining_credits=minimum_remaining,
+    )
+
+
+def _consume_balance(accounts: list[_SimulationAccount], amount_credits: float) -> None:
+    remaining_to_consume = amount_credits
+    for account in sorted(accounts, key=lambda item: item.reset_at_ms):
+        if remaining_to_consume <= 0:
+            return
+        consumed = min(account.balance_credits, remaining_to_consume)
+        account.balance_credits -= consumed
+        remaining_to_consume -= consumed
+
+
+def _total_balance(accounts: list[_SimulationAccount]) -> float:
+    return sum(account.balance_credits for account in accounts)
+
+
+def _advance_reset_at(reset_at_ms: float, window_ms: float, now_ms: float) -> float:
+    if reset_at_ms > now_ms:
+        return reset_at_ms
+    missed_windows = int((now_ms - reset_at_ms) // window_ms) + 1
+    return reset_at_ms + (missed_windows * window_ms)
+
+
+def _weekly_pace_status(delta_percent: float, projected_shortfall_credits: float) -> WeeklyCreditPaceStatus:
+    if projected_shortfall_credits > 0:
+        return "danger"
+    if delta_percent < -5:
+        return "behind"
+    if delta_percent > 5:
+        return "ahead"
+    return "on_track"
+
+
+def _confidence(
+    account_count: int,
+    rate_sample_count: int,
+    stale_account_count: int,
+) -> Literal["high", "medium", "low"]:
+    if rate_sample_count >= account_count and stale_account_count == 0:
+        return "high"
+    if rate_sample_count > 0:
+        return "medium"
+    return "low"
+
+
+def _freshness_seconds(usage_refresh_interval_seconds: int) -> float:
+    return max(MIN_FRESHNESS_SECONDS, float(usage_refresh_interval_seconds) * FRESHNESS_MISSED_REFRESH_CYCLES)
+
+
+def _clamp(value: float, min_value: float, max_value: float) -> float:
+    return min(max_value, max(min_value, value))
+
+
+def _is_finite_positive(value: object) -> bool:
+    return isinstance(value, int | float) and isfinite(value) and value > 0

--- a/app/modules/dashboard/weekly_pace.py
+++ b/app/modules/dashboard/weekly_pace.py
@@ -200,7 +200,7 @@ def _weekly_timing(summary: AccountSummary, now_ms: float) -> tuple[float, float
     full_credits = float(raw_full_credits)
     remaining_credits = float(raw_remaining_credits)
     window_minutes = float(raw_window_minutes)
-    reset_at_ms = reset_at.timestamp() * 1000.0
+    reset_at_ms = naive_utc_to_epoch(reset_at) * 1000.0
     window_ms = window_minutes * 60_000.0
     if not _is_finite_positive(reset_at_ms) or not _is_finite_positive(window_ms):
         return None

--- a/frontend/src/features/accounts/components/oauth-dialog.test.tsx
+++ b/frontend/src/features/accounts/components/oauth-dialog.test.tsx
@@ -244,8 +244,9 @@ describe("OauthDialog", () => {
       />,
     );
 
-    expect(callbackInput).toHaveValue("");
-    expect(callbackInput).toBeDisabled();
+    const disabledCallbackInput = screen.getByRole("textbox");
+    expect(disabledCallbackInput).toHaveValue("");
+    expect(disabledCallbackInput).toBeDisabled();
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 });

--- a/frontend/src/features/accounts/components/oauth-dialog.tsx
+++ b/frontend/src/features/accounts/components/oauth-dialog.tsx
@@ -56,21 +56,21 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-function ManualCallbackInput({
-  onSubmit,
-  disabled = false,
-}: {
+type ManualCallbackInputProps = {
   onSubmit: (callbackUrl: string) => Promise<void>;
   disabled?: boolean;
-}) {
+};
+
+function ManualCallbackInput(props: ManualCallbackInputProps) {
+  return <ManualCallbackInputBody key={props.disabled ? "disabled" : "enabled"} {...props} />;
+}
+
+function ManualCallbackInputBody({
+  onSubmit,
+  disabled = false,
+}: ManualCallbackInputProps) {
   const [callbackUrl, setCallbackUrl] = useState("");
   const [submitting, setSubmitting] = useState(false);
-
-  useEffect(() => {
-    if (disabled) {
-      setCallbackUrl("");
-    }
-  }, [disabled]);
 
   const handleSubmit = useCallback(async () => {
     if (!callbackUrl.trim()) return;

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
@@ -11,7 +11,9 @@ const BASE_PACE: WeeklyCreditPace = {
   actualUsedPercent: 50,
   scheduledUsedPercent: 14,
   deltaPercent: 36,
+  scheduleGapCredits: 360_000,
   overPlanCredits: 360_000,
+  projectedShortfallCredits: 360_000,
   pauseForBreakEvenHours: 60.5,
   paceMultiplier: 50 / 14,
   throttleToPercent: 28,
@@ -20,12 +22,17 @@ const BASE_PACE: WeeklyCreditPace = {
   proAccountsToCoverOverPlan: 8,
   projectedDepletionHours: 8,
   projectedMinimumRemainingCredits: 0,
+  forecastBurnRateCreditsPerHour: 12_000,
+  scheduledBurnRateCreditsPerHour: 3_000,
   status: "danger",
   accountCount: 2,
+  staleAccountCount: 0,
+  inactiveAccountCount: 0,
+  confidence: "high",
 };
 
 describe("WeeklyCreditsPaceCard", () => {
-  it("renders weekly pace percentages and over-plan credits", () => {
+  it("renders weekly pace percentages and separates schedule gap from forecast shortfall", () => {
     render(<WeeklyCreditsPaceCard pace={BASE_PACE} />);
 
     expect(screen.getByText("Weekly credits pace")).toBeInTheDocument();
@@ -35,7 +42,7 @@ describe("WeeklyCreditsPaceCard", () => {
     expect(screen.getByText("Pace gap")).toBeInTheDocument();
     expect(screen.getByText("50%")).toBeInTheDocument();
     expect(screen.getByText("14%")).toBeInTheDocument();
-    expect(screen.getByText("3.57x scheduled pace")).toBeInTheDocument();
+    expect(screen.getByText("3.57x recent/scheduled")).toBeInTheDocument();
     expect(screen.getByText("Recovery options")).toBeInTheDocument();
     expect(screen.getByText("Pause")).toBeInTheDocument();
     expect(screen.getByText("2d 12h until reset")).toBeInTheDocument();
@@ -43,7 +50,8 @@ describe("WeeklyCreditsPaceCard", () => {
     expect(screen.getByText("Reduce ongoing weekly-credit load by ~72%")).toBeInTheDocument();
     expect(screen.getByText("Add capacity")).toBeInTheDocument();
     expect(screen.getByText("7.1x Pro weekly pool (~8 accounts)")).toBeInTheDocument();
-    expect(screen.getByText("360K credits short before reset")).toBeInTheDocument();
+    expect(screen.getByText("360K credits behind schedule now")).toBeInTheDocument();
+    expect(screen.getByText("360K credits projected short before reset")).toBeInTheDocument();
     expect(screen.queryByText("500K")).not.toBeInTheDocument();
     expect(screen.getByText("Schedule marker")).toBeInTheDocument();
   });
@@ -54,7 +62,9 @@ describe("WeeklyCreditsPaceCard", () => {
         pace={{
           ...BASE_PACE,
           deltaPercent: -8,
-          overPlanCredits: -80_000,
+          scheduleGapCredits: 0,
+          overPlanCredits: 0,
+          projectedShortfallCredits: 0,
           pauseForBreakEvenHours: null,
           paceMultiplier: null,
           throttleToPercent: null,
@@ -62,6 +72,7 @@ describe("WeeklyCreditsPaceCard", () => {
           proAccountEquivalentToCoverOverPlan: null,
           proAccountsToCoverOverPlan: null,
           projectedMinimumRemainingCredits: 80_000,
+          forecastBurnRateCreditsPerHour: 0,
           status: "behind",
         }}
       />,
@@ -86,6 +97,32 @@ describe("WeeklyCreditsPaceCard", () => {
     );
 
     expect(screen.getByText("0.53x Pro weekly pool (~1 account)")).toBeInTheDocument();
+  });
+
+  it("shows schedule gap without recovery when recent forecast is safe", () => {
+    render(
+      <WeeklyCreditsPaceCard
+        pace={{
+          ...BASE_PACE,
+          scheduleGapCredits: 3_096,
+          overPlanCredits: 3_096,
+          projectedShortfallCredits: 0,
+          pauseForBreakEvenHours: null,
+          paceMultiplier: 0,
+          throttleToPercent: null,
+          reduceByPercent: null,
+          proAccountEquivalentToCoverOverPlan: null,
+          proAccountsToCoverOverPlan: null,
+          forecastBurnRateCreditsPerHour: 0,
+          status: "ahead",
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Pause")).not.toBeInTheDocument();
+    expect(screen.queryByText("Throttle")).not.toBeInTheDocument();
+    expect(screen.getByText("3.1K credits behind schedule now")).toBeInTheDocument();
+    expect(screen.getByText("No weekly shortfall projected at recent pace")).toBeInTheDocument();
   });
 
   it("does not render fake pace when data is unavailable", () => {

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
@@ -31,19 +31,32 @@ function statusLabel(pace: WeeklyCreditPace): string {
   if (pace.status === "on_track") return "On pace";
   const direction = pace.deltaPercent > 0 ? "above schedule" : "below schedule";
   if (pace.paceMultiplier != null && pace.paceMultiplier > 0) {
-    return `${pace.paceMultiplier.toFixed(2)}x scheduled pace`;
+    return `${pace.paceMultiplier.toFixed(2)}x recent/scheduled`;
   }
   return `${formatSignedPercent(pace.deltaPercent)} ${direction}`;
 }
 
 function scheduleGapLine(pace: WeeklyCreditPace): string {
-  if (pace.overPlanCredits > 0) {
-    return `${formatCompactNumber(pace.overPlanCredits)} credits short before reset`;
+  if (pace.scheduleGapCredits > 0) {
+    return `${formatCompactNumber(pace.scheduleGapCredits)} credits behind schedule now`;
+  }
+  if (pace.deltaPercent < 0) {
+    return `${formatSignedPercent(pace.deltaPercent)} ahead of schedule now`;
+  }
+  return "On the current linear weekly schedule";
+}
+
+function forecastLine(pace: WeeklyCreditPace): string {
+  if (pace.projectedShortfallCredits > 0) {
+    return `${formatCompactNumber(pace.projectedShortfallCredits)} credits projected short before reset`;
+  }
+  if (pace.forecastBurnRateCreditsPerHour === 0) {
+    return "No weekly shortfall projected at recent pace";
   }
   if (pace.projectedMinimumRemainingCredits != null) {
     return `${formatCompactNumber(pace.projectedMinimumRemainingCredits)} credits projected low-water mark`;
   }
-  return "Pool covers current pace through upcoming resets";
+  return "Pool covers recent pace through upcoming resets";
 }
 
 function formatDurationHours(hours: number): string {
@@ -62,7 +75,7 @@ function formatDurationHours(hours: number): string {
 }
 
 function breakEvenLine(pace: WeeklyCreditPace): string {
-  if (pace.overPlanCredits <= 0) {
+  if (pace.projectedShortfallCredits <= 0) {
     return "No pause needed";
   }
   if (pace.pauseForBreakEvenHours == null) {
@@ -106,7 +119,7 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
     pace.status === "danger" ? "bg-red-500" : pace.status === "ahead" ? "bg-amber-500" : "bg-primary";
   const throttle = throttleLine(pace);
   const proAccounts = proAccountsLine(pace);
-  const showRecovery = pace.overPlanCredits > 0 || Boolean(throttle) || Boolean(proAccounts);
+  const showRecovery = pace.projectedShortfallCredits > 0 || Boolean(throttle) || Boolean(proAccounts);
 
   return (
     <section className="rounded-xl border bg-card p-5" aria-label="Weekly credits pace">
@@ -152,6 +165,10 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
               Schedule marker
             </span>
           </div>
+          <div className="rounded-lg border bg-background/60 px-3 py-2 text-xs text-muted-foreground">
+            <p>{scheduleGapLine(pace)}</p>
+            <p className="mt-1">{forecastLine(pace)}</p>
+          </div>
         </div>
 
         {showRecovery ? (
@@ -175,7 +192,6 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
                 </div>
               ) : null}
             </div>
-            <p className="mt-2 text-muted-foreground">{scheduleGapLine(pace)}</p>
           </div>
         ) : null}
       </div>

--- a/frontend/src/features/dashboard/schemas.ts
+++ b/frontend/src/features/dashboard/schemas.ts
@@ -79,6 +79,33 @@ export const DepletionSchema = z.object({
   secondsUntilExhaustion: z.number().nullable().optional(),
 });
 
+export const WeeklyCreditPaceSchema = z.object({
+  totalFullCredits: z.number(),
+  totalActualRemainingCredits: z.number(),
+  totalExpectedRemainingCredits: z.number(),
+  actualUsedPercent: z.number(),
+  scheduledUsedPercent: z.number(),
+  deltaPercent: z.number(),
+  scheduleGapCredits: z.number(),
+  overPlanCredits: z.number(),
+  projectedShortfallCredits: z.number(),
+  pauseForBreakEvenHours: z.number().nullable(),
+  paceMultiplier: z.number().nullable(),
+  throttleToPercent: z.number().nullable(),
+  reduceByPercent: z.number().nullable(),
+  proAccountEquivalentToCoverOverPlan: z.number().nullable(),
+  proAccountsToCoverOverPlan: z.number().int().nullable(),
+  projectedDepletionHours: z.number().nullable(),
+  projectedMinimumRemainingCredits: z.number().nullable(),
+  forecastBurnRateCreditsPerHour: z.number().nullable(),
+  scheduledBurnRateCreditsPerHour: z.number(),
+  status: z.enum(["behind", "on_track", "ahead", "danger"]),
+  accountCount: z.number().int().nonnegative(),
+  staleAccountCount: z.number().int().nonnegative(),
+  inactiveAccountCount: z.number().int().nonnegative(),
+  confidence: z.enum(["high", "medium", "low"]),
+});
+
 export const DashboardOverviewSchema = z.object({
   lastSyncAt: z.string().datetime({ offset: true }).nullable(),
   timeframe: DashboardOverviewTimeframeSchema,
@@ -97,6 +124,7 @@ export const DashboardOverviewSchema = z.object({
   additionalQuotas: z.array(AccountAdditionalQuotaSchema).default([]),
   depletionPrimary: DepletionSchema.nullable().optional(),
   depletionSecondary: DepletionSchema.nullable().optional(),
+  weeklyCreditPace: WeeklyCreditPaceSchema.nullable().optional(),
 });
 
 export const RequestLogSchema = z.object({
@@ -167,3 +195,4 @@ export type RequestLogsResponse = z.infer<typeof RequestLogsResponseSchema>;
 export type RequestLogFilterOptions = z.infer<typeof RequestLogFilterOptionsSchema>;
 export type FilterState = z.infer<typeof FilterStateSchema>;
 export type Depletion = z.infer<typeof DepletionSchema>;
+export type ServerWeeklyCreditPace = z.infer<typeof WeeklyCreditPaceSchema>;

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -696,6 +696,33 @@ describe("buildDashboardView", () => {
     expect(view.weeklyCreditPace).toBe(serverPace);
   });
 
+  it("keeps an explicit null backend weekly credit pace instead of falling back locally", () => {
+    const weeklyResetAt = new Date(Date.now() + 3.5 * 24 * 60 * 60 * 1000).toISOString();
+    const overview = createDashboardOverview({
+      weeklyCreditPace: null,
+      accounts: [
+        account({
+          accountId: "acc-null-server-pace",
+          email: "null-pace@example.com",
+          usage: {
+            primaryRemainingPercent: null,
+            secondaryRemainingPercent: 50,
+          },
+          capacityCreditsSecondary: 50_400,
+          remainingCreditsSecondary: 25_200,
+          resetAtSecondary: weeklyResetAt,
+          windowMinutesSecondary: 10_080,
+        }),
+      ],
+    });
+
+    expect(buildWeeklyCreditPace(overview.accounts)).not.toBeNull();
+
+    const view = buildDashboardView(overview, createDefaultRequestLogs(), false);
+
+    expect(view.weeklyCreditPace).toBeNull();
+  });
+
   it("keeps donut totals anchored to window capacity even when displayed slices are constrained", () => {
     const overview = createDashboardOverview({
       accounts: [

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -10,6 +10,7 @@ import {
   sumRemaining,
   weeklyCreditPaceStatus,
   type RemainingItem,
+  type WeeklyCreditPace,
 } from "@/features/dashboard/utils";
 import { createDashboardOverview, createDefaultRequestLogs } from "@/test/mocks/factories";
 import { formatCompactAccountId } from "@/utils/account-identifiers";
@@ -444,7 +445,8 @@ describe("buildWeeklyCreditPace", () => {
 
     expect(pace).not.toBeNull();
     expect(pace?.totalExpectedRemainingCredits).toBeCloseTo(800_000);
-    expect(pace?.overPlanCredits).toBeCloseTo(3_950_000);
+    expect(pace?.scheduleGapCredits).toBeCloseTo(790_000);
+    expect(pace?.projectedShortfallCredits).toBeCloseTo(3_950_000);
     expect(pace?.deltaPercent).toBeCloseTo(79);
     expect(pace?.pauseForBreakEvenHours).toBeCloseTo(134.06);
     expect(pace?.paceMultiplier).toBeCloseTo(4.95);
@@ -469,9 +471,10 @@ describe("buildWeeklyCreditPace", () => {
     expect(pace?.totalExpectedRemainingCredits).toBeCloseTo(100_000);
     expect(pace?.scheduledUsedPercent).toBeCloseTo(50);
     expect(pace?.actualUsedPercent).toBeCloseTo(50);
-    expect(pace?.overPlanCredits).toBeGreaterThan(0);
+    expect(pace?.scheduleGapCredits).toBeCloseTo(0);
+    expect(pace?.projectedShortfallCredits).toBeGreaterThan(0);
     expect(pace?.pauseForBreakEvenHours).toBeCloseTo(90.72);
-    expect(pace?.paceMultiplier).toBeCloseTo(1);
+    expect(pace?.paceMultiplier).toBeCloseTo(2.78);
     expect(pace?.proAccountEquivalentToCoverOverPlan).toBeGreaterThan(0);
     expect(pace?.proAccountsToCoverOverPlan).toBe(6);
     expect(pace?.status).toBe("danger");
@@ -516,7 +519,8 @@ describe("buildWeeklyCreditPace", () => {
     );
 
     expect(pace).not.toBeNull();
-    expect(pace?.overPlanCredits).toBeCloseTo(59_999.01);
+    expect(pace?.scheduleGapCredits).toBeCloseTo(30_000.02);
+    expect(pace?.projectedShortfallCredits).toBeCloseTo(59_999.01);
     expect(pace?.projectedDepletionHours).toBeLessThan(40);
     expect(pace?.proAccountEquivalentToCoverOverPlan).toBeGreaterThan(1);
     expect(pace?.proAccountsToCoverOverPlan).toBe(2);
@@ -533,10 +537,11 @@ describe("buildWeeklyCreditPace", () => {
     );
 
     expect(pace).not.toBeNull();
-    expect(pace?.overPlanCredits).toBeCloseTo(900_000);
+    expect(pace?.scheduleGapCredits).toBeCloseTo(100_000);
+    expect(pace?.projectedShortfallCredits).toBeCloseTo(900_000);
     expect(pace?.pauseForBreakEvenHours).toBeGreaterThan(0);
     expect(pace?.pauseForBreakEvenHours).toBeCloseTo(136.08);
-    expect(pace?.paceMultiplier).toBeCloseTo(2);
+    expect(pace?.paceMultiplier).toBeCloseTo(5.56);
     expect(pace?.throttleToPercent).toBeCloseTo(10);
     expect(pace?.reduceByPercent).toBeCloseTo(90);
     expect(pace?.proAccountEquivalentToCoverOverPlan).toBeCloseTo(17.86);
@@ -555,7 +560,8 @@ describe("buildWeeklyCreditPace", () => {
     );
 
     expect(pace).not.toBeNull();
-    expect(pace?.overPlanCredits).toBeCloseTo(99_999.01);
+    expect(pace?.scheduleGapCredits).toBeCloseTo(50_000.02);
+    expect(pace?.projectedShortfallCredits).toBeCloseTo(99_999.01);
     expect(pace?.pauseForBreakEvenHours).toBeCloseTo(84);
     expect(pace?.throttleToPercent).toBeCloseTo(0.002);
     expect(pace?.projectedDepletionHours).toBeCloseTo(0);
@@ -618,7 +624,8 @@ describe("buildWeeklyCreditPace", () => {
     expect(pace).not.toBeNull();
     expect(pace?.accountCount).toBe(5);
     expect(pace?.totalActualRemainingCredits).toBeCloseTo(58_438.8);
-    expect(pace?.overPlanCredits).toBeCloseTo(20_510.96);
+    expect(pace?.scheduleGapCredits).toBeCloseTo(17_226.02);
+    expect(pace?.projectedShortfallCredits).toBeCloseTo(20_510.96);
     expect(pace?.pauseForBreakEvenHours).toBeGreaterThan(0);
     expect(pace?.paceMultiplier).toBeGreaterThan(1);
     expect(pace?.throttleToPercent).toBeGreaterThanOrEqual(0);
@@ -644,6 +651,51 @@ describe("buildWeeklyCreditPace", () => {
 });
 
 describe("buildDashboardView", () => {
+  it("prefers backend weekly credit pace when the overview provides it", () => {
+    const serverPace: WeeklyCreditPace = {
+      totalFullCredits: 50_400,
+      totalActualRemainingCredits: 38_304,
+      totalExpectedRemainingCredits: 41_904,
+      actualUsedPercent: 24,
+      scheduledUsedPercent: 16.86,
+      deltaPercent: 7.14,
+      scheduleGapCredits: 3_600,
+      overPlanCredits: 3_600,
+      projectedShortfallCredits: 0,
+      pauseForBreakEvenHours: null,
+      paceMultiplier: 0,
+      throttleToPercent: null,
+      reduceByPercent: null,
+      proAccountEquivalentToCoverOverPlan: null,
+      proAccountsToCoverOverPlan: null,
+      projectedDepletionHours: null,
+      projectedMinimumRemainingCredits: 38_304,
+      forecastBurnRateCreditsPerHour: 0,
+      scheduledBurnRateCreditsPerHour: 300,
+      status: "ahead",
+      accountCount: 1,
+      staleAccountCount: 0,
+      inactiveAccountCount: 0,
+      confidence: "high",
+    };
+    const overview = createDashboardOverview({
+      accounts: [
+        account({
+          accountId: "acc-server-pace",
+          email: "pace@example.com",
+          capacityCreditsSecondary: 50_400,
+          remainingCreditsSecondary: 50_400,
+          resetAtSecondary: "2026-01-14T12:00:00Z",
+          windowMinutesSecondary: 10_080,
+        }),
+      ],
+    });
+
+    const view = buildDashboardView({ ...overview, weeklyCreditPace: serverPace }, createDefaultRequestLogs(), false);
+
+    expect(view.weeklyCreditPace).toBe(serverPace);
+  });
+
   it("keeps donut totals anchored to window capacity even when displayed slices are constrained", () => {
     const overview = createDashboardOverview({
       accounts: [

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -604,6 +604,9 @@ export function buildDashboardView(
     requestLogs,
     safeLinePrimary: buildDepletionView(overview.depletionPrimary),
     safeLineSecondary: buildDepletionView(overview.depletionSecondary),
-    weeklyCreditPace: overview.weeklyCreditPace ?? buildWeeklyCreditPace(overview.accounts),
+    weeklyCreditPace:
+      overview.weeklyCreditPace !== undefined
+        ? overview.weeklyCreditPace
+        : buildWeeklyCreditPace(overview.accounts),
   };
 }

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -53,7 +53,10 @@ export type WeeklyCreditPace = {
   actualUsedPercent: number;
   scheduledUsedPercent: number;
   deltaPercent: number;
+  scheduleGapCredits: number;
+  /** Legacy alias for scheduleGapCredits while older components migrate. */
   overPlanCredits: number;
+  projectedShortfallCredits: number;
   pauseForBreakEvenHours: number | null;
   paceMultiplier: number | null;
   throttleToPercent: number | null;
@@ -62,8 +65,13 @@ export type WeeklyCreditPace = {
   proAccountsToCoverOverPlan: number | null;
   projectedDepletionHours: number | null;
   projectedMinimumRemainingCredits: number | null;
+  forecastBurnRateCreditsPerHour: number | null;
+  scheduledBurnRateCreditsPerHour: number;
   status: WeeklyCreditPaceStatus;
   accountCount: number;
+  staleAccountCount: number;
+  inactiveAccountCount: number;
+  confidence: "high" | "medium" | "low";
 };
 
 export type DashboardView = {
@@ -456,17 +464,25 @@ export function buildWeeklyCreditPace(
   const actualUsedPercent = (100 * (totalFullCredits - totalActualRemainingCredits)) / totalFullCredits;
   const scheduledUsedPercent = (100 * (totalFullCredits - totalExpectedRemainingCredits)) / totalFullCredits;
   const deltaPercent = actualUsedPercent - scheduledUsedPercent;
+  const scheduleGapCredits = Math.max(0, totalExpectedRemainingCredits - totalActualRemainingCredits);
+  const scheduledBurnRateCreditsPerHour = weeklyAccounts.reduce(
+    (sum, account) => sum + (account.fullCredits / account.windowMs) * 3_600_000,
+    0,
+  );
   const projection = buildWeeklyPoolProjection(weeklyAccounts, nowMs);
-  const overPlanCredits = projection?.projectedShortfallCredits ?? 0;
+  const projectedShortfallCredits = projection?.projectedShortfallCredits ?? 0;
   const pauseForBreakEvenHours =
-    projection && overPlanCredits > 0 && projection.burnRateCreditsPerMs > 0
-      ? overPlanCredits / projection.burnRateCreditsPerMs / 3_600_000
+    projection && projectedShortfallCredits > 0 && projection.burnRateCreditsPerMs > 0
+      ? projectedShortfallCredits / projection.burnRateCreditsPerMs / 3_600_000
       : null;
-  const paceMultiplier = overPlanCredits > 0 && scheduledUsedPercent > 0 ? actualUsedPercent / scheduledUsedPercent : null;
+  const paceMultiplier =
+    projection && projectedShortfallCredits > 0 && projection.burnRateCreditsPerMs > 0 && scheduledBurnRateCreditsPerHour > 0
+      ? (projection.burnRateCreditsPerMs * 3_600_000) / scheduledBurnRateCreditsPerHour
+      : null;
   const throttleToPercent =
-    projection && overPlanCredits > 0 && projection.firstReplenishmentWaitMs && projection.burnRateCreditsPerMs > 0
+    projection && projectedShortfallCredits > 0 && projection.firstReplenishmentWaitMs && projection.burnRateCreditsPerMs > 0
       ? clamp(
-          ((projection.firstReplenishmentWaitMs * projection.burnRateCreditsPerMs - overPlanCredits) /
+          ((projection.firstReplenishmentWaitMs * projection.burnRateCreditsPerMs - projectedShortfallCredits) /
             (projection.firstReplenishmentWaitMs * projection.burnRateCreditsPerMs)) *
             100,
           0,
@@ -475,9 +491,9 @@ export function buildWeeklyCreditPace(
       : null;
   const reduceByPercent = throttleToPercent != null ? 100 - throttleToPercent : null;
   const proAccountEquivalentToCoverOverPlan =
-    overPlanCredits > 0 ? overPlanCredits / PRO_WEEKLY_CAPACITY_CREDITS : null;
+    projectedShortfallCredits > 0 ? projectedShortfallCredits / PRO_WEEKLY_CAPACITY_CREDITS : null;
   const proAccountsToCoverOverPlan =
-    overPlanCredits > 0 ? Math.ceil(overPlanCredits / PRO_WEEKLY_CAPACITY_CREDITS) : null;
+    projectedShortfallCredits > 0 ? Math.ceil(projectedShortfallCredits / PRO_WEEKLY_CAPACITY_CREDITS) : null;
 
   return {
     totalFullCredits,
@@ -486,7 +502,9 @@ export function buildWeeklyCreditPace(
     actualUsedPercent,
     scheduledUsedPercent,
     deltaPercent,
-    overPlanCredits,
+    scheduleGapCredits,
+    overPlanCredits: scheduleGapCredits,
+    projectedShortfallCredits,
     pauseForBreakEvenHours,
     paceMultiplier,
     throttleToPercent,
@@ -495,8 +513,13 @@ export function buildWeeklyCreditPace(
     proAccountsToCoverOverPlan,
     projectedDepletionHours: projection?.projectedDepletionHours ?? null,
     projectedMinimumRemainingCredits: projection?.projectedMinimumRemainingCredits ?? null,
-    status: weeklyCreditPaceStatus(deltaPercent, overPlanCredits),
+    forecastBurnRateCreditsPerHour: projection ? projection.burnRateCreditsPerMs * 3_600_000 : null,
+    scheduledBurnRateCreditsPerHour,
+    status: weeklyCreditPaceStatus(deltaPercent, projectedShortfallCredits),
     accountCount,
+    staleAccountCount: 0,
+    inactiveAccountCount: 0,
+    confidence: "low",
   };
 }
 
@@ -581,6 +604,6 @@ export function buildDashboardView(
     requestLogs,
     safeLinePrimary: buildDepletionView(overview.depletionPrimary),
     safeLineSecondary: buildDepletionView(overview.depletionSecondary),
-    weeklyCreditPace: buildWeeklyCreditPace(overview.accounts),
+    weeklyCreditPace: overview.weeklyCreditPace ?? buildWeeklyCreditPace(overview.accounts),
   };
 }

--- a/openspec/changes/fix-weekly-credit-pace/proposal.md
+++ b/openspec/changes/fix-weekly-credit-pace/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+The dashboard weekly credits pace card currently mixes two different concepts: current linear-schedule variance and a future shortfall forecast. It also derives forecast burn from the average consumed across the entire weekly window, so old bursts dominate the card even when all active accounts have fresh data and recent load is low. Deactivated or stale usage rows can also remain in the frontend input and be advanced into a future reset cycle, producing false plan and recovery numbers.
+
+## What Changes
+
+- Move weekly credits pace calculation to the dashboard backend where account status, usage freshness, and usage history are available together.
+- Include only active accounts with fresh weekly usage samples in the pace pool; stale or inactive rows are excluded and counted for operator context.
+- Keep the current schedule comparison as a separate `scheduleGapCredits` value.
+- Compute forecast/recovery from recent weekly usage slope (EWMA over history), not the full-window cumulative average.
+- Surface forecast burn rate, scheduled burn rate, projected shortfall, and confidence metadata so the UI can label the card accurately.
+- Keep frontend fallback calculation for older responses, but prefer the server-provided weekly pace contract.
+
+## Impact
+
+- Dashboard `/api/dashboard/overview` gains an optional `weeklyCreditPace` object.
+- The weekly pace card copy changes from ambiguous future-shortfall wording to explicit schedule-gap and forecast wording.
+- No routing behavior changes.

--- a/openspec/changes/fix-weekly-credit-pace/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-weekly-credit-pace/specs/frontend-architecture/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard weekly credits pace
+
+The dashboard SHALL show weekly quota pace when account weekly capacity credits, remaining credits, reset time, and window length are available. The pace calculation MUST use credit totals rather than averaging per-account percentages, because weekly ChatGPT quota credits are not the same unit as raw request tokens. The dashboard MUST prefer the backend-provided `weeklyCreditPace` object from `GET /api/dashboard/overview` when present, and MAY fall back to a local calculation only for older responses that do not include that field.
+
+#### Scenario: Weekly credits pace uses account reset deadlines
+
+- **WHEN** multiple accounts have weekly quota data with different `resetAtSecondary` values
+- **THEN** the system computes each account's expected remaining weekly credits from that account's own reset time and window length before summing totals
+
+#### Scenario: Weekly credits pace excludes inactive or stale usage rows
+
+- **WHEN** an account is not active or its latest weekly usage sample is older than the freshness window derived from the usage refresh interval
+- **THEN** the account is not included in weekly pace totals or forecasts
+- **AND** the response reports the excluded stale account count separately from the included account count
+
+#### Scenario: Current schedule gap is separate from forecast shortfall
+
+- **WHEN** actual remaining weekly credits are lower than scheduled remaining weekly credits
+- **THEN** the response reports `scheduleGapCredits` for the current deficit against the linear schedule
+- **AND** the response reports `projectedShortfallCredits` only for a future shortfall forecast based on recent burn
+- **AND** the dashboard labels the two concepts separately
+
+#### Scenario: Forecast burn uses recent weekly usage slope
+
+- **WHEN** an account has high cumulative weekly usage from earlier in the window but no recent increase in weekly used percent
+- **THEN** the projected shortfall forecast is based on the recent slope and does not assume the earlier full-window average continues
+
+#### Scenario: Near-reset depletion is not a false alarm
+
+- **WHEN** an account has consumed 99% of its weekly quota and 99% of its weekly window has elapsed
+- **THEN** the weekly pace treats that account as on pace rather than over plan
+
+#### Scenario: Missing weekly credit data is omitted
+
+- **WHEN** an account is missing weekly capacity credits, remaining credits, reset time, or window length
+- **THEN** that account is omitted from weekly pace calculation
+
+#### Scenario: No valid weekly credit data hides pace
+
+- **WHEN** no account has complete, active, fresh weekly credits pace data
+- **THEN** the dashboard does not render a fake weekly pace value

--- a/openspec/changes/fix-weekly-credit-pace/tasks.md
+++ b/openspec/changes/fix-weekly-credit-pace/tasks.md
@@ -1,0 +1,23 @@
+## 1. Contract
+
+- [x] 1.1 Add backend dashboard `weeklyCreditPace` response schema fields for schedule gap, recent-rate forecast, freshness exclusions, and confidence.
+- [x] 1.2 Add frontend zod/type support for the optional server-provided pace object.
+
+## 2. Calculation
+
+- [x] 2.1 Compute weekly pace server-side from active accounts only.
+- [x] 2.2 Exclude weekly usage samples whose latest `recorded_at` is stale relative to the configured usage refresh interval.
+- [x] 2.3 Compute current linear schedule gap separately from projected shortfall.
+- [x] 2.4 Use recent usage history/EWMA for forecast burn instead of full-window cumulative average.
+
+## 3. UI
+
+- [x] 3.1 Prefer backend `weeklyCreditPace` when present and keep a frontend fallback for older payloads.
+- [x] 3.2 Update card labels so current schedule gap and future forecast are not conflated.
+
+## 4. Verification
+
+- [x] 4.1 Backend integration tests cover inactive/stale exclusion and recent low-burn forecast.
+- [x] 4.2 Frontend unit/component tests cover backend pace preference and updated labels.
+- [x] 4.3 Run targeted backend and frontend tests.
+- [x] 4.4 Run local lint/type/spec validation where available.

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import time
 from datetime import datetime, timedelta
 
 import pytest
@@ -9,6 +11,8 @@ from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
+from app.modules.accounts.schemas import AccountSummary
+from app.modules.dashboard.weekly_pace import _weekly_timing
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import UsageRepository
 
@@ -33,6 +37,42 @@ def _make_account(
         status=status,
         deactivation_reason=None,
     )
+
+
+def test_weekly_credit_pace_timing_treats_naive_reset_as_utc():
+    if not hasattr(time, "tzset"):
+        pytest.skip("tzset is required to simulate non-UTC local time")
+
+    original_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Asia/Seoul"
+    time.tzset()
+    try:
+        fixed_now = datetime(2026, 5, 18, 12, 0, 0)
+        reset_at = fixed_now + timedelta(days=4)
+        now_ms = naive_utc_to_epoch(fixed_now) * 1000.0
+        timing = _weekly_timing(
+            AccountSummary(
+                account_id="acc_tz",
+                email="tz@example.com",
+                display_name="tz@example.com",
+                plan_type="pro",
+                status="active",
+                reset_at_secondary=reset_at,
+                window_minutes_secondary=10080,
+                capacity_credits_secondary=50_400.0,
+                remaining_credits_secondary=40_320.0,
+            ),
+            now_ms,
+        )
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()
+
+    assert timing is not None
+    assert timing[2] == pytest.approx(naive_utc_to_epoch(reset_at) * 1000.0)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -15,7 +15,12 @@ from app.modules.usage.repository import UsageRepository
 pytestmark = pytest.mark.integration
 
 
-def _make_account(account_id: str, email: str, plan_type: str = "plus") -> Account:
+def _make_account(
+    account_id: str,
+    email: str,
+    plan_type: str = "plus",
+    status: AccountStatus = AccountStatus.ACTIVE,
+) -> Account:
     encryptor = TokenEncryptor()
     return Account(
         id=account_id,
@@ -25,7 +30,7 @@ def _make_account(account_id: str, email: str, plan_type: str = "plus") -> Accou
         refresh_token_encrypted=encryptor.encrypt("refresh"),
         id_token_encrypted=encryptor.encrypt("id"),
         last_refresh=utcnow(),
-        status=AccountStatus.ACTIVE,
+        status=status,
         deactivation_reason=None,
     )
 
@@ -223,6 +228,127 @@ async def test_dashboard_overview_counts_prolite_capacity(async_client, db_setup
     assert payload["summary"]["primaryWindow"]["remainingCredits"] == pytest.approx(1125.0)
     assert payload["summary"]["secondaryWindow"]["capacityCredits"] == pytest.approx(37800.0)
     assert payload["summary"]["secondaryWindow"]["remainingCredits"] == pytest.approx(37800.0)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_weekly_credit_pace_excludes_inactive_and_stale_accounts(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fixed_now = datetime(2026, 5, 18, 12, 0, 0)
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: fixed_now)
+    reset_at = int(naive_utc_to_epoch(fixed_now + timedelta(days=4)))
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_active_fresh", "fresh@example.com", plan_type="pro"))
+        await accounts_repo.upsert(_make_account("acc_active_stale", "stale@example.com", plan_type="pro"))
+        await accounts_repo.upsert(
+            _make_account(
+                "acc_inactive_fresh",
+                "inactive@example.com",
+                plan_type="pro",
+                status=AccountStatus.DEACTIVATED,
+            )
+        )
+
+        await usage_repo.add_entry(
+            "acc_active_fresh",
+            20.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=reset_at,
+            recorded_at=fixed_now - timedelta(minutes=1),
+        )
+        await usage_repo.add_entry(
+            "acc_active_stale",
+            80.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=reset_at,
+            recorded_at=fixed_now - timedelta(minutes=10),
+        )
+        await usage_repo.add_entry(
+            "acc_inactive_fresh",
+            90.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=reset_at,
+            recorded_at=fixed_now - timedelta(minutes=1),
+        )
+
+    response = await async_client.get("/api/dashboard/overview")
+    assert response.status_code == 200
+    payload = response.json()
+
+    pace = payload["weeklyCreditPace"]
+    assert pace["accountCount"] == 1
+    assert pace["staleAccountCount"] == 1
+    assert pace["inactiveAccountCount"] == 1
+    assert pace["totalFullCredits"] == pytest.approx(50_400.0)
+    assert pace["actualUsedPercent"] == pytest.approx(20.0)
+    assert pace["scheduledUsedPercent"] == pytest.approx(42.857, abs=0.01)
+    assert pace["scheduleGapCredits"] == 0
+    assert pace["status"] == "behind"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_weekly_credit_pace_forecast_uses_recent_slope_not_full_window_average(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fixed_now = datetime(2026, 5, 18, 12, 0, 0)
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: fixed_now)
+    reset_at = int(naive_utc_to_epoch(fixed_now + timedelta(days=5, hours=18)))
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_recent_flat", "flat@example.com", plan_type="pro"))
+        await usage_repo.add_entry(
+            "acc_recent_flat",
+            0.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=reset_at,
+            recorded_at=fixed_now - timedelta(days=1),
+        )
+        await usage_repo.add_entry(
+            "acc_recent_flat",
+            24.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=reset_at,
+            recorded_at=fixed_now - timedelta(hours=3),
+        )
+        await usage_repo.add_entry(
+            "acc_recent_flat",
+            24.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=reset_at,
+            recorded_at=fixed_now - timedelta(minutes=1),
+        )
+
+    response = await async_client.get("/api/dashboard/overview")
+    assert response.status_code == 200
+    payload = response.json()
+
+    pace = payload["weeklyCreditPace"]
+    assert pace["accountCount"] == 1
+    assert pace["actualUsedPercent"] == pytest.approx(24.0)
+    assert pace["scheduledUsedPercent"] == pytest.approx(17.857, abs=0.01)
+    assert pace["scheduleGapCredits"] == pytest.approx(3_096.0, abs=1.0)
+    assert pace["projectedShortfallCredits"] == 0
+    assert pace["forecastBurnRateCreditsPerHour"] == pytest.approx(0.0)
+    assert pace["paceMultiplier"] == pytest.approx(0.0)
+    assert pace["pauseForBreakEvenHours"] is None
+    assert pace["status"] == "ahead"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.17.0"
+version = "1.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Move weekly credits pace calculation to the dashboard backend so it can use account status, freshness, and usage history together.
- Exclude inactive and stale weekly usage rows from pace totals, while surfacing excluded counts and confidence.
- Split current schedule gap from recent-rate forecast shortfall, and update the card copy/recovery display accordingly.
- Keep a frontend fallback for older overview payloads and fix the OAuth manual callback lint error uncovered by the local lint run.

## Test Plan
- [x] `uv run pytest tests/integration/test_dashboard_overview.py tests/unit -q`
- [x] `uv run ruff check app tests`
- [x] `uv run ty check app tests`
- [x] `npm run typecheck`
- [x] `npm run lint` (passes with existing warnings in `account-multi-select.tsx`)
- [x] `npm run test -- src/features/dashboard/utils.test.ts src/features/dashboard/components/weekly-credits-pace-card.test.tsx`
- [x] `openspec validate fix-weekly-credit-pace --strict`
- [x] `openspec validate --specs`
