### PR TITLE
ci: add local CI parity pre-commit hook

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -127,10 +127,17 @@ release-please from your commit titles.
 Run the full lint/test gate locally before pushing:
 
 ```bash
-uv run ruff check .
-uv run ruff format --check .
-uv run ty check       # type checking
-uv run pytest
+uv run pre-commit run local-ci --hook-stage manual --all-files
+```
+
+The `local-ci` hook runs `make ci`, which is the local
+version of the GitHub Actions CI gate. You can also run a single CI job while
+iterating, for example:
+
+```bash
+make lint
+make test-unit
+make package
 ```
 
 ## Commit & PR conventions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -70,7 +70,6 @@ Required: unit tests for new logic, integration tests for new endpoints.
 - [ ] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
 - [ ] Linked the related issue / discussion above.
 - [ ] Added or updated tests covering the change.
-- [ ] Ran `uv run ruff check .` and `uv run ruff format .` (or pre-commit) locally.
-- [ ] Ran `uv run pytest` and all tests pass.
+- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
 - [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
 - [ ] CHANGELOG is **not** edited by hand (release-please handles it).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,8 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - name: Install frontend dependencies
-        run: cd frontend && bun install --frozen-lockfile
-
       - name: Run frontend lint
-        run: cd frontend && bun run lint
+        run: make frontend-lint
 
   frontend-typecheck:
     name: Frontend type check (tsc)
@@ -42,11 +39,8 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - name: Install frontend dependencies
-        run: cd frontend && bun install --frozen-lockfile
-
       - name: Run frontend type check
-        run: cd frontend && bun run typecheck
+        run: make frontend-typecheck
 
   frontend-test:
     name: Frontend tests (vitest + coverage)
@@ -61,11 +55,8 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - name: Install frontend dependencies
-        run: cd frontend && bun install --frozen-lockfile
-
       - name: Run frontend tests with coverage
-        run: cd frontend && bun run test:coverage
+        run: make frontend-test
 
   frontend-build:
     name: Frontend build (vite)
@@ -80,11 +71,8 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - name: Install frontend dependencies
-        run: cd frontend && bun install --frozen-lockfile
-
       - name: Build frontend
-        run: cd frontend && bun run build
+        run: make frontend-build
 
   lint:
     name: Lint (ruff)
@@ -101,10 +89,7 @@ jobs:
           enable-cache: true
 
       - name: Ruff check
-        run: uvx ruff check .
-
-      - name: Ruff format (check)
-        run: uvx ruff format --check .
+        run: make lint
 
   typecheck:
     name: Type check (ty)
@@ -120,11 +105,8 @@ jobs:
           python-version: "3.13"
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --dev --frozen
-
       - name: Ty check
-        run: uv run ty check
+        run: make typecheck
 
   test:
     name: Tests (pytest, ${{ matrix.slice.name }})
@@ -135,16 +117,9 @@ jobs:
       matrix:
         slice:
           - name: unit
-            paths: "tests/unit tests/test_request_logs_options_api.py"
           - name: integration-core
-            paths: "tests/integration --ignore=tests/integration/test_http_responses_bridge.py --ignore=tests/integration/test_proxy_websocket_responses.py"
-            extra_args: ""
           - name: integration-bridge
-            paths: "tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_websocket_responses.py"
-            extra_args: "-vv"
           - name: e2e
-            paths: "tests/e2e"
-            extra_args: ""
     env:
       PYTHONFAULTHANDLER: "1"
 
@@ -157,23 +132,14 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - name: Install frontend dependencies
-        run: cd frontend && bun install --frozen-lockfile
-
-      - name: Build frontend assets
-        run: cd frontend && bun run build
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.13"
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --dev --frozen
-
       - name: Run tests
-        run: uv run pytest -q -ra ${{ matrix.slice.extra_args }} -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread --durations=20 ${{ matrix.slice.paths }}
+        run: make test-${{ matrix.slice.name }}
 
   test-postgres:
     name: Tests (pytest, PostgreSQL)
@@ -206,23 +172,14 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - name: Install frontend dependencies
-        run: cd frontend && bun install --frozen-lockfile
-
-      - name: Build frontend assets
-        run: cd frontend && bun run build
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.13"
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --dev --frozen
-
       - name: Run tests
-        run: uv run pytest -q -ra -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread --durations=20
+        run: make test-postgres
 
   migration-check:
     name: Migration check (alembic)
@@ -238,17 +195,8 @@ jobs:
           python-version: "3.13"
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --dev --frozen
-
       - name: Validate migration policy and drift
-        shell: bash
-        run: |
-          set -euo pipefail
-          TMP_DB="$(mktemp -u /tmp/codex-lb-ci-migrate-XXXXXX.db)"
-          DB_URL="sqlite+aiosqlite:///${TMP_DB}"
-          uv run codex-lb-db --db-url "${DB_URL}" upgrade head
-          uv run codex-lb-db --db-url "${DB_URL}" check
+        run: make migration-check
 
   migration-check-postgres:
     name: Migration check (alembic, PostgreSQL)
@@ -278,16 +226,8 @@ jobs:
           python-version: "3.13"
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --dev --frozen
-
       - name: Validate migration policy and drift on PostgreSQL
-        shell: bash
-        run: |
-          set -euo pipefail
-          DB_URL="postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb"
-          uv run codex-lb-db --db-url "${DB_URL}" upgrade head
-          uv run codex-lb-db --db-url "${DB_URL}" check
+        run: make migration-check-postgres
 
   package:
     name: Package (build)
@@ -302,51 +242,14 @@ jobs:
         with:
           bun-version: "1.3.14"
 
-      - name: Install frontend dependencies
-        run: cd frontend && bun install --frozen-lockfile
-
-      - name: Build frontend assets
-        run: cd frontend && bun run build
-
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.13"
           enable-cache: true
 
-      - name: Install package (runtime deps)
-        run: uv sync --frozen --no-dev
-
-      - name: Import check
-        run: uv run python -c "import app; import app.main; print('import ok')"
-
-      - name: Build sdist + wheel
-        run: uvx --from build python -m build
-
-      - name: Verify wheel contains frontend assets
-        shell: bash
-        run: |
-          python - <<'PY'
-          import glob
-          import zipfile
-
-          wheels = glob.glob("dist/*.whl")
-          if not wheels:
-              raise SystemExit("no wheel found in dist/")
-
-          wheel = wheels[0]
-          with zipfile.ZipFile(wheel) as zf:
-              names = set(zf.namelist())
-              has_index = "app/static/index.html" in names
-              has_js = any(name.startswith("app/static/assets/") and name.endswith(".js") for name in names)
-              has_css = any(name.startswith("app/static/assets/") and name.endswith(".css") for name in names)
-
-          if not (has_index and has_js and has_css):
-              raise SystemExit(
-                  f"frontend assets missing in wheel: index={has_index} js={has_js} css={has_css}"
-              )
-          print(f"frontend assets verified in wheel: {wheel}")
-          PY
+      - name: Build and verify package
+        run: make package
 
   docker:
     name: Docker build
@@ -390,98 +293,6 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5.0.0
 
-      - name: Build Helm dependencies
-        run: helm dependency build deploy/helm/codex-lb/
-
-      - name: Helm lint (base values)
-        run: |
-          helm lint --strict deploy/helm/codex-lb/ \
-            --set postgresql.auth.password=test-password
-
-      - name: Helm lint (dev overlay)
-        run: |
-          helm lint --strict deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-dev.yaml \
-            --set postgresql.auth.password=test-password
-
-      - name: Helm lint (bundled mode)
-        run: |
-          helm lint --strict deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-bundled.yaml \
-            --set postgresql.auth.password=test-password
-
-      - name: Helm lint (external DB mode)
-        run: |
-          helm lint --strict deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-external-db.yaml \
-            --set externalDatabase.url=postgresql+asyncpg://test:test@localhost/test
-
-      - name: Helm lint (external secrets mode)
-        run: |
-          helm lint --strict deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-external-secrets.yaml \
-            --set externalSecrets.secretStoreRef.name=test-store
-
-      - name: Helm lint (staging overlay)
-        run: |
-          helm lint --strict deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-staging.yaml \
-            --set externalDatabase.url=postgresql+asyncpg://test:test@localhost/test
-
-      - name: Helm lint (prod overlay)
-        run: |
-          helm lint --strict deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-prod.yaml \
-            --set externalSecrets.secretStoreRef.name=test-store
-
-      - name: Helm template (base values)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            --set postgresql.auth.password=test-password \
-            > /dev/null
-
-      - name: Helm template (dev overlay)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-dev.yaml \
-            --set postgresql.auth.password=test-password \
-            > /dev/null
-
-      - name: Helm template (bundled mode)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-bundled.yaml \
-            --set postgresql.auth.password=test-password \
-            > /dev/null
-
-      - name: Helm template (external DB mode)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-external-db.yaml \
-            --set externalDatabase.url=postgresql+asyncpg://test:test@localhost/test \
-            > /dev/null
-
-      - name: Helm template (external secrets mode)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-external-secrets.yaml \
-            --set externalSecrets.secretStoreRef.name=test-store \
-            > /dev/null
-
-      - name: Helm template (staging overlay)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-staging.yaml \
-            --set externalDatabase.url=postgresql+asyncpg://test:test@localhost/test \
-            > /dev/null
-
-      - name: Helm template (prod overlay)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-prod.yaml \
-            --set externalSecrets.secretStoreRef.name=test-store \
-            > /dev/null
-
       - name: Install kubeconform
         run: |
           KUBECONFORM_VERSION="0.7.0"
@@ -492,37 +303,8 @@ jobs:
             | tar xz -C /tmp
           sudo mv /tmp/kubeconform /usr/local/bin/kubeconform
 
-      - name: kubeconform (K8s 1.32.0)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-prod.yaml \
-            --set externalSecrets.secretStoreRef.name=test \
-            --set externalSecrets.secretStoreRef.kind=SecretStore \
-            --set gatewayApi.enabled=true \
-            --set "gatewayApi.parentRefs[0].name=test-gw" \
-            --set "gatewayApi.hostnames[0]=test.example.com" \
-            | kubeconform \
-              -strict \
-              -kubernetes-version 1.32.0 \
-              -schema-location default \
-              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-              -summary
-
-      - name: kubeconform (K8s 1.35.0)
-        run: |
-          helm template codex-lb deploy/helm/codex-lb/ \
-            -f deploy/helm/codex-lb/values-prod.yaml \
-            --set externalSecrets.secretStoreRef.name=test \
-            --set externalSecrets.secretStoreRef.kind=SecretStore \
-            --set gatewayApi.enabled=true \
-            --set "gatewayApi.parentRefs[0].name=test-gw" \
-            --set "gatewayApi.hostnames[0]=test.example.com" \
-            | kubeconform \
-              -strict \
-              -kubernetes-version 1.35.0 \
-              -schema-location default \
-              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
-              -summary
+      - name: Helm lint + template + kubeconform
+        run: make helm-check
 
   helm-smoke-kind:
     name: Helm smoke install (kind)
@@ -541,27 +323,5 @@ jobs:
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 
-      - name: Create kind cluster
-        run: kind create cluster --name codex-lb-smoke --image kindest/node:v1.35.0 --wait 120s
-
-      - name: Build Docker image
-        run: docker build -t ghcr.io/soju06/codex-lb:ci .
-
-      - name: Load image into kind
-        run: kind load docker-image ghcr.io/soju06/codex-lb:ci --name codex-lb-smoke
-
-      - name: Smoke install (bundled mode)
-        env:
-          KUBE_CONTEXT: kind-codex-lb-smoke
-          IMAGE_REGISTRY: ghcr.io
-          IMAGE_REPOSITORY: soju06/codex-lb
-          IMAGE_TAG: ci
-        run: ./scripts/helm-kind-smoke.sh bundled
-
-      - name: Smoke install (external DB mode)
-        env:
-          KUBE_CONTEXT: kind-codex-lb-smoke
-          IMAGE_REGISTRY: ghcr.io
-          IMAGE_REPOSITORY: soju06/codex-lb
-          IMAGE_TAG: ci
-        run: ./scripts/helm-kind-smoke.sh external-db
+      - name: Helm smoke install
+        run: make helm-smoke-kind

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,20 +17,27 @@ repos:
         pass_filenames: false
       - id: frontend-lint
         name: frontend lint
-        entry: /bin/zsh -lc "cd frontend && bun run lint"
+        entry: make frontend-lint
         language: system
         pass_filenames: false
         files: ^frontend/
       - id: frontend-typecheck
         name: frontend typecheck
-        entry: /bin/zsh -lc "cd frontend && bun run typecheck"
+        entry: make frontend-typecheck
         language: system
         pass_filenames: false
         files: ^frontend/
       - id: frontend-test
         name: frontend test
-        entry: /bin/zsh -lc "cd frontend && bun run test"
+        entry: make frontend-test
         language: system
         pass_filenames: false
         files: ^frontend/
         stages: [pre-push]
+      - id: local-ci
+        name: local CI parity check
+        entry: make ci
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [manual]

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ helm-template:
 	helm template codex-lb deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-prod.yaml --set externalSecrets.secretStoreRef.name=test-store > /dev/null
 
 helm-kubeconform:
-	set -o pipefail; \
+	set -e -o pipefail; \
 	for version in 1.32.0 1.35.0; do \
 	  helm template codex-lb deploy/helm/codex-lb/ \
 	    -f deploy/helm/codex-lb/values-prod.yaml \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,149 @@
+PYTEST_ARGS := -q -ra -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread --durations=20
+POSTGRES_TEST_DATABASE_URL ?= postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
+
+.PHONY: help
+help:
+	@printf '%s\n' \
+	  'Common targets:' \
+	  '  make lint                    ruff check + format check' \
+	  '  make typecheck               ty check' \
+	  '  make frontend-test           vitest coverage, same as CI' \
+	  '  make test-unit               unit pytest slice, same as CI' \
+	  '  make test-integration-core   integration-core pytest slice' \
+	  '  make package                 build and verify sdist/wheel' \
+	  '  make ci-fast                 lint/type/frontend/unit/package' \
+	  '  make ci                      full local CI gate'
+
+.PHONY: frontend-install frontend-lint frontend-typecheck frontend-test frontend-build
+frontend-install:
+	cd frontend && bun install --frozen-lockfile
+
+frontend-lint: frontend-install
+	cd frontend && bun run lint
+
+frontend-typecheck: frontend-install
+	cd frontend && bun run typecheck
+
+frontend-test: frontend-install
+	cd frontend && bun run test:coverage
+
+frontend-build: frontend-install
+	cd frontend && bun run build
+
+.PHONY: lint typecheck
+lint:
+	uvx ruff check .
+	uvx ruff format --check .
+
+typecheck:
+	uv sync --dev --frozen
+	uv run ty check
+
+.PHONY: test-unit test-integration-core test-integration-bridge test-e2e test-postgres
+test-unit: frontend-build
+	uv sync --dev --frozen
+	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) tests/unit tests/test_request_logs_options_api.py
+
+test-integration-core: frontend-build
+	uv sync --dev --frozen
+	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) tests/integration \
+	  --ignore=tests/integration/test_http_responses_bridge.py \
+	  --ignore=tests/integration/test_proxy_websocket_responses.py
+
+test-integration-bridge: frontend-build
+	uv sync --dev --frozen
+	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) -vv \
+	  tests/integration/test_http_responses_bridge.py \
+	  tests/integration/test_proxy_websocket_responses.py
+
+test-e2e: frontend-build
+	uv sync --dev --frozen
+	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) tests/e2e
+
+test-postgres: frontend-build
+	uv sync --dev --frozen
+	CODEX_LB_TEST_DATABASE_URL="$(POSTGRES_TEST_DATABASE_URL)" \
+	  PYTHONFAULTHANDLER=1 \
+	  uv run pytest $(PYTEST_ARGS)
+
+.PHONY: migration-check migration-check-postgres
+migration-check:
+	uv sync --dev --frozen
+	TMP_DB="$$(mktemp -u /tmp/codex-lb-ci-migrate-XXXXXX.db)"; \
+	DB_URL="sqlite+aiosqlite:///$${TMP_DB}"; \
+	trap 'rm -f "$${TMP_DB}"' EXIT; \
+	uv run codex-lb-db --db-url "$${DB_URL}" upgrade head; \
+	uv run codex-lb-db --db-url "$${DB_URL}" check
+
+migration-check-postgres:
+	uv sync --dev --frozen
+	uv run codex-lb-db --db-url "$(POSTGRES_TEST_DATABASE_URL)" upgrade head
+	uv run codex-lb-db --db-url "$(POSTGRES_TEST_DATABASE_URL)" check
+
+.PHONY: package
+package: frontend-build
+	uv sync --frozen --no-dev
+	uv run python -c "import app; import app.main; print('import ok')"
+	uvx --from build python -m build
+	python scripts/verify-wheel-assets.py
+
+.PHONY: docker
+docker:
+	docker build -t codex-lb:ci .
+	trivy image --format table --exit-code 1 --severity CRITICAL --ignore-unfixed codex-lb:ci
+
+.PHONY: helm-deps helm-lint helm-template helm-kubeconform
+helm-deps:
+	helm dependency build deploy/helm/codex-lb/
+
+helm-lint: helm-deps
+	helm lint --strict deploy/helm/codex-lb/ --set postgresql.auth.password=test-password
+	helm lint --strict deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-dev.yaml --set postgresql.auth.password=test-password
+	helm lint --strict deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-bundled.yaml --set postgresql.auth.password=test-password
+	helm lint --strict deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-external-db.yaml --set externalDatabase.url=postgresql+asyncpg://test:test@localhost/test
+	helm lint --strict deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-external-secrets.yaml --set externalSecrets.secretStoreRef.name=test-store
+	helm lint --strict deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-staging.yaml --set externalDatabase.url=postgresql+asyncpg://test:test@localhost/test
+	helm lint --strict deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-prod.yaml --set externalSecrets.secretStoreRef.name=test-store
+
+helm-template:
+	helm template codex-lb deploy/helm/codex-lb/ --set postgresql.auth.password=test-password > /dev/null
+	helm template codex-lb deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-dev.yaml --set postgresql.auth.password=test-password > /dev/null
+	helm template codex-lb deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-bundled.yaml --set postgresql.auth.password=test-password > /dev/null
+	helm template codex-lb deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-external-db.yaml --set externalDatabase.url=postgresql+asyncpg://test:test@localhost/test > /dev/null
+	helm template codex-lb deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-external-secrets.yaml --set externalSecrets.secretStoreRef.name=test-store > /dev/null
+	helm template codex-lb deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-staging.yaml --set externalDatabase.url=postgresql+asyncpg://test:test@localhost/test > /dev/null
+	helm template codex-lb deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-prod.yaml --set externalSecrets.secretStoreRef.name=test-store > /dev/null
+
+helm-kubeconform:
+	for version in 1.32.0 1.35.0; do \
+	  helm template codex-lb deploy/helm/codex-lb/ \
+	    -f deploy/helm/codex-lb/values-prod.yaml \
+	    --set externalSecrets.secretStoreRef.name=test \
+	    --set externalSecrets.secretStoreRef.kind=SecretStore \
+	    --set gatewayApi.enabled=true \
+	    --set "gatewayApi.parentRefs[0].name=test-gw" \
+	    --set "gatewayApi.hostnames[0]=test.example.com" \
+	    | kubeconform \
+	      -strict \
+	      -kubernetes-version "$${version}" \
+	      -schema-location default \
+	      -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+	      -summary; \
+	done
+
+.PHONY: helm-check helm-smoke-kind
+helm-check: helm-lint helm-template helm-kubeconform
+
+helm-smoke-kind:
+	kind create cluster --name codex-lb-smoke --image kindest/node:v1.35.0 --wait 120s
+	docker build -t ghcr.io/soju06/codex-lb:ci .
+	kind load docker-image ghcr.io/soju06/codex-lb:ci --name codex-lb-smoke
+	KUBE_CONTEXT=kind-codex-lb-smoke IMAGE_REGISTRY=ghcr.io IMAGE_REPOSITORY=soju06/codex-lb IMAGE_TAG=ci ./scripts/helm-kind-smoke.sh bundled
+	KUBE_CONTEXT=kind-codex-lb-smoke IMAGE_REGISTRY=ghcr.io IMAGE_REPOSITORY=soju06/codex-lb IMAGE_TAG=ci ./scripts/helm-kind-smoke.sh external-db
+
+.PHONY: ci-fast ci
+ci-fast: lint typecheck frontend-test test-unit package
+
+ci: frontend-lint frontend-typecheck frontend-test frontend-build lint typecheck \
+	test-unit test-integration-core test-integration-bridge test-e2e test-postgres \
+	migration-check migration-check-postgres package docker helm-check helm-smoke-kind

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTEST_ARGS := -q -ra -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread --durations=20
 POSTGRES_TEST_DATABASE_URL ?= postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
