### PR TITLE
fix(openai): preserve json mode instruction messages

### DIFF
--- a/app/core/openai/chat_requests.py
+++ b/app/core/openai/chat_requests.py
@@ -132,6 +132,7 @@ class ChatCompletionsRequest(BaseModel):
         tools = _normalize_chat_tools(data.pop("tools", []))
         tool_choice = _normalize_tool_choice(data.pop("tool_choice", None))
         reasoning_effort = data.pop("reasoning_effort", None)
+        preserve_instruction_roles = _is_json_object_response_format(response_format)
         if reasoning_effort is not None and "reasoning" not in data:
             data["reasoning"] = {"effort": reasoning_effort}
         normalize_reasoning_aliases(data)
@@ -141,7 +142,11 @@ class ChatCompletionsRequest(BaseModel):
             include_obfuscation = stream_options.get("include_obfuscation")
             if include_obfuscation is not None:
                 data["stream_options"] = {"include_obfuscation": include_obfuscation}
-        instructions, input_items = coerce_messages("", cast(list[JsonValue], messages))
+        instructions, input_items = coerce_messages(
+            "",
+            cast(list[JsonValue], messages),
+            preserve_instruction_roles=preserve_instruction_roles,
+        )
         data["instructions"] = instructions
         data["input"] = input_items
         data["tools"] = tools
@@ -233,6 +238,14 @@ def _normalize_tool_choice(tool_choice: JsonValue | None) -> JsonValue | None:
         if isinstance(name, str) and name:
             return {"type": tool_type or "function", "name": name}
     return tool_choice
+
+
+def _is_json_object_response_format(response_format: JsonValue | None) -> bool:
+    if isinstance(response_format, str):
+        return response_format == "json_object"
+    if not is_json_mapping(response_format):
+        return False
+    return response_format.get("type") == "json_object"
 
 
 def _apply_response_format(data: dict[str, JsonValue], response_format: JsonValue) -> None:

--- a/app/core/openai/message_coercion.py
+++ b/app/core/openai/message_coercion.py
@@ -30,7 +30,12 @@ def _content_parts(content: JsonValue) -> list[JsonValue]:
     return [content]
 
 
-def coerce_messages(existing_instructions: str, messages: Sequence[JsonValue]) -> tuple[str, list[JsonValue]]:
+def coerce_messages(
+    existing_instructions: str,
+    messages: Sequence[JsonValue],
+    *,
+    preserve_instruction_roles: bool = False,
+) -> tuple[str, list[JsonValue]]:
     instruction_parts: list[str] = []
     input_messages: list[JsonValue] = []
     for message in messages:
@@ -45,6 +50,9 @@ def coerce_messages(existing_instructions: str, messages: Sequence[JsonValue]) -
             raise ClientPayloadError(f"Unsupported message role: {role}", param="messages")
         if role in ("system", "developer"):
             _ensure_text_only_content(message_dict.get("content"), role)
+            if preserve_instruction_roles:
+                input_messages.append(cast(JsonValue, _normalize_message_content(cast(OpenAIMessage, message_dict))))
+                continue
             content_text = _content_to_text(message_dict.get("content"))
             if content_text:
                 instruction_parts.append(content_text)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -12985,7 +12985,8 @@ def _extract_message_content_text(content: object) -> str | None:
     if isinstance(content, str):
         return content
     if isinstance(content, dict):
-        text = content.get("text")
+        content_mapping = cast(Mapping[str, object], content)
+        text = content_mapping.get("text")
         return text if isinstance(text, str) else None
     if not isinstance(content, list):
         return None
@@ -12996,7 +12997,8 @@ def _extract_message_content_text(content: object) -> str | None:
             continue
         if not isinstance(part, dict):
             continue
