### PR TITLE
fix(archive): throttle backpressure warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,7 @@ CODEX_LB_LOG_FORMAT=text
 # Full upstream conversation archive (opt-in; stores request/response bodies/events as gzip JSONL)
 CODEX_LB_CONVERSATION_ARCHIVE_ENABLED=false
 # CODEX_LB_CONVERSATION_ARCHIVE_DIR=~/.codex-lb/conversation-archive
+# CODEX_LB_CONVERSATION_ARCHIVE_QUEUE_MAX_BYTES=8388608
 
 # Leader election (opt-in)
 CODEX_LB_LEADER_ELECTION_ENABLED=false

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -184,6 +184,7 @@ class Settings(BaseSettings):
     log_upstream_request_payload: bool = False
     conversation_archive_enabled: bool = False
     conversation_archive_dir: Path = DEFAULT_HOME_DIR / "conversation-archive"
+    conversation_archive_queue_max_bytes: int = Field(default=8 * 1024 * 1024, gt=0)
     max_decompressed_body_bytes: int = Field(default=32 * 1024 * 1024, gt=0)
     image_inline_fetch_enabled: bool = True
     image_inline_allowed_hosts: Annotated[list[str], NoDecode] = Field(default_factory=list)

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -42,6 +42,10 @@ _WRITE_QUEUE_BYTES = 0
 _WRITE_QUEUE_BYTES_LOCK = threading.Lock()
 _WRITE_QUEUE: queue.Queue[tuple[Path, dict[str, Any], int] | None] = queue.Queue(maxsize=_WRITE_QUEUE_MAX_RECORDS)
 _WRITER_THREAD: threading.Thread | None = None
+_BACKPRESSURE_WARNING_INTERVAL_SECONDS = 60.0
+_BACKPRESSURE_LAST_WARNING_AT = -_BACKPRESSURE_WARNING_INTERVAL_SECONDS
+_BACKPRESSURE_SUPPRESSED_WARNINGS = 0
+_BACKPRESSURE_WARNING_LOCK = threading.Lock()
 _RECOVERY_CHECKED_PATHS: set[Path] = set()
 _DISK_PRESSURE_PAUSE_SECONDS = 60.0
 _DISK_PRESSURE_WARNING_INTERVAL_SECONDS = 300.0
@@ -175,13 +179,17 @@ def _enqueue_record(path: Path, record: dict[str, Any]) -> None:
         return
     queued_bytes = _serialized_record_size(record)
     if not _reserve_archive_queue_bytes(queued_bytes):
-        logger.warning(
-            "Conversation archive writer queue byte budget is full; applying synchronous archive write backpressure",
-            extra={
-                "queue_max_bytes": _WRITE_QUEUE_MAX_BYTES,
-                "record_bytes": queued_bytes,
-            },
-        )
+        should_warn, suppressed_warnings = _archive_backpressure_warning_state()
+        if should_warn:
+            logger.warning(
+                "Conversation archive writer queue byte budget is full; "
+                "applying synchronous archive write backpressure",
+                extra={
+                    "queue_max_bytes": _archive_queue_max_bytes(),
+                    "record_bytes": queued_bytes,
+                    "suppressed_warnings": suppressed_warnings,
+                },
+            )
         _append_record(path, record)
         return
     queued = False
@@ -261,7 +269,7 @@ def _serialized_record_size(record: Mapping[str, Any]) -> int:
 def _reserve_archive_queue_bytes(size: int) -> bool:
     global _WRITE_QUEUE_BYTES
     with _WRITE_QUEUE_BYTES_LOCK:
-        if _WRITE_QUEUE_BYTES + size > _WRITE_QUEUE_MAX_BYTES:
+        if _WRITE_QUEUE_BYTES + size > _archive_queue_max_bytes():
             return False
         _WRITE_QUEUE_BYTES += size
         return True
@@ -271,6 +279,24 @@ def _release_archive_queue_bytes(size: int) -> None:
     global _WRITE_QUEUE_BYTES
     with _WRITE_QUEUE_BYTES_LOCK:
         _WRITE_QUEUE_BYTES = max(0, _WRITE_QUEUE_BYTES - size)
+
+
+def _archive_queue_max_bytes() -> int:
+    configured = getattr(get_settings(), "conversation_archive_queue_max_bytes", _WRITE_QUEUE_MAX_BYTES)
+    return max(1, int(configured))
+
+
+def _archive_backpressure_warning_state() -> tuple[bool, int]:
+    global _BACKPRESSURE_LAST_WARNING_AT, _BACKPRESSURE_SUPPRESSED_WARNINGS
+    now = time.monotonic()
+    with _BACKPRESSURE_WARNING_LOCK:
+        if now - _BACKPRESSURE_LAST_WARNING_AT >= _BACKPRESSURE_WARNING_INTERVAL_SECONDS:
+            suppressed = _BACKPRESSURE_SUPPRESSED_WARNINGS
+            _BACKPRESSURE_SUPPRESSED_WARNINGS = 0
+            _BACKPRESSURE_LAST_WARNING_AT = now
+            return True, suppressed
+        _BACKPRESSURE_SUPPRESSED_WARNINGS += 1
+        return False, 0
 
 
 def _write_gzip_member(path: Path, data: bytes) -> None:

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -26,9 +26,10 @@ def _reset_archive_disk_pressure() -> None:
 
 
 class _ArchiveSettings:
