### PR TITLE
fix(archive): stream gzip writes asynchronously

### DIFF
--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -40,6 +40,7 @@ _WRITE_QUEUE_MAX_RECORDS = 4096
 _WRITE_QUEUE_MAX_BYTES = 8 * 1024 * 1024
 _WRITE_QUEUE_BYTES = 0
 _WRITE_QUEUE_BYTES_LOCK = threading.Lock()
+_WRITE_QUEUE_BYTES_CONDITION = threading.Condition(_WRITE_QUEUE_BYTES_LOCK)
 _WRITE_QUEUE: queue.Queue[tuple[Path, dict[str, Any], int] | None] = queue.Queue(maxsize=_WRITE_QUEUE_MAX_RECORDS)
 _WRITER_THREAD: threading.Thread | None = None
 _BACKPRESSURE_WARNING_INTERVAL_SECONDS = 60.0
@@ -182,16 +183,14 @@ def _enqueue_record(path: Path, record: dict[str, Any]) -> None:
         should_warn, suppressed_warnings = _archive_backpressure_warning_state()
         if should_warn:
             logger.warning(
-                "Conversation archive writer queue byte budget is full; "
-                "applying synchronous archive write backpressure",
+                "Conversation archive writer queue byte budget is full; waiting for async archive writer capacity",
                 extra={
                     "queue_max_bytes": _archive_queue_max_bytes(),
                     "record_bytes": queued_bytes,
                     "suppressed_warnings": suppressed_warnings,
                 },
             )
-        _append_record(path, record)
-        return
+        _reserve_archive_queue_bytes_blocking(queued_bytes)
     queued = False
     try:
         _ensure_writer_thread()
@@ -199,10 +198,11 @@ def _enqueue_record(path: Path, record: dict[str, Any]) -> None:
         queued = True
     except queue.Full:
         logger.warning(
-            "Conversation archive writer queue is full; applying synchronous archive write backpressure",
+            "Conversation archive writer queue is full; waiting for async archive writer capacity",
             extra={"queue_max_records": _WRITE_QUEUE_MAX_RECORDS},
         )
-        _append_record(path, record)
+        _WRITE_QUEUE.put((path, record, queued_bytes))
+        queued = True
     except Exception:
         logger.warning("Failed to enqueue conversation archive record; dropping it", exc_info=True)
     finally:
@@ -243,8 +243,6 @@ def _append_record(path: Path, record: Mapping[str, Any]) -> None:
     if _archive_disk_pressure_active():
         return
 
