### PR TITLE
fix(api-keys): size usage reservations from request budget

### DIFF
--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -7,6 +7,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
+from math import ceil
 from typing import Protocol
 
 from sqlalchemy.exc import OperationalError
@@ -37,6 +38,11 @@ _SQLITE_BUSY_RETRY_ATTEMPTS = 4
 _SQLITE_BUSY_RETRY_BASE_SECONDS = 0.1
 _SPARKLINE_DAYS = 7
 _DETAIL_BUCKET_SECONDS = 3600
+API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET = 8_192
+API_KEY_USAGE_RESERVATION_DEFAULT_INPUT_TOKENS = API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+API_KEY_USAGE_RESERVATION_DEFAULT_OUTPUT_TOKENS = 2_048
+_API_KEY_USAGE_RESERVATION_UNKNOWN_MODEL_MICRODOLLARS = 2_000_000
+_API_KEY_USAGE_RESERVATION_UNKNOWN_MODEL_BASE_TOKENS = API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET * 2
 
 
 class ApiKeysRepositoryProtocol(Protocol):
@@ -183,6 +189,12 @@ class ApiKeyRateLimitExceededError(ValueError):
     def __init__(self, *, message: str, reset_at: datetime) -> None:
         super().__init__(message)
         self.reset_at = reset_at
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyRequestUsageBudget:
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -519,6 +531,7 @@ class ApiKeysService:
         *,
         request_model: str | None,
         request_service_tier: str | None = None,
+        request_usage_budget: ApiKeyRequestUsageBudget | None = None,
     ) -> ApiKeyUsageReservationData:
         for attempt in range(_SQLITE_BUSY_RETRY_ATTEMPTS):
             try:
@@ -526,6 +539,7 @@ class ApiKeysService:
                     key_id,
                     request_model=request_model,
                     request_service_tier=request_service_tier,
+                    request_usage_budget=request_usage_budget,
                 )
             except OperationalError as exc:
                 await self._repository.rollback()
@@ -541,6 +555,7 @@ class ApiKeysService:
         *,
         request_model: str | None,
         request_service_tier: str | None,
+        request_usage_budget: ApiKeyRequestUsageBudget | None,
     ) -> ApiKeyUsageReservationData:
         now = utcnow()
         async with sqlite_writer_section():
@@ -553,6 +568,7 @@ class ApiKeysService:
                 raise ApiKeyInvalidError("API key has expired")
 
             reservation_items: list[UsageReservationItemData] = []
+            normalized_usage_budget = _normalize_request_usage_budget(request_usage_budget)
             try:
                 for limit in refreshed.limits:
                     if not _limit_applies_for_request(limit, request_model=request_model):
@@ -563,16 +579,16 @@ class ApiKeysService:
                         limit,
                         request_model=request_model,
                         request_service_tier=request_service_tier,
+                        request_usage_budget=normalized_usage_budget,
                     )
