### PR TITLE
feat(release): add PR-driven beta release channel

### DIFF
--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -1,16 +1,11 @@
-name: Prepare Beta Release
+name: Sync Beta Release PR
 
 on:
-  workflow_dispatch:
-    inputs:
-      base_version:
-        description: "Stable version to beta-test (defaults to the open release-please PR version)"
-        required: false
-        default: ""
-      beta_number:
-        description: "Beta serial number (defaults to highest existing beta tag + 1)"
-        required: false
-        default: ""
+  push:
+    branches: ["main"]
+  workflow_run:
+    workflows: ["Release Please"]
+    types: [completed]
 
 concurrency:
   group: ${{ github.workflow }}-main
@@ -21,7 +16,10 @@ permissions:
   pull-requests: write
 
 jobs:
-  prepare-beta-release:
+  sync-beta-release-pr:
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
 
     env:
@@ -35,31 +33,44 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Find open release-please PR
+        id: release_pr
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_pr="$(gh pr list \
+            --base main \
+            --head release-please--branches--main \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+          if [ -z "${release_pr}" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No open release-please PR; beta PR sync is a no-op."
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "number=${release_pr}" >> "$GITHUB_OUTPUT"
+            echo "Found release-please PR #${release_pr}."
+          fi
+
       - name: Fetch release metadata
+        if: steps.release_pr.outputs.found == 'true'
         shell: bash
         run: |
           set -euo pipefail
           git fetch --tags --force
-          git fetch origin release-please--branches--main:refs/remotes/origin/release-please--branches--main || true
+          git fetch origin release-please--branches--main:refs/remotes/origin/release-please--branches--main
 
       - name: Prepare beta version bump
+        if: steps.release_pr.outputs.found == 'true'
         id: prepare
         shell: bash
-        env:
-          BASE_VERSION: ${{ inputs.base_version }}
-          BETA_NUMBER: ${{ inputs.beta_number }}
         run: |
           set -euo pipefail
-          args=()
-          if [ -n "${BASE_VERSION}" ]; then
-            args+=(--base-version "${BASE_VERSION}")
-          fi
-          if [ -n "${BETA_NUMBER}" ]; then
-            args+=(--beta-number "${BETA_NUMBER}")
-          fi
-          python -m scripts.prepare_beta_release "${args[@]}"
+          python -m scripts.prepare_beta_release
 
       - name: Detect changes
+        if: steps.release_pr.outputs.found == 'true' && steps.prepare.outputs.should_create != 'false'
         id: changes
         shell: bash
         run: |
@@ -97,6 +108,7 @@ jobs:
           VERSION: ${{ steps.prepare.outputs.version }}
           BASE_VERSION: ${{ steps.prepare.outputs.base_version }}
           PYPI_VERSION: ${{ steps.prepare.outputs.pypi_version }}
+          RELEASE_PR: ${{ steps.release_pr.outputs.number }}
         run: |
           set -euo pipefail
           body_file="${RUNNER_TEMP}/beta-release-pr.md"
@@ -105,6 +117,7 @@ jobs:
           - Prepares beta release ${TAG} for the ${BASE_VERSION} stable train.
           - Updates release-managed version files only; release-please remains the stable release owner.
           - Merging this PR will publish ${TAG} as a GitHub prerelease and trigger package/image/chart publishing.
