### PR TITLE
fix: Codex websocket pre-created keepalives

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3539,6 +3539,7 @@ class ProxyService:
                             proxy_request_budget_seconds=runtime_settings.proxy_request_budget_seconds,
                             stream_idle_timeout_seconds=runtime_settings.stream_idle_timeout_seconds,
                             downstream_activity=downstream_activity,
+                            codex_session_affinity=codex_session_affinity,
                         )
                     )
 
@@ -7220,6 +7221,7 @@ class ProxyService:
         proxy_request_budget_seconds: float,
         stream_idle_timeout_seconds: float,
         downstream_activity: _DownstreamWebSocketActivity,
+        codex_session_affinity: bool = True,
         continuity_state: "_WebSocketContinuityState | None" = None,
     ) -> None:
         try:
@@ -7257,6 +7259,7 @@ class ProxyService:
                                 pending_lock=pending_lock,
                                 client_send_lock=client_send_lock,
                                 downstream_activity=downstream_activity,
+                                codex_session_affinity=codex_session_affinity,
                             )
                         except Exception:
                             downstream_activity.mark_disconnected()
@@ -7858,13 +7861,16 @@ class ProxyService:
         pending_lock: anyio.Lock,
         client_send_lock: anyio.Lock,
         downstream_activity: _DownstreamWebSocketActivity,
+        codex_session_affinity: bool,
     ) -> bool:
         async with pending_lock:
             keepalive_ids = [
                 request_state.response_id for request_state in pending_requests if request_state.response_id is not None
             ]
-        if not keepalive_ids:
-            return False
+            precreated_request_ids = [
+                request_state.request_id for request_state in pending_requests if request_state.response_id is None
+            ]
+        emitted = False
         for response_id in keepalive_ids:
             event = {
                 "type": "response.in_progress",
@@ -7876,7 +7882,22 @@ class ProxyService:
                 text=json.dumps(event, ensure_ascii=True, separators=(",", ":")),
                 downstream_activity=downstream_activity,
             )
