### PR TITLE
fix(proxy): bound HTTP bridge startup waits

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -97,7 +97,7 @@ from app.core.openai.requests import (
     extract_input_file_ids,
     extract_input_image_file_references,
 )
-from app.core.resilience.overload import is_local_overload_error_code
+from app.core.resilience.overload import is_local_overload_error_code, local_overload_error
 from app.core.types import JsonValue
 from app.core.usage.types import UsageWindowRow
 from app.core.utils.json_guards import is_json_mapping
@@ -211,6 +211,51 @@ _DOWNSTREAM_WEBSOCKET_RECEIVE_POLL_SECONDS = 1.0
 # error probe window. If a keepalive becomes the first yielded chunk, the HTTP
 # status is committed as 200 and startup ProxyResponseError handling is masked.
 _HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS = 0.5
+_DEFAULT_PROXY_ADMISSION_WAIT_TIMEOUT_SECONDS = 10.0
+
+
+def _proxy_admission_wait_timeout_seconds(settings: Any | None = None) -> float:
+    settings = settings or get_settings()
+    raw_timeout = getattr(
+        settings,
+        "proxy_admission_wait_timeout_seconds",
+        _DEFAULT_PROXY_ADMISSION_WAIT_TIMEOUT_SECONDS,
+    )
+    try:
+        timeout = float(raw_timeout)
+    except (TypeError, ValueError):
+        timeout = _DEFAULT_PROXY_ADMISSION_WAIT_TIMEOUT_SECONDS
+    return max(0.001, timeout)
+
+
+def _http_bridge_startup_wait_timeout_error(stage: str) -> ProxyResponseError:
+    message = f"codex-lb is temporarily overloaded during {stage}"
+    return ProxyResponseError(429, local_overload_error(message))
+
+
+def _log_http_bridge_startup_wait_timeout(
+    *,
+    stage: str,
+    timeout_seconds: float,
+    key: "_HTTPBridgeSessionKey | None" = None,
+    request_id: str | None = None,
+    request_model: str | None = None,
+    pending_count: int | None = None,
+    inflight_count: int | None = None,
+    available: int | None = None,
+) -> None:
+    logger.warning(
+        "http_bridge_startup_wait_timeout request_id=%s stage=%s wait_timeout_seconds=%.1f "
+        "affinity_kind=%s model_class=%s pending_count=%s inflight_count=%s available=%s",
+        request_id or get_request_id() or "unknown",
+        stage,
+        timeout_seconds,
+        key.affinity_kind if key is not None else None,
+        _extract_model_class(request_model) if request_model else None,
+        pending_count,
+        inflight_count,
+        available,
+    )
 
 
 async def _await_cancelled_task(
@@ -3961,8 +4006,22 @@ class ProxyService:
         response_create_gate: asyncio.Semaphore,
         compact: bool = False,
     ) -> None:
+        timeout_seconds = _proxy_admission_wait_timeout_seconds()
         request_state.response_create_gate = response_create_gate
-        await response_create_gate.acquire()
+        try:
+            await asyncio.wait_for(response_create_gate.acquire(), timeout=timeout_seconds)
+        except TimeoutError as exc:
+            request_state.response_create_gate = None
+            request_state.response_create_gate_acquired = False
+            request_state.awaiting_response_created = False
+            _log_http_bridge_startup_wait_timeout(
+                stage="response_create_gate",
+                timeout_seconds=timeout_seconds,
+                request_id=request_state.request_id,
+                request_model=request_state.model,
+                available=getattr(response_create_gate, "_value", None),
+            )
+            raise _http_bridge_startup_wait_timeout_error("http_bridge_response_create_gate") from exc
         request_state.response_create_gate_acquired = True
         request_state.awaiting_response_created = True
         try:
@@ -4536,6 +4595,47 @@ class ProxyService:
 
         supported_kwargs = {name: value for name, value in kwargs.items() if name in signature.parameters}
         return await create_session_any(key, **supported_kwargs)