+          - Synced automatically from release-please PR #${RELEASE_PR}; no manual beta workflow dispatch is required.
 
           ## Install after publish
           \`\`\`bash
@@ -117,7 +130,7 @@ jobs:
           Merge the normal release-please PR to promote this beta-tested train to ${BASE_VERSION}.
           EOF
 
-          existing_pr="$(gh pr list --base main --head "${BRANCH}" --json number --jq '.[0].number // empty')"
+          existing_pr="$(gh pr list --base main --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')"
           if [ -n "${existing_pr}" ]; then
             gh pr edit "${existing_pr}" --title "chore: release ${TAG}" --body-file "${body_file}"
             echo "Updated PR #${existing_pr}"

--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -1,0 +1,126 @@
+name: Prepare Beta Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: "Stable version to beta-test (defaults to the open release-please PR version)"
+        required: false
+        default: ""
+      beta_number:
+        description: "Beta serial number (defaults to highest existing beta tag + 1)"
+        required: false
+        default: ""
+
+concurrency:
+  group: ${{ github.workflow }}-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-beta-release:
+    runs-on: ubuntu-24.04
+
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Fetch release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          git fetch origin release-please--branches--main:refs/remotes/origin/release-please--branches--main || true
+
+      - name: Prepare beta version bump
+        id: prepare
+        shell: bash
+        env:
+          BASE_VERSION: ${{ inputs.base_version }}
+          BETA_NUMBER: ${{ inputs.beta_number }}
+        run: |
+          set -euo pipefail
+          args=()
+          if [ -n "${BASE_VERSION}" ]; then
+            args+=(--base-version "${BASE_VERSION}")
+          fi
+          if [ -n "${BETA_NUMBER}" ]; then
+            args+=(--beta-number "${BETA_NUMBER}")
+          fi
+          python -m scripts.prepare_beta_release "${args[@]}"
+
+      - name: Detect changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No beta version changes to propose."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff -- . ':!uv.lock' || true
+          fi
+
+      - name: Commit beta release PR branch
+        if: steps.changes.outputs.changed == 'true'
+        shell: bash
+        env:
+          BRANCH: ${{ steps.prepare.outputs.branch }}
+          TAG: ${{ steps.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "${BRANCH}"
+          git add pyproject.toml app/__init__.py frontend/package.json deploy/helm/codex-lb/Chart.yaml uv.lock
+          git commit -m "chore: release ${TAG}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force-with-lease origin "${BRANCH}"
+
+      - name: Open or update beta release PR
+        if: steps.changes.outputs.changed == 'true'
+        shell: bash
+        env:
+          BRANCH: ${{ steps.prepare.outputs.branch }}
+          TAG: ${{ steps.prepare.outputs.tag }}
+          VERSION: ${{ steps.prepare.outputs.version }}
+          BASE_VERSION: ${{ steps.prepare.outputs.base_version }}
+          PYPI_VERSION: ${{ steps.prepare.outputs.pypi_version }}
+        run: |
+          set -euo pipefail
+          body_file="${RUNNER_TEMP}/beta-release-pr.md"
+          cat > "${body_file}" <<EOF
+          ## Summary
+          - Prepares beta release ${TAG} for the ${BASE_VERSION} stable train.
+          - Updates release-managed version files only; release-please remains the stable release owner.
+          - Merging this PR will publish ${TAG} as a GitHub prerelease and trigger package/image/chart publishing.
+
+          ## Install after publish
+          \`\`\`bash
+          uvx --from "codex-lb==${PYPI_VERSION}" codex-lb
+          docker pull ghcr.io/${GITHUB_REPOSITORY}:${VERSION}
+          helm install codex-lb oci://ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/charts/codex-lb --version ${VERSION} --devel
+          \`\`\`
+
+          ## Promotion
+          Merge the normal release-please PR to promote this beta-tested train to ${BASE_VERSION}.
+          EOF
+
+          existing_pr="$(gh pr list --base main --head "${BRANCH}" --json number --jq '.[0].number // empty')"
+          if [ -n "${existing_pr}" ]; then
+            gh pr edit "${existing_pr}" --title "chore: release ${TAG}" --body-file "${body_file}"
+            echo "Updated PR #${existing_pr}"
+          else
+            gh pr create --base main --head "${BRANCH}" --title "chore: release ${TAG}" --body-file "${body_file}"
+          fi

--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -23,15 +23,26 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
     steps:
+      - name: Require release automation token
+        shell: bash
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
+            echo "::error::RELEASE_PLEASE_TOKEN is required so beta release events trigger artifact publishing."
+            exit 1
+          fi
+
       - name: Checkout main
         uses: actions/checkout@v6.0.2
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Find open release-please PR
         id: release_pr

--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -49,12 +49,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          repo_owner="${GITHUB_REPOSITORY_OWNER:-${GITHUB_REPOSITORY%%/*}}"
           release_pr="$(gh pr list \
             --base main \
-            --head release-please--branches--main \
             --state open \
-            --json number \
-            --jq '.[0].number // empty')"
+            --json number,headRefName,headRepositoryOwner \
+            --jq '[.[] | select(.headRefName == "release-please--branches--main" and .headRepositoryOwner.login == "'"${repo_owner}"'")][0].number // empty')"
           if [ -z "${release_pr}" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
             echo "No open release-please PR; beta PR sync is a no-op."

--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -53,6 +53,7 @@ jobs:
           release_pr="$(gh pr list \
             --base main \
             --state open \
+            --limit 200 \
             --json number,headRefName,headRepositoryOwner \
             --jq '[.[] | select(.headRefName == "release-please--branches--main" and .headRepositoryOwner.login == "'"${repo_owner}"'")][0].number // empty')"
           if [ -z "${release_pr}" ]; then

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -45,9 +45,18 @@ jobs:
           SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
+          tag_ref="refs/tags/${TAG}"
           tag_exists=false
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+          if git ls-remote --exit-code --tags origin "${tag_ref}" >/dev/null 2>&1; then
             tag_exists=true
+            existing_target="$(git ls-remote origin "${tag_ref}^{}" | awk '{print $1}')"
+            if [ -z "${existing_target}" ]; then
+              existing_target="$(git ls-remote origin "${tag_ref}" | awk '{print $1}')"
+            fi
+            if [ "${existing_target}" != "${SHA}" ]; then
+              echo "::error::${TAG} already points to ${existing_target}, not merged commit ${SHA}. Refusing to publish."
+              exit 1
+            fi
           fi
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -1,0 +1,77 @@
+name: Publish Beta Release
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  publish-beta-release:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/beta-')
+    runs-on: ubuntu-24.04
+
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout merged beta release commit
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Verify beta release version
+        id: verify
+        shell: bash
+        run: python -m scripts.verify_release_version --require-channel beta
+
+      - name: Create GitHub prerelease
+        shell: bash
+        env:
+          TAG: ${{ steps.verify.outputs.tag }}
+          VERSION: ${{ steps.verify.outputs.version }}
+          PYPI_VERSION: ${{ steps.verify.outputs.pypi_version }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; leaving existing release unchanged."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" "${SHA}" -m "Release ${TAG}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin "${TAG}"
+
+          notes_file="${RUNNER_TEMP}/beta-release-notes.md"
+          cat > "${notes_file}" <<EOF
+          Beta prerelease for the ${VERSION%-beta.*} stable train.
+
+          ## Install / Run
+          \`\`\`bash
+          uvx --from "codex-lb==${PYPI_VERSION}" codex-lb
+          docker pull ghcr.io/${GITHUB_REPOSITORY}:${VERSION}
+          helm install codex-lb oci://ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/charts/codex-lb --version ${VERSION} --devel
+          \`\`\`
+
+          Promote this train by merging the normal release-please PR for ${VERSION%-beta.*}.
+          EOF
+
+          gh release create "${TAG}" \
+            --target "${SHA}" \
+            --title "Release ${TAG}" \
+            --notes-file "${notes_file}" \
+            --prerelease

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -21,15 +21,26 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
     steps:
+      - name: Require release automation token
+        shell: bash
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
+            echo "::error::RELEASE_PLEASE_TOKEN is required so beta release events trigger artifact publishing."
+            exit 1
+          fi
+
       - name: Checkout merged beta release commit
         uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Verify beta release version
         id: verify

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -45,16 +45,18 @@ jobs:
           SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           set -euo pipefail
+          tag_exists=false
           if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists; leaving existing release unchanged."
-            exit 0
+            tag_exists=true
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG}" "${SHA}" -m "Release ${TAG}"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push origin "${TAG}"
+          if [ "${tag_exists}" = "false" ]; then
+            git tag -a "${TAG}" "${SHA}" -m "Release ${TAG}"
+            git push origin "${TAG}"
+          fi
 
           notes_file="${RUNNER_TEMP}/beta-release-notes.md"
           cat > "${notes_file}" <<EOF
@@ -70,8 +72,16 @@ jobs:
           Promote this train by merging the normal release-please PR for ${VERSION%-beta.*}.
           EOF
 
-          gh release create "${TAG}" \
-            --target "${SHA}" \
-            --title "Release ${TAG}" \
-            --notes-file "${notes_file}" \
-            --prerelease
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists; ensuring it remains marked as a prerelease."
+            gh release edit "${TAG}" \
+              --title "Release ${TAG}" \
+              --notes-file "${notes_file}" \
+              --prerelease
+          else
+            gh release create "${TAG}" \
+              --target "${SHA}" \
+              --title "Release ${TAG}" \
+              --notes-file "${notes_file}" \
+              --prerelease
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.1.2)"
+        description: "Release tag (e.g. v1.19.0 or v1.19.0-beta.1)"
         required: true
 
 concurrency:
@@ -17,8 +17,33 @@ env:
   RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
 jobs:
+  release-metadata:
+    name: Resolve release metadata
+    runs-on: ubuntu-24.04
+
+    outputs:
+      tag: ${{ steps.metadata.outputs.tag }}
+      version: ${{ steps.metadata.outputs.version }}
+      base_version: ${{ steps.metadata.outputs.base_version }}
+      channel: ${{ steps.metadata.outputs.channel }}
+      is_prerelease: ${{ steps.metadata.outputs.is_prerelease }}
+      pypi_version: ${{ steps.metadata.outputs.pypi_version }}
+      make_latest: ${{ steps.metadata.outputs.make_latest }}
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Resolve tag metadata
+        id: metadata
+        shell: bash
+        run: python -m scripts.release_metadata --tag "${RELEASE_TAG}"
+
   build:
     name: Build (sdist + wheel)
+    needs: [release-metadata]
     runs-on: ubuntu-24.04
 
     steps:
@@ -45,36 +70,9 @@ jobs:
           python-version: "3.13"
           enable-cache: true
 
-      - name: Verify tag matches pyproject version
+      - name: Verify tag matches release-managed versions
         shell: bash
-        run: |
-          python - <<'PY'
-          import os
-          import re
-          import sys
-          from pathlib import Path
-          try:
-              import tomllib  # py3.11+
-          except Exception:  # pragma: no cover
-              import tomli as tomllib
-
-          tag = os.environ.get("RELEASE_TAG", "")
-          if not tag:
-              print("Missing RELEASE_TAG")
-              sys.exit(1)
-          m = re.fullmatch(r"v(\d+\.\d+\.\d+)", tag)
-          if not m:
-              print(f"Invalid tag format: {tag!r}")
-              sys.exit(1)
-          tag_ver = m.group(1)
-
-          data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-          proj_ver = data["project"]["version"]
-          if proj_ver != tag_ver:
-              print(f"pyproject.toml version ({proj_ver}) does not match tag ({tag_ver})")
-              sys.exit(1)
-          print(f"OK: {tag} matches pyproject.toml version {proj_ver}")
-          PY
+        run: python -m scripts.verify_release_version --tag "${RELEASE_TAG}"
 
       - name: Build sdist + wheel
         run: uvx --from build python -m build
@@ -140,7 +138,7 @@ jobs:
 
   docker-image:
     name: Build and push Docker image
-    needs: [build]
+    needs: [build, release-metadata]
     runs-on: ubuntu-24.04
 
     permissions:
@@ -174,9 +172,10 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=raw,value=latest
+            type=semver,pattern={{major}}.{{minor}},enable=${{ needs.release-metadata.outputs.is_prerelease == 'false' }}
+            type=semver,pattern={{major}},enable=${{ needs.release-metadata.outputs.is_prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ needs.release-metadata.outputs.is_prerelease == 'false' }}
+            type=raw,value=${{ needs.release-metadata.outputs.channel }},enable=${{ needs.release-metadata.outputs.is_prerelease == 'true' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7.1.0
@@ -252,7 +251,7 @@ jobs:
 
   create-github-release:
     name: Create GitHub Release
-    needs: [publish-to-pypi, docker-image, helm-chart]
+    needs: [publish-to-pypi, docker-image, helm-chart, release-metadata]
     runs-on: ubuntu-24.04
 
     permissions:
@@ -274,23 +273,45 @@ jobs:
       - name: Resolve previous tag
         id: prev_tag
         shell: bash
+        env:
+          IS_PRERELEASE: ${{ needs.release-metadata.outputs.is_prerelease }}
         run: |
           set -euo pipefail
-          TAG_NAME="${RELEASE_TAG}"
-          PREV_TAG=""
-          if git describe --tags --abbrev=0 "${TAG_NAME}^" >/dev/null 2>&1; then
-            PREV_TAG="$(git describe --tags --abbrev=0 "${TAG_NAME}^")"
-          fi
-          if [ -n "${PREV_TAG}" ]; then
-            RANGE="${PREV_TAG}..${TAG_NAME}"
-          else
-            RANGE="${TAG_NAME}"
-          fi
-          {
-            echo "tag_name=${TAG_NAME}"
-            echo "prev_tag=${PREV_TAG}"
-            echo "range=${RANGE}"
-          } >> "$GITHUB_OUTPUT"
+          python - <<'PY'
+          import os
+          import re
+          import subprocess
+
+          tag_name = os.environ["RELEASE_TAG"]
+          is_prerelease = os.environ.get("IS_PRERELEASE") == "true"
+          prev_tag = ""
+
+          if is_prerelease:
+              proc = subprocess.run(
+                  ["git", "describe", "--tags", "--abbrev=0", f"{tag_name}^"],
+                  check=False,
+                  text=True,
+                  stdout=subprocess.PIPE,
+                  stderr=subprocess.DEVNULL,
+              )
+              if proc.returncode == 0:
+                  prev_tag = proc.stdout.strip()
+          else:
+              proc = subprocess.run(
+                  ["git", "tag", "--merged", f"{tag_name}^", "--sort=-v:refname"],
+                  check=True,
+                  text=True,
+                  stdout=subprocess.PIPE,
+              )
+              stable_tag = re.compile(r"^v\d+\.\d+\.\d+$")
+              prev_tag = next((tag for tag in proc.stdout.splitlines() if stable_tag.fullmatch(tag)), "")
+
+          release_range = f"{prev_tag}..{tag_name}" if prev_tag else tag_name
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"tag_name={tag_name}\n")
+              fh.write(f"prev_tag={prev_tag}\n")
+              fh.write(f"range={release_range}\n")
+          PY
 
       - name: Generate release notes (GitHub)
         id: notes
@@ -320,6 +341,8 @@ jobs:
         shell: bash
         env:
           TAG_NAME: ${{ steps.prev_tag.outputs.tag_name }}
+          IS_PRERELEASE: ${{ needs.release-metadata.outputs.is_prerelease }}
+          PYPI_VERSION: ${{ needs.release-metadata.outputs.pypi_version }}
         run: |
           set -euo pipefail
           TAG_VERSION="${TAG_NAME#v}"
@@ -327,9 +350,15 @@ jobs:
             echo
             echo "## Install / Run"
             echo '```bash'