-        return True
+            emitted = True
+        if codex_session_affinity:
+            for request_id in precreated_request_ids:
+                event = {
+                    "type": "codex.keepalive",
+                    "request_id": request_id,
+                    "status": "pending_response_created",
+                }
+                await self._send_downstream_websocket_text(
+                    websocket,
+                    client_send_lock=client_send_lock,
+                    text=json.dumps(event, ensure_ascii=True, separators=(",", ":")),
+                    downstream_activity=downstream_activity,
+                )
+                emitted = True
+        return emitted
 
     async def _downstream_websocket_is_idle(
         self,

--- a/openspec/changes/fix-ws-precreated-heartbeat/proposal.md
+++ b/openspec/changes/fix-ws-precreated-heartbeat/proposal.md
@@ -1,0 +1,18 @@
+# Fix WebSocket pre-created heartbeat gap
+
+## Why
+
+Codex WebSocket clients reset their stream idle watchdog only when an application text frame reaches the client. WebSocket protocol ping/pong frames are handled below that layer and do not reset Codex's `idle timeout waiting for websocket` timer.
+
+codex-lb already emits `response.in_progress` keepalives after upstream assigns a `response.id`, but it deliberately emits nothing before `response.created`. If ChatGPT stays silent before assigning the response id while the proxy is still actively waiting, Codex clients can disconnect even though the upstream WebSocket transport is healthy.
+
+## What Changes
+
+- Emit a Codex-native vendor heartbeat for pending Codex WebSocket requests that do not yet have a `response.id`.
+- Preserve existing `response.in_progress` keepalives once `response.created` assigns a response id.
+- Keep public `/v1/responses` WebSocket behavior unchanged: no vendor pre-created heartbeat on OpenAI-style WebSocket sessions.
+- Add regression coverage for the pre-created silence gap and for public `/v1` isolation.
+
+## Impact
+
+Codex CLI WebSocket turns survive extended upstream silence before `response.created`. OpenAI-style `/v1/responses` WebSocket clients do not receive new `codex.*` vendor frames.

--- a/openspec/changes/fix-ws-precreated-heartbeat/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-ws-precreated-heartbeat/specs/responses-api-compat/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Codex WebSocket pre-created turns receive application heartbeats
+When serving the Codex-native `/backend-api/codex/responses` WebSocket route, the proxy SHALL emit a parseable Codex vendor heartbeat while a `response.create` request is pending but upstream has not yet emitted `response.created`. The heartbeat MUST be an application text frame so Codex clients reset stream-idle watchdogs that do not observe WebSocket protocol ping/pong frames. Once upstream assigns a response id, the proxy MUST continue using the existing `response.in_progress` heartbeat shape for that response id.
+
+#### Scenario: Codex websocket upstream is silent before response.created
+- **GIVEN** a Codex-native WebSocket `/backend-api/codex/responses` request is pending
+- **AND** upstream has not emitted `response.created` for the request
+- **WHEN** no upstream application frame arrives before the configured keepalive interval
+- **THEN** the proxy emits a `codex.keepalive` text event downstream
+- **AND** the request remains pending for the upstream `response.created` or terminal event
+
+#### Scenario: OpenAI-style v1 websocket does not receive Codex vendor heartbeat
+- **GIVEN** an OpenAI-style WebSocket `/v1/responses` request is pending
+- **AND** upstream has not emitted `response.created` for the request
+- **WHEN** no upstream application frame arrives before the configured keepalive interval
+- **THEN** the proxy MUST NOT emit a `codex.keepalive` vendor event downstream

--- a/openspec/changes/fix-ws-precreated-heartbeat/tasks.md
+++ b/openspec/changes/fix-ws-precreated-heartbeat/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+- [x] Add a responses-api-compat delta for Codex-native pre-created WebSocket heartbeats and public `/v1` isolation.
+
+## 2. Tests
+- [x] Add/update unit coverage proving Codex-native WebSocket relays emit a parseable vendor heartbeat before `response.created`.
+- [x] Add unit coverage proving OpenAI-style `/v1` WebSocket relays do not emit the vendor heartbeat before `response.created`.
+- [x] Keep existing post-created `response.in_progress` heartbeat coverage green.
+
+## 3. Implementation
+- [x] Teach the WebSocket relay whether the downstream route is Codex-native.
+- [x] Emit `codex.keepalive` for pending unresolved Codex-native requests when upstream is silent.
+- [x] Preserve the existing `response.in_progress` keepalive after a response id is known.
+
+## 4. Verification
+- [x] Run focused websocket regression tests.
+- [x] Run OpenSpec validation.
+- [x] Run the relevant Python test subset / lint gates.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5566,7 +5566,16 @@ async def test_v1_responses_http_bridge_does_not_evict_queued_session_when_pool_
     app_instance,
     monkeypatch,
 ):
