### PR TITLE
fix(ci): unblock main — replace removed lucide-react Github icon + merge alembic heads

### DIFF
--- a/app/db/alembic/versions/20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads.py
+++ b/app/db/alembic/versions/20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads.py
@@ -1,0 +1,24 @@
+"""merge api_key_apply_to_codex_model and http_bridge_sqlite_recovery heads
+
+Revision ID: 20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads
+Revises: 20260513_000000_add_api_key_apply_to_codex_model, 20260518_010000_merge_http_bridge_and_sqlite_recovery_heads
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+revision = "20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads"
+down_revision = (
+    "20260513_000000_add_api_key_apply_to_codex_model",
+    "20260518_010000_merge_http_bridge_and_sqlite_recovery_heads",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/frontend/src/components/layout/status-bar.tsx
+++ b/frontend/src/components/layout/status-bar.tsx
@@ -1,6 +1,20 @@
-import { useEffect, useState } from "react";
-import { Activity, ArrowRightLeft, Github, Tag } from "lucide-react";
+import { useEffect, useState, type SVGProps } from "react";
+import { Activity, ArrowRightLeft, Tag } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+
+function GithubMarkIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      fill="currentColor"
+      role="img"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.807 1.305 3.492.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
 
 import { getDashboardOverview } from "@/features/dashboard/api";
 import { DEFAULT_OVERVIEW_TIMEFRAME } from "@/features/dashboard/schemas";
@@ -82,7 +96,7 @@ export function StatusBar() {
           target="_blank"
           title="GitHub"
         >
-          <Github className="h-3.5 w-3.5" aria-hidden="true" />
+          <GithubMarkIcon className="h-3.5 w-3.5" aria-hidden="true" />
         </a>
       </div>
     </footer>


### PR DESCRIPTION
## Why

`main` CI is fully red on `f9bf001` and so is every open PR. Two unrelated maintainer-side breakages compound to take down most jobs:

1. **`lucide-react@1.16.0`** (pinned by `frontend/package.json`) dropped all brand icons in v1.0, so `tsc` fails on `src/components/layout/status-bar.tsx`:
   \`\`\`
   src/components/layout/status-bar.tsx(2,36): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
   \`\`\`
   This single failure breaks `make frontend-build`, which is a dependency for Frontend typecheck/build/vitest, Tests pytest (unit / integration-core / integration-bridge / e2e / PostgreSQL), Package build, and Docker build.

2. **Two open alembic heads** on `main` (`20260513_000000_add_api_key_apply_to_codex_model`, `20260518_010000_merge_http_bridge_and_sqlite_recovery_heads`) make `alembic upgrade head` fail with `Multiple head revisions are present`. This breaks `Migration check (alembic)`, `Migration check (alembic, PostgreSQL)`, and the pytest jobs that run migrations as setup.

Each fix alone leaves the other failure hitting most jobs, so this PR bundles both as a single \"unblock main CI\" change — one commit per concern for review.

## Commits

### `2cf4f17` — fix(frontend): replace removed lucide-react Github icon with inline SVG

Single-file diff: drop `Github` from the `lucide-react` import in `src/components/layout/status-bar.tsx`, add a small inline `GithubMarkIcon` component using the official 24x24 octicon path. Same `h-3.5 w-3.5` sizing, same `aria-hidden="true"`, same anchor — no behavioural or layout change, no new dependency.

### `67f4c84` — fix(db): merge api_key_codex_model and sqlite_recovery heads

Add `app/db/alembic/versions/20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads.py`. Standard empty merge revision joining the two heads. Same shape as every prior head-merge in the repo (`20260517_..._merge_sqlite_hot_path_and_request_log_delete_heads`, `20260518_010000_merge_http_bridge_and_sqlite_recovery_heads`, etc.) — no upgrade / downgrade SQL, purely a graph-topology fix.

## Local verification

Frontend:
\`\`\`
cd frontend
bun install --frozen-lockfile
bun run typecheck    # tsc -b — clean
bun run build        # vite — clean
bun run lint         # eslint — clean
bun run test         # vitest — 402 / 402 pass
\`\`\`

Migrations:
\`\`\`
$ make migration-check
...
current_revision=20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads
migration_policy=ok
schema_drift=none
\`\`\`

## OpenSpec

No OpenSpec change — pure CI-unblock with no schema or behavioural delta. The frontend change is a one-for-one visual substitution under the existing `frontend-architecture` capability; the alembic change is a graph-topology fix under `database-migrations`.

## Follow-up

This supersedes #721, which can be closed.