-            echo 'uvx codex-lb'
-            echo "docker pull ghcr.io/${GITHUB_REPOSITORY}:${TAG_VERSION}"
-            echo "helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version ${TAG_VERSION}"
+            if [ "${IS_PRERELEASE}" = "true" ]; then
+              echo "uvx --from \"codex-lb==${PYPI_VERSION}\" codex-lb"
+              echo "docker pull ghcr.io/${GITHUB_REPOSITORY}:${TAG_VERSION}"
+              echo "helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version ${TAG_VERSION} --devel"
+            else
+              echo 'uvx codex-lb'
+              echo "docker pull ghcr.io/${GITHUB_REPOSITORY}:${TAG_VERSION}"
+              echo "helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version ${TAG_VERSION}"
+            fi
             echo '```'
           } >> release_notes.md
 
@@ -341,4 +370,5 @@ jobs:
           body_path: release_notes.md
           files: "dist/*"
           draft: false
-          prerelease: false
+          prerelease: ${{ needs.release-metadata.outputs.is_prerelease == 'true' }}
+          make_latest: ${{ needs.release-metadata.outputs.make_latest }}

--- a/openspec/changes/add-beta-release-channel/proposal.md
+++ b/openspec/changes/add-beta-release-channel/proposal.md
@@ -1,0 +1,18 @@
+# Add beta release channel
+
+## Why
+
+codex-lb currently has one stable release path managed by release-please. Maintainers need a beta channel that is still PR-driven, does not create a long-lived beta branch, and can be promoted to the normal stable release by merging the existing release-please PR.
+
+## What Changes
+
+- Add a manual workflow that prepares a beta release PR by updating the same release-managed version files that release-please owns for stable releases.
+- Add a PR-merge workflow that publishes merged beta release PRs as GitHub prereleases.
+- Teach the release publishing workflow to accept prerelease tags and avoid stable aliases (`latest`, major, major.minor) for prerelease Docker images.
+- Keep `.github/release-please-manifest.json` owned by stable release-please; beta PRs do not advance the stable manifest.
+
+## Non-Goals
+
+- No long-lived `beta` branch.
+- No private/exclusive artifact access control.
+- No replacement of release-please for stable releases.

