### PR TITLE
fix(proxy): repair interrupted Codex response continuity

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -14,6 +14,16 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--port", type=int, default=int(os.getenv("PORT", "2455")))
     parser.add_argument("--ssl-certfile", default=os.getenv("SSL_CERTFILE"))
     parser.add_argument("--ssl-keyfile", default=os.getenv("SSL_KEYFILE"))
+    parser.add_argument(
+        "--timeout-keep-alive",
+        type=int,
+        default=int(os.getenv("UVICORN_TIMEOUT_KEEP_ALIVE", "300")),
+        help=(
+            "Seconds to keep idle HTTP connections open. Codex CLI reuses local "
+            "connections for compact POSTs; uvicorn's 5s default can leave the "
+            "client writing to a stale socket before the request reaches the app."
+        ),
+    )
 
     return parser.parse_args()
 
@@ -32,6 +42,7 @@ def main() -> None:
         port=args.port,
         ssl_certfile=args.ssl_certfile,
         ssl_keyfile=args.ssl_keyfile,
+        timeout_keep_alive=args.timeout_keep_alive,
         log_config=build_log_config(),
     )
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2590,6 +2590,7 @@ async def _normalize_public_responses_stream(
             relies on the upstream's native event shape.
     """
     terminal_seen = False
+    done_seen = False
     contract_violation_kind: str | None = None
     seen_text_delta_keys: set[tuple[str | None, int | None]] = set()
     # Collect output items from streamed ``response.output_item.added`` /
@@ -2642,6 +2643,7 @@ async def _normalize_public_responses_stream(
 
     async for event_block in stream:
         if event_block.strip() == "data: [DONE]":
+            done_seen = True
             if terminal_seen:
                 yield event_block
             continue
@@ -2726,6 +2728,8 @@ async def _normalize_public_responses_stream(
         if isinstance(event_type, str) and event_type in _PUBLIC_RESPONSE_STREAM_TERMINAL_TYPES:
             terminal_seen = True
     if terminal_seen:
+        if not done_seen and not enforce_openai_sdk_contract:
+            yield "data: [DONE]\n\n"
         return
     error_kind = contract_violation_kind or "upstream_stream_truncated"
     include_created = enforce_openai_sdk_contract and not created_emitted

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10901,7 +10901,6 @@ def _response_output_item_done_function_call_id(payload: dict[str, JsonValue] | 
     return call_id if isinstance(call_id, str) and call_id else None
 
 
-
 def _openai_error_envelope_from_response_failed_payload(
     payload: dict[str, JsonValue] | None,
 ) -> OpenAIErrorEnvelope:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -815,29 +815,91 @@ class ProxyService:
             # Only the trim branch below (which verifies the stored prefix
             # fingerprint) is allowed to flip this flag to ``True``.
             request_state.fresh_upstream_request_is_retry_safe = False
-        session_or_forward = await self._get_or_create_http_bridge_session(
-            bridge_session_key,
-            headers=dict(headers),
-            affinity=affinity,
-            api_key=api_key,
-            request_model=effective_payload.model,
-            idle_ttl_seconds=_effective_http_bridge_idle_ttl_seconds(
+        try:
+            session_or_forward = await self._get_or_create_http_bridge_session(
+                bridge_session_key,
+                headers=dict(headers),
                 affinity=affinity,
-                idle_ttl_seconds=idle_ttl_seconds,
-                codex_idle_ttl_seconds=codex_idle_ttl_seconds,
-                prompt_cache_idle_ttl_seconds=prompt_cache_idle_ttl_seconds,
-            ),
-            max_sessions=max_sessions,
-            previous_response_id=request_state.previous_response_id,
-            gateway_safe_mode=runtime_config.gateway_safe_mode,
-            allow_forward_to_owner=True,
-            forwarded_request=forwarded_request,
-            forwarded_affinity_kind=forwarded_affinity_kind,
-            forwarded_affinity_key=forwarded_affinity_key,
-            durable_lookup=durable_lookup,
-            request_stage=request_state.request_stage,
-            preferred_account_id=request_state.preferred_account_id,
-        )
+                api_key=api_key,
+                request_model=effective_payload.model,
+                idle_ttl_seconds=_effective_http_bridge_idle_ttl_seconds(
+                    affinity=affinity,
+                    idle_ttl_seconds=idle_ttl_seconds,
+                    codex_idle_ttl_seconds=codex_idle_ttl_seconds,
+                    prompt_cache_idle_ttl_seconds=prompt_cache_idle_ttl_seconds,
+                ),
+                max_sessions=max_sessions,
+                previous_response_id=request_state.previous_response_id,
+                gateway_safe_mode=runtime_config.gateway_safe_mode,
+                allow_forward_to_owner=True,
+                forwarded_request=forwarded_request,
+                forwarded_affinity_kind=forwarded_affinity_kind,
+                forwarded_affinity_key=forwarded_affinity_key,
+                durable_lookup=durable_lookup,
+                request_stage=request_state.request_stage,
+                preferred_account_id=request_state.preferred_account_id,
+            )
+        except ProxyResponseError as exc:
+            if not (
+                _http_bridge_is_previous_response_owner_unavailable(exc)
+                and proxy_injected_previous_response_id
+                and fresh_upstream_request_text is not None
+                and durable_full_resend_anchor_count is not None
+                and durable_full_resend_anchor_fingerprint is not None
+            ):
+                raise
+            _log_http_bridge_event(
+                "owner_unavailable_fresh_resend",
+                bridge_session_key,
+                account_id=request_state.preferred_account_id,
+                model=payload.model,
+                detail="outcome=fresh_full_resend_without_anchor",
+                cache_key_family=bridge_session_key.affinity_kind,
+                model_class=_extract_model_class(payload.model) if payload.model else None,
+            )
+            request_state, text_data = self._prepare_http_bridge_request(
+                payload,
+                headers,
+                api_key=api_key,
+                api_key_reservation=api_key_reservation,
+                request_id=request_id,
+            )
+            if downstream_turn_state is not None:
+                request_state.session_id = _normalize_session_id(downstream_turn_state)
+            request_state.transport = _REQUEST_TRANSPORT_HTTP
+            request_state.request_stage = _http_bridge_request_stage(
+                headers=headers,
+                payload=payload,
+                durable_lookup=None,
+            )
+            request_state.preferred_account_id = rewritten_file_account_id
+            if request_state.preferred_account_id is None:
+                request_state.preferred_account_id = await self._resolve_file_account_for_responses(payload, headers)
+            durable_full_resend_anchor_count = None
+            durable_full_resend_anchor_fingerprint = None
+            session_or_forward = await self._get_or_create_http_bridge_session(
+                bridge_session_key,
+                headers=dict(headers),
+                affinity=affinity,
+                api_key=api_key,
+                request_model=payload.model,
+                idle_ttl_seconds=_effective_http_bridge_idle_ttl_seconds(
+                    affinity=affinity,
+                    idle_ttl_seconds=idle_ttl_seconds,
+                    codex_idle_ttl_seconds=codex_idle_ttl_seconds,
+                    prompt_cache_idle_ttl_seconds=prompt_cache_idle_ttl_seconds,
+                ),
+                max_sessions=max_sessions,
+                previous_response_id=None,
+                gateway_safe_mode=runtime_config.gateway_safe_mode,
+                allow_forward_to_owner=True,
+                forwarded_request=forwarded_request,
+                forwarded_affinity_kind=forwarded_affinity_kind,
+                forwarded_affinity_key=forwarded_affinity_key,
+                durable_lookup=None,
+                request_stage=request_state.request_stage,
+                preferred_account_id=request_state.preferred_account_id,
+            )
         if isinstance(session_or_forward, _HTTPBridgeOwnerForward):
             forwarded_any = False
             try:
@@ -13553,6 +13615,21 @@ def _http_bridge_should_attempt_local_previous_response_recovery(exc: ProxyRespo
     message_value = error.get("message")
     message = message_value.strip() if isinstance(message_value, str) and message_value.strip() else None
     return _is_previous_response_not_found_error(code=code, param=param, message=message)
+
+
+def _http_bridge_is_previous_response_owner_unavailable(exc: ProxyResponseError) -> bool:
+    if exc.status_code != 502:
+        return False
+    payload = exc.payload
+    if not isinstance(payload, dict):
+        return False
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return False
+    return (
+        error.get("code") == "upstream_unavailable"
+        and error.get("message") == "Previous response owner account is unavailable; retry later."
+    )
 
 
 def _http_bridge_is_context_overflow_error(exc: ProxyResponseError) -> bool:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10859,7 +10859,9 @@ def _synthetic_interrupted_function_call_output(call_id: str) -> dict[str, JsonV
     return {
         "type": "function_call_output",
         "call_id": call_id,
-        "output": "Tool call was not executed because the previous turn was interrupted before tool output was available.",
+        "output": (
+            "Tool call was not executed because the previous turn was interrupted before tool output was available."
+        ),
     }
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3607,6 +3607,32 @@ class ProxyService:
                     "input": original_input_items[session_anchor.stored_input_item_count :],
                 }
             )
+        if (
+            continuity_state is not None
+            and responses_payload.previous_response_id is not None
+            and responses_payload.previous_response_id == continuity_state.last_completed_response_id
+            and continuity_state.last_pending_function_call_ids
+            and isinstance(responses_payload.input, list)
+        ):
+            input_items = cast(list[JsonValue], responses_payload.input)
+            missing_call_ids = _missing_function_call_outputs_for_previous_response(
+                input_items,
+                pending_call_ids=continuity_state.last_pending_function_call_ids,
+            )
+            if missing_call_ids:
+                responses_payload = responses_payload.model_copy(
+                    update={
+                        "input": _inject_missing_interrupted_function_call_outputs(
+                            input_items,
+                            missing_call_ids=missing_call_ids,
+                        )
+                    }
+                )
+                logger.warning(
+                    "websocket_interrupted_tool_outputs_injected previous_response_id=%s missing_call_count=%s",
+                    responses_payload.previous_response_id,
+                    len(missing_call_ids),
+                )
         reservation = await self._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -6578,6 +6604,12 @@ class ProxyService:
                 if actual_service_tier is not None:
                     matched_request_state.actual_service_tier = actual_service_tier
                     matched_request_state.service_tier = actual_service_tier
+                completed_function_call_id = _response_output_item_done_function_call_id(payload)
+                if (
+                    completed_function_call_id is not None
+                    and completed_function_call_id not in matched_request_state.pending_function_call_ids
+                ):
+                    matched_request_state.pending_function_call_ids.append(completed_function_call_id)
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
                     seen_tool_call_keys=matched_request_state.seen_tool_call_keys,
@@ -7474,6 +7506,12 @@ class ProxyService:
                 if actual_service_tier is not None:
                     request_state.actual_service_tier = actual_service_tier
                     request_state.service_tier = actual_service_tier
+                completed_function_call_id = _response_output_item_done_function_call_id(payload)
+                if (
+                    completed_function_call_id is not None
+                    and completed_function_call_id not in request_state.pending_function_call_ids
+                ):
+                    request_state.pending_function_call_ids.append(completed_function_call_id)
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
                     seen_tool_call_keys=request_state.seen_tool_call_keys,
@@ -10506,6 +10544,7 @@ class _WebSocketRequestState:
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
     suppressed_downstream_tool_call: bool = False
     suppressed_duplicate_tool_call: bool = False
+    pending_function_call_ids: list[str] = field(default_factory=list)
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
@@ -10579,6 +10618,7 @@ class _WebSocketContinuityState:
     last_completed_input_count: int = 0
     last_completed_response_id: str | None = None
     last_completed_input_prefix_fingerprint: str | None = None
+    last_pending_function_call_ids: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)
@@ -10680,10 +10720,12 @@ def _record_websocket_continuity_completion(
         continuity_state.last_completed_response_id = None
         continuity_state.last_completed_input_count = 0
         continuity_state.last_completed_input_prefix_fingerprint = None
+        continuity_state.last_pending_function_call_ids = []
         return
     continuity_state.last_completed_response_id = response_id
     continuity_state.last_completed_input_count = request_state.input_item_count
     continuity_state.last_completed_input_prefix_fingerprint = request_state.input_full_fingerprint
+    continuity_state.last_pending_function_call_ids = list(request_state.pending_function_call_ids)
 
 
 async def _wait_for_websocket_continuity_gap(
@@ -10727,6 +10769,60 @@ def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int
     if isinstance(status, int):
         return status
     return None
+
+
+def _function_call_output_call_ids(input_items: list[JsonValue]) -> set[str]:
+    call_ids: set[str] = set()
+    for item in input_items:
+        if not isinstance(item, dict) or _websocket_input_item_type(item) != "function_call_output":
+            continue
+        call_id = item.get("call_id")
+        if isinstance(call_id, str) and call_id:
+            call_ids.add(call_id)
+    return call_ids
+
+
+def _missing_function_call_outputs_for_previous_response(
+    input_items: list[JsonValue],
+    *,
+    pending_call_ids: list[str],
+) -> list[str]:
+    if not pending_call_ids:
+        return []
+    present_call_ids = _function_call_output_call_ids(input_items)
+    return [call_id for call_id in pending_call_ids if call_id not in present_call_ids]
+
+
+def _synthetic_interrupted_function_call_output(call_id: str) -> dict[str, JsonValue]:
+    return {
+        "type": "function_call_output",
+        "call_id": call_id,
+        "output": "Tool call was not executed because the previous turn was interrupted before tool output was available.",
+    }
+
+
+def _inject_missing_interrupted_function_call_outputs(
+    input_items: list[JsonValue],
+    *,
+    missing_call_ids: list[str],
+) -> list[JsonValue]:
+    if not missing_call_ids:
+        return input_items
+    return [
+        *[_synthetic_interrupted_function_call_output(call_id) for call_id in missing_call_ids],
+        *input_items,
+    ]
+
+
+def _response_output_item_done_function_call_id(payload: dict[str, JsonValue] | None) -> str | None:
+    if not isinstance(payload, dict) or payload.get("type") != "response.output_item.done":
+        return None
+    item = payload.get("item")
+    if not isinstance(item, dict) or item.get("type") != "function_call":
+        return None
+    call_id = item.get("call_id")
+    return call_id if isinstance(call_id, str) and call_id else None
+
 
 
 def _openai_error_envelope_from_response_failed_payload(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6420,7 +6420,7 @@ class ProxyService:
                 return False
             if request_state.replay_count >= 1:
                 return False
-            if request_state.response_event_count > 0:
+            if request_state.response_event_count > 0 or request_state.downstream_visible:
                 return False
             close_classification = _classify_upstream_close(
                 session.last_upstream_close_code,
@@ -6680,6 +6680,8 @@ class ProxyService:
                 ):
                     matched_request_state.suppressed_duplicate_tool_call = True
                     return
+                if event_type in _TEXT_DELTA_EVENT_TYPES:
+                    matched_request_state.downstream_visible = True
                 if payload is not None:
                     event_block = format_sse_event(payload)
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7700,7 +7700,7 @@ class ProxyService:
         _record_response_event(request_state, event_type)
 
         if request_state is None:
-            if is_previous_response_not_found_event and not pending_requests:
+            if is_previous_response_not_found_event:
                 upstream_control.reconnect_requested = True
                 downstream_text = json.dumps(
                     cast(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -875,6 +875,11 @@ class ProxyService:
             request_state.preferred_account_id = rewritten_file_account_id
             if request_state.preferred_account_id is None:
                 request_state.preferred_account_id = await self._resolve_file_account_for_responses(payload, headers)
+            effective_payload = payload
+            untrimmed_effective_payload = payload
+            proxy_injected_previous_response_id = False
+            previous_response_trimmed_input_count = None
+            previous_response_trimmed_input_fingerprint = None
             durable_full_resend_anchor_count = None
             durable_full_resend_anchor_fingerprint = None
             session_or_forward = await self._get_or_create_http_bridge_session(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8755,6 +8755,12 @@ class ProxyService:
         deadline = start + base_settings.proxy_request_budget_seconds
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
         upstream_stream_transport = _resolve_upstream_stream_transport(settings.upstream_stream_transport)
+        if request_transport == _REQUEST_TRANSPORT_HTTP and upstream_stream_transport == "websocket":
+            # HTTP/SSE clients can retry a half-rendered turn after an upstream
+            # websocket close, making the same visible message restart. Keep
+            # native websocket clients on their dedicated path, but use upstream
+            # HTTP/SSE for downstream HTTP streams.
+            upstream_stream_transport = "http"
         if rewritten_file_account_id is None:
             self._raise_for_unsupported_input_image_references(payload)
             rewritten_file_account_id = await self._resolve_file_account_for_responses(payload, headers)

--- a/tests/integration/test_codex_client_compat.py
+++ b/tests/integration/test_codex_client_compat.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.integration
 
 def _extract_first_event(lines: list[str]) -> dict:
     for line in lines:
-        if line.startswith("data: "):
+        if line.startswith("data: ") and not line.startswith("data: [DONE]"):
             return json.loads(line[6:])
     raise AssertionError("No SSE data event found")
 

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -4408,7 +4408,7 @@ async def test_v1_responses_http_bridge_streaming_path_uses_persistent_upstream_
         assert response.status_code == 200
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
 
-    events = [json.loads(line[6:]) for line in lines]
+    events = [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
     _assert_created_text_delta_completed(events)
     assert connect_count == 1
 
@@ -6764,7 +6764,7 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
         assert response.status_code == 200
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
 
-    events = [json.loads(line[6:]) for line in lines]
+    events = [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
     assert [event["type"] for event in events] == ["response.created", "response.failed"]
     assert events[-1]["response"]["error"]["code"] == "stream_incomplete"
 

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -80,7 +80,7 @@ async def _collect_sse_events(
     async with async_client.stream("POST", path, json=json_body, headers=headers) as response:
         assert response.status_code == 200
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
-    return [json.loads(line[6:]) for line in lines]
+    return [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
 
 
 async def _collect_sse_events_with_headers(
@@ -94,7 +94,7 @@ async def _collect_sse_events_with_headers(
         assert response.status_code == 200
         response_headers = dict(response.headers)
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
-    return [json.loads(line[6:]) for line in lines], response_headers
+    return [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"], response_headers
 
 
 def _assert_created_text_delta_completed(events: list[dict]) -> None:

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -471,12 +471,12 @@ async def test_v1_responses_previous_response_followup_without_http_bridge_recov
 
 
 @pytest.mark.asyncio
-async def test_v1_responses_without_http_bridge_websocket_upstream_rejects_oversized_response_create_before_connect(
+async def test_v1_responses_without_http_bridge_forces_http_upstream_when_dashboard_requests_websocket(
     async_client,
     monkeypatch,
 ):
-    email = "stream-ws-oversized@example.com"
-    raw_account_id = "acc_stream_ws_oversized"
+    email = "stream-http-forced@example.com"
+    raw_account_id = "acc_stream_http_forced"
     auth_json = _make_auth_json(raw_account_id, email)
     files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
     response = await async_client.post("/api/accounts/import", files=files)
@@ -531,7 +531,26 @@ async def test_v1_responses_without_http_bridge_websocket_upstream_rejects_overs
 
     async def fail_open_upstream_websocket(**kwargs):
         del kwargs
-        raise AssertionError("oversized response.create must fail before upstream websocket connect")
+        raise AssertionError("HTTP /v1/responses must not open upstream websocket")
+
+    captured: dict[str, object] = {}
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        upstream_stream_transport_override=None,
+    ):
+        del headers, access_token, account_id, base_url, raise_for_status
+        captured["transport"] = upstream_stream_transport_override
+        captured["payload"] = payload.to_payload()
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_http_forced","object":"response",'
+            '"status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}\n\n'
+        )
 
     monkeypatch.setattr(proxy_module, "get_settings", lambda: app_settings)
     monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _SettingsCache())
@@ -539,6 +558,7 @@ async def test_v1_responses_without_http_bridge_websocket_upstream_rejects_overs
     monkeypatch.setattr(proxy_client_module, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64, raising=False)
     monkeypatch.setattr(proxy_client_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 128, raising=False)
     monkeypatch.setattr(proxy_client_module, "_open_upstream_websocket", fail_open_upstream_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
 
     response = await async_client.post(
         "/v1/responses",
@@ -549,21 +569,21 @@ async def test_v1_responses_without_http_bridge_websocket_upstream_rejects_overs
         },
     )
 
-    assert response.status_code == 413
-    payload = response.json()
-    assert payload["error"]["code"] == "payload_too_large"
-    assert payload["error"]["type"] == "invalid_request_error"
-    assert payload["error"]["param"] == "input"
-    assert "response.create is too large for upstream websocket" in payload["error"]["message"]
+    assert response.status_code == 200
+    assert response.json()["id"] == "resp_http_forced"
+    assert captured["transport"] == "http"
+    assert cast(dict[str, object], captured["payload"])["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "x" * 256}]}
+    ]
 
 
 @pytest.mark.asyncio
-async def test_v1_responses_without_http_bridge_websocket_upstream_slims_historical_inline_artifacts_and_succeeds(
+async def test_v1_responses_without_http_bridge_http_upstream_preserves_historical_inline_artifacts(
     async_client,
     monkeypatch,
 ):
-    email = "stream-ws-slim@example.com"
-    raw_account_id = "acc_stream_ws_slim"
+    email = "stream-http-inline@example.com"
+    raw_account_id = "acc_stream_http_inline"
     auth_json = _make_auth_json(raw_account_id, email)
     files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
     response = await async_client.post("/api/accounts/import", files=files)
@@ -616,48 +636,36 @@ async def test_v1_responses_without_http_bridge_websocket_upstream_slims_histori
         proxy_request_budget_seconds = 75.0
         log_upstream_request_summary = False
 
-    fake_upstream = _FakeUpstreamWebSocket(
-        [
-            SimpleNamespace(
-                type=proxy_client_module.aiohttp.WSMsgType.TEXT,
-                data=json.dumps(
-                    {
-                        "type": "response.created",
-                        "response": {"id": "resp_http_stream_slim", "object": "response", "status": "in_progress"},
-                    },
-                    separators=(",", ":"),
-                ),
-                extra=None,
-            ),
-            SimpleNamespace(
-                type=proxy_client_module.aiohttp.WSMsgType.TEXT,
-                data=json.dumps(
-                    {
-                        "type": "response.completed",
-                        "response": {
-                            "id": "resp_http_stream_slim",
-                            "object": "response",
-                            "status": "completed",
-                            "usage": {"input_tokens": 3, "output_tokens": 1, "total_tokens": 4},
-                        },
-                    },
-                    separators=(",", ":"),
-                ),
-                extra=None,
-            ),
-        ]
-    )
+    captured: dict[str, object] = {}
 
-    async def fake_open_upstream_websocket(**kwargs):
+    async def fail_open_upstream_websocket(**kwargs):
         del kwargs
-        return fake_upstream, fake_upstream
+        raise AssertionError("HTTP /v1/responses must not open upstream websocket")
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        upstream_stream_transport_override=None,
+    ):
+        del headers, access_token, account_id, base_url, raise_for_status
+        captured["transport"] = upstream_stream_transport_override
+        captured["payload"] = payload.to_payload()
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_http_stream_inline","object":"response",'
+            '"status":"completed","output":[],"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}\n\n'
+        )
 
     monkeypatch.setattr(proxy_module, "get_settings", lambda: app_settings)
     monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _SettingsCache())
     monkeypatch.setattr(proxy_client_module, "get_settings", lambda: _CoreProxySettings())
     monkeypatch.setattr(proxy_client_module, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 64, raising=False)
     monkeypatch.setattr(proxy_client_module, "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES", 640, raising=False)
-    monkeypatch.setattr(proxy_client_module, "_open_upstream_websocket", fake_open_upstream_websocket)
+    monkeypatch.setattr(proxy_client_module, "_open_upstream_websocket", fail_open_upstream_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
 
     response = await async_client.post(
         "/v1/responses",
@@ -686,17 +694,18 @@ async def test_v1_responses_without_http_bridge_websocket_upstream_slims_histori
     )
 
     assert response.status_code == 200
-    assert response.json()["id"] == "resp_http_stream_slim"
-    assert fake_upstream.sent_json
-    request_input = fake_upstream.sent_json[0]["input"]
+    assert response.json()["id"] == "resp_http_stream_inline"
+    assert captured["transport"] == "http"
+    request_input = cast(dict[str, object], captured["payload"])["input"]
     assert isinstance(request_input, list)
     tool_input = cast(dict[str, object], request_input[1])
     assistant_input = cast(dict[str, object], request_input[2])
-    assert tool_input["output"] == proxy_module._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(
-        bytes=len(("data:image/png;base64," + ("A" * 1200)).encode("utf-8"))
-    )
+    assert tool_input["output"] == "data:image/png;base64," + ("A" * 1200)
     assert assistant_input["content"] == [
-        {"type": "input_text", "text": proxy_module._RESPONSE_CREATE_IMAGE_OMISSION_NOTICE}
+        {
+            "type": "input_image",
+            "image_url": "data:image/png;base64," + ("B" * 1200),
+        }
     ]
 
 

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -879,6 +879,8 @@ async def test_v1_responses_stream_preserves_done_text_events(async_client, monk
     for line in lines:
         if not line.startswith("data: "):
             continue
+        if line.startswith("data: [DONE]"):
+            continue
         data = json.loads(line[6:])
         event_type = data.get("type")
         if isinstance(event_type, str):

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -119,7 +119,10 @@ def _extract_events(lines: list[str]) -> list[dict]:
     events = []
     for line in lines:
         if line.startswith("data: "):
-            events.append(json.loads(line[6:]))
+            data = line[6:]
+            if data == "[DONE]":
+                continue
+            events.append(json.loads(data))
     return events
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -31,6 +31,22 @@ def test_main_passes_timestamped_log_config(monkeypatch):
     formatters = log_config["formatters"]
     assert formatters["default"]["fmt"].startswith("%(asctime)s ")
     assert formatters["access"]["fmt"].startswith("%(asctime)s ")
+    assert kwargs["timeout_keep_alive"] == 300
+
+
+def test_main_passes_custom_keep_alive_timeout(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(sys, "argv", ["codex-lb", "--timeout-keep-alive", "900"])
+    monkeypatch.setattr(cli.uvicorn, "run", fake_run)
+
+    cli.main()
+
+    assert captured["kwargs"]["timeout_keep_alive"] == 900
 
 
 def test_utc_default_formatter_formats_without_converter_binding_error():

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -814,7 +814,7 @@ async def test_normalize_public_responses_stream_codex_route_truncated_stream_do
 async def test_normalize_public_responses_stream_codex_route_does_not_backfill_output() -> None:
     """`enforce_openai_sdk_contract=False` MUST NOT backfill terminal
     `response.completed.output` from streamed item events. The Codex CLI
-    expects upstream's exact shape."""
+    expects upstream's native item shape."""
     blocks = [
         block
         async for block in proxy_api_module._normalize_public_responses_stream(
@@ -842,6 +842,47 @@ async def test_normalize_public_responses_stream_codex_route_does_not_backfill_o
     # Output stays empty — Codex CLI handles its own assembly.
     response_obj = cast(dict[str, Any], completed["response"])
     assert response_obj["output"] == []
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_codex_route_appends_done_after_terminal() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.created","sequence_number":0,'
+                    '"response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.completed","sequence_number":1,'
+                    '"response":{"id":"resp_1","object":"response","status":"completed","output":[]}}\n\n'
+                ),
+            ),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert blocks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_codex_route_does_not_duplicate_done() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.completed","sequence_number":1,'
+                    '"response":{"id":"resp_1","object":"response","status":"completed","output":[]}}\n\n'
+                ),
+                "data: [DONE]\n\n",
+            ),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert blocks.count("data: [DONE]\n\n") == 1
 
 
 # ----------------------------------------------------------------------------

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -114,7 +114,8 @@ async def test_normalize_public_responses_stream_preserves_comment_keepalive() -
     ]
 
     assert blocks[0] == ": keepalive\n\n"
