### PR TITLE
ci: harden workflow supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   frontend-lint:
     name: Frontend lint (eslint)
@@ -17,10 +20,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
 
@@ -33,10 +38,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
 
@@ -49,10 +56,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
 
@@ -65,10 +74,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
 
@@ -81,10 +92,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
           enable-cache: true
@@ -98,10 +111,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
           enable-cache: true
@@ -126,15 +141,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
           enable-cache: true
@@ -166,15 +183,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
           enable-cache: true
@@ -188,10 +207,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
           enable-cache: true
@@ -219,10 +240,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
           enable-cache: true
@@ -236,15 +259,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
           enable-cache: true
@@ -259,27 +284,31 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    env:
+      DOCKER_CACHE_SCOPE: ${{ github.event_name == 'pull_request' && format('codex-lb-pr-{0}', github.event.pull_request.number) || 'codex-lb-main' }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Build Docker image
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: Dockerfile
           push: false
           load: true
           tags: codex-lb:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ env.DOCKER_CACHE_SCOPE }}
+          cache-to: type=gha,mode=max,scope=${{ env.DOCKER_CACHE_SCOPE }}
 
       - name: Scan Docker image with Trivy (SARIF)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: codex-lb:ci
           format: sarif
@@ -288,7 +317,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: trivy-results.sarif
@@ -297,7 +326,7 @@ jobs:
           category: .github/workflows/ci.yml:docker
 
       - name: Enforce Trivy high-severity gate
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: codex-lb:ci
           format: table
@@ -311,19 +340,29 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5.0.0
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
       - name: Install kubeconform
         run: |
+          set -euo pipefail
           KUBECONFORM_VERSION="0.7.0"
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ARCH=$(uname -m)
-          if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; fi
-          curl -sSL "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-${OS}-${ARCH}.tar.gz" \
-            | tar xz -C /tmp
+          case "$ARCH" in
+            x86_64) ARCH="amd64" ;;
+            aarch64) ARCH="arm64" ;;
+          esac
+          ASSET="kubeconform-${OS}-${ARCH}.tar.gz"
+          BASE_URL="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}"
+          curl -fsSLO "${BASE_URL}/CHECKSUMS"
+          curl -fsSLO "${BASE_URL}/${ASSET}"
+          grep "  ${ASSET}$" CHECKSUMS | sha256sum -c -
+          tar xzf "${ASSET}" -C /tmp
           sudo mv /tmp/kubeconform /usr/local/bin/kubeconform
 
       - name: Helm lint + template + kubeconform
@@ -335,16 +374,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5.0.0
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
       - name: Install kind
         run: |
-          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
-          chmod +x ./kind
-          sudo mv ./kind /usr/local/bin/kind
+          set -euo pipefail
+          KIND_VERSION="0.30.0"
+          BASE_URL="https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}"
+          curl -fsSLO "${BASE_URL}/kind-linux-amd64"
+          curl -fsSLO "${BASE_URL}/kind-linux-amd64.sha256sum"
+          sha256sum -c ./kind-linux-amd64.sha256sum
+          chmod +x ./kind-linux-amd64
+          sudo mv ./kind-linux-amd64 /usr/local/bin/kind
 
       - name: Helm smoke install
         run: make helm-smoke-kind

--- a/.github/workflows/codex-review-labels.yml
+++ b/.github/workflows/codex-review-labels.yml
@@ -36,8 +36,9 @@ jobs:
 
     steps:
       - name: Checkout trusted base
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Sync labels
@@ -63,8 +64,9 @@ jobs:
 
     steps:
       - name: Checkout trusted base
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Sync labels

--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -38,8 +38,9 @@ jobs:
           fi
 
       - name: Checkout main
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -110,6 +111,7 @@ jobs:
           git commit -m "chore: release ${TAG}"
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --force-with-lease origin "${BRANCH}"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Open or update beta release PR
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -36,8 +36,9 @@ jobs:
           fi
 
       - name: Checkout merged beta release commit
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -77,6 +78,7 @@ jobs:
             git tag -a "${TAG}" "${SHA}" -m "Release ${TAG}"
             git push origin "${TAG}"
           fi
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
           notes_file="${RUNNER_TEMP}/beta-release-notes.md"
           cat > "${notes_file}" <<EOF

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@v4.4.1
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
@@ -32,8 +35,9 @@ jobs:
 
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Resolve tag metadata
@@ -48,15 +52,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
+          no-cache: true
 
       - name: Install frontend dependencies
         run: cd frontend && bun install --frozen-lockfile
@@ -65,17 +71,17 @@ jobs:
         run: cd frontend && bun run build
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
-          enable-cache: true
+          enable-cache: false
 
       - name: Verify tag matches release-managed versions
         shell: bash
         run: python -m scripts.verify_release_version --tag "${RELEASE_TAG}"
 
       - name: Build sdist + wheel
-        run: uvx --from build python -m build
+        run: uvx --from build==1.3.0 python -m build
 
       - name: Verify wheel contains frontend assets
         shell: bash
@@ -103,7 +109,7 @@ jobs:
           PY
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dist
           path: dist/*
@@ -122,7 +128,7 @@ jobs:
 
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@fc02353415da80201a0da48ab47022efd7725d11
         with:
           name: dist
           path: dist
@@ -131,7 +137,7 @@ jobs:
         run: ls -la dist/
 
       - name: Publish to PyPI (Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           verbose: true
           print-hash: true
@@ -148,18 +154,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -167,7 +174,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6.0.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -178,7 +185,7 @@ jobs:
             type=raw,value=${{ needs.release-metadata.outputs.channel }},enable=${{ needs.release-metadata.outputs.is_prerelease == 'true' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: Dockerfile
@@ -186,15 +193,17 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=codex-lb-release
+          cache-to: type=gha,mode=max,scope=codex-lb-release
 
       - name: Set lowercase image ref
         id: image
-        run: echo "ref=ghcr.io/${GITHUB_REPOSITORY,,}:${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+        env:
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
+        run: echo "ref=ghcr.io/${GITHUB_REPOSITORY,,}:${IMAGE_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Scan Docker image with Trivy (SARIF)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           image-ref: ${{ steps.image.outputs.ref }}
           format: sarif
@@ -203,7 +212,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4.35.5
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba
         if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         with:
           sarif_file: trivy-results.sarif
@@ -222,21 +231,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5.0.0
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
       - name: Build Helm dependencies
         run: helm dependency build deploy/helm/codex-lb/
 
       - name: Log in to GHCR (Helm)
+        env:
+          REGISTRY_USERNAME: ${{ github.actor }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | helm registry login ghcr.io \
-              --username ${{ github.actor }} \
+              --username "${REGISTRY_USERNAME}" \
               --password-stdin
 
       - name: Package Helm chart
@@ -259,13 +271,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@fc02353415da80201a0da48ab47022efd7725d11
         with:
           name: dist
           path: dist
@@ -315,7 +328,7 @@ jobs:
 
       - name: Generate release notes (GitHub)
         id: notes
-        uses: actions/github-script@v7.1.0
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           TAG_NAME: ${{ steps.prev_tag.outputs.tag_name }}
           PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
@@ -363,7 +376,7 @@ jobs:
           } >> release_notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2.6.2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           tag_name: ${{ steps.notes.outputs.tag_name }}
           name: Release ${{ steps.notes.outputs.tag_name }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Mark needs-info issues stale and close after timeout
-        uses: actions/stale@v9.1.0
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           # 7 days with no activity after needs-info is applied -> mark stale
           days-before-issue-stale: 7

--- a/.github/workflows/windows-startup.yml
+++ b/.github/workflows/windows-startup.yml
@@ -3,6 +3,9 @@ name: Windows Startup Regression
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-windows-startup:
     name: Windows startup regression
@@ -10,10 +13,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.13"
           enable-cache: true

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ package: frontend-build
 	uv sync --frozen --no-dev
 	uv run python -c "import app; import app.main; print('import ok')"
 	rm -rf build dist *.egg-info
-	uvx --from build python -m build
+	uvx --from build==1.3.0 python -m build
 	python scripts/verify-wheel-assets.py
 
 .PHONY: docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ codex-lb = "app.cli:main"
 codex-lb-db = "app.db.migrate:main"
 
 [build-system]
-requires = ["hatchling>=1.27.0"]
+requires = ["hatchling==1.27.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]


### PR DESCRIPTION
## Summary
- Pins every GitHub Actions `uses:` reference to a full commit SHA to remove tag-retargeting exposure.
- Disables checkout credential persistence on jobs that do not need git write access; release automation now supplies write credentials only at the push point.
- Verifies downloaded `kubeconform` and `kind` binaries with upstream SHA256 manifests before executing them.
- Separates Docker BuildKit GHA cache scopes for PR CI vs trusted release/main builds.
- Pins Python package build tooling (`build==1.3.0`, `hatchling==1.27.0`) for CI and release package creation.

## Validation
- `PATH="$HOME/.bun/bin:$PATH" make package`
- Parsed all workflow YAML files with PyYAML.
- Verified all 18 unique pinned action SHAs resolve through the GitHub API.
- Smoke-tested the new `kubeconform` and `kind` checksum verification snippets.
- Ran `uvx zizmor .github/workflows --no-progress`; remaining findings are the existing intentional privileged `pull_request_target` / `workflow_run` automation and `softprops/action-gh-release` superfluous-action suggestion.