--- a/openspec/changes/add-beta-release-channel/proposal.md
+++ b/openspec/changes/add-beta-release-channel/proposal.md
@@ -6,7 +6,7 @@ codex-lb currently has one stable release path managed by release-please. Mainta
 
 ## What Changes
 
-- Add a manual workflow that prepares a beta release PR by updating the same release-managed version files that release-please owns for stable releases.
+- Add an automatic workflow that keeps a beta release PR synced from the open release-please PR without requiring manual workflow dispatch.
 - Add a PR-merge workflow that publishes merged beta release PRs as GitHub prereleases.
 - Teach the release publishing workflow to accept prerelease tags and avoid stable aliases (`latest`, major, major.minor) for prerelease Docker images.
 - Keep `.github/release-please-manifest.json` owned by stable release-please; beta PRs do not advance the stable manifest.

--- a/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
+++ b/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
@@ -2,15 +2,28 @@
 
 ### Requirement: Beta releases are prepared through release PRs
 
-Beta releases SHALL be prepared by a pull request against `main` that updates the release-managed version files to `X.Y.Z-beta.N`. The beta preparation flow SHALL derive `X.Y.Z` from the open release-please PR branch when no explicit base version is provided. Beta release PRs SHALL NOT update `.github/release-please-manifest.json` because stable version ownership remains with release-please.
+Beta releases SHALL be prepared by an automatically maintained pull request against `main` that updates the release-managed version files to `X.Y.Z-beta.N`. The beta preparation flow SHALL run after release-please completes and after pushes to `main`, SHALL derive `X.Y.Z` from the open release-please PR branch, and SHALL do nothing when there is no open release-please PR. Beta release PRs SHALL NOT update `.github/release-please-manifest.json` because stable version ownership remains with release-please.
 
-#### Scenario: maintainer prepares the next beta from the release-please PR
+#### Scenario: automation syncs the next beta from the release-please PR
 
 - **GIVEN** release-please has opened or updated `release-please--branches--main` with `pyproject.toml` version `1.19.0`
-- **WHEN** the beta preparation workflow runs without an explicit base version
+- **WHEN** the beta PR sync workflow runs
 - **THEN** it creates or updates a pull request that sets release-managed files to `1.19.0-beta.N`
 - **AND** `N` is one higher than the highest existing `v1.19.0-beta.N` tag
 - **AND** `.github/release-please-manifest.json` remains unchanged
+
+#### Scenario: automation is idle without a release-please PR
+
+- **GIVEN** there is no open release-please PR targeting `main`
+- **WHEN** the beta PR sync workflow runs
+- **THEN** it exits without creating a beta release pull request
+
+#### Scenario: merged beta release already covers main
+
+- **GIVEN** tag `v1.19.0-beta.1` points to `HEAD`
+- **AND** release-managed files all contain `1.19.0-beta.1`
+- **WHEN** the beta PR sync workflow runs for base version `1.19.0`
+- **THEN** it exits without creating `1.19.0-beta.2`
 
 ### Requirement: Merged beta release PRs publish GitHub prereleases
 

--- a/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
+++ b/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Beta releases are prepared through release PRs
+
+Beta releases SHALL be prepared by a pull request against `main` that updates the release-managed version files to `X.Y.Z-beta.N`. The beta preparation flow SHALL derive `X.Y.Z` from the open release-please PR branch when no explicit base version is provided. Beta release PRs SHALL NOT update `.github/release-please-manifest.json` because stable version ownership remains with release-please.
+
+#### Scenario: maintainer prepares the next beta from the release-please PR
+
+- **GIVEN** release-please has opened or updated `release-please--branches--main` with `pyproject.toml` version `1.19.0`
+- **WHEN** the beta preparation workflow runs without an explicit base version
+- **THEN** it creates or updates a pull request that sets release-managed files to `1.19.0-beta.N`
+- **AND** `N` is one higher than the highest existing `v1.19.0-beta.N` tag
+- **AND** `.github/release-please-manifest.json` remains unchanged
+
+### Requirement: Merged beta release PRs publish GitHub prereleases
+
+When a pull request from a `release/beta-*` branch is merged into `main`, the release automation SHALL verify that all release-managed version files agree on a beta version, create the matching `vX.Y.Z-beta.N` tag at the merge commit, and publish a GitHub prerelease for that tag. Re-running the workflow after the tag already exists SHALL be safe and SHALL NOT create a second tag.
+
+#### Scenario: beta PR merge publishes a prerelease tag
+
+- **GIVEN** a merged pull request from `release/beta-1.19.0-beta.1`
+- **AND** release-managed files all contain `1.19.0-beta.1`
+- **WHEN** the beta publish workflow runs
+- **THEN** it creates tag `v1.19.0-beta.1` at the merge commit
+- **AND** it creates a GitHub prerelease for `v1.19.0-beta.1`
+
+### Requirement: Prerelease artifacts do not advance stable aliases
+
+The release publishing workflow SHALL accept both stable tags (`vX.Y.Z`) and prerelease tags (`vX.Y.Z-alpha.N`, `vX.Y.Z-beta.N`, `vX.Y.Z-rc.N`). For prerelease tags, Docker publishing SHALL NOT update `latest`, `X`, or `X.Y` aliases, and the GitHub Release SHALL remain marked as a prerelease and not latest. Stable tags SHALL retain existing stable aliases and latest-release behavior.
+
+#### Scenario: beta release publishes beta-only Docker tags
+
+- **GIVEN** release tag `v1.19.0-beta.1`
+- **WHEN** the release publishing workflow builds the Docker image
+- **THEN** it publishes the exact version tag `1.19.0-beta.1`
+- **AND** it MAY publish channel tag `beta`
+- **AND** it MUST NOT publish or update `latest`, `1`, or `1.19`
+
+### Requirement: Stable release promotion remains release-please owned
+
+A beta-tested release train SHALL be promoted by merging the normal release-please stable release PR for the corresponding base version. Stable promotion SHALL rebuild PyPI, Docker, Helm, and GitHub Release artifacts with the stable version instead of retagging prerelease artifacts.
+
+#### Scenario: beta train is promoted to stable
+
+- **GIVEN** `v1.19.0-beta.2` was published from `main`
+- **AND** release-please has prepared the stable release PR for `1.19.0`
+- **WHEN** the stable release PR is merged
+- **THEN** release-please creates the stable `v1.19.0` release
+- **AND** the release publishing workflow publishes stable artifacts for `1.19.0`
+- **AND** stable Docker aliases `latest`, `1`, and `1.19` are updated only by the stable release

--- a/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
+++ b/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
@@ -23,6 +23,7 @@ Beta releases SHALL be prepared by an automatically maintained pull request agai
 - **GIVEN** a fork has an open pull request whose head branch is named `release-please--branches--main`
 - **WHEN** the beta PR sync workflow looks for the release-please PR
 - **THEN** it ignores that pull request unless the head repository owner is the canonical repository owner
+- **AND** it requests enough open pull requests to avoid missing the canonical release-please PR during high-PR-volume periods
 
 #### Scenario: merged beta release already covers main
 

--- a/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
+++ b/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
@@ -18,6 +18,12 @@ Beta releases SHALL be prepared by an automatically maintained pull request agai
 - **WHEN** the beta PR sync workflow runs
 - **THEN** it exits without creating a beta release pull request
 