-    assert "response.completed" in blocks[-1]
+    assert "response.completed" in blocks[-2]
+    assert blocks[-1] == "data: [DONE]\n\n"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7173,6 +7173,60 @@ async def test_process_http_bridge_upstream_text_scopes_tool_dedupe_to_request_s
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_marks_text_delta_downstream_visible() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-bridge-visible",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        response_id="resp_bridge_visible",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-visible", None),
+        headers={"x-codex-session-id": "sid-visible"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-visible",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-visible", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "response.output_text.delta",
+                "response_id": "resp_bridge_visible",
+                "delta": "I started",
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert request_state.downstream_visible is True
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    forwarded = await asyncio.wait_for(event_queue.get(), timeout=1.0)
+    assert forwarded is not None
+    assert proxy_service.parse_sse_data_json(forwarded)["delta"] == "I started"
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_request_on_fresh_upstream_refuses_to_resend_previous_response_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7223,7 +7223,9 @@ async def test_process_http_bridge_upstream_text_marks_text_delta_downstream_vis
     assert event_queue is not None
     forwarded = await asyncio.wait_for(event_queue.get(), timeout=1.0)
     assert forwarded is not None
-    assert proxy_service.parse_sse_data_json(forwarded)["delta"] == "I started"
+    forwarded_payload = proxy_service.parse_sse_data_json(forwarded)
+    assert forwarded_payload is not None
+    assert forwarded_payload["delta"] == "I started"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2560,6 +2560,159 @@ async def test_stream_via_http_bridge_does_not_inject_durable_anchor_when_forwar
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_clears_injected_anchor_after_owner_unavailable_fresh_resend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    prefix_items = [{"role": "user", "content": "one"}, {"role": "assistant", "content": "two"}]
+    input_items = [*prefix_items, {"role": "user", "content": "three"}]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": input_items},
+    )
+    payload_prefix_items = cast(list[proxy_service.JsonValue], payload.input)[: len(prefix_items)]
+    request_states: list[proxy_service._WebSocketRequestState] = []
+    prepared_previous_response_ids: list[str | None] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id
+        prepared_previous_response_ids.append(prepared_payload.previous_response_id)
+        state = proxy_service._WebSocketRequestState(
+            request_id=f"req-{len(request_states)}",
+            model="gpt-5.4",
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=1.0,
+            event_queue=asyncio.Queue(),
+            previous_response_id=prepared_payload.previous_response_id,
+            transport="http",
+        )
+        request_states.append(state)
+        return state, proxy_service._response_create_text(
+            prepared_payload,
+            include_type_field=True,
+            client_metadata=None,
+        )
+
+    owner_forward = proxy_service._HTTPBridgeOwnerForward(
+        owner_instance="instance-b",
+        owner_endpoint="http://instance-b",
+        key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_fresh", None),
+    )
+    owner_unavailable = proxy_service.ProxyResponseError(
+        502,
+        {
+            "error": {
+                "type": "server_error",
+                "code": "upstream_unavailable",
+                "message": "Previous response owner account is unavailable; retry later.",
+            }
+        },
+    )
+    get_or_create_calls = 0
+
+    async def fake_get_or_create_http_bridge_session(*args: object, **kwargs: object):
+        nonlocal get_or_create_calls
+        del args, kwargs
+        get_or_create_calls += 1
+        if get_or_create_calls == 1:
+            raise owner_unavailable
+        return owner_forward
+
+    forwarded_payloads: list[proxy_service.ResponsesRequest] = []
+
+    async def fake_forward_http_bridge_request_to_owner(**kwargs: object):
+        forwarded_payloads.append(cast(proxy_service.ResponsesRequest, kwargs["payload"]))
+        if False:
+            yield ""
+        return
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: Settings(
+            http_responses_session_bridge_enabled=True,
+            http_responses_session_bridge_instance_id="instance-a",
+        ),
+    )
+    monkeypatch.setattr(
+        service._durable_bridge,
+        "lookup_request_targets",
+        AsyncMock(
+            return_value=proxy_service.DurableBridgeLookup(
+                session_id="sess-fresh-owner-unavailable",
+                canonical_kind="turn_state_header",
+                canonical_key="http_turn_fresh",
+                api_key_scope="__anonymous__",
+                account_id="acc-1",
+                owner_instance_id="instance-b",
+                owner_epoch=1,
+                lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+                state=HttpBridgeSessionState.ACTIVE,
+                latest_turn_state="http_turn_fresh",
+                latest_response_id="resp_latest",
+                latest_input_item_count=len(prefix_items),
+                latest_input_full_fingerprint=proxy_service._fingerprint_input_items(payload_prefix_items),
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value="acc-1"))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create_http_bridge_session)
+    monkeypatch.setattr(service, "_forward_http_bridge_request_to_owner", fake_forward_http_bridge_request_to_owner)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"x-codex-turn-state": "http_turn_fresh"},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == []
+    assert prepared_previous_response_ids[-2:] == ["resp_latest", None]
+    assert forwarded_payloads == [payload]
+    assert request_states[-1].previous_response_id is None
+    assert request_states[-1].proxy_injected_previous_response_id is False
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_anchor_for_derived_prompt_cache_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7520,6 +7520,143 @@ async def test_create_http_bridge_session_fails_closed_when_previous_response_ow
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_replays_durable_full_resend_when_owner_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    historical_input: list[proxy_service.JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
+        {"type": "function_call_output", "call_id": "call_old", "output": "old output"},
+    ]
+    new_input: proxy_service.JsonValue = {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "next question"}],
+    }
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [*historical_input, new_input],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-owner-unavailable",
+        canonical_kind="session_header",
+        canonical_key="sid-owner-unavailable",
+        api_key_scope="__anonymous__",
+        account_id="acc-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="sid-owner-unavailable",
+        latest_response_id="resp_completed_anchor",
+        latest_input_item_count=len(historical_input),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+    )
+    owner_unavailable = ProxyResponseError(
+        502,
+        proxy_service.openai_error(
+            "upstream_unavailable",
+            "Previous response owner account is unavailable; retry later.",
+            error_type="server_error",
+        ),
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-owner-unavailable", None),
+        headers={"session_id": "sid-owner-unavailable"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-owner-unavailable",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-fallback", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    get_or_create = AsyncMock(side_effect=[owner_unavailable, session])
+    captured_request_states: list[proxy_service._WebSocketRequestState] = []
+    captured_text_data: list[str] = []
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+        propagate_http_errors: bool,
+        downstream_turn_state: str | None,
+    ):
+        del queue_limit, propagate_http_errors, downstream_turn_state
+        captured_request_states.append(request_state)
+        captured_text_data.append(text_data)
+        yield "data: {\"type\":\"response.completed\"}\n\n"
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"session_id": "sid-owner-unavailable"},
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ["data: {\"type\":\"response.completed\"}\n\n"]
+    assert get_or_create.await_count == 2
+    first_call = get_or_create.await_args_list[0]
+    second_call = get_or_create.await_args_list[1]
+    assert first_call.kwargs["previous_response_id"] == "resp_completed_anchor"
+    assert first_call.kwargs["preferred_account_id"] == "acc-owner"
+    assert second_call.kwargs["previous_response_id"] is None
+    assert second_call.kwargs["preferred_account_id"] is None
+    assert second_call.kwargs["durable_lookup"] is None
+    assert captured_request_states[0].previous_response_id is None
+    replay_payload = json.loads(captured_text_data[0])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["input"] == [*historical_input, new_input]
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_prompt_cache_mismatch_stays_local_when_gateway_safe_mode_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7652,7 +7652,7 @@ async def test_stream_via_http_bridge_replays_durable_full_resend_when_owner_is_
         del queue_limit, propagate_http_errors, downstream_turn_state
         captured_request_states.append(request_state)
         captured_text_data.append(text_data)