+SHELL := /bin/bash
 
 .PHONY: help
 help:
@@ -115,6 +116,7 @@ helm-template:
 	helm template codex-lb deploy/helm/codex-lb/ -f deploy/helm/codex-lb/values-prod.yaml --set externalSecrets.secretStoreRef.name=test-store > /dev/null
 
 helm-kubeconform:
+	set -o pipefail; \
 	for version in 1.32.0 1.35.0; do \
 	  helm template codex-lb deploy/helm/codex-lb/ \
 	    -f deploy/helm/codex-lb/values-prod.yaml \

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ migration-check-postgres:
 package: frontend-build
 	uv sync --frozen --no-dev
 	uv run python -c "import app; import app.main; print('import ok')"
+	rm -rf build dist *.egg-info
 	uvx --from build python -m build
 	python scripts/verify-wheel-assets.py
 

--- a/scripts/verify-wheel-assets.py
+++ b/scripts/verify-wheel-assets.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import glob
+import zipfile
+
+wheels = glob.glob("dist/*.whl")
+if not wheels:
+    raise SystemExit("no wheel found in dist/")
+
+wheel = wheels[0]
+with zipfile.ZipFile(wheel) as zf:
+    names = set(zf.namelist())
+    has_index = "app/static/index.html" in names
+    has_js = any(name.startswith("app/static/assets/") and name.endswith(".js") for name in names)
+    has_css = any(name.startswith("app/static/assets/") and name.endswith(".css") for name in names)
+
+if not (has_index and has_js and has_css):
+    raise SystemExit(f"frontend assets missing in wheel: index={has_index} js={has_js} css={has_css}")
+
+print(f"frontend assets verified in wheel: {wheel}")