-                    if reserve_delta <= 0:
-                        continue
-                    result = await self._repository.try_reserve_usage(
-                        limit.id,
-                        delta=reserve_delta,
-                        expected_reset_at=limit.reset_at,
-                    )
-                    if not result.success:
-                        raise _rate_limit_exceeded_error(limit)
+                    if reserve_delta > 0:
+                        result = await self._repository.try_reserve_usage(
+                            limit.id,
+                            delta=reserve_delta,
+                            expected_reset_at=limit.reset_at,
+                        )
+                        if not result.success:
+                            raise _rate_limit_exceeded_error(limit)
                     reservation_items.append(
                         UsageReservationItemData(
                             limit_id=limit.id,
@@ -1118,6 +1134,7 @@ def _reserve_delta_for_limit(
     *,
     request_model: str | None,
     request_service_tier: str | None,
+    request_usage_budget: ApiKeyRequestUsageBudget,
 ) -> int:
     remaining = limit.max_value - limit.current_value
     if remaining <= 0:
@@ -1126,8 +1143,33 @@ def _reserve_delta_for_limit(
         limit.limit_type,
         request_model=request_model,
         request_service_tier=request_service_tier,
+        request_usage_budget=request_usage_budget,
     )
     return min(remaining, budget)
+
+
+def _normalize_request_usage_budget(budget: ApiKeyRequestUsageBudget | None) -> ApiKeyRequestUsageBudget:
+    if budget is None:
+        return ApiKeyRequestUsageBudget(
+            input_tokens=API_KEY_USAGE_RESERVATION_DEFAULT_INPUT_TOKENS,
+            output_tokens=API_KEY_USAGE_RESERVATION_DEFAULT_OUTPUT_TOKENS,
+        )
+    return ApiKeyRequestUsageBudget(
+        input_tokens=_normalize_reservation_token_budget(
+            budget.input_tokens,
+            default=API_KEY_USAGE_RESERVATION_DEFAULT_INPUT_TOKENS,
+        ),
+        output_tokens=_normalize_reservation_token_budget(
+            budget.output_tokens,
+            default=API_KEY_USAGE_RESERVATION_DEFAULT_OUTPUT_TOKENS,
+        ),
+    )
+
+
+def _normalize_reservation_token_budget(value: int | None, *, default: int) -> int:
+    if value is None:
+        return default
+    return max(0, min(int(value), API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET))
 
 
 def _reserve_budget_for_limit_type(
@@ -1135,31 +1177,60 @@ def _reserve_budget_for_limit_type(
     *,
     request_model: str | None,
     request_service_tier: str | None,
+    request_usage_budget: ApiKeyRequestUsageBudget,
 ) -> int:
+    input_tokens = request_usage_budget.input_tokens or 0
+    output_tokens = request_usage_budget.output_tokens or 0
     if limit_type == LimitType.TOTAL_TOKENS:
-        return 8_192
+        return input_tokens + output_tokens
     if limit_type == LimitType.INPUT_TOKENS:
-        return 8_192
+        return input_tokens
     if limit_type == LimitType.OUTPUT_TOKENS:
-        return 8_192
+        return output_tokens
     if limit_type == LimitType.COST_USD:
-        return _reserve_cost_budget_microdollars(request_model, request_service_tier)
+        return _reserve_cost_budget_microdollars(
+            request_model,
+            request_service_tier,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
     if limit_type == LimitType.CREDITS:
         return 0
     return 1
 
 
-def _reserve_cost_budget_microdollars(model: str | None, service_tier: str | None) -> int:
+def _reserve_cost_budget_microdollars(
+    model: str | None,
+    service_tier: str | None,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+) -> int:
     if not model:
-        return 2_000_000
+        return _unknown_model_reserve_cost_budget_microdollars(input_tokens=input_tokens, output_tokens=output_tokens)
     cost_microdollars = _calculate_cost_microdollars(
         model,
-        8_192,
-        8_192,
+        input_tokens,
+        output_tokens,
         0,
         service_tier,
     )
-    return cost_microdollars if cost_microdollars > 0 else 2_000_000
+    return (
+        cost_microdollars
+        if cost_microdollars > 0
+        else _unknown_model_reserve_cost_budget_microdollars(input_tokens=input_tokens, output_tokens=output_tokens)
+    )
+
+
+def _unknown_model_reserve_cost_budget_microdollars(*, input_tokens: int, output_tokens: int) -> int:
+    token_budget = max(0, input_tokens) + max(0, output_tokens)
+    if token_budget <= 0:
+        return 0
+    return ceil(
+        _API_KEY_USAGE_RESERVATION_UNKNOWN_MODEL_MICRODOLLARS
+        * token_budget
+        / _API_KEY_USAGE_RESERVATION_UNKNOWN_MODEL_BASE_TOKENS
+    )
 
 
 def _compute_increment_for_limit_type(

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -191,10 +191,21 @@ class ApiKeyRateLimitExceededError(ValueError):
         self.reset_at = reset_at
 
 
+def _ensure_optional_int_token_budget(field_name: str, value: int | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an int or None")
+
+
 @dataclass(frozen=True, slots=True)
 class ApiKeyRequestUsageBudget:
     input_tokens: int | None = None
     output_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        _ensure_optional_int_token_budget("input_tokens", self.input_tokens)
+        _ensure_optional_int_token_budget("output_tokens", self.output_tokens)
 
 
 @dataclass(frozen=True, slots=True)
@@ -1169,7 +1180,7 @@ def _normalize_request_usage_budget(budget: ApiKeyRequestUsageBudget | None) -> 
 def _normalize_reservation_token_budget(value: int | None, *, default: int) -> int:
     if value is None:
         return default
-    return max(0, min(int(value), API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET))
+    return max(0, min(value, API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET))
 
 
 def _reserve_budget_for_limit_type(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -75,6 +75,7 @@ from app.modules.api_keys.service import (
     ApiKeyData,
     ApiKeyInvalidError,
     ApiKeyRateLimitExceededError,
+    ApiKeyRequestUsageBudget,
     ApiKeySelfLimitData,
     ApiKeysService,
     ApiKeyUsageReservationData,
@@ -83,6 +84,7 @@ from app.modules.firewall.repository import FirewallRepository
 from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
 from app.modules.proxy import images_service as images_service_module
 from app.modules.proxy import service as proxy_service_module
+from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.helpers import _rate_limit_details
 from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
 from app.modules.proxy.request_policy import (
@@ -1735,13 +1737,14 @@ async def v1_chat_completions(
     except ValidationError as exc:
         error = openai_validation_error(exc)
         return _logged_error_json_response(request, 400, error, headers=rate_limit_headers)
+    apply_api_key_enforcement(responses_payload, api_key)
     reservation = await _enforce_request_limits(
         api_key,
-        request_model=effective_model,
+        request_model=responses_payload.model,
         request_service_tier=responses_payload.service_tier,
+        request_usage_budget=estimate_api_key_request_usage(responses_payload),
     )
     responses_payload.stream = True
-    apply_api_key_enforcement(responses_payload, api_key)
     stream = context.service.stream_responses(
         responses_payload,
         request.headers,
@@ -1827,6 +1830,7 @@ async def _stream_responses(
             api_key,
             request_model=payload.model,
             request_service_tier=payload.service_tier,
+            request_usage_budget=estimate_api_key_request_usage(payload),
         )
     )
 
@@ -1926,6 +1930,7 @@ async def _collect_responses(
         api_key,
         request_model=payload.model,
         request_service_tier=payload.service_tier,
+        request_usage_budget=estimate_api_key_request_usage(payload),
     )
 
     rate_limit_headers = await context.service.rate_limit_headers()
@@ -2048,6 +2053,7 @@ async def _compact_responses(
         api_key,
         request_model=payload.model,
         request_service_tier=_compact_request_service_tier(payload),
+        request_usage_budget=estimate_api_key_request_usage(payload),
     )
 
     rate_limit_headers = await context.service.rate_limit_headers()
@@ -2378,6 +2384,7 @@ async def _enforce_request_limits(
     *,
     request_model: str | None,
     request_service_tier: str | None,
+    request_usage_budget: ApiKeyRequestUsageBudget | None = None,
 ) -> ApiKeyUsageReservationData | None:
     if api_key is None:
         return None
@@ -2389,6 +2396,7 @@ async def _enforce_request_limits(
                 api_key.id,
                 request_model=request_model,
                 request_service_tier=request_service_tier,
+                request_usage_budget=request_usage_budget,
             )
         except ApiKeyRateLimitExceededError as exc:
             message = f"{exc}. Usage resets at {exc.reset_at.isoformat()}Z."

--- a/app/modules/proxy/api_key_usage.py
+++ b/app/modules/proxy/api_key_usage.py
@@ -55,7 +55,6 @@ def _estimate_request_input_tokens(payload: object) -> int | None:
     return min(len(serialized.encode("utf-8")), API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET)
 
 
-
 def _payload_field(payload: object, field: str) -> object:
     if isinstance(payload, Mapping):
         mapping = cast(Mapping[str, object], payload)

--- a/app/modules/proxy/api_key_usage.py
+++ b/app/modules/proxy/api_key_usage.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any, cast
+
+from pydantic import BaseModel
+
+from app.modules.api_keys.service import (
+    API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET,
+    ApiKeyRequestUsageBudget,
+)
+
+_OPAQUE_INPUT_ITEM_TYPES = frozenset({"input_file", "input_image"})
+_INPUT_BUDGET_EXCLUDED_FIELDS = frozenset(
+    {
+        "model",
+        "service_tier",
+        "stream",
+        "store",
+        "max_output_tokens",
+        "max_completion_tokens",
+        "max_tokens",
+    }
+)
+
+
+def estimate_api_key_request_usage(payload: object) -> ApiKeyRequestUsageBudget:
+    """Return a bounded local usage budget for API-key reservation admission.
+
+    ``None`` means the proxy cannot size that side of the request locally, so
+    API-key enforcement should use its conservative default for that dimension.
+    """
+
+    return ApiKeyRequestUsageBudget(
+        input_tokens=_estimate_request_input_tokens(payload),
+        output_tokens=None,
+    )
+
+
+def _estimate_request_input_tokens(payload: object) -> int | None:
+    if _payload_field(payload, "previous_response_id") is not None:
+        return None
+    if _payload_field(payload, "conversation") is not None:
+        return None
+    if _contains_opaque_input_reference(_payload_field(payload, "input")):
+        return None
+
+    data = _payload_mapping(payload)
+    for field in _INPUT_BUDGET_EXCLUDED_FIELDS:
+        data.pop(field, None)
+    serialized = json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str)
+    if not serialized:
+        return 0
+    return min(len(serialized.encode("utf-8")), API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET)
+
+
+
+def _payload_field(payload: object, field: str) -> object:
+    if isinstance(payload, Mapping):
+        mapping = cast(Mapping[str, object], payload)
+        return mapping.get(field)
+    extra = getattr(payload, "model_extra", None)
+    if isinstance(extra, Mapping):
+        extra_mapping = cast(Mapping[str, object], extra)
+        if field in extra_mapping:
+            return extra_mapping[field]
+    return getattr(payload, field, None)
+
+
+def _payload_mapping(payload: object) -> dict[str, Any]:
+    if isinstance(payload, BaseModel):
+        return dict(payload.model_dump(mode="json", exclude_none=True))
+    if isinstance(payload, Mapping):
+        mapping = cast(Mapping[object, Any], payload)
+        return {str(key): value for key, value in mapping.items()}
+    data: dict[str, Any] = {}
+    for field in ("instructions", "input", "tools", "tool_choice", "reasoning", "text"):
+        value = _payload_field(payload, field)
+        if value is not None:
+            data[field] = value
+    return data
+
+
+def _contains_opaque_input_reference(value: object) -> bool:
+    if isinstance(value, Mapping):
+        mapping = cast(Mapping[str, object], value)
+        item_type = mapping.get("type")
+        if isinstance(item_type, str) and item_type in _OPAQUE_INPUT_ITEM_TYPES:
+            return True
+        if "file_id" in mapping:
+            return True
+        return any(_contains_opaque_input_reference(child) for child in mapping.values())
+    if isinstance(value, list | tuple):
+        return any(_contains_opaque_input_reference(item) for item in value)
+    return False

--- a/app/modules/proxy/api_key_usage.py
+++ b/app/modules/proxy/api_key_usage.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
-from typing import Any, cast
+from typing import TypeAlias
 
-from pydantic import BaseModel
-
+from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+from app.core.types import JsonObject, JsonValue
+from app.core.utils.json_guards import is_json_list, is_json_mapping
 from app.modules.api_keys.service import (
     API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET,
     ApiKeyRequestUsageBudget,
 )
+
+ApiKeyUsageEstimableRequest: TypeAlias = ResponsesRequest | ResponsesCompactRequest
 
 _OPAQUE_INPUT_ITEM_TYPES = frozenset({"input_file", "input_image"})
 _INPUT_BUDGET_EXCLUDED_FIELDS = frozenset(
@@ -25,71 +27,52 @@ _INPUT_BUDGET_EXCLUDED_FIELDS = frozenset(
 )
 
 
-def estimate_api_key_request_usage(payload: object) -> ApiKeyRequestUsageBudget:
+def estimate_api_key_request_usage(payload: ApiKeyUsageEstimableRequest) -> ApiKeyRequestUsageBudget:
     """Return a bounded local usage budget for API-key reservation admission.
 
     ``None`` means the proxy cannot size that side of the request locally, so
     API-key enforcement should use its conservative default for that dimension.
     """
 
+    upstream_payload = payload.to_payload()
     return ApiKeyRequestUsageBudget(
-        input_tokens=_estimate_request_input_tokens(payload),
+        input_tokens=_estimate_request_input_tokens(payload, upstream_payload),
         output_tokens=None,
     )
 
 
-def _estimate_request_input_tokens(payload: object) -> int | None:
-    if _payload_field(payload, "previous_response_id") is not None:
+def _estimate_request_input_tokens(payload: ApiKeyUsageEstimableRequest, upstream_payload: JsonObject) -> int | None:
+    if _has_opaque_upstream_context(upstream_payload):
         return None
-    if _payload_field(payload, "conversation") is not None:
-        return None
-    if _contains_opaque_input_reference(_payload_field(payload, "input")):
+    if _contains_opaque_input_reference(payload.input):
         return None
 
-    data = _payload_mapping(payload)
-    for field in _INPUT_BUDGET_EXCLUDED_FIELDS:
-        data.pop(field, None)
+    data = _input_budget_payload(upstream_payload)
     serialized = json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True, default=str)
     if not serialized:
         return 0
     return min(len(serialized.encode("utf-8")), API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET)
 
 
-def _payload_field(payload: object, field: str) -> object:
-    if isinstance(payload, Mapping):
-        mapping = cast(Mapping[str, object], payload)
-        return mapping.get(field)
-    extra = getattr(payload, "model_extra", None)
-    if isinstance(extra, Mapping):
-        extra_mapping = cast(Mapping[str, object], extra)
-        if field in extra_mapping:
-            return extra_mapping[field]
-    return getattr(payload, field, None)
-
-
-def _payload_mapping(payload: object) -> dict[str, Any]:
-    if isinstance(payload, BaseModel):
-        return dict(payload.model_dump(mode="json", exclude_none=True))
-    if isinstance(payload, Mapping):
-        mapping = cast(Mapping[object, Any], payload)
-        return {str(key): value for key, value in mapping.items()}
-    data: dict[str, Any] = {}
-    for field in ("instructions", "input", "tools", "tool_choice", "reasoning", "text"):
-        value = _payload_field(payload, field)
-        if value is not None:
-            data[field] = value
+def _input_budget_payload(payload: JsonObject) -> dict[str, JsonValue]:
+    data = dict(payload.items())
+    for field in _INPUT_BUDGET_EXCLUDED_FIELDS:
+        data.pop(field, None)
     return data
 
 
-def _contains_opaque_input_reference(value: object) -> bool:
-    if isinstance(value, Mapping):
-        mapping = cast(Mapping[str, object], value)
-        item_type = mapping.get("type")
+def _has_opaque_upstream_context(payload: JsonObject) -> bool:
+    return payload.get("previous_response_id") is not None or payload.get("conversation") is not None
+
+
+def _contains_opaque_input_reference(value: JsonValue) -> bool:
+    if is_json_mapping(value):
+        item_type = value.get("type")
         if isinstance(item_type, str) and item_type in _OPAQUE_INPUT_ITEM_TYPES:
             return True
-        if "file_id" in mapping:
+        if "file_id" in value:
             return True
-        return any(_contains_opaque_input_reference(child) for child in mapping.values())
-    if isinstance(value, list | tuple):
+        return any(_contains_opaque_input_reference(child) for child in value.values())
+    if is_json_list(value):
         return any(_contains_opaque_input_reference(item) for item in value)
     return False

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -119,9 +119,11 @@ from app.modules.api_keys.service import (
     ApiKeyData,
     ApiKeyInvalidError,
     ApiKeyRateLimitExceededError,
+    ApiKeyRequestUsageBudget,
     ApiKeysService,
     ApiKeyUsageReservationData,
 )
+from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.durable_bridge_coordinator import (
     DurableBridgeLookup,
     DurableBridgeSessionCoordinator,
@@ -939,6 +941,7 @@ class ProxyService:
                             request_service_tier=_normalize_service_tier_value(
                                 dict(effective_payload.to_payload()).get("service_tier"),
                             ),
+                            request_usage_budget=estimate_api_key_request_usage(effective_payload),
                         )
                         retry_reservation_reacquired = True
 
@@ -1285,6 +1288,7 @@ class ProxyService:
                         request_service_tier=_normalize_service_tier_value(
                             dict(retry_payload.to_payload()).get("service_tier"),
                         ),
+                        request_usage_budget=estimate_api_key_request_usage(retry_payload),
                     )
                     retry_reservation_reacquired = True
 
@@ -3606,6 +3610,7 @@ class ProxyService:
             request_service_tier=_normalize_service_tier_value(
                 dict(responses_payload.to_payload()).get("service_tier")
             ),
+            request_usage_budget=estimate_api_key_request_usage(responses_payload),
         )
         try:
             session_id = _owner_lookup_session_id_from_headers(headers)
@@ -8153,6 +8158,7 @@ class ProxyService:
         *,
         request_model: str | None,
         request_service_tier: str | None,
+        request_usage_budget: ApiKeyRequestUsageBudget | None = None,
     ) -> ApiKeyUsageReservationData | None:
         if api_key is None:
             return None
@@ -8165,6 +8171,7 @@ class ProxyService:
                         api_key.id,
                         request_model=request_model,
                         request_service_tier=request_service_tier,
+                        request_usage_budget=request_usage_budget,
                     )
                 except ApiKeyRateLimitExceededError as exc:
                     message = f"{exc}. Usage resets at {exc.reset_at.isoformat()}Z."

--- a/openspec/changes/fix-api-key-reservation-budget/proposal.md
+++ b/openspec/changes/fix-api-key-reservation-budget/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+One API key can return proxy-side 429s when several Codex lanes start at the same time even though the completed requests would be within the key's configured usage limits. The local API-key admission path currently reserves a fixed 8192 input + 8192 output token budget for every in-flight request, and prices `cost_usd` reservations from that budget. With `enforced_service_tier=priority`, a single `gpt-5.5` reservation is about $0.716799, so eight concurrent lanes require about $5.73 of temporary cost headroom before any request has actually completed.
+
+This makes usage limits double as an implicit concurrency limit and causes false 429s for normal multi-lane Codex operation.
+
+## What Changes
+
+- Add request-usage reservation budgets to API-key limit enforcement so admission can reserve a bounded estimate instead of the old unconditional 8192/8192 token pair.
+- Use a lower bounded default output-token reservation while preserving the existing 8192-token ceiling for strict/opaque inputs.
+- Estimate request input budget from the serialized request shape when the payload is self-contained; fall back to the conservative input default for previous-response/conversation/file/image references whose true upstream input is opaque to the proxy.
+- Do not trust client-provided output caps that codex-lb does not currently enforce upstream; actual output is still charged during final settlement.
+- Keep final accounting unchanged: successful requests settle every applicable reservation item to authoritative usage and service-tier pricing; failed/early-exit requests release the reservation.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `api-keys`: API-key usage reservation admission MUST reserve from a request-aware budget and MUST NOT require `concurrent_lanes * 8192 output tokens` of temporary headroom.
+
+## Impact
+
+- **Code**: `app/modules/api_keys/service.py`, proxy request-limit call sites, and a small proxy usage-budget helper.
+- **Tests**: unit coverage for eight concurrent priority lanes under a $5 cost limit, unsupported output-cap handling, zero-reservation finalization, and opaque-input fallback.
+- **Schema/API**: no database migration and no public API-field changes.
+- **Operational**: priority service-tier enforcement still affects actual cost accounting; the admission reservation is now a bounded estimate rather than a worst-case 16k-token pre-charge.

--- a/openspec/changes/fix-api-key-reservation-budget/specs/api-keys/spec.md
+++ b/openspec/changes/fix-api-key-reservation-budget/specs/api-keys/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Request-aware API-key usage reservations
+
+API-key usage reservation admission MUST reserve a bounded request-aware budget instead of an unconditional fixed 8192 input-token plus 8192 output-token pre-charge for every request. The reservation budget MUST be used only for admission and in-flight accounting; final usage accounting MUST continue to settle to the authoritative completed request usage and service-tier pricing.
+
+For token limits, admission MUST reserve from the request input and output token budgets. The input budget MAY be estimated from self-contained request payloads, while opaque upstream context MUST fall back to a conservative input budget. The output budget MUST use a bounded system default unless codex-lb can verify that a client-provided output cap is actually enforced upstream. For `cost_usd` limits, admission MUST compute the reservation cost from the same input and output token budgets and the effective request service tier. Reservation finalization MUST adjust every applicable reserved value to actual completed usage exactly once, including limits whose admission reservation was zero.
+
+#### Scenario: Concurrent priority lanes do not require 8 × 8192 output-token headroom
+
+- **WHEN** an API key has a `cost_usd` limit with enough remaining value for the bounded request-aware reservations
+- **AND** eight `gpt-5.5` requests using `service_tier = "priority"` are admitted concurrently
+- **THEN** the proxy allows all eight reservations instead of rejecting a lane solely because the old 8192-output-token pre-charge would exceed the limit
+
+#### Scenario: Opaque input uses conservative input fallback
+
+- **WHEN** a request references input that the proxy cannot size locally, such as `previous_response_id`, `conversation`, `input_file`, or `input_image`
+- **THEN** API-key admission uses the conservative default input-token reservation budget for input tokens
+- **AND** final accounting still settles to actual completed usage
+
+#### Scenario: Zero-reservation limits still settle actual usage
+
+- **WHEN** API-key admission records a zero-delta reservation item for an applicable limit
+- **AND** the request completes with non-zero actual usage for that limit
+- **THEN** reservation finalization increments the limit by the actual usage instead of skipping the limit

--- a/openspec/changes/fix-api-key-reservation-budget/tasks.md
+++ b/openspec/changes/fix-api-key-reservation-budget/tasks.md
@@ -1,0 +1,19 @@
+## 1. Reservation Budgeting
+
+- [x] 1.1 Add a typed request-usage reservation budget to API-key limit enforcement.
+- [x] 1.2 Replace unconditional 8192/8192 token cost reservations with input/output budget-aware reservations.
+- [x] 1.3 Preserve final usage settlement and release semantics.
+
+## 2. Proxy Integration
+
+- [x] 2.1 Estimate self-contained Responses/compact request input size from serialized payload bytes.
+- [x] 2.2 Fall back to conservative input reservation for previous-response, conversation, file, or image references.
+- [x] 2.3 Use a bounded default output reservation and avoid trusting output caps that codex-lb does not enforce upstream.
+- [x] 2.4 Pass the estimated budget through HTTP and websocket reservation paths.
+
+## 3. Tests and Validation
+
+- [x] 3.1 Add regression coverage for eight simultaneous priority-lane reservations under a $5 cost limit.
+- [x] 3.2 Add coverage for unsupported output caps, zero-reservation finalization, and opaque-input fallback.
+- [x] 3.3 Run focused tests for API-key service and proxy usage-budget helper.
+- [x] 3.4 Run `uv run ruff check` and `openspec validate --specs`.

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -2168,7 +2168,7 @@ async def test_release_stale_usage_reservations_restores_reserved_usage(async_cl
                 allowed_models=None,
                 expires_at=None,
                 limits=[
-                    LimitRuleInput(limit_type="total_tokens", limit_window="weekly", max_value=30_000),
+                    LimitRuleInput(limit_type="total_tokens", limit_window="weekly", max_value=50_000),
                 ],
             )
         )

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+from typing import Any, cast
 
 import pytest
 from sqlalchemy.exc import OperationalError
@@ -940,6 +941,13 @@ async def test_enforce_limits_reserves_tier_aware_cost_budget() -> None:
     standard_limits = await repo.get_limits_by_key(standard_created.id)
     standard_cost_limit = next(lim for lim in standard_limits if lim.limit_type == LimitType.COST_USD)
     assert standard_cost_limit.current_value == 143_360
+
+
+def test_api_key_request_usage_budget_rejects_non_integer_tokens() -> None:
+    with pytest.raises(TypeError, match="input_tokens"):
+        ApiKeyRequestUsageBudget(input_tokens=cast(Any, "128"))
+    with pytest.raises(TypeError, match="output_tokens"):
+        ApiKeyRequestUsageBudget(output_tokens=cast(Any, True))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -20,6 +21,7 @@ from app.modules.api_keys.service import (
     ApiKeyCreateData,
     ApiKeyInvalidError,
     ApiKeyRateLimitExceededError,
+    ApiKeyRequestUsageBudget,
     ApiKeysRepositoryProtocol,
     ApiKeysService,
     ApiKeyUpdateData,
@@ -909,6 +911,7 @@ async def test_enforce_limits_reserves_tier_aware_cost_budget() -> None:
         priority_created.id,
         request_model="gpt-5.4",
         request_service_tier="priority",
+        request_usage_budget=ApiKeyRequestUsageBudget(input_tokens=8192, output_tokens=8192),
     )
     assert priority_reservation.key_id == priority_created.id
 
@@ -930,12 +933,110 @@ async def test_enforce_limits_reserves_tier_aware_cost_budget() -> None:
         standard_created.id,
         request_model="gpt-5.4",
         request_service_tier=None,
+        request_usage_budget=ApiKeyRequestUsageBudget(input_tokens=8192, output_tokens=8192),
     )
     assert standard_reservation.key_id == standard_created.id
 
     standard_limits = await repo.get_limits_by_key(standard_created.id)
     standard_cost_limit = next(lim for lim in standard_limits if lim.limit_type == LimitType.COST_USD)
     assert standard_cost_limit.current_value == 143_360
+
+
+@pytest.mark.asyncio
+async def test_enforce_limits_default_budget_allows_eight_priority_lanes_under_five_dollars() -> None:
+    repo = _FakeApiKeysRepository()
+    service = ApiKeysService(repo)
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="priority-lanes",
+            allowed_models=None,
+            expires_at=None,
+            limits=[LimitRuleInput(limit_type="cost_usd", limit_window="weekly", max_value=5_000_000)],
+        )
+    )
+
+    reservations = await asyncio.gather(
+        *(
+            service.enforce_limits_for_request(
+                created.id,
+                request_model="gpt-5.5",
+                request_service_tier="priority",
+            )
+            for _ in range(8)
+        )
+    )
+
+    assert len(reservations) == 8
+    assert {reservation.key_id for reservation in reservations} == {created.id}
+    limits = await repo.get_limits_by_key(created.id)
+    cost_limit = next(lim for lim in limits if lim.limit_type == LimitType.COST_USD)
+    assert 0 < cost_limit.current_value < 5_000_000
+
+
+@pytest.mark.asyncio
+async def test_enforce_limits_request_budget_bounds_token_and_cost_reservations() -> None:
+    repo = _FakeApiKeysRepository()
+    service = ApiKeysService(repo)
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="bounded-request",
+            allowed_models=None,
+            expires_at=None,
+            limits=[
+                LimitRuleInput(limit_type="input_tokens", limit_window="weekly", max_value=1_000_000),
+                LimitRuleInput(limit_type="output_tokens", limit_window="weekly", max_value=1_000_000),
+                LimitRuleInput(limit_type="total_tokens", limit_window="weekly", max_value=1_000_000),
+                LimitRuleInput(limit_type="cost_usd", limit_window="weekly", max_value=1_000_000),
+            ],
+        )
+    )
+
+    await service.enforce_limits_for_request(
+        created.id,
+        request_model="gpt-5.5",
+        request_service_tier="priority",
+        request_usage_budget=ApiKeyRequestUsageBudget(input_tokens=123, output_tokens=456),
+    )
+
+    limits = await repo.get_limits_by_key(created.id)
+    by_type = {limit.limit_type: limit.current_value for limit in limits}
+    assert by_type[LimitType.INPUT_TOKENS] == 123
+    assert by_type[LimitType.OUTPUT_TOKENS] == 456
+    assert by_type[LimitType.TOTAL_TOKENS] == 579
+    assert 0 < by_type[LimitType.COST_USD] < 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_finalize_usage_reservation_accounts_for_zero_reserved_limit_item() -> None:
+    repo = _FakeApiKeysRepository()
+    service = ApiKeysService(repo)
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="zero-output-reserve",
+            allowed_models=None,
+            expires_at=None,
+            limits=[LimitRuleInput(limit_type="output_tokens", limit_window="weekly", max_value=1_000)],
+        )
+    )
+
+    reservation = await service.enforce_limits_for_request(
+        created.id,
+        request_model="gpt-5.5",
+        request_usage_budget=ApiKeyRequestUsageBudget(input_tokens=0, output_tokens=0),
+    )
+
+    limits = await repo.get_limits_by_key(created.id)
+    output_limit = next(limit for limit in limits if limit.limit_type == LimitType.OUTPUT_TOKENS)
+    assert output_limit.current_value == 0
+
+    await service.finalize_usage_reservation(
+        reservation.reservation_id,
+        model="gpt-5.5",
+        input_tokens=0,
+        output_tokens=100,
+    )
+
+    assert output_limit.current_value == 100
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_api_key_usage.py
+++ b/tests/unit/test_proxy_api_key_usage.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from app.core.openai.requests import ResponsesRequest
+import pytest
+
+from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
 from app.modules.api_keys.service import API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 