-        text = part.get("text")
+        part_mapping = cast(Mapping[str, object], part)
+        text = part_mapping.get("text")
         if isinstance(text, str):
             parts.append(text)
     return "".join(parts) if parts else None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -12906,7 +12906,8 @@ def _derive_prompt_cache_key(
 ) -> str:
     """Derive a stable, session-scoped prompt_cache_key when the client does not provide one.
 
-    The generated key is scoped to (model-class, api-key, instructions-prefix, first-user-input) so that:
+    The generated key is scoped to (model-class, api-key, instructions-prefix,
+    instruction-role input, first-user-input) so that:
     - Different model classes get *different* keys (prevents cache pollution).
     - Parallel sessions from the same API key get *different* keys (different first input).
     - Successive turns within one session get the *same* key (first input stays constant).
@@ -12923,6 +12924,10 @@ def _derive_prompt_cache_key(
     if isinstance(instructions, str) and instructions:
         parts.append(sha256(instructions[:512].encode()).hexdigest()[:12])
 
+    instruction_input_text = _extract_instruction_input(payload)
+    if instruction_input_text:
+        parts.append(sha256(instruction_input_text[:512].encode()).hexdigest()[:12])
+
     first_user_text = _extract_first_user_input(payload)
     if first_user_text:
         parts.append(sha256(first_user_text[:512].encode()).hexdigest()[:12])
@@ -12932,6 +12937,28 @@ def _derive_prompt_cache_key(
         return f"{model_class}-{random_suffix}" if model_class is not None else random_suffix
 
     return "-".join([model_class, *parts]) if model_class is not None else "-".join(parts)
+
+
+def _extract_instruction_input(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
+    input_value = getattr(payload, "input", None)
+    if not isinstance(input_value, list):
+        return None
+    parts: list[str] = []
+    for item in input_value:
+        if not isinstance(item, dict):
+            continue
+        if item.get("role") not in ("system", "developer"):
+            continue
+        content_text = _extract_message_content_text(item.get("content"))
+        if content_text:
+            parts.append(content_text)
+        else:
+            parts.append(json.dumps(item, sort_keys=True, ensure_ascii=False))
+        if sum(len(part) for part in parts) >= 512:
+            break
+    if not parts:
+        return None
+    return "\n".join(parts)[:512]
 
 
 def _extract_first_user_input(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
@@ -12947,16 +12974,32 @@ def _extract_first_user_input(payload: ResponsesRequest | ResponsesCompactReques
         role = item.get("role")
         if role == "user":
             content = item.get("content")
-            if isinstance(content, str):
-                return content[:512]
-            if isinstance(content, list):
-                for part in content:
-                    if isinstance(part, dict):
-                        text = part.get("text")
-                        if isinstance(text, str):
-                            return text[:512]
+            content_text = _extract_message_content_text(content)
+            if content_text:
+                return content_text[:512]
             return json.dumps(item, sort_keys=True, ensure_ascii=False)[:512]
     return None
+
+
+def _extract_message_content_text(content: object) -> str | None:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        text = content.get("text")
+        return text if isinstance(text, str) else None
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, str):
+            parts.append(part)
+            continue
+        if not isinstance(part, dict):
+            continue
+        text = part.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+    return "".join(parts) if parts else None
 
 
 def _sticky_key_from_payload(payload: ResponsesRequest) -> str | None:

--- a/openspec/changes/fix-chat-json-mode-instruction-roles/proposal.md
+++ b/openspec/changes/fix-chat-json-mode-instruction-roles/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Chat Completions JSON mode currently fails when the explicit JSON instruction appears in a `system` or `developer` message. The chat-to-Responses mapper moves those messages into `instructions`, but the upstream JSON-mode validation requires the JSON marker to remain in the input context.
+
+OpenAI-compatible JSON mode allows clients to instruct JSON output via conversation messages, including system messages, so codex-lb should not require clients to duplicate that instruction in a user message.
+
+## What Changes
+
+- Preserve `system` and `developer` messages as Responses `input` role messages only for Chat Completions requests with `response_format.type == "json_object"`.
+- Keep the existing `instructions` merge behavior for non-JSON-mode requests and for `json_schema` structured outputs.
+- Include preserved instruction-role input text in derived prompt-cache keys.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `chat-completions-compat`: JSON object response format mapping MUST keep instruction-role messages in Responses `input`.
+
+## Impact
+
+- **Code**: `app/core/openai/chat_requests.py`, `app/core/openai/message_coercion.py`, `app/modules/proxy/service.py`
+- **Tests**: focused unit coverage for chat mapping and prompt-cache key derivation
+- **Behavior**: `/v1/chat/completions` accepts JSON mode requests whose JSON instruction is in a `system` or `developer` message.

--- a/openspec/changes/fix-chat-json-mode-instruction-roles/specs/chat-completions-compat/spec.md
+++ b/openspec/changes/fix-chat-json-mode-instruction-roles/specs/chat-completions-compat/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Map chat requests to Responses wire format
+
+The service MUST map chat messages into the Responses request format by merging `system`/`developer` content into `instructions` and forwarding all other messages as `input`. When `response_format.type` is `json_object`, the service MUST instead preserve `system`/`developer` messages as Responses input role messages so JSON-mode instructions remain in the request context. Tool definitions MUST be normalized to the Responses tool schema, and `tool_choice`, `reasoning_effort`, and `response_format` MUST be mapped consistently. Unsupported fields MUST not be silently ignored if they change behavior.
+
+#### Scenario: System message normalization
+- **WHEN** the client sends a `system` message followed by a `user` message
+- **AND** the request does not use `response_format.type = "json_object"`
+- **THEN** the service maps the system content to `instructions` and the user message to `input`
+
+#### Scenario: JSON object response format preserves instruction-role messages
+- **WHEN** the client sends `response_format: {"type":"json_object"}` with a `system` or `developer` message that instructs JSON output
+- **THEN** the mapped Responses payload keeps that message in `input` with its original role
+- **AND** the mapped `instructions` value does not contain that message content
+
+#### Scenario: Tool choice values
+- **WHEN** the client sets `tool_choice` to `none`, `auto`, or `required`
+- **THEN** the service forwards the value consistently in the mapped Responses request

--- a/openspec/changes/fix-chat-json-mode-instruction-roles/tasks.md
+++ b/openspec/changes/fix-chat-json-mode-instruction-roles/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+- [x] 1.1 Preserve `system`/`developer` messages in `input` for Chat Completions `json_object` response format.
+- [x] 1.2 Keep existing `instructions` mapping for non-JSON-mode requests and `json_schema`.
+- [x] 1.3 Include preserved instruction-role input in derived prompt-cache keys.
+
+## 2. Tests and Specs
+
+- [x] 2.1 Add regression coverage for `json_object` with instruction-role messages.
+- [x] 2.2 Add prompt-cache key coverage for instruction-role input.
+- [x] 2.3 Update the `chat-completions-compat` spec for the JSON-mode mapping exception.

--- a/openspec/specs/chat-completions-compat/spec.md
+++ b/openspec/specs/chat-completions-compat/spec.md
@@ -27,11 +27,17 @@ The service MUST enforce role-specific message content rules: `system` and `deve
 - **THEN** the service accepts the request and forwards the content parts in order
 
 ### Requirement: Map chat requests to Responses wire format
-The service MUST map chat messages into the Responses request format by merging `system`/`developer` content into `instructions` and forwarding all other messages as `input`. Tool definitions MUST be normalized to the Responses tool schema, and `tool_choice`, `reasoning_effort`, and `response_format` MUST be mapped consistently. Unsupported fields MUST not be silently ignored if they change behavior.
+The service MUST map chat messages into the Responses request format by merging `system`/`developer` content into `instructions` and forwarding all other messages as `input`. When `response_format.type` is `json_object`, the service MUST instead preserve `system`/`developer` messages as Responses input role messages so JSON-mode instructions remain in the request context. Tool definitions MUST be normalized to the Responses tool schema, and `tool_choice`, `reasoning_effort`, and `response_format` MUST be mapped consistently. Unsupported fields MUST not be silently ignored if they change behavior.
 
 #### Scenario: System message normalization
 - **WHEN** the client sends a `system` message followed by a `user` message
+- **AND** the request does not use `response_format.type = "json_object"`
 - **THEN** the service maps the system content to `instructions` and the user message to `input`
+
+#### Scenario: JSON object response format preserves instruction-role messages
+- **WHEN** the client sends `response_format: {"type":"json_object"}` with a `system` or `developer` message that instructs JSON output
+- **THEN** the mapped Responses payload keeps that message in `input` with its original role
+- **AND** the mapped `instructions` value does not contain that message content
 
 #### Scenario: Tool choice values
 - **WHEN** the client sets `tool_choice` to `none`, `auto`, or `required`
@@ -189,4 +195,3 @@ When Chat Completions clients send provider-specific reasoning controls that are
 - **AND** no explicit `reasoning` or `reasoning_effort` override is present
 - **THEN** the mapped Responses payload includes `reasoning.effort: "medium"`
 - **AND** the forwarded upstream payload does not include `thinking`
-

--- a/tests/unit/test_chat_request_mapping.py
+++ b/tests/unit/test_chat_request_mapping.py
@@ -322,6 +322,29 @@ def test_chat_response_format_json_object_maps_to_text_format():
     assert text.get("format") == {"type": "json_object"}
 
 
+def test_chat_response_format_json_object_preserves_instruction_roles_in_input():
+    payload = {
+        "model": "gpt-5.2",
+        "messages": [
+            {"role": "system", "content": "Return JSON."},
+            {"role": "developer", "content": "Keep it short."},
+            {"role": "user", "content": "Say hello."},
+        ],
+        "response_format": {"type": "json_object"},
+    }
+    req = ChatCompletionsRequest.model_validate(payload)
+    responses = req.to_responses_request()
+    dumped = responses.to_payload()
+
+    assert dumped["instructions"] == ""
+    assert dumped["input"] == [
+        {"role": "system", "content": [{"type": "input_text", "text": "Return JSON."}]},
+        {"role": "developer", "content": [{"type": "input_text", "text": "Keep it short."}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "Say hello."}]},
+    ]
+    assert dumped["text"] == {"format": {"type": "json_object"}}
+
+
 def test_chat_response_format_json_schema_maps_schema_fields():
     payload = {
         "model": "gpt-5.2",
@@ -346,6 +369,29 @@ def test_chat_response_format_json_schema_maps_schema_fields():
     assert fmt.get("name") == "output"
     assert fmt.get("schema") == {"type": "object", "properties": {"ok": {"type": "boolean"}}}
     assert fmt.get("strict") is True
+
+
+def test_chat_response_format_json_schema_keeps_system_in_instructions():
+    payload = {
+        "model": "gpt-5.2",
+        "messages": [
+            {"role": "system", "content": "Return JSON."},
+            {"role": "user", "content": "hi"},
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "output",
+                "schema": {"type": "object", "properties": {"ok": {"type": "boolean"}}},
+                "strict": True,
+            },
+        },
+    }
+    req = ChatCompletionsRequest.model_validate(payload)
+    responses = req.to_responses_request()
+
+    assert responses.instructions == "Return JSON."
+    assert responses.input == [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
 
 
 def test_chat_stream_options_include_obfuscation_passthrough():

--- a/tests/unit/test_prompt_cache_key_derivation.py
+++ b/tests/unit/test_prompt_cache_key_derivation.py
@@ -11,6 +11,7 @@ from app.modules.api_keys.service import ApiKeyData
 from app.modules.proxy.service import (
     _derive_prompt_cache_key,
     _extract_first_user_input,
+    _extract_instruction_input,
 )
 
 pytestmark = pytest.mark.unit
@@ -128,6 +129,26 @@ class TestExtractFirstUserInput:
         assert _extract_first_user_input(payload) == "compact hello"
 
 
+class TestExtractInstructionInput:
+    def test_extracts_system_and_developer_input(self):
+        payload = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="",
+            input=_json_value(
+                [
+                    {"role": "system", "content": [{"type": "input_text", "text": "Return JSON."}]},
+                    {"role": "developer", "content": "Keep it short."},
+                    {"role": "user", "content": "hello"},
+                ]
+            ),
+        )
+        assert _extract_instruction_input(payload) == "Return JSON.\nKeep it short."
+
+    def test_ignores_string_input(self):
+        payload = ResponsesRequest(model="gpt-5.4", instructions="", input="hello")
+        assert _extract_instruction_input(payload) is None
+
+
 class TestDerivePromptCacheKey:
     def test_same_session_across_turns_produces_same_key(self):
         turn1 = ResponsesRequest(
@@ -189,6 +210,31 @@ class TestDerivePromptCacheKey:
             instructions="You are a reviewer",
             input=_json_value([{"role": "user", "content": "hello"}]),
         )
+        assert _derive_prompt_cache_key(p1, api_key) != _derive_prompt_cache_key(p2, api_key)
+
+    def test_different_instruction_role_input_produce_different_keys(self):
+        api_key = _make_api_key()
+        p1 = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="",
+            input=_json_value(
+                [
+                    {"role": "system", "content": [{"type": "input_text", "text": "Return JSON."}]},
+                    {"role": "user", "content": "hello"},
+                ]
+            ),
+        )
+        p2 = ResponsesRequest(
+            model="gpt-5.4",
+            instructions="",
+            input=_json_value(
+                [
+                    {"role": "system", "content": [{"type": "input_text", "text": "Return XML."}]},
+                    {"role": "user", "content": "hello"},
+                ]
+            ),
+        )
+
         assert _derive_prompt_cache_key(p1, api_key) != _derive_prompt_cache_key(p2, api_key)
 
     def test_no_api_key_still_produces_key(self):


### PR DESCRIPTION
Linked issue: Closes #730

## OpenSpec

Change directory: `openspec/changes/fix-chat-json-mode-instruction-roles/`

## Changes

This fixes a Chat Completions JSON mode compatibility issue surfaced by mem0.

mem0 sends `response_format: {"type":"json_object"}` with the JSON instruction in a `system` or `developer` message. codex-lb was moving those messages into Responses `instructions`, which made the JSON instruction unavailable to JSON-mode validation.

This PR keeps `system` and `developer` messages in Responses `input` for `json_object` requests, while leaving the existing `instructions` behavior unchanged for normal requests and `json_schema`.

It also updates the derived prompt-cache key so preserved instruction-role input is included, and adds the matching regression tests and OpenSpec change.

## References

- OpenAI JSON mode docs: Chat Completions enables JSON mode with `response_format: {"type":"json_object"}` and requires instructing the model to produce JSON via a conversation message, for example a system message: https://developers.openai.com/api/docs/guides/structured-outputs#json-mode
- OpenAI message roles docs: developer messages are application-provided instructions prioritized ahead of user messages: https://developers.openai.com/api/docs/guides/text#message-roles-and-instruction-following

## Testing

```sh
make lint
make typecheck
uv run pytest tests/unit/test_chat_request_mapping.py tests/unit/test_prompt_cache_key_derivation.py tests/integration/test_openai_compat_features.py::test_v1_chat_completions_maps_response_format
PYTHONFAULTHANDLER=1 uv run pytest -q -ra -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread --durations=20 tests/unit tests/test_request_logs_options_api.py
```

Targeted tests passed with `74 passed`; the Python unit slice passed with `1883 passed, 3 skipped`.