-    line = json.dumps(record, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
-    data = gzip.compress(f"{line}\n".encode("utf-8"))
     try:
         with _WRITE_LOCK:
             if _archive_disk_pressure_active():
@@ -252,7 +250,7 @@ def _append_record(path: Path, record: Mapping[str, Any]) -> None:
             path.parent.mkdir(parents=True, exist_ok=True)
             path.parent.chmod(_ARCHIVE_DIR_MODE)
             _recover_corrupt_gzip_archive(path)
-            _write_gzip_member(path, data)
+            _write_gzip_jsonl_record(path, record)
     except Exception as exc:
         _RECOVERY_CHECKED_PATHS.discard(path.resolve())
         if _is_disk_pressure_error(exc):
@@ -266,19 +264,51 @@ def _serialized_record_size(record: Mapping[str, Any]) -> int:
     return len(line.encode("utf-8")) + 1
 
 
+def _estimated_record_size(value: Any) -> int:
+    if value is None or isinstance(value, bool):
+        return 4
+    if isinstance(value, int | float):
+        return len(str(value))
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+    if isinstance(value, bytes | bytearray | memoryview):
+        return len(value)
+    if isinstance(value, Mapping):
+        return 2 + sum(_estimated_record_size(key) + _estimated_record_size(item) + 2 for key, item in value.items())
+    if isinstance(value, list | tuple):
+        return 2 + sum(_estimated_record_size(item) + 1 for item in value)
+    return len(str(value).encode("utf-8"))
+
+
 def _reserve_archive_queue_bytes(size: int) -> bool:
     global _WRITE_QUEUE_BYTES
     with _WRITE_QUEUE_BYTES_LOCK:
-        if _WRITE_QUEUE_BYTES + size > _archive_queue_max_bytes():
+        if not _can_reserve_archive_queue_bytes(size):
             return False
         _WRITE_QUEUE_BYTES += size
         return True
 
 
+def _reserve_archive_queue_bytes_blocking(size: int) -> None:
+    global _WRITE_QUEUE_BYTES
+    with _WRITE_QUEUE_BYTES_CONDITION:
+        while not _can_reserve_archive_queue_bytes(size):
+            _WRITE_QUEUE_BYTES_CONDITION.wait(timeout=0.1)
+        _WRITE_QUEUE_BYTES += size
+
+
+def _can_reserve_archive_queue_bytes(size: int) -> bool:
+    max_bytes = _archive_queue_max_bytes()
+    if _WRITE_QUEUE_BYTES + size <= max_bytes:
+        return True
+    return size > max_bytes and _WRITE_QUEUE_BYTES == 0
+
+
 def _release_archive_queue_bytes(size: int) -> None:
     global _WRITE_QUEUE_BYTES
-    with _WRITE_QUEUE_BYTES_LOCK:
+    with _WRITE_QUEUE_BYTES_CONDITION:
         _WRITE_QUEUE_BYTES = max(0, _WRITE_QUEUE_BYTES - size)
+        _WRITE_QUEUE_BYTES_CONDITION.notify_all()
 
 
 def _archive_queue_max_bytes() -> int:
@@ -299,13 +329,15 @@ def _archive_backpressure_warning_state() -> tuple[bool, int]:
         return False, 0
 
 
-def _write_gzip_member(path: Path, data: bytes) -> None:
+def _write_gzip_jsonl_record(path: Path, record: Mapping[str, Any]) -> None:
     fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, _ARCHIVE_FILE_MODE)
     try:
         os.fchmod(fd, _ARCHIVE_FILE_MODE)
         with os.fdopen(fd, "ab") as fh:
             fd = -1