+
+    async def _fail_http_bridge_inflight_session_creation(
+        self,
+        key: "_HTTPBridgeSessionKey",
+        inflight_future: asyncio.Future["_HTTPBridgeSession"] | None,
+        exc: BaseException,
+    ) -> bool:
+        if inflight_future is None:
+            return False
+        async with self._http_bridge_lock:
+            current_future = self._http_bridge_inflight_sessions.get(key)
+            if current_future is not inflight_future:
+                return False
+            self._http_bridge_inflight_sessions.pop(key, None)
+            if inflight_future.done():
+                return True
+            if isinstance(exc, asyncio.CancelledError):
+                inflight_future.cancel()
+            else:
+                inflight_future.set_exception(exc)
+                inflight_future.exception()
+            return True
+
+    async def _evict_http_bridge_inflight_waiter(
+        self,
+        inflight_future: asyncio.Future["_HTTPBridgeSession"],
+        exc: BaseException,
+    ) -> "_HTTPBridgeSessionKey | None":
+        async with self._http_bridge_lock:
+            stale_key = None
+            for candidate_key, candidate_future in self._http_bridge_inflight_sessions.items():
+                if candidate_future is inflight_future:
+                    stale_key = candidate_key
+                    break
+            if stale_key is None:
+                return None
+            self._http_bridge_inflight_sessions.pop(stale_key, None)
+            if not inflight_future.done():
+                inflight_future.set_exception(exc)
+                inflight_future.exception()
+            return stale_key
 
     @overload
     async def _get_or_create_http_bridge_session(
@@ -5334,8 +5434,13 @@ class ProxyService:
                             self._http_bridge_inflight_sessions[key] = inflight_future
                             owns_creation = True
 
-            for stale_session in sessions_to_close:
-                await self._close_http_bridge_session(stale_session)
+            try:
+                for stale_session in sessions_to_close:
+                    await self._close_http_bridge_session(stale_session)
+            except BaseException as exc:
+                if owns_creation:
+                    await self._fail_http_bridge_inflight_session_creation(key, inflight_future, exc)
+                raise
 
             if session_to_return_after_close is not None:
                 return session_to_return_after_close
@@ -5350,12 +5455,28 @@ class ProxyService:
                 raise continuity_error
 
             if capacity_wait_future is not None:
+                wait_timeout_seconds = _proxy_admission_wait_timeout_seconds(settings)
                 try:
-                    await asyncio.shield(capacity_wait_future)
+                    await asyncio.wait_for(
+                        asyncio.shield(capacity_wait_future),
+                        timeout=wait_timeout_seconds,
+                    )
                 except asyncio.CancelledError:
                     if capacity_wait_future.cancelled():
                         continue
                     raise
+                except TimeoutError as exc:
+                    timeout_error = _http_bridge_startup_wait_timeout_error("http_bridge_capacity")
+                    stale_key = await self._evict_http_bridge_inflight_waiter(capacity_wait_future, timeout_error)
+                    _log_http_bridge_startup_wait_timeout(
+                        stage="capacity",
+                        timeout_seconds=wait_timeout_seconds,
+                        key=stale_key or key,
+                        request_model=request_model,
+                        pending_count=len(self._http_bridge_sessions),
+                        inflight_count=len(self._http_bridge_inflight_sessions),
+                    )
+                    raise timeout_error from exc
                 except ProxyResponseError:
                     raise
                 except Exception:
@@ -5363,12 +5484,28 @@ class ProxyService:
                 continue
 
             if inflight_future is not None and not owns_creation:
+                wait_timeout_seconds = _proxy_admission_wait_timeout_seconds(settings)
                 try:
-                    session = await asyncio.shield(inflight_future)
+                    session = await asyncio.wait_for(
+                        asyncio.shield(inflight_future),
+                        timeout=wait_timeout_seconds,
+                    )
                 except asyncio.CancelledError:
                     if inflight_future.cancelled():
                         continue
                     raise
+                except TimeoutError as exc:
+                    timeout_error = _http_bridge_startup_wait_timeout_error("http_bridge_inflight_session")
+                    await self._fail_http_bridge_inflight_session_creation(key, inflight_future, timeout_error)
+                    _log_http_bridge_startup_wait_timeout(
+                        stage="inflight_session",
+                        timeout_seconds=wait_timeout_seconds,
+                        key=key,
+                        request_model=request_model,
+                        pending_count=len(self._http_bridge_sessions),
+                        inflight_count=len(self._http_bridge_inflight_sessions),
+                    )
+                    raise timeout_error from exc
                 except Exception:
                     raise
                 if session is None:
@@ -5434,6 +5571,8 @@ class ProxyService:
                         session_registered = True
                         if inflight_future is not None and not inflight_future.done():
                             inflight_future.set_result(created_session)
+                if not session_registered:
+                    raise _http_bridge_startup_wait_timeout_error("http_bridge_session_registration")
             except BaseException as exc:
                 async with self._http_bridge_lock:
                     current_future = self._http_bridge_inflight_sessions.get(key)

--- a/openspec/changes/bound-http-bridge-startup-waits/proposal.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/proposal.md
@@ -1,0 +1,20 @@
+# Change: Bound HTTP Bridge Startup Waits
+
+## Why
+
+Production observed HTTP Responses bridge streams that emitted only local keepalive comments for minutes while direct upstream requests and fresh in-process bridge calls succeeded. Restarting the replica cleared the stuck in-memory state.
+
+The bridge currently has unbounded waits before the first upstream `response.*` event: waiting for per-session response-create gate capacity, waiting for global bridge capacity to be freed by an in-flight session, and waiting for another request's in-flight session creation. If one of these waits wedges, the API startup probe can return a streaming response and downstream clients only see keepalives until their own watchdog aborts.
+
+## What Changes
+
+- Bound HTTP bridge startup waits with the configured proxy admission wait timeout.
+- Clean up in-flight bridge session creation futures when the owner request is cancelled while closing stale sessions.
+- Evict stale in-flight bridge session futures after startup wait timeout so a replica can self-heal without restart.
+- Return a local `proxy_overloaded` error when bridge startup admission cannot proceed in time.
+- Log the timeout stage and request id without exposing raw affinity keys.
+- Add regression coverage for session gate, capacity wait, and in-flight session wait timeouts.
+
+## Impact
+
+Affected clients receive a terminal local-overload error after the configured timeout instead of a keepalive-only stream that can last until a 300s client watchdog aborts. A stuck in-flight bridge session marker is also removed so later requests can create a fresh bridge session instead of repeatedly waiting on the same orphaned future.

--- a/openspec/changes/bound-http-bridge-startup-waits/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/specs/proxy-admission-control/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge startup admission waits are bounded
+
+The proxy MUST apply the configured proxy admission wait timeout to HTTP bridge startup waits for per-session response-create gate acquisition, bridge capacity waiters, and in-flight session creation waiters. When the timeout expires, the proxy MUST reject the request locally with HTTP 429 and an OpenAI-style `proxy_overloaded` error envelope. Timing out while observing another request's pending in-flight session creation MUST evict that in-flight marker when it is still pending so later requests can attempt a fresh bridge session instead of waiting on the same stalled future.
+
+If a request owns in-flight bridge session creation and is cancelled or fails after publishing the in-flight marker but before registering the created session, the proxy MUST remove or settle that in-flight marker. If a session owner later finishes creation after its in-flight marker was evicted, the owner MUST NOT return an unregistered bridge session to the caller.
+
+#### Scenario: Per-session response-create gate does not open
+
+- **WHEN** a bridged Responses request waits for a session response-create gate
+- **AND** the gate does not open before the configured proxy admission wait timeout
+- **THEN** the request is rejected locally with HTTP 429
+- **AND** the error payload uses `error.code = "proxy_overloaded"`
+- **AND** no response-create gate lease is recorded on that request state
+
+#### Scenario: In-flight bridge session creation does not finish
+
+- **WHEN** a bridged Responses request waits on another request's in-flight session creation
+- **AND** the in-flight creation does not finish before the configured proxy admission wait timeout
+- **THEN** the waiter is rejected locally with HTTP 429 and `error.code = "proxy_overloaded"`
+- **AND** the stalled in-flight marker is evicted if it is still pending
+
+#### Scenario: Bridge capacity waiter does not make progress
+
+- **WHEN** the HTTP bridge is at capacity and a request waits for in-flight bridge work to free capacity
+- **AND** no capacity becomes available before the configured proxy admission wait timeout
+- **THEN** the waiter is rejected locally with HTTP 429 and `error.code = "proxy_overloaded"`
+
+#### Scenario: In-flight owner is cancelled during stale session close
+
+- **WHEN** a bridge session creation owner has published an in-flight marker
+- **AND** it is cancelled while closing a stale local bridge session before creating the replacement session
+- **THEN** the in-flight marker is removed or settled
+- **AND** later requests do not remain blocked on that cancelled owner's future

--- a/openspec/changes/bound-http-bridge-startup-waits/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge startup wait timeouts are logged
+
+When an HTTP bridge startup wait times out locally, the service MUST log the request id, timeout stage, timeout seconds, and low-cardinality bridge affinity family. The log MUST NOT include raw prompt-cache keys, session ids, turn-state ids, API keys, or request payload content.
+
+#### Scenario: Bridge startup admission timeout is diagnosable
+
+- **WHEN** a HTTP bridge startup wait exceeds the configured proxy admission wait timeout
+- **THEN** the console log includes the timeout stage and request id
+- **AND** the log includes only low-cardinality affinity metadata, not raw affinity key values

--- a/openspec/changes/bound-http-bridge-startup-waits/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/specs/responses-api-compat/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge startup waits fail with terminal local overload
+
+When the HTTP responses bridge cannot start upstream work because its local bridge startup waits do not make progress within the configured proxy admission wait timeout, the service MUST surface a terminal local-overload error instead of leaving `/v1/responses`, `/backend-api/codex/responses`, or compact responses streams on keepalives only.
+
+#### Scenario: HTTP bridge startup wait stalls before first upstream event
+
+- **WHEN** a streaming Responses request enters the HTTP responses bridge
+- **AND** bridge startup is blocked by local bridge admission state before any upstream `response.*` event can be emitted
+- **AND** the wait exceeds the configured proxy admission wait timeout
+- **THEN** the request fails with a terminal error
+- **AND** the error payload identifies local proxy overload with `error.code = "proxy_overloaded"`

--- a/openspec/changes/bound-http-bridge-startup-waits/tasks.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/tasks.md
@@ -1,0 +1,10 @@
+## Tasks
+
+- [x] Add OpenSpec requirements for bounded HTTP bridge startup waits.
+- [x] Bound per-session response-create gate acquisition.
+- [x] Bound HTTP bridge capacity and in-flight session waits.
+- [x] Clean up in-flight markers when creation owners are cancelled during stale session close.
+- [x] Evict stalled in-flight markers on startup wait timeout.
+- [x] Log timeout diagnostics without raw affinity keys.
+- [x] Add regression tests for timeout behavior.
+- [x] Validate OpenSpec and run targeted unit tests.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5948,6 +5948,7 @@ async def test_v1_responses_http_bridge_singleflights_same_session_key_during_cr
         app_settings=_make_app_settings(
             enabled=True,
             max_sessions=8,
+            admission_wait_timeout_seconds=1.0,
             codex_idle_ttl_seconds=120.0,
             instance_id="instance-a",
             instance_ring=[],
@@ -6121,6 +6122,7 @@ async def test_v1_responses_http_bridge_singleflight_follower_refreshes_session_
         app_settings=_make_app_settings(
             enabled=True,
             max_sessions=8,
+            admission_wait_timeout_seconds=1.0,
             codex_idle_ttl_seconds=120.0,
             instance_id="instance-a",
             instance_ring=[],
@@ -6207,6 +6209,7 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
         app_settings=_make_app_settings(
             enabled=True,
             max_sessions=8,
+            admission_wait_timeout_seconds=1.0,
             codex_idle_ttl_seconds=120.0,
             instance_id="instance-a",
             instance_ring=[],
@@ -6312,6 +6315,7 @@ async def test_v1_responses_http_bridge_singleflights_stale_session_replacement(
         app_settings=_make_app_settings(
             enabled=True,
             max_sessions=8,
+            admission_wait_timeout_seconds=1.0,
             codex_idle_ttl_seconds=120.0,
             instance_id="instance-a",
             instance_ring=[],

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5792,6 +5792,53 @@ async def test_get_or_create_http_bridge_session_waiter_propagates_terminal_infl
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_inflight_wait_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-stuck-inflight", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    service._http_bridge_inflight_sessions[key] = inflight_future
+    settings = _make_app_settings()
+    settings.proxy_admission_wait_timeout_seconds = 0.01
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await asyncio.wait_for(
+            service._get_or_create_http_bridge_session(
+                key,
+                headers={"x-codex-session-id": "sid-stuck-inflight"},
+                affinity=proxy_service._AffinityPolicy(
+                    key="sid-stuck-inflight",
+                    kind=proxy_service.StickySessionKind.CODEX_SESSION,
+                ),
+                api_key=None,
+                request_model="gpt-5.4",
+                idle_ttl_seconds=120.0,
+                max_sessions=8,
+            ),
+            timeout=1.0,
+        )
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert key not in service._http_bridge_inflight_sessions
+    with pytest.raises(ProxyResponseError) as future_exc_info:
+        await inflight_future
+    assert future_exc_info.value.status_code == 429
+    assert future_exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+
+
+@pytest.mark.asyncio
 async def test_close_all_http_bridge_sessions_fails_inflight_waiters() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-shutdown", None)
@@ -5877,6 +5924,222 @@ async def test_close_all_http_bridge_sessions_fails_capacity_waiters_instead_of_
     assert exc_info.value.status_code == 503
     assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
     create_http_bridge_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_capacity_wait_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    existing_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-existing", None)
+    existing = proxy_service._HTTPBridgeSession(
+        key=existing_key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-capacity-existing",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-existing", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=cast(deque[proxy_service._WebSocketRequestState], deque()),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+        prewarm_lock=anyio.Lock(),
+    )
+    service._http_bridge_sessions[existing_key] = existing
+    inflight_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-inflight", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    service._http_bridge_inflight_sessions[inflight_key] = inflight_future
+    settings = _make_app_settings()
+    settings.proxy_admission_wait_timeout_seconds = 0.01
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_http_bridge_pending_count", AsyncMock(return_value=1))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+    create_http_bridge_session = AsyncMock()
+    monkeypatch.setattr(service, "_create_http_bridge_session_compatible", create_http_bridge_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await asyncio.wait_for(
+            service._get_or_create_http_bridge_session(
+                proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-request", None),
+                headers={"x-codex-session-id": "sid-capacity-request"},
+                affinity=proxy_service._AffinityPolicy(
+                    key="sid-capacity-request",
+                    kind=proxy_service.StickySessionKind.CODEX_SESSION,
+                ),
+                api_key=None,
+                request_model="gpt-5.4",
+                idle_ttl_seconds=120.0,
+                max_sessions=1,
+            ),
+            timeout=1.0,
+        )
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert inflight_key not in service._http_bridge_inflight_sessions
+    with pytest.raises(ProxyResponseError) as future_exc_info:
+        await inflight_future
+    assert future_exc_info.value.status_code == 429
+    assert future_exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    create_http_bridge_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_cancel_during_stale_close_cleans_inflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-stale-close-cancel", None)
+    stale = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-stale-close-cancel",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-stale", status=AccountStatus.DEACTIVATED)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=cast(deque[proxy_service._WebSocketRequestState], deque()),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+        prewarm_lock=anyio.Lock(),
+    )
+    service._http_bridge_sessions[key] = stale
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    async def close_stale_session(session: proxy_service._HTTPBridgeSession, **_: object) -> None:
+        assert session is stale
+        close_started.set()
+        await release_close.wait()
+
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_stale_session)
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+    create_http_bridge_session = AsyncMock()
+    monkeypatch.setattr(service, "_create_http_bridge_session_compatible", create_http_bridge_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+
+    task = asyncio.create_task(
+        service._get_or_create_http_bridge_session(
+            key,
+            headers={"x-codex-session-id": "sid-stale-close-cancel"},
+            affinity=proxy_service._AffinityPolicy(
+                key="sid-stale-close-cancel",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=8,
+        )
+    )
+    await asyncio.wait_for(close_started.wait(), timeout=1.0)
+    assert key in service._http_bridge_inflight_sessions
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release_close.set()
+
+    assert key not in service._http_bridge_inflight_sessions
+    create_http_bridge_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict_closes_unregistered_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-late-owner", None)
+    settings = _make_app_settings()
+    settings.proxy_admission_wait_timeout_seconds = 0.01
+    created = _make_bridge_session(key_value="sid-late-owner")
+    create_started = asyncio.Event()
+    finish_create = asyncio.Event()
+
+    async def create_session(*_: object, **__: object) -> proxy_service._HTTPBridgeSession:
+        create_started.set()
+        await finish_create.wait()
+        return created
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_create_http_bridge_session_compatible", create_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    close_http_bridge_session = AsyncMock()
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_http_bridge_session)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    async def get_session() -> proxy_service._HTTPBridgeSession | proxy_service._HTTPBridgeOwnerForward:
+        return await service._get_or_create_http_bridge_session(
+            key,
+            headers={"x-codex-session-id": "sid-late-owner"},
+            affinity=proxy_service._AffinityPolicy(
+                key="sid-late-owner",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=8,
+        )
+
+    owner_task = asyncio.create_task(get_session())
+    await asyncio.wait_for(create_started.wait(), timeout=1.0)
+    assert key in service._http_bridge_inflight_sessions
+
+    with pytest.raises(ProxyResponseError) as waiter_exc_info:
+        await asyncio.wait_for(get_session(), timeout=1.0)
+
+    assert waiter_exc_info.value.status_code == 429
+    assert waiter_exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert key not in service._http_bridge_inflight_sessions
+
+    finish_create.set()
+    with pytest.raises(ProxyResponseError) as owner_exc_info:
+        await asyncio.wait_for(owner_task, timeout=1.0)
+
+    assert owner_exc_info.value.status_code == 429
+    assert owner_exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert key not in service._http_bridge_sessions
+    close_http_bridge_session.assert_awaited_once_with(created)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12569,6 +12569,43 @@ async def test_response_create_admission_failure_releases_session_gate(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_response_create_admission_session_gate_timeout_returns_proxy_overloaded(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_response_create_limit = 64
+    settings.proxy_admission_wait_timeout_seconds = 0.01
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_gate_timeout",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    try:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            await service._acquire_request_state_response_create_admission(
+                request_state,
+                response_create_gate=response_create_gate,
+            )
+    finally:
+        response_create_gate.release()
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 429
+    assert _proxy_error_code(exc) == "proxy_overloaded"
+    assert request_state.response_create_gate is None
+    assert request_state.awaiting_response_created is False
+    assert request_state.response_create_gate_acquired is False
+    assert request_state.response_create_admission is None
+
+
+@pytest.mark.asyncio
 async def test_response_create_admission_waits_on_session_gate_before_shared_capacity(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.proxy_response_create_limit = 2


### PR DESCRIPTION
## Summary
- Fixed the reproducible HTTP bridge wedge: an owner request could publish an in-flight session future, then get cancelled while closing a stale local bridge session before entering the creation cleanup block, leaving `_http_bridge_inflight_sessions` stuck until process restart.
- Bound session gate, bridge capacity, and in-flight startup waits with `proxy_admission_wait_timeout_seconds`, returning local 429 `proxy_overloaded` instead of keepalive-only streams.
- Added self-heal for stale in-flight markers: wait timeout evicts the pending marker, and a late owner that finishes after eviction closes its unregistered session instead of returning it.
- Added OpenSpec deltas and deterministic regression coverage for session gate timeout, in-flight timeout eviction, capacity timeout eviction, cancellation during stale close, and late-owner cleanup.

## Root cause
The production symptom matched a live `ProxyService` in-memory HTTP bridge state wedge, not upstream/network failure: direct upstream and fresh in-process bridge calls produced `response.created`, while the public live app emitted only keepalives. The concrete code-level wedge was an unguarded cancellation window after `_http_bridge_inflight_sessions[key] = future` and before the create/claim `try` cleanup. If the client/request was cancelled while stale session close was awaited, later requests kept waiting on that orphaned future/capacity state.

## Verification
- .venv/bin/python -m pytest tests/unit/test_proxy_http_bridge.py
- .venv/bin/python -m pytest tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_inflight_wait_times_out tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_capacity_wait_times_out tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_cancel_during_stale_close_cleans_inflight tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_late_owner_after_inflight_evict_closes_unregistered_session tests/unit/test_proxy_utils.py::test_response_create_admission_session_gate_timeout_returns_proxy_overloaded
- .venv/bin/python -m ruff check app/modules/proxy/service.py tests/unit/test_proxy_http_bridge.py tests/unit/test_proxy_utils.py
- openspec validate bound-http-bridge-startup-waits --strict
- openspec validate --specs
- git diff --check

## Production check
- Restarted 10.0.0.113 codex-lb.
- After restart, replayed the Hermes Responses request through public /v1/responses: response.created arrived in about 2.1s and output_item.added in about 4.9s.