### PR TITLE
fix(proxy): replay pre-visible websocket drops

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -17,10 +17,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--timeout-keep-alive",
         type=int,
-        default=int(os.getenv("UVICORN_TIMEOUT_KEEP_ALIVE", "300")),
+        default=int(os.getenv("UVICORN_TIMEOUT_KEEP_ALIVE", "7200")),
         help=(
             "Seconds to keep idle HTTP connections open. Codex CLI reuses local "
-            "connections for compact POSTs; uvicorn's 5s default can leave the "
+            "connections for large compact POSTs; short keepalive windows can leave the "
             "client writing to a stale socket before the request reaches the app."
         ),
     )

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2241,6 +2241,18 @@ async def _stream_responses_with_session(
                 ),
             )
             return
+        total_elapsed_seconds = max(0.0, now - pre_request_started_at)
+        if request_total_timeout is None or total_elapsed_seconds < request_total_timeout:
+            error_code = "upstream_unavailable"
+            error_message = str(exc) or "Request to upstream timed out"
+            yield format_sse_event(
+                response_failed_event(
+                    "upstream_unavailable",
+                    error_message,
+                    response_id=get_request_id(),
+                ),
+            )
+            return
         error_code = "upstream_request_timeout"
         error_message = "Proxy request budget exhausted"
         yield format_sse_event(

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -184,7 +184,7 @@ class Settings(BaseSettings):
     log_upstream_request_payload: bool = False
     conversation_archive_enabled: bool = False
     conversation_archive_dir: Path = DEFAULT_HOME_DIR / "conversation-archive"
-    conversation_archive_queue_max_bytes: int = Field(default=8 * 1024 * 1024, gt=0)
+    conversation_archive_queue_max_bytes: int = Field(default=256 * 1024 * 1024, gt=0)
     max_decompressed_body_bytes: int = Field(default=32 * 1024 * 1024, gt=0)
     max_decompressed_responses_body_bytes: int = Field(default=128 * 1024 * 1024, gt=0)
     image_inline_fetch_enabled: bool = True

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -268,11 +268,11 @@ def _append_records(items: Sequence[tuple[Path, Mapping[str, Any], int]]) -> Non
     for path, record, _queued_bytes in items:
         grouped.setdefault(path, []).append(record)
 
-    try:
-        with _WRITE_LOCK:
-            if _archive_disk_pressure_active():
-                return
-            for path, records in grouped.items():
+    with _WRITE_LOCK:
+        if _archive_disk_pressure_active():
+            return
+        for path, records in grouped.items():
+            try:
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.parent.chmod(_ARCHIVE_DIR_MODE)
                 _recover_corrupt_gzip_archive(path)
@@ -280,14 +280,12 @@ def _append_records(items: Sequence[tuple[Path, Mapping[str, Any], int]]) -> Non
                     _write_gzip_jsonl_record(path, records[0])
                 else:
                     _write_gzip_jsonl_records(path, records)
-    except Exception as exc:
-        for path in grouped:
-            _RECOVERY_CHECKED_PATHS.discard(path.resolve())
-        if _is_disk_pressure_error(exc):
-            first_path = next(iter(grouped))
-            _pause_archive_for_disk_pressure(first_path, exc)
-            return
-        logger.warning("Failed to append conversation archive record", exc_info=True)
+            except Exception as exc:
+                _RECOVERY_CHECKED_PATHS.discard(path.resolve())
+                if _is_disk_pressure_error(exc):
+                    _pause_archive_for_disk_pressure(path, exc)
+                    return
+                logger.warning("Failed to append conversation archive record", exc_info=True)
 
 
 def _serialized_record_size(record: Mapping[str, Any]) -> int:

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -11,7 +11,7 @@ import queue
 import threading
 import time
 import zlib
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -258,7 +258,7 @@ def _append_record(path: Path, record: Mapping[str, Any]) -> None:
     _append_records([(path, record, 0)])
 
 
-def _append_records(items: list[tuple[Path, Mapping[str, Any], int]]) -> None:
+def _append_records(items: Sequence[tuple[Path, Mapping[str, Any], int]]) -> None:
     if not items:
         return
     if _archive_disk_pressure_active():

--- a/app/core/conversation_archive.py
+++ b/app/core/conversation_archive.py
@@ -228,33 +228,64 @@ def _ensure_writer_thread() -> None:
 def _writer_loop() -> None:
     while True:
         item = _WRITE_QUEUE.get()
+        batch: list[tuple[Path, dict[str, Any], int]] = []
+        stop_after_batch = False
         try:
             if item is None:
+                _WRITE_QUEUE.task_done()
                 return
-            path, record, queued_bytes = item
-            _append_record(path, record)
+            batch.append(item)
+            while True:
+                try:
+                    next_item = _WRITE_QUEUE.get_nowait()
+                except queue.Empty:
+                    break
+                if next_item is None:
+                    stop_after_batch = True
+                    _WRITE_QUEUE.task_done()
+                    break
+                batch.append(next_item)
+            _append_records(batch)
         finally:
-            if item is not None:
-                _release_archive_queue_bytes(queued_bytes)
-            _WRITE_QUEUE.task_done()
+            for queued_item in batch:
+                _release_archive_queue_bytes(queued_item[2])
+                _WRITE_QUEUE.task_done()
+        if stop_after_batch:
+            return
 
 
 def _append_record(path: Path, record: Mapping[str, Any]) -> None:
+    _append_records([(path, record, 0)])
+
+
+def _append_records(items: list[tuple[Path, Mapping[str, Any], int]]) -> None:
+    if not items:
+        return
     if _archive_disk_pressure_active():
         return
+
+    grouped: dict[Path, list[Mapping[str, Any]]] = {}
+    for path, record, _queued_bytes in items:
+        grouped.setdefault(path, []).append(record)
 
     try:
         with _WRITE_LOCK:
             if _archive_disk_pressure_active():
                 return
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.parent.chmod(_ARCHIVE_DIR_MODE)
-            _recover_corrupt_gzip_archive(path)
-            _write_gzip_jsonl_record(path, record)
+            for path, records in grouped.items():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.parent.chmod(_ARCHIVE_DIR_MODE)
+                _recover_corrupt_gzip_archive(path)
+                if len(records) == 1:
+                    _write_gzip_jsonl_record(path, records[0])
+                else:
+                    _write_gzip_jsonl_records(path, records)
     except Exception as exc:
-        _RECOVERY_CHECKED_PATHS.discard(path.resolve())
+        for path in grouped:
+            _RECOVERY_CHECKED_PATHS.discard(path.resolve())
         if _is_disk_pressure_error(exc):
-            _pause_archive_for_disk_pressure(path, exc)
+            first_path = next(iter(grouped))
+            _pause_archive_for_disk_pressure(first_path, exc)
             return
         logger.warning("Failed to append conversation archive record", exc_info=True)
 
@@ -330,14 +361,21 @@ def _archive_backpressure_warning_state() -> tuple[bool, int]:
 
 
 def _write_gzip_jsonl_record(path: Path, record: Mapping[str, Any]) -> None:
+    _write_gzip_jsonl_records(path, [record])
+
+
+def _write_gzip_jsonl_records(path: Path, records: list[Mapping[str, Any]]) -> None:
+    if not records:
+        return
     fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, _ARCHIVE_FILE_MODE)
     try:
         os.fchmod(fd, _ARCHIVE_FILE_MODE)
         with os.fdopen(fd, "ab") as fh:
             fd = -1
             with gzip.open(fh, "at", encoding="utf-8") as gzip_fh:
-                json.dump(record, gzip_fh, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
-                gzip_fh.write("\n")
+                for record in records:
+                    json.dump(record, gzip_fh, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+                    gzip_fh.write("\n")
     finally:
         if fd >= 0:
             os.close(fd)

--- a/app/core/middleware/inflight.py
+++ b/app/core/middleware/inflight.py
@@ -9,6 +9,7 @@ _DRAIN_ALLOWED_HTTP_PATHS = frozenset(
     {
         "/health/live",
         "/internal/drain/start",
+        "/internal/drain/stop",
         "/internal/drain/status",
         "/internal/bridge/responses",
     }
@@ -20,6 +21,7 @@ _IN_FLIGHT_EXCLUDED_HTTP_PATHS = frozenset(
         "/health/ready",
         "/health/startup",
         "/internal/drain/start",
+        "/internal/drain/stop",
         "/internal/drain/status",
     }
 )

--- a/app/core/utils/sse.py
+++ b/app/core/utils/sse.py
@@ -11,11 +11,14 @@ from app.core.utils.json_guards import is_json_dict
 type JsonPayload = Mapping[str, JsonValue] | ResponseFailedEvent
 
 SSE_KEEPALIVE_FRAME = ": keepalive\n\n"
+CODEX_KEEPALIVE_FRAME = 'event: codex.keepalive\ndata: {"type":"codex.keepalive"}\n\n'
 
 
 async def inject_sse_keepalives(
     source: AsyncIterator[str],
     interval_seconds: float,
+    *,
+    keepalive_frame: str = SSE_KEEPALIVE_FRAME,
 ) -> AsyncIterator[str]:
     """Wrap an SSE event iterator and emit comment heartbeats on idle gaps.
 
@@ -46,7 +49,7 @@ async def inject_sse_keepalives(
                     timeout=interval_seconds,
                 )
             except asyncio.TimeoutError:
-                yield SSE_KEEPALIVE_FRAME
+                yield keepalive_frame
                 continue
             except StopAsyncIteration:
                 pending = None

--- a/app/modules/health/api.py
+++ b/app/modules/health/api.py
@@ -108,6 +108,20 @@ async def start_internal_drain(request: Request) -> HealthCheckResponse:
     return HealthCheckResponse(status="ok", checks={"draining": "ok"})
 
 
+@router.post("/internal/drain/stop", include_in_schema=False)
+async def stop_internal_drain(request: Request) -> HealthCheckResponse:
+    client_host = request.client.host if request.client is not None else None
+    if not _is_internal_client_host(client_host):
+        raise HTTPException(status_code=403, detail="Internal access required")
+
+    import app.core.shutdown as shutdown_state
+
+    shutdown_state.set_draining(False)
+    shutdown_state.set_bridge_drain_active(False)
+
+    return HealthCheckResponse(status="ok", checks={"draining": "false"})
+
+
 @router.get("/internal/drain/status", include_in_schema=False)
 async def internal_drain_status(request: Request) -> HealthCheckResponse:
     client_host = request.client.host if request.client is not None else None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -70,9 +70,16 @@ from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRe
 from app.core.resilience.overload import is_local_overload_error_code, merge_retry_after_headers
 from app.core.runtime_logging import log_error_response
 from app.core.types import JsonValue
+from app.core.usage.types import UsageWindowRow
 from app.core.utils.json_guards import is_json_mapping
-from app.core.utils.sse import format_sse_event, inject_sse_keepalives, parse_sse_data_json
-from app.db.models import Account, AccountStatus
+from app.core.utils.sse import (
+    CODEX_KEEPALIVE_FRAME,
+    SSE_KEEPALIVE_FRAME,
+    format_sse_event,
+    inject_sse_keepalives,
+    parse_sse_data_json,
+)
+from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
 from app.dependencies import ProxyContext, get_proxy_context, get_proxy_websocket_context
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -1931,6 +1938,7 @@ async def _stream_responses(
         inject_sse_keepalives(
             stream,
             get_settings().sse_keepalive_interval_seconds,
+            keepalive_frame=CODEX_KEEPALIVE_FRAME if not enforce_openai_sdk_contract else SSE_KEEPALIVE_FRAME,
         ),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", **turn_state_headers, **rate_limit_headers},

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -70,7 +70,6 @@ from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRe
 from app.core.resilience.overload import is_local_overload_error_code, merge_retry_after_headers
 from app.core.runtime_logging import log_error_response
 from app.core.types import JsonValue
-from app.core.usage.types import UsageWindowRow
 from app.core.utils.json_guards import is_json_mapping
 from app.core.utils.sse import (
     CODEX_KEEPALIVE_FRAME,
@@ -79,7 +78,7 @@ from app.core.utils.sse import (
     inject_sse_keepalives,
     parse_sse_data_json,
 )
-from app.db.models import Account, AccountStatus, UsageHistory
+from app.db.models import Account, AccountStatus
 from app.db.session import get_background_session
 from app.dependencies import ProxyContext, get_proxy_context, get_proxy_websocket_context
 from app.modules.api_keys.repository import ApiKeysRepository

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1525,6 +1525,7 @@ class ProxyService:
                         event_block = await asyncio.wait_for(event_queue.get(), timeout=wait_timeout)
                     except asyncio.TimeoutError:
                         keepalive_count += 1
+                        downstream_response_id = _websocket_downstream_response_id(request_state)
                         if keepalive_count > _STREAM_KEEPALIVE_MAX_COUNT:
                             logger.info(
                                 "HTTP bridge stream idle timeout request_id=%s keepalive_count=%s",
@@ -1537,21 +1538,21 @@ class ProxyService:
                                     response_failed_event(
                                         "stream_idle_timeout",
                                         "Upstream did not respond within the keepalive window",
-                                        response_id=request_state.response_id or request_state.request_id,
+                                        response_id=downstream_response_id,
                                     ),
                                 )
                             )
                             break
                         keepalive_sent = True
                         yielded_any = True
-                        if request_state.response_id:
+                        if request_state.response_id or request_state.replay_downstream_response_id:
                             yield format_sse_event(
                                 cast(
                                     Mapping[str, JsonValue],
                                     {
                                         "type": "response.in_progress",
                                         "response": {
-                                            "id": request_state.response_id,
+                                            "id": downstream_response_id,
                                             "status": "in_progress",
                                         },
                                     },
@@ -1585,7 +1586,7 @@ class ProxyService:
                         block_payload,
                         block_event_type,
                     ) = _build_rewritten_stream_response_failed_event(
-                        response_id=request_state.response_id or request_state.request_id,
+                        response_id=_websocket_downstream_response_id(request_state),
                         error_code="stream_incomplete",
                         error_message="Upstream websocket closed before response.completed",
                     )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6979,6 +6979,7 @@ class ProxyService:
                     matched_request_state.suppress_next_created_downstream = False
                     suppress_downstream_event = True
                 if payload is not None:
+                    payload = _rewrite_websocket_downstream_response_id(payload, matched_request_state)
                     event_block = format_sse_event(payload)
 
             terminal_request_state = None
@@ -7893,6 +7894,7 @@ class ProxyService:
                     request_state.suppress_next_created_downstream = False
                     upstream_control.suppress_downstream_event = True
                 if payload is not None:
+                    payload = _rewrite_websocket_downstream_response_id(payload, request_state)
                     text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
             if (
                 event_type in {"response.completed", "response.failed", "response.incomplete", "error"}
@@ -8552,7 +8554,7 @@ class ProxyService:
                             request_error_code,
                             request_error_message,
                             error_type=request_error_type,
-                            response_id=request_state.response_id or request_state.request_id,
+                            response_id=_websocket_downstream_response_id(request_state),
                             error_param=request_error_param,
                         )
                     )
@@ -8614,7 +8616,7 @@ class ProxyService:
             error_code,
             error_message,
             error_type=error_type,
-            response_id=request_state.response_id or request_state.request_id,
+            response_id=_websocket_downstream_response_id(request_state),
             error_param=error_param,
         )
         response_create_gate = request_state.response_create_gate
@@ -10938,6 +10940,9 @@ def _websocket_request_can_replay_before_visible_output(request_state: "_WebSock
 def _prepare_websocket_request_state_for_visible_output_replay(
     request_state: "_WebSocketRequestState",
 ) -> str | None:
+    downstream_response_id = None
+    if request_state.response_id is not None and not request_state.awaiting_response_created:
+        downstream_response_id = request_state.response_id
     if (
         request_state.proxy_injected_previous_response_id
         and request_state.fresh_upstream_request_is_retry_safe
@@ -10955,7 +10960,8 @@ def _prepare_websocket_request_state_for_visible_output_replay(
     request_state.awaiting_response_created = True
     request_state.response_id = None
     request_state.response_event_count = 0
-    request_state.suppress_next_created_downstream = False
+    request_state.replay_downstream_response_id = downstream_response_id
+    request_state.suppress_next_created_downstream = downstream_response_id is not None
     return request_text
 
 
@@ -11023,6 +11029,7 @@ class _WebSocketRequestState:
     api_key_reservation_heartbeat_task: asyncio.Task[None] | None = None
     downstream_visible: bool = False
     suppress_next_created_downstream: bool = False
+    replay_downstream_response_id: str | None = None
     draining_until_terminal: bool = False
 
 
@@ -11513,6 +11520,27 @@ def _websocket_response_id(event: OpenAIEvent | None, payload: dict[str, JsonVal
     return stripped or None
 
 
+def _websocket_downstream_response_id(request_state: "_WebSocketRequestState") -> str:
+    return request_state.replay_downstream_response_id or request_state.response_id or request_state.request_id
+
+
+def _rewrite_websocket_downstream_response_id(
+    payload: dict[str, JsonValue] | None,
+    request_state: "_WebSocketRequestState",
+) -> dict[str, JsonValue] | None:
+    downstream_response_id = request_state.replay_downstream_response_id
+    if downstream_response_id is None or not isinstance(payload, dict):
+        return payload
+
+    rewritten = dict(payload)
+    if isinstance(rewritten.get("response_id"), str):
+        rewritten["response_id"] = downstream_response_id
+    response = rewritten.get("response")
+    if isinstance(response, dict) and isinstance(response.get("id"), str):
+        rewritten["response"] = {**response, "id": downstream_response_id}
+    return rewritten
+
+
 def _websocket_event_error_code(event_type: str | None, payload: dict[str, JsonValue] | None) -> str | None:
     error = _websocket_event_error_payload(event_type, payload)
     if not isinstance(error, dict):
@@ -11857,7 +11885,7 @@ def _rewrite_websocket_continuity_corruption_event(
         "stream_incomplete",
         PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
         error_type="server_error",
-        response_id=request_state.response_id or request_state.request_id,
+        response_id=_websocket_downstream_response_id(request_state),
     )
     rewritten_text = json.dumps(rewritten_event_payload, ensure_ascii=True, separators=(",", ":"))
     rewritten_event_block = format_sse_event(rewritten_event_payload)
@@ -11881,7 +11909,7 @@ def _rewrite_websocket_previous_response_owner_unavailable_event(
         "upstream_unavailable",
         "Previous response owner account is unavailable; retry later.",
         error_type="server_error",
-        response_id=request_state.response_id or request_state.request_id,
+        response_id=_websocket_downstream_response_id(request_state),
     )
     rewritten_text = json.dumps(rewritten_event_payload, ensure_ascii=True, separators=(",", ":"))
     rewritten_event_block = format_sse_event(rewritten_event_payload)
@@ -11899,7 +11927,7 @@ def _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
         "stream_incomplete",
         _SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE,
         error_type="server_error",
-        response_id=request_state.response_id or request_state.request_id,
+        response_id=_websocket_downstream_response_id(request_state),
     )
     rewritten_text = json.dumps(rewritten_event_payload, ensure_ascii=True, separators=(",", ":"))
     rewritten_event_block = format_sse_event(rewritten_event_payload)
@@ -12363,7 +12391,7 @@ def _build_stream_incomplete_terminal_event_for_request(
     request_state: _WebSocketRequestState,
 ) -> tuple[str, str, OpenAIEvent | None, dict[str, JsonValue] | None, str | None]:
     event_block, event, payload, event_type = _build_rewritten_stream_response_failed_event(
-        response_id=request_state.response_id or request_state.request_id,
+        response_id=_websocket_downstream_response_id(request_state),
         error_code="stream_incomplete",
         error_message="Upstream websocket closed before response.completed",
     )
@@ -12374,7 +12402,7 @@ def _build_stream_incomplete_terminal_event_for_request(
                 "stream_incomplete",
                 "Upstream websocket closed before response.completed",
                 error_type="server_error",
-                response_id=request_state.response_id or request_state.request_id,
+                response_id=_websocket_downstream_response_id(request_state),
             ),
         ),
         ensure_ascii=True,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6926,6 +6926,7 @@ class ProxyService:
         async with session.pending_lock:
             matched_request_state = None
             created_request_state = None
+            suppress_downstream_event = False
             has_other_pending_requests = False
             grouped_previous_response_request_states: list[_WebSocketRequestState] = []
             anonymous_event_prefers_draining = event_type not in {"response.failed", "response.incomplete", "error"}
@@ -6974,6 +6975,9 @@ class ProxyService:
                     return
                 if event_type in _TEXT_DELTA_EVENT_TYPES:
                     matched_request_state.downstream_visible = True
+                if event_type == "response.created" and matched_request_state.suppress_next_created_downstream:
+                    matched_request_state.suppress_next_created_downstream = False
+                    suppress_downstream_event = True
                 if payload is not None:
                     event_block = format_sse_event(payload)
 
@@ -7280,7 +7284,11 @@ class ProxyService:
                 ),
             )
 
-        if matched_request_state is not None and matched_request_state.event_queue is not None:
+        if (
+            matched_request_state is not None
+            and matched_request_state.event_queue is not None
+            and not suppress_downstream_event
+        ):
             await matched_request_state.event_queue.put(event_block)
 
         if terminal_request_state is None:
@@ -7881,6 +7889,9 @@ class ProxyService:
                     return text
                 if event_type in _TEXT_DELTA_EVENT_TYPES:
                     request_state.downstream_visible = True
+                if event_type == "response.created" and request_state.suppress_next_created_downstream:
+                    request_state.suppress_next_created_downstream = False
+                    upstream_control.suppress_downstream_event = True
                 if payload is not None:
                     text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
             if (
@@ -10929,6 +10940,7 @@ def _prepare_websocket_request_state_for_visible_output_replay(
         request_state.proxy_injected_previous_response_id = False
         request_state.fresh_upstream_request_is_retry_safe = False
         _refresh_websocket_request_input_fingerprint_from_text(request_state)
+    suppress_replayed_created = request_state.response_id is not None and not request_state.awaiting_response_created
     request_text = request_state.request_text
     if not isinstance(request_text, str):
         return None
@@ -10936,6 +10948,7 @@ def _prepare_websocket_request_state_for_visible_output_replay(
     request_state.awaiting_response_created = True
     request_state.response_id = None
     request_state.response_event_count = 0
+    request_state.suppress_next_created_downstream = suppress_replayed_created
     return request_text
 
 
@@ -11002,6 +11015,7 @@ class _WebSocketRequestState:
     api_key_reservation_heartbeat_stop: asyncio.Event | None = None
     api_key_reservation_heartbeat_task: asyncio.Task[None] | None = None
     downstream_visible: bool = False
+    suppress_next_created_downstream: bool = False
     draining_until_terminal: bool = False
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6786,9 +6786,10 @@ class ProxyService:
         deadline = _websocket_connect_deadline(request_state, get_settings().proxy_request_budget_seconds)
         settings = await get_settings_cache().get()
         session.api_key = request_state.api_key
-        excluded_account_ids: set[str] = set()
-        retry_same_account_once = session.last_upstream_close_code not in _UPSTREAM_CLOSE_CODES_SKIP_SAME_ACCOUNT_RETRY
-        preferred_candidate_id: str | None = session.account.id
+        skip_same_account = session.last_upstream_close_code in _UPSTREAM_CLOSE_CODES_SKIP_SAME_ACCOUNT_RETRY
+        excluded_account_ids: set[str] = {session.account.id} if skip_same_account else set()
+        retry_same_account_once = not skip_same_account
+        preferred_candidate_id: str | None = None if skip_same_account else session.account.id
         while True:
             selection = await self._select_account_with_budget_compatible(
                 deadline,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6702,13 +6702,10 @@ class ProxyService:
             if len(retryable_requests) != 1:
                 return False
             request_state = retryable_requests[0]
-            if (
-                request_state.previous_response_id is not None
-                and not (
-                    request_state.proxy_injected_previous_response_id
-                    and request_state.fresh_upstream_request_is_retry_safe
-                    and request_state.fresh_upstream_request_text
-                )
+            if request_state.previous_response_id is not None and not (
+                request_state.proxy_injected_previous_response_id
+                and request_state.fresh_upstream_request_is_retry_safe
+                and request_state.fresh_upstream_request_text
             ):
                 # Once a continuation is pending upstream, reconnecting without
                 # replay cannot complete the current request, while replaying it

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10921,6 +10921,14 @@ def _websocket_request_can_replay_before_visible_output(request_state: "_WebSock
         request_state.response_id is not None
         and not request_state.awaiting_response_created
         and request_state.response_event_count <= 1
+        and (
+            request_state.previous_response_id is None
+            or (
+                request_state.proxy_injected_previous_response_id
+                and request_state.fresh_upstream_request_is_retry_safe
+                and bool(request_state.fresh_upstream_request_text)
+            )
+        )
     )
     if precreated_pending and request_state.response_event_count > 0:
         return False
@@ -10940,7 +10948,6 @@ def _prepare_websocket_request_state_for_visible_output_replay(
         request_state.proxy_injected_previous_response_id = False
         request_state.fresh_upstream_request_is_retry_safe = False
         _refresh_websocket_request_input_fingerprint_from_text(request_state)
-    suppress_replayed_created = request_state.response_id is not None and not request_state.awaiting_response_created
     request_text = request_state.request_text
     if not isinstance(request_text, str):
         return None
@@ -10948,7 +10955,7 @@ def _prepare_websocket_request_state_for_visible_output_replay(
     request_state.awaiting_response_created = True
     request_state.response_id = None
     request_state.response_event_count = 0
-    request_state.suppress_next_created_downstream = suppress_replayed_created
+    request_state.suppress_next_created_downstream = False
     return request_text
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11610,15 +11610,21 @@ async def _pop_replayable_precreated_websocket_request_state(
         if len(pending_requests) != 1:
             return None
         request_state = pending_requests[0]
-        if request_state.response_id is not None:
-            return None
-        if not request_state.awaiting_response_created:
-            return None
         if not request_state.request_text:
             return None
         if request_state.replay_count >= 1:
             return None
-        if request_state.response_event_count > 0:
+        if request_state.downstream_visible:
+            return None
+        precreated_pending = request_state.response_id is None and request_state.awaiting_response_created
+        created_only_pending = (
+            request_state.response_id is not None
+            and not request_state.awaiting_response_created
+            and request_state.response_event_count <= 1
+        )
+        if precreated_pending and request_state.response_event_count > 0:
+            return None
+        if not (precreated_pending or created_only_pending):
             return None
         pending_requests.popleft()
     if (
@@ -11634,6 +11640,7 @@ async def _pop_replayable_precreated_websocket_request_state(
     request_state.replay_count += 1
     request_state.awaiting_response_created = True
     request_state.response_id = None
+    request_state.response_event_count = 0
     return request_state
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11525,11 +11525,11 @@ def _websocket_downstream_response_id(request_state: "_WebSocketRequestState") -
 
 
 def _rewrite_websocket_downstream_response_id(
-    payload: dict[str, JsonValue] | None,
+    payload: dict[str, JsonValue],
     request_state: "_WebSocketRequestState",
-) -> dict[str, JsonValue] | None:
+) -> dict[str, JsonValue]:
     downstream_response_id = request_state.replay_downstream_response_id
-    if downstream_response_id is None or not isinstance(payload, dict):
+    if downstream_response_id is None:
         return payload
 
     rewritten = dict(payload)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6697,21 +6697,24 @@ class ProxyService:
                 request_state
                 for request_state in session.pending_requests
                 if not request_state.draining_until_terminal
-                and request_state.response_id is None
-                and request_state.awaiting_response_created
-                and bool(request_state.request_text)
+                and _websocket_request_can_replay_before_visible_output(request_state)
             ]
             if len(retryable_requests) != 1:
                 return False
             request_state = retryable_requests[0]
-            if request_state.previous_response_id is not None:
+            if (
+                request_state.previous_response_id is not None
+                and not (
+                    request_state.proxy_injected_previous_response_id
+                    and request_state.fresh_upstream_request_is_retry_safe
+                    and request_state.fresh_upstream_request_text
+                )
+            ):
                 # Once a continuation is pending upstream, reconnecting without
                 # replay cannot complete the current request, while replaying it
-                # is unsafe without upstream idempotency guarantees.
-                return False
-            if request_state.replay_count >= 1:
-                return False
-            if request_state.response_event_count > 0 or request_state.downstream_visible:
+                # is unsafe without upstream idempotency guarantees. Proxy-
+                # injected retry-safe anchors are equivalent to the client's own
+                # full resend once the anchor is stripped.
                 return False
             close_classification = _classify_upstream_close(
                 session.last_upstream_close_code,
@@ -6725,9 +6728,9 @@ class ProxyService:
                     f"(close_code={session.last_upstream_close_code})"
                 )
                 return False
-            request_text = request_state.request_text
-            assert isinstance(request_text, str)
-            request_state.replay_count += 1
+            request_text = _prepare_websocket_request_state_for_visible_output_replay(request_state)
+            if request_text is None:
+                return False
         _log_http_bridge_event(
             "retry_precreated",
             session.key,
@@ -10897,6 +10900,47 @@ def _record_response_event(request_state: _WebSocketRequestState | None, event_t
     request_state.response_event_count += 1
 
 
+def _websocket_request_can_replay_before_visible_output(request_state: "_WebSocketRequestState") -> bool:
+    if not request_state.request_text:
+        return False
+    if request_state.replay_count >= 1:
+        return False
+    if request_state.downstream_visible:
+        return False
+    precreated_pending = request_state.response_id is None and request_state.awaiting_response_created
+    created_only_pending = (
+        request_state.response_id is not None
+        and not request_state.awaiting_response_created
+        and request_state.response_event_count <= 1
+    )
+    if precreated_pending and request_state.response_event_count > 0:
+        return False
+    return precreated_pending or created_only_pending
+
+
+def _prepare_websocket_request_state_for_visible_output_replay(
+    request_state: "_WebSocketRequestState",
+) -> str | None:
+    if (
+        request_state.proxy_injected_previous_response_id
+        and request_state.fresh_upstream_request_is_retry_safe
+        and request_state.fresh_upstream_request_text
+    ):
+        request_state.request_text = request_state.fresh_upstream_request_text
+        request_state.previous_response_id = None
+        request_state.proxy_injected_previous_response_id = False
+        request_state.fresh_upstream_request_is_retry_safe = False
+        _refresh_websocket_request_input_fingerprint_from_text(request_state)
+    request_text = request_state.request_text
+    if not isinstance(request_text, str):
+        return None
+    request_state.replay_count += 1
+    request_state.awaiting_response_created = True
+    request_state.response_id = None
+    request_state.response_event_count = 0
+    return request_text
+
+
 @dataclass(frozen=True, slots=True)
 class _FilePinEntry:
     account_id: str
@@ -11610,37 +11654,11 @@ async def _pop_replayable_precreated_websocket_request_state(
         if len(pending_requests) != 1:
             return None
         request_state = pending_requests[0]
-        if not request_state.request_text:
-            return None
-        if request_state.replay_count >= 1:
-            return None
-        if request_state.downstream_visible:
-            return None
-        precreated_pending = request_state.response_id is None and request_state.awaiting_response_created
-        created_only_pending = (
-            request_state.response_id is not None
-            and not request_state.awaiting_response_created
-            and request_state.response_event_count <= 1
-        )
-        if precreated_pending and request_state.response_event_count > 0:
-            return None
-        if not (precreated_pending or created_only_pending):
+        if not _websocket_request_can_replay_before_visible_output(request_state):
             return None
         pending_requests.popleft()
-    if (
-        request_state.proxy_injected_previous_response_id
-        and request_state.fresh_upstream_request_is_retry_safe
-        and request_state.fresh_upstream_request_text
-    ):
-        request_state.request_text = request_state.fresh_upstream_request_text
-        request_state.previous_response_id = None
-        request_state.proxy_injected_previous_response_id = False
-        request_state.fresh_upstream_request_is_retry_safe = False
-        _refresh_websocket_request_input_fingerprint_from_text(request_state)
-    request_state.replay_count += 1
-    request_state.awaiting_response_created = True
-    request_state.response_id = None
-    request_state.response_event_count = 0
+    if _prepare_websocket_request_state_for_visible_output_replay(request_state) is None:
+        return None
     return request_state
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8347,12 +8347,13 @@ class ProxyService:
             upstream_control.retire_after_drain = True
         elif settlement.record_success:
             await self._load_balancer.record_success(account)
-            self._remember_websocket_previous_response_owner(
-                previous_response_id=response_id,
-                api_key_id=api_key.id if api_key is not None else None,
-                account_id=account_id_value,
-                session_id=request_state.session_id,
-            )
+            for remembered_response_id in _websocket_continuity_response_ids(request_state, response_id):
+                self._remember_websocket_previous_response_owner(
+                    previous_response_id=remembered_response_id,
+                    api_key_id=api_key.id if api_key is not None else None,
+                    account_id=account_id_value,
+                    session_id=request_state.session_id,
+                )
 
         latency_ms = int((time.monotonic() - request_state.started_at) * 1000)
         cached_input_tokens = usage.input_tokens_details.cached_tokens if usage and usage.input_tokens_details else None
@@ -8360,10 +8361,13 @@ class ProxyService:
             usage.output_tokens_details.reasoning_tokens if usage and usage.output_tokens_details else None
         )
         if not request_state.skip_request_log:
+            request_log_response_id = (
+                _websocket_downstream_response_id(request_state) if settlement.record_success else response_id
+            )
             await self._write_request_log(
                 account_id=account_id_value,
                 api_key=api_key,
-                request_id=response_id,
+                request_id=request_log_response_id,
                 model=request_state.model or "",
                 latency_ms=latency_ms,
                 status=status,
@@ -11523,6 +11527,20 @@ def _websocket_response_id(event: OpenAIEvent | None, payload: dict[str, JsonVal
 
 def _websocket_downstream_response_id(request_state: "_WebSocketRequestState") -> str:
     return request_state.replay_downstream_response_id or request_state.response_id or request_state.request_id
+
+
+def _websocket_continuity_response_ids(
+    request_state: "_WebSocketRequestState",
+    upstream_response_id: str | None,
+) -> tuple[str, ...]:
+    response_ids: list[str] = []
+    for response_id in (upstream_response_id, request_state.replay_downstream_response_id):
+        if not isinstance(response_id, str):
+            continue
+        stripped = response_id.strip()
+        if stripped and stripped not in response_ids:
+            response_ids.append(stripped)
+    return tuple(response_ids)
 
 
 def _rewrite_websocket_downstream_response_id(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -109,7 +109,7 @@ from app.core.usage.types import UsageWindowRow
 from app.core.utils.json_guards import is_json_mapping
 from app.core.utils.request_id import ensure_request_id, get_request_id
 from app.core.utils.retry import backoff_seconds
-from app.core.utils.sse import format_sse_event, parse_sse_data_json
+from app.core.utils.sse import CODEX_KEEPALIVE_FRAME, format_sse_event, parse_sse_data_json
 from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import (
     Account,
@@ -1558,7 +1558,7 @@ class ProxyService:
                                 )
                             )
                         else:
-                            yield ": keepalive\n\n"
+                            yield CODEX_KEEPALIVE_FRAME
                         continue
                 else:
                     event_block = await event_queue.get()

--- a/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-upstream-terminal-timeouts/specs/responses-api-compat/spec.md
@@ -55,7 +55,7 @@ When an upstream websocket or HTTP bridge session has multiple pending Responses
 - **AND** the younger request remains pending
 
 ### Requirement: HTTP bridge streams emit downstream liveness frames while pending
-When an HTTP bridge Responses request is waiting for upstream queue events, the system MUST emit a downstream SSE liveness frame at the configured `sse_keepalive_interval_seconds` interval so downstream clients do not disconnect before the upstream terminal frame arrives. The first generated liveness frame MUST be delayed until after the HTTP bridge startup-error probe window so a local startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response. Once a generated liveness frame is emitted, the stream MUST be considered started for later HTTP-error propagation decisions, so a subsequent upstream `response.failed` is forwarded in-stream instead of being raised as a startup HTTP error. If the pending request already has a response id, the liveness frame MAY be a `response.in_progress` SSE event for that response id. If no response id is known yet, the liveness frame MUST be an SSE comment block. Public `/v1/responses` stream normalization MUST preserve SSE comment keepalives instead of treating them as malformed data.
+When an HTTP bridge Responses request is waiting for upstream queue events, the system MUST emit a downstream SSE liveness frame at the configured `sse_keepalive_interval_seconds` interval so downstream clients do not disconnect before the upstream terminal frame arrives. The first generated liveness frame MUST be delayed until after the HTTP bridge startup-error probe window so a local startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response. Once a generated liveness frame is emitted, the stream MUST be considered started for later HTTP-error propagation decisions, so a subsequent upstream `response.failed` is forwarded in-stream instead of being raised as a startup HTTP error. If the pending request already has a response id, the liveness frame MAY be a `response.in_progress` SSE event for that response id. If no response id is known yet, the Codex CLI route MUST emit an ignored `codex.keepalive` SSE data event because comment-only frames do not reset the CLI's EventSource idle timer. Public `/v1/responses` stream normalization MUST preserve SSE comment keepalives instead of treating them as malformed data, and MUST drop `codex.*` liveness events from the public OpenAI SDK contract surface.
 
 #### Scenario: HTTP bridge emits response in-progress keepalive after response id is known
 - **GIVEN** an HTTP bridge request has a known response id
@@ -63,10 +63,10 @@ When an HTTP bridge Responses request is waiting for upstream queue events, the 
 - **THEN** the downstream stream emits a `response.in_progress` event for that response id
 - **AND** the request remains pending
 
-#### Scenario: HTTP bridge emits comment keepalive before response id is known
+#### Scenario: HTTP bridge emits Codex keepalive before response id is known
 - **GIVEN** an HTTP bridge request does not yet have a response id
 - **WHEN** no upstream event arrives before the SSE keepalive interval elapses
-- **THEN** the downstream stream emits an SSE comment keepalive block
+- **THEN** the downstream stream emits a `codex.keepalive` SSE data event
 - **AND** the request remains pending
 
 #### Scenario: First HTTP bridge keepalive is delayed past startup probe

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -6778,8 +6778,8 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
 
     events = [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
-    assert [event["type"] for event in events] == ["response.created", "response.created", "response.failed"]
-    assert events[1]["response"]["id"] == events[-1]["response"]["id"]
+    assert [event["type"] for event in events] == ["response.created", "response.failed"]
+    assert events[0]["response"]["id"] == events[-1]["response"]["id"]
     assert events[-1]["response"]["error"]["code"] == "stream_incomplete"
 
 

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -6778,7 +6778,8 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
 
     events = [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
-    assert [event["type"] for event in events] == ["response.created", "response.failed"]
+    assert [event["type"] for event in events] == ["response.created", "response.created", "response.failed"]
+    assert events[1]["response"]["id"] == events[-1]["response"]["id"]
     assert events[-1]["response"]["error"]["code"] == "stream_incomplete"
 
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -16,7 +16,7 @@ import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
 from app.core.clients import proxy as core_proxy
 from app.core.clients.proxy import ProxyResponseError
-from app.core.utils.sse import SSE_KEEPALIVE_FRAME
+from app.core.utils.sse import CODEX_KEEPALIVE_FRAME, SSE_KEEPALIVE_FRAME
 from app.db.models import Account, AccountStatus, RequestLog
 from app.db.session import SessionLocal
 from app.dependencies import ProxyContext
@@ -787,6 +787,59 @@ async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event
     iterator = response.body_iterator.__aiter__()
     first_chunk = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
     assert first_chunk == SSE_KEEPALIVE_FRAME
+    release_upstream.set()
+    chunks = [cast(str, await asyncio.wait_for(iterator.__anext__(), timeout=0.2)) for _ in range(2)]
+    assert any("response.completed" in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_codex_route_stream_responses_starts_event_keepalive_before_first_upstream_event(monkeypatch):
+    upstream_started = asyncio.Event()
+    release_upstream = asyncio.Event()
+
+    class _FakeService:
+        async def rate_limit_headers(self):
+            return {}
+
+        async def stream_responses(self, *args, **kwargs):
+            del args, kwargs
+            upstream_started.set()
+            await release_upstream.wait()
+            event = {"type": "response.completed", "response": {"id": "resp_delayed"}}
+            yield _sse_event(event)
+
+    settings = SimpleNamespace(
+        http_responses_session_bridge_enabled=False,
+        sse_keepalive_interval_seconds=0.01,
+    )
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module.proxy_service_module, "get_settings", lambda: settings)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/backend-api/codex/responses",
+            "headers": [],
+        }
+    )
+    payload = proxy_api_module.ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    )
+
+    response = await proxy_api_module._stream_responses(
+        request,
+        payload,
+        ProxyContext(service=cast(proxy_module.ProxyService, _FakeService())),
+        api_key=None,
+        enforce_openai_sdk_contract=False,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    assert upstream_started.is_set() is True
+    iterator = response.body_iterator.__aiter__()
+    first_chunk = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert first_chunk == CODEX_KEEPALIVE_FRAME
     release_upstream.set()
     chunks = [cast(str, await asyncio.wait_for(iterator.__anext__(), timeout=0.2)) for _ in range(2)]
     assert any("response.completed" in chunk for chunk in chunks)

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -5556,14 +5556,11 @@ def test_backend_responses_websocket_emits_response_failed_before_close_on_upstr
         with client.websocket_connect("/backend-api/codex/responses") as websocket:
             websocket.send_text(json.dumps(request_payload))
             created_event = json.loads(websocket.receive_text())
-            retry_created_event = json.loads(websocket.receive_text())
             failed_event = json.loads(websocket.receive_text())
 
     assert created_event["type"] == "response.created"
-    assert retry_created_event["type"] == "response.created"
-    assert retry_created_event["response"]["id"] == "resp_ws_eof_retry"
     assert failed_event["type"] == "response.failed"
-    assert failed_event["response"]["id"] == "resp_ws_eof_retry"
+    assert failed_event["response"]["id"] == "resp_ws_eof"
     assert failed_event["response"]["error"]["code"] == "stream_incomplete"
     assert "close_code=1011" in failed_event["response"]["error"]["message"]
     assert len(log_calls) == 1

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -5471,17 +5471,24 @@ def test_backend_responses_websocket_matches_terminal_events_by_response_id(app_
 
 
 def test_backend_responses_websocket_emits_response_failed_before_close_on_upstream_eof(app_instance, monkeypatch):
-    upstream_messages = [
-        _FakeUpstreamMessage(
-            "text",
-            text=json.dumps(
-                {"type": "response.created", "response": {"id": "resp_ws_eof", "status": "in_progress"}},
-                separators=(",", ":"),
-            ),
-        ),
-        _FakeUpstreamMessage("close", close_code=1011),
+    def upstream_created_then_eof(response_id: str) -> _FakeUpstreamWebSocket:
+        return _FakeUpstreamWebSocket(
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {"type": "response.created", "response": {"id": response_id, "status": "in_progress"}},
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage("close", close_code=1011),
+            ]
+        )
+
+    upstreams = [
+        upstream_created_then_eof("resp_ws_eof"),
+        upstream_created_then_eof("resp_ws_eof_retry"),
     ]
-    fake_upstream = _FakeUpstreamWebSocket(upstream_messages)
     log_calls: list[dict[str, object]] = []
 
     class _FakeSettingsCache:
@@ -5525,7 +5532,7 @@ def test_backend_responses_websocket_emits_response_failed_before_close_on_upstr
             client_send_lock,
             websocket,
         )
-        return SimpleNamespace(id="acct_ws_proxy"), fake_upstream
+        return SimpleNamespace(id="acct_ws_proxy"), upstreams.pop(0)
 
     async def fake_write_request_log(self, **kwargs):
         del self
@@ -5553,10 +5560,10 @@ def test_backend_responses_websocket_emits_response_failed_before_close_on_upstr
 
     assert created_event["type"] == "response.created"
     assert failed_event["type"] == "response.failed"
-    assert failed_event["response"]["id"] == "resp_ws_eof"
+    assert failed_event["response"]["id"] == "resp_ws_eof_retry"
     assert failed_event["response"]["error"]["code"] == "stream_incomplete"
     assert "close_code=1011" in failed_event["response"]["error"]["message"]
     assert len(log_calls) == 1
-    assert log_calls[0]["request_id"] == "resp_ws_eof"
+    assert log_calls[0]["request_id"] == "resp_ws_eof_retry"
     assert log_calls[0]["status"] == "error"
     assert log_calls[0]["error_code"] == "stream_incomplete"

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -5556,9 +5556,12 @@ def test_backend_responses_websocket_emits_response_failed_before_close_on_upstr
         with client.websocket_connect("/backend-api/codex/responses") as websocket:
             websocket.send_text(json.dumps(request_payload))
             created_event = json.loads(websocket.receive_text())
+            retry_created_event = json.loads(websocket.receive_text())
             failed_event = json.loads(websocket.receive_text())
 
     assert created_event["type"] == "response.created"
+    assert retry_created_event["type"] == "response.created"
+    assert retry_created_event["response"]["id"] == "resp_ws_eof_retry"
     assert failed_event["type"] == "response.failed"
     assert failed_event["response"]["id"] == "resp_ws_eof_retry"
     assert failed_event["response"]["error"]["code"] == "stream_incomplete"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -31,7 +31,7 @@ def test_main_passes_timestamped_log_config(monkeypatch):
     formatters = log_config["formatters"]
     assert formatters["default"]["fmt"].startswith("%(asctime)s ")
     assert formatters["access"]["fmt"].startswith("%(asctime)s ")
-    assert kwargs["timeout_keep_alive"] == 300
+    assert kwargs["timeout_keep_alive"] == 7200
 
 
 def test_main_passes_custom_keep_alive_timeout(monkeypatch):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -9,7 +9,7 @@ import queue
 import stat
 import threading
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -533,6 +533,29 @@ def test_archive_write_failure_forgets_prior_recovery_check(monkeypatch, tmp_pat
     conversation_archive._append_record(path, {"request_id": "req_new_2"})
 
     assert path.resolve() not in conversation_archive._RECOVERY_CHECKED_PATHS
+
+
+def test_archive_batch_write_failure_does_not_drop_other_paths(monkeypatch, tmp_path):
+    bad_path = tmp_path / "bad" / "2026-04-30T12.jsonl.gz"
+    good_path = tmp_path / "good" / "2026-04-30T12.jsonl.gz"
+
+    def write_record(path: Path, record: Mapping[str, object]) -> None:
+        if path == bad_path:
+            raise OSError("simulated archive write failure")
+        conversation_archive._write_gzip_jsonl_records(path, [record])
+
+    monkeypatch.setattr(conversation_archive, "_write_gzip_jsonl_record", write_record)
+
+    conversation_archive._append_records(
+        [
+            (bad_path, {"request_id": "req_bad"}, 0),
+            (good_path, {"request_id": "req_good"}, 0),
+        ]
+    )
+
+    assert not bad_path.exists()
+    with gzip.open(good_path, "rt", encoding="utf-8") as handle:
+        assert json.loads(handle.readline()) == {"request_id": "req_good"}
 
 
 def test_archive_disk_full_pauses_writes_without_traceback_spam(monkeypatch, tmp_path, caplog):

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -175,7 +175,8 @@ def test_archive_queue_byte_limit_preserves_oversized_record_with_backpressure(m
     )
     conversation_archive.flush_archive_writer()
 
-    assert list(tmp_path.glob("*.jsonl.gz")) == []
+    [record] = _archive_records(tmp_path)
+    assert record["payload"] == {"text": "x" * 256}
     with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
         assert conversation_archive._WRITE_QUEUE_BYTES == 0
 

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -175,8 +175,7 @@ def test_archive_queue_byte_limit_preserves_oversized_record_with_backpressure(m
     )
     conversation_archive.flush_archive_writer()
 
-    [record] = _archive_records(tmp_path)
-    assert record["payload"] == {"text": "x" * 256}
+    assert list(tmp_path.glob("*.jsonl.gz")) == []
     with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
         assert conversation_archive._WRITE_QUEUE_BYTES == 0
 

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -9,6 +9,7 @@ import queue
 import stat
 import threading
 import time
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -300,18 +301,18 @@ def test_archive_writer_streams_gzip_without_precompressing_record(monkeypatch, 
 
 def test_archive_writer_batches_queued_records(monkeypatch, tmp_path):
     archive_queue: queue.Queue[tuple[Path, dict[str, object], int] | None] = queue.Queue()
-    first = (tmp_path / "archive.jsonl.gz", {"payload": "one"}, 11)
-    second = (tmp_path / "archive.jsonl.gz", {"payload": "two"}, 13)
+    first: tuple[Path, dict[str, object], int] = (tmp_path / "archive.jsonl.gz", {"payload": "one"}, 11)
+    second: tuple[Path, dict[str, object], int] = (tmp_path / "archive.jsonl.gz", {"payload": "two"}, 13)
     archive_queue.put(first)
     archive_queue.put(second)
     archive_queue.put(None)
     monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", archive_queue)
     with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
-        conversation_archive._WRITE_QUEUE_BYTES = 24
+        setattr(conversation_archive, "_WRITE_QUEUE_BYTES", 24)
 
-    batches: list[list[tuple[Path, object, int]]] = []
+    batches: list[list[tuple[Path, dict[str, object], int]]] = []
 
-    def capture_batch(items):
+    def capture_batch(items: Sequence[tuple[Path, dict[str, object], int]]) -> None:
         batches.append(list(items))
 
     monkeypatch.setattr(conversation_archive, "_append_records", capture_batch)

--- a/tests/unit/test_conversation_archive.py
+++ b/tests/unit/test_conversation_archive.py
@@ -298,6 +298,32 @@ def test_archive_writer_streams_gzip_without_precompressing_record(monkeypatch, 
     assert record["payload"] == {"text": "x" * 1024}
 
 
+def test_archive_writer_batches_queued_records(monkeypatch, tmp_path):
+    archive_queue: queue.Queue[tuple[Path, dict[str, object], int] | None] = queue.Queue()
+    first = (tmp_path / "archive.jsonl.gz", {"payload": "one"}, 11)
+    second = (tmp_path / "archive.jsonl.gz", {"payload": "two"}, 13)
+    archive_queue.put(first)
+    archive_queue.put(second)
+    archive_queue.put(None)
+    monkeypatch.setattr(conversation_archive, "_WRITE_QUEUE", archive_queue)
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        conversation_archive._WRITE_QUEUE_BYTES = 24
+
+    batches: list[list[tuple[Path, object, int]]] = []
+
+    def capture_batch(items):
+        batches.append(list(items))
+
+    monkeypatch.setattr(conversation_archive, "_append_records", capture_batch)
+
+    conversation_archive._writer_loop()
+
+    assert [[item[1]["payload"] for item in batch] for batch in batches] == [["one", "two"]]
+    assert archive_queue.unfinished_tasks == 0
+    with conversation_archive._WRITE_QUEUE_BYTES_LOCK:
+        assert conversation_archive._WRITE_QUEUE_BYTES == 0
+
+
 def test_archive_queue_thread_start_failure_drops_record(monkeypatch, tmp_path):
     monkeypatch.setattr(
         conversation_archive,

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -252,3 +252,43 @@ async def test_in_flight_middleware_allows_drain_status_during_drain() -> None:
 
     assert app_called is True
     assert sent_messages[0]["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_in_flight_middleware_allows_drain_stop_during_drain() -> None:
+    shutdown_state.set_draining(True)
+    app_called = False
+
+    async def inner_app(scope, receive, send):  # noqa: ANN001, ARG001
+        nonlocal app_called
+        app_called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b'{"ok":true}'})
+
+    middleware = InFlightMiddleware(inner_app)
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/internal/drain/stop",
+        "raw_path": b"/internal/drain/stop",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [],
+        "client": ("127.0.0.1", 50000),
+        "server": ("testserver", 80),
+    }
+
+    async def receive():  # noqa: ANN202
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent_messages: list[dict] = []
+
+    async def send(msg):  # noqa: ANN001, ANN202
+        sent_messages.append(msg)
+
+    await middleware(scope, receive, send)
+
+    assert app_called is True
+    assert sent_messages[0]["status"] == 200

--- a/tests/unit/test_health_probes.py
+++ b/tests/unit/test_health_probes.py
@@ -380,6 +380,36 @@ async def test_internal_drain_start_rejects_non_loopback_clients():
 
 
 @pytest.mark.asyncio
+async def test_internal_drain_stop_clears_draining_flags():
+    from app.modules.health.api import stop_internal_drain
+
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+
+    with (
+        patch("app.core.shutdown.set_bridge_drain_active") as set_bridge_drain_active,
+        patch("app.core.shutdown.set_draining") as set_draining,
+    ):
+        response = await stop_internal_drain(cast(Any, request))
+
+    set_draining.assert_called_once_with(False)
+    set_bridge_drain_active.assert_called_once_with(False)
+    assert response.status == "ok"
+    assert response.checks == {"draining": "false"}
+
+
+@pytest.mark.asyncio
+async def test_internal_drain_stop_rejects_non_loopback_clients():
+    from app.modules.health.api import stop_internal_drain
+
+    request = SimpleNamespace(client=SimpleNamespace(host="8.8.8.8"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await stop_internal_drain(cast(Any, request))
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
 async def test_internal_drain_start_rejects_private_network_clients():
     from app.modules.health.api import start_internal_drain
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14613,6 +14613,70 @@ async def test_http_bridge_session_events_keepalive_backstop_with_response_id(mo
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_session_events_keepalive_backstop_uses_replay_downstream_response_id(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.sse_keepalive_interval_seconds = 0.01
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_replay_backstop",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id=None,
+        replay_downstream_response_id="resp_created_then_closed",
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_replay_backstop"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_KEEPALIVE_MAX_COUNT", 2)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    events = service._stream_http_bridge_session_events(
+        session,
+        request_state=request_state,
+        text_data='{"type":"response.create"}',
+        queue_limit=10,
+        propagate_http_errors=False,
+        downstream_turn_state=None,
+    )
+    collected: list[str] = []
+    try:
+        async for event in events:
+            collected.append(event)
+            if len(collected) >= 3:
+                break
+    finally:
+        await events.aclose()
+
+    first = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[0]))
+    assert cast(dict[str, object], first["response"])["id"] == "resp_created_then_closed"
+    last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[2]))
+    assert cast(dict[str, object], last["response"])["id"] == "resp_created_then_closed"
+    assert cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"] == "stream_idle_timeout"
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11098,6 +11098,37 @@ async def test_pop_replayable_created_without_visible_output_request_state():
     assert pending_request.awaiting_response_created is True
     assert pending_request.response_id is None
     assert pending_request.response_event_count == 0
+    assert pending_request.suppress_next_created_downstream is False
+
+
+@pytest.mark.asyncio
+async def test_pop_replayable_created_request_refuses_client_previous_response_id():
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_created_client_previous_response_id",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text=(
+            '{"type":"response.create","model":"gpt-5.1","previous_response_id":"resp_anchor","input":"retry"}'
+        ),
+        response_id="resp_created_then_closed",
+        previous_response_id="resp_anchor",
+        awaiting_response_created=False,
+        response_event_count=1,
+        downstream_visible=False,
+    )
+    pending_requests = deque([pending_request])
+
+    replayed_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replayed_request is None
+    assert list(pending_requests) == [pending_request]
+    assert pending_request.replay_count == 0
 
 
 @pytest.mark.asyncio
@@ -14435,8 +14466,8 @@ async def test_http_bridge_session_events_keepalive_backstop(monkeypatch):
         await events.aclose()
 
     assert len(collected) == 3, f"Expected 3 events (2 keepalives + stream_idle_timeout), got {len(collected)}"
-    assert collected[0] == ": keepalive\n\n"
-    assert collected[1] == ": keepalive\n\n"
+    assert collected[0] == proxy_service.CODEX_KEEPALIVE_FRAME
+    assert collected[1] == proxy_service.CODEX_KEEPALIVE_FRAME
     last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[2]))
     assert last["type"] == "response.failed"
     assert cast(dict[str, object], last["response"])["status"] == "failed"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14683,6 +14683,159 @@ async def test_retry_http_bridge_precreated_request_suppresses_retry_after_respo
 
 
 @pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_replays_created_without_visible_output(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    send_text = AsyncMock()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_created_no_output",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text='{"type":"response.create","model":"gpt-5.1","input":"retry"}',
+        response_id="resp_bridge_created_then_closed",
+        awaiting_response_created=False,
+        response_event_count=1,
+        downstream_visible=False,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_created_no_output"),
+        upstream=AsyncMock(send_text=send_text),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+        last_upstream_close_code=1011,
+    )
+    reconnect = AsyncMock(return_value=None)
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    retried = await service._retry_http_bridge_precreated_request(session)
+
+    assert retried is True
+    reconnect.assert_awaited_once_with(session, request_state=request_state)
+    send_text.assert_awaited_once_with('{"type":"response.create","model":"gpt-5.1","input":"retry"}')
+    assert request_state.replay_count == 1
+    assert request_state.awaiting_response_created is True
+    assert request_state.response_id is None
+    assert request_state.response_event_count == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_refuses_created_after_visible_output(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    send_text = AsyncMock()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_created_visible_refuse",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text='{"type":"response.create","model":"gpt-5.1","input":"retry"}',
+        response_id="resp_bridge_created_visible",
+        awaiting_response_created=False,
+        response_event_count=2,
+        downstream_visible=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_created_visible_refuse"),
+        upstream=AsyncMock(send_text=send_text),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+        last_upstream_close_code=1011,
+    )
+    reconnect = AsyncMock(return_value=None)
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    retried = await service._retry_http_bridge_precreated_request(session)
+
+    assert retried is False
+    reconnect.assert_not_awaited()
+    send_text.assert_not_awaited()
+    assert request_state.replay_count == 0
+    assert session.pending_requests == deque([request_state])
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_strips_retry_safe_injected_anchor(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    original_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "previous_response_id": "resp_anchor",
+        "input": [{"role": "user", "content": "full resend"}],
+    }
+    fresh_payload = dict(original_payload)
+    fresh_payload.pop("previous_response_id")
+    fresh_text = json.dumps(fresh_payload, separators=(",", ":"))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_injected_anchor",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(original_payload, separators=(",", ":")),
+        previous_response_id="resp_anchor",
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_text=fresh_text,
+        fresh_upstream_request_is_retry_safe=True,
+        input_item_count=1,
+        input_full_fingerprint=proxy_service._fingerprint_input_items(original_payload["input"]),
+    )
+    send_text = AsyncMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_injected_anchor"),
+        upstream=AsyncMock(send_text=send_text),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+        last_upstream_close_code=1011,
+    )
+    reconnect = AsyncMock(return_value=None)
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    retried = await service._retry_http_bridge_precreated_request(session)
+
+    assert retried is True
+    send_text.assert_awaited_once_with(fresh_text)
+    assert request_state.previous_response_id is None
+    assert request_state.proxy_injected_previous_response_id is False
+    assert request_state.fresh_upstream_request_is_retry_safe is False
+    assert request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(fresh_payload["input"])
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_precreated_request_refuses_after_downstream_text():
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14263,7 +14263,7 @@ async def test_http_bridge_session_events_emit_keepalive_while_pending(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_http_bridge_session_events_emit_comment_keepalive_before_response_id(monkeypatch):
+async def test_http_bridge_session_events_emit_codex_keepalive_before_response_id(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
@@ -14313,7 +14313,7 @@ async def test_http_bridge_session_events_emit_comment_keepalive_before_response
     finally:
         await events.aclose()
 
-    assert keepalive == ": keepalive\n\n"
+    assert keepalive == proxy_service.CODEX_KEEPALIVE_FRAME
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11098,7 +11098,74 @@ async def test_pop_replayable_created_without_visible_output_request_state():
     assert pending_request.awaiting_response_created is True
     assert pending_request.response_id is None
     assert pending_request.response_event_count == 0
-    assert pending_request.suppress_next_created_downstream is False
+    assert pending_request.suppress_next_created_downstream is True
+    assert pending_request.replay_downstream_response_id == "resp_created_then_closed"
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_rewrites_replayed_created_only_response_id():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_created_replay")
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_created_replay_rewrite",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text='{"type":"response.create","model":"gpt-5.1","input":"retry"}',
+        response_id="resp_downstream_original",
+        awaiting_response_created=False,
+        response_event_count=1,
+        downstream_visible=False,
+    )
+    pending_requests = deque([pending_request])
+    replayed_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+    assert replayed_request is pending_request
+    pending_requests.append(pending_request)
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+
+    replay_created = {
+        "type": "response.created",
+        "response": {"id": "resp_upstream_replayed", "status": "in_progress"},
+    }
+    created_text = await service._process_upstream_websocket_text(
+        json.dumps(replay_created, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+    assert json.loads(created_text)["response"]["id"] == "resp_downstream_original"
+    assert upstream_control.suppress_downstream_event is True
+    assert pending_request.response_id == "resp_upstream_replayed"
+
+    upstream_control.suppress_downstream_event = False
+    replay_failed = {
+        "type": "response.failed",
+        "response": {"id": "resp_upstream_replayed", "status": "failed", "error": {"code": "upstream_unavailable"}},
+    }
+    failed_text = await service._process_upstream_websocket_text(
+        json.dumps(replay_failed, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert json.loads(failed_text)["response"]["id"] == "resp_downstream_original"
+    assert upstream_control.suppress_downstream_event is False
+    assert pending_requests == deque()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2170,7 +2170,7 @@ async def test_stream_responses_honors_timeout_overrides(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_maps_total_timeout_to_request_timeout(monkeypatch):
+async def test_stream_responses_maps_inner_pre_response_timeout_to_upstream_unavailable(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 8.0
@@ -2201,7 +2201,8 @@ async def test_stream_responses_maps_total_timeout_to_request_timeout(monkeypatc
     ]
 
     event = json.loads(events[0].split("data: ", 1)[1])
-    assert event["response"]["error"]["code"] == "upstream_request_timeout"
+    assert event["response"]["error"]["code"] == "upstream_unavailable"
+    assert event["response"]["error"]["message"] == "Request to upstream timed out"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -13887,18 +13887,16 @@ async def test_reconnect_http_bridge_skips_extra_same_account_retry_after_keepal
         excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
         seen_excluded_account_ids.append(excluded_account_ids)
         seen_account_ids.append(cast(set[str] | None, account_ids))
-        if account_ids == {account_a.id}:
-            return AccountSelection(account=account_a, error_message=None)
-        if len(seen_excluded_account_ids) == 1:
+        if account_a.id not in excluded_account_ids:
             return AccountSelection(account=account_a, error_message=None)
         return AccountSelection(account=account_b, error_message=None)
 
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account_b))
     monkeypatch.setattr(
         service,
         "_open_upstream_websocket_with_budget",
-        AsyncMock(side_effect=[asyncio.TimeoutError(), new_upstream]),
+        AsyncMock(return_value=new_upstream),
     )
 
     request_state = proxy_service._WebSocketRequestState(
@@ -13928,8 +13926,8 @@ async def test_reconnect_http_bridge_skips_extra_same_account_retry_after_keepal
 
     await service._reconnect_http_bridge_session(session, request_state=request_state)
 
-    assert seen_excluded_account_ids == [set(), {account_a.id}]
-    assert seen_account_ids == [{account_a.id}, None]
+    assert seen_excluded_account_ids == [{account_a.id}]
+    assert seen_account_ids == [None]
     assert session.account == account_b
     assert session.upstream is new_upstream
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10936,6 +10936,26 @@ def test_remember_websocket_previous_response_owner_eviction_keeps_latest_entrie
     assert ("resp_prev_4096", "key_1", None) in service._websocket_previous_response_account_index
 
 
+def test_websocket_continuity_response_ids_include_replay_downstream_alias_once():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_replay_alias",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        replay_downstream_response_id="resp_downstream_visible",
+    )
+
+    assert proxy_service._websocket_continuity_response_ids(request_state, "resp_upstream_retry") == (
+        "resp_upstream_retry",
+        "resp_downstream_visible",
+    )
+    assert proxy_service._websocket_continuity_response_ids(request_state, "resp_downstream_visible") == (
+        "resp_downstream_visible",
+    )
+
+
 @pytest.mark.asyncio
 async def test_process_upstream_websocket_text_retries_precreated_previous_response_not_found(monkeypatch):
     """A precreated retry-safe full-resend turn (with both

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11070,6 +11070,62 @@ async def test_pop_replayable_precreated_request_refreshes_fresh_replay_fingerpr
 
 
 @pytest.mark.asyncio
+async def test_pop_replayable_created_without_visible_output_request_state():
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_created_no_output_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text='{"type":"response.create","model":"gpt-5.1","input":"retry"}',
+        response_id="resp_created_then_closed",
+        awaiting_response_created=False,
+        response_event_count=1,
+        downstream_visible=False,
+    )
+    pending_requests = deque([pending_request])
+
+    replayed_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replayed_request is pending_request
+    assert pending_requests == deque()
+    assert pending_request.replay_count == 1
+    assert pending_request.awaiting_response_created is True
+    assert pending_request.response_id is None
+    assert pending_request.response_event_count == 0
+
+
+@pytest.mark.asyncio
+async def test_pop_replayable_created_request_refuses_visible_output():
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_created_visible_refuse",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text='{"type":"response.create","model":"gpt-5.1","input":"retry"}',
+        response_id="resp_created_visible",
+        awaiting_response_created=False,
+        response_event_count=2,
+        downstream_visible=True,
+    )
+    pending_requests = deque([pending_request])
+
+    replayed_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replayed_request is None
+    assert list(pending_requests) == [pending_request]
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_masks_previous_response_not_found_for_unique_followup_request(
     monkeypatch,
 ):

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -27,6 +27,7 @@ def test_settings_multi_replica_defaults():
     assert settings.proxy_response_create_limit == 256
     assert settings.proxy_compact_response_create_limit == 64
     assert settings.compact_request_budget_seconds == 180.0
+    assert settings.proxy_request_budget_seconds == 600.0
     assert settings.stream_idle_timeout_seconds == 600.0
     assert settings.proxy_downstream_websocket_idle_timeout_seconds == 120.0
     assert settings.max_sse_event_bytes == 16 * 1024 * 1024

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -31,7 +31,7 @@ def test_settings_multi_replica_defaults():
     assert settings.proxy_downstream_websocket_idle_timeout_seconds == 120.0
     assert settings.max_sse_event_bytes == 16 * 1024 * 1024
     assert settings.proxy_refresh_failure_cooldown_seconds == 5.0
-    assert settings.conversation_archive_queue_max_bytes == 8 * 1024 * 1024
+    assert settings.conversation_archive_queue_max_bytes == 256 * 1024 * 1024
     assert settings.usage_refresh_auth_failure_cooldown_seconds == 300.0
     assert settings.otel_enabled is False
     assert settings.otel_exporter_endpoint == ""

--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator
 
 import pytest
 
-from app.core.utils.sse import SSE_KEEPALIVE_FRAME, format_sse_event, inject_sse_keepalives
+from app.core.utils.sse import CODEX_KEEPALIVE_FRAME, SSE_KEEPALIVE_FRAME, format_sse_event, inject_sse_keepalives
 
 pytestmark = pytest.mark.unit
 
@@ -45,6 +45,21 @@ async def test_inject_sse_keepalives_emits_pings_on_idle_gap():
     assert out[-1] == "a\n\n"
     assert SSE_KEEPALIVE_FRAME in out
     assert out.count(SSE_KEEPALIVE_FRAME) >= 2
+
+
+@pytest.mark.asyncio
+async def test_inject_sse_keepalives_can_emit_codex_event_frame():
+    out = [
+        chunk
+        async for chunk in inject_sse_keepalives(
+            _slow_agen(["a\n\n"], delay=0.25),
+            0.05,
+            keepalive_frame=CODEX_KEEPALIVE_FRAME,
+        )
+    ]
+    assert out[-1] == "a\n\n"
+    assert CODEX_KEEPALIVE_FRAME in out
+    assert out.count(CODEX_KEEPALIVE_FRAME) >= 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep websocket connect/refresh transport failures on the deterministic account-failover path instead of surfacing the first account timeout
- avoid misclassifying inner upstream websocket connect timeouts as proxy request budget exhaustion unless the outer proxy budget elapsed
- replay a request once when upstream closes after `response.created` but before any visible output, while still refusing replay after visible output or ambiguous response events

## Testing
- `uv run pytest tests/unit/test_proxy_utils.py -q -k 'websocket_connect or connect_proxy_websocket or open_upstream_websocket or pop_replayable_created or pop_replayable_precreated or replays_precreated_request_after_upstream_close_race'`
- `uv run pytest tests/unit/test_proxy_utils.py::test_proxy_responses_websocket_replays_precreated_request_after_upstream_close_race -q`
- `uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `git diff --check origin/main..HEAD`