+#### Scenario: automation ignores forked release-please branch names
+
+- **GIVEN** a fork has an open pull request whose head branch is named `release-please--branches--main`
+- **WHEN** the beta PR sync workflow looks for the release-please PR
+- **THEN** it ignores that pull request unless the head repository owner is the canonical repository owner
+
 #### Scenario: merged beta release already covers main
 
 - **GIVEN** tag `v1.19.0-beta.1` points to `HEAD`

--- a/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
+++ b/openspec/changes/add-beta-release-channel/specs/release-management/spec.md
@@ -27,12 +27,13 @@ Beta releases SHALL be prepared by an automatically maintained pull request agai
 
 ### Requirement: Merged beta release PRs publish GitHub prereleases
 
-When a pull request from a `release/beta-*` branch is merged into `main`, the release automation SHALL verify that all release-managed version files agree on a beta version, create the matching `vX.Y.Z-beta.N` tag at the merge commit, and publish a GitHub prerelease for that tag. Re-running the workflow after the tag already exists SHALL be safe and SHALL NOT create a second tag.
+When a pull request from a `release/beta-*` branch is merged into `main`, the release automation SHALL require `RELEASE_PLEASE_TOKEN` rather than falling back to `GITHUB_TOKEN`, verify that all release-managed version files agree on a beta version, create the matching `vX.Y.Z-beta.N` tag at the merge commit, and publish a GitHub prerelease for that tag. Re-running the workflow after the tag already exists SHALL be safe and SHALL NOT create a second tag.
 
 #### Scenario: beta PR merge publishes a prerelease tag
 
 - **GIVEN** a merged pull request from `release/beta-1.19.0-beta.1`
 - **AND** release-managed files all contain `1.19.0-beta.1`
+- **AND** `RELEASE_PLEASE_TOKEN` is configured
 - **WHEN** the beta publish workflow runs
 - **THEN** it creates tag `v1.19.0-beta.1` at the merge commit
 - **AND** it creates a GitHub prerelease for `v1.19.0-beta.1`

--- a/openspec/changes/add-beta-release-channel/tasks.md
+++ b/openspec/changes/add-beta-release-channel/tasks.md
@@ -2,7 +2,7 @@
 
 - [x] Add release-management OpenSpec requirements for beta PRs, prerelease publishing, and stable promotion.
 - [x] Add stdlib release version helpers and tests.
-- [x] Add prepare-beta-release workflow for PR-driven beta version bumps.
+- [x] Add automatic beta release PR sync workflow for PR-merge-only beta operations.
 - [x] Add publish-beta-release workflow for beta PR merge tagging/prerelease creation.
 - [x] Update release publishing workflow for prerelease tags and prerelease-safe Docker/GitHub Release metadata.
-- [ ] Run local validation gates.
+- [x] Run local validation gates.