@@ -19,6 +21,42 @@ def test_estimate_api_key_request_usage_does_not_trust_unsupported_output_caps()
 
     assert budget.input_tokens is not None
     assert 0 < budget.input_tokens < API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+    assert budget.output_tokens is None
+
+
+def test_estimate_api_key_request_usage_accepts_compact_request_shape() -> None:
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "compress",
+            "input": "hello",
+            "service_tier": "priority",
+        }
+    )
+
+    budget = estimate_api_key_request_usage(payload)
+
+    assert budget.input_tokens is not None
+    assert 0 < budget.input_tokens < API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+    assert budget.output_tokens is None
+
+
+@pytest.mark.parametrize("opaque_field", ["previous_response_id", "conversation"])
+def test_estimate_api_key_request_usage_uses_conservative_input_for_compact_opaque_context(
+    opaque_field: str,
+) -> None:
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "compress",
+            "input": "hello",
+            opaque_field: "opaque_123",
+        }
+    )
+
+    budget = estimate_api_key_request_usage(payload)
+
+    assert budget.input_tokens is None
     assert budget.output_tokens is None
 
 

--- a/tests/unit/test_proxy_api_key_usage.py
+++ b/tests/unit/test_proxy_api_key_usage.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from app.core.openai.requests import ResponsesRequest
+from app.modules.api_keys.service import API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
+
+
+def test_estimate_api_key_request_usage_does_not_trust_unsupported_output_caps() -> None:
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "be brief",
+            "input": "hello",
+            "max_output_tokens": 128,
+        }
+    )
+
+    budget = estimate_api_key_request_usage(payload)
+
+    assert budget.input_tokens is not None
+    assert 0 < budget.input_tokens < API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET
+    assert budget.output_tokens is None
+
+
+def test_estimate_api_key_request_usage_uses_conservative_input_for_previous_response() -> None:
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "continue",
+            "input": "next",
+            "previous_response_id": "resp_123",
+        }
+    )
+
+    budget = estimate_api_key_request_usage(payload)
+
+    assert budget.input_tokens is None
+    assert budget.output_tokens is None
+
+
+def test_estimate_api_key_request_usage_uses_conservative_input_for_file_reference() -> None:
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "summarize",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_file", "file_id": "file_123"}],
+                }
+            ],
+        }
+    )
+
+    budget = estimate_api_key_request_usage(payload)
+
+    assert budget.input_tokens is None

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -241,7 +241,10 @@ async def test_stream_responses_prefers_forwarded_downstream_turn_state(monkeypa
     def fake_validate_model_access(_api_key, _model):
         return None
 
-    async def fake_enforce_request_limits(_api_key, *, request_model=None, request_service_tier=None):
+    async def fake_enforce_request_limits(
+        _api_key, *, request_model=None, request_service_tier=None, request_usage_budget=None
+    ):
+        del request_model, request_service_tier, request_usage_budget
         return None
 
     async def fake_release_reservation(_reservation):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6138,11 +6138,14 @@ async def test_prepare_websocket_response_create_request_normalizes_payload_and_
         api_key=stale_api_key,
     )
 
