### PR TITLE
fix(proxy): fail over websocket connect timeouts

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4148,26 +4148,49 @@ class ProxyService:
         last_failover_account: Account | None = None
         for attempt in range(max_attempts):
             is_retry = attempt > 0
-            account = await self._select_websocket_connect_account(
-                deadline,
-                sticky_key=sticky_key,
-                sticky_kind=sticky_kind,
-                prefer_earlier_reset=prefer_earlier_reset,
-                routing_strategy=routing_strategy,
-                model=model,
-                request_state=request_state,
-                api_key=api_key,
-                client_send_lock=client_send_lock,
-                websocket=websocket,
-                reallocate_sticky=True if is_retry else reallocate_sticky,
-                sticky_max_age_seconds=sticky_max_age_seconds,
-                exclude_account_ids=excluded_account_ids,
-                preferred_account_id=request_state.preferred_account_id,
-                require_preferred_account=(
-                    request_state.previous_response_id is not None and request_state.preferred_account_id is not None
-                ),
+            require_preferred_account = (
+                request_state.previous_response_id is not None and request_state.preferred_account_id is not None
             )
+            select_kwargs: dict[str, Any] = {
+                "sticky_key": sticky_key,
+                "sticky_kind": sticky_kind,
+                "prefer_earlier_reset": prefer_earlier_reset,
+                "routing_strategy": routing_strategy,
+                "model": model,
+                "request_state": request_state,
+                "api_key": api_key,
+                "client_send_lock": client_send_lock,
+                "websocket": websocket,
+                "reallocate_sticky": True if is_retry else reallocate_sticky,
+                "sticky_max_age_seconds": sticky_max_age_seconds,
+                "exclude_account_ids": excluded_account_ids,
+                "preferred_account_id": request_state.preferred_account_id,
+                "require_preferred_account": require_preferred_account,
+            }
+            if "defer_no_account_error" in inspect.signature(self._select_websocket_connect_account).parameters:
+                select_kwargs["defer_no_account_error"] = (
+                    last_failover_exc is not None and not require_preferred_account
+                )
+            try:
+                account = await self._select_websocket_connect_account(deadline, **select_kwargs)
+            except _WebSocketConnectFailureEmitted:
+                return None, None
             if account is None:
+                if (
+                    last_failover_exc is not None
+                    and not require_preferred_account
+                    and _remaining_budget_seconds(deadline) <= 0
+                ):
+                    await self._emit_websocket_connect_timeout(
+                        websocket=websocket,
+                        client_send_lock=client_send_lock,
+                        account_id=None,
+                        api_key=api_key,
+                        request_state=request_state,
+                    )
+                    return None, None
+                if last_failover_exc is not None and not require_preferred_account:
+                    break
                 return None, None
 
             try:
@@ -4249,6 +4272,7 @@ class ProxyService:
         exclude_account_ids: set[str],
         preferred_account_id: str | None,
         require_preferred_account: bool,
+        defer_no_account_error: bool = False,
     ) -> Account | None:
         try:
             selection = await self._select_account_with_budget_compatible(
@@ -4275,7 +4299,7 @@ class ProxyService:
                     api_key=api_key,
                     request_state=request_state,
                 )
-                return None
+                raise _WebSocketConnectFailureEmitted
             raise
 
         account = selection.account
@@ -4311,6 +4335,8 @@ class ProxyService:
             return None
         if account:
             return account
+        if defer_no_account_error:
+            return None
         error_code = selection.error_code or "no_accounts"
         error_message = selection.error_message or "No active accounts available"
         if require_preferred_account and preferred_account_id is not None:
@@ -4436,22 +4462,14 @@ class ProxyService:
             return None
         except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
             message = str(exc) or "Request to upstream timed out"
