### PR TITLE
feat(api-ui): Add account cost distribution for API

### DIFF
--- a/app/db/alembic/versions/20260520_010000_add_request_logs_api_key_account_index.py
+++ b/app/db/alembic/versions/20260520_010000_add_request_logs_api_key_account_index.py
@@ -1,0 +1,45 @@
+"""add request_logs api_key account index for account-cost breakdown
+
+Revision ID: 20260520_010000_add_request_logs_api_key_account_index
+Revises: 20260520_000000_merge_api_key_and_http_bridge_heads
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260520_010000_add_request_logs_api_key_account_index"
+down_revision = "20260520_000000_merge_api_key_and_http_bridge_heads"
+branch_labels = None
+depends_on = None
+
+_INDEX_NAME = "idx_logs_api_key_time_account"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("request_logs"):
+        return
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes("request_logs")}
+    if _INDEX_NAME not in existing_indexes:
+        op.create_index(
+            _INDEX_NAME,
+            "request_logs",
+            ["api_key_id", sa.text("requested_at DESC"), "account_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("request_logs"):
+        return
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes("request_logs")}
+    if _INDEX_NAME in existing_indexes:
+        op.drop_index(_INDEX_NAME, table_name="request_logs")

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -75,6 +75,7 @@ _MANUAL_DRIFT_INDEX_REQUIREMENTS: dict[str, frozenset[str]] = {
             "idx_logs_requested_at_model_tier",
             "idx_logs_model_effort_time",
             "idx_logs_status_error_time",
+            "idx_logs_api_key_time_account",
         }
     ),
     "api_keys": frozenset({"idx_api_keys_name"}),

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -630,6 +630,7 @@ Index("idx_accounts_email", Account.email)
 Index("idx_api_keys_name", ApiKey.name)
 Index("idx_logs_account_time", RequestLog.account_id, RequestLog.requested_at)
 Index("idx_logs_api_key_time", RequestLog.api_key_id, RequestLog.requested_at.desc(), RequestLog.id.desc())
+Index("idx_logs_api_key_time_account", RequestLog.api_key_id, RequestLog.requested_at.desc(), RequestLog.account_id)
 Index("idx_logs_requested_at", RequestLog.requested_at)
 Index("idx_logs_requested_at_id", RequestLog.requested_at.desc(), RequestLog.id.desc())
 Index(

--- a/app/modules/api_keys/api.py
+++ b/app/modules/api_keys/api.py
@@ -7,6 +7,7 @@ from app.core.auth.dependencies import set_dashboard_error_format, validate_dash
 from app.core.exceptions import DashboardBadRequestError, DashboardNotFoundError
 from app.dependencies import ApiKeysContext, get_api_keys_context
 from app.modules.api_keys.schemas import (
+    ApiKeyAccountCostResponse,
     ApiKeyCreateRequest,
     ApiKeyCreateResponse,
     ApiKeyResponse,
@@ -262,4 +263,13 @@ async def get_api_key_usage_7d(
         total_cost_usd=result.total_cost_usd,
         total_requests=result.total_requests,
         cached_input_tokens=result.cached_input_tokens,
+        account_costs=[
+            ApiKeyAccountCostResponse(
+                account_id=ac.account_id,
+                email=ac.email,
+                cost_usd=ac.cost_usd,
+                is_deleted=ac.is_deleted,
+            )
+            for ac in result.account_costs
+        ],
     )

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Sequence
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import Integer, cast, delete, func, select, update
+from sqlalchemy import Integer, cast, delete, func, select, true, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -72,6 +73,15 @@ class ApiKeyUsageTotals:
     total_tokens: int
     cached_input_tokens: int
     total_cost_usd: float
+    account_costs: list["ApiKeyAccountCost"] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyAccountCost:
+    account_id: str | None
+    email: str | None
+    cost_usd: float
+    is_deleted: bool = False
 
 
 class _Unset(Enum):
@@ -86,6 +96,41 @@ _STALE_USAGE_RESERVATION_RELEASE_BATCH_SIZE = 500
 class ApiKeysRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
+
+    @staticmethod
+    def _build_account_costs(rows: Sequence[object]) -> list[ApiKeyAccountCost]:
+        account_costs: list[ApiKeyAccountCost] = []
+        deleted_cost = 0.0
+
+        for row in rows:
+            cost = round(float(getattr(row, "cost_usd", 0.0) or 0.0), 6)
+            if cost <= 0:
+                continue
+            is_deleted = bool(getattr(row, "is_deleted", False))
+            if is_deleted:
+                deleted_cost += cost
+                continue
+            account_costs.append(
+                ApiKeyAccountCost(
+                    account_id=getattr(row, "account_id", None),
+                    email=getattr(row, "email", None),
+                    cost_usd=cost,
+                    is_deleted=False,
+                )
+            )
+
+        if deleted_cost > 0:
+            account_costs.append(
+                ApiKeyAccountCost(
+                    account_id=None,
+                    email=None,
+                    cost_usd=round(deleted_cost, 6),
+                    is_deleted=True,
+                )
+            )
+
+        account_costs.sort(key=lambda item: item.cost_usd, reverse=True)
+        return account_costs
 
     def _select_api_key(self):
         return (
@@ -709,6 +754,31 @@ class ApiKeysRepository:
 
         return released_count
 
+    async def usage_7d_by_account(
+        self,
+        key_id: str,
+        since: datetime,
+        until: datetime,
+    ) -> list[ApiKeyAccountCost]:
+        deleted_expr = func.coalesce(RequestLog.deleted_at.is_not(None), False)
+        stmt = (
+            select(
+                RequestLog.account_id,
+                Account.email,
+                deleted_expr.label("is_deleted"),
+                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
+            )
+            .outerjoin(Account, Account.id == RequestLog.account_id)
+            .where(
+                RequestLog.api_key_id == key_id,
+                RequestLog.requested_at >= since,
+                RequestLog.requested_at < until,
+            )
+            .group_by(RequestLog.account_id, Account.email, deleted_expr)
+        )
+        result = await self._session.execute(stmt)
+        return self._build_account_costs(result.all())
+
     async def trends_by_key(
         self,
         key_id: str,
@@ -754,22 +824,62 @@ class ApiKeysRepository:
         ]
 
     async def usage_7d(self, key_id: str, since: datetime, until: datetime) -> ApiKeyUsageTotals:
-        stmt = select(
-            func.count(RequestLog.id).label("total_requests"),
-            func.coalesce(func.sum(RequestLog.input_tokens), 0).label("total_input_tokens"),
-            func.coalesce(
-                func.sum(func.coalesce(RequestLog.output_tokens, RequestLog.reasoning_tokens, 0)),
-                0,
-            ).label("total_output_tokens"),
-            func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
-            func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
-        ).where(
-            RequestLog.api_key_id == key_id,
-            RequestLog.requested_at >= since,
-            RequestLog.requested_at < until,
+        filtered_logs = (
+            select(
+                RequestLog.id.label("id"),
+                RequestLog.account_id.label("account_id"),
+                RequestLog.deleted_at.label("deleted_at"),
+                RequestLog.input_tokens.label("input_tokens"),
+                RequestLog.output_tokens.label("output_tokens"),
+                RequestLog.reasoning_tokens.label("reasoning_tokens"),
+                RequestLog.cached_input_tokens.label("cached_input_tokens"),
+                RequestLog.cost_usd.label("cost_usd"),
+            )
+            .where(
+                RequestLog.api_key_id == key_id,
+                RequestLog.requested_at >= since,
+                RequestLog.requested_at < until,
+            )
+            .cte("filtered_logs")
         )
+        usage_totals = (
+            select(
+                func.count(filtered_logs.c.id).label("total_requests"),
+                func.coalesce(func.sum(filtered_logs.c.input_tokens), 0).label("total_input_tokens"),
+                func.coalesce(
+                    func.sum(func.coalesce(filtered_logs.c.output_tokens, filtered_logs.c.reasoning_tokens, 0)),
+                    0,
+                ).label("total_output_tokens"),
+                func.coalesce(func.sum(filtered_logs.c.cached_input_tokens), 0).label("cached_input_tokens"),
+                func.coalesce(func.sum(filtered_logs.c.cost_usd), 0.0).label("total_cost_usd"),
+            ).cte("usage_totals")
+        )
+        deleted_expr = func.coalesce(filtered_logs.c.deleted_at.is_not(None), False)
+        usage_grouped = (
+            select(
+                filtered_logs.c.account_id.label("account_id"),
+                Account.email.label("email"),
+                deleted_expr.label("is_deleted"),
+                func.coalesce(func.sum(filtered_logs.c.cost_usd), 0.0).label("cost_usd"),
+            )
+            .select_from(filtered_logs.outerjoin(Account, Account.id == filtered_logs.c.account_id))
+            .group_by(filtered_logs.c.account_id, Account.email, deleted_expr)
+            .cte("usage_grouped")
+        )
+        stmt = select(
+            usage_totals.c.total_requests,
+            usage_totals.c.total_input_tokens,
+            usage_totals.c.total_output_tokens,
+            usage_totals.c.cached_input_tokens,
+            usage_totals.c.total_cost_usd,
+            usage_grouped.c.account_id,
+            usage_grouped.c.email,
+            usage_grouped.c.is_deleted,
+            usage_grouped.c.cost_usd,
+        ).select_from(usage_totals.outerjoin(usage_grouped, true()))
         result = await self._session.execute(stmt)
-        row = result.one()
+        rows = result.all()
+        row = rows[0]
         input_sum = int(row.total_input_tokens or 0)
         output_sum = int(row.total_output_tokens or 0)
         cached_sum = int(row.cached_input_tokens or 0)
@@ -779,6 +889,7 @@ class ApiKeysRepository:
             total_tokens=input_sum + output_sum,
             cached_input_tokens=cached_sum,
             total_cost_usd=round(float(row.total_cost_usd or 0.0), 6),
+            account_costs=self._build_account_costs(rows),
         )
 
 

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -842,18 +842,16 @@ class ApiKeysRepository:
             )
             .cte("filtered_logs")
         )
-        usage_totals = (
-            select(
-                func.count(filtered_logs.c.id).label("total_requests"),
-                func.coalesce(func.sum(filtered_logs.c.input_tokens), 0).label("total_input_tokens"),
-                func.coalesce(
-                    func.sum(func.coalesce(filtered_logs.c.output_tokens, filtered_logs.c.reasoning_tokens, 0)),
-                    0,
-                ).label("total_output_tokens"),
-                func.coalesce(func.sum(filtered_logs.c.cached_input_tokens), 0).label("cached_input_tokens"),
-                func.coalesce(func.sum(filtered_logs.c.cost_usd), 0.0).label("total_cost_usd"),
-            ).cte("usage_totals")
-        )
+        usage_totals = select(
+            func.count(filtered_logs.c.id).label("total_requests"),
+            func.coalesce(func.sum(filtered_logs.c.input_tokens), 0).label("total_input_tokens"),
+            func.coalesce(
+                func.sum(func.coalesce(filtered_logs.c.output_tokens, filtered_logs.c.reasoning_tokens, 0)),
+                0,
+            ).label("total_output_tokens"),
+            func.coalesce(func.sum(filtered_logs.c.cached_input_tokens), 0).label("cached_input_tokens"),
+            func.coalesce(func.sum(filtered_logs.c.cost_usd), 0.0).label("total_cost_usd"),
+        ).cte("usage_totals")
         deleted_expr = func.coalesce(filtered_logs.c.deleted_at.is_not(None), False)
         usage_grouped = (
             select(

--- a/app/modules/api_keys/schemas.py
+++ b/app/modules/api_keys/schemas.py
@@ -93,9 +93,17 @@ class ApiKeyTrendsResponse(DashboardModel):
     tokens: list[ApiKeyTrendPoint] = Field(default_factory=list)
 
 
+class ApiKeyAccountCostResponse(DashboardModel):
+    account_id: str | None = None
+    email: str | None = None
+    cost_usd: float = 0
+    is_deleted: bool = False
+
+
 class ApiKeyUsage7DayResponse(DashboardModel):
     key_id: str
     total_tokens: int = 0
     total_cost_usd: float = 0
     total_requests: int = 0
     cached_input_tokens: int = 0
+    account_costs: list[ApiKeyAccountCostResponse] = Field(default_factory=list)

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -943,6 +943,15 @@ class ApiKeysService:
             total_cost_usd=data.total_cost_usd,
             total_requests=data.total_requests,
             cached_input_tokens=data.cached_input_tokens,
+            account_costs=[
+                ApiKeyAccountCostData(
+                    account_id=ac.account_id,
+                    email=ac.email,
+                    cost_usd=ac.cost_usd,
+                    is_deleted=ac.is_deleted,
+                )
+                for ac in data.account_costs
+            ],
         )
 
 
@@ -960,12 +969,21 @@ class ApiKeyTrendsData:
 
 
 @dataclass(frozen=True, slots=True)
+class ApiKeyAccountCostData:
+    account_id: str | None
+    email: str | None
+    cost_usd: float
+    is_deleted: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class ApiKeyUsage7DayData:
     key_id: str
     total_tokens: int = 0
     total_cost_usd: float = 0.0
     total_requests: int = 0
     cached_input_tokens: int = 0
+    account_costs: list[ApiKeyAccountCostData] = field(default_factory=list)
 
 
 @dataclass(frozen=True, slots=True)

--- a/frontend/src/features/apis/components/account-cost-donut.test.tsx
+++ b/frontend/src/features/apis/components/account-cost-donut.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { createApiKeyUsage7Day } from "@/test/mocks/factories";
 import { renderWithProviders } from "@/test/utils";
+import { usePrivacyStore } from "@/hooks/use-privacy";
 
 import { AccountCostDonut } from "./account-cost-donut";
 
@@ -83,6 +84,25 @@ describe("AccountCostDonut", () => {
 
 		expect(screen.queryByTestId("account-cost-total")).not.toBeInTheDocument();
 		expect(screen.getByTestId("account-cost-legend-list")).toHaveClass("w-full");
+	});
+
+	it("blurs active account labels but not deleted account labels in privacy mode", () => {
+		act(() => usePrivacyStore.setState({ blurred: true }));
+		const usage = createApiKeyUsage7Day({
+			totalCostUsd: 0.75,
+			accountCosts: [
+				{ accountId: "acc-1", email: "a@example.com", costUsd: 0.45, isDeleted: false },
+				{ accountId: null, email: null, costUsd: 0.3, isDeleted: true },
+			],
+		});
+
+		renderWithProviders(
+			<AccountCostDonut accountCosts={usage.accountCosts} totalCostUsd={usage.totalCostUsd} />,
+		);
+
+		expect(screen.getByText("a@example.com")).toHaveClass("privacy-blur");
+		expect(screen.getByText("Deleted Account")).not.toHaveClass("privacy-blur");
+		act(() => usePrivacyStore.setState({ blurred: false }));
 	});
 
 	it("scrolls the hovered pie item into view in the legend list", async () => {

--- a/frontend/src/features/apis/components/account-cost-donut.test.tsx
+++ b/frontend/src/features/apis/components/account-cost-donut.test.tsx
@@ -68,6 +68,23 @@ describe("AccountCostDonut", () => {
 		expect(screen.getByTestId("account-cost-legend-5")).toBeInTheDocument();
 	});
 
+	it("renders the legend below the donut and omits the header total summary", () => {
+		const usage = createApiKeyUsage7Day({
+			totalCostUsd: 0.75,
+			accountCosts: [
+				{ accountId: "acc-1", email: "a@example.com", costUsd: 0.45, isDeleted: false },
+				{ accountId: "acc-2", email: "b@example.com", costUsd: 0.3, isDeleted: false },
+			],
+		});
+
+		renderWithProviders(
+			<AccountCostDonut accountCosts={usage.accountCosts} totalCostUsd={usage.totalCostUsd} />,
+		);
+
+		expect(screen.queryByTestId("account-cost-total")).not.toBeInTheDocument();
+		expect(screen.getByTestId("account-cost-legend-list")).toHaveClass("w-full");
+	});
+
 	it("scrolls the hovered pie item into view in the legend list", async () => {
 		const scrollIntoView = vi.fn();
 		Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {

--- a/frontend/src/features/apis/components/account-cost-donut.test.tsx
+++ b/frontend/src/features/apis/components/account-cost-donut.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { createApiKeyUsage7Day } from "@/test/mocks/factories";
+import { renderWithProviders } from "@/test/utils";
+
+import { AccountCostDonut } from "./account-cost-donut";
+
+describe("AccountCostDonut", () => {
+	it("highlights the matching legend row when a legend item is hovered", () => {
+		const usage = createApiKeyUsage7Day({
+			totalCostUsd: 0.75,
+			accountCosts: [
+				{ accountId: "acc-1", email: "a@example.com", costUsd: 0.45, isDeleted: false },
+				{ accountId: "acc-2", email: "b@example.com", costUsd: 0.3, isDeleted: false },
+			],
+		});
+
+		renderWithProviders(
+			<AccountCostDonut accountCosts={usage.accountCosts} totalCostUsd={usage.totalCostUsd} />,
+		);
+
+		const legendRow = screen.getByTestId("account-cost-legend-0");
+		fireEvent.mouseEnter(legendRow);
+		expect(legendRow).toHaveAttribute("data-active", "true");
+
+		fireEvent.mouseLeave(legendRow);
+		expect(legendRow).toHaveAttribute("data-active", "false");
+	});
+
+	it("highlights the matching legend row when a pie slice is hovered", () => {
+		const usage = createApiKeyUsage7Day({
+			totalCostUsd: 0.75,
+			accountCosts: [
+				{ accountId: "acc-1", email: "a@example.com", costUsd: 0.45, isDeleted: false },
+				{ accountId: "acc-2", email: "b@example.com", costUsd: 0.3, isDeleted: false },
+			],
+		});
+
+		renderWithProviders(
+			<AccountCostDonut accountCosts={usage.accountCosts} totalCostUsd={usage.totalCostUsd} />,
+		);
+
+		const slices = document.querySelectorAll(".recharts-pie-sector");
+		fireEvent.mouseEnter(slices[0]!);
+
+		expect(screen.getByTestId("account-cost-legend-0")).toHaveAttribute("data-active", "true");
+	});
+
+	it("limits the legend viewport to five visible rows before scrolling", () => {
+		const usage = createApiKeyUsage7Day({
+			totalCostUsd: 2.8,
+			accountCosts: Array.from({ length: 6 }, (_, index) => ({
+				accountId: `acc-${index}`,
+				email: `user${index}@example.com`,
+				costUsd: 0.4 + index * 0.05,
+				isDeleted: false,
+			})),
+		});
+
+		renderWithProviders(
+			<AccountCostDonut accountCosts={usage.accountCosts} totalCostUsd={usage.totalCostUsd} />,
+		);
+
+		expect(screen.getByTestId("account-cost-legend-list")).toHaveStyle({
+			maxHeight: "calc(5 * 1.75rem + 4 * 0rem)",
+		});
+		expect(screen.getByTestId("account-cost-legend-5")).toBeInTheDocument();
+	});
+
+	it("scrolls the hovered pie item into view in the legend list", async () => {
+		const scrollIntoView = vi.fn();
+		Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+			configurable: true,
+			value: scrollIntoView,
+		});
+
+		const usage = createApiKeyUsage7Day({
+			totalCostUsd: 5.6,
+			accountCosts: Array.from({ length: 6 }, (_, index) => ({
+				accountId: `acc-${index}`,
+				email: `user${index}@example.com`,
+				costUsd: 1 - index * 0.1,
+				isDeleted: false,
+			})),
+		});
+
+		renderWithProviders(
+			<AccountCostDonut accountCosts={usage.accountCosts} totalCostUsd={usage.totalCostUsd} />,
+		);
+
+		const slices = document.querySelectorAll(".recharts-pie-sector");
+		fireEvent.mouseEnter(slices[5]!);
+
+		expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
+	});
+});

--- a/frontend/src/features/apis/components/account-cost-donut.tsx
+++ b/frontend/src/features/apis/components/account-cost-donut.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Cell, Pie, PieChart, Sector, type PieSectorShapeProps } from "recharts";
 
 import { buildDonutPalette } from "@/utils/colors";
@@ -20,7 +20,9 @@ const PIE_CY = 72;
 const INNER_R = 53;
 const OUTER_R = 68;
 const ACTIVE_RADIUS_OFFSET = 4;
-const MAX_LEGEND_ITEMS = 4;
+const LEGEND_VISIBLE_COUNT = 5;
+const LEGEND_ROW_HEIGHT_REM = 1.75;
+const LEGEND_ROW_GAP_REM = 0;
 
 type DonutDatum = {
   id: string;
@@ -33,6 +35,8 @@ export function AccountCostDonut({ accountCosts, totalCostUsd }: AccountCostDonu
   const isDark = useThemeStore((s) => s.theme === "dark");
   const blurred = usePrivacyStore((s) => s.blurred);
   const reducedMotion = useReducedMotion();
+  const [activeLegendId, setActiveLegendId] = useState<string | null>(null);
+  const legendRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const consumedColor = isDark ? "#404040" : "#d3d3d3";
 
 	const { chartData, legendItems } = useMemo(() => {
@@ -73,99 +77,135 @@ export function AccountCostDonut({ accountCosts, totalCostUsd }: AccountCostDonu
     return { chartData: data, legendItems: items };
   }, [accountCosts, totalCostUsd, isDark, consumedColor]);
 
+  useEffect(() => {
+    if (!activeLegendId) {
+      return;
+    }
+
+    const legendNode = legendRefs.current[activeLegendId];
+    if (typeof legendNode?.scrollIntoView === "function") {
+      legendNode.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
+  }, [activeLegendId]);
+
   const renderDonutShape = (props: PieSectorShapeProps) => {
+    const isHighlighted = props.isActive || (props.payload as DonutDatum | undefined)?.id === activeLegendId;
     return (
       <Sector
         {...props}
         outerRadius={
           typeof props.outerRadius === "number"
-            ? props.outerRadius + (props.isActive ? ACTIVE_RADIUS_OFFSET : 0)
-            : OUTER_R + (props.isActive ? ACTIVE_RADIUS_OFFSET : 0)
+            ? props.outerRadius + (isHighlighted ? ACTIVE_RADIUS_OFFSET : 0)
+            : OUTER_R + (isHighlighted ? ACTIVE_RADIUS_OFFSET : 0)
         }
-        stroke={props.isActive ? "hsl(var(--background))" : "none"}
-        strokeWidth={props.isActive ? 2 : 0}
+        stroke={isHighlighted ? "hsl(var(--background))" : "none"}
+        strokeWidth={isHighlighted ? 2 : 0}
       />
     );
   };
 
   return (
-    <div className="rounded-xl border bg-card p-5">
-      <div className="mb-3">
-        <h3 className="text-sm font-semibold">7-Day Cost by Account</h3>
-        <p className="mt-0.5 text-xs text-muted-foreground">Breakdown of usage cost</p>
-      </div>
-
-      <div className="flex flex-col items-center gap-2">
-        <div className="relative h-[152px] w-[152px] overflow-visible">
-          <PieChart width={CHART_SIZE} height={CHART_SIZE} margin={{ top: CHART_MARGIN, right: CHART_MARGIN, bottom: CHART_MARGIN, left: CHART_MARGIN }}>
-            <Pie
-              data={chartData}
-              cx={PIE_CX}
-              cy={PIE_CY}
-              innerRadius={INNER_R}
-              outerRadius={OUTER_R}
-              startAngle={90}
-              endAngle={-270}
-              dataKey="value"
-              stroke="none"
-              shape={renderDonutShape}
-              isAnimationActive={!reducedMotion}
-              animationDuration={600}
-              animationEasing="ease-out"
-            >
-              {chartData.map((entry) => (
-                <Cell key={entry.id} fill={entry.fill} />
-              ))}
-            </Pie>
-          </PieChart>
-          <div className="absolute inset-[22px] flex items-center justify-center rounded-full text-center pointer-events-none">
-            <div>
-              <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">7-Day Cost</p>
-              <p className="text-base font-semibold tabular-nums">{formatCurrency(totalCostUsd)}</p>
-            </div>
-          </div>
+    <div data-testid="account-cost-panel">
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold">7-Day Cost by Account</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">Breakdown of usage cost</p>
         </div>
-
-        <p className="text-[11px] tabular-nums text-muted-foreground">
+        <p className="shrink-0 text-[11px] tabular-nums text-muted-foreground" data-testid="account-cost-total">
           Total {formatCurrency(totalCostUsd)}
         </p>
       </div>
 
-      {legendItems.length > 0 && (
-        <div className="mt-3 space-y-0.5">
-          {legendItems.slice(0, MAX_LEGEND_ITEMS).map((item) => (
-            <div
-              key={item.id}
-              className="flex h-7 items-center justify-between px-1.5 gap-3 text-xs"
-            >
-              <div className="flex min-w-0 items-center gap-2">
-                <span
-                  aria-hidden
-                  className="h-2.5 w-2.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: item.color }}
-                />
-                <span className="truncate font-medium">
-                  {item.isDeleted ? (
-                    item.label
-                  ) : blurred ? (
-                    <span className="privacy-blur">{item.label}</span>
-                  ) : (
-                    item.label
-                  )}
-                </span>
+      <div className="flex items-center gap-6">
+        <div className="flex shrink-0 flex-col items-center">
+          <div className="relative h-[152px] w-[152px] overflow-visible">
+            <PieChart width={CHART_SIZE} height={CHART_SIZE} margin={{ top: CHART_MARGIN, right: CHART_MARGIN, bottom: CHART_MARGIN, left: CHART_MARGIN }}>
+              <Pie
+                data={chartData}
+                cx={PIE_CX}
+                cy={PIE_CY}
+                innerRadius={INNER_R}
+                outerRadius={OUTER_R}
+                startAngle={90}
+                endAngle={-270}
+                dataKey="value"
+                stroke="none"
+                shape={renderDonutShape}
+                isAnimationActive={!reducedMotion}
+                animationDuration={600}
+                animationEasing="ease-out"
+                onMouseEnter={(data) => {
+                  const datum = data.payload as DonutDatum | undefined;
+                  if (typeof datum?.id === "string") {
+                    setActiveLegendId(datum.id);
+                  }
+                }}
+                onMouseLeave={() => setActiveLegendId(null)}
+                onMouseOut={() => setActiveLegendId(null)}
+              >
+                {chartData.map((entry) => (
+                  <Cell key={entry.id} fill={entry.fill} />
+                ))}
+              </Pie>
+            </PieChart>
+            <div className="absolute inset-[22px] flex items-center justify-center rounded-full text-center pointer-events-none">
+              <div>
+                <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">7-Day Cost</p>
+                <p className="text-base font-semibold tabular-nums">{formatCurrency(totalCostUsd)}</p>
               </div>
-              <span className="shrink-0 tabular-nums text-muted-foreground">
-                {formatCurrency(item.value)}
-              </span>
             </div>
-          ))}
-          {legendItems.length > MAX_LEGEND_ITEMS && (
-            <p className="px-1.5 text-[10px] text-muted-foreground">
-              +{legendItems.length - MAX_LEGEND_ITEMS} more
-            </p>
-          )}
+          </div>
         </div>
-      )}
+        {legendItems.length > 0 && (
+          <div
+            className="flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            data-testid="account-cost-legend-list"
+            style={{ maxHeight: `calc(${LEGEND_VISIBLE_COUNT} * ${LEGEND_ROW_HEIGHT_REM}rem + ${(LEGEND_VISIBLE_COUNT - 1) * LEGEND_ROW_GAP_REM}rem)` }}
+          >
+            {legendItems.map((item, i) => {
+              const isActive = activeLegendId === item.id;
+
+              return (
+                <button
+                  ref={(node) => {
+                    legendRefs.current[item.id] = node;
+                  }}
+                  type="button"
+                  key={item.id}
+                  className="animate-fade-in-up flex h-7 w-full items-center justify-between px-1.5 gap-3 rounded-lg border bg-transparent text-xs transition-all"
+                  style={{ animationDelay: `${i * 75}ms`, borderColor: isActive ? item.color : "transparent" }}
+                  onMouseEnter={() => setActiveLegendId(item.id)}
+                  onMouseLeave={() => setActiveLegendId(null)}
+                  onFocus={() => setActiveLegendId(item.id)}
+                  onBlur={() => setActiveLegendId(null)}
+                  data-active={isActive ? "true" : "false"}
+                  data-testid={`account-cost-legend-${i}`}
+                >
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span
+                      aria-hidden
+                      className="h-2.5 w-2.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: item.color }}
+                    />
+                    <span className="truncate font-medium">
+                      {item.isDeleted ? (
+                        item.label
+                      ) : blurred ? (
+                        <span className="privacy-blur">{item.label}</span>
+                      ) : (
+                        item.label
+                      )}
+                    </span>
+                  </div>
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
+                    {formatCurrency(item.value)}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/apis/components/account-cost-donut.tsx
+++ b/frontend/src/features/apis/components/account-cost-donut.tsx
@@ -1,0 +1,171 @@
+import { useMemo } from "react";
+import { Cell, Pie, PieChart, Sector, type PieSectorShapeProps } from "recharts";
+
+import { buildDonutPalette } from "@/utils/colors";
+import { formatCurrency } from "@/utils/formatters";
+import { usePrivacyStore } from "@/hooks/use-privacy";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import { useThemeStore } from "@/hooks/use-theme";
+import type { ApiKeyAccountCost } from "@/features/apis/schemas";
+
+export type AccountCostDonutProps = {
+  accountCosts: ApiKeyAccountCost[];
+  totalCostUsd: number;
+};
+
+const CHART_SIZE = 152;
+const CHART_MARGIN = 4;
+const PIE_CX = 72;
+const PIE_CY = 72;
+const INNER_R = 53;
+const OUTER_R = 68;
+const ACTIVE_RADIUS_OFFSET = 4;
+const MAX_LEGEND_ITEMS = 4;
+
+type DonutDatum = {
+  id: string;
+  name: string;
+  value: number;
+  fill: string;
+};
+
+export function AccountCostDonut({ accountCosts, totalCostUsd }: AccountCostDonutProps) {
+  const isDark = useThemeStore((s) => s.theme === "dark");
+  const blurred = usePrivacyStore((s) => s.blurred);
+  const reducedMotion = useReducedMotion();
+  const consumedColor = isDark ? "#404040" : "#d3d3d3";
+
+	const { chartData, legendItems } = useMemo(() => {
+		const visibleCosts = accountCosts.filter((ac) => ac.costUsd > 0);
+		const palette = buildDonutPalette(visibleCosts.length, isDark);
+
+		const items = visibleCosts.map((ac, i) => {
+			const isDeleted = ac.isDeleted;
+			return {
+				id: isDeleted ? "__deleted__" : (ac.accountId ?? `__unknown_${i}__`),
+				label: isDeleted ? "Deleted Account" : (ac.email ?? "Unknown Account"),
+				isDeleted,
+				value: ac.costUsd,
+				color: isDeleted ? consumedColor : palette[i % palette.length],
+			};
+		});
+
+    const totalValue = items.reduce((sum, item) => sum + item.value, 0);
+    const remaining = Math.max(0, totalCostUsd - totalValue);
+
+    const data: DonutDatum[] = [
+      ...items.map((item) => ({
+        id: item.id,
+        name: item.label,
+        value: item.value,
+        fill: item.color,
+      })),
+      ...(remaining > 0
+        ? [{ id: "__remaining__", name: "__remaining__", value: remaining, fill: consumedColor }]
+        : []),
+    ];
+
+    if (!data.some((d) => d.value > 0)) {
+      data.length = 0;
+      data.push({ id: "__empty__", name: "__empty__", value: 1, fill: consumedColor });
+    }
+
+    return { chartData: data, legendItems: items };
+  }, [accountCosts, totalCostUsd, isDark, consumedColor]);
+
+  const renderDonutShape = (props: PieSectorShapeProps) => {
+    return (
+      <Sector
+        {...props}
+        outerRadius={
+          typeof props.outerRadius === "number"
+            ? props.outerRadius + (props.isActive ? ACTIVE_RADIUS_OFFSET : 0)
+            : OUTER_R + (props.isActive ? ACTIVE_RADIUS_OFFSET : 0)
+        }
+        stroke={props.isActive ? "hsl(var(--background))" : "none"}
+        strokeWidth={props.isActive ? 2 : 0}
+      />
+    );
+  };
+
+  return (
+    <div className="rounded-xl border bg-card p-5">
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold">7-Day Cost by Account</h3>
+        <p className="mt-0.5 text-xs text-muted-foreground">Breakdown of usage cost</p>
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <div className="relative h-[152px] w-[152px] overflow-visible">
+          <PieChart width={CHART_SIZE} height={CHART_SIZE} margin={{ top: CHART_MARGIN, right: CHART_MARGIN, bottom: CHART_MARGIN, left: CHART_MARGIN }}>
+            <Pie
+              data={chartData}
+              cx={PIE_CX}
+              cy={PIE_CY}
+              innerRadius={INNER_R}
+              outerRadius={OUTER_R}
+              startAngle={90}
+              endAngle={-270}
+              dataKey="value"
+              stroke="none"
+              shape={renderDonutShape}
+              isAnimationActive={!reducedMotion}
+              animationDuration={600}
+              animationEasing="ease-out"
+            >
+              {chartData.map((entry) => (
+                <Cell key={entry.id} fill={entry.fill} />
+              ))}
+            </Pie>
+          </PieChart>
+          <div className="absolute inset-[22px] flex items-center justify-center rounded-full text-center pointer-events-none">
+            <div>
+              <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">7-Day Cost</p>
+              <p className="text-base font-semibold tabular-nums">{formatCurrency(totalCostUsd)}</p>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-[11px] tabular-nums text-muted-foreground">
+          Total {formatCurrency(totalCostUsd)}
+        </p>
+      </div>
+
+      {legendItems.length > 0 && (
+        <div className="mt-3 space-y-0.5">
+          {legendItems.slice(0, MAX_LEGEND_ITEMS).map((item) => (
+            <div
+              key={item.id}
+              className="flex h-7 items-center justify-between px-1.5 gap-3 text-xs"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <span
+                  aria-hidden
+                  className="h-2.5 w-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: item.color }}
+                />
+                <span className="truncate font-medium">
+                  {item.isDeleted ? (
+                    item.label
+                  ) : blurred ? (
+                    <span className="privacy-blur">{item.label}</span>
+                  ) : (
+                    item.label
+                  )}
+                </span>
+              </div>
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                {formatCurrency(item.value)}
+              </span>
+            </div>
+          ))}
+          {legendItems.length > MAX_LEGEND_ITEMS && (
+            <p className="px-1.5 text-[10px] text-muted-foreground">
+              +{legendItems.length - MAX_LEGEND_ITEMS} more
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/apis/components/account-cost-donut.tsx
+++ b/frontend/src/features/apis/components/account-cost-donut.tsx
@@ -106,17 +106,14 @@ export function AccountCostDonut({ accountCosts, totalCostUsd }: AccountCostDonu
 
   return (
     <div data-testid="account-cost-panel">
-      <div className="mb-5 flex items-start justify-between gap-4">
+      <div className="mb-5">
         <div>
           <h3 className="text-sm font-semibold">7-Day Cost by Account</h3>
           <p className="mt-0.5 text-xs text-muted-foreground">Breakdown of usage cost</p>
         </div>
-        <p className="shrink-0 text-[11px] tabular-nums text-muted-foreground" data-testid="account-cost-total">
-          Total {formatCurrency(totalCostUsd)}
-        </p>
       </div>
 
-      <div className="flex items-center gap-6">
+      <div className="flex flex-col items-center gap-4">
         <div className="flex shrink-0 flex-col items-center">
           <div className="relative h-[152px] w-[152px] overflow-visible">
             <PieChart width={CHART_SIZE} height={CHART_SIZE} margin={{ top: CHART_MARGIN, right: CHART_MARGIN, bottom: CHART_MARGIN, left: CHART_MARGIN }}>
@@ -158,7 +155,7 @@ export function AccountCostDonut({ accountCosts, totalCostUsd }: AccountCostDonu
         </div>
         {legendItems.length > 0 && (
           <div
-            className="flex-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            className="w-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             data-testid="account-cost-legend-list"
             style={{ maxHeight: `calc(${LEGEND_VISIBLE_COUNT} * ${LEGEND_ROW_HEIGHT_REM}rem + ${(LEGEND_VISIBLE_COUNT - 1) * LEGEND_ROW_GAP_REM}rem)` }}
           >

--- a/frontend/src/features/apis/components/api-detail.test.tsx
+++ b/frontend/src/features/apis/components/api-detail.test.tsx
@@ -146,6 +146,31 @@ describe("ApiDetail", () => {
 		expect(screen.queryByText("Usage Trend")).not.toBeInTheDocument();
 	});
 
+	it("lets the donut use the full usage panel width when no trend data is available", () => {
+		renderApiDetail({
+			trends: createApiKeyTrends({ cost: [], tokens: [] }),
+			usage7Day: createApiKeyUsage7Day({
+				accountCosts: [{ accountId: "acc-1", email: "a@example.com", costUsd: 0.12, isDeleted: false }],
+				totalCostUsd: 0.12,
+			}),
+		});
+
+		const donutWrapper = screen.getByTestId("account-cost-panel").parentElement;
+		expect(donutWrapper).not.toHaveClass("lg:w-[25%]");
+		expect(donutWrapper).not.toHaveClass("lg:pr-4");
+	});
+
+	it("names the accumulated trend switch for assistive technology", () => {
+		renderApiDetail({
+			trends: createApiKeyTrends({
+				cost: [{ t: "2026-01-01T00:00:00Z", v: 0.12 }],
+				tokens: [{ t: "2026-01-01T00:00:00Z", v: 1200 }],
+			}),
+		});
+
+		expect(screen.getByRole("switch", { name: "Accumulated" })).toBeInTheDocument();
+	});
+
 	it("does not fall back to list summary usage while the 7 day query is loading", () => {
 		renderApiDetail({
 			apiKey: createApiKey({

--- a/frontend/src/features/apis/components/api-detail.test.tsx
+++ b/frontend/src/features/apis/components/api-detail.test.tsx
@@ -131,6 +131,21 @@ describe("ApiDetail", () => {
 		expect(screen.getByTestId("api-trend-panel")).toHaveClass("lg:border-l");
 	});
 
+	it("does not render an empty trend pane when only donut data is available", () => {
+		renderApiDetail({
+			trends: createApiKeyTrends({ cost: [], tokens: [] }),
+			usage7Day: createApiKeyUsage7Day({
+				accountCosts: [{ accountId: "acc-1", email: "a@example.com", costUsd: 0.12, isDeleted: false }],
+				totalCostUsd: 0.12,
+			}),
+		});
+
+		const usagePanel = screen.getByTestId("api-usage-panel");
+		expect(usagePanel).toContainElement(screen.getByTestId("account-cost-panel"));
+		expect(screen.queryByTestId("api-trend-panel")).not.toBeInTheDocument();
+		expect(screen.queryByText("Usage Trend")).not.toBeInTheDocument();
+	});
+
 	it("does not fall back to list summary usage while the 7 day query is loading", () => {
 		renderApiDetail({
 			apiKey: createApiKey({

--- a/frontend/src/features/apis/components/api-detail.test.tsx
+++ b/frontend/src/features/apis/components/api-detail.test.tsx
@@ -70,6 +70,7 @@ describe("ApiDetail", () => {
 		expect(screen.getByRole("heading", { name: "Analytics Key" })).toBeInTheDocument();
 		expect(screen.getByText("Tokens")).toBeInTheDocument();
 		expect(screen.getByText("Cost")).toBeInTheDocument();
+		expect(screen.getByTestId("api-trend-legend")).toBeInTheDocument();
 		expect(screen.getByRole("switch")).toBeInTheDocument();
 		expect(screen.getByText("Key Details")).toBeInTheDocument();
 	});
@@ -110,6 +111,24 @@ describe("ApiDetail", () => {
 
 		expect(screen.getByText("Unknown Account")).toBeInTheDocument();
 		expect(screen.getByText("Deleted Account")).toBeInTheDocument();
+	});
+
+	it("renders the donut and trend sections inside a shared usage panel", () => {
+		renderApiDetail({
+			trends: createApiKeyTrends({
+				cost: [{ t: "2026-01-01T00:00:00Z", v: 0.12 }],
+				tokens: [{ t: "2026-01-01T00:00:00Z", v: 1200 }],
+			}),
+			usage7Day: createApiKeyUsage7Day({
+				accountCosts: [{ accountId: "acc-1", email: "a@example.com", costUsd: 0.12, isDeleted: false }],
+				totalCostUsd: 0.12,
+			}),
+		});
+
+		const usagePanel = screen.getByTestId("api-usage-panel");
+		expect(usagePanel).toContainElement(screen.getByTestId("account-cost-panel"));
+		expect(usagePanel).toContainElement(screen.getByTestId("api-trend-panel"));
+		expect(screen.getByTestId("api-trend-panel")).toHaveClass("lg:border-l");
 	});
 
 	it("does not fall back to list summary usage while the 7 day query is loading", () => {

--- a/frontend/src/features/apis/components/api-detail.test.tsx
+++ b/frontend/src/features/apis/components/api-detail.test.tsx
@@ -98,6 +98,20 @@ describe("ApiDetail", () => {
 		expect(screen.getByText(/\$2.47/)).toBeInTheDocument();
 	});
 
+	it("renders unknown and deleted account buckets distinctly in the cost donut", () => {
+		renderApiDetail({
+			usage7Day: createApiKeyUsage7Day({
+				accountCosts: [
+					{ accountId: null, email: null, costUsd: 0.11, isDeleted: false },
+					{ accountId: null, email: null, costUsd: 0.29, isDeleted: true },
+				],
+			}),
+		});
+
+		expect(screen.getByText("Unknown Account")).toBeInTheDocument();
+		expect(screen.getByText("Deleted Account")).toBeInTheDocument();
+	});
+
 	it("does not fall back to list summary usage while the 7 day query is loading", () => {
 		renderApiDetail({
 			apiKey: createApiKey({
@@ -220,7 +234,13 @@ describe("ApiDetail", () => {
 
 	it("disables all mutation actions while busy", async () => {
 		const user = userEvent.setup();
-		renderApiDetail({ busy: true });
+		renderApiDetail({
+			busy: true,
+			trends: createApiKeyTrends({
+				cost: [{ t: "2026-01-01T00:00:00Z", v: 0.2 }],
+				tokens: [{ t: "2026-01-01T00:00:00Z", v: 1500 }],
+			}),
+		});
 
 		expect(screen.getByRole("button", { name: "Actions" })).toBeDisabled();
 		expect(screen.getByRole("button", { name: "Disable" })).toBeDisabled();

--- a/frontend/src/features/apis/components/api-detail.tsx
+++ b/frontend/src/features/apis/components/api-detail.tsx
@@ -145,7 +145,7 @@ export function ApiDetail({
 					data-testid="api-usage-panel"
 				>
 					{hasDonutData && (
-						<div className="lg:w-[25%] lg:shrink-0 lg:pr-4">
+						<div className={hasTrends ? "lg:w-[25%] lg:shrink-0 lg:pr-4" : "lg:w-full"}>
 							<AccountCostDonut
 								accountCosts={usage7Day.accountCosts}
 								totalCostUsd={usage7Day.totalCostUsd}
@@ -178,9 +178,10 @@ export function ApiDetail({
 										</span>
 									</div>
 									<div className="flex items-center gap-1.5 rounded-md border px-2 py-1">
-										<span className="text-[10px]">Accumulated</span>
+										<span id="api-trend-accumulated-label" className="text-[10px]">Accumulated</span>
 										<Switch
 											size="sm"
+											aria-labelledby="api-trend-accumulated-label"
 											checked={showAccumulated}
 											onCheckedChange={setShowAccumulated}
 										/>

--- a/frontend/src/features/apis/components/api-detail.tsx
+++ b/frontend/src/features/apis/components/api-detail.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
 import type { ApiKey } from "@/features/api-keys/schemas";
+import { AccountCostDonut } from "@/features/apis/components/account-cost-donut";
 import { ApiKeyInfo } from "@/features/apis/components/api-key-info";
 import { ApiTrendChart } from "@/features/apis/components/api-trend-chart";
 import type { ApiKeyUsage7DayResponse } from "@/features/apis/schemas";
@@ -87,6 +88,9 @@ export function ApiDetail({
 		return null;
 	}, [usage7Day, usage7DayError, usage7DayLoading]);
 
+	const hasDonutData = usage7Day && usage7Day.accountCosts.length > 0;
+	const hasTrends = trends && (trends.cost.length > 0 || trends.tokens.length > 0);
+
 	if (!apiKey) {
 		return (
 			<div className="flex flex-col items-center justify-center rounded-xl border border-dashed p-12">
@@ -102,9 +106,6 @@ export function ApiDetail({
 			</div>
 		);
 	}
-
-	const hasTrends =
-		trends && (trends.cost.length > 0 || trends.tokens.length > 0);
 
 	return (
 		<div
@@ -138,32 +139,43 @@ export function ApiDetail({
 				</DropdownMenu>
 			</div>
 
-			<div className="space-y-4 rounded-lg border bg-muted/30 p-4">
-				<div className="flex items-center justify-end gap-3">
-					<div className="flex items-center gap-3 text-[10px] text-muted-foreground">
-						<span className="flex items-center gap-1.5">
-							Tokens
-							<span className="inline-block h-2 w-2 rounded-full bg-chart-2" />
-						</span>
-						<span className="flex items-center gap-1.5">
-							Cost
-							<span className="inline-block h-2 w-2 rounded-full bg-chart-1" />
-						</span>
-					</div>
-					<div className="flex items-center gap-1.5 rounded-md border px-2 py-1">
-						<span className="text-[10px]">Accumulated</span>
-						<Switch
-							size="sm"
-							checked={showAccumulated}
-							onCheckedChange={setShowAccumulated}
+			{hasDonutData || hasTrends ? (
+				<div className={`grid gap-4 ${hasDonutData ? "lg:grid-cols-[25fr_75fr]" : ""}`}>
+					{hasDonutData && (
+						<AccountCostDonut
+							accountCosts={usage7Day.accountCosts}
+							totalCostUsd={usage7Day.totalCostUsd}
 						/>
+					)}
+					<div className="rounded-xl border bg-card p-4">
+						<div className="mb-2">
+							<h3 className="text-sm font-semibold">Usage Trend</h3>
+							<p className="text-xs text-muted-foreground">7-day token and cost activity</p>
+						</div>
+						<div className="flex items-center justify-end gap-1.5 rounded-md border px-2 py-1 w-fit ml-auto mb-3">
+							<span className="text-[10px]">Accumulated</span>
+							<Switch
+								size="sm"
+								checked={showAccumulated}
+								onCheckedChange={setShowAccumulated}
+							/>
+						</div>
+						<div className="flex items-center gap-3 text-[10px] text-muted-foreground mb-3">
+							<span className="flex items-center gap-1.5">
+								Tokens
+								<span className="inline-block h-2 w-2 rounded-full bg-chart-2" />
+							</span>
+							<span className="flex items-center gap-1.5">
+								Cost
+								<span className="inline-block h-2 w-2 rounded-full bg-chart-1" />
+							</span>
+						</div>
+						{hasTrends && chartData && (
+							<ApiTrendChart cost={chartData.cost} tokens={chartData.tokens} />
+						)}
 					</div>
 				</div>
-
-				{hasTrends && chartData && (
-					<ApiTrendChart cost={chartData.cost} tokens={chartData.tokens} />
-				)}
-			</div>
+			) : null}
 
 			{usage7DayError ? (
 				<AlertMessage variant="error">{usage7DayError}</AlertMessage>

--- a/frontend/src/features/apis/components/api-detail.tsx
+++ b/frontend/src/features/apis/components/api-detail.tsx
@@ -152,44 +152,46 @@ export function ApiDetail({
 							/>
 						</div>
 					)}
-					<div
-						className={
-							hasDonutData
-								? "mt-4 border-t pt-4 lg:mt-0 lg:max-w-[75%] lg:flex-1 lg:border-t-0 lg:border-l lg:pl-4 lg:pt-0"
-								: ""
-						}
-						data-testid="api-trend-panel"
-					>
-						<div className="mb-3 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-							<div>
-								<h3 className="text-sm font-semibold">Usage Trend</h3>
-								<p className="text-xs text-muted-foreground">7-day token and cost activity</p>
-							</div>
-							<div className="flex flex-wrap items-center justify-start gap-3 md:justify-end">
-								<div className="flex items-center gap-3 text-[10px] text-muted-foreground" data-testid="api-trend-legend">
-									<span className="flex items-center gap-1.5">
-										Tokens
-										<span className="inline-block h-2 w-2 rounded-full bg-chart-2" />
-									</span>
-									<span className="flex items-center gap-1.5">
-										Cost
-										<span className="inline-block h-2 w-2 rounded-full bg-chart-1" />
-									</span>
+					{hasTrends ? (
+						<div
+							className={
+								hasDonutData
+									? "mt-4 border-t pt-4 lg:mt-0 lg:max-w-[75%] lg:flex-1 lg:border-t-0 lg:border-l lg:pl-4 lg:pt-0"
+									: ""
+							}
+							data-testid="api-trend-panel"
+						>
+							<div className="mb-3 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+								<div>
+									<h3 className="text-sm font-semibold">Usage Trend</h3>
+									<p className="text-xs text-muted-foreground">7-day token and cost activity</p>
 								</div>
-								<div className="flex items-center gap-1.5 rounded-md border px-2 py-1">
-									<span className="text-[10px]">Accumulated</span>
-									<Switch
-										size="sm"
-										checked={showAccumulated}
-										onCheckedChange={setShowAccumulated}
-									/>
+								<div className="flex flex-wrap items-center justify-start gap-3 md:justify-end">
+									<div className="flex items-center gap-3 text-[10px] text-muted-foreground" data-testid="api-trend-legend">
+										<span className="flex items-center gap-1.5">
+											Tokens
+											<span className="inline-block h-2 w-2 rounded-full bg-chart-2" />
+										</span>
+										<span className="flex items-center gap-1.5">
+											Cost
+											<span className="inline-block h-2 w-2 rounded-full bg-chart-1" />
+										</span>
+									</div>
+									<div className="flex items-center gap-1.5 rounded-md border px-2 py-1">
+										<span className="text-[10px]">Accumulated</span>
+										<Switch
+											size="sm"
+											checked={showAccumulated}
+											onCheckedChange={setShowAccumulated}
+										/>
+									</div>
 								</div>
 							</div>
+							{chartData ? (
+								<ApiTrendChart cost={chartData.cost} tokens={chartData.tokens} />
+							) : null}
 						</div>
-						{hasTrends && chartData && (
-							<ApiTrendChart cost={chartData.cost} tokens={chartData.tokens} />
-						)}
-					</div>
+					) : null}
 				</div>
 			) : null}
 

--- a/frontend/src/features/apis/components/api-detail.tsx
+++ b/frontend/src/features/apis/components/api-detail.tsx
@@ -140,35 +140,51 @@ export function ApiDetail({
 			</div>
 
 			{hasDonutData || hasTrends ? (
-				<div className={`grid gap-4 ${hasDonutData ? "lg:grid-cols-[25fr_75fr]" : ""}`}>
+				<div
+					className="rounded-xl border bg-card p-4 lg:flex lg:items-start"
+					data-testid="api-usage-panel"
+				>
 					{hasDonutData && (
-						<AccountCostDonut
-							accountCosts={usage7Day.accountCosts}
-							totalCostUsd={usage7Day.totalCostUsd}
-						/>
-					)}
-					<div className="rounded-xl border bg-card p-4">
-						<div className="mb-2">
-							<h3 className="text-sm font-semibold">Usage Trend</h3>
-							<p className="text-xs text-muted-foreground">7-day token and cost activity</p>
-						</div>
-						<div className="flex items-center justify-end gap-1.5 rounded-md border px-2 py-1 w-fit ml-auto mb-3">
-							<span className="text-[10px]">Accumulated</span>
-							<Switch
-								size="sm"
-								checked={showAccumulated}
-								onCheckedChange={setShowAccumulated}
+						<div className="lg:w-[25%] lg:shrink-0 lg:pr-4">
+							<AccountCostDonut
+								accountCosts={usage7Day.accountCosts}
+								totalCostUsd={usage7Day.totalCostUsd}
 							/>
 						</div>
-						<div className="flex items-center gap-3 text-[10px] text-muted-foreground mb-3">
-							<span className="flex items-center gap-1.5">
-								Tokens
-								<span className="inline-block h-2 w-2 rounded-full bg-chart-2" />
-							</span>
-							<span className="flex items-center gap-1.5">
-								Cost
-								<span className="inline-block h-2 w-2 rounded-full bg-chart-1" />
-							</span>
+					)}
+					<div
+						className={
+							hasDonutData
+								? "mt-4 border-t pt-4 lg:mt-0 lg:max-w-[75%] lg:flex-1 lg:border-t-0 lg:border-l lg:pl-4 lg:pt-0"
+								: ""
+						}
+						data-testid="api-trend-panel"
+					>
+						<div className="mb-3 flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+							<div>
+								<h3 className="text-sm font-semibold">Usage Trend</h3>
+								<p className="text-xs text-muted-foreground">7-day token and cost activity</p>
+							</div>
+							<div className="flex flex-wrap items-center justify-start gap-3 md:justify-end">
+								<div className="flex items-center gap-3 text-[10px] text-muted-foreground" data-testid="api-trend-legend">
+									<span className="flex items-center gap-1.5">
+										Tokens
+										<span className="inline-block h-2 w-2 rounded-full bg-chart-2" />
+									</span>
+									<span className="flex items-center gap-1.5">
+										Cost
+										<span className="inline-block h-2 w-2 rounded-full bg-chart-1" />
+									</span>
+								</div>
+								<div className="flex items-center gap-1.5 rounded-md border px-2 py-1">
+									<span className="text-[10px]">Accumulated</span>
+									<Switch
+										size="sm"
+										checked={showAccumulated}
+										onCheckedChange={setShowAccumulated}
+									/>
+								</div>
+							</div>
 						</div>
 						{hasTrends && chartData && (
 							<ApiTrendChart cost={chartData.cost} tokens={chartData.tokens} />

--- a/frontend/src/features/apis/components/api-trend-chart.tsx
+++ b/frontend/src/features/apis/components/api-trend-chart.tsx
@@ -99,7 +99,7 @@ function CustomTooltip({ active, payload, label }: ChartTooltipProps) {
   );
 }
 
-const CHART_MARGIN = { top: 4, right: 48, bottom: 0, left: 0 } as const;
+const CHART_MARGIN = { top: 4, right: 8, bottom: 0, left: 0 } as const;
 
 export type ApiTrendChartProps = {
   cost: ApiKeyTrendPoint[];

--- a/frontend/src/features/apis/schemas.ts
+++ b/frontend/src/features/apis/schemas.ts
@@ -11,14 +11,23 @@ export const ApiKeyTrendsResponseSchema = z.object({
   tokens: z.array(ApiKeyTrendPointSchema),
 });
 
+export const ApiKeyAccountCostSchema = z.object({
+  accountId: z.string().nullable().default(null),
+  email: z.string().nullable().default(null),
+  costUsd: z.number().default(0),
+  isDeleted: z.boolean().default(false),
+});
+
 export const ApiKeyUsage7DayResponseSchema = z.object({
   keyId: z.string(),
   totalTokens: z.number().int(),
   totalCostUsd: z.number(),
   totalRequests: z.number().int(),
   cachedInputTokens: z.number().int(),
+  accountCosts: z.array(ApiKeyAccountCostSchema).default([]),
 });
 
+export type ApiKeyAccountCost = z.infer<typeof ApiKeyAccountCostSchema>;
 export type ApiKeyTrendPoint = z.infer<typeof ApiKeyTrendPointSchema>;
 export type ApiKeyTrendsResponse = z.infer<typeof ApiKeyTrendsResponseSchema>;
 export type ApiKeyUsage7DayResponse = z.infer<typeof ApiKeyUsage7DayResponseSchema>;

--- a/openspec/changes/add-api-key-account-cost-donut/.openspec.yaml
+++ b/openspec/changes/add-api-key-account-cost-donut/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/add-api-key-account-cost-donut/design.md
+++ b/openspec/changes/add-api-key-account-cost-donut/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The existing APIs tab already had two independent data sources for a selected API key: a trend query and a 7-day usage summary query. The implemented change builds on the 7-day usage query instead of introducing a third endpoint, because the donut only needs aggregate 7-day cost totals and should stay aligned with the summary card totals already shown in the detail panel.
+
+This change spans backend aggregation, API schema updates, frontend rendering, and a query-performance migration. It also has one behavior detail that differs from the original request text: the deleted-account bucket is currently sorted by descending cost with all other buckets rather than being pinned to the final slice. The backfilled OpenSpec needs to match the implemented behavior so verification remains truthful.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose a single 7-day API-key usage payload that includes both total usage and per-account cost breakdown.
+- Preserve historical deleted-account cost in the API-key detail view.
+- Reuse the dashboard donut visual language so the APIs tab feels consistent.
+- Keep the account-cost query indexable for the 7-day filtered API-key lookup path.
+
+**Non-Goals:**
+
+- Do not add a new dedicated account-cost endpoint.
+- Do not replace the existing trend visualization.
+- Do not introduce account display-name fields beyond the currently available email-based label.
+- Do not retrofit unimplemented behavior such as forcing the deleted-account slice to the end regardless of cost.
+
+## Decisions
+
+### Reuse `usage-7d` instead of adding another API
+
+The backend now computes total 7-day usage and grouped account costs together in `ApiKeysRepository.usage_7d(...)`. This keeps the donut totals consistent with the summary totals, avoids a second round-trip from the frontend, and allows the service/API layer to expose one stable response shape.
+
+Alternative considered: a separate `usage-7d-by-account` endpoint. Rejected because it duplicates the same time-window filtering and creates coordination risk between summary and breakdown totals.
+
+### Represent deleted-account cost as a synthetic grouped bucket
+
+Rows with `request_logs.deleted_at IS NOT NULL` are folded into one synthetic bucket with `accountId: null`, `email: null`, and `isDeleted: true`. Unknown-but-not-deleted account usage stays separate as `isDeleted: false`.
+
+Alternative considered: dropping deleted rows from the donut. Rejected because it would make the per-account donut total disagree with the 7-day summary total.
+
+### Sort all account-cost buckets by descending cost
+
+The repository sorts grouped buckets by `cost_usd DESC` after building the deleted-account synthetic bucket. This means the deleted-account bucket participates in the same descending order as all other buckets.
+
+Alternative considered: always pin deleted usage to the final slice. Rejected in the implemented code path; the spec backfill preserves the shipped descending-cost behavior.
+
+### Mirror the dashboard donut's sizing and motion rules with a focused component
+
+The frontend uses a dedicated `AccountCostDonut` component that reuses the dashboard donut's sizing constants, palette generation, consumed gray color, center-value treatment, and reduced-motion animation behavior while simplifying features not needed in the APIs tab.
+
+Alternative considered: directly reusing the generic dashboard donut component. Rejected because the APIs-tab donut needs currency formatting and a smaller fixed legend contract.
+
+### Add a composite request-log index for the aggregation path
+
+The migration adds `idx_logs_api_key_time_account` on `request_logs(api_key_id, requested_at DESC, account_id)` so the 7-day filtered grouping path does not degrade into a full table scan as request-log volume grows.
+
+Alternative considered: relying on existing `api_key_id` or `requested_at` indexes independently. Rejected because the implemented query filters by API key and time range, then groups by account.
+
+## Risks / Trade-offs
+
+- [Spec vs request-text drift] -> The original request asked for deleted usage to render last, but the shipped code sorts by descending cost. The backfilled spec matches code to keep verification honest.
+- [Label fidelity] -> The frontend legend currently uses `email` or `Unknown Account`, not a richer display-name field. This keeps the contract aligned with the existing payload.
+- [UI duplication] -> The APIs-tab donut intentionally duplicates some dashboard donut behavior in a focused component. This avoids over-generalizing the generic donut at the cost of some repeated constants.
+- [Query shape growth] -> The single-query `usage_7d` aggregation is more complex than a raw totals query. The added composite index mitigates the performance risk.

--- a/openspec/changes/add-api-key-account-cost-donut/proposal.md
+++ b/openspec/changes/add-api-key-account-cost-donut/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The APIs tab already exposes a 7-day usage trend for each API key, but operators could not see which accounts generated that cost without inspecting raw request logs. The implemented change adds an account-cost breakdown beside the existing trend and extends the API-key usage payload so the frontend can render that breakdown directly.
+
+## What Changes
+
+- Extend `GET /api/api-keys/{key_id}/usage-7d` with `accountCosts[]` entries that aggregate 7-day request-log cost by account.
+- Preserve deleted-account historical cost as a separate `Deleted Account` bucket instead of dropping it from the API-key detail view.
+- Add an APIs-tab donut card that shows the 7-day account-cost breakdown beside the usage trend.
+- Move the usage-trend Tokens/Cost legend below the accumulated toggle and tighten the chart right margin for the split layout.
+- Add a request-log index optimized for API-key account-cost lookups over the 7-day window.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: API-key 7-day usage now includes per-account cost breakdown data and requires an index for that aggregation path.
+- `frontend-architecture`: The APIs tab detail panel now includes a 7-day account-cost donut and updated trend-card layout behavior.
+
+## Impact
+
+- Backend: `app/modules/api_keys/{repository,service,api,schemas}.py`
+- Database: `request_logs` index coverage for API-key/time/account aggregation
+- Frontend: `frontend/src/features/apis/components/*` and `frontend/src/features/apis/schemas.ts`
+- Tests: API-key usage integration tests, repository unit tests, and APIs-tab component tests

--- a/openspec/changes/add-api-key-account-cost-donut/specs/api-keys/spec.md
+++ b/openspec/changes/add-api-key-account-cost-donut/specs/api-keys/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: API key 7-day usage includes account cost breakdown
+
+`GET /api/api-keys/{key_id}/usage-7d` SHALL return `accountCosts[]` in addition to the existing 7-day totals for the selected API key. Each `accountCosts[]` item SHALL include `accountId`, `email`, `costUsd`, and `isDeleted`.
+
+The system MUST aggregate `accountCosts[]` from request-log rows whose `api_key_id` matches the selected key and whose `requested_at` falls inside the rolling 7-day window used by the endpoint totals.
+
+#### Scenario: Account costs are sorted by descending cost
+- **WHEN** a client loads `GET /api/api-keys/{key_id}/usage-7d`
+- **AND** multiple grouped account-cost buckets exist in the 7-day window
+- **THEN** `accountCosts[]` is ordered by `costUsd` descending
+
+#### Scenario: Unknown account usage remains separate
+- **WHEN** request-log rows in the 7-day window have `account_id = NULL`
+- **AND** those rows are not soft-deleted
+- **THEN** the response includes an `accountCosts[]` item with `accountId: null`, `email: null`, and `isDeleted: false`
+
+#### Scenario: Deleted account usage is grouped into one bucket
+- **WHEN** request-log rows in the 7-day window are marked deleted
+- **THEN** the response groups their cost into a synthetic `accountCosts[]` item with `accountId: null`, `email: null`, and `isDeleted: true`
+
+#### Scenario: Deleted and unknown account usage stay distinct
+- **WHEN** the same API key has both soft-deleted request-log cost and unknown non-deleted request-log cost inside the 7-day window
+- **THEN** the response returns separate `accountCosts[]` items for the deleted and non-deleted buckets
+
+### Requirement: API key 7-day account-cost queries use a composite request-log index
+
+The database SHALL provide an index that supports filtering request logs by API key and 7-day requested-at range before grouping by account for the API-key account-cost breakdown.
+
+#### Scenario: Composite account-cost index exists after migration
+- **WHEN** database migrations are applied
+- **THEN** the `request_logs` table includes an index covering `api_key_id`, descending `requested_at`, and `account_id`

--- a/openspec/changes/add-api-key-account-cost-donut/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-api-key-account-cost-donut/specs/frontend-architecture/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: APIs tab shows a 7-day account-cost donut for selected API keys
+
+When the selected API key's 7-day usage payload contains one or more `accountCosts[]` items, the APIs tab detail panel SHALL render an account-cost donut card beside the usage trend card. On large screens, the split layout SHALL use a 25:75 width ratio with the donut on the left and the trend on the right.
+
+The donut card SHALL include a title and subtitle, SHALL show the 7-day total cost in the donut center, and SHALL render a legend beneath the donut.
+
+#### Scenario: Donut renders beside the usage trend
+- **WHEN** a selected API key has 7-day account-cost data and trend data
+- **THEN** the detail panel renders the account-cost donut card to the left of the trend card
+- **AND** the large-screen grid uses a 25:75 width split
+
+#### Scenario: Donut is omitted when no account-cost buckets exist
+- **WHEN** the selected API key's `usage-7d.accountCosts[]` array is empty
+- **THEN** the APIs tab does not render the account-cost donut card
+
+### Requirement: APIs tab account-cost donut uses existing account labels and privacy rules
+
+The donut legend SHALL use the account label derived from the existing payload fields: `Deleted Account` for `isDeleted: true`, otherwise the account `email` when present, otherwise `Unknown Account`. Non-deleted account labels MUST respect the hide-account-info privacy setting used elsewhere in the dashboard.
+
+The legend SHALL show each visible bucket's 7-day cost, SHALL display at most four account rows, and SHALL indicate when additional rows exist beyond the first four.
+
+#### Scenario: Deleted account label is explicit
+- **WHEN** an `accountCosts[]` item has `isDeleted: true`
+- **THEN** the legend label is `Deleted Account`
+
+#### Scenario: Privacy hiding applies to non-deleted account labels
+- **WHEN** the hide-account-info setting is enabled
+- **AND** a visible donut legend row represents a non-deleted account label
+- **THEN** the label text is privacy-blurred
+
+#### Scenario: Legend is capped at four visible rows
+- **WHEN** more than four account-cost buckets are present
+- **THEN** the donut legend renders only the first four rows
+- **AND** the card indicates how many additional rows remain hidden
+
+### Requirement: APIs tab account-cost donut follows the dashboard donut visual system
+
+The account-cost donut SHALL use the same sizing, palette generation, reduced-motion behavior, and gray consumed/deleted color treatment as the dashboard donut visual system.
+
+#### Scenario: Deleted-account slice uses the consumed gray color
+- **WHEN** the donut renders a deleted-account bucket
+- **THEN** that bucket uses the same gray color family used by the dashboard donut's consumed or used segment
+
+### Requirement: APIs tab usage trend control layout is compact in the split view
+
+The APIs tab usage trend card SHALL keep its heading and subtitle, SHALL render the accumulated toggle above the Tokens/Cost legend, and SHALL reduce the chart right margin to fit the split layout.
+
+#### Scenario: Tokens and cost legend sits below accumulated toggle
+- **WHEN** the usage trend card renders
+- **THEN** the accumulated toggle appears above the Tokens/Cost legend
+
+#### Scenario: Usage trend uses compact right margin
+- **WHEN** the usage trend chart renders in the split APIs-tab layout
+- **THEN** the chart right margin is reduced from the previous wider layout to a compact right margin

--- a/openspec/changes/add-api-key-account-cost-donut/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-api-key-account-cost-donut/specs/frontend-architecture/spec.md
@@ -2,14 +2,14 @@
 
 ### Requirement: APIs tab shows a 7-day account-cost donut for selected API keys
 
-When the selected API key's 7-day usage payload contains one or more `accountCosts[]` items, the APIs tab detail panel SHALL render an account-cost donut card beside the usage trend card. On large screens, the split layout SHALL use a 25:75 width ratio with the donut on the left and the trend on the right.
+When the selected API key's 7-day usage payload contains one or more `accountCosts[]` items, the APIs tab detail panel SHALL render the account-cost donut section and usage-trend section inside a single shared card. On large screens, the split layout SHALL use a 25:75 width ratio with the donut on the left, the trend on the right, and a vertical separator between them.
 
-The donut card SHALL include a title and subtitle, SHALL show the 7-day total cost in the donut center, and SHALL render a legend beneath the donut.
+The donut section SHALL include a title and subtitle, SHALL show the 7-day total cost in the donut center, SHALL render a visible `Total $...` summary in the section header, and SHALL render the legend beside the donut on larger screens.
 
-#### Scenario: Donut renders beside the usage trend
+#### Scenario: Donut renders inside the shared usage card
 - **WHEN** a selected API key has 7-day account-cost data and trend data
-- **THEN** the detail panel renders the account-cost donut card to the left of the trend card
-- **AND** the large-screen grid uses a 25:75 width split
+- **THEN** the detail panel renders the account-cost donut section to the left of the trend section inside one shared card
+- **AND** the large-screen layout uses a 25:75 split with a vertical separator between the sections
 
 #### Scenario: Donut is omitted when no account-cost buckets exist
 - **WHEN** the selected API key's `usage-7d.accountCosts[]` array is empty
@@ -19,7 +19,7 @@ The donut card SHALL include a title and subtitle, SHALL show the 7-day total co
 
 The donut legend SHALL use the account label derived from the existing payload fields: `Deleted Account` for `isDeleted: true`, otherwise the account `email` when present, otherwise `Unknown Account`. Non-deleted account labels MUST respect the hide-account-info privacy setting used elsewhere in the dashboard.
 
-The legend SHALL show each visible bucket's 7-day cost, SHALL display at most four account rows, and SHALL indicate when additional rows exist beyond the first four.
+The legend SHALL show each visible bucket's 7-day cost, SHALL coordinate hover highlighting with the matching pie slice, and SHALL use the same vertically scrollable five-row viewport pattern as the dashboard donuts when more rows exist than fit without scrolling.
 
 #### Scenario: Deleted account label is explicit
 - **WHEN** an `accountCosts[]` item has `isDeleted: true`
@@ -30,14 +30,14 @@ The legend SHALL show each visible bucket's 7-day cost, SHALL display at most fo
 - **AND** a visible donut legend row represents a non-deleted account label
 - **THEN** the label text is privacy-blurred
 
-#### Scenario: Legend is capped at four visible rows
-- **WHEN** more than four account-cost buckets are present
-- **THEN** the donut legend renders only the first four rows
-- **AND** the card indicates how many additional rows remain hidden
+#### Scenario: Legend scroll viewport matches dashboard donuts
+- **WHEN** more than five account-cost buckets are present
+- **THEN** the donut legend keeps all rows available
+- **AND** the visible legend viewport shows five rows before scrolling
 
 ### Requirement: APIs tab account-cost donut follows the dashboard donut visual system
 
-The account-cost donut SHALL use the same sizing, palette generation, reduced-motion behavior, and gray consumed/deleted color treatment as the dashboard donut visual system.
+The account-cost donut SHALL use the same sizing, palette generation, reduced-motion behavior, hover-linked legend highlighting, and gray consumed/deleted color treatment as the dashboard donut visual system.
 
 #### Scenario: Deleted-account slice uses the consumed gray color
 - **WHEN** the donut renders a deleted-account bucket
@@ -45,11 +45,12 @@ The account-cost donut SHALL use the same sizing, palette generation, reduced-mo
 
 ### Requirement: APIs tab usage trend control layout is compact in the split view
 
-The APIs tab usage trend card SHALL keep its heading and subtitle, SHALL render the accumulated toggle above the Tokens/Cost legend, and SHALL reduce the chart right margin to fit the split layout.
+The APIs tab usage trend card SHALL keep its heading and subtitle, SHALL align the accumulated toggle and Tokens/Cost legend to the right side of the heading block on larger screens, and SHALL reduce the chart right margin to fit the split layout.
 
-#### Scenario: Tokens and cost legend sits below accumulated toggle
+#### Scenario: Usage trend controls align with the heading row
 - **WHEN** the usage trend card renders
-- **THEN** the accumulated toggle appears above the Tokens/Cost legend
+- **THEN** the Tokens/Cost legend appears to the right of the heading block on larger screens
+- **AND** the accumulated toggle remains in the same right-side controls group
 
 #### Scenario: Usage trend uses compact right margin
 - **WHEN** the usage trend chart renders in the split APIs-tab layout

--- a/openspec/changes/add-api-key-account-cost-donut/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-api-key-account-cost-donut/specs/frontend-architecture/spec.md
@@ -4,7 +4,7 @@
 
 When the selected API key's 7-day usage payload contains one or more `accountCosts[]` items, the APIs tab detail panel SHALL render the account-cost donut section and usage-trend section inside a single shared card. On large screens, the split layout SHALL use a 25:75 width ratio with the donut on the left, the trend on the right, and a vertical separator between them.
 
-The donut section SHALL include a title and subtitle, SHALL show the 7-day total cost in the donut center, SHALL render a visible `Total $...` summary in the section header, and SHALL render the legend beside the donut on larger screens.
+The donut section SHALL include a title and subtitle, SHALL show the 7-day total cost in the donut center, SHALL not render a separate `Total $...` summary in the section header, and SHALL render the legend below the donut.
 
 #### Scenario: Donut renders inside the shared usage card
 - **WHEN** a selected API key has 7-day account-cost data and trend data

--- a/openspec/changes/add-api-key-account-cost-donut/tasks.md
+++ b/openspec/changes/add-api-key-account-cost-donut/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec Backfill
+
+- [ ] 1.1 Add the API-key `usage-7d` account-cost breakdown requirement.
+- [ ] 1.2 Add the APIs-tab donut and trend-layout requirements.
+- [ ] 1.3 Document the request-log index requirement for the account-cost aggregation path.
+
+## 2. Verification
+
+- [ ] 2.1 Verify the `usage-7d` response contract against the implemented API, service, and repository code.
+- [ ] 2.2 Verify frontend behavior against the implemented APIs-tab donut and trend components.
+- [ ] 2.3 Validate the OpenSpec change locally.

--- a/openspec/changes/add-api-key-account-cost-donut/tasks.md
+++ b/openspec/changes/add-api-key-account-cost-donut/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Spec Backfill
 
-- [ ] 1.1 Add the API-key `usage-7d` account-cost breakdown requirement.
-- [ ] 1.2 Add the APIs-tab donut and trend-layout requirements.
-- [ ] 1.3 Document the request-log index requirement for the account-cost aggregation path.
+- [x] 1.1 Add the API-key `usage-7d` account-cost breakdown requirement.
+- [x] 1.2 Add the APIs-tab donut and trend-layout requirements.
+- [x] 1.3 Document the request-log index requirement for the account-cost aggregation path.
 
 ## 2. Verification
 
-- [ ] 2.1 Verify the `usage-7d` response contract against the implemented API, service, and repository code.
-- [ ] 2.2 Verify frontend behavior against the implemented APIs-tab donut and trend components.
-- [ ] 2.3 Validate the OpenSpec change locally.
+- [x] 2.1 Verify the `usage-7d` response contract against the implemented API, service, and repository code.
+- [x] 2.2 Verify frontend behavior against the implemented APIs-tab donut and trend components.
+- [x] 2.3 Validate the OpenSpec change locally.

--- a/tests/integration/test_api_keys_trends_api.py
+++ b/tests/integration/test_api_keys_trends_api.py
@@ -361,6 +361,14 @@ async def test_usage_7d_sums_only_recent_request_logs(async_client):
         "totalCostUsd": 0.53,
         "totalRequests": 3,
         "cachedInputTokens": 21,
+        "accountCosts": [
+            {
+                "accountId": None,
+                "email": None,
+                "costUsd": 0.53,
+                "isDeleted": False,
+            }
+        ],
     }
 
 
@@ -405,4 +413,63 @@ async def test_usage_7d_clamps_cached_input_tokens_to_total_input(async_client):
         "totalCostUsd": 0.15,
         "totalRequests": 2,
         "cachedInputTokens": 14,
+        "accountCosts": [
+            {
+                "accountId": None,
+                "email": None,
+                "costUsd": 0.15,
+                "isDeleted": False,
+            }
+        ],
     }
+
+
+@pytest.mark.asyncio
+async def test_usage_7d_keeps_unknown_account_usage_separate_from_deleted_account_usage(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    key_id = await _create_api_key(async_client, name="usage-key-account-breakdown")
+    now = datetime(2026, 5, 20, 12, 0, 0)
+    monkeypatch.setattr("app.modules.api_keys.service.utcnow", lambda: now)
+
+    await _insert_request_logs(
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-usage-unknown",
+            requested_at=now - timedelta(hours=3),
+            model="gpt-5.1",
+            status="ok",
+            account_id=None,
+            cost_usd=0.11,
+        ),
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-usage-deleted",
+            requested_at=now - timedelta(hours=2),
+            model="gpt-5.1",
+            status="ok",
+            account_id=None,
+            deleted_at=now - timedelta(hours=1),
+            cost_usd=0.29,
+        ),
+    )
+
+    response = await async_client.get(f"/api/api-keys/{key_id}/usage-7d")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["accountCosts"] == [
+        {
+            "accountId": None,
+            "email": None,
+            "costUsd": 0.29,
+            "isDeleted": True,
+        },
+        {
+            "accountId": None,
+            "email": None,
+            "costUsd": 0.11,
+            "isDeleted": False,
+        },
+    ]

--- a/tests/unit/test_api_keys_repository.py
+++ b/tests/unit/test_api_keys_repository.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.db.models import LimitWindow
-from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.api_keys.repository import ApiKeyAccountCost, ApiKeysRepository
 
 pytestmark = pytest.mark.unit
 
@@ -46,3 +46,159 @@ async def test_reset_expired_limits_counts_successful_updates_without_rowcount()
     assert "RETURNING api_key_limits.id" in executed_sql[1]
     assert "RETURNING api_key_limits.id" in executed_sql[2]
     session.commit.assert_awaited_once()
+
+
+class TestUsage7dByAccount:
+    @pytest.mark.asyncio
+    async def test_groups_known_accounts_sorted_by_cost_descending(self) -> None:
+        session = AsyncMock()
+        repo = ApiKeysRepository(session)
+        since = datetime(2026, 5, 1, 0, 0, 0)
+        until = datetime(2026, 5, 8, 0, 0, 0)
+
+        rows = [
+            SimpleNamespace(account_id="acc_1", email="alice@example.com", is_deleted=False, cost_usd=1.5),
+            SimpleNamespace(account_id="acc_2", email="bob@example.com", is_deleted=False, cost_usd=3.2),
+        ]
+
+        session.execute.return_value = SimpleNamespace(all=lambda: rows)
+
+        result = await repo.usage_7d_by_account("key_1", since, until)
+
+        assert len(result) == 2
+        assert result[0] == ApiKeyAccountCost(
+            account_id="acc_2",
+            email="bob@example.com",
+            cost_usd=3.2,
+            is_deleted=False,
+        )
+        assert result[1] == ApiKeyAccountCost(
+            account_id="acc_1",
+            email="alice@example.com",
+            cost_usd=1.5,
+            is_deleted=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_deleted_account_bucket_is_sorted_by_cost_without_folding_unknown_account_usage(self) -> None:
+        session = AsyncMock()
+        repo = ApiKeysRepository(session)
+        since = datetime(2026, 5, 1, 0, 0, 0)
+        until = datetime(2026, 5, 8, 0, 0, 0)
+
+        rows = [
+            SimpleNamespace(account_id="acc_1", email="alice@example.com", is_deleted=False, cost_usd=1.0),
+            SimpleNamespace(account_id=None, email=None, is_deleted=False, cost_usd=0.5),
+            SimpleNamespace(account_id="acc_del", email=None, is_deleted=True, cost_usd=0.8),
+        ]
+
+        session.execute.return_value = SimpleNamespace(all=lambda: rows)
+
+        result = await repo.usage_7d_by_account("key_1", since, until)
+
+        assert len(result) == 3
+        assert result[0].account_id == "acc_1"
+        assert result[0].cost_usd == 1.0
+        assert result[0].is_deleted is False
+        assert result[1] == ApiKeyAccountCost(
+            account_id=None,
+            email=None,
+            cost_usd=0.8,
+            is_deleted=True,
+        )
+        assert result[2] == ApiKeyAccountCost(
+            account_id=None,
+            email=None,
+            cost_usd=0.5,
+            is_deleted=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_zero_cost_rows_excluded(self) -> None:
+        session = AsyncMock()
+        repo = ApiKeysRepository(session)
+        since = datetime(2026, 5, 1, 0, 0, 0)
+        until = datetime(2026, 5, 8, 0, 0, 0)
+
+        rows = [
+            SimpleNamespace(account_id="acc_1", email="alice@example.com", is_deleted=False, cost_usd=0.0),
+            SimpleNamespace(account_id="acc_2", email="bob@example.com", is_deleted=False, cost_usd=2.0),
+        ]
+
+        session.execute.return_value = SimpleNamespace(all=lambda: rows)
+
+        result = await repo.usage_7d_by_account("key_1", since, until)
+
+        assert len(result) == 1
+        assert result[0].account_id == "acc_2"
+
+    @pytest.mark.asyncio
+    async def test_empty_result_when_no_logs(self) -> None:
+        session = AsyncMock()
+        repo = ApiKeysRepository(session)
+        since = datetime(2026, 5, 1, 0, 0, 0)
+        until = datetime(2026, 5, 8, 0, 0, 0)
+
+        session.execute.return_value = SimpleNamespace(all=lambda: [])
+
+        result = await repo.usage_7d_by_account("key_1", since, until)
+
+        assert result == []
+
+
+class TestUsage7d:
+    @pytest.mark.asyncio
+    async def test_returns_totals_and_account_costs_from_single_execute(self) -> None:
+        session = AsyncMock()
+        repo = ApiKeysRepository(session)
+        since = datetime(2026, 5, 1, 0, 0, 0)
+        until = datetime(2026, 5, 8, 0, 0, 0)
+
+        rows = [
+            SimpleNamespace(
+                total_requests=3,
+                total_input_tokens=200,
+                total_output_tokens=50,
+                cached_input_tokens=25,
+                total_cost_usd=1.8,
+                account_id="acc_1",
+                email="alice@example.com",
+                is_deleted=False,
+                cost_usd=1.0,
+            ),
+            SimpleNamespace(
+                total_requests=3,
+                total_input_tokens=200,
+                total_output_tokens=50,
+                cached_input_tokens=25,
+                total_cost_usd=1.8,
+                account_id="acc_del",
+                email=None,
+                is_deleted=True,
+                cost_usd=0.8,
+            ),
+        ]
+
+        session.execute.return_value = SimpleNamespace(all=lambda: rows)
+
+        result = await repo.usage_7d("key_1", since, until)
+
+        assert result.total_requests == 3
+        assert result.total_tokens == 250
+        assert result.cached_input_tokens == 25
+        assert result.total_cost_usd == 1.8
+        assert result.account_costs == [
+            ApiKeyAccountCost(
+                account_id="acc_1",
+                email="alice@example.com",
+                cost_usd=1.0,
+                is_deleted=False,
+            ),
+            ApiKeyAccountCost(
+                account_id=None,
+                email=None,
+                cost_usd=0.8,
+                is_deleted=True,
+            ),
+        ]
+        session.execute.assert_awaited_once()


### PR DESCRIPTION
<!--
Thanks for contributing to codex-lb! 🙏
Fill in the sections below. Delete sections that don't apply.
-->

## Summary

Add a donut to show a 7-day account cost distribution for a specific API
## Type of change

<!-- Check the box that matches your PR. Commit titles must follow Conventional Commits. -->

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: <!-- e.g. Closes #123, Fixes #456 -->

## OpenSpec

<!--
codex-lb is OpenSpec-first. If this PR changes observable behavior, requirements,
contracts, or schema, it needs an OpenSpec change under openspec/changes/<change>/.

If this PR touches an upstream-mimicking code path (Codex CLI / ChatGPT request
shape, image pipeline, response.create framing, etc.), it must stay
**codex-faithful** — i.e. preserve the exact wire format the real upstream
emits. Call out anything that intentionally diverges, and link the spec section
that records the divergence.
-->

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

<img width="932" height="385" alt="螢幕截圖 2026-05-20 23 26 21" src="https://github.com/user-attachments/assets/7bb5c588-82e8-4e25-9ce5-dc866cac55b6" />