-        yield "data: {\"type\":\"response.completed\"}\n\n"
+        yield 'data: {"type":"response.completed"}\n\n'
 
     monkeypatch.setattr(
         proxy_service,
@@ -7697,7 +7697,7 @@ async def test_stream_via_http_bridge_replays_durable_full_resend_when_owner_is_
         )
     ]
 
-    assert chunks == ["data: {\"type\":\"response.completed\"}\n\n"]
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
     assert get_or_create.await_count == 2
     first_call = get_or_create.await_args_list[0]
     second_call = get_or_create.await_args_list[1]

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6465,16 +6465,19 @@ async def test_prepare_websocket_response_create_request_fills_interrupted_pendi
 
     upstream_payload = json.loads(prepared.text_data)
     assert upstream_payload["previous_response_id"] == "resp_pending_tool_calls"
+    interrupted_tool_output = (
+        "Tool call was not executed because the previous turn was interrupted before tool output was available."
+    )
     assert upstream_payload["input"][:2] == [
         {
             "type": "function_call_output",
             "call_id": "call_missing_a",
-            "output": "Tool call was not executed because the previous turn was interrupted before tool output was available.",
+            "output": interrupted_tool_output,
         },
         {
             "type": "function_call_output",
             "call_id": "call_missing_b",
-            "output": "Tool call was not executed because the previous turn was interrupted before tool output was available.",
+            "output": interrupted_tool_output,
         },
     ]
     assert upstream_payload["input"][2:] == interrupted_input