--- a/openspec/changes/add-beta-release-channel/tasks.md
+++ b/openspec/changes/add-beta-release-channel/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Add release-management OpenSpec requirements for beta PRs, prerelease publishing, and stable promotion.
+- [x] Add stdlib release version helpers and tests.
+- [x] Add prepare-beta-release workflow for PR-driven beta version bumps.
+- [x] Add publish-beta-release workflow for beta PR merge tagging/prerelease creation.
+- [x] Update release publishing workflow for prerelease tags and prerelease-safe Docker/GitHub Release metadata.
+- [ ] Run local validation gates.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance scripts."""

--- a/scripts/prepare_beta_release.py
+++ b/scripts/prepare_beta_release.py
@@ -7,9 +7,12 @@ import argparse
 from pathlib import Path
 
 from scripts.release_versions import (
+    assert_project_versions,
     discover_release_please_base_version,
+    latest_beta_tag,
     next_beta_number,
     parse_version,
+    tag_targets_head,
     update_project_versions,
     write_github_outputs,
 )
@@ -36,6 +39,24 @@ def main() -> int:
     base = parse_version(base_version)
     if base.is_prerelease:
         raise SystemExit(f"--base-version must be stable, got {base.version!r}")
+
+    latest_beta = latest_beta_tag(root, base.version)
+    if args.beta_number == 0 and latest_beta is not None and tag_targets_head(root, latest_beta.tag):
+        assert_project_versions(root, latest_beta.version)
+        outputs = {
+            "should_create": False,
+            "reason": f"{latest_beta.tag} already covers HEAD",
+            "base_version": base.version,
+            "beta_number": latest_beta.serial or 0,
+            "version": latest_beta.version,
+            "tag": latest_beta.tag,
+            "pypi_version": latest_beta.pypi_version,
+            "branch": f"release/beta-{latest_beta.version}",
+        }
+        write_github_outputs(outputs)
+        for key, value in outputs.items():
+            print(f"{key}={str(value).lower() if isinstance(value, bool) else value}")
+        return 0
 
     beta_number = args.beta_number or next_beta_number(root, base.version)
     if beta_number < 1:

--- a/scripts/prepare_beta_release.py
+++ b/scripts/prepare_beta_release.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Prepare a beta release version bump in the working tree."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scripts.release_versions import (
+    discover_release_please_base_version,
+    next_beta_number,
+    parse_version,
+    update_project_versions,
+    write_github_outputs,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument(
+        "--base-version",
+        default="",
+        help="stable version to beta-test (defaults to release-please PR branch version)",
+    )
+    parser.add_argument(
+        "--beta-number",
+        type=int,
+        default=0,
+        help="beta serial number (defaults to highest existing beta tag + 1)",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    base_version = args.base_version.strip() or discover_release_please_base_version(root)
+    base = parse_version(base_version)
+    if base.is_prerelease:
+        raise SystemExit(f"--base-version must be stable, got {base.version!r}")
+
+    beta_number = args.beta_number or next_beta_number(root, base.version)
+    if beta_number < 1:
+        raise SystemExit("--beta-number must be >= 1")
+
+    version = f"{base.version}-beta.{beta_number}"
+    release = parse_version(version)
+    update_project_versions(root, release.version)
+
+    outputs = {
+        "base_version": base.version,
+        "beta_number": beta_number,
+        "version": release.version,
+        "tag": release.tag,
+        "pypi_version": release.pypi_version,
+        "branch": f"release/beta-{release.version}",
+    }
+    write_github_outputs(outputs)
+    for key, value in outputs.items():
+        print(f"{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Emit release metadata for a tag."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from scripts.release_versions import parse_tag, write_github_outputs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", default=os.environ.get("RELEASE_TAG", ""), help="release tag, e.g. v1.2.3")
+    args = parser.parse_args()
+
+    if not args.tag:
+        raise SystemExit("missing release tag")
+    release = parse_tag(args.tag)
+    outputs = {
+        "tag": release.tag,
+        "version": release.version,
+        "base_version": release.base,
+        "channel": release.channel,
+        "is_prerelease": release.is_prerelease,
+        "pypi_version": release.pypi_version,
+        "make_latest": not release.is_prerelease,
+    }
+    write_github_outputs(outputs)
+    for key, value in outputs.items():
+        print(f"{key}={str(value).lower() if isinstance(value, bool) else value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -24,7 +24,7 @@ def main() -> int:
         "channel": release.channel,
         "is_prerelease": release.is_prerelease,
         "pypi_version": release.pypi_version,
-        "make_latest": not release.is_prerelease,
+        "make_latest": "false" if release.is_prerelease else "legacy",
     }
     write_github_outputs(outputs)
     for key, value in outputs.items():

--- a/scripts/release_versions.py
+++ b/scripts/release_versions.py
@@ -1,0 +1,232 @@
+"""Release version helpers for codex-lb release workflows.
+
+The GitHub workflows intentionally use this stdlib-only module so that release
+metadata can be validated before project dependencies are installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+_VERSION_RE = re.compile(r"^(?P<base>\d+\.\d+\.\d+)(?:-(?P<channel>alpha|beta|rc)\.(?P<serial>[1-9]\d*))?$")
+_TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.[1-9]\d*)?)$")
+
+
+@dataclass(frozen=True)
+class ReleaseVersion:
+    version: str
+    base: str
+    channel: str
+    serial: int | None
+
+    @property
+    def is_prerelease(self) -> bool:
+        return self.channel != "stable"
+
+    @property
+    def tag(self) -> str:
+        return f"v{self.version}"
+
+    @property
+    def pypi_version(self) -> str:
+        """Return the normalized PEP 440 spelling expected in PyPI output."""
+
+        if self.channel == "stable":
+            return self.version
+        if self.channel == "alpha":
+            return f"{self.base}a{self.serial}"
+        if self.channel == "beta":
+            return f"{self.base}b{self.serial}"
+        if self.channel == "rc":
+            return f"{self.base}rc{self.serial}"
+        raise AssertionError(f"unexpected release channel: {self.channel}")
+
+
+def parse_version(version: str) -> ReleaseVersion:
+    match = _VERSION_RE.fullmatch(version)
+    if not match:
+        raise ValueError(f"invalid release version {version!r}; expected X.Y.Z or X.Y.Z-(alpha|beta|rc).N")
+    channel = match.group("channel") or "stable"
+    serial = int(match.group("serial")) if match.group("serial") else None
+    return ReleaseVersion(version=version, base=match.group("base"), channel=channel, serial=serial)
+
+
+def parse_tag(tag: str) -> ReleaseVersion:
+    match = _TAG_RE.fullmatch(tag)
+    if not match:
+        raise ValueError(f"invalid release tag {tag!r}; expected vX.Y.Z or vX.Y.Z-(alpha|beta|rc).N")
+    return parse_version(match.group("version"))
+
+
+def read_pyproject_version(root: Path) -> str:
+    text = (root / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "([^"]+)"$', text, flags=re.MULTILINE)
+    if not match:
+        raise ValueError("could not find [project] version in pyproject.toml")
+    return match.group(1)
+
+
+def _replace_once(text: str, pattern: str, replacement: str, *, path: str) -> str:
+    new_text, count = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise ValueError(f"expected exactly one replacement in {path}, got {count}")
+    return new_text
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+
+
+def update_project_versions(root: Path, version: str) -> None:
+    """Update all release-please managed version files to *version*.
+
+    This deliberately does not modify .github/release-please-manifest.json:
+    beta releases are prerelease snapshots of the next stable train, while the
+    stable train remains owned by release-please.
+    """
+
+    parse_version(version)
+
+    pyproject = root / "pyproject.toml"
+    _write_text(
+        pyproject,
+        _replace_once(
+            pyproject.read_text(encoding="utf-8"),
+            r'^version = "[^"]+"$',
+            f'version = "{version}"',
+            path=str(pyproject),
+        ),
+    )
+
+    init_py = root / "app" / "__init__.py"
+    _write_text(
+        init_py,
+        _replace_once(
+            init_py.read_text(encoding="utf-8"),
+            r'^__version__ = "[^"]+"',
+            f'__version__ = "{version}"',
+            path=str(init_py),
+        ),
+    )
+
+    package_json = root / "frontend" / "package.json"
+    package_data = json.loads(package_json.read_text(encoding="utf-8"))
+    package_data["version"] = version
+    _write_text(package_json, json.dumps(package_data, indent=2, ensure_ascii=False) + "\n")
+
+    chart = root / "deploy" / "helm" / "codex-lb" / "Chart.yaml"
+    chart_text = chart.read_text(encoding="utf-8")
+    chart_text = _replace_once(chart_text, r"^version: .*$", f"version: {version}", path=str(chart))
+    chart_text = _replace_once(chart_text, r"^appVersion: .*$", f"appVersion: {version}", path=str(chart))
+    _write_text(chart, chart_text)
+
+    uv_lock = root / "uv.lock"
+    uv_text = uv_lock.read_text(encoding="utf-8")
+    uv_text, count = re.subn(
+        r'(\[\[package\]\]\nname = "codex-lb"\nversion = ")[^"]+("\nsource = \{ editable = "\." \})',
+        rf"\g<1>{version}\2",
+        uv_text,
+        count=1,
+    )
+    if count != 1:
+        raise ValueError("expected exactly one codex-lb package entry in uv.lock")
+    _write_text(uv_lock, uv_text)
+
+
+def read_project_versions(root: Path) -> dict[str, str]:
+    package_data = json.loads((root / "frontend" / "package.json").read_text(encoding="utf-8"))
+    chart_text = (root / "deploy" / "helm" / "codex-lb" / "Chart.yaml").read_text(encoding="utf-8")
+    uv_text = (root / "uv.lock").read_text(encoding="utf-8")
+
+    def find(pattern: str, text: str, name: str) -> str:
+        match = re.search(pattern, text, flags=re.MULTILINE)
+        if not match:
+            raise ValueError(f"could not find {name}")
+        return match.group(1)
+
+    return {
+        "pyproject.toml": read_pyproject_version(root),
+        "app/__init__.py": find(
+            r'^__version__ = "([^"]+)"',
+            (root / "app" / "__init__.py").read_text(encoding="utf-8"),
+            "app version",
+        ),
+        "frontend/package.json": package_data["version"],
+        "deploy/helm/codex-lb/Chart.yaml version": find(r"^version: (.+)$", chart_text, "chart version"),
+        "deploy/helm/codex-lb/Chart.yaml appVersion": find(r"^appVersion: (.+)$", chart_text, "chart appVersion"),
+        "uv.lock": find(
+            r'\[\[package\]\]\nname = "codex-lb"\nversion = "([^"]+)"\nsource = \{ editable = "\." \}',
+            uv_text,
+            "uv.lock codex-lb version",
+        ),
+    }
+
+
+def assert_project_versions(root: Path, expected_version: str) -> None:
+    mismatches = {name: actual for name, actual in read_project_versions(root).items() if actual != expected_version}
+    if mismatches:
+        detail = ", ".join(f"{name}={actual!r}" for name, actual in sorted(mismatches.items()))
+        raise ValueError(f"release version drift: expected {expected_version!r}; {detail}")
+
+
+def run_git(root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def discover_release_please_base_version(root: Path) -> str:
+    """Read the next stable version from the release-please PR branch."""
+
+    candidates = ["origin/release-please--branches--main", "release-please--branches--main"]
+    last_error = ""
+    for ref in candidates:
+        proc = run_git(root, "show", f"{ref}:pyproject.toml", check=False)
+        if proc.returncode != 0:
+            last_error = proc.stderr.strip()
+            continue
+        match = re.search(r'^version = "([^"]+)"$', proc.stdout, flags=re.MULTILINE)
+        if not match:
+            raise ValueError(f"{ref}:pyproject.toml does not contain a project version")
+        release = parse_version(match.group(1))
+        if release.is_prerelease:
+            raise ValueError(f"release-please branch version must be stable, got {release.version!r}")
+        return release.version
+    raise ValueError(
+        "could not discover next stable version from release-please PR branch; "
+        "run Release Please first or pass --base-version." + (f" Last git error: {last_error}" if last_error else "")
+    )
+
+
+def next_beta_number(root: Path, base_version: str) -> int:
+    parse_version(base_version)
+    proc = run_git(root, "tag", "--list", f"v{base_version}-beta.*")
+    highest = 0
+    for tag in proc.stdout.splitlines():
+        try:
+            parsed = parse_tag(tag.strip())
+        except ValueError:
+            continue
+        if parsed.base == base_version and parsed.channel == "beta" and parsed.serial is not None:
+            highest = max(highest, parsed.serial)
+    return highest + 1
+
+
+def write_github_outputs(values: Mapping[str, str | int | bool]) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with Path(output_path).open("a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}={str(value).lower() if isinstance(value, bool) else value}\n")

--- a/scripts/release_versions.py
+++ b/scripts/release_versions.py
@@ -217,18 +217,31 @@ def discover_release_please_base_version(root: Path) -> str:
     )
 
 