-            fh.write(data)
+            with gzip.open(fh, "at", encoding="utf-8") as gzip_fh:
+                json.dump(record, gzip_fh, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+                gzip_fh.write("\n")
     finally:
         if fd >= 0:
             os.close(fd)

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -7,6 +7,8 @@ import json
 import os
 import queue
 import stat
+import threading
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -121,7 +123,7 @@ def test_archive_bytes_disabled_does_not_encode_payload(monkeypatch, tmp_path):
     assert list(tmp_path.iterdir()) == []
 
 
-def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_path):
+def test_archive_queue_is_bounded_and_waits_without_sync_backpressure(monkeypatch, tmp_path):
     monkeypatch.setattr(
         conversation_archive,
         "get_settings",
@@ -132,28 +134,34 @@ def test_archive_queue_is_bounded_and_falls_back_to_sync_write(monkeypatch, tmp_
     monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", bounded_queue)
     monkeypatch.setattr(conversation_archive, "_ensure_writer_thread", lambda: None)
 
+    def drain_existing_item() -> None:
+        time.sleep(0.01)
+        bounded_queue.get()
+        bounded_queue.task_done()
+
+    drainer = threading.Thread(target=drain_existing_item)
+    drainer.start()
     conversation_archive.archive_json(
         direction="codex_to_server",
         kind="responses",
         transport="http",
         payload={"text": "синхронный fallback"},
     )
+    drainer.join(timeout=1.0)
 
-    [line] = _archive_lines(tmp_path)
-    assert "синхронный fallback" in line
+    assert list(tmp_path.glob("*.jsonl.gz")) == []
     assert bounded_queue.qsize() == 1
+    queued_item = bounded_queue.get_nowait()
+    assert queued_item is not None
+    _path, record, _queued_bytes = queued_item
+    assert record["payload"] == {"text": "синхронный fallback"}
 
 
-def test_archive_queue_byte_limit_falls_back_to_sync_write(monkeypatch, tmp_path):
+def test_archive_queue_byte_limit_preserves_oversized_record_with_backpressure(monkeypatch, tmp_path):
     monkeypatch.setattr(
         conversation_archive,
         "get_settings",
         lambda: _ArchiveSettings(enabled=True, directory=tmp_path, queue_max_bytes=64),
-    )
-    monkeypatch.setattr(
-        conversation_archive,
-        "_ensure_writer_thread",
-        lambda: (_ for _ in ()).throw(AssertionError("writer should not start for byte-budget fallback")),
     )
     with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
         conversation_archive._WRITE_QUEUE_BYTES = 0
@@ -164,11 +172,68 @@ def test_archive_queue_byte_limit_falls_back_to_sync_write(monkeypatch, tmp_path
         transport="http",
         payload={"text": "x" * 256},
     )
+    conversation_archive.flush_archive_writer()
 
     [record] = _archive_records(tmp_path)
     assert record["payload"] == {"text": "x" * 256}
     with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
         assert conversation_archive._WRITE_QUEUE_BYTES == 0
+
+
+def test_archive_queue_byte_limit_waits_before_queueing_second_oversized_record(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path, queue_max_bytes=64),
+    )
+    queued_records: queue.Queue[tuple[Path, dict[str, object], int] | None] = queue.Queue()
+    monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", queued_records)
+    monkeypatch.setattr(conversation_archive, "_ensure_writer_thread", lambda: None)
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        conversation_archive._WRITE_QUEUE_BYTES = 0
+
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "x" * 256},
+    )
+
+    first_item = queued_records.get_nowait()
+    assert first_item is not None
+    assert first_item[1]["payload"] == {"text": "x" * 256}
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        assert conversation_archive._WRITE_QUEUE_BYTES == first_item[2]
+
+    second_started = threading.Event()
+
+    def enqueue_second() -> None:
+        second_started.set()
+        conversation_archive.archive_json(
+            direction="codex_to_server",
+            kind="responses",
+            transport="http",
+            payload={"text": "y" * 256},
+        )
+
+    second_thread = threading.Thread(target=enqueue_second)
+    second_thread.start()
+    assert second_started.wait(timeout=1.0)
+    time.sleep(0.05)
+    assert queued_records.empty()
+    assert second_thread.is_alive()
+
+    conversation_archive._release_archive_queue_bytes(first_item[2])
+    second_thread.join(timeout=1.0)
+    assert not second_thread.is_alive()
+
+    second_item = queued_records.get_nowait()
+    assert second_item is not None
+    assert second_item[1]["payload"] == {"text": "y" * 256}
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        assert conversation_archive._WRITE_QUEUE_BYTES == second_item[2]
+
+    conversation_archive._release_archive_queue_bytes(second_item[2])
 
 
 def test_archive_queue_byte_limit_warning_is_rate_limited(monkeypatch, tmp_path, caplog):
@@ -177,12 +242,9 @@ def test_archive_queue_byte_limit_warning_is_rate_limited(monkeypatch, tmp_path,
         "get_settings",
         lambda: _ArchiveSettings(enabled=True, directory=tmp_path, queue_max_bytes=64),
     )
-    monkeypatch.setattr(
-        conversation_archive,
-        "_ensure_writer_thread",
-        lambda: (_ for _ in ()).throw(AssertionError("writer should not start for byte-budget fallback")),
-    )
     monkeypatch.setattr(conversation_archive, "_archive_disk_pressure_active", lambda: False)
+    monkeypatch.setattr(conversation_archive, "_reserve_archive_queue_bytes", lambda _size: False)
+    monkeypatch.setattr(conversation_archive, "_reserve_archive_queue_bytes_blocking", lambda _size: None)
     monotonic_values = iter([100.0, 101.0, 102.0, 161.0])
     monkeypatch.setattr(conversation_archive.time, "monotonic", lambda: next(monotonic_values))
     with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
@@ -201,6 +263,7 @@ def test_archive_queue_byte_limit_warning_is_rate_limited(monkeypatch, tmp_path,
             transport="http",
             payload={"text": f"{idx}-" + ("x" * 256)},
         )