@@ -13868,6 +13871,45 @@ async def test_retry_http_bridge_precreated_request_suppresses_retry_after_respo
 
 
 @pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_refuses_after_downstream_text():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    send_text = AsyncMock()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_visible_retry",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","input":"full resend"}',
+        downstream_visible=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_visible_retry"),
+        upstream=AsyncMock(send_text=send_text),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    retried = await service._retry_http_bridge_precreated_request(session)
+
+    assert retried is False
+    assert request_state.replay_count == 0
+    send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_precreated_request_preserves_reconnect_timeout_cause(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -13930,3 +13972,4 @@ async def test_pop_replayable_precreated_request_suppresses_replay_after_respons
 
     assert replayed is None
     assert pending_requests == deque([request_state])
+

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14035,4 +14035,3 @@ async def test_pop_replayable_precreated_request_suppresses_replay_after_respons
 
     assert replayed is None
     assert pending_requests == deque([request_state])
-

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6398,6 +6398,90 @@ async def test_prepare_websocket_response_create_request_trims_codex_session_ful
 
 
 @pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_fills_interrupted_pending_tool_outputs(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_interrupted_tools",
+        name="ws-interrupted-tools",
+        key_prefix="sk-ws-tools",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_response_id="resp_pending_tool_calls",
+        last_pending_function_call_ids=["call_missing_a", "call_missing_b"],
+    )
+    interrupted_input: list[JsonValue] = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": "<turn_aborted>\nThe user interrupted the previous turn on purpose.\n</turn_aborted>",
+                }
+            ],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "Write tests for @filename"}]},
+    ]
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_pending_tool_calls",
+                "input": interrupted_input,
+            },
+        ),
+        headers={"session_id": "turn_ws_interrupted_tools"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_pending_tool_calls"
+    assert upstream_payload["input"][:2] == [
+        {
+            "type": "function_call_output",
+            "call_id": "call_missing_a",
+            "output": "Tool call was not executed because the previous turn was interrupted before tool output was available.",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_missing_b",
+            "output": "Tool call was not executed because the previous turn was interrupted before tool output was available.",
+        },
+    ]
+    assert upstream_payload["input"][2:] == interrupted_input
+    assert prepared.request_state.input_item_count == 4
+
+
+@pytest.mark.asyncio
 async def test_prepare_websocket_full_replay_retry_text_uses_size_guard(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4708,7 +4708,7 @@ async def test_stream_responses_logs_actual_service_tier_and_requested_tier_trac
 
 
 @pytest.mark.asyncio
-async def test_service_stream_responses_uses_dashboard_upstream_transport_override(monkeypatch):
+async def test_service_stream_responses_forces_http_upstream_for_http_stream_clients(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     setattr(settings, "upstream_stream_transport", "websocket")
     request_logs = _RequestLogsRecorder()
@@ -4752,7 +4752,7 @@ async def test_service_stream_responses_uses_dashboard_upstream_transport_overri
     chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
 
     assert chunks
-    assert captured["override"] == "websocket"
+    assert captured["override"] == "http"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7765,10 +7765,13 @@ async def test_process_upstream_websocket_text_skips_foreign_prev_nf_for_mismatc
         response_create_gate=asyncio.Semaphore(1),
     )
 
-    assert downstream_text == json.dumps(payload, separators=(",", ":"))
+    assert '"type":"response.failed"' in downstream_text
+    assert '"code":"stream_incomplete"' in downstream_text
+    assert "previous_response_not_found" not in downstream_text
+    assert "resp_anchor_a" not in downstream_text
     finalize_request_state.assert_not_awaited()
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is False
+    assert upstream_control.reconnect_requested is True
     assert list(pending_requests) == [pending_request]
 
 
@@ -8098,10 +8101,13 @@ async def test_process_upstream_websocket_text_skips_anonymous_prev_nf_for_misma
         response_create_gate=asyncio.Semaphore(1),
     )
 
-    assert downstream_text == json.dumps(payload, separators=(",", ":"))
+    assert '"type":"response.failed"' in downstream_text
+    assert '"code":"stream_incomplete"' in downstream_text
+    assert "previous_response_not_found" not in downstream_text
+    assert "resp_anchor_a" not in downstream_text
     finalize_request_state.assert_not_awaited()
     handle_stream_error.assert_not_awaited()
-    assert upstream_control.reconnect_requested is False
+    assert upstream_control.reconnect_requested is True
     assert list(pending_requests) == [followup_request]
 
 
@@ -8647,6 +8653,63 @@ async def test_process_upstream_websocket_text_masks_unmatched_previous_response
     finalize_request_state.assert_not_awaited()
     handle_stream_error.assert_not_awaited()
     assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_masks_unmatched_previous_response_not_found_with_pending(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_unmatched_previous_response_not_found_pending")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="req-unrelated-pending",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_different_anchor",
+        awaiting_response_created=True,
+        request_text='{"type":"response.create"}',
+    )
+    pending_requests: deque[proxy_service._WebSocketRequestState] = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "previous_response_not_found",
+            "message": "Previous response with id 'resp_unmatched_anchor' not found.",
+            "param": "previous_response_id",
+        },
+    }
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"type":"response.failed"' in downstream_text
+    assert '"code":"stream_incomplete"' in downstream_text
+    assert "previous_response_not_found" not in downstream_text
+    assert "resp_unmatched_anchor" not in downstream_text
+    assert list(pending_requests) == []
+    finalize_request_state.assert_awaited_once()
+    handle_stream_error.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Track function-call IDs emitted by websocket `response.output_item.done` events for the latest completed response.
- When the next websocket `response.create` resumes that `previous_response_id` after an interrupted turn, inject synthetic `function_call_output` items for any missing pending calls.
- Ensure `/backend-api/codex/responses` emits `data: [DONE]` after a terminal event when upstream closes after `response.completed` without sending `[DONE]`, so Codex CLI does not treat a completed response as a disconnected stream.
- Add regression tests for both interrupted missing tool outputs and Codex-route terminal stream closure.

## Tests
- `python3 -m py_compile app/modules/proxy/service.py`
- `python3 -m py_compile app/modules/proxy/api.py app/modules/proxy/service.py`
- `uv run python -m pytest tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_fills_interrupted_pending_tool_outputs tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_trims_codex_session_full_replay tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_trims_replayed_tool_call_items_with_previous_response_id`
- `uv run python -m pytest tests/unit/test_proxy_api_responses_contract.py::test_normalize_public_responses_stream_codex_route_appends_done_after_terminal tests/unit/test_proxy_api_responses_contract.py::test_normalize_public_responses_stream_codex_route_does_not_duplicate_done tests/unit/test_proxy_api_responses_contract.py::test_normalize_public_responses_stream_codex_route_preserves_codex_events tests/unit/test_proxy_api_responses_contract.py::test_normalize_public_responses_stream_codex_route_does_not_backfill_output tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_fills_interrupted_pending_tool_outputs`

## Deployment note
- Hotfixed locally from a live-image source tree as `codex-lb:live-stack-bc5fa6b`; readiness check returned OK.
