### PR TITLE
feat(request-log): detail cost breakdown for each request

### DIFF
--- a/app/core/usage/logs.py
+++ b/app/core/usage/logs.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from app.core.usage.pricing import UsageTokens, calculate_cost_from_usage, get_pricing_for_model
+from app.core.usage.pricing import (
+    UsageCostBreakdown,
+    UsageTokens,
+    calculate_cost_breakdown_from_usage,
+    calculate_cost_from_usage,
+    get_pricing_for_model,
+)
 
 
 class RequestLogLike(Protocol):
@@ -43,7 +49,7 @@ def usage_tokens_from_log(log: RequestLogLike) -> UsageTokens | None:
     input_tokens = log.input_tokens
     if input_tokens is None:
         return None
-    output_tokens = log.output_tokens if log.output_tokens is not None else log.reasoning_tokens
+    output_tokens = output_tokens_from_log(log)
     if output_tokens is None:
         return None
     cached_tokens = cached_input_tokens_from_log(log) or 0
@@ -52,6 +58,16 @@ def usage_tokens_from_log(log: RequestLogLike) -> UsageTokens | None:
         output_tokens=float(output_tokens),
         cached_input_tokens=float(cached_tokens),
     )
+
+
+def output_tokens_from_log(log: RequestLogLike) -> int | None:
+    output_tokens = log.output_tokens
+    if output_tokens is not None:
+        return int(output_tokens)
+    reasoning_tokens = log.reasoning_tokens
+    if reasoning_tokens is None:
+        return None
+    return int(reasoning_tokens)
 
 
 def calculated_cost_from_log(log: RequestLogLike, *, precision: int | None = None) -> float | None:
@@ -81,11 +97,103 @@ def cost_from_log(log: RequestLogLike, *, precision: int | None = None) -> float
     return round(float(cost), precision)
 
 
+def _totals_match(left: float | None, right: float | None, *, precision: int | None) -> bool:
+    if left is None or right is None:
+        return False
+    if precision is None:
+        return left == right
+    return abs(left - right) < (10 ** (-precision)) / 2
+
+
+def cost_breakdown_from_log(log: RequestLogLike, *, precision: int | None = None) -> UsageCostBreakdown:
+    full_breakdown: UsageCostBreakdown | None = None
+    input_usd: float | None = None
+    cached_input_usd: float | None = None
+    output_usd: float | None = None
+    raw_total_usd: float | None = None
+    total_usd: float | None = None
+    if log.model:
+        resolved = get_pricing_for_model(log.model, None, None)
+        if resolved is not None:
+            _, price = resolved
+            input_tokens = log.input_tokens
+            cached_tokens = cached_input_tokens_from_log(log) or 0
+            output_tokens = output_tokens_from_log(log)
+            usage = usage_tokens_from_log(log)
+            if usage is not None:
+                raw_full_breakdown = calculate_cost_breakdown_from_usage(usage, price, service_tier=log.service_tier)
+                if raw_full_breakdown is not None:
+                    raw_total_usd = raw_full_breakdown.total_usd
+                full_breakdown = calculate_cost_breakdown_from_usage(
+                    usage,
+                    price,
+                    service_tier=log.service_tier,
+                    precision=precision,
+                )
+                if full_breakdown is not None:
+                    total_usd = full_breakdown.total_usd
+            if input_tokens is not None:
+                input_breakdown = calculate_cost_breakdown_from_usage(
+                    UsageTokens(
+                        input_tokens=float(input_tokens),
+                        output_tokens=0.0,
+                        cached_input_tokens=float(cached_tokens),
+                    ),
+                    price,
+                    service_tier=log.service_tier,
+                    precision=precision,
+                )
+                if input_breakdown is not None:
+                    input_usd = input_breakdown.input_usd
+                    cached_input_usd = input_breakdown.cached_input_usd
+            if output_tokens is not None:
+                output_breakdown = calculate_cost_breakdown_from_usage(
+                    UsageTokens(
+                        input_tokens=float(input_tokens or 0),
+                        output_tokens=float(output_tokens),
+                        cached_input_tokens=float(cached_tokens),
+                    ),
+                    price,
+                    service_tier=log.service_tier,
+                    precision=precision,
+                )
+                if output_breakdown is not None:
+                    output_usd = output_breakdown.output_usd
+
+    persisted_cost = cost_from_log(log, precision=precision)
+    if persisted_cost is not None:
+        persisted_raw_cost = cost_from_log(log)
+        if not _totals_match(persisted_raw_cost, raw_total_usd, precision=precision):
+            return UsageCostBreakdown(
+                input_usd=None,
+                cached_input_usd=None,
+                output_usd=None,
+                total_usd=persisted_cost,
+            )
+        return UsageCostBreakdown(
+            input_usd=input_usd,
+            cached_input_usd=cached_input_usd,
+            output_usd=output_usd,
+            total_usd=persisted_cost,
+        )
+    if full_breakdown is not None:
+        return UsageCostBreakdown(
+            input_usd=input_usd,
+            cached_input_usd=cached_input_usd,
+            output_usd=output_usd,
+            total_usd=total_usd,
+        )
+    return UsageCostBreakdown(
+        input_usd=input_usd,
+        cached_input_usd=cached_input_usd,
+        output_usd=output_usd,
+        total_usd=None,
+    )
+
+
 def total_tokens_from_log(log: RequestLogLike) -> int | None:
     input_tokens = log.input_tokens
-    output_tokens = log.output_tokens
-    if output_tokens is None and log.reasoning_tokens is not None:
-        output_tokens = log.reasoning_tokens
+    output_tokens = output_tokens_from_log(log)
     if input_tokens is None and output_tokens is None:
         return None
     return (input_tokens or 0) + (output_tokens or 0)

