### PR TITLE
fix(proxy): report backend context window in v1 models

### DIFF
--- a/app/db/alembic/versions/20260520_000000_merge_api_key_and_http_bridge_heads.py
+++ b/app/db/alembic/versions/20260520_000000_merge_api_key_and_http_bridge_heads.py
@@ -1,0 +1,26 @@
+"""merge API key model-scope and HTTP bridge heads
+
+Revision ID: 20260520_000000_merge_api_key_and_http_bridge_heads
+Revises: 20260513_000000_add_api_key_apply_to_codex_model,
+    20260518_010000_merge_http_bridge_and_sqlite_recovery_heads
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+# revision identifiers, used by Alembic.
+revision = "20260520_000000_merge_api_key_and_http_bridge_heads"
+down_revision = (
+    "20260513_000000_add_api_key_apply_to_codex_model",
+    "20260518_010000_merge_http_bridge_and_sqlite_recovery_heads",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -191,12 +191,6 @@ _STREAM_STARTUP_ERROR_PROBE_SECONDS = 0.05
 # Keep bridge startup probing above tiny event-loop scheduling jitter:
 # PostgreSQL-backed failures may need a DB round trip before the first item.
 _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS = 0.5
-_V1_FULL_CONTEXT_WINDOW_OVERRIDES: Final[dict[str, int]] = {
-    "gpt-5.4": 1_000_000,
-    "gpt-5.5": 400_000,
-    "gpt-5.4-mini": 400_000,
-    "gpt-5.3-codex": 400_000,
-}
 _V1_MAX_OUTPUT_TOKEN_OVERRIDES: Final[dict[str, int]] = {
     "gpt-5.4": 128_000,
     "gpt-5.5": 128_000,
@@ -1648,34 +1642,13 @@ def _effective_context_window(model: UpstreamModel) -> int:
     return overrides.get(model.slug, model.context_window)
 
 
-def _raw_positive_int(raw: Mapping[str, JsonValue], key: str) -> int | None:
-    value = raw.get(key)
-    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        return None
-    return value
-
-
 def _v1_full_context_window(model: UpstreamModel) -> int:
     overrides = get_settings().model_context_window_overrides
-    explicit_override = overrides.get(model.slug)
-    if explicit_override is not None:
-        return explicit_override
-
-    known_context_window = _V1_FULL_CONTEXT_WINDOW_OVERRIDES.get(model.slug)
-    if known_context_window is not None:
-        return known_context_window
-
-    upstream_context_window = model.context_window
-    raw_max_context_window = _raw_positive_int(model.raw, "max_context_window")
-    if raw_max_context_window is not None and raw_max_context_window > upstream_context_window:
-        return raw_max_context_window
-
-    return upstream_context_window
+    return overrides.get(model.slug, model.context_window)
 
 
-def _v1_input_context_window(model: UpstreamModel) -> int | None:
-    input_context_window = model.context_window
-    return input_context_window if input_context_window != _v1_full_context_window(model) else None
+def _v1_input_context_window(model: UpstreamModel) -> int:
+    return model.context_window
 
 
 def _v1_max_output_tokens(model: UpstreamModel) -> int | None:

--- a/frontend/src/components/layout/status-bar.tsx
+++ b/frontend/src/components/layout/status-bar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Activity, ArrowRightLeft, Github, Tag } from "lucide-react";
+import { Activity, ArrowRightLeft, Tag } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getDashboardOverview } from "@/features/dashboard/api";
@@ -82,7 +82,9 @@ export function StatusBar() {
           target="_blank"
           title="GitHub"
         >
-          <Github className="h-3.5 w-3.5" aria-hidden="true" />
+          <svg className="h-3.5 w-3.5" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.63 7.63 0 0 1 8 3.86c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+          </svg>
         </a>
       </div>
     </footer>

--- a/openspec/changes/report-v1-model-full-context/proposal.md
+++ b/openspec/changes/report-v1-model-full-context/proposal.md
@@ -1,33 +1,26 @@
 ## Why
 
-`codex-lb` exposes `/v1/models` as the OpenAI-compatible model catalog for generic SDKs and client frameworks. That endpoint currently copies the upstream Codex `context_window` value into `metadata.context_window`.
+`codex-lb` exposes `/v1/models` as the OpenAI-compatible model catalog for generic SDKs and client frameworks. The endpoint previously promoted Codex backend metadata into a guessed "full context" value (`400000` for `gpt-5.5`/mini/codex and `1000000` for `gpt-5.4`) while carrying the backend budget separately in `metadata.input_context_window`.
 
-The upstream Codex catalog's `context_window` is not the same semantic as the context-window value generic OpenAI-compatible clients expect. For the GPT-5 Codex family, upstream reports `context_window=272000` even when the full model window is larger. The value matches the conservative Codex input / auto-compaction budget: for 400k-class models, `400000 - 128000 = 272000`, leaving room for output and hidden reasoning. `gpt-5.4` separately advertises `max_context_window=1000000` while still reporting the same `context_window=272000` compact budget.
-
-Passing the conservative input budget through `/v1/models` makes generic clients believe models such as `gpt-5.5`, `gpt-5.4-mini`, and `gpt-5.3-codex` are 272k-context models rather than 400k-context models, and hides that `gpt-5.4` is a 1M-context model. Native Codex clients still need the conservative compact budget, so changing `/backend-api/codex/models` would be the wrong fix. The OpenAI-compatible `/v1/models` metadata needs its own full-context normalization while preserving the Codex-native fields on the Codex route.
+That split is unsafe for generic OpenAI-compatible clients because many clients only read `metadata.context_window`. Direct ChatGPT/Codex backend behavior reports `context_window=272000` for these models, and requests above that input budget fail with `context_length_exceeded`. Advertising `400000` or `1000000` therefore makes clients overfill the upstream request and produces retry/fallback failures instead of preflight compression.
 
 ## What Changes
 
-- Normalize `/v1/models` `metadata.context_window` to the full model context for known GPT-5 Codex models:
-  - `gpt-5.4` → `1_000_000`
-  - `gpt-5.5` → `400_000`
-  - `gpt-5.4-mini` → `400_000`
-  - `gpt-5.3-codex` → `400_000`
-- Add `/v1/models` metadata fields that preserve the split semantics:
-  - `input_context_window` carries the Codex-native conservative input / compact budget (`272000` for these models).
-  - `max_output_tokens` carries the output/reasoning reserve (`128000` for these GPT-5 Codex models).
-- Keep `/backend-api/codex/models` behavior unchanged so Codex-native clients continue to receive the upstream compact-budget semantics.
+- Make `/v1/models` `metadata.context_window` match the upstream backend `context_window` budget by default.
+- Stop promoting raw `max_context_window` or hard-coded full-context guesses into `metadata.context_window`.
+- Keep `metadata.input_context_window` explicit and equal to the backend input/context budget, so clients that understand the split still have a stable field to read.
 - Preserve the existing `model_context_window_overrides` escape hatch as the highest-priority reported-context override.
+- Keep `/backend-api/codex/models` behavior unchanged so Codex-native clients continue to receive the backend catalog fields.
 
 ## Capabilities
 
 ### Added Capabilities
 
-- `model-catalog-compat`: `/v1/models` exposes OpenAI-compatible full-context metadata without conflating it with Codex-native compact-budget metadata.
+- `model-catalog-compat`: `/v1/models` exposes OpenAI-compatible context metadata that matches the ChatGPT/Codex backend input budget and avoids over-advertising context to generic clients.
 
 ## Impact
 
-- **Code**: `app/modules/proxy/schemas.py`, `app/modules/proxy/api.py`
+- **Code**: `app/modules/proxy/api.py`
 - **Tests**: `tests/integration/test_v1_models.py`
-- **Behavior**: generic OpenAI-compatible clients reading `/v1/models` see the intended full context windows; native Codex endpoint semantics remain unchanged.
-- **Non-goals**: no live probing or dynamic measurement of model limits, no change to account routing, and no change to request truncation/compaction behavior.
+- **Behavior**: generic OpenAI-compatible clients reading `/v1/models` see the usable backend context window (`272000` for current GPT-5 Codex models) instead of speculative larger windows.
+- **Non-goals**: no live probing or dynamic measurement of model limits, no change to account routing, and no request truncation/compaction behavior change.

--- a/openspec/changes/report-v1-model-full-context/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/report-v1-model-full-context/specs/model-catalog-compat/spec.md
@@ -1,41 +1,32 @@
 ## ADDED Requirements
 
-### Requirement: OpenAI-compatible model metadata uses full context windows
+### Requirement: OpenAI-compatible model metadata uses backend context windows
 
-When serving `GET /v1/models`, the system SHALL expose `metadata.context_window` as the model's full context window for generic OpenAI-compatible clients, not the Codex-native compact-budget window. The system MUST report these full-context values for known GPT-5 Codex models:
+When serving `GET /v1/models`, the system SHALL expose `metadata.context_window` as the upstream backend `context_window` budget by default. The system MUST NOT promote raw `max_context_window` values or hard-coded full-context guesses into `metadata.context_window`. Explicit operator context-window overrides remain the highest-priority reported-context value.
 
-| model | `metadata.context_window` |
-| --- | ---: |
-| `gpt-5.4` | `1000000` |
-| `gpt-5.5` | `400000` |
-| `gpt-5.4-mini` | `400000` |
-| `gpt-5.3-codex` | `400000` |
+#### Scenario: GPT-5 Codex models are reported with the backend context window on /v1/models
 
-For models without a known full-context override, the system SHOULD use an upstream `max_context_window` value when it is a positive integer larger than the Codex-native `context_window`; otherwise it MAY fall back to the Codex-native `context_window`. Explicit operator context-window overrides remain the highest-priority reported-context value.
+- **WHEN** the upstream model catalog contains `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex`, or `gpt-5.4` with `context_window=272000`
+- **THEN** `GET /v1/models` returns each entry with `metadata.context_window=272000`
 
-#### Scenario: GPT-5.4 is reported as a 1M context model on /v1/models
+#### Scenario: raw max_context_window does not inflate /v1/models context_window
 
-- **WHEN** the upstream model catalog contains `gpt-5.4` with `context_window=272000` and `max_context_window=1000000`
-- **THEN** `GET /v1/models` returns the `gpt-5.4` entry with `metadata.context_window=1000000`
+- **WHEN** the upstream model catalog contains a model with `context_window=272000` and `max_context_window=900000`
+- **THEN** `GET /v1/models` returns that entry with `metadata.context_window=272000`
 
-#### Scenario: 400k GPT-5 Codex models are reported with full context on /v1/models
+### Requirement: OpenAI-compatible model metadata preserves the backend input budget explicitly
 
-- **WHEN** the upstream model catalog contains `gpt-5.5`, `gpt-5.4-mini`, or `gpt-5.3-codex` with `context_window=272000`
-- **THEN** `GET /v1/models` returns each entry with `metadata.context_window=400000`
+When serving `GET /v1/models`, the system SHALL expose the upstream backend input/context budget in `metadata.input_context_window`. For models whose reported `metadata.context_window` is not operator-overridden, `metadata.context_window` and `metadata.input_context_window` SHOULD be equal. The system SHOULD expose `metadata.max_output_tokens` for known GPT-5 Codex models when that output-budget value is known; that value MUST NOT be used to inflate `metadata.context_window`.
 
-### Requirement: OpenAI-compatible model metadata preserves Codex input-budget semantics separately
-
-When serving `GET /v1/models`, the system SHALL preserve the Codex-native compact/input budget in `metadata.input_context_window` when that budget differs from `metadata.context_window`. The system SHOULD expose `metadata.max_output_tokens` for known GPT-5 Codex models whose full-context window is derived by reserving output/reasoning budget from the full context; for `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex`, that value is `128000`.
-
-#### Scenario: /v1/models exposes the 272k Codex input budget separately
+#### Scenario: /v1/models exposes the 272k backend input budget explicitly
 
 - **WHEN** the upstream model catalog contains a known GPT-5 Codex model with `context_window=272000`
 - **THEN** `GET /v1/models` returns that model with `metadata.input_context_window=272000`
-- **AND** `metadata.context_window` remains the model's full context window
+- **AND** `metadata.context_window=272000`
 
-#### Scenario: Explicit reported-context overrides do not hide the Codex input budget
+#### Scenario: Explicit reported-context overrides do not hide the backend input budget
 
-- **WHEN** an operator override sets a known GPT-5 Codex model's reported `metadata.context_window` to `515000`
+- **WHEN** an operator override sets a model's reported `metadata.context_window` to `515000`
 - **AND** the upstream model catalog contains that model with `context_window=272000`
 - **THEN** `GET /v1/models` returns that model with `metadata.context_window=515000`
 - **AND** `metadata.input_context_window=272000`
@@ -45,9 +36,9 @@ When serving `GET /v1/models`, the system SHALL preserve the Codex-native compac
 - **WHEN** `GET /v1/models` returns `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, or `gpt-5.3-codex`
 - **THEN** the entry's metadata includes `max_output_tokens=128000`
 
-### Requirement: Codex-native model catalog keeps upstream compact-budget fields
+### Requirement: Codex-native model catalog keeps backend catalog fields
 
-When serving `GET /backend-api/codex/models`, the system MUST keep Codex-native model catalog semantics unchanged: the top-level `context_window` field remains the upstream Codex compact/input budget, and upstream raw fields such as `max_context_window` remain available when upstream provides them. The `/v1/models` full-context normalization MUST NOT change this native Codex endpoint.
+When serving `GET /backend-api/codex/models`, the system MUST keep Codex-native model catalog semantics unchanged: the top-level `context_window` field remains the backend compact/input budget unless an explicit operator override applies, and upstream raw fields such as `max_context_window` remain available when upstream provides them. The `/v1/models` compatibility metadata MUST NOT mutate the native Codex endpoint.
 
 #### Scenario: Native Codex route preserves compact budget
 

--- a/openspec/changes/report-v1-model-full-context/tasks.md
+++ b/openspec/changes/report-v1-model-full-context/tasks.md
@@ -1,16 +1,18 @@
 ## 1. Implementation
 
-- [x] 1.1 Add `/v1/models` metadata fields for full-context semantics: `context_window`, `input_context_window`, and `max_output_tokens`
-- [x] 1.2 Normalize known GPT-5 Codex full context windows (`gpt-5.4` = 1M; `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.3-codex` = 400k)
-- [x] 1.3 Keep `/backend-api/codex/models` Codex-native `context_window` semantics unchanged
+- [x] 1.1 Report `/v1/models` `metadata.context_window` from the backend `context_window` budget by default
+- [x] 1.2 Stop promoting raw `max_context_window` or hard-coded full-context guesses into `/v1/models` `metadata.context_window`
+- [x] 1.3 Keep `/v1/models` `metadata.input_context_window` explicit and equal to the backend input/context budget
+- [x] 1.4 Keep `/backend-api/codex/models` Codex-native catalog semantics unchanged
 
 ## 2. Tests
 
-- [x] 2.1 Integration: `/v1/models` reports full context windows for `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, and `gpt-5.3-codex`
-- [x] 2.2 Integration: `/v1/models` preserves the Codex input budget in `metadata.input_context_window` and exposes `metadata.max_output_tokens`
-- [x] 2.3 Integration: `/backend-api/codex/models` still reports the upstream Codex compact-budget `context_window`
+- [x] 2.1 Integration: `/v1/models` reports backend context windows for `gpt-5.4`, `gpt-5.5`, `gpt-5.4-mini`, and `gpt-5.3-codex`
+- [x] 2.2 Integration: `/v1/models` does not promote raw `max_context_window` for unknown models
+- [x] 2.3 Integration: `/v1/models` preserves the backend input budget in `metadata.input_context_window` and exposes known `metadata.max_output_tokens`
+- [x] 2.4 Integration: `/backend-api/codex/models` still reports the backend compact-budget `context_window`
 
 ## 3. Spec Delta
 
-- [x] 3.1 Add `model-catalog-compat` spec delta covering full-context `/v1/models` metadata and native Codex route preservation
+- [x] 3.1 Update `model-catalog-compat` spec delta to require backend-context `/v1/models` metadata and native Codex route preservation
 - [x] 3.2 Validate specs locally with `openspec validate report-v1-model-full-context --strict`

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -475,7 +475,7 @@ def _raw_with_max_context_window(max_context_window: int) -> dict[str, JsonValue
 
 
 @pytest.mark.asyncio
-async def test_v1_models_reports_full_context_and_preserves_codex_budget(async_client):
+async def test_v1_models_reports_backend_context_window(async_client):
     registry = get_model_registry()
     models = [
         _make_upstream_model("gpt-5.4", raw=_raw_with_max_context_window(1_000_000)),
@@ -489,15 +489,9 @@ async def test_v1_models_reports_full_context_and_preserves_codex_budget(async_c
     assert resp_v1.status_code == 200
     metadata_by_id = {item["id"]: item["metadata"] for item in resp_v1.json()["data"]}
 
-    expected_context_windows = {
-        "gpt-5.4": 1_000_000,
-        "gpt-5.5": 400_000,
-        "gpt-5.4-mini": 400_000,
-        "gpt-5.3-codex": 400_000,
-    }
-    for slug, full_context_window in expected_context_windows.items():
+    for slug in ("gpt-5.4", "gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex"):
         metadata = metadata_by_id[slug]
-        assert metadata["context_window"] == full_context_window
+        assert metadata["context_window"] == 272_000
         assert metadata["input_context_window"] == 272_000
         assert metadata["max_output_tokens"] == 128_000
 
@@ -511,7 +505,7 @@ async def test_v1_models_reports_full_context_and_preserves_codex_budget(async_c
 
 
 @pytest.mark.asyncio
-async def test_v1_models_uses_raw_max_context_window_for_unknown_models(async_client):
+async def test_v1_models_does_not_promote_raw_max_context_window(async_client):
     registry = get_model_registry()
     models = [_make_upstream_model("gpt-custom", raw=_raw_with_max_context_window(900_000))]
     await registry.update({"pro": models})
@@ -520,6 +514,6 @@ async def test_v1_models_uses_raw_max_context_window_for_unknown_models(async_cl
     assert resp.status_code == 200
     entry = next(item for item in resp.json()["data"] if item["id"] == "gpt-custom")
 
-    assert entry["metadata"]["context_window"] == 900_000
+    assert entry["metadata"]["context_window"] == 272_000
     assert entry["metadata"]["input_context_window"] == 272_000
     assert entry["metadata"].get("max_output_tokens") is None


### PR DESCRIPTION
## Summary
- Report `/v1/models` `metadata.context_window` from the upstream/backend `context_window` budget instead of promoting `max_context_window` or hard-coded full-context guesses.
- Keep `metadata.input_context_window` explicit as the backend input budget for clients that understand the split.
- Update OpenSpec model catalog compatibility notes and regression coverage for GPT-5 Codex models and raw `max_context_window` handling.

## Test Plan
- `uv run pytest tests/integration/test_v1_models.py -q`
- `uv run openspec validate report-v1-model-full-context --strict`
- `uv run ruff check app/modules/proxy/api.py tests/integration/test_v1_models.py`