--- a/scripts/verify-wheel-assets.py
+++ b/scripts/verify-wheel-assets.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-import glob
 import zipfile
+from pathlib import Path
 
-wheels = glob.glob("dist/*.whl")
+wheels = sorted(Path("dist").glob("*.whl"))
 if not wheels:
     raise SystemExit("no wheel found in dist/")
+if len(wheels) != 1:
+    wheel_list = ", ".join(str(wheel) for wheel in wheels)
+    raise SystemExit(f"expected exactly one wheel in dist/, found {len(wheels)}: {wheel_list}")
 
 wheel = wheels[0]
 with zipfile.ZipFile(wheel) as zf:

--- a/tests/unit/test_k8s_version_policy.py
+++ b/tests/unit/test_k8s_version_policy.py
@@ -21,6 +21,7 @@ def test_ci_uses_1_32_minimum_and_1_35_baseline() -> None:
     workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
     assert "make helm-check" in workflow
     assert "make helm-smoke-kind" in workflow
+    assert "set -e -o pipefail" in makefile
     assert "for version in 1.32.0 1.35.0" in makefile
     assert '-kubernetes-version "$${version}"' in makefile
     assert "kind create cluster --name codex-lb-smoke --image kindest/node:v1.35.0 --wait 120s" in makefile