-    def __init__(self, *, enabled: bool, directory: Path) -> None:
+    def __init__(self, *, enabled: bool, directory: Path, queue_max_bytes: int = 8 * 1024 * 1024) -> None:
         self.conversation_archive_enabled = enabled
         self.conversation_archive_dir = directory
+        self.conversation_archive_queue_max_bytes = queue_max_bytes
 
 
 def _archive_records(directory: Path) -> list[dict[str, object]]:
@@ -147,9 +148,8 @@ def test_archive_queue_byte_limit_falls_back_to_sync_write(monkeypatch, tmp_path
     monkeypatch.setattr(
         conversation_archive,
         "get_settings",
-        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path, queue_max_bytes=64),
     )
-    monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE_MAX_BYTES", 64)
     monkeypatch.setattr(
         conversation_archive,
         "_ensure_writer_thread",
@@ -169,6 +169,47 @@ def test_archive_queue_byte_limit_falls_back_to_sync_write(monkeypatch, tmp_path
     assert record["payload"] == {"text": "x" * 256}
     with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
         assert conversation_archive._WRITE_QUEUE_BYTES == 0
+
+
+def test_archive_queue_byte_limit_warning_is_rate_limited(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path, queue_max_bytes=64),
+    )
+    monkeypatch.setattr(
+        conversation_archive,
+        "_ensure_writer_thread",
+        lambda: (_ for _ in ()).throw(AssertionError("writer should not start for byte-budget fallback")),
+    )
+    monkeypatch.setattr(conversation_archive, "_archive_disk_pressure_active", lambda: False)
+    monotonic_values = iter([100.0, 101.0, 102.0, 161.0])
+    monkeypatch.setattr(conversation_archive.time, "monotonic", lambda: next(monotonic_values))
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        conversation_archive._WRITE_QUEUE_BYTES = 0
+    with conversation_archive._BACKPRESSURE_WARNING_LOCK:
+        conversation_archive._BACKPRESSURE_LAST_WARNING_AT = (
+            -conversation_archive._BACKPRESSURE_WARNING_INTERVAL_SECONDS
+        )
+        conversation_archive._BACKPRESSURE_SUPPRESSED_WARNINGS = 0
+
+    caplog.set_level("WARNING", logger="app.core.conversation_archive")
+    for idx in range(4):
+        conversation_archive.archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="http",
+            payload={"text": f"{idx}-" + ("x" * 256)},
+        )
+
+    warnings = [
+        record
+        for record in caplog.records
+        if "Conversation archive writer queue byte budget is full" in record.getMessage()
+    ]
+    assert len(warnings) == 2
+    assert warnings[0].suppressed_warnings == 0
+    assert warnings[1].suppressed_warnings == 2
 
 
 def test_archive_queue_thread_start_failure_drops_record(monkeypatch, tmp_path):

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -31,6 +31,7 @@ def test_settings_multi_replica_defaults():
     assert settings.proxy_downstream_websocket_idle_timeout_seconds == 120.0
     assert settings.max_sse_event_bytes == 16 * 1024 * 1024
     assert settings.proxy_refresh_failure_cooldown_seconds == 5.0
+    assert settings.conversation_archive_queue_max_bytes == 8 * 1024 * 1024
     assert settings.usage_refresh_auth_failure_cooldown_seconds == 300.0
     assert settings.otel_enabled is False
     assert settings.otel_exporter_endpoint == ""
@@ -62,6 +63,12 @@ def test_settings_log_format_from_env(monkeypatch):
     monkeypatch.setenv("CODEX_LB_LOG_FORMAT", "json")
     settings = Settings()
     assert settings.log_format == "json"
+
+
+def test_settings_conversation_archive_queue_max_bytes_from_env(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_CONVERSATION_ARCHIVE_QUEUE_MAX_BYTES", "16777216")
+    settings = Settings()
+    assert settings.conversation_archive_queue_max_bytes == 16 * 1024 * 1024
 
 
 def test_settings_leader_election_enabled_from_env(monkeypatch):


### PR DESCRIPTION
## Summary

Throttle conversation archive byte-budget backpressure warnings and make the queue byte budget configurable. The archive still falls back to synchronous writes when saturated, but high-volume sessions no longer emit one warning per overflow record.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Related to #554

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Add `CODEX_LB_CONVERSATION_ARCHIVE_QUEUE_MAX_BYTES` for tuning the async archive queue byte budget.
- Rate-limit archive byte-budget backpressure warnings and include a suppressed-warning count on the next emitted warning.
- Cover the tunable queue budget and warning throttling with focused unit tests.

## Test plan

```
uv run python -m pytest -q tests/unit/test_conversation_archive.py::test_archive_queue_byte_limit_falls_back_to_sync_write tests/unit/test_conversation_archive.py::test_archive_queue_byte_limit_warning_is_rate_limited tests/unit/test_conversation_archive.py::test_archive_queue_thread_start_failure_drops_record tests/unit/test_settings_multi_replica.py::test_settings_multi_replica_defaults tests/unit/test_settings_multi_replica.py::test_settings_conversation_archive_queue_max_bytes_from_env
uv run ruff check app/core/conversation_archive.py app/core/config/settings.py tests/unit/test_conversation_archive.py tests/unit/test_settings_multi_replica.py && git diff --check
```

## Screenshots / output (optional)

```
.....                                                                    [100%]
5 passed in 0.03s
All checks passed!
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

Note: I ran the relevant focused subset for this archive/config change, not full `local-ci`. Current `origin/main` CI is separately red; PR #715 is the green main-CI repair.