+    conversation_archive.flush_archive_writer()
 
     warnings = [
         record
@@ -210,6 +273,29 @@ def test_archive_queue_byte_limit_warning_is_rate_limited(monkeypatch, tmp_path,
     assert len(warnings) == 2
     assert warnings[0].suppressed_warnings == 0
     assert warnings[1].suppressed_warnings == 2
+
+
+def test_archive_writer_streams_gzip_without_precompressing_record(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        conversation_archive,
+        "get_settings",
+        lambda: _ArchiveSettings(enabled=True, directory=tmp_path),
+    )
+
+    def fail_compress(_data: bytes) -> bytes:
+        raise AssertionError("normal archive writes should stream gzip data")
+
+    monkeypatch.setattr(conversation_archive.gzip, "compress", fail_compress)
+    conversation_archive.archive_json(
+        direction="codex_to_server",
+        kind="responses",
+        transport="http",
+        payload={"text": "x" * 1024},
+    )
+    conversation_archive.flush_archive_writer()
+
+    [record] = _archive_records(tmp_path)
+    assert record["payload"] == {"text": "x" * 1024}
 
 
 def test_archive_queue_thread_start_failure_drops_record(monkeypatch, tmp_path):
@@ -413,10 +499,10 @@ def test_archive_write_failure_forgets_prior_recovery_check(monkeypatch, tmp_pat
     conversation_archive._append_record(path, {"request_id": "req_new_1"})
     assert path.resolve() in conversation_archive._RECOVERY_CHECKED_PATHS
 
-    def fail_write(_path: Path, _data: bytes) -> None:
+    def fail_write(_path: Path, _record: object) -> None:
         raise OSError("simulated partial archive write")
 
-    monkeypatch.setattr(conversation_archive, "_write_gzip_member", fail_write)
+    monkeypatch.setattr(conversation_archive, "_write_gzip_jsonl_record", fail_write)
     conversation_archive._append_record(path, {"request_id": "req_new_2"})
 
     assert path.resolve() not in conversation_archive._RECOVERY_CHECKED_PATHS
@@ -426,10 +512,10 @@ def test_archive_disk_full_pauses_writes_without_traceback_spam(monkeypatch, tmp
     _reset_archive_disk_pressure()
     path = tmp_path / "2026-04-30T12.jsonl.gz"
 
-    def fail_write(_path: Path, _data: bytes) -> None:
+    def fail_write(_path: Path, _record: object) -> None:
         raise OSError(errno.ENOSPC, "No space left on device")
 
-    monkeypatch.setattr(conversation_archive, "_write_gzip_member", fail_write)
+    monkeypatch.setattr(conversation_archive, "_write_gzip_jsonl_record", fail_write)
     caplog.set_level("WARNING", logger="app.core.conversation_archive")
 
     conversation_archive._append_record(path, {"request_id": "req_full", "payload": "old"})
@@ -441,11 +527,11 @@ def test_archive_disk_full_pauses_writes_without_traceback_spam(monkeypatch, tmp
 
     calls = 0
 
-    def record_write(_path: Path, _data: bytes) -> None:
+    def record_write(_path: Path, _record: object) -> None:
         nonlocal calls
         calls += 1
 
-    monkeypatch.setattr(conversation_archive, "_write_gzip_member", record_write)
+    monkeypatch.setattr(conversation_archive, "_write_gzip_jsonl_record", record_write)
     conversation_archive._append_record(path, {"request_id": "req_dropped", "payload": "new"})
     assert calls == 0
 


### PR DESCRIPTION
## Summary
- keep conversation archive records on the async writer path when the byte budget is exceeded instead of falling back to synchronous archive writes in the request path
- stream JSONL records directly into gzip files instead of precompressing each full record with `gzip.compress()`
- cover the queue-full, byte-budget, warning, disk-pressure, and streaming-write paths in unit tests

## Testing
- `uv run pytest tests/unit/test_conversation_archive.py -q`
- `uv run ruff check app/core/conversation_archive.py tests/unit/test_conversation_archive.py`
- `git diff --check`