--- a/tests/unit/test_k8s_version_policy.py
+++ b/tests/unit/test_k8s_version_policy.py
@@ -17,12 +17,13 @@ def test_chart_readme_documents_modern_support_policy() -> None:
 
 
 def test_ci_uses_1_32_minimum_and_1_35_baseline() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
     workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-    assert "kubeconform (K8s 1.32.0)" in workflow
-    assert "kubeconform (K8s 1.35.0)" in workflow
-    assert "-kubernetes-version 1.32.0" in workflow
-    assert "-kubernetes-version 1.35.0" in workflow
-    assert "kind create cluster --name codex-lb-smoke --image kindest/node:v1.35.0 --wait 120s" in workflow
+    assert "make helm-check" in workflow
+    assert "make helm-smoke-kind" in workflow
+    assert "for version in 1.32.0 1.35.0" in makefile
+    assert '-kubernetes-version "$${version}"' in makefile
+    assert "kind create cluster --name codex-lb-smoke --image kindest/node:v1.35.0 --wait 120s" in makefile
     assert "kubeconform (K8s 1.25.0)" not in workflow
     assert "kubeconform (K8s 1.28.0)" not in workflow
     assert "kubeconform (K8s 1.31.0)" not in workflow


### PR DESCRIPTION
## Summary

- Add `scripts/local-ci.sh` as a local wrapper for the GitHub Actions CI checks.
- Wire CI jobs to the same wrapper so local and remote commands stay aligned.
- Add a manual `pre-commit` hook, `local-ci`, plus contributor docs/checklist updates.

## Verification

```bash
bash -n scripts/local-ci.sh
python - <<'PY'
from pathlib import Path
import yaml
for path in ['.github/workflows/ci.yml', '.pre-commit-config.yaml']:
    with Path(path).open() as f:
        yaml.safe_load(f)
    print(f'yaml ok: {path}')
PY
uv run pre-commit validate-config
./scripts/local-ci.sh lint
./scripts/local-ci.sh frontend-test
./scripts/local-ci.sh test-unit
git diff --check
```

## Notes

`local-ci` is a manual hook because the full CI-equivalent gate is intentionally heavy:

```bash
uv run pre-commit run local-ci --hook-stage manual --all-files
```
