### PR TITLE
fix(db): merge api_key_codex_model and sqlite_recovery alembic heads

### DIFF
--- a/app/db/alembic/versions/20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads.py
+++ b/app/db/alembic/versions/20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads.py
@@ -1,0 +1,24 @@
+"""merge api_key_apply_to_codex_model and http_bridge_sqlite_recovery heads
+
+Revision ID: 20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads
+Revises: 20260513_000000_add_api_key_apply_to_codex_model, 20260518_010000_merge_http_bridge_and_sqlite_recovery_heads
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+revision = "20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads"
+down_revision = (
+    "20260513_000000_add_api_key_apply_to_codex_model",
+    "20260518_010000_merge_http_bridge_and_sqlite_recovery_heads",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Why

The alembic graph on `main` has two open heads:

- `20260513_000000_add_api_key_apply_to_codex_model`
- `20260518_010000_merge_http_bridge_and_sqlite_recovery_heads`

Both descend from `20260518_000000_add_http_bridge_durable_input_prefix`, but nothing rejoins them, so `alembic upgrade head` fails:

\`\`\`
alembic.util.exc.CommandError: Multiple head revisions are present for given argument 'head'
\`\`\`

That breaks `Migration check (alembic)` and `Migration check (alembic, PostgreSQL)` on main and every open PR (see main CI run 26105773048 on `f9bf001`).

## What

Add a standard empty merge revision joining the two heads. Same shape as every prior head-merge in the repo (`20260517_000000_merge_sqlite_hot_path_and_request_log_delete_heads`, `20260518_010000_merge_http_bridge_and_sqlite_recovery_heads`, etc.) — no upgrade / downgrade SQL, purely a graph-topology fix.

## Local verification

\`\`\`
\$ make migration-check
...
current_revision=20260520_000000_merge_api_key_codex_model_and_sqlite_recovery_heads
migration_policy=ok
schema_drift=none
\`\`\`

## OpenSpec

No OpenSpec change — pure migration-graph join with no schema or behaviour delta.