### PR TITLE
fix(proxy): mask websocket prepare continuity errors

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import time
 from typing import Literal, NotRequired, TypedDict
 
@@ -41,12 +42,58 @@ class ResponseFailedEvent(TypedDict):
     response: ResponseFailedResponse
 
 
+PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE = "Upstream websocket closed before response.completed"
+
+
 def openai_error(code: str, message: str, error_type: str = "server_error") -> OpenAIErrorEnvelope:
     return {"error": {"message": message, "type": error_type, "code": code}}
 
 
 def dashboard_error(code: str, message: str) -> DashboardErrorEnvelope:
     return {"error": {"code": code, "message": message}}
+
+
+def previous_response_stream_incomplete_error() -> OpenAIErrorEnvelope:
+    return openai_error(
+        "stream_incomplete",
+        PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+        error_type="server_error",
+    )
+
+
+def is_previous_response_not_found_message(message: str | None) -> bool:
+    if message is None:
+        return False
+    normalized = " ".join(message.lower().split())
+    return "previous response" in normalized and "not found" in normalized
+
+
+def previous_response_id_from_not_found_message(message: str | None) -> str | None:
+    if message is None:
+        return None
+    normalized = " ".join(message.split())
+    match = re.search(
+        r"""previous\s+response\s+with\s+id\s+['"](?P<response_id>[^'"]+)['"]\s+not\s+found""",
+        normalized,
+        re.IGNORECASE,
+    )
+    if match is None:
+        return None
+    response_id = match.group("response_id").strip()
+    return response_id or None
+
+
+def is_previous_response_not_found_error(
+    *,
+    code: str | None,
+    param: str | None,
+    message: str | None,
+) -> bool:
+    if code == "previous_response_not_found":
+        return True
+    if code != "invalid_request_error" or param != "previous_response_id":
+        return False
+    return is_previous_response_not_found_message(message)
 
 
 def response_failed_event(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -40,7 +40,13 @@ from app.core.clients.files import FileProxyError
 from app.core.clients.proxy import ProxyResponseError
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
-from app.core.errors import OpenAIErrorEnvelope, openai_error, response_failed_event
+from app.core.errors import (
+    PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+    OpenAIErrorEnvelope,
+    is_previous_response_not_found_error,
+    openai_error,
+    response_failed_event,
+)
 from app.core.exceptions import ProxyAuthError, ProxyRateLimitError
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, bridge_public_contract_error_total
 from app.core.middleware.api_firewall import _parse_trusted_proxy_networks, resolve_connection_client_ip
@@ -2987,7 +2993,7 @@ def _normalize_public_stream_payload(
                     dict[str, JsonValue],
                     response_failed_event(
                         "stream_incomplete",
-                        "Upstream websocket closed before response.completed",
+                        PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
                     ),
                 ),
                 None,
@@ -3337,15 +3343,10 @@ def _error_envelope_from_response(error_value: OpenAIError | None) -> OpenAIErro
 def _is_previous_response_not_found_public_error(error_value: OpenAIError | None) -> bool:
     if error_value is None:
         return False
-    if error_value.code == "previous_response_not_found":
-        return True
-    message = error_value.message or ""
-    normalized_message = " ".join(message.lower().split())
-    return (
-        error_value.code == "invalid_request_error"
-        and error_value.param == "previous_response_id"
-        and "previous response" in normalized_message
-        and "not found" in normalized_message
+    return is_previous_response_not_found_error(
+        code=error_value.code,
+        param=error_value.param,
+        message=error_value.message,
     )
 
 
@@ -3360,7 +3361,7 @@ def _mask_previous_response_not_found_error(
         502,
         OpenAIErrorEnvelopeModel(
             error=OpenAIError(
-                message="Upstream websocket closed before response.completed",
+                message=PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
                 type="server_error",
                 code="stream_incomplete",
             )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -64,10 +64,15 @@ from app.core.config.settings import DEFAULT_HOME_DIR, Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
+    PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
     OpenAIErrorDetail,
     OpenAIErrorEnvelope,
     ResponseFailedEvent,
+    is_previous_response_not_found_error,
+    is_previous_response_not_found_message,
     openai_error,
+    previous_response_id_from_not_found_message,
+    previous_response_stream_incomplete_error,
     response_failed_event,
 )
 from app.core.exceptions import AppError, ProxyAuthError, ProxyRateLimitError
@@ -8419,6 +8424,18 @@ class ProxyService:
             request_error_message = request_state.error_message_override or error_message
             request_error_type = request_state.error_type_override or "server_error"
             request_error_param = request_state.error_param_override
+            (
+                request_error_code,
+                request_error_message,
+                request_error_type,
+                request_error_param,
+            ) = _sanitize_websocket_terminal_error_fields(
+                request_state=request_state,
+                error_code=request_error_code,
+                error_message=request_error_message,
+                error_type=request_error_type,
+                error_param=request_error_param,
+            )
             if index == last_index:
                 _maybe_dump_oversized_response_create_request(
                     request_state,
@@ -8486,6 +8503,13 @@ class ProxyService:
         error_param: str | None = None,
         downstream_activity: _DownstreamWebSocketActivity | None = None,
     ) -> None:
+        error_code, error_message, error_type, error_param = _sanitize_websocket_terminal_error_fields(
+            request_state=request_state,
+            error_code=error_code,
+            error_message=error_message,
+            error_type=error_type,
+            error_param=error_param,
+        )
         event = response_failed_event(
             error_code,
             error_message,
@@ -11378,25 +11402,11 @@ def _websocket_event_error_message(event_type: str | None, payload: dict[str, Js
 
 
 def _is_previous_response_not_found_message(message: str | None) -> bool:
-    if message is None:
-        return False
-    normalized = " ".join(message.lower().split())
-    return "previous response" in normalized and "not found" in normalized
+    return is_previous_response_not_found_message(message)
 
 
 def _previous_response_id_from_not_found_message(message: str | None) -> str | None:
-    if message is None:
-        return None
-    normalized = " ".join(message.split())
-    match = re.search(
-        r"""previous\s+response\s+with\s+id\s+['"](?P<response_id>[^'"]+)['"]\s+not\s+found""",
-        normalized,
-        re.IGNORECASE,
-    )
-    if match is None:
-        return None
-    response_id = match.group("response_id").strip()
-    return response_id or None
+    return previous_response_id_from_not_found_message(message)
 
 
 def _message_mentions_previous_response_id(message: str | None, previous_response_id: str | None) -> bool:
@@ -11569,11 +11579,7 @@ def _is_previous_response_not_found_error(
     param: str | None,
     message: str | None,
 ) -> bool:
-    if code == "previous_response_not_found":
-        return True
-    if code != "invalid_request_error" or param != "previous_response_id":
-        return False
-    return _is_previous_response_not_found_message(message)
+    return is_previous_response_not_found_error(code=code, param=param, message=message)
 
 
 def _compact_previous_response_not_found_error(exc: ProxyResponseError) -> ProxyResponseError | None:
@@ -11589,11 +11595,7 @@ def _compact_previous_response_not_found_error(exc: ProxyResponseError) -> Proxy
         return None
     return ProxyResponseError(
         502,
-        openai_error(
-            "stream_incomplete",
-            "Upstream websocket closed before response.completed",
-            error_type="server_error",
-        ),
+        previous_response_stream_incomplete_error(),
         failure_phase=exc.failure_phase,
         retryable_same_contract=False,
         failure_detail="previous_response_not_found",
@@ -11708,7 +11710,7 @@ def _rewrite_websocket_continuity_corruption_event(
     )
     rewritten_event_payload = response_failed_event(
         "stream_incomplete",
-        "Upstream websocket closed before response.completed",
+        PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
         error_type="server_error",
         response_id=request_state.response_id or request_state.request_id,
     )
@@ -11815,7 +11817,7 @@ def _sanitize_websocket_previous_response_error(
     if not should_rewrite:
         return status_code, payload, error_code, error_message
 
-    rewritten_message = "Upstream websocket closed before response.completed"
+    rewritten_message = PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE
     _record_continuity_fail_closed(
         surface=surface,
         reason=reason,
@@ -11832,6 +11834,36 @@ def _sanitize_websocket_previous_response_error(
         ),
         "stream_incomplete",
         rewritten_message,
+    )
+
+
+def _sanitize_websocket_terminal_error_fields(
+    *,
+    request_state: _WebSocketRequestState,
+    error_code: str,
+    error_message: str,
+    error_type: str,
+    error_param: str | None,
+) -> tuple[str, str, str, str | None]:
+    normalized_code = _normalize_error_code(error_code, error_type)
+    if not _is_previous_response_not_found_error(
+        code=normalized_code,
+        param=error_param,
+        message=error_message,
+    ):
+        return error_code, error_message, error_type, error_param
+    _record_continuity_fail_closed(
+        surface="websocket_terminal",
+        reason="previous_response_not_found",
+        previous_response_id=request_state.previous_response_id,
+        session_id=request_state.session_id,
+        upstream_error_code=normalized_code,
+    )
+    return (
+        "stream_incomplete",
+        PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+        "server_error",
+        None,
     )
 
 
@@ -11868,7 +11900,7 @@ def _rewrite_previous_response_stream_error(
         )
         return (
             "stream_incomplete",
-            "Upstream websocket closed before response.completed",
+            PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
             None,
         )
     if _is_missing_tool_output_error(
@@ -11884,7 +11916,7 @@ def _rewrite_previous_response_stream_error(
         )
         return (
             "stream_incomplete",
-            "Upstream websocket closed before response.completed",
+            PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
             None,
         )
     normalized_code = _normalize_error_code(error_code, error_type)
@@ -12780,11 +12812,7 @@ def _wrapped_websocket_error_event(
         message=error_message,
     ):
         status_code = 502
-        payload = openai_error(
-            "stream_incomplete",
-            "Upstream websocket closed before response.completed",
-            error_type="server_error",
-        )
+        payload = previous_response_stream_incomplete_error()
     error_payload = cast(JsonValue, dict(payload["error"]))
     event: dict[str, JsonValue] = {
         "type": "error",
@@ -13861,11 +13889,7 @@ def _http_bridge_previous_response_error_envelope(
 
 
 def _http_bridge_continuity_lost_error_envelope() -> OpenAIErrorEnvelope:
-    return openai_error(
-        "stream_incomplete",
-        "Upstream websocket closed before response.completed",
-        error_type="server_error",
-    )
+    return previous_response_stream_incomplete_error()
 
 
 def _http_bridge_owner_lookup_unavailable_error_envelope() -> OpenAIErrorEnvelope:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -12767,6 +12767,24 @@ def _wrapped_websocket_error_event(
     status_code: int,
     payload: OpenAIErrorEnvelope,
 ) -> dict[str, JsonValue]:
+    error = payload["error"]
+    error_code = _normalize_error_code(
+        cast(str | None, error.get("code")),
+        cast(str | None, error.get("type")),
+    )
+    error_param = cast(str | None, error.get("param"))
+    error_message = cast(str | None, error.get("message"))
+    if _is_previous_response_not_found_error(
+        code=error_code,
+        param=error_param,
+        message=error_message,
+    ):
+        status_code = 502
+        payload = openai_error(
+            "stream_incomplete",
+            "Upstream websocket closed before response.completed",
+            error_type="server_error",
+        )
     error_payload = cast(JsonValue, dict(payload["error"]))
     event: dict[str, JsonValue] = {
         "type": "error",

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -12801,11 +12801,11 @@ def _wrapped_websocket_error_event(
 ) -> dict[str, JsonValue]:
     error = payload["error"]
     error_code = _normalize_error_code(
-        cast(str | None, error.get("code")),
-        cast(str | None, error.get("type")),
+        error.get("code"),
+        error.get("type"),
     )
-    error_param = cast(str | None, error.get("param"))
-    error_message = cast(str | None, error.get("message"))
+    error_param = error.get("param")
+    error_message = error.get("message")
     if _is_previous_response_not_found_error(
         code=error_code,
         param=error_param,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3327,10 +3327,24 @@ class ProxyService:
                                 request_affinity = prepared_request.affinity_policy
                                 text_data = prepared_request.text_data
                             except ProxyResponseError as exc:
+                                (
+                                    status_code,
+                                    error_payload,
+                                    _error_code,
+                                    _error_message,
+                                ) = _sanitize_websocket_previous_response_error(
+                                    previous_response_id=_previous_response_id_from_payload(payload),
+                                    session_id=_owner_lookup_session_id_from_headers(headers),
+                                    status_code=exc.status_code,
+                                    payload=exc.payload,
+                                    error_code="upstream_error",
+                                    error_message="Upstream error",
+                                    surface="websocket_connect",
+                                )
                                 async with client_send_lock:
                                     await websocket.send_text(
                                         _serialize_websocket_error_event(
-                                            _wrapped_websocket_error_event(exc.status_code, exc.payload)
+                                            _wrapped_websocket_error_event(status_code, error_payload)
                                         )
                                     )
                                 continue
@@ -11756,9 +11770,29 @@ def _sanitize_websocket_connect_failure(
     error_code: str,
     error_message: str,
 ) -> tuple[int, OpenAIErrorEnvelope, str, str]:
-    if request_state.previous_response_id is None:
-        return status_code, payload, error_code, error_message
+    return _sanitize_websocket_previous_response_error(
+        previous_response_id=request_state.previous_response_id,
+        session_id=request_state.session_id,
+        status_code=status_code,
+        payload=payload,
+        error_code=error_code,
+        error_message=error_message,
+        surface="websocket_connect",
+    )
 
+
+def _sanitize_websocket_previous_response_error(
+    *,
+    previous_response_id: str | None,
+    session_id: str | None,
+    status_code: int,
+    payload: OpenAIErrorEnvelope,
+    error_code: str,
+    error_message: str,
+    surface: str,
+) -> tuple[int, OpenAIErrorEnvelope, str, str]:
+    if previous_response_id is None:
+        return status_code, payload, error_code, error_message
     parsed_error = _parse_openai_error(payload)
     normalized_code = _normalize_error_code(
         parsed_error.code if parsed_error else error_code,
@@ -11783,10 +11817,10 @@ def _sanitize_websocket_connect_failure(
 
     rewritten_message = "Upstream websocket closed before response.completed"
     _record_continuity_fail_closed(
-        surface="websocket_connect",
+        surface=surface,
         reason=reason,
-        previous_response_id=request_state.previous_response_id,
-        session_id=request_state.session_id,
+        previous_response_id=previous_response_id,
+        session_id=session_id,
         upstream_error_code=normalized_code,
     )
     return (
@@ -11799,6 +11833,15 @@ def _sanitize_websocket_connect_failure(
         "stream_incomplete",
         rewritten_message,
     )
+
+
+def _previous_response_id_from_payload(payload: Mapping[str, JsonValue] | None) -> str | None:
+    if not isinstance(payload, Mapping):
+        return None
+    previous_response_id = payload.get("previous_response_id")
+    if isinstance(previous_response_id, str) and previous_response_id.strip():
+        return previous_response_id.strip()
+    return None
 
 
 def _rewrite_previous_response_stream_error(

--- a/tests/unit/test_openai_errors.py
+++ b/tests/unit/test_openai_errors.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from app.core.errors import response_failed_event
+from app.core.errors import (
+    PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+    is_previous_response_not_found_error,
+    previous_response_id_from_not_found_message,
+    previous_response_stream_incomplete_error,
+    response_failed_event,
+)
 
 
 def test_response_failed_event_includes_incomplete_details():
@@ -21,3 +27,38 @@ def test_response_failed_event_accepts_incomplete_details():
 
     response = event["response"]
     assert response.get("incomplete_details") == {"reason": "max_output_tokens"}
+
+
+def test_previous_response_not_found_classifier_covers_openai_shapes():
+    assert is_previous_response_not_found_error(
+        code="previous_response_not_found",
+        param=None,
+        message="Previous response with id 'resp_abc' not found.",
+    )
+    assert is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param="previous_response_id",
+        message='Previous response with id "resp_abc" not found.',
+    )
+    assert not is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param="input",
+        message='Previous response with id "resp_abc" not found.',
+    )
+
+
+def test_previous_response_id_from_not_found_message_extracts_anchor():
+    assert (
+        previous_response_id_from_not_found_message(
+            'Previous response with id "resp_0ba42212936dca97016a0d52aec2588191bc2499d3088e4e3e" not found.'
+        )
+        == "resp_0ba42212936dca97016a0d52aec2588191bc2499d3088e4e3e"
+    )
+
+
+def test_previous_response_stream_incomplete_error_is_public_safe():
+    payload = previous_response_stream_incomplete_error()
+
+    assert payload["error"]["code"] == "stream_incomplete"
+    assert payload["error"]["type"] == "server_error"
+    assert payload["error"]["message"] == PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -102,6 +102,39 @@ async def test_normalize_public_responses_stream_preserves_initial_error_details
 
 
 @pytest.mark.asyncio
+async def test_normalize_public_responses_stream_masks_initial_previous_response_not_found() -> None:
+    raw_response_id = "resp_0ba42212936dca97016a0d52aec2588191bc2499d3088e4e3e"
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"error","status":400,"error":{"type":"invalid_request_error",'
+                    '"code":"previous_response_not_found",'
+                    f'"message":"Previous response with id \'{raw_response_id}\' not found.",'
+                    '"param":"previous_response_id"}}\n\n'
+                )
+            )
+        )
+    ]
+
+    joined = "".join(blocks)
+    assert "previous_response_not_found" not in joined
+    assert raw_response_id not in joined
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    payloads = [payload for payload in payloads if payload is not None]
+    assert [payload["type"] for payload in payloads] == ["response.created", "response.failed"]
+    response = payloads[1]["response"]
+    assert isinstance(response, dict)
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert error["type"] == "server_error"
+    assert error["code"] == "stream_incomplete"
+    assert error["message"] == "Upstream websocket closed before response.completed"
+    assert "param" not in error
+
+
+@pytest.mark.asyncio
 async def test_normalize_public_responses_stream_preserves_comment_keepalive() -> None:
     terminal = 'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n\n'
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11627,6 +11627,27 @@ def test_sanitize_websocket_connect_failure_rewrites_invalid_request_previous_re
     assert rewritten_error_message == "Upstream websocket closed before response.completed"
 
 
+def test_wrapped_websocket_error_event_masks_previous_response_not_found():
+    payload = proxy_module.openai_error(
+        "previous_response_not_found",
+        "Previous response with id 'resp_prev_anchor' not found.",
+        error_type="invalid_request_error",
+    )
+    payload["error"]["param"] = "previous_response_id"
+
+    event = proxy_service._wrapped_websocket_error_event(400, payload)
+
+    assert event["type"] == "error"
+    assert event["status"] == 502
+    error = event["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "stream_incomplete"
+    assert error["message"] == "Upstream websocket closed before response.completed"
+    assert error["type"] == "server_error"
+    assert "previous_response_not_found" not in json.dumps(event)
+    assert "resp_prev_anchor" not in json.dumps(event)
+
+
 def test_sanitize_websocket_connect_failure_rewrites_missing_tool_output():
     request_state = proxy_service._WebSocketRequestState(
         request_id="ws_req_missing_tool_output_connect",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10506,6 +10506,82 @@ async def test_proxy_responses_websocket_previous_response_owner_lookup_failure_
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_websocket_masks_prepare_previous_response_not_found(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.stream_idle_timeout_seconds = 300.0
+    settings.proxy_downstream_websocket_idle_timeout_seconds = 120.0
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    class _FakeDownstreamWebSocket:
+        def __init__(self, request_text: str) -> None:
+            self._request_text = request_text
+            self._request_sent = False
+            self._done = asyncio.Event()
+            self.sent_text: list[str] = []
+
+        async def receive(self) -> dict[str, object]:
+            if not self._request_sent:
+                self._request_sent = True
+                return {"type": "websocket.receive", "text": self._request_text}
+            await self._done.wait()
+            return {"type": "websocket.disconnect"}
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+            self._done.set()
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+        async def close(self, code: int = 1000, reason: str | None = None) -> None:
+            del code, reason
+            self._done.set()
+
+    async def fail_prepare(*args, **kwargs):
+        del args, kwargs
+        error = proxy_module.openai_error(
+            "previous_response_not_found",
+            "Previous response with id 'resp_missing_prepare' not found.",
+            error_type="invalid_request_error",
+        )
+        error["error"]["param"] = "previous_response_id"
+        raise proxy_module.ProxyResponseError(400, error)
+
+    monkeypatch.setattr(service, "_prepare_websocket_response_create_request", fail_prepare)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
+        "previous_response_id": "resp_missing_prepare",
+        "stream": True,
+    }
+    downstream = _FakeDownstreamWebSocket(json.dumps(request_payload, separators=(",", ":")))
+
+    await service.proxy_responses_websocket(
+        cast(WebSocket, downstream),
+        {"session_id": "sid_prepare_prev_missing"},
+        codex_session_affinity=False,
+        openai_cache_affinity=False,
+        api_key=None,
+    )
+
+    assert len(downstream.sent_text) == 1
+    assert "previous_response_not_found" not in downstream.sent_text[0]
+    assert "resp_missing_prepare" not in downstream.sent_text[0]
+    payload = json.loads(downstream.sent_text[0])
+    assert payload["type"] == "error"
+    assert payload["status"] == 502
+    assert payload["error"]["code"] == "stream_incomplete"
+    assert payload["error"]["message"] == "Upstream websocket closed before response.completed"
+
+
+@pytest.mark.asyncio
 async def test_stream_with_retry_releases_api_key_reservation_when_owner_lookup_fails(monkeypatch):
     request_logs = _RequestLogsRecorder()
     get_usage_reservation_mock = AsyncMock(return_value=SimpleNamespace(status="reserved", items=[]))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11768,6 +11768,95 @@ async def test_emit_websocket_terminal_error_releases_response_create_gate():
     assert request_state.response_create_gate is None
 
 
+@pytest.mark.asyncio
+async def test_emit_websocket_terminal_error_masks_previous_response_override():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_terminal",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_terminal_leak",
+        session_id="sid-terminal",
+    )
+    websocket_send = AsyncMock()
+    websocket = cast(WebSocket, SimpleNamespace(send_text=websocket_send))
+
+    await service._emit_websocket_terminal_error(
+        websocket,
+        client_send_lock=anyio.Lock(),
+        request_state=request_state,
+        error_code="previous_response_not_found",
+        error_message="Previous response with id 'resp_terminal_leak' not found.",
+        error_type="invalid_request_error",
+        error_param="previous_response_id",
+    )
+
+    websocket_send.assert_awaited_once()
+    send_call = websocket_send.await_args
+    assert send_call is not None
+    payload_text = send_call.args[0]
+    assert "previous_response_not_found" not in payload_text
+    assert "resp_terminal_leak" not in payload_text
+    payload = json.loads(payload_text)
+    error = payload["response"]["error"]
+    assert error["code"] == "stream_incomplete"
+    assert error["type"] == "server_error"
+    assert error["message"] == "Upstream websocket closed before response.completed"
+    assert "param" not in error
+
+
+@pytest.mark.asyncio
+async def test_fail_pending_websocket_requests_masks_previous_response_override_in_queued_event(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+    event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_pending",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_pending_leak",
+        session_id="sid-pending",
+        event_queue=event_queue,
+        skip_request_log=True,
+    )
+    request_state.error_code_override = "invalid_request_error"
+    request_state.error_message_override = "Previous response with id 'resp_pending_leak' not found."
+    request_state.error_type_override = "invalid_request_error"
+    request_state.error_param_override = "previous_response_id"
+
+    await service._fail_pending_websocket_requests(
+        account_id_value=None,
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        error_code="stream_incomplete",
+        error_message="fallback",
+        api_key=None,
+        penalize_account=False,
+    )
+
+    event_block = await event_queue.get()
+    assert event_block is not None
+    assert await event_queue.get() is None
+    assert "previous_response_not_found" not in event_block
+    assert "resp_pending_leak" not in event_block
+    payload = parse_sse_data_json(event_block)
+    assert isinstance(payload, dict)
+    response = payload["response"]
+    assert isinstance(response, dict)
+    error = response["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == "stream_incomplete"
+    assert error["type"] == "server_error"
+    assert error["message"] == "Upstream websocket closed before response.completed"
+    assert "param" not in error
+
+
 def test_sanitize_websocket_connect_failure_leaves_unrelated_previous_response_error_unchanged():
     request_state = proxy_service._WebSocketRequestState(
         request_id="ws_req_prev_connect_failure_unrelated",


### PR DESCRIPTION
## Summary

Mask websocket `response.create` preparation failures caused by stale `previous_response_id` values before they reach Codex clients. This keeps the prepare-error path consistent with the existing websocket continuity sanitizer.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Related to #554

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Reuse the existing websocket previous-response sanitizer when `_prepare_websocket_response_create_request` fails before upstream connection.
- Extract the `previous_response_id` from the websocket payload so prepare failures can be recorded and rewritten without leaking raw upstream continuity errors.
- Add regression coverage for masking prepare-time `previous_response_not_found` errors.

## Test plan

```
uv run python -m pytest -q tests/unit/test_proxy_utils.py::test_proxy_responses_websocket_masks_prepare_previous_response_not_found tests/unit/test_proxy_utils.py::test_sanitize_websocket_connect_failure_rewrites_previous_response_not_found tests/unit/test_proxy_utils.py::test_sanitize_websocket_connect_failure_rewrites_missing_tool_output
uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py && git diff --check
```

## Screenshots / output (optional)

```
3 passed in 0.33s
All checks passed!
```

## CI note

The PR head is currently `UNSTABLE` because current `main` (`f9bf001f`) is already red. The failing checks reproduce on the latest `main` CI run and are unrelated to this two-file proxy patch:

- frontend/build/package/Docker/pytest jobs hit `src/components/layout/status-bar.tsx(2,36): error TS2305: Module '"lucide-react"' has no exported member 'Github'`
- migration checks report pre-existing missing indexes / Alembic drift

PR #715 is the existing green fix for restoring `main` CI. This PR should be rechecked after #715 lands or after equivalent `main` CI repairs are merged.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