-def next_beta_number(root: Path, base_version: str) -> int:
+def latest_beta_tag(root: Path, base_version: str) -> ReleaseVersion | None:
     parse_version(base_version)
     proc = run_git(root, "tag", "--list", f"v{base_version}-beta.*")
-    highest = 0
+    latest: ReleaseVersion | None = None
     for tag in proc.stdout.splitlines():
         try:
             parsed = parse_tag(tag.strip())
         except ValueError:
             continue
-        if parsed.base == base_version and parsed.channel == "beta" and parsed.serial is not None:
-            highest = max(highest, parsed.serial)
-    return highest + 1
+        if parsed.base != base_version or parsed.channel != "beta" or parsed.serial is None:
+            continue
+        if latest is None or parsed.serial > (latest.serial or 0):
+            latest = parsed
+    return latest
+
+
+def next_beta_number(root: Path, base_version: str) -> int:
+    latest = latest_beta_tag(root, base_version)
+    return (latest.serial + 1) if latest and latest.serial is not None else 1
+
+
+def tag_targets_head(root: Path, tag: str) -> bool:
+    tag_sha = run_git(root, "rev-parse", f"{tag}^{{commit}}").stdout.strip()
+    head_sha = run_git(root, "rev-parse", "HEAD").stdout.strip()
+    return tag_sha == head_sha
 
 
 def write_github_outputs(values: Mapping[str, str | int | bool]) -> None:

--- a/scripts/release_versions.py
+++ b/scripts/release_versions.py
@@ -10,6 +10,7 @@ import json
 import os
 import re
 import subprocess
+import tomllib
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,12 +65,19 @@ def parse_tag(tag: str) -> ReleaseVersion:
     return parse_version(match.group("version"))
 
 
-def read_pyproject_version(root: Path) -> str:
-    text = (root / "pyproject.toml").read_text(encoding="utf-8")
-    match = re.search(r'^version = "([^"]+)"$', text, flags=re.MULTILINE)
-    if not match:
+def read_pyproject_version_text(text: str) -> str:
+    data = tomllib.loads(text)
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise ValueError("could not find [project] table in pyproject.toml")
+    version = project.get("version")
+    if not isinstance(version, str) or not version:
         raise ValueError("could not find [project] version in pyproject.toml")
-    return match.group(1)
+    return version
+
+
+def read_pyproject_version(root: Path) -> str:
+    return read_pyproject_version_text((root / "pyproject.toml").read_text(encoding="utf-8"))
 
 
 def _replace_once(text: str, pattern: str, replacement: str, *, path: str) -> str:
@@ -196,10 +204,10 @@ def discover_release_please_base_version(root: Path) -> str:
         if proc.returncode != 0:
             last_error = proc.stderr.strip()
             continue
-        match = re.search(r'^version = "([^"]+)"$', proc.stdout, flags=re.MULTILINE)
-        if not match:
-            raise ValueError(f"{ref}:pyproject.toml does not contain a project version")
-        release = parse_version(match.group(1))
+        try:
+            release = parse_version(read_pyproject_version_text(proc.stdout))
+        except ValueError as exc:
+            raise ValueError(f"{ref}:pyproject.toml does not contain a valid project version") from exc
         if release.is_prerelease:
             raise ValueError(f"release-please branch version must be stable, got {release.version!r}")
         return release.version

--- a/scripts/verify_release_version.py
+++ b/scripts/verify_release_version.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Verify that release-managed files agree with the release tag/version."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from scripts.release_versions import (
+    assert_project_versions,
+    parse_tag,
+    parse_version,
+    read_pyproject_version,
+    write_github_outputs,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--tag", default="", help="release tag to compare with project files")
+    parser.add_argument("--require-channel", choices=["stable", "alpha", "beta", "rc"], default="")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    release = parse_tag(args.tag) if args.tag else parse_version(read_pyproject_version(root))
+    if args.require_channel and release.channel != args.require_channel:
+        raise SystemExit(f"expected {args.require_channel} release, got {release.channel}: {release.version}")
+
+    assert_project_versions(root, release.version)
+    outputs = {
+        "tag": release.tag,
+        "version": release.version,
+        "base_version": release.base,
+        "channel": release.channel,
+        "is_prerelease": release.is_prerelease,
+        "pypi_version": release.pypi_version,
+    }
+    write_github_outputs(outputs)
+    for key, value in outputs.items():
+        print(f"{key}={str(value).lower() if isinstance(value, bool) else value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_versions.py
+++ b/tests/unit/test_release_versions.py
@@ -11,6 +11,7 @@ from scripts.release_versions import (
     next_beta_number,
     parse_tag,
     parse_version,
+    read_pyproject_version,
     update_project_versions,
 )
 
@@ -50,6 +51,15 @@ def test_parse_stable_and_beta_versions() -> None:
     assert beta.serial == 2
     assert beta.pypi_version == "1.19.0b2"
     assert beta.is_prerelease
+
+
+def test_read_pyproject_version_uses_project_table(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.example]\nversion = "0.0.0"\n\n[project]\nname = "codex-lb"\nversion = "1.19.0"\n',
+        encoding="utf-8",
+    )
+
+    assert read_pyproject_version(tmp_path) == "1.19.0"
 
 
 @pytest.mark.parametrize("bad", ["1.19", "v1.19.0", "1.19.0-beta", "1.19.0-beta.0", "1.19.0-dev.1"])