-    reserve_usage.assert_awaited_once_with(
-        refreshed_api_key,
-        request_model="gpt-5.2",
-        request_service_tier="priority",
-    )
+    reserve_usage.assert_awaited_once()
+    assert reserve_usage.await_args is not None
+    reserve_args, reserve_kwargs = reserve_usage.await_args
+    assert reserve_args == (refreshed_api_key,)
+    assert reserve_kwargs["request_model"] == "gpt-5.2"
+    assert reserve_kwargs["request_service_tier"] == "priority"
+    assert reserve_kwargs["request_usage_budget"].input_tokens is not None
+    assert reserve_kwargs["request_usage_budget"].output_tokens is None
     assert prepared.request_state.model == "gpt-5.2"
     assert prepared.request_state.service_tier == "priority"
     assert prepared.request_state.reasoning_effort == "high"


### PR DESCRIPTION
## Summary
- Size API-key usage reservations from request-aware input/output budgets instead of a fixed 8192/8192 pre-charge.
- Use a typed `ResponsesRequest | ResponsesCompactRequest` request-usage estimation surface with `JsonValue`/`JsonObject` helpers, avoiding generic `object`/`Any`/`getattr` duck-typing.
- Add proxy-side request usage estimation for HTTP and websocket paths, with conservative fallbacks for opaque context and output usage.
- Preserve authoritative final settlement, including zero-delta reservation items, so actual completed usage still updates applicable limits.
- Document the behavior in OpenSpec and add regressions for eight concurrent priority lanes under a $5 cost limit.

## Test Plan
- `make lint`
- `uv run ty check`
- `uv run pytest tests/unit/test_proxy_api_key_usage.py tests/unit/test_api_keys_service.py tests/unit/test_proxy_api_websocket_auth.py tests/unit/test_proxy_utils.py tests/integration/test_api_keys_api.py -q`
- `openspec validate --specs`

## Notes
- No database migration or public API field changes.
- Client output caps are not trusted for reservation sizing unless codex-lb can verify upstream enforcement; final settlement still charges actual usage.
- Compact request extra `previous_response_id` / `conversation` fields still force conservative input fallback.