--- a/app/core/usage/logs.py
+++ b/app/core/usage/logs.py
@@ -117,7 +117,7 @@ def cost_breakdown_from_log(log: RequestLogLike, *, precision: int | None = None
         if resolved is not None:
             _, price = resolved
             input_tokens = log.input_tokens
-            cached_tokens = cached_input_tokens_from_log(log) or 0
+            cached_tokens = cached_input_tokens_from_log(log)
             output_tokens = output_tokens_from_log(log)
             usage = usage_tokens_from_log(log)
             if usage is not None:
@@ -132,7 +132,7 @@ def cost_breakdown_from_log(log: RequestLogLike, *, precision: int | None = None
                 )
                 if full_breakdown is not None:
                     total_usd = full_breakdown.total_usd
-            if input_tokens is not None:
+            if input_tokens is not None and cached_tokens is not None:
                 input_breakdown = calculate_cost_breakdown_from_usage(
                     UsageTokens(
                         input_tokens=float(input_tokens),
@@ -151,7 +151,7 @@ def cost_breakdown_from_log(log: RequestLogLike, *, precision: int | None = None
                     UsageTokens(
                         input_tokens=float(input_tokens or 0),
                         output_tokens=float(output_tokens),
-                        cached_input_tokens=float(cached_tokens),
+                        cached_input_tokens=float(cached_tokens or 0),
                     ),
                     price,
                     service_tier=log.service_tier,

--- a/app/core/usage/pricing.py
+++ b/app/core/usage/pricing.py
@@ -35,6 +35,14 @@ class UsageTokens:
 
 
 @dataclass(frozen=True)
+class UsageCostBreakdown:
+    input_usd: float | None
+    cached_input_usd: float | None
+    output_usd: float | None
+    total_usd: float | None
+
+
+@dataclass(frozen=True)
 class CostItem:
     model: str
     usage: UsageTokens
@@ -49,7 +57,17 @@ def _as_number(value: int | float | None) -> float | None:
 
 def _normalize_usage(usage: UsageTokens | ResponseUsage | None) -> UsageTokens | None:
     if isinstance(usage, UsageTokens):
-        return usage
+        input_tokens = _as_number(usage.input_tokens)
+        output_tokens = _as_number(usage.output_tokens)
+        cached_tokens = _as_number(usage.cached_input_tokens)
+        if input_tokens is None or output_tokens is None:
+            return None
+        cached_tokens = max(0.0, min(cached_tokens or 0.0, input_tokens))
+        return UsageTokens(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_input_tokens=cached_tokens,
+        )
     if not usage:
         return None
     input_tokens = _as_number(usage.input_tokens)
@@ -403,10 +421,23 @@ def calculate_cost_from_usage(
     *,
     service_tier: str | None = None,
 ) -> float | None:
+    breakdown = calculate_cost_breakdown_from_usage(usage, price, service_tier=service_tier)
+    if breakdown is None:
+        return None
+    return breakdown.total_usd
+
+
+def calculate_cost_breakdown_from_usage(
+    usage: UsageTokens | ResponseUsage | None,
+    price: ModelPrice,
+    *,
+    service_tier: str | None = None,
+    precision: int | None = None,
+) -> UsageCostBreakdown | None:
     normalized = _normalize_usage(usage)
     if not normalized:
         return None
-    billable_input = normalized.input_tokens - normalized.cached_input_tokens
+    billable_input = max(0.0, normalized.input_tokens - normalized.cached_input_tokens)
 
     input_rate, cached_rate, output_rate = _effective_rates(
         normalized,
@@ -414,10 +445,25 @@ def calculate_cost_from_usage(
         service_tier=service_tier,
     )
 
-    return (
-        (billable_input / 1_000_000) * input_rate
-        + (normalized.cached_input_tokens / 1_000_000) * cached_rate
-        + (normalized.output_tokens / 1_000_000) * output_rate
+    input_usd = (billable_input / 1_000_000) * input_rate
+    cached_input_usd = (normalized.cached_input_tokens / 1_000_000) * cached_rate
+    output_usd = (normalized.output_tokens / 1_000_000) * output_rate
+
+    if precision is not None:
+        input_usd = round(input_usd, precision)
+        cached_input_usd = round(cached_input_usd, precision)
+        output_usd = round(output_usd, precision)
+
+    total_usd = input_usd + cached_input_usd + output_usd
+
+    if precision is not None:
+        total_usd = round(total_usd, precision)
+
+    return UsageCostBreakdown(
+        input_usd=input_usd,
+        cached_input_usd=cached_input_usd,
+        output_usd=output_usd,
+        total_usd=total_usd,
     )
 
 

--- a/app/modules/request_logs/mappers.py
+++ b/app/modules/request_logs/mappers.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 from typing import cast as typing_cast
 
-from app.core.usage.logs import RequestLogLike, cached_input_tokens_from_log, cost_from_log, total_tokens_from_log
+from app.core.usage.logs import (
+    RequestLogLike,
+    cached_input_tokens_from_log,
+    cost_breakdown_from_log,
+    output_tokens_from_log,
+    total_tokens_from_log,
+)
 from app.db.models import RequestLog
-from app.modules.request_logs.schemas import RequestLogEntry
+from app.modules.request_logs.schemas import RequestLogCostBreakdown, RequestLogEntry
 
 RATE_LIMIT_CODES = {"rate_limit_exceeded", "usage_limit_reached"}
 QUOTA_CODES = {"insufficient_quota", "usage_not_included", "quota_exceeded"}
@@ -26,6 +32,7 @@ def log_status(log: RequestLog) -> str:
 
 def to_request_log_entry(log: RequestLog, *, api_key_name: str | None = None) -> RequestLogEntry:
     log_like = typing_cast(RequestLogLike, log)
+    cost_breakdown = cost_breakdown_from_log(log_like, precision=6)
     return RequestLogEntry(
         requested_at=log.requested_at,
         account_id=log.account_id,
@@ -43,8 +50,11 @@ def to_request_log_entry(log: RequestLog, *, api_key_name: str | None = None) ->
         error_code=log.error_code,
         error_message=log.error_message,
         tokens=total_tokens_from_log(log_like),
+        input_tokens=log.input_tokens,
+        output_tokens=output_tokens_from_log(log_like),
         cached_input_tokens=cached_input_tokens_from_log(log_like),
-        cost_usd=cost_from_log(log_like, precision=6),
+        cost_usd=cost_breakdown.total_usd,
+        cost_breakdown=RequestLogCostBreakdown(**cost_breakdown.__dict__),
         latency_ms=log.latency_ms,
         latency_first_token_ms=log.latency_first_token_ms,
     )

--- a/app/modules/request_logs/schemas.py
+++ b/app/modules/request_logs/schemas.py
@@ -7,6 +7,13 @@ from pydantic import Field
 from app.modules.shared.schemas import DashboardModel
 
 
+class RequestLogCostBreakdown(DashboardModel):
+    input_usd: float | None = None
+    cached_input_usd: float | None = None
+    output_usd: float | None = None
+    total_usd: float | None = None
+
+
 class RequestLogEntry(DashboardModel):
     requested_at: datetime
     account_id: str | None = None
@@ -23,9 +30,12 @@ class RequestLogEntry(DashboardModel):
     error_code: str | None = None
     error_message: str | None = None
     tokens: int | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
     cached_input_tokens: int | None = None
     reasoning_effort: str | None = None
     cost_usd: float | None = None
+    cost_breakdown: RequestLogCostBreakdown = Field(default_factory=RequestLogCostBreakdown)
     latency_ms: int | None = None
     latency_first_token_ms: int | None = None
 

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RecentRequestsTable } from "@/features/dashboard/components/recent-requests-table";
@@ -31,6 +31,11 @@ const PAGINATION_PROPS = {
   onLimitChange: vi.fn(),
   onOffsetChange: vi.fn(),
 };
+
+function openRequestDetails() {
+  fireEvent.click(screen.getByRole("button", { name: "View Details" }));
+  return screen.getByRole("dialog");
+}
 
 describe("RecentRequestsTable", () => {
   beforeEach(() => {
@@ -73,21 +78,29 @@ describe("RecentRequestsTable", () => {
             requestedServiceTier: "priority",
             actualServiceTier: "default",
             transport: "websocket",
-            status: "rate_limit",
-            errorCode: "rate_limit_exceeded",
-            errorMessage: longError,
-            tokens: 1200,
-            cachedInputTokens: 200,
-            reasoningEffort: "high",
-            costUsd: 0.01,
-            latencyMs: 1000,
-          },
-        ]}
-      />,
+             status: "rate_limit",
+             errorCode: "rate_limit_exceeded",
+             errorMessage: longError,
+             tokens: 1200,
+             inputTokens: 1000,
+             outputTokens: 200,
+             cachedInputTokens: 200,
+             reasoningEffort: "high",
+             costUsd: 0.01,
+             costBreakdown: {
+               inputUsd: 0.004,
+               cachedInputUsd: 0.001,
+               outputUsd: 0.005,
+               totalUsd: 0.01,
+             },
+             latencyMs: 1000,
+           },
+         ]}
+       />,
     );
 
     expect(screen.getByText("Primary Account")).toBeInTheDocument();
-    expect(screen.getAllByText("Plus")[0]).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "Plus" })).toBeInTheDocument();
     expect(screen.getByText("Key Alpha")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.1 (high, default)")).toBeInTheDocument();
     expect(screen.getByText("Requested priority")).toBeInTheDocument();
@@ -95,14 +108,12 @@ describe("RecentRequestsTable", () => {
     expect(screen.getByText("Rate limit")).toBeInTheDocument();
     expect(screen.getByText("rate_limit_exceeded")).toBeInTheDocument();
 
-    const viewButton = screen.getByRole("button", { name: "View Details" });
-    fireEvent.click(viewButton);
-    const dialog = screen.getByRole("dialog");
+    const dialog = openRequestDetails();
     expect(dialog).toBeInTheDocument();
-    expect(screen.getByText("Request Details")).toBeInTheDocument();
-    expect(screen.getByText("req-1")).toBeInTheDocument();
-    expect(screen.getByTestId("request-archive-panel")).toHaveTextContent("Archive for req-1");
-    expect(screen.getAllByText("rate_limit_exceeded")[0]).toBeInTheDocument();
+    expect(within(dialog).getByText("Request Details")).toBeInTheDocument();
+    expect(within(dialog).getByText("req-1")).toBeInTheDocument();
+    expect(within(dialog).getByTestId("request-archive-panel")).toHaveTextContent("Archive for req-1");
+    expect(within(dialog).getByText("rate_limit_exceeded")).toBeInTheDocument();
     expect(dialog.textContent).toContain("Rate limit reached while processing this request");
 
     await act(async () => {
@@ -145,20 +156,25 @@ describe("RecentRequestsTable", () => {
             requestedServiceTier: null,
             actualServiceTier: null,
             transport: null,
-            status: "ok",
-            errorCode: null,
-            errorMessage: null,
-            tokens: 1,
-            cachedInputTokens: null,
-            reasoningEffort: null,
-            costUsd: 0,
-            latencyMs: 1,
-          },
-        ]}
-      />,
+             status: "ok",
+             errorCode: null,
+             errorMessage: null,
+             tokens: 1,
+             inputTokens: 1,
+             outputTokens: 0,
+             cachedInputTokens: null,
+             reasoningEffort: null,
+             costUsd: 0,
+             costBreakdown: null,
+             latencyMs: 1,
+           },
+         ]}
+       />,
     );
 
-    expect(screen.getAllByText("--")[0]).toBeInTheDocument();
+    const row = screen.getByText("gpt-5.1").closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getAllByText("--").length).toBeGreaterThan(0);
   });
 
   it("shows details action for error-code-only rows", async () => {
@@ -179,23 +195,211 @@ describe("RecentRequestsTable", () => {
             requestedServiceTier: null,
             actualServiceTier: null,
             transport: "http",
+             status: "error",
+             errorCode: "upstream_error",
+             errorMessage: null,
+             tokens: 1,
+             inputTokens: 1,
+             outputTokens: 0,
+             cachedInputTokens: null,
+             reasoningEffort: null,
+             costUsd: 0,
+             costBreakdown: null,
+             latencyMs: 1,
+           },
+         ]}
+       />,
+    );
+
+    const dialog = openRequestDetails();
+
+    expect(dialog).toHaveTextContent("upstream_error");
+    expect(dialog).toHaveTextContent("Full Error");
+  });
+
+  it("shows a cost section for ok rows", () => {
+    render(
+      <RecentRequestsTable
+        {...PAGINATION_PROPS}
+        accounts={[]}
+        requests={[
+          {
+            requestedAt: ISO,
+            accountId: "acc-cost",
+            planType: "plus",
+            apiKeyName: "Key Cost",
+            apiKeyId: "key-cost",
+            requestId: "req-cost",
+            model: "gpt-5.1",
+            serviceTier: null,
+            requestedServiceTier: null,
+            actualServiceTier: null,
+            transport: "http",
+            status: "ok",
+            errorCode: null,
+            errorMessage: null,
+            tokens: 1400,
+            inputTokens: 1000,
+            outputTokens: 400,
+            cachedInputTokens: 200,
+            reasoningEffort: null,
+            costUsd: 0.01,
+            costBreakdown: {
+              inputUsd: 0.004,
+              cachedInputUsd: 0.002,
+              outputUsd: 0.004,
+              totalUsd: 0.01,
+            },
+            latencyMs: 100,
+          },
+        ]}
+      />,
+    );
+
+    const dialog = openRequestDetails();
+    const costSection = within(dialog).getByText("Cost").closest("div.space-y-2");
+
+    expect(within(dialog).getByText("Cost")).toBeInTheDocument();
+    expect(costSection).toHaveTextContent("$0.01 =");
+    expect(costSection).toHaveTextContent("800 Input ($0.00)");
+    expect(costSection).toHaveTextContent("200 Cached ($0.00)");
+    expect(costSection).toHaveTextContent("400 Output ($0.00)");
+  });
+
+  it("hides the cost section for non-ok rows", () => {
+    render(
+      <RecentRequestsTable
+        {...PAGINATION_PROPS}
+        accounts={[]}
+        requests={[
+          {
+            requestedAt: ISO,
+            accountId: "acc-no-cost",
+            planType: null,
+            apiKeyName: null,
+            apiKeyId: null,
+            requestId: "req-no-cost",
+            model: "gpt-5.1",
+            serviceTier: null,
+            requestedServiceTier: null,
+            actualServiceTier: null,
+            transport: "http",
             status: "error",
             errorCode: "upstream_error",
-            errorMessage: null,
+            errorMessage: "boom",
             tokens: 1,
-            cachedInputTokens: null,
+            inputTokens: 1,
+            outputTokens: 0,
+            cachedInputTokens: 0,
             reasoningEffort: null,
-            costUsd: 0,
+            costUsd: 0.01,
+            costBreakdown: {
+              inputUsd: 0.01,
+              cachedInputUsd: null,
+              outputUsd: null,
+              totalUsd: 0.01,
+            },
             latencyMs: 1,
           },
         ]}
       />,
     );
 
-    expect(screen.getAllByText("upstream_error")[0]).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "View Details" }));
+    const dialog = openRequestDetails();
 
