### PR TITLE
fix(proxy): recover stale websocket previous response anchors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,11 +291,9 @@ jobs:
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: trivy-results.sarif
-          # PR uploads use the existing release category so GitHub can compare
-          # against the current main-branch baseline while this workflow change
-          # is still under review. Push uploads use a CI-specific category so
-          # they do not overwrite release-workflow analyses on tagged commits.
-          category: ${{ github.event_name == 'pull_request' && '.github/workflows/release.yml:docker-image' || '.github/workflows/ci.yml:docker' }}
+          # Keep PR and main uploads in the same CI category so Code Scanning
+          # can compare pull-request alerts against the default-branch baseline.
+          category: .github/workflows/ci.yml:docker
 
       - name: Enforce Trivy high-severity gate
         uses: aquasecurity/trivy-action@v0.36.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,9 @@ jobs:
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: trivy-results.sarif
-          category: .github/workflows/release.yml:docker-image
+          # Use the same Trivy category as CI so PR Code Scanning only has
+          # one default-branch Docker baseline to compare against.
+          category: .github/workflows/ci.yml:docker
 
   helm-chart:
     name: Publish Helm chart to GHCR

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3648,14 +3648,30 @@ class ProxyService:
         responses_payload = normalize_responses_request_payload(payload, openai_compat=openai_cache_affinity)
         previous_response_trimmed_input_count: int | None = None
         previous_response_trimmed_input_fingerprint: str | None = None
+        client_full_resend_payload: ResponsesRequest | None = None
+        client_full_resend_input_items: list[JsonValue] | None = None
+        client_full_resend_retry_safe = False
         if responses_payload.previous_response_id is not None and isinstance(responses_payload.input, list):
             previous_response_input_items = cast(list[JsonValue], responses_payload.input)
+            client_full_resend_input_items = previous_response_input_items
+            client_full_resend_retry_safe = _websocket_client_previous_response_full_resend_is_retry_safe(
+                previous_response_id=responses_payload.previous_response_id,
+                input_value=responses_payload.input,
+                continuity_state=continuity_state,
+            )
             trimmed_input_items = _trim_websocket_previous_response_input_items(previous_response_input_items)
             if len(trimmed_input_items) != len(previous_response_input_items):
                 previous_response_trimmed_input_count = len(previous_response_input_items)
                 previous_response_trimmed_input_fingerprint = _fingerprint_input_items(previous_response_input_items)
                 responses_payload = responses_payload.model_copy(update={"input": trimmed_input_items})
         apply_api_key_enforcement(responses_payload, refreshed_api_key)
+        if client_full_resend_retry_safe and client_full_resend_input_items is not None:
+            client_full_resend_payload = responses_payload.model_copy(
+                update={
+                    "previous_response_id": None,
+                    "input": client_full_resend_input_items,
+                }
+            )
         validate_model_access(refreshed_api_key, responses_payload.model)
         self._raise_for_unsupported_input_image_references(responses_payload)
         rewritten_file_account_id = await self._resolve_file_account_for_responses(responses_payload, headers)
@@ -3763,6 +3779,25 @@ class ProxyService:
                 else None,
                 responses_payload.previous_response_id,
             )
+        if client_full_resend_payload is not None and not request_state.proxy_injected_previous_response_id:
+            request_state.fresh_upstream_request_text = _response_create_text_with_size_guard(
+                client_full_resend_payload,
+                include_type_field=True,
+                client_metadata=client_metadata,
+                request_state=request_state,
+                transport=_REQUEST_TRANSPORT_WEBSOCKET,
+            )
+            request_state.fresh_upstream_request_is_retry_safe = request_state.fresh_upstream_request_text is not None
+            if request_state.fresh_upstream_request_is_retry_safe:
+                logger.info(
+                    (
+                        "websocket_client_previous_response_full_resend_retry_prepared request_id=%s "
+                        "previous_response_id=%s input_items=%s"
+                    ),
+                    request_state.request_id,
+                    responses_payload.previous_response_id,
+                    request_state.input_item_count,
+                )
         affinity_policy = _sticky_key_for_responses_request(
             responses_payload,
             headers,
@@ -10790,6 +10825,33 @@ def _websocket_continuity_anchor_for_payload(
         previous_response_id=previous_response_id,
         stored_input_item_count=stored_count,
     )
+
+
+def _websocket_client_previous_response_full_resend_is_retry_safe(
+    *,
+    previous_response_id: str | None,
+    input_value: JsonValue,
+    continuity_state: _WebSocketContinuityState | None,
+) -> bool:
+    if previous_response_id is None or not isinstance(input_value, list):
+        return False
+    input_items = cast(list[JsonValue], input_value)
+    if len(input_items) <= 1:
+        return False
+    if (
+        continuity_state is not None
+        and continuity_state.last_completed_response_id == previous_response_id
+        and (
+            continuity_state.last_completed_input_count > 0
+            or continuity_state.last_completed_input_prefix_fingerprint is not None
+        )
+    ):
+        return _input_prefix_matches_stored_context(
+            input_value,
+            stored_count=continuity_state.last_completed_input_count,
+            stored_fingerprint=continuity_state.last_completed_input_prefix_fingerprint,
+        )
+    return True
 
 
 def _record_websocket_continuity_completion(

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1644,7 +1644,9 @@ def test_v1_responses_websocket_marks_fresh_turn_as_retry_safe_at_prep_time(
     assert connect_record[0]["fresh_upstream_request_text_set"] is True
 
 
-def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_retry(
+@pytest.mark.parametrize("endpoint", ["/v1/responses", "/backend-api/codex/responses"])
+def test_responses_websocket_replays_client_full_resend_previous_response_miss_without_anchor(
+    endpoint,
     app_instance,
     monkeypatch,
 ):
@@ -1693,6 +1695,33 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
             ],
         ],
     )
+    recovered_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.created",
+                            "response": {"id": "resp_ws_prev_retry", "status": "in_progress"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_ws_prev_retry", "status": "completed"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+            ]
+        ],
+    )
     connect_count = 0
 
     class _FakeSettingsCache:
@@ -1738,7 +1767,9 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
         )
         nonlocal connect_count
         connect_count += 1
-        return SimpleNamespace(id="acct_ws_prev_mask"), first_upstream
+        if connect_count == 1:
+            return SimpleNamespace(id="acct_ws_prev_mask"), first_upstream
+        return SimpleNamespace(id="acct_ws_prev_mask"), recovered_upstream
 
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
     monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
@@ -1752,13 +1783,13 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
     ]
 
     with TestClient(app_instance) as client:
-        with client.websocket_connect("/v1/responses") as websocket:
+        with client.websocket_connect(endpoint) as websocket:
             websocket.send_text(
                 json.dumps(
                     {
                         "type": "response.create",
                         "model": "gpt-5.4",
-                        "input": "hello",
+                        "input": [full_resend_input[0]],
                         "stream": True,
                     }
                 )
@@ -1779,13 +1810,18 @@ def test_v1_responses_websocket_masks_multi_item_previous_response_miss_without_
                     }
                 )
             )
-            failed_2 = json.loads(websocket.receive_text())
+            created_2 = json.loads(websocket.receive_text())
+            completed_2 = json.loads(websocket.receive_text())
 
-    assert failed_2["type"] == "response.failed"
-    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert "previous_response_not_found" not in json.dumps(failed_2)
-    assert connect_count == 1
+    assert created_2["type"] == "response.created"
+    assert created_2["response"]["id"] == "resp_ws_prev_retry"
+    assert completed_2["type"] == "response.completed"
+    assert "previous_response_not_found" not in json.dumps(created_2)
+    assert connect_count == 2
     assert json.loads(first_upstream.sent_text[-1])["previous_response_id"] == "resp_ws_prev_anchor"
+    replay_payload = json.loads(recovered_upstream.sent_text[-1])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["input"] == full_resend_input
 
 
 def test_v1_responses_websocket_masks_invalid_request_previous_response_not_found_without_retry(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6401,6 +6401,102 @@ async def test_prepare_websocket_response_create_request_trims_codex_session_ful
 
 
 @pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_captures_client_full_resend_anchor_replay(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_client_full_resend",
+        name="ws-client-full-resend",
+        key_prefix="sk-ws-full",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    full_resend_input: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "old answer"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "next question"}]},
+    ]
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=1,
+        last_completed_response_id="resp_client_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(full_resend_input[:1]),
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_client_anchor",
+                "input": full_resend_input,
+            },
+        ),
+        headers={"session_id": "turn_ws_client_full_resend"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_client_anchor"
+    assert upstream_payload["input"] == full_resend_input
+    assert prepared.request_state.previous_response_id == "resp_client_anchor"
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is True
+    assert prepared.request_state.fresh_upstream_request_text is not None
+    fresh_payload = json.loads(prepared.request_state.fresh_upstream_request_text)
+    assert "previous_response_id" not in fresh_payload
+    assert fresh_payload["input"] == full_resend_input
+
+
+def test_websocket_client_previous_response_full_resend_retry_requires_matching_prefix() -> None:
+    stored_prefix: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]}
+    ]
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=1,
+        last_completed_response_id="resp_client_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(stored_prefix),
+    )
+    mismatched_full_resend: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "different question"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "old answer"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "next question"}]},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=mismatched_full_resend,
+            continuity_state=continuity_state,
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
 async def test_prepare_websocket_response_create_request_fills_interrupted_pending_tool_outputs(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6472,9 +6472,7 @@ async def test_prepare_websocket_response_create_request_captures_client_full_re
 
 
 def test_websocket_client_previous_response_full_resend_retry_requires_matching_prefix() -> None:
-    stored_prefix: list[JsonValue] = [
-        {"role": "user", "content": [{"type": "input_text", "text": "old question"}]}
-    ]
+    stored_prefix: list[JsonValue] = [{"role": "user", "content": [{"type": "input_text", "text": "old question"}]}]
     continuity_state = proxy_service._WebSocketContinuityState(
         last_completed_input_count=1,
         last_completed_response_id="resp_client_anchor",


### PR DESCRIPTION
## Summary
- prepare an anchorless full-resend payload when a WebSocket client sends `previous_response_id` together with the full input history
- guard that recovery with continuity prefix validation so edited/mismatched histories fall back to `stream_incomplete`
- cover both public `/v1/responses` and native `/backend-api/codex/responses` WebSocket paths so stale-anchor 400s do not leak to Codex clients

## Test Plan
- `uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/integration/test_proxy_websocket_responses.py`
- `uv run ty check app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/integration/test_proxy_websocket_responses.py`
- `uv run pytest tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_captures_client_full_resend_anchor_replay tests/unit/test_proxy_utils.py::test_websocket_client_previous_response_full_resend_retry_requires_matching_prefix tests/integration/test_proxy_websocket_responses.py::test_responses_websocket_replays_client_full_resend_previous_response_miss_without_anchor -q`
- `uv run pytest tests/unit/test_proxy_utils.py -k 'websocket_response_create_request_trims_codex_session_full_replay or client_previous_response_full_resend or full_replay_retry_text or previous_response or full_resend or fresh_turn' tests/integration/test_proxy_websocket_responses.py -k 'previous_response or full_resend or fresh_turn or full_replay' -q`