-    _install_bridge_settings_with_limits(monkeypatch, enabled=True, max_sessions=1)
+    _install_bridge_settings_with_limits(
+        monkeypatch,
+        enabled=True,
+        max_sessions=1,
+        # This test verifies pool accounting for a queued request. Keep the
+        # synthetic request queued long enough on slow CI hosts so the
+        # response-create gate timeout does not drain it before the pool-full
+        # assertion runs.
+        admission_wait_timeout_seconds=30.0,
+    )
     account_id = await _import_account(
         async_client,
         "acc_http_bridge_queued_capacity",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9504,7 +9504,7 @@ async def test_relay_upstream_websocket_emits_keepalive_while_upstream_is_silent
 
 
 @pytest.mark.asyncio
-async def test_relay_upstream_websocket_does_not_invent_keepalive_id_before_response_created(monkeypatch):
+async def test_relay_upstream_websocket_emits_codex_keepalive_before_response_created(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
@@ -9560,6 +9560,85 @@ async def test_relay_upstream_websocket_does_not_invent_keepalive_id_before_resp
             proxy_request_budget_seconds=5.0,
             stream_idle_timeout_seconds=5.0,
             downstream_activity=proxy_service._DownstreamWebSocketActivity(),
+        )
+    )
+
+    try:
+        for _ in range(20):
+            if downstream.sent_text:
+                break
+            await asyncio.sleep(0.01)
+        assert downstream.sent_text
+        emitted = json.loads(downstream.sent_text[0])
+        assert emitted == {
+            "type": "codex.keepalive",
+            "request_id": "ws_req_precreated_keepalive",
+            "status": "pending_response_created",
+        }
+    finally:
+        relay.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await relay
+
+
+@pytest.mark.asyncio
+async def test_relay_upstream_websocket_omits_codex_keepalive_for_v1_before_response_created(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.sse_keepalive_interval_seconds = 0.01
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    class _FakeDownstreamWebSocket:
+        def __init__(self) -> None:
+            self.sent_text: list[str] = []
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+    class _SilentBeforeCreatedUpstream:
+        def __init__(self) -> None:
+            self._closed = asyncio.Event()
+
+        async def receive(self) -> SimpleNamespace:
+            await self._closed.wait()
+            return SimpleNamespace(kind="close", text=None, data=None, close_code=1000, error=None)
+
+        async def close(self) -> None:
+            self._closed.set()
+
+    downstream = _FakeDownstreamWebSocket()
+    upstream = _SilentBeforeCreatedUpstream()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_v1_precreated_keepalive",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    pending_requests = deque([request_state])
+
+    relay = asyncio.create_task(
+        service._relay_upstream_websocket_messages(
+            cast(WebSocket, downstream),
+            cast(proxy_service.UpstreamResponsesWebSocket, upstream),
+            account=_make_account("acc_ws_v1_precreated_keepalive"),
+            account_id_value="acc_ws_v1_precreated_keepalive",
+            pending_requests=pending_requests,
+            pending_lock=anyio.Lock(),
+            client_send_lock=anyio.Lock(),
+            api_key=None,
+            upstream_control=proxy_service._WebSocketUpstreamControl(),
+            response_create_gate=asyncio.Semaphore(1),
+            proxy_request_budget_seconds=5.0,
+            stream_idle_timeout_seconds=5.0,
+            downstream_activity=proxy_service._DownstreamWebSocketActivity(),
+            codex_session_affinity=False,
         )
     )
 


### PR DESCRIPTION
## Summary
- diagnose and codify the Codex WebSocket pre-`response.created` idle gap: protocol ping/pong does not reset Codex's application stream idle watchdog
- emit a Codex-native `codex.keepalive` text event for `/backend-api/codex/responses` while a request is pending but no `response.id` exists yet
- preserve public `/v1/responses` compatibility by suppressing the vendor heartbeat on OpenAI-style WebSocket sessions, and keep post-created `response.in_progress` keepalives unchanged

## Root cause
Codex clients time out on application-message silence. codex-lb already sent `response.in_progress` after `response.created`, but before that point there is no `response_id`, so the proxy had no legal `response.in_progress` envelope to send. If upstream stayed silent before assigning the response id, the downstream Codex client could hit `idle timeout waiting for websocket` even while the upstream WebSocket transport remained alive.

## Tests
- `uv run pytest tests/unit/test_proxy_utils.py::test_relay_upstream_websocket_emits_keepalive_while_upstream_is_silent tests/unit/test_proxy_utils.py::test_relay_upstream_websocket_emits_codex_keepalive_before_response_created tests/unit/test_proxy_utils.py::test_relay_upstream_websocket_omits_codex_keepalive_for_v1_before_response_created tests/integration/test_proxy_websocket_responses.py -q`
- `uv run pytest tests/unit/test_proxy_utils.py -q`
- `uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `uv run ruff format --check app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `uv run openspec validate fix-ws-precreated-heartbeat --strict`