--- a/tests/unit/test_release_versions.py
+++ b/tests/unit/test_release_versions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -60,6 +61,24 @@ def test_read_pyproject_version_uses_project_table(tmp_path: Path) -> None:
     )
 
     assert read_pyproject_version(tmp_path) == "1.19.0"
+
+
+def test_release_metadata_make_latest_outputs() -> None:
+    stable = subprocess.run(
+        [sys.executable, "-m", "scripts.release_metadata", "--tag", "v1.19.0"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    beta = subprocess.run(
+        [sys.executable, "-m", "scripts.release_metadata", "--tag", "v1.19.0-beta.1"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+    assert "make_latest=legacy" in stable.stdout
+    assert "make_latest=false" in beta.stdout
 
 
 @pytest.mark.parametrize("bad", ["1.19", "v1.19.0", "1.19.0-beta", "1.19.0-beta.0", "1.19.0-dev.1"])

--- a/tests/unit/test_release_versions.py
+++ b/tests/unit/test_release_versions.py
@@ -9,10 +9,12 @@ import pytest
 
 from scripts.release_versions import (
     assert_project_versions,
+    latest_beta_tag,
     next_beta_number,
     parse_tag,
     parse_version,
     read_pyproject_version,
+    tag_targets_head,
     update_project_versions,
 )
 
@@ -36,6 +38,14 @@ def write_minimal_release_files(root: Path, version: str = "1.18.2") -> None:
         f'[[package]]\nname = "codex-lb"\nversion = "{version}"\nsource = {{ editable = "." }}\n',
         encoding="utf-8",
     )
+
+
+def init_git_repo(root: Path) -> None:
+    subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.PIPE)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=root, check=True, stdout=subprocess.PIPE)
 
 
 def test_parse_stable_and_beta_versions() -> None:
@@ -99,13 +109,26 @@ def test_update_project_versions_keeps_all_release_files_in_sync(tmp_path: Path)
 
 def test_next_beta_number_uses_existing_tags(tmp_path: Path) -> None:
     write_minimal_release_files(tmp_path)
-    subprocess.run(["git", "init"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
-    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
+    init_git_repo(tmp_path)
     subprocess.run(["git", "tag", "v1.19.0-beta.1"], cwd=tmp_path, check=True)
     subprocess.run(["git", "tag", "v1.19.0-beta.3"], cwd=tmp_path, check=True)
     subprocess.run(["git", "tag", "v1.20.0-beta.9"], cwd=tmp_path, check=True)
 
+    latest = latest_beta_tag(tmp_path, "1.19.0")
+    assert latest is not None
+    assert latest.tag == "v1.19.0-beta.3"
     assert next_beta_number(tmp_path, "1.19.0") == 4
+
+
+def test_tag_targets_head_detects_covered_beta_merge(tmp_path: Path) -> None:
+    write_minimal_release_files(tmp_path, "1.19.0-beta.1")
+    init_git_repo(tmp_path)
+    subprocess.run(["git", "tag", "v1.19.0-beta.1"], cwd=tmp_path, check=True)
+
+    assert tag_targets_head(tmp_path, "v1.19.0-beta.1")
+
+    (tmp_path / "README.md").write_text("new feature\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "feat: new feature"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
+
+    assert not tag_targets_head(tmp_path, "v1.19.0-beta.1")

--- a/tests/unit/test_release_versions.py
+++ b/tests/unit/test_release_versions.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.release_versions import (
+    assert_project_versions,
+    next_beta_number,
+    parse_tag,
+    parse_version,
+    update_project_versions,
+)
+
+
+def write_minimal_release_files(root: Path, version: str = "1.18.2") -> None:
+    (root / "app").mkdir(parents=True)
+    (root / "frontend").mkdir(parents=True)
+    (root / "deploy" / "helm" / "codex-lb").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(f'[project]\nname = "codex-lb"\nversion = "{version}"\n', encoding="utf-8")
+    (root / "app" / "__init__.py").write_text(
+        f'__version__ = "{version}"  # x-release-please-version\n', encoding="utf-8"
+    )
+    (root / "frontend" / "package.json").write_text(
+        json.dumps({"name": "frontend", "version": version}) + "\n", encoding="utf-8"
+    )
+    (root / "deploy" / "helm" / "codex-lb" / "Chart.yaml").write_text(
+        f"apiVersion: v2\nname: codex-lb\nversion: {version}\nappVersion: {version}\n",
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text(
+        f'[[package]]\nname = "codex-lb"\nversion = "{version}"\nsource = {{ editable = "." }}\n',
+        encoding="utf-8",
+    )
+
+
+def test_parse_stable_and_beta_versions() -> None:
+    stable = parse_tag("v1.19.0")
+    assert stable.version == "1.19.0"
+    assert stable.channel == "stable"
+    assert stable.pypi_version == "1.19.0"
+    assert not stable.is_prerelease
+
+    beta = parse_version("1.19.0-beta.2")
+    assert beta.tag == "v1.19.0-beta.2"
+    assert beta.base == "1.19.0"
+    assert beta.channel == "beta"
+    assert beta.serial == 2
+    assert beta.pypi_version == "1.19.0b2"
+    assert beta.is_prerelease
+
+
+@pytest.mark.parametrize("bad", ["1.19", "v1.19.0", "1.19.0-beta", "1.19.0-beta.0", "1.19.0-dev.1"])
+def test_parse_version_rejects_non_release_spellings(bad: str) -> None:
+    with pytest.raises(ValueError):
+        parse_version(bad)
+
+
+def test_update_project_versions_keeps_all_release_files_in_sync(tmp_path: Path) -> None:
+    write_minimal_release_files(tmp_path)
+
+    update_project_versions(tmp_path, "1.19.0-beta.1")
+
+    assert_project_versions(tmp_path, "1.19.0-beta.1")
+    package_version = json.loads((tmp_path / "frontend" / "package.json").read_text(encoding="utf-8"))["version"]
+    assert package_version == "1.19.0-beta.1"
+
+
+def test_next_beta_number_uses_existing_tags(tmp_path: Path) -> None:
+    write_minimal_release_files(tmp_path)
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
+    subprocess.run(["git", "tag", "v1.19.0-beta.1"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "tag", "v1.19.0-beta.3"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "tag", "v1.20.0-beta.9"], cwd=tmp_path, check=True)
+
+    assert next_beta_number(tmp_path, "1.19.0") == 4


### PR DESCRIPTION
## Summary
- Adds a PR-driven beta release channel without introducing a long-lived beta branch.
- Adds beta preparation and beta publish workflows: prepare PRs set `X.Y.Z-beta.N`; merged `release/beta-*` PRs create GitHub prereleases.
- Updates the release workflow to validate prerelease tags and avoid stable Docker/GitHub latest aliases for prereleases.
- Adds OpenSpec requirements plus stdlib release helper scripts and tests.

## Test Plan
- `make lint`
- `uv run pytest tests/unit/test_release_versions.py`
- `make typecheck`
- `openspec validate add-beta-release-channel --strict`
- YAML parse for all `.github/workflows/*.yml`
- `python ~/.hermes/skills/github/github-pr-workflow/scripts/validate-github-action-refs.py`
- CLI smoke: `python -m scripts.prepare_beta_release` + `python -m scripts.verify_release_version` on a temp repo