-    expect(screen.getByRole("dialog")).toHaveTextContent("upstream_error");
-    expect(screen.getByRole("dialog")).toHaveTextContent("Full Error");
+    expect(within(dialog).queryByText("Cost")).not.toBeInTheDocument();
+  });
+
+  it("renders only available cost segments for partial data", () => {
+    render(
+      <RecentRequestsTable
+        {...PAGINATION_PROPS}
+        accounts={[]}
+        requests={[
+          {
+            requestedAt: ISO,
+            accountId: "acc-partial-cost",
+            planType: "plus",
+            apiKeyName: "Key Partial",
+            apiKeyId: "key-partial",
+            requestId: "req-partial-cost",
+            model: "gpt-5.1",
+            serviceTier: null,
+            requestedServiceTier: null,
+            actualServiceTier: null,
+            transport: "http",
+            status: "ok",
+            errorCode: null,
+            errorMessage: null,
+            tokens: 700,
+            inputTokens: 700,
+            outputTokens: null,
+            cachedInputTokens: 200,
+            reasoningEffort: null,
+            costUsd: 0.01,
+            costBreakdown: {
+              inputUsd: 0.006,
+              cachedInputUsd: 0.004,
+              outputUsd: null,
+              totalUsd: 0.01,
+            },
+            latencyMs: 1,
+          },
+        ]}
+      />,
+    );
+
+    const dialog = openRequestDetails();
+    const costSection = within(dialog).getByText("Cost").closest("div.space-y-2");
+
+    expect(within(dialog).getByText("Cost")).toBeInTheDocument();
+    expect(costSection).toHaveTextContent("$0.01 =");
+    expect(costSection).toHaveTextContent("500 Input ($0.01)");
+    expect(costSection).toHaveTextContent("200 Cached ($0.00)");
+    expect(costSection).not.toHaveTextContent("Output");
+  });
+
+  it("hides the cost section for total-only cost breakdown rows", () => {
+    render(
+      <RecentRequestsTable
+        {...PAGINATION_PROPS}
+        accounts={[]}
+        requests={[
+          {
+            requestedAt: ISO,
+            accountId: "acc-total-only-cost",
+            planType: "plus",
+            apiKeyName: "Key Total Only",
+            apiKeyId: "key-total-only",
+            requestId: "req-total-only-cost",
+            model: "gpt-5.1",
+            serviceTier: null,
+            requestedServiceTier: null,
+            actualServiceTier: null,
+            transport: "http",
+            status: "ok",
+            errorCode: null,
+            errorMessage: null,
+            tokens: 1500,
+            inputTokens: 1000,
+            outputTokens: 500,
+            cachedInputTokens: null,
+            reasoningEffort: null,
+            costUsd: 4.321234,
+            costBreakdown: {
+              inputUsd: null,
+              cachedInputUsd: null,
+              outputUsd: null,
+              totalUsd: 4.321234,
+            },
+            latencyMs: 1,
+          },
+        ]}
+      />,
+    );
+
+    const dialog = openRequestDetails();
+
+    expect(within(dialog).queryByText("Cost")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -359,6 +359,55 @@ describe("RecentRequestsTable", () => {
     expect(costSection).not.toHaveTextContent("Output");
   });
 
+  it("renders available cost segments when total cost is unavailable", () => {
+    render(
+      <RecentRequestsTable
+        {...PAGINATION_PROPS}
+        accounts={[]}
+        requests={[
+          {
+            requestedAt: ISO,
+            accountId: "acc-partial-no-total",
+            planType: "plus",
+            apiKeyName: "Key Partial No Total",
+            apiKeyId: "key-partial-no-total",
+            requestId: "req-partial-no-total",
+            model: "gpt-5.1",
+            serviceTier: null,
+            requestedServiceTier: null,
+            actualServiceTier: null,
+            transport: "http",
+            status: "ok",
+            errorCode: null,
+            errorMessage: null,
+            tokens: null,
+            inputTokens: 1000,
+            outputTokens: null,
+            cachedInputTokens: 200,
+            reasoningEffort: null,
+            costUsd: null,
+            costBreakdown: {
+              inputUsd: 0.006,
+              cachedInputUsd: 0.004,
+              outputUsd: null,
+              totalUsd: null,
+            },
+            latencyMs: 1,
+          },
+        ]}
+      />,
+    );
+
+    const dialog = openRequestDetails();
+    const costSection = within(dialog).getByText("Cost").closest("div.space-y-2");
+
+    expect(within(dialog).getByText("Cost")).toBeInTheDocument();
+    expect(costSection).not.toHaveTextContent("=");
+    expect(costSection).toHaveTextContent("800 Input ($0.01)");
+    expect(costSection).toHaveTextContent("200 Cached ($0.00)");
+    expect(costSection).not.toHaveTextContent("Output");
+  });
+
   it("hides the cost section for total-only cost breakdown rows", () => {
     render(
       <RecentRequestsTable

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -71,6 +71,46 @@ export type RecentRequestsTableProps = {
   onOffsetChange: (offset: number) => void;
 };
 
+function formatRequestCostSummary(request: RequestLog | null): string | null {
+  if (!request || request.status !== "ok") {
+    return null;
+  }
+
+  const totalUsd = request.costBreakdown?.totalUsd ?? request.costUsd;
+  if (totalUsd == null) {
+    return null;
+  }
+
+  const segments: string[] = [];
+  const cachedInputTokens = request.cachedInputTokens ?? 0;
+  const nonCachedInputTokens =
+    request.inputTokens == null ? null : Math.max(0, request.inputTokens - cachedInputTokens);
+
+  if (nonCachedInputTokens != null && request.costBreakdown?.inputUsd != null) {
+    segments.push(
+      `${formatCompactNumber(nonCachedInputTokens)} Input (${formatCurrency(request.costBreakdown.inputUsd)})`,
+    );
+  }
+
+  if (request.cachedInputTokens != null && request.costBreakdown?.cachedInputUsd != null) {
+    segments.push(
+      `${formatCompactNumber(request.cachedInputTokens)} Cached (${formatCurrency(request.costBreakdown.cachedInputUsd)})`,
+    );
+  }
+
+  if (request.outputTokens != null && request.costBreakdown?.outputUsd != null) {
+    segments.push(
+      `${formatCompactNumber(request.outputTokens)} Output (${formatCurrency(request.costBreakdown.outputUsd)})`,
+    );
+  }
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  return `${formatCurrency(totalUsd)} = ${segments.join(" + ")}`;
+}
+
 export function RecentRequestsTable({
   requests,
   accounts,
@@ -83,6 +123,7 @@ export function RecentRequestsTable({
 }: RecentRequestsTableProps) {
   const [selectedRequest, setSelectedRequest] = useState<RequestLog | null>(null);
   const blurred = usePrivacyStore((s) => s.blurred);
+  const selectedRequestCostSummary = formatRequestCostSummary(selectedRequest);
 
   const accountLabelMap = useMemo(() => {
     const index = new Map<string, string>();
@@ -302,6 +343,17 @@ export function RecentRequestsTable({
             </div>
 
             <RequestArchivePanel requestId={selectedRequest?.requestId} requestedAt={selectedRequest?.requestedAt} />
+
+            {selectedRequestCostSummary ? (
+              <div className="space-y-2">
+                <h3 className="text-sm font-medium">Cost</h3>
+                <div className="rounded-md bg-muted/50 p-3">
+                  <p className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
+                    {selectedRequestCostSummary}
+                  </p>
+                </div>
+              </div>
+            ) : null}
 
             <div className="space-y-2">
               <div className="flex items-center gap-2">

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -77,10 +77,6 @@ function formatRequestCostSummary(request: RequestLog | null): string | null {
   }
 
   const totalUsd = request.costBreakdown?.totalUsd ?? request.costUsd;
-  if (totalUsd == null) {
-    return null;
-  }
-
   const segments: string[] = [];
   const cachedInputTokens = request.cachedInputTokens ?? 0;
   const nonCachedInputTokens =
@@ -106,6 +102,10 @@ function formatRequestCostSummary(request: RequestLog | null): string | null {
 
   if (segments.length === 0) {
     return null;
+  }
+
+  if (totalUsd == null) {
+    return segments.join(" + ");
   }
 
   return `${formatCurrency(totalUsd)} = ${segments.join(" + ")}`;

--- a/frontend/src/features/dashboard/schemas.test.ts
+++ b/frontend/src/features/dashboard/schemas.test.ts
@@ -145,9 +145,17 @@ describe("RequestLogsResponseSchema", () => {
           errorCode: null,
           errorMessage: null,
           tokens: 10,
+          inputTokens: 8,
+          outputTokens: 2,
           cachedInputTokens: 0,
           reasoningEffort: null,
           costUsd: 0.001,
+          costBreakdown: {
+            inputUsd: 0.0004,
+            cachedInputUsd: 0,
+            outputUsd: 0.0006,
+            totalUsd: 0.001,
+          },
           latencyMs: 42,
         },
       ],
@@ -159,6 +167,78 @@ describe("RequestLogsResponseSchema", () => {
     expect(parsed.requests[0]?.apiKeyId).toBe("key-1");
     expect(parsed.requests[0]?.planType).toBe("plus");
     expect(parsed.requests[0]?.transport).toBe("websocket");
+    expect(parsed.requests[0]?.inputTokens).toBe(8);
+    expect(parsed.requests[0]?.outputTokens).toBe(2);
+    expect(parsed.requests[0]?.costBreakdown?.totalUsd).toBe(0.001);
+  });
+
+  it("defaults omitted cost fields to null for backward compatibility", () => {
+    const parsed = RequestLogsResponseSchema.parse({
+      requests: [
+        {
+          requestedAt: ISO,
+          accountId: "acc-1",
+          planType: "plus",
+          apiKeyName: "Key A",
+          apiKeyId: "key-1",
+          requestId: "req-legacy-cost-fields",
+          model: "gpt-5.1",
+          transport: "websocket",
+          status: "ok",
+          errorCode: null,
+          errorMessage: null,
+          tokens: 10,
+          cachedInputTokens: 0,
+          reasoningEffort: null,
+          costUsd: 0.001,
+          latencyMs: 42,
+        },
+      ],
+      total: 1,
+      hasMore: false,
+    });
+
+    expect(parsed.requests[0]?.inputTokens).toBeNull();
+    expect(parsed.requests[0]?.outputTokens).toBeNull();
+    expect(parsed.requests[0]?.costBreakdown).toBeNull();
+  });
+
+  it("defaults omitted nested cost breakdown fields to null", () => {
+    const parsed = RequestLogsResponseSchema.parse({
+      requests: [
+        {
+          requestedAt: ISO,
+          accountId: "acc-1",
+          planType: "plus",
+          apiKeyName: "Key A",
+          apiKeyId: "key-1",
+          requestId: "req-partial-breakdown",
+          model: "gpt-5.1",
+          transport: "websocket",
+          status: "ok",
+          errorCode: null,
+          errorMessage: null,
+          tokens: 10,
+          inputTokens: 8,
+          outputTokens: 2,
+          cachedInputTokens: 0,
+          reasoningEffort: null,
+          costUsd: 0.001,
+          costBreakdown: {
+            inputUsd: 0.0004,
+            totalUsd: 0.001,
+          },
+          latencyMs: 42,
+        },
+      ],
+      total: 1,
+      hasMore: false,
+    });
+
+    expect(parsed.requests[0]?.costBreakdown?.inputUsd).toBe(0.0004);
+    expect(parsed.requests[0]?.costBreakdown?.cachedInputUsd).toBeNull();
+    expect(parsed.requests[0]?.costBreakdown?.outputUsd).toBeNull();
+    expect(parsed.requests[0]?.costBreakdown?.totalUsd).toBe(0.001);
   });
 
   it("parses request-log filter options including API keys", () => {

--- a/frontend/src/features/dashboard/schemas.ts
+++ b/frontend/src/features/dashboard/schemas.ts
@@ -127,6 +127,13 @@ export const DashboardOverviewSchema = z.object({
   weeklyCreditPace: WeeklyCreditPaceSchema.nullable().optional(),
 });
 
+export const RequestLogCostBreakdownSchema = z.object({
+  inputUsd: z.number().nullable().optional().default(null),
+  cachedInputUsd: z.number().nullable().optional().default(null),
+  outputUsd: z.number().nullable().optional().default(null),
+  totalUsd: z.number().nullable().optional().default(null),
+});
+
 export const RequestLogSchema = z.object({
   requestedAt: z.string().datetime({ offset: true }),
   accountId: z.string().nullable(),
@@ -143,9 +150,12 @@ export const RequestLogSchema = z.object({
   errorCode: z.string().nullable(),
   errorMessage: z.string().nullable(),
   tokens: z.number().nullable(),
+  inputTokens: z.number().nullable().optional().default(null),
+  outputTokens: z.number().nullable().optional().default(null),
   cachedInputTokens: z.number().nullable(),
   reasoningEffort: z.string().nullable(),
   costUsd: z.number().nullable(),
+  costBreakdown: RequestLogCostBreakdownSchema.nullable().optional().default(null),
   latencyMs: z.number().nullable(),
 });
 

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -262,9 +262,17 @@ export function createRequestLogEntry(
 		errorCode: null,
 		errorMessage: null,
 		tokens: 1800,
+		inputTokens: 1200,
+		outputTokens: 600,
 		cachedInputTokens: 320,
 		reasoningEffort: null,
 		costUsd: 0.0132,
+		costBreakdown: {
+			inputUsd: 0.0054,
+			cachedInputUsd: 0.0012,
+			outputUsd: 0.0066,
+			totalUsd: 0.0132,
+		},
 		latencyMs: 920,
 		...overrides,
 	});

--- a/openspec/changes/add-request-log-cost-breakdown/proposal.md
+++ b/openspec/changes/add-request-log-cost-breakdown/proposal.md
@@ -1,0 +1,15 @@
+# Proposal: add-request-log-cost-breakdown
+
+## Why
+The request-log detail dialog currently shows only the aggregated request cost. Operators cannot tell how much of the bill came from non-cached input, cached input, or output tokens, even though the backend already stores the token counts needed to explain that total.
+
+## What Changes
+- Expose `inputTokens`, `outputTokens`, and `costBreakdown` on `GET /api/request-logs`.
+- Fall back to `reasoning_tokens` for `outputTokens` when `output_tokens` is unavailable.
+- Show a `Cost` section under the archive panel in the dashboard request-log `View Details` dialog.
+- Render the section only for successful (`ok`) requests.
+- Reuse existing token and currency formatting and hide unavailable segments instead of failing legacy rows.
+
+## Capabilities
+### Modified Capabilities
+- `frontend-architecture`

--- a/openspec/changes/add-request-log-cost-breakdown/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-request-log-cost-breakdown/specs/frontend-architecture/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Request logs expose cost breakdown details
+When a request log has sufficient usage data, the dashboard request-log API MUST expose raw input/output token counts and a cost breakdown that separates non-cached input, cached input, and output cost.
+
+#### Scenario: Successful request log exposes token and cost segments
+- **WHEN** a successful request log row has persisted input, cached-input, and output usage
+- **THEN** `GET /api/request-logs` includes `inputTokens`, `outputTokens`, and `costBreakdown`
+- **AND** `costBreakdown` includes `inputUsd`, `cachedInputUsd`, `outputUsd`, and `totalUsd`
+
+#### Scenario: Request log output falls back to reasoning tokens
+- **WHEN** a successful request log row has no persisted `output_tokens` and does have `reasoning_tokens`
+- **THEN** `GET /api/request-logs` uses the reasoning-token value for `outputTokens`
+
+#### Scenario: Request log response preserves shape for legacy partial data
+- **WHEN** a successful request log row is missing one or more persisted token or cost segments
+- **THEN** `GET /api/request-logs` still includes `inputTokens`, `outputTokens`, and `costBreakdown`
+- **AND** any unavailable top-level token field is returned as `null`
+- **AND** `costBreakdown` includes `inputUsd`, `cachedInputUsd`, `outputUsd`, and `totalUsd`
+- **AND** any unavailable `costBreakdown` field is returned as `null`
+- **AND** clients can render only the available token and cost segments without treating the row as invalid
+
+### Requirement: Request detail dialog renders successful cost breakdowns
+The dashboard request-log `View Details` dialog MUST render a `Cost` section under `Archive` for successful request rows and MUST hide the section for non-success rows.
+
+#### Scenario: Successful request displays ordered cost details
+- **WHEN** a request log detail dialog opens for an `ok` row with available breakdown data
+- **THEN** the dialog displays the total cost first
+- **AND** the dialog lists available cost segments in this order: input, cached, output
+- **AND** each displayed segment includes its token count and matching currency value
+- **AND** token counts use the same compact formatting as the request-log tokens column
+- **AND** currency values are rounded to two decimals
+
+#### Scenario: Missing cost segments are omitted without breaking the dialog
+- **WHEN** a successful request log row is missing one or more token or cost segments
+- **THEN** the dialog renders only the available segments
+- **AND** if no segments are available the `Cost` section is hidden

--- a/openspec/changes/add-request-log-cost-breakdown/tasks.md
+++ b/openspec/changes/add-request-log-cost-breakdown/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: add-request-log-cost-breakdown
+
+## 1. Specs
+- [ ] 1.1 Add request-log cost-breakdown requirements.
+- [ ] 1.2 Validate OpenSpec changes.
+
+## 2. Backend
+- [ ] 2.1 Add reusable request-log pricing breakdown helpers.
+- [ ] 2.2 Expose `inputTokens`, `outputTokens`, and `costBreakdown` from `/api/request-logs`, including `reasoning_tokens` fallback for `outputTokens` and `null` placeholders for unavailable legacy breakdown segments.
+
+## 3. Frontend
+- [ ] 3.1 Extend the dashboard request-log schema for the new payload.
+- [ ] 3.2 Render the `Cost` section in the request detail dialog only for `ok` rows.
+
+## 4. Tests
+- [ ] 4.1 Add backend coverage for request-log breakdown payloads.
+- [ ] 4.2 Add frontend schema and dialog rendering coverage.

--- a/tests/integration/test_request_logs_api.py
+++ b/tests/integration/test_request_logs_api.py
@@ -104,8 +104,8 @@ async def test_request_logs_api_returns_recent(async_client, db_setup):
     assert older["outputTokens"] == 200
     assert older["cachedInputTokens"] is None
     assert older["costBreakdown"] == {
-        "inputUsd": pytest.approx(0.000125),
-        "cachedInputUsd": pytest.approx(0.0),
+        "inputUsd": None,
+        "cachedInputUsd": None,
         "outputUsd": pytest.approx(0.002),
         "totalUsd": pytest.approx(0.002125),
     }

--- a/tests/integration/test_request_logs_api.py
+++ b/tests/integration/test_request_logs_api.py
@@ -61,7 +61,7 @@ async def test_request_logs_api_returns_recent(async_client, db_setup):
         await logs_repo.add_log(
             account_id="acc_logs",
             request_id="req_logs_2",
-            model="gpt-5.1",
+            model="legacy-model",
             input_tokens=50,
             output_tokens=0,
             latency_ms=300,
@@ -87,6 +87,12 @@ async def test_request_logs_api_returns_recent(async_client, db_setup):
     assert latest["apiKeyName"] == "Debug Key"
     assert latest["errorCode"] == "rate_limit_exceeded"
     assert latest["errorMessage"] == "Rate limit reached"
+    assert latest["costBreakdown"] == {
+        "inputUsd": None,
+        "cachedInputUsd": None,
+        "outputUsd": None,
+        "totalUsd": None,
+    }
     assert latest["transport"] == "websocket"
 
     older = payload[1]
@@ -94,5 +100,13 @@ async def test_request_logs_api_returns_recent(async_client, db_setup):
     assert older["apiKeyId"] is None
     assert older["apiKeyName"] is None
     assert older["tokens"] == 300
+    assert older["inputTokens"] == 100
+    assert older["outputTokens"] == 200
     assert older["cachedInputTokens"] is None
+    assert older["costBreakdown"] == {
+        "inputUsd": pytest.approx(0.000125),
+        "cachedInputUsd": pytest.approx(0.0),
+        "outputUsd": pytest.approx(0.002),
+        "totalUsd": pytest.approx(0.002125),
+    }
     assert older["transport"] == "http"

--- a/tests/integration/test_request_logs_filters.py
+++ b/tests/integration/test_request_logs_filters.py
@@ -455,10 +455,85 @@ async def test_request_logs_tokens_and_cost_use_reasoning_tokens(async_client, d
     assert len(payload) == 1
     entry = payload[0]
     assert entry["tokens"] == 1400
+    assert entry["inputTokens"] == 1000
+    assert entry["outputTokens"] == 400
     assert entry["cachedInputTokens"] == 100
     assert entry["reasoningEffort"] == "xhigh"
     expected = round(_cost(1000, 400, 100), 6)
     assert entry["costUsd"] == pytest.approx(expected)
+    assert entry["costBreakdown"]["inputUsd"] == pytest.approx(round((900 / 1_000_000) * 1.25, 6))
+    assert entry["costBreakdown"]["cachedInputUsd"] == pytest.approx(round((100 / 1_000_000) * 0.125, 6))
+    assert entry["costBreakdown"]["outputUsd"] == pytest.approx(round((400 / 1_000_000) * 10.0, 6))
+    assert entry["costBreakdown"]["totalUsd"] == pytest.approx(expected)
+
+
+@pytest.mark.asyncio
+async def test_request_logs_partial_rows_keep_nullable_cost_breakdown_shape(async_client, db_setup):
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_partial_log", "partial-log@example.com"))
+
+        await logs_repo.add_log(
+            account_id="acc_partial_log",
+            request_id="req_partial_log_1",
+            model="gpt-5.1",
+            input_tokens=1000,
+            output_tokens=None,
+            cached_input_tokens=100,
+            reasoning_tokens=None,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=now,
+        )
+
+    response = await async_client.get("/api/request-logs?accountId=acc_partial_log&limit=1")
+    assert response.status_code == 200
+    payload = response.json()["requests"]
+    assert len(payload) == 1
+    entry = payload[0]
+    assert entry["inputTokens"] == 1000
+    assert entry["outputTokens"] is None
+    assert entry["costUsd"] is None
+    assert entry["costBreakdown"] == {
+        "inputUsd": pytest.approx(round((900 / 1_000_000) * 1.25, 6)),
+        "cachedInputUsd": pytest.approx(round((100 / 1_000_000) * 0.125, 6)),
+        "outputUsd": None,
+        "totalUsd": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_logs_cost_uses_computed_total_when_persisted_cost_missing(async_client, db_setup):
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_missing_persisted_cost", "missing-persisted-cost@example.com"))
+
+        log = await logs_repo.add_log(
+            account_id="acc_missing_persisted_cost",
+            request_id="req_missing_persisted_cost_1",
+            model="gpt-5.1",
+            input_tokens=1000,
+            output_tokens=500,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=now,
+        )
+        await session.execute(update(log.__class__).where(log.__class__.id == log.id).values(cost_usd=None))
+        await session.commit()
+
+    response = await async_client.get("/api/request-logs?accountId=acc_missing_persisted_cost&limit=1")
+    assert response.status_code == 200
+    payload = response.json()["requests"]
+    assert len(payload) == 1
+    expected = round(_cost(1000, 500), 6)
+    assert payload[0]["costUsd"] == pytest.approx(expected)
+    assert payload[0]["costBreakdown"]["totalUsd"] == pytest.approx(expected)
 
 
 async def test_request_logs_cost_uses_priority_service_tier(async_client, db_setup):
@@ -521,6 +596,7 @@ async def test_request_logs_cost_uses_flex_service_tier(async_client, db_setup):
     assert entry["serviceTier"] == "flex"
     expected = round(_cost(300_000, 100_000, 50_000, input_rate=2.5, cached_rate=0.25, output_rate=11.25), 6)
     assert entry["costUsd"] == pytest.approx(expected)
+    assert entry["costBreakdown"]["outputUsd"] == pytest.approx(round((100_000 / 1_000_000) * 11.25, 6))
 
 
 @pytest.mark.asyncio
@@ -550,6 +626,10 @@ async def test_request_logs_cost_uses_persisted_cost_field(async_client, db_setu
     payload = response.json()["requests"]
     assert len(payload) == 1
     assert payload[0]["costUsd"] == pytest.approx(4.321234)
+    assert payload[0]["costBreakdown"]["inputUsd"] is None
+    assert payload[0]["costBreakdown"]["cachedInputUsd"] is None
+    assert payload[0]["costBreakdown"]["outputUsd"] is None
+    assert payload[0]["costBreakdown"]["totalUsd"] == pytest.approx(4.321234)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -9,6 +9,7 @@ from app.core.usage.pricing import (
     CostItem,
     ModelPrice,
     UsageTokens,
+    calculate_cost_breakdown_from_usage,
     calculate_cost_from_usage,
     calculate_costs,
     get_pricing_for_model,
@@ -107,6 +108,87 @@ def test_calculate_cost_from_usage_cached_tokens():
     cost = calculate_cost_from_usage(usage, price)
     expected = (800 / 1_000_000) * 2.0 + (200 / 1_000_000) * 0.5 + (500 / 1_000_000) * 4.0
     assert cost == pytest.approx(expected)
+
+
+def test_calculate_cost_breakdown_from_usage_cached_tokens():
+    usage = UsageTokens(
+        input_tokens=1_000.0,
+        output_tokens=500.0,
+        cached_input_tokens=200.0,
+    )
+    price = ModelPrice(input_per_1m=2.0, cached_input_per_1m=0.5, output_per_1m=4.0)
+
+    breakdown = calculate_cost_breakdown_from_usage(usage, price)
+
+    assert breakdown is not None
+    assert breakdown.input_usd == pytest.approx((800 / 1_000_000) * 2.0)
+    assert breakdown.cached_input_usd == pytest.approx((200 / 1_000_000) * 0.5)
+    assert breakdown.output_usd == pytest.approx((500 / 1_000_000) * 4.0)
+    assert breakdown.total_usd == pytest.approx(
+        ((800 / 1_000_000) * 2.0) + ((200 / 1_000_000) * 0.5) + ((500 / 1_000_000) * 4.0)
+    )
+
+
+def test_calculate_cost_breakdown_from_usage_clamps_cached_tokens():
+    usage = UsageTokens(
+        input_tokens=100.0,
+        output_tokens=500.0,
+        cached_input_tokens=200.0,
+    )
+    price = ModelPrice(input_per_1m=2.0, cached_input_per_1m=0.5, output_per_1m=4.0)
+
+    breakdown = calculate_cost_breakdown_from_usage(usage, price)
+
+    assert breakdown is not None
+    assert breakdown.input_usd == pytest.approx(0.0)
+    assert breakdown.cached_input_usd == pytest.approx((100 / 1_000_000) * 0.5)
+    assert breakdown.output_usd == pytest.approx((500 / 1_000_000) * 4.0)
+    assert breakdown.total_usd == pytest.approx(((100 / 1_000_000) * 0.5) + ((500 / 1_000_000) * 4.0))
+
+
+def test_calculate_cost_breakdown_from_usage_priority_service_tier():
+    usage = UsageTokens(
+        input_tokens=1_000_000.0,
+        output_tokens=1_000_000.0,
+        cached_input_tokens=100_000.0,
+    )
+    price = ModelPrice(
+        input_per_1m=2.5,
+        cached_input_per_1m=0.25,
+        output_per_1m=15.0,
+        priority_input_per_1m=5.0,
+        priority_cached_input_per_1m=0.5,
+        priority_output_per_1m=30.0,
+    )
+
+    breakdown = calculate_cost_breakdown_from_usage(
+        usage,
+        price,
+        service_tier="priority",
+    )
+
+    assert breakdown is not None
+    assert breakdown.input_usd == pytest.approx(4.5)
+    assert breakdown.cached_input_usd == pytest.approx(0.05)
+    assert breakdown.output_usd == pytest.approx(30.0)
+    assert breakdown.total_usd == pytest.approx(34.55)
+
+
+def test_calculate_cost_breakdown_from_usage_precision_rounds_components_first():
+    usage = UsageTokens(
+        input_tokens=200_000.0,
+        output_tokens=100_000.0,
+        cached_input_tokens=100_000.0,
+    )
+    price = ModelPrice(input_per_1m=0.144, cached_input_per_1m=0.144, output_per_1m=0.144)
+
+    breakdown = calculate_cost_breakdown_from_usage(usage, price, precision=2)
+
+    assert breakdown is not None
+    assert breakdown.input_usd == pytest.approx(0.01)
+    assert breakdown.cached_input_usd == pytest.approx(0.01)
+    assert breakdown.output_usd == pytest.approx(0.01)
+    assert breakdown.total_usd == pytest.approx(0.03)
 
 
 def test_calculate_cost_from_usage_priority_service_tier():


### PR DESCRIPTION
## Summary

Add a cost breakdown on each request.

## Type of change

<!-- Check the box that matches your PR. Commit titles must follow Conventional Commits. -->

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: <!-- e.g. Closes #123, Fixes #456 -->

## OpenSpec

<!--
codex-lb is OpenSpec-first. If this PR changes observable behavior, requirements,
contracts, or schema, it needs an OpenSpec change under openspec/changes/<change>/.

If this PR touches an upstream-mimicking code path (Codex CLI / ChatGPT request
shape, image pipeline, response.create framing, etc.), it must stay
**codex-faithful** — i.e. preserve the exact wire format the real upstream
emits. Call out anything that intentionally diverges, and link the spec section
that records the divergence.
-->

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior
<img width="636" height="311" alt="螢幕截圖 2026-05-18 14 35 41" src="https://github.com/user-attachments/assets/6291f8fc-8a32-4522-85cb-b7f31b481655" />

