### PR TITLE
fix(proxy): keep idle timeout classification after scheduler jitter

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1910,6 +1910,7 @@ async def stream_responses(
 
     seen_terminal = False
     status_code: int | None = None
+    response_started_at: float | None = None
     error_code: str | None = None
     error_message: str | None = None
     client_session = session or get_http_client().session
@@ -1957,7 +1958,7 @@ async def stream_responses(
         current_headers: Mapping[str, str],
         current_timeout: aiohttp.ClientTimeout,
     ) -> AsyncIterator[str]:
-        nonlocal status_code, error_code, error_message, seen_terminal
+        nonlocal status_code, response_started_at, error_code, error_message, seen_terminal
 
         async with _service_circuit_breaker_context(
             client_session.post(
@@ -1970,6 +1971,7 @@ async def stream_responses(
             account_id=account_id,
         ) as resp:
             status_code = resp.status
+            response_started_at = time.monotonic()
             if resp.status >= 400:
                 if raise_for_status:
                     error_payload = await _error_payload_from_response(resp)
@@ -2194,11 +2196,14 @@ async def stream_responses(
                 response_failed_event("upstream_unavailable", error_message, response_id=get_request_id()),
             )
             return
-        elapsed_seconds = max(0.0, time.monotonic() - started_at)
+        now = time.monotonic()
+        body_elapsed_seconds = (
+            max(0.0, now - response_started_at) if response_started_at is not None else None
+        )
         if (
-            status_code is not None
+            body_elapsed_seconds is not None
             and effective_idle_timeout <= (request_total_timeout or effective_idle_timeout)
-            and elapsed_seconds >= effective_idle_timeout
+            and body_elapsed_seconds >= effective_idle_timeout
         ):
             error_code = "stream_idle_timeout"
             error_message = "Upstream stream idle timeout"

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2197,9 +2197,7 @@ async def stream_responses(
             )
             return
         now = time.monotonic()
-        body_elapsed_seconds = (
-            max(0.0, now - response_started_at) if response_started_at is not None else None
-        )
+        body_elapsed_seconds = max(0.0, now - response_started_at) if response_started_at is not None else None
         if (
             body_elapsed_seconds is not None
             and effective_idle_timeout <= (request_total_timeout or effective_idle_timeout)

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2194,6 +2194,21 @@ async def stream_responses(
                 response_failed_event("upstream_unavailable", error_message, response_id=get_request_id()),
             )
             return
+        elapsed_seconds = max(0.0, time.monotonic() - started_at)
+        if (
+            effective_idle_timeout <= (request_total_timeout or effective_idle_timeout)
+            and elapsed_seconds >= effective_idle_timeout
+        ):
+            error_code = "stream_idle_timeout"
+            error_message = "Upstream stream idle timeout"
+            yield format_sse_event(
+                response_failed_event(
+                    "stream_idle_timeout",
+                    "Upstream stream idle timeout",
+                    response_id=get_request_id(),
+                ),
+            )
+            return
         error_code = "upstream_request_timeout"
         error_message = "Proxy request budget exhausted"
         yield format_sse_event(

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1910,7 +1910,7 @@ async def stream_responses(
 
     seen_terminal = False
     status_code: int | None = None
-    response_started_at: float | None = None
+    last_stream_activity_at: float | None = None
     error_code: str | None = None
     error_message: str | None = None
     client_session = session or get_http_client().session
@@ -1958,7 +1958,7 @@ async def stream_responses(
         current_headers: Mapping[str, str],
         current_timeout: aiohttp.ClientTimeout,
     ) -> AsyncIterator[str]:
-        nonlocal status_code, response_started_at, error_code, error_message, seen_terminal
+        nonlocal status_code, last_stream_activity_at, error_code, error_message, seen_terminal
 
         async with _service_circuit_breaker_context(
             client_session.post(
@@ -1971,7 +1971,7 @@ async def stream_responses(
             account_id=account_id,
         ) as resp:
             status_code = resp.status
-            response_started_at = time.monotonic()
+            last_stream_activity_at = time.monotonic()
             if resp.status >= 400:
                 if raise_for_status:
                     error_payload = await _error_payload_from_response(resp)
@@ -2011,6 +2011,7 @@ async def stream_responses(
                 effective_idle_timeout,
                 settings.max_sse_event_bytes,
             ):
+                last_stream_activity_at = time.monotonic()
                 event_block = _normalize_sse_event_block(event_block)
                 event = parse_sse_event(event_block)
                 if event:
@@ -2197,11 +2198,11 @@ async def stream_responses(
             )
             return
         now = time.monotonic()
-        body_elapsed_seconds = max(0.0, now - response_started_at) if response_started_at is not None else None
+        idle_elapsed_seconds = max(0.0, now - last_stream_activity_at) if last_stream_activity_at is not None else None
         if (
-            body_elapsed_seconds is not None
+            idle_elapsed_seconds is not None
             and effective_idle_timeout <= (request_total_timeout or effective_idle_timeout)
-            and body_elapsed_seconds >= effective_idle_timeout
+            and idle_elapsed_seconds >= effective_idle_timeout
         ):
             error_code = "stream_idle_timeout"
             error_message = "Upstream stream idle timeout"

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2196,7 +2196,8 @@ async def stream_responses(
             return
         elapsed_seconds = max(0.0, time.monotonic() - started_at)
         if (
-            effective_idle_timeout <= (request_total_timeout or effective_idle_timeout)
+            status_code is not None
+            and effective_idle_timeout <= (request_total_timeout or effective_idle_timeout)
             and elapsed_seconds >= effective_idle_timeout
         ):
             error_code = "stream_idle_timeout"

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2608,6 +2608,9 @@ async def _normalize_public_responses_stream(
             if terminal_seen:
                 yield event_block
             continue
+        if _looks_like_sse_comment_block(event_block):
+            yield event_block
+            continue
         payload = _parse_sse_payload(event_block)
         if payload is None:
             if _looks_like_sse_data_block(event_block):
@@ -2973,6 +2976,12 @@ def _extract_public_output_item_text(item: Mapping[str, JsonValue]) -> str | Non
 
 def _looks_like_sse_data_block(event_block: str) -> bool:
     return "data:" in event_block
+
+
+def _looks_like_sse_comment_block(event_block: str) -> bool:
+    return bool(event_block.strip()) and all(
+        not line.strip() or line.lstrip().startswith(":") for line in event_block.splitlines()
+    )
 
 
 def _public_contract_error_message(kind: str) -> str:

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -294,6 +294,12 @@ def _owner_forward_receive_timeout(
 ) -> _OwnerForwardReceiveTimeout:
     idle_timeout_seconds = max(0.001, stream_idle_timeout_seconds)
     remaining_budget = _remaining_budget_seconds(request_started_at + proxy_request_budget_seconds)
+    if idle_timeout_seconds == max(0.001, proxy_request_budget_seconds):
+        return _OwnerForwardReceiveTimeout(
+            timeout_seconds=remaining_budget,
+            error_code="stream_idle_timeout",
+            error_message="Upstream stream idle timeout",
+        )
     if remaining_budget <= 0:
         return _OwnerForwardReceiveTimeout(
             timeout_seconds=0.0,

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -294,7 +294,14 @@ def _owner_forward_receive_timeout(
 ) -> _OwnerForwardReceiveTimeout:
     idle_timeout_seconds = max(0.001, stream_idle_timeout_seconds)
     remaining_budget = _remaining_budget_seconds(request_started_at + proxy_request_budget_seconds)
-    if idle_timeout_seconds == max(0.001, proxy_request_budget_seconds):
+    idle_timeout_matches_request_budget = idle_timeout_seconds == max(0.001, proxy_request_budget_seconds)
+    if remaining_budget <= 0 and idle_timeout_matches_request_budget:
+        return _OwnerForwardReceiveTimeout(
+            timeout_seconds=0.0,
+            error_code="stream_idle_timeout",
+            error_message="Upstream stream idle timeout",
+        )
+    if idle_timeout_matches_request_budget and remaining_budget >= idle_timeout_seconds:
         return _OwnerForwardReceiveTimeout(
             timeout_seconds=remaining_budget,
             error_code="stream_idle_timeout",

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11472,7 +11472,7 @@ def _websocket_receive_timeout_for_pending_requests(
             error_code="stream_idle_timeout",
             error_message="Upstream stream idle timeout",
         )
-    if remaining_budget > 0 and idle_timeout_matches_request_budget:
+    if idle_timeout_matches_request_budget and remaining_budget >= idle_timeout_seconds:
         return _WebSocketReceiveTimeout(
             timeout_seconds=remaining_budget,
             error_code="stream_idle_timeout",

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1347,7 +1347,29 @@ class ProxyService:
             assert event_queue is not None
             yielded_any = False
             while True:
-                event_block = await event_queue.get()
+                keepalive_interval = getattr(get_settings(), "sse_keepalive_interval_seconds", 10.0)
+                if keepalive_interval > 0:
+                    try:
+                        event_block = await asyncio.wait_for(event_queue.get(), timeout=keepalive_interval)
+                    except asyncio.TimeoutError:
+                        if request_state.response_id:
+                            yield format_sse_event(
+                                cast(
+                                    Mapping[str, JsonValue],
+                                    {
+                                        "type": "response.in_progress",
+                                        "response": {
+                                            "id": request_state.response_id,
+                                            "status": "in_progress",
+                                        },
+                                    },
+                                )
+                            )
+                        else:
+                            yield ": keepalive\n\n"
+                        continue
+                else:
+                    event_block = await event_queue.get()
                 if event_block is None:
                     break
                 block_payload = parse_sse_data_json(event_block)
@@ -11431,8 +11453,22 @@ def _websocket_receive_timeout_for_pending_requests(
 
     idle_timeout_seconds = max(0.001, stream_idle_timeout_seconds)
     oldest_started_at = min(started_ats)
-    remaining_budget = _remaining_budget_seconds(oldest_started_at + proxy_request_budget_seconds)
+    budget_deadline = oldest_started_at + proxy_request_budget_seconds
+    remaining_budget = _remaining_budget_seconds(budget_deadline)
+    idle_timeout_matches_request_budget = idle_timeout_seconds == max(0.001, proxy_request_budget_seconds)
 
+    if remaining_budget <= 0 and idle_timeout_matches_request_budget:
+        return _WebSocketReceiveTimeout(
+            timeout_seconds=0.0,
+            error_code="stream_idle_timeout",
+            error_message="Upstream stream idle timeout",
+        )
+    if remaining_budget > 0 and idle_timeout_matches_request_budget:
+        return _WebSocketReceiveTimeout(
+            timeout_seconds=remaining_budget,
+            error_code="stream_idle_timeout",
+            error_message="Upstream stream idle timeout",
+        )
     if remaining_budget <= 0:
         return _WebSocketReceiveTimeout(
             timeout_seconds=0.0,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1361,6 +1361,7 @@ class ProxyService:
                         event_block = await asyncio.wait_for(event_queue.get(), timeout=wait_timeout)
                     except asyncio.TimeoutError:
                         keepalive_sent = True
+                        yielded_any = True
                         if request_state.response_id:
                             yield format_sse_event(
                                 cast(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -205,6 +205,10 @@ _TaskResultT = TypeVar("_TaskResultT")
 _ResponsesPayloadT = TypeVar("_ResponsesPayloadT", ResponsesRequest, ResponsesCompactRequest)
 _DOWNSTREAM_WEBSOCKET_IDLE_CLOSE_REASON = "Idle downstream websocket timeout"
 _DOWNSTREAM_WEBSOCKET_RECEIVE_POLL_SECONDS = 1.0
+# Keep the first HTTP bridge liveness frame behind the API layer's startup
+# error probe window. If a keepalive becomes the first yielded chunk, the HTTP
+# status is committed as 200 and startup ProxyResponseError handling is masked.
+_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS = 0.5
 
 
 async def _await_cancelled_task(
@@ -1346,12 +1350,17 @@ class ProxyService:
             event_queue = request_state.event_queue
             assert event_queue is not None
             yielded_any = False
+            keepalive_sent = False
             while True:
                 keepalive_interval = getattr(get_settings(), "sse_keepalive_interval_seconds", 10.0)
                 if keepalive_interval > 0:
+                    wait_timeout = keepalive_interval
+                    if not yielded_any and not keepalive_sent:
+                        wait_timeout = max(wait_timeout, _HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS)
                     try:
-                        event_block = await asyncio.wait_for(event_queue.get(), timeout=keepalive_interval)
+                        event_block = await asyncio.wait_for(event_queue.get(), timeout=wait_timeout)
                     except asyncio.TimeoutError:
+                        keepalive_sent = True
                         if request_state.response_id:
                             yield format_sse_event(
                                 cast(

--- a/openspec/changes/fix-upstream-terminal-timeouts/proposal.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Long-running Codex Responses turns can hit two deadlines at nearly the same time: the upstream stream idle timeout and the overall proxy request budget. The defaults intentionally set both to 600 seconds. When the event loop wakes a few milliseconds after that shared deadline, the proxy was classifying the terminal condition as `upstream_request_timeout` in some paths even though the configured idle watchdog was the deadline operators expected to see.
+
+The websocket and HTTP bridge paths add a second failure mode: they can multiplex multiple pending turns over one upstream session. Treating an equal idle/budget tie as a fail-all idle timeout can close younger sibling turns that still have their own request budget remaining. That produces misleading `HTTP bridge session closed before response.completed` failures on unrelated in-flight requests.
+
+HTTP bridge responses also need liveness frames while a request is waiting on the upstream event queue; otherwise downstream SSE clients can disconnect before the terminal upstream frame arrives.
+
+## What Changes
+
+- Preserve `stream_idle_timeout` classification when the configured stream idle timeout equals the request budget and scheduler jitter wakes after the shared deadline.
+- Keep true shorter request budgets classified as `upstream_request_timeout`.
+- For multiplexed websocket / HTTP bridge pending queues, avoid fail-all behavior on equal idle/budget ties; expire only requests whose own budget elapsed so younger siblings continue waiting.
+- Emit HTTP bridge downstream SSE liveness frames while a pending turn has no upstream event yet.
+- Preserve SSE comment keepalives through the public `/v1/responses` stream normalizer.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: streaming Responses timeout classification and downstream liveness behavior.
+
+## Impact
+
+- **Code**: `app/core/clients/proxy.py`, `app/modules/proxy/api.py`, `app/modules/proxy/http_bridge_forwarding.py`, `app/modules/proxy/service.py`
+- **Tests**: focused unit coverage in `tests/unit/test_proxy_utils.py`, `tests/unit/test_http_bridge_forwarding.py`, and `tests/unit/test_proxy_api_responses_contract.py`
+- **Behavior**: equal idle/budget deadline ties now surface as `stream_idle_timeout`; younger multiplexed pending requests are preserved; downstream SSE connections receive keepalive frames while waiting.

--- a/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Equal idle and request-budget stream deadlines preserve idle classification
-When the configured upstream stream idle timeout is equal to the proxy request budget, and an already-started streaming Responses body has been idle for the full shared window, the system MUST classify the timeout as `stream_idle_timeout` even if scheduler jitter observes the deadline after it has elapsed. When the request budget is strictly shorter than the stream idle timeout, when the generic total timeout fires before an upstream response has started, or when the remaining request budget for the next read is shorter than a fresh idle window, the system MUST continue to classify the timeout as `upstream_request_timeout`.
+When the configured upstream stream idle timeout is equal to the proxy request budget, and an already-started streaming Responses body has had no upstream activity for the full shared window, the system MUST classify the timeout as `stream_idle_timeout` even if scheduler jitter observes the deadline after it has elapsed. When the request budget is strictly shorter than the stream idle timeout, when the generic total timeout fires before an upstream response has started, when the remaining request budget for the next read is shorter than a fresh idle window, or when a generic total timeout follows recent upstream body activity, the system MUST continue to classify the timeout as `upstream_request_timeout`.
 
 #### Scenario: Direct HTTP stream body deadline tie is classified as idle
 - **GIVEN** `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`
@@ -13,6 +13,13 @@ When the configured upstream stream idle timeout is equal to the proxy request b
 #### Scenario: Pre-response total timeout remains request-timeout classified
 - **GIVEN** `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`
 - **WHEN** the generic request total timeout fires before an upstream response has started
+- **THEN** the downstream failure event uses `error.code = "upstream_request_timeout"`
+- **AND** the error message is `"Proxy request budget exhausted"`
+
+#### Scenario: Direct HTTP total timeout after recent activity remains request-timeout classified
+- **GIVEN** `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`
+- **AND** an upstream HTTP response body chunk was received less than a full idle window ago
+- **WHEN** the generic request total timeout fires at the request-budget deadline
 - **THEN** the downstream failure event uses `error.code = "upstream_request_timeout"`
 - **AND** the error message is `"Proxy request budget exhausted"`
 
@@ -48,7 +55,7 @@ When an upstream websocket or HTTP bridge session has multiple pending Responses
 - **AND** the younger request remains pending
 
 ### Requirement: HTTP bridge streams emit downstream liveness frames while pending
-When an HTTP bridge Responses request is waiting for upstream queue events, the system MUST emit a downstream SSE liveness frame at the configured `sse_keepalive_interval_seconds` interval so downstream clients do not disconnect before the upstream terminal frame arrives. The first generated liveness frame MUST be delayed until after the HTTP bridge startup-error probe window so a local startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response. If the pending request already has a response id, the liveness frame MAY be a `response.in_progress` SSE event for that response id. If no response id is known yet, the liveness frame MUST be an SSE comment block. Public `/v1/responses` stream normalization MUST preserve SSE comment keepalives instead of treating them as malformed data.
+When an HTTP bridge Responses request is waiting for upstream queue events, the system MUST emit a downstream SSE liveness frame at the configured `sse_keepalive_interval_seconds` interval so downstream clients do not disconnect before the upstream terminal frame arrives. The first generated liveness frame MUST be delayed until after the HTTP bridge startup-error probe window so a local startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response. Once a generated liveness frame is emitted, the stream MUST be considered started for later HTTP-error propagation decisions, so a subsequent upstream `response.failed` is forwarded in-stream instead of being raised as a startup HTTP error. If the pending request already has a response id, the liveness frame MAY be a `response.in_progress` SSE event for that response id. If no response id is known yet, the liveness frame MUST be an SSE comment block. Public `/v1/responses` stream normalization MUST preserve SSE comment keepalives instead of treating them as malformed data.
 
 #### Scenario: HTTP bridge emits response in-progress keepalive after response id is known
 - **GIVEN** an HTTP bridge request has a known response id
@@ -68,6 +75,12 @@ When an HTTP bridge Responses request is waiting for upstream queue events, the 
 - **WHEN** no upstream event arrives before the configured keepalive interval
 - **THEN** the first generated keepalive is not emitted until the startup-error probe window has elapsed
 - **AND** a startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response before any keepalive commits the stream
+
+#### Scenario: HTTP bridge keepalive commits stream for later response-failed events
+- **GIVEN** an HTTP bridge request emits a generated keepalive as its first downstream chunk
+- **WHEN** the next upstream event is a `response.failed` with an HTTP status override
+- **THEN** the `response.failed` event is forwarded on the SSE stream
+- **AND** it is not raised as a startup HTTP error after bytes have already been emitted
 
 #### Scenario: Public Responses normalizer preserves comment keepalive blocks
 - **WHEN** the public `/v1/responses` stream normalizer receives an SSE comment keepalive block before a terminal event

--- a/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Equal idle and request-budget stream deadlines preserve idle classification
+When the configured upstream stream idle timeout is equal to the proxy request budget, and a streaming Responses request reaches that shared deadline, the system MUST classify the timeout as `stream_idle_timeout` even if scheduler jitter observes the deadline after it has elapsed. When the request budget is strictly shorter than the stream idle timeout, the system MUST continue to classify the timeout as `upstream_request_timeout`.
+
+#### Scenario: Direct HTTP stream deadline tie is classified as idle
+- **GIVEN** `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`
+- **WHEN** a direct HTTP/SSE Responses stream times out just after that shared deadline
+- **THEN** the downstream failure event uses `error.code = "stream_idle_timeout"`
+- **AND** the error message is `"Upstream stream idle timeout"`
+
+#### Scenario: Shorter request budget remains request-timeout classified
+- **GIVEN** `proxy_request_budget_seconds` is strictly shorter than `stream_idle_timeout_seconds`
+- **WHEN** the request budget elapses before the idle timeout
+- **THEN** the downstream failure event uses `error.code = "upstream_request_timeout"`
+- **AND** the error message is `"Proxy request budget exhausted"`
+
+#### Scenario: Owner-forward receive deadline tie is classified as idle
+- **GIVEN** an HTTP bridge owner-forward stream has equal idle and request-budget deadlines
+- **WHEN** receiving the next upstream chunk times out at that shared deadline
+- **THEN** the owner-forward timeout uses `error_code = "stream_idle_timeout"`
+
+### Requirement: Multiplexed websocket timeout ties preserve younger pending requests
+When an upstream websocket or HTTP bridge session has multiple pending Responses turns and the oldest pending turn reaches an equal idle/request-budget deadline, the system MUST NOT fail all pending turns solely because the equal deadline is classified as `stream_idle_timeout`. It MUST fail only pending turns whose own request budget has elapsed, and it MUST keep younger pending turns queued until their own terminal event or timeout.
+
+#### Scenario: Equal deadline on oldest pending request does not fail younger sibling
+- **GIVEN** two pending websocket Responses requests share an upstream session
+- **AND** the oldest request has reached an equal idle/request-budget deadline
+- **AND** the younger request still has request budget remaining
+- **WHEN** the upstream receive watchdog fires
+- **THEN** the timeout classification is `stream_idle_timeout`
+- **AND** the fail-all-pending path is not used
+- **AND** only the expired oldest request is failed
+- **AND** the younger request remains pending
+
+### Requirement: HTTP bridge streams emit downstream liveness frames while pending
+When an HTTP bridge Responses request is waiting for upstream queue events, the system MUST emit a downstream SSE liveness frame at the configured `sse_keepalive_interval_seconds` interval so downstream clients do not disconnect before the upstream terminal frame arrives. If the pending request already has a response id, the liveness frame MAY be a `response.in_progress` SSE event for that response id. If no response id is known yet, the liveness frame MUST be an SSE comment block. Public `/v1/responses` stream normalization MUST preserve SSE comment keepalives instead of treating them as malformed data.
+
+#### Scenario: HTTP bridge emits response in-progress keepalive after response id is known
+- **GIVEN** an HTTP bridge request has a known response id
+- **WHEN** no upstream event arrives before the SSE keepalive interval elapses
+- **THEN** the downstream stream emits a `response.in_progress` event for that response id
+- **AND** the request remains pending
+
+#### Scenario: HTTP bridge emits comment keepalive before response id is known
+- **GIVEN** an HTTP bridge request does not yet have a response id
+- **WHEN** no upstream event arrives before the SSE keepalive interval elapses
+- **THEN** the downstream stream emits an SSE comment keepalive block
+- **AND** the request remains pending
+
+#### Scenario: Public Responses normalizer preserves comment keepalive blocks
+- **WHEN** the public `/v1/responses` stream normalizer receives an SSE comment keepalive block before a terminal event
+- **THEN** it forwards the comment keepalive block unchanged
+- **AND** it continues normalizing the subsequent Responses events normally

--- a/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Equal idle and request-budget stream deadlines preserve idle classification
-When the configured upstream stream idle timeout is equal to the proxy request budget, and an already-started streaming Responses body reaches that shared deadline, the system MUST classify the timeout as `stream_idle_timeout` even if scheduler jitter observes the deadline after it has elapsed. When the request budget is strictly shorter than the stream idle timeout, or when the generic total timeout fires before an upstream response has started, the system MUST continue to classify the timeout as `upstream_request_timeout`.
+When the configured upstream stream idle timeout is equal to the proxy request budget, and an already-started streaming Responses body has been idle for the full shared window, the system MUST classify the timeout as `stream_idle_timeout` even if scheduler jitter observes the deadline after it has elapsed. When the request budget is strictly shorter than the stream idle timeout, when the generic total timeout fires before an upstream response has started, or when the remaining request budget for the next read is shorter than a fresh idle window, the system MUST continue to classify the timeout as `upstream_request_timeout`.
 
 #### Scenario: Direct HTTP stream body deadline tie is classified as idle
 - **GIVEN** `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`
@@ -24,8 +24,15 @@ When the configured upstream stream idle timeout is equal to the proxy request b
 
 #### Scenario: Owner-forward receive deadline tie is classified as idle
 - **GIVEN** an HTTP bridge owner-forward stream has equal idle and request-budget deadlines
+- **AND** the remaining request budget for the next read is at least a full idle window
 - **WHEN** receiving the next upstream chunk times out at that shared deadline
 - **THEN** the owner-forward timeout uses `error_code = "stream_idle_timeout"`
+
+#### Scenario: Owner-forward shorter remaining budget is request-timeout classified
+- **GIVEN** an HTTP bridge owner-forward stream has equal configured idle and request-budget deadlines
+- **AND** the remaining request budget for the next read is shorter than a fresh idle window
+- **WHEN** receiving the next upstream chunk times out at the request-budget deadline
+- **THEN** the owner-forward timeout uses `error_code = "upstream_request_timeout"`
 
 ### Requirement: Multiplexed websocket timeout ties preserve younger pending requests
 When an upstream websocket or HTTP bridge session has multiple pending Responses turns and the oldest pending turn reaches an equal idle/request-budget deadline, the system MUST NOT fail all pending turns solely because the equal deadline is classified as `stream_idle_timeout`. It MUST fail only pending turns whose own request budget has elapsed, and it MUST keep younger pending turns queued until their own terminal event or timeout.

--- a/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
@@ -1,13 +1,20 @@
 ## ADDED Requirements
 
 ### Requirement: Equal idle and request-budget stream deadlines preserve idle classification
-When the configured upstream stream idle timeout is equal to the proxy request budget, and a streaming Responses request reaches that shared deadline, the system MUST classify the timeout as `stream_idle_timeout` even if scheduler jitter observes the deadline after it has elapsed. When the request budget is strictly shorter than the stream idle timeout, the system MUST continue to classify the timeout as `upstream_request_timeout`.
+When the configured upstream stream idle timeout is equal to the proxy request budget, and an already-started streaming Responses body reaches that shared deadline, the system MUST classify the timeout as `stream_idle_timeout` even if scheduler jitter observes the deadline after it has elapsed. When the request budget is strictly shorter than the stream idle timeout, or when the generic total timeout fires before an upstream response has started, the system MUST continue to classify the timeout as `upstream_request_timeout`.
 
-#### Scenario: Direct HTTP stream deadline tie is classified as idle
+#### Scenario: Direct HTTP stream body deadline tie is classified as idle
 - **GIVEN** `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`
-- **WHEN** a direct HTTP/SSE Responses stream times out just after that shared deadline
+- **AND** the upstream HTTP response headers have been received
+- **WHEN** reading the response body times out just after that shared deadline
 - **THEN** the downstream failure event uses `error.code = "stream_idle_timeout"`
 - **AND** the error message is `"Upstream stream idle timeout"`
+
+#### Scenario: Pre-response total timeout remains request-timeout classified
+- **GIVEN** `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`
+- **WHEN** the generic request total timeout fires before an upstream response has started
+- **THEN** the downstream failure event uses `error.code = "upstream_request_timeout"`
+- **AND** the error message is `"Proxy request budget exhausted"`
 
 #### Scenario: Shorter request budget remains request-timeout classified
 - **GIVEN** `proxy_request_budget_seconds` is strictly shorter than `stream_idle_timeout_seconds`
@@ -34,7 +41,7 @@ When an upstream websocket or HTTP bridge session has multiple pending Responses
 - **AND** the younger request remains pending
 
 ### Requirement: HTTP bridge streams emit downstream liveness frames while pending
-When an HTTP bridge Responses request is waiting for upstream queue events, the system MUST emit a downstream SSE liveness frame at the configured `sse_keepalive_interval_seconds` interval so downstream clients do not disconnect before the upstream terminal frame arrives. If the pending request already has a response id, the liveness frame MAY be a `response.in_progress` SSE event for that response id. If no response id is known yet, the liveness frame MUST be an SSE comment block. Public `/v1/responses` stream normalization MUST preserve SSE comment keepalives instead of treating them as malformed data.
+When an HTTP bridge Responses request is waiting for upstream queue events, the system MUST emit a downstream SSE liveness frame at the configured `sse_keepalive_interval_seconds` interval so downstream clients do not disconnect before the upstream terminal frame arrives. The first generated liveness frame MUST be delayed until after the HTTP bridge startup-error probe window so a local startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response. If the pending request already has a response id, the liveness frame MAY be a `response.in_progress` SSE event for that response id. If no response id is known yet, the liveness frame MUST be an SSE comment block. Public `/v1/responses` stream normalization MUST preserve SSE comment keepalives instead of treating them as malformed data.
 
 #### Scenario: HTTP bridge emits response in-progress keepalive after response id is known
 - **GIVEN** an HTTP bridge request has a known response id
@@ -47,6 +54,13 @@ When an HTTP bridge Responses request is waiting for upstream queue events, the 
 - **WHEN** no upstream event arrives before the SSE keepalive interval elapses
 - **THEN** the downstream stream emits an SSE comment keepalive block
 - **AND** the request remains pending
+
+#### Scenario: First HTTP bridge keepalive is delayed past startup probe
+- **GIVEN** an HTTP bridge request is waiting for upstream queue events
+- **AND** `sse_keepalive_interval_seconds` is shorter than the bridge startup-error probe window
+- **WHEN** no upstream event arrives before the configured keepalive interval
+- **THEN** the first generated keepalive is not emitted until the startup-error probe window has elapsed
+- **AND** a startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response before any keepalive commits the stream
 
 #### Scenario: Public Responses normalizer preserves comment keepalive blocks
 - **WHEN** the public `/v1/responses` stream normalizer receives an SSE comment keepalive block before a terminal event

--- a/openspec/changes/fix-upstream-terminal-timeouts/tasks.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Implementation
 
-- [x] 1.1 Preserve `stream_idle_timeout` classification when `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`, the upstream response has started, and scheduler jitter wakes after the shared deadline.
-- [x] 1.2 Preserve `upstream_request_timeout` classification when the request budget is strictly shorter than the idle timeout or when a generic total timeout fires before an upstream response has started.
+- [x] 1.1 Preserve `stream_idle_timeout` classification when `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`, the upstream response body has been idle for a full idle window, and scheduler jitter wakes after the shared deadline.
+- [x] 1.2 Preserve `upstream_request_timeout` classification when the request budget is strictly shorter than the idle timeout, when remaining request budget is shorter than a fresh idle window, or when a generic total timeout fires before an upstream response has started.
 - [x] 1.3 Avoid fail-all pending behavior for equal idle/budget websocket timeout ties so younger pending requests keep their own budget.
 - [x] 1.4 Emit HTTP bridge downstream SSE liveness frames while waiting for upstream queue events, but delay the first generated keepalive until after the startup-error probe window.
 - [x] 1.5 Preserve SSE comment keepalives through public `/v1/responses` stream normalization.
@@ -9,9 +9,9 @@
 ## 2. Tests
 
 - [x] 2.1 Unit: direct HTTP/SSE stream maps equal total/idle deadline ties after response startup to `stream_idle_timeout`, keeps pre-response total timeout as `upstream_request_timeout`, and preserves shorter budgets as `upstream_request_timeout`.
-- [x] 2.2 Unit: websocket timeout selection preserves idle classification without setting `fail_all_pending` on equal idle/budget ties.
+- [x] 2.2 Unit: websocket timeout selection preserves idle classification without setting `fail_all_pending` only for full-window equal idle/budget ties, and keeps shorter remaining-budget waits classified as `upstream_request_timeout`.
 - [x] 2.3 Unit: expired websocket pending requests are failed without removing younger pending requests.
-- [x] 2.4 Unit: HTTP owner-forward receive timeout preserves idle classification on equal idle/budget ties.
+- [x] 2.4 Unit: HTTP owner-forward receive timeout preserves idle classification on full-window equal idle/budget ties and preserves budget classification when remaining budget is shorter than a fresh idle window.
 - [x] 2.5 Unit: HTTP bridge event streams emit liveness frames, delay the first generated keepalive past the startup probe window, and public stream normalization preserves comment keepalives.
 
 ## 3. Spec Delta

--- a/openspec/changes/fix-upstream-terminal-timeouts/tasks.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Implementation
 
-- [x] 1.1 Preserve `stream_idle_timeout` classification when `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds` and scheduler jitter wakes after the shared deadline.
-- [x] 1.2 Preserve `upstream_request_timeout` classification when the request budget is strictly shorter than the idle timeout.
+- [x] 1.1 Preserve `stream_idle_timeout` classification when `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`, the upstream response has started, and scheduler jitter wakes after the shared deadline.
+- [x] 1.2 Preserve `upstream_request_timeout` classification when the request budget is strictly shorter than the idle timeout or when a generic total timeout fires before an upstream response has started.
 - [x] 1.3 Avoid fail-all pending behavior for equal idle/budget websocket timeout ties so younger pending requests keep their own budget.
-- [x] 1.4 Emit HTTP bridge downstream SSE liveness frames while waiting for upstream queue events.
+- [x] 1.4 Emit HTTP bridge downstream SSE liveness frames while waiting for upstream queue events, but delay the first generated keepalive until after the startup-error probe window.
 - [x] 1.5 Preserve SSE comment keepalives through public `/v1/responses` stream normalization.
 
 ## 2. Tests
 
-- [x] 2.1 Unit: direct HTTP/SSE stream maps equal total/idle deadline ties to `stream_idle_timeout` and shorter budgets to `upstream_request_timeout`.
+- [x] 2.1 Unit: direct HTTP/SSE stream maps equal total/idle deadline ties after response startup to `stream_idle_timeout`, keeps pre-response total timeout as `upstream_request_timeout`, and preserves shorter budgets as `upstream_request_timeout`.
 - [x] 2.2 Unit: websocket timeout selection preserves idle classification without setting `fail_all_pending` on equal idle/budget ties.
 - [x] 2.3 Unit: expired websocket pending requests are failed without removing younger pending requests.
 - [x] 2.4 Unit: HTTP owner-forward receive timeout preserves idle classification on equal idle/budget ties.
-- [x] 2.5 Unit: HTTP bridge event streams emit liveness frames and public stream normalization preserves comment keepalives.
+- [x] 2.5 Unit: HTTP bridge event streams emit liveness frames, delay the first generated keepalive past the startup probe window, and public stream normalization preserves comment keepalives.
 
 ## 3. Spec Delta
 

--- a/openspec/changes/fix-upstream-terminal-timeouts/tasks.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/tasks.md
@@ -1,0 +1,20 @@
+## 1. Implementation
+
+- [x] 1.1 Preserve `stream_idle_timeout` classification when `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds` and scheduler jitter wakes after the shared deadline.
+- [x] 1.2 Preserve `upstream_request_timeout` classification when the request budget is strictly shorter than the idle timeout.
+- [x] 1.3 Avoid fail-all pending behavior for equal idle/budget websocket timeout ties so younger pending requests keep their own budget.
+- [x] 1.4 Emit HTTP bridge downstream SSE liveness frames while waiting for upstream queue events.
+- [x] 1.5 Preserve SSE comment keepalives through public `/v1/responses` stream normalization.
+
+## 2. Tests
+
+- [x] 2.1 Unit: direct HTTP/SSE stream maps equal total/idle deadline ties to `stream_idle_timeout` and shorter budgets to `upstream_request_timeout`.
+- [x] 2.2 Unit: websocket timeout selection preserves idle classification without setting `fail_all_pending` on equal idle/budget ties.
+- [x] 2.3 Unit: expired websocket pending requests are failed without removing younger pending requests.
+- [x] 2.4 Unit: HTTP owner-forward receive timeout preserves idle classification on equal idle/budget ties.
+- [x] 2.5 Unit: HTTP bridge event streams emit liveness frames and public stream normalization preserves comment keepalives.
+
+## 3. Spec Delta
+
+- [x] 3.1 Add `responses-api-compat` requirements for timeout tie classification, multiplexed pending preservation, and HTTP bridge SSE liveness frames.
+- [x] 3.2 Validate the OpenSpec change with `openspec validate fix-upstream-terminal-timeouts --strict`.

--- a/openspec/changes/fix-upstream-terminal-timeouts/tasks.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Implementation
 
-- [x] 1.1 Preserve `stream_idle_timeout` classification when `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`, the upstream response body has been idle for a full idle window, and scheduler jitter wakes after the shared deadline.
-- [x] 1.2 Preserve `upstream_request_timeout` classification when the request budget is strictly shorter than the idle timeout, when remaining request budget is shorter than a fresh idle window, or when a generic total timeout fires before an upstream response has started.
+- [x] 1.1 Preserve `stream_idle_timeout` classification when `stream_idle_timeout_seconds` equals `proxy_request_budget_seconds`, the upstream response body has had no activity for a full idle window, and scheduler jitter wakes after the shared deadline.
+- [x] 1.2 Preserve `upstream_request_timeout` classification when the request budget is strictly shorter than the idle timeout, when remaining request budget is shorter than a fresh idle window, when a generic total timeout fires before an upstream response has started, or when a generic total timeout follows recent body activity.
 - [x] 1.3 Avoid fail-all pending behavior for equal idle/budget websocket timeout ties so younger pending requests keep their own budget.
-- [x] 1.4 Emit HTTP bridge downstream SSE liveness frames while waiting for upstream queue events, but delay the first generated keepalive until after the startup-error probe window.
+- [x] 1.4 Emit HTTP bridge downstream SSE liveness frames while waiting for upstream queue events, delay the first generated keepalive until after the startup-error probe window, and mark emitted keepalives as streamed bytes for later response-failed handling.
 - [x] 1.5 Preserve SSE comment keepalives through public `/v1/responses` stream normalization.
 
 ## 2. Tests
 
-- [x] 2.1 Unit: direct HTTP/SSE stream maps equal total/idle deadline ties after response startup to `stream_idle_timeout`, keeps pre-response total timeout as `upstream_request_timeout`, and preserves shorter budgets as `upstream_request_timeout`.
+- [x] 2.1 Unit: direct HTTP/SSE stream maps equal total/idle deadline ties after response startup and no recent body activity to `stream_idle_timeout`, keeps pre-response total timeout as `upstream_request_timeout`, preserves shorter budgets as `upstream_request_timeout`, and keeps post-chunk total timeouts classified by request budget when recent body activity exists.
 - [x] 2.2 Unit: websocket timeout selection preserves idle classification without setting `fail_all_pending` only for full-window equal idle/budget ties, and keeps shorter remaining-budget waits classified as `upstream_request_timeout`.
 - [x] 2.3 Unit: expired websocket pending requests are failed without removing younger pending requests.
 - [x] 2.4 Unit: HTTP owner-forward receive timeout preserves idle classification on full-window equal idle/budget ties and preserves budget classification when remaining budget is shorter than a fresh idle window.
-- [x] 2.5 Unit: HTTP bridge event streams emit liveness frames, delay the first generated keepalive past the startup probe window, and public stream normalization preserves comment keepalives.
+- [x] 2.5 Unit: HTTP bridge event streams emit liveness frames, delay the first generated keepalive past the startup probe window, mark generated keepalives as already-yielded stream bytes for later response-failed handling, and public stream normalization preserves comment keepalives.
 
 ## 3. Spec Delta
 

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -237,7 +237,7 @@ def test_owner_forward_receive_timeout_prefers_idle_after_scheduler_jitter(
     assert timeout.error_code == "stream_idle_timeout"
 
 
-def test_owner_forward_receive_timeout_keeps_idle_when_equal_budget_is_sooner(
+def test_owner_forward_receive_timeout_uses_budget_when_equal_budget_is_sooner(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("app.modules.proxy.http_bridge_forwarding.time.monotonic", lambda: 400.0)
@@ -249,7 +249,7 @@ def test_owner_forward_receive_timeout_keeps_idle_when_equal_budget_is_sooner(
     )
 
     assert timeout.timeout_seconds == pytest.approx(300.0)
-    assert timeout.error_code == "stream_idle_timeout"
+    assert timeout.error_code == "upstream_request_timeout"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -222,6 +222,36 @@ def test_owner_forward_receive_timeout_clamps_to_remaining_budget(monkeypatch: p
     assert timeout.error_code == "upstream_request_timeout"
 
 
+def test_owner_forward_receive_timeout_prefers_idle_after_scheduler_jitter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.modules.proxy.http_bridge_forwarding.time.monotonic", lambda: 610.01)
+
+    timeout = _owner_forward_receive_timeout(
+        request_started_at=10.0,
+        proxy_request_budget_seconds=600.0,
+        stream_idle_timeout_seconds=600.0,
+    )
+
+    assert timeout.timeout_seconds == pytest.approx(0.0)
+    assert timeout.error_code == "stream_idle_timeout"
+
+
+def test_owner_forward_receive_timeout_keeps_idle_when_equal_budget_is_sooner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.modules.proxy.http_bridge_forwarding.time.monotonic", lambda: 400.0)
+
+    timeout = _owner_forward_receive_timeout(
+        request_started_at=100.0,
+        proxy_request_budget_seconds=600.0,
+        stream_idle_timeout_seconds=600.0,
+    )
+
+    assert timeout.timeout_seconds == pytest.approx(300.0)
+    assert timeout.error_code == "stream_idle_timeout"
+
+
 @pytest.mark.asyncio
 async def test_owner_forward_uses_direct_session_without_env_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -72,6 +72,37 @@ async def test_normalize_public_responses_stream_appends_response_failed_on_inva
 
 
 @pytest.mark.asyncio
+async def test_normalize_public_responses_stream_preserves_comment_keepalive() -> None:
+    terminal = 'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n\n'
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(": keepalive\n\n", terminal),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert blocks[0] == ": keepalive\n\n"
+    assert "response.completed" in blocks[-1]
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_preserves_comment_keepalive_for_public_contract() -> None:
+    terminal = 'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n\n'
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(": keepalive\n\n", terminal),
+        )
+    ]
+
+    assert blocks[0] == ": keepalive\n\n"
+    assert "response.completed" in blocks[-1]
+
+
+@pytest.mark.asyncio
 async def test_normalize_public_responses_stream_normalizes_unknown_terminal_output_item() -> None:
     blocks = [
         block

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -191,6 +191,94 @@ async def test_http_bridge_stream_masks_single_top_level_previous_response_error
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_keepalive_counts_as_first_yield_before_late_response_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: SimpleNamespace(sse_keepalive_interval_seconds=0.001),
+    )
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
+
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-keepalive-first", None),
+        headers={"session_id": "sid-keepalive-first"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-keepalive-first",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.1",
+        account=cast(Any, SimpleNamespace(id="acc-keepalive-first", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-keepalive-first",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        response_id="resp_keepalive_first",
+    )
+
+    async def fake_submit_http_bridge_request(
+        target_session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+    ) -> None:
+        del text_data, queue_limit
+        target_session.pending_requests.append(request_state)
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", fake_submit_http_bridge_request)
+
+    stream = service._stream_http_bridge_session_events(
+        session,
+        request_state=request_state,
+        text_data="{}",
+        queue_limit=8,
+        propagate_http_errors=True,
+        downstream_turn_state=None,
+    )
+
+    keepalive = await asyncio.wait_for(anext(stream), timeout=1.0)
+    assert "response.in_progress" in keepalive
+
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    request_state.error_http_status_override = 502
+    await event_queue.put(
+        proxy_service.format_sse_event(
+            proxy_service.response_failed_event(
+                "upstream_unavailable",
+                "upstream failed after keepalive",
+                response_id="resp_keepalive_first",
+            )
+        )
+    )
+    failed = await asyncio.wait_for(anext(stream), timeout=1.0)
+    assert "response.failed" in failed
+    assert "upstream_unavailable" in failed
+
+    await event_queue.put(None)
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(anext(stream), timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_reuses_live_local_session_without_ring_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2058,7 +2058,7 @@ async def test_stream_responses_prefers_idle_timeout_when_total_deadline_ties_af
         proxy_request_budget_seconds = 600.0
         upstream_stream_transport = "http"
 
-    monotonic_values = iter([100.0, 100.0, 100.0, 700.01])
+    monotonic_values = iter([100.0, 100.0, 100.0, 100.0, 700.01])
 
     monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
     monkeypatch.setattr(proxy_module.time, "monotonic", lambda: next(monotonic_values, 700.01))
@@ -6572,7 +6572,7 @@ def test_websocket_receive_timeout_keeps_idle_classification_after_scheduler_jit
     assert timeout.fail_all_pending is False
 
 
-def test_websocket_receive_timeout_keeps_idle_classification_when_equal_budget_is_sooner(monkeypatch):
+def test_websocket_receive_timeout_uses_budget_when_equal_budget_is_sooner(monkeypatch):
     monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 400.0)
 
     timeout = proxy_service._websocket_receive_timeout_for_pending_requests(
@@ -6583,8 +6583,8 @@ def test_websocket_receive_timeout_keeps_idle_classification_when_equal_budget_i
 
     assert timeout is not None
     assert timeout.timeout_seconds == 300.0
-    assert timeout.error_code == "stream_idle_timeout"
-    assert timeout.error_message == "Upstream stream idle timeout"
+    assert timeout.error_code == "upstream_request_timeout"
+    assert timeout.error_message == "Proxy request budget exhausted"
     assert timeout.fail_all_pending is False
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1271,6 +1271,43 @@ class _TimeoutSseSession:
         raise asyncio.TimeoutError
 
 
+class _TimeoutChunkIterator:
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> bytes:
+        raise asyncio.TimeoutError
+
+
+class _TimeoutContent(proxy_module.SSEContentProtocol):
+    def iter_chunked(self, size: int) -> _TimeoutChunkIterator:
+        del size
+        return _TimeoutChunkIterator()
+
+
+class _TimeoutAfterHeadersSseResponse:
+    status = 200
+    content = _TimeoutContent()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _TimeoutAfterHeadersSseSession:
+    def post(
+        self,
+        url: str,
+        *,
+        json=None,
+        headers: dict[str, str] | None = None,
+        timeout=None,
+    ):
+        return _TimeoutAfterHeadersSseResponse()
+
+
 class _TimeoutCompactSession:
     def post(
         self,
@@ -1971,7 +2008,7 @@ async def test_stream_responses_maps_total_timeout_to_request_timeout(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_prefers_idle_timeout_when_total_deadline_ties(monkeypatch):
+async def test_stream_responses_keeps_pre_response_total_timeout_as_request_timeout_when_deadline_ties(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 8.0
@@ -2001,6 +2038,45 @@ async def test_stream_responses_prefers_idle_timeout_when_total_deadline_ties(mo
             access_token="token",
             account_id="acc_1",
             session=cast(proxy_module.aiohttp.ClientSession, _TimeoutSseSession()),
+        )
+    ]
+
+    event = json.loads(events[0].split("data: ", 1)[1])
+    assert event["response"]["error"]["code"] == "upstream_request_timeout"
+    assert event["response"]["error"]["message"] == "Proxy request budget exhausted"
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_prefers_idle_timeout_when_total_deadline_ties_after_headers(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 600.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 600.0
+        upstream_stream_transport = "http"
+
+    monotonic_values = iter([100.0, 100.0, 100.0, 700.01])
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module.time, "monotonic", lambda: next(monotonic_values, 700.01))
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, _TimeoutAfterHeadersSseSession()),
         )
     ]
 
@@ -12771,6 +12847,70 @@ async def test_http_bridge_session_events_emit_comment_keepalive_before_response
         await events.aclose()
 
     assert keepalive == ": keepalive\n\n"
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_session_events_delays_first_keepalive_until_startup_probe_window(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.sse_keepalive_interval_seconds = 0.01
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_keepalive_delayed",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_bridge_keepalive_delayed",
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_keepalive_delayed"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.05)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    events = service._stream_http_bridge_session_events(
+        session,
+        request_state=request_state,
+        text_data='{"type":"response.create"}',
+        queue_limit=10,
+        propagate_http_errors=False,
+        downstream_turn_state=None,
+    )
+    first_event = asyncio.create_task(events.__anext__())
+    try:
+        await asyncio.sleep(0.02)
+        assert first_event.done() is False
+        keepalive = await asyncio.wait_for(first_event, timeout=0.2)
+    finally:
+        await events.aclose()
+
+    assert proxy_service.parse_sse_data_json(keepalive) == {
+        "type": "response.in_progress",
+        "response": {
+            "id": "resp_bridge_keepalive_delayed",
+            "status": "in_progress",
+        },
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1308,6 +1308,60 @@ class _TimeoutAfterHeadersSseSession:
         return _TimeoutAfterHeadersSseResponse()
 
 
+class _ActiveThenTotalTimeoutChunkIterator:
+    def __init__(self, clock: dict[str, float]) -> None:
+        self._clock = clock
+        self._sent_chunk = False
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> bytes:
+        if not self._sent_chunk:
+            self._sent_chunk = True
+            self._clock["now"] = 650.0
+            return b'data: {"type":"response.output_text.delta","delta":"still active"}\n\n'
+        self._clock["now"] = 700.01
+        raise asyncio.TimeoutError
+
+
+class _ActiveThenTotalTimeoutContent(proxy_module.SSEContentProtocol):
+    def __init__(self, clock: dict[str, float]) -> None:
+        self._clock = clock
+
+    def iter_chunked(self, size: int) -> _ActiveThenTotalTimeoutChunkIterator:
+        del size
+        return _ActiveThenTotalTimeoutChunkIterator(self._clock)
+
+
+class _ActiveThenTotalTimeoutSseResponse:
+    status = 200
+
+    def __init__(self, clock: dict[str, float]) -> None:
+        self.content = _ActiveThenTotalTimeoutContent(clock)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ActiveThenTotalTimeoutSseSession:
+    def __init__(self, clock: dict[str, float]) -> None:
+        self._clock = clock
+
+    def post(
+        self,
+        url: str,
+        *,
+        json=None,
+        headers: dict[str, str] | None = None,
+        timeout=None,
+    ):
+        return _ActiveThenTotalTimeoutSseResponse(self._clock)
+
+
 class _TimeoutCompactSession:
     def post(
         self,
@@ -2083,6 +2137,46 @@ async def test_stream_responses_prefers_idle_timeout_when_total_deadline_ties_af
     event = json.loads(events[0].split("data: ", 1)[1])
     assert event["response"]["error"]["code"] == "stream_idle_timeout"
     assert event["response"]["error"]["message"] == "Upstream stream idle timeout"
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_keeps_budget_timeout_after_recent_body_activity(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 600.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 600.0
+        upstream_stream_transport = "http"
+
+    clock = {"now": 100.0}
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, _ActiveThenTotalTimeoutSseSession(clock)),
+        )
+    ]
+
+    assert "response.output_text.delta" in events[0]
+    event = json.loads(events[-1].split("data: ", 1)[1])
+    assert event["response"]["error"]["code"] == "upstream_request_timeout"
+    assert event["response"]["error"]["message"] == "Proxy request budget exhausted"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1971,6 +1971,84 @@ async def test_stream_responses_maps_total_timeout_to_request_timeout(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_prefers_idle_timeout_when_total_deadline_ties(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 600.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 600.0
+        upstream_stream_transport = "http"
+
+    monotonic_values = iter([100.0, 100.0, 100.0, 700.01])
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module.time, "monotonic", lambda: next(monotonic_values, 700.01))
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, _TimeoutSseSession()),
+        )
+    ]
+
+    event = json.loads(events[0].split("data: ", 1)[1])
+    assert event["response"]["error"]["code"] == "stream_idle_timeout"
+    assert event["response"]["error"]["message"] == "Upstream stream idle timeout"
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_keeps_budget_timeout_when_budget_precedes_idle(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 600.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 300.0
+        upstream_stream_transport = "http"
+
+    monotonic_values = iter([100.0, 100.0, 100.0, 400.01])
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module.time, "monotonic", lambda: next(monotonic_values, 400.01))
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, _TimeoutSseSession()),
+        )
+    ]
+
+    event = json.loads(events[0].split("data: ", 1)[1])
+    assert event["response"]["error"]["code"] == "upstream_request_timeout"
+    assert event["response"]["error"]["message"] == "Proxy request budget exhausted"
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_maps_connect_timeout_to_upstream_unavailable(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
@@ -6402,6 +6480,38 @@ def test_websocket_receive_timeout_prefers_request_budget_when_sooner(monkeypatc
     assert timeout.error_message == "Proxy request budget exhausted"
 
 
+def test_websocket_receive_timeout_keeps_idle_classification_after_scheduler_jitter(monkeypatch):
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 700.001)
+
+    timeout = proxy_service._websocket_receive_timeout_for_pending_requests(
+        [100.0],
+        proxy_request_budget_seconds=600.0,
+        stream_idle_timeout_seconds=600.0,
+    )
+
+    assert timeout is not None
+    assert timeout.timeout_seconds == 0.0
+    assert timeout.error_code == "stream_idle_timeout"
+    assert timeout.error_message == "Upstream stream idle timeout"
+    assert timeout.fail_all_pending is False
+
+
+def test_websocket_receive_timeout_keeps_idle_classification_when_equal_budget_is_sooner(monkeypatch):
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 400.0)
+
+    timeout = proxy_service._websocket_receive_timeout_for_pending_requests(
+        [100.0],
+        proxy_request_budget_seconds=600.0,
+        stream_idle_timeout_seconds=600.0,
+    )
+
+    assert timeout is not None
+    assert timeout.timeout_seconds == 300.0
+    assert timeout.error_code == "stream_idle_timeout"
+    assert timeout.error_message == "Upstream stream idle timeout"
+    assert timeout.fail_all_pending is False
+
+
 def test_websocket_receive_timeout_honors_idle_when_equal_to_full_budget(monkeypatch):
     monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 100.0)
 
@@ -6415,6 +6525,7 @@ def test_websocket_receive_timeout_honors_idle_when_equal_to_full_budget(monkeyp
     assert timeout.timeout_seconds == 600.0
     assert timeout.error_code == "stream_idle_timeout"
     assert timeout.error_message == "Upstream stream idle timeout"
+    assert timeout.fail_all_pending is False
 
 
 @pytest.mark.asyncio
@@ -12542,6 +12653,124 @@ async def test_http_bridge_tool_call_dedupe_survives_upstream_reconnect():
     assert forwarded_created is not None
     assert proxy_service.parse_sse_data_json(forwarded_created) == replay_created_payload
     assert event_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_session_events_emit_keepalive_while_pending(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.sse_keepalive_interval_seconds = 0.01
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_keepalive",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_bridge_keepalive",
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_keepalive"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    submit_http_bridge_request = AsyncMock()
+    detach_http_bridge_request = AsyncMock()
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit_http_bridge_request)
+    monkeypatch.setattr(service, "_detach_http_bridge_request", detach_http_bridge_request)
+
+    events = service._stream_http_bridge_session_events(
+        session,
+        request_state=request_state,
+        text_data='{"type":"response.create"}',
+        queue_limit=10,
+        propagate_http_errors=False,
+        downstream_turn_state=None,
+    )
+    try:
+        keepalive = await asyncio.wait_for(events.__anext__(), timeout=1.0)
+    finally:
+        await events.aclose()
+
+    assert proxy_service.parse_sse_data_json(keepalive) == {
+        "type": "response.in_progress",
+        "response": {
+            "id": "resp_bridge_keepalive",
+            "status": "in_progress",
+        },
+    }
+    submit_http_bridge_request.assert_awaited_once()
+    detach_http_bridge_request.assert_awaited_once_with(session, request_state=request_state)
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_session_events_emit_comment_keepalive_before_response_id(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.sse_keepalive_interval_seconds = 0.01
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_keepalive_precreated",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id=None,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_keepalive"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    events = service._stream_http_bridge_session_events(
+        session,
+        request_state=request_state,
+        text_data='{"type":"response.create"}',
+        queue_limit=10,
+        propagate_http_errors=False,
+        downstream_turn_state=None,
+    )
+    try:
+        keepalive = await asyncio.wait_for(events.__anext__(), timeout=1.0)
+    finally:
+        await events.aclose()
+
+    assert keepalive == ": keepalive\n\n"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve `stream_idle_timeout` classification when the event loop wakes just after an equal idle/request-budget deadline
- apply the same idle-vs-budget rule to websocket pending requests, HTTP owner-forward receive timeouts, and HTTP SSE total-timeout ties
- avoid `fail_all_pending` for equal idle/budget deadline expiry so a timed-out older bridge turn does not close younger sibling turns as `HTTP bridge session closed before response.completed`
- preserve HTTP bridge SSE comment keepalives through public stream normalization instead of dropping comment-only blocks
- emit parser-visible `response.in_progress` HTTP bridge keepalives after `response_id` is known, so downstream Codex clients do not disconnect with `idle timeout waiting for SSE` before the terminal frame arrives
- keep true shorter request budgets classified as `upstream_request_timeout`

## Head
`ec5f5d0a3bc57275ead6697490d98574f3871723`

## Tests
```
uv run ruff check app/modules/proxy/api.py app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_api_responses_contract.py
uv run ty check
uv run pytest tests/unit/test_proxy_utils.py tests/unit/test_http_bridge_forwarding.py tests/unit/test_proxy_api_responses_contract.py -k "http_bridge_session_events_emit_keepalive or http_bridge_session_events_emit_comment_keepalive or http_bridge_session_events_delays_first_keepalive or websocket_receive_timeout or fail_expired_pending or stream_responses_keeps_pre_response_total_timeout_as_request_timeout_when_deadline_ties or stream_responses_prefers_idle_timeout_when_total_deadline_ties_after_headers or stream_responses_keeps_budget_timeout_when_budget_precedes_idle or owner_forward_receive_timeout or websocket_receive_timeout_uses_budget_when_equal_budget_is_sooner or owner_forward_receive_timeout_uses_budget_when_equal_budget_is_sooner or stream_responses_keeps_budget_timeout_after_recent_body_activity or http_bridge_keepalive_counts_as_first_yield_before_late_response_failed or comment_keepalive" -q
uv run pytest tests/unit/test_proxy_utils.py -k "http_bridge_session_events_emit_keepalive or http_bridge_session_events_emit_comment_keepalive_before_response_id" tests/unit/test_proxy_api_responses_contract.py -k "comment_keepalive or invalid_json"
```

Earlier focused coverage on this branch also passed:
```
uv run ruff check app/core/clients/proxy.py app/modules/proxy/http_bridge_forwarding.py app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/unit/test_http_bridge_forwarding.py
uv run pytest tests/unit/test_http_bridge_forwarding.py -k "owner_forward_receive_timeout"
```

## Live Deploy Note
The same runtime code path is deployed in the live aggregate image `codex-lb:live-stack-01fae03`.