-            await self._emit_websocket_connect_failure(
-                websocket,
-                client_send_lock=client_send_lock,
-                account_id=account.id,
-                api_key=api_key,
-                request_state=request_state,
-                status_code=502,
-                payload=openai_error(
+            raise ProxyResponseError(
+                502,
+                openai_error(
                     "upstream_unavailable",
                     message,
                     error_type="server_error",
                 ),
-                error_code="upstream_unavailable",
-                error_message=message,
-            )
-            return None
+            ) from exc
 
     async def _retry_websocket_connect_after_401(
         self,
@@ -4501,22 +4519,14 @@ class ProxyService:
             return None
         except (aiohttp.ClientError, asyncio.TimeoutError) as refresh_transport_exc:
             message = str(refresh_transport_exc) or "Request to upstream timed out"
-            await self._emit_websocket_connect_failure(
-                websocket,
-                client_send_lock=client_send_lock,
-                account_id=account.id,
-                api_key=api_key,
-                request_state=request_state,
-                status_code=502,
-                payload=openai_error(
+            raise ProxyResponseError(
+                502,
+                openai_error(
                     "upstream_unavailable",
                     message,
                     error_type="server_error",
                 ),
-                error_code="upstream_unavailable",
-                error_message=message,
-            )
-            return None
+            ) from refresh_transport_exc
 
         try:
             remaining_budget = _remaining_budget_seconds(deadline)
@@ -4600,10 +4610,13 @@ class ProxyService:
         *,
         timeout_seconds: float,
     ) -> UpstreamResponsesWebSocket:
+        started_at = time.monotonic()
         try:
             with anyio.fail_after(timeout_seconds):
                 return await self._open_upstream_websocket(account, headers)
         except TimeoutError:
+            if time.monotonic() - started_at < timeout_seconds:
+                raise
             _raise_proxy_budget_exhausted()
 
     async def _open_upstream_websocket(
@@ -10765,6 +10778,10 @@ class _RetryableStreamError(Exception):
         self.code = code
         self.error = error
         self.exclude_account = exclude_account
+
+
+class _WebSocketConnectFailureEmitted(Exception):
+    pass
 
 
 class _TransientStreamError(Exception):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5725,18 +5725,32 @@ async def test_connect_proxy_websocket_surfaces_local_connect_overload_without_p
 
 
 @pytest.mark.asyncio
-async def test_connect_proxy_websocket_surfaces_refresh_transport_error(monkeypatch):
+async def test_connect_proxy_websocket_fails_over_after_refresh_transport_error(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
-    account = _make_account("acc_ws_refresh_timeout")
+    first_account = _make_account("acc_ws_refresh_timeout")
+    second_account = _make_account("acc_ws_refresh_ok")
     release_reservation = AsyncMock()
+    record_error = AsyncMock()
+    upstream = SimpleNamespace()
 
     monkeypatch.setattr(
         service._load_balancer,
         "select_account",
-        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+        AsyncMock(
+            side_effect=[
+                AccountSelection(account=first_account, error_message=None),
+                AccountSelection(account=second_account, error_message=None),
+            ]
+        ),
     )
-    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=asyncio.TimeoutError()))
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=[asyncio.TimeoutError(), second_account]),
+    )
+    monkeypatch.setattr(proxy_service, "connect_responses_websocket", AsyncMock(return_value=upstream))
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
     monkeypatch.setattr(service, "_release_websocket_reservation", release_reservation)
 
     request_state = proxy_service._WebSocketRequestState(
@@ -5763,18 +5777,132 @@ async def test_connect_proxy_websocket_surfaces_refresh_transport_error(monkeypa
         websocket=websocket,
     )
 
+    assert selected_account == second_account
+    assert selected_upstream == upstream
+    record_error.assert_awaited_once_with(first_account)
+    websocket_send.assert_not_awaited()
+    release_reservation.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_proxy_websocket_fails_over_after_upstream_connect_timeout(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    first_account = _make_account("acc_ws_connect_timeout")
+    second_account = _make_account("acc_ws_connect_ok")
+    release_reservation = AsyncMock()
+    record_error = AsyncMock()
+    upstream = SimpleNamespace()
+
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(
+            side_effect=[
+                AccountSelection(account=first_account, error_message=None),
+                AccountSelection(account=second_account, error_message=None),
+            ]
+        ),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[first_account, second_account]))
+    monkeypatch.setattr(
+        proxy_service,
+        "connect_responses_websocket",
+        AsyncMock(side_effect=[asyncio.TimeoutError(), upstream]),
+    )
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service, "_release_websocket_reservation", release_reservation)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_connect_timeout",
+        model="gpt-5.1",
+        service_tier="fast",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+
+    websocket_send = AsyncMock()
+    websocket = cast(WebSocket, SimpleNamespace(send_text=websocket_send))
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=websocket,
+    )
+
+    assert selected_account == second_account
+    assert selected_upstream == upstream
+    record_error.assert_awaited_once_with(first_account)
+    websocket_send.assert_not_awaited()
+    release_reservation.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_proxy_websocket_surfaces_connect_timeout_when_no_failover_account(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    first_account = _make_account("acc_ws_only_timeout")
+    record_error = AsyncMock()
+
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(
+            side_effect=[
+                AccountSelection(account=first_account, error_message=None),
+                AccountSelection(
+                    account=None,
+                    error_message="No active accounts available",
+                    error_code="no_accounts",
+                ),
+            ]
+        ),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=first_account))
+    monkeypatch.setattr(proxy_service, "connect_responses_websocket", AsyncMock(side_effect=asyncio.TimeoutError()))
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_single_connect_timeout",
+        model="gpt-5.1",
+        service_tier="fast",
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+
+    websocket_send = AsyncMock()
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=cast(WebSocket, SimpleNamespace(send_text=websocket_send)),
+    )
+
     assert selected_account is None
     assert selected_upstream is None
-    release_reservation.assert_awaited_once_with(None)
+    record_error.assert_awaited_once_with(first_account)
     await_args = websocket_send.await_args
     assert await_args is not None
     sent_payload = json.loads(await_args.args[0])
     assert sent_payload["status"] == 502
     assert sent_payload["error"]["code"] == "upstream_unavailable"
-    assert sent_payload["error"]["message"] == "Request to upstream timed out"
-    assert request_logs.calls[0]["request_id"] == "ws_req_refresh_timeout"
+    assert request_logs.calls[0]["account_id"] == first_account.id
     assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
-    assert request_logs.calls[0]["transport"] == "websocket"
 
 
 @pytest.mark.asyncio
@@ -5967,20 +6095,37 @@ async def test_select_websocket_connect_account_preferred_owner_missing_fails_cl
 
 
 @pytest.mark.asyncio
-async def test_connect_proxy_websocket_surfaces_forced_refresh_transport_error(monkeypatch):
+async def test_connect_proxy_websocket_fails_over_after_forced_refresh_transport_error(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
-    account = _make_account("acc_ws_forced_refresh_timeout")
+    first_account = _make_account("acc_ws_forced_refresh_timeout")
+    second_account = _make_account("acc_ws_forced_refresh_ok")
     initial_error = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "expired"))
     release_reservation = AsyncMock()
+    record_error = AsyncMock()
+    upstream = SimpleNamespace()
 
     monkeypatch.setattr(
         service._load_balancer,
         "select_account",
-        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+        AsyncMock(
+            side_effect=[
+                AccountSelection(account=first_account, error_message=None),
+                AccountSelection(account=second_account, error_message=None),
+            ]
+        ),
     )
-    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account, asyncio.TimeoutError()]))
-    monkeypatch.setattr(service, "_open_upstream_websocket", AsyncMock(side_effect=initial_error))
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=[first_account, asyncio.TimeoutError(), second_account]),
+    )
+    monkeypatch.setattr(
+        service,
+        "_open_upstream_websocket",
+        AsyncMock(side_effect=[initial_error, upstream]),
+    )
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
     monkeypatch.setattr(service, "_release_websocket_reservation", release_reservation)
 
     request_state = proxy_service._WebSocketRequestState(
@@ -6007,18 +6152,11 @@ async def test_connect_proxy_websocket_surfaces_forced_refresh_transport_error(m
         websocket=websocket,
     )
 
-    assert selected_account is None
-    assert selected_upstream is None
-    release_reservation.assert_awaited_once_with(None)
-    await_args = websocket_send.await_args
-    assert await_args is not None
-    sent_payload = json.loads(await_args.args[0])
-    assert sent_payload["status"] == 502
-    assert sent_payload["error"]["code"] == "upstream_unavailable"
-    assert sent_payload["error"]["message"] == "Request to upstream timed out"
-    assert request_logs.calls[0]["request_id"] == "ws_req_forced_refresh_timeout"
-    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
-    assert request_logs.calls[0]["transport"] == "websocket"
+    assert selected_account == second_account
+    assert selected_upstream == upstream
+    record_error.assert_awaited_once_with(first_account)
+    websocket_send.assert_not_awaited()
+    release_reservation.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- route websocket connect, refresh, and forced-refresh transport timeouts through deterministic account failover instead of surfacing the first account failure to the client
- avoid classifying inner upstream websocket connect timeouts as proxy request budget exhaustion unless the outer proxy budget actually elapsed
- update websocket connect tests to assert retryable pre-visible transport failures reach the next account without emitting a downstream error

## Testing
- `uv run pytest tests/unit/test_proxy_utils.py -q -k 'websocket_connect or connect_proxy_websocket or open_upstream_websocket'`
- `uv run pytest tests/integration/test_proxy_websocket_responses.py -q -k 'connect or reconnect or retry or failover'`
- `uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `git diff --check origin/main..HEAD`
