### PR TITLE
fix(ci): harden Codex label sync token writes

### DIFF
--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -733,18 +733,70 @@ def unresolved_codex_finding_thread_urls(
     return tuple(urls)
 
 
-def ensure_label(repo: str, label: str, *, color: str, description: str, apply: bool) -> None:
+def is_github_app_write_denial(exc: BaseException) -> bool:
+    """Return True when GitHub rejected a write from the current token."""
+
+    text = str(exc)
+    return "Resource not accessible by integration" in text and "HTTP 403" in text
+
+
+def write_warning(action: str, exc: BaseException) -> str:
+    return f"{action}: skipped because the GitHub token cannot write this resource ({exc})"
+
+
+def gh_api_write(
+    path: str,
+    *,
+    method: str = "GET",
+    input_json: Any | None = None,
+    tolerate_permission_errors: bool,
+    action: str,
+) -> str | None:
+    try:
+        gh_api(path, method=method, input_json=input_json)
+    except GhError as exc:
+        if tolerate_permission_errors and is_github_app_write_denial(exc):
+            return write_warning(action, exc)
+        raise
+    return None
+
+
+def run_gh_write(
+    args: list[str],
+    *,
+    timeout_seconds: int,
+    tolerate_permission_errors: bool,
+    action: str,
+) -> str | None:
+    try:
+        run_gh(args, timeout_seconds=timeout_seconds)
+    except GhError as exc:
+        if tolerate_permission_errors and is_github_app_write_denial(exc):
+            return write_warning(action, exc)
+        raise
+    return None
+
+
+def ensure_label(
+    repo: str,
+    label: str,
+    *,
+    color: str,
+    description: str,
+    apply: bool,
+    tolerate_permission_errors: bool = False,
+) -> tuple[str, ...]:
     if not apply:
-        return
+        return ()
     try:
         gh_api(f"/repos/{repo}/labels/{quote(label, safe='')}")
-        return
+        return ()
     except GhError as exc:
         if "HTTP 404" not in str(exc):
             raise
 
     try:
-        gh_api(
+        warning = gh_api_write(
             f"/repos/{repo}/labels",
             method="POST",
             input_json={
@@ -752,10 +804,14 @@ def ensure_label(repo: str, label: str, *, color: str, description: str, apply: 
                 "color": color,
                 "description": description,
             },
+            tolerate_permission_errors=tolerate_permission_errors,
+            action=f"create label {repo}:{label}",
         )
+        return (warning,) if warning else ()
     except GhError as exc:
         if "already_exists" not in str(exc) and "already exists" not in str(exc).lower():
             raise
+    return ()
 
 
 def decide_pr(
@@ -872,38 +928,70 @@ def decide_pr(
     )
 
 
-def apply_decision(decision: SyncDecision) -> None:
+def apply_decision(decision: SyncDecision, *, tolerate_permission_errors: bool = False) -> tuple[str, ...]:
+    warnings: list[str] = []
+
+    def record(warning: str | None) -> None:
+        if warning:
+            warnings.append(warning)
+
     if decision.ok_action == "add":
-        gh_api(
-            f"/repos/{decision.repo}/issues/{decision.number}/labels",
-            method="POST",
-            input_json={"labels": [CODEX_OK_LABEL]},
+        record(
+            gh_api_write(
+                f"/repos/{decision.repo}/issues/{decision.number}/labels",
+                method="POST",
+                input_json={"labels": [CODEX_OK_LABEL]},
+                tolerate_permission_errors=tolerate_permission_errors,
+                action=f"add {CODEX_OK_LABEL} to {decision.repo}#{decision.number}",
+            )
         )
     elif decision.ok_action == "remove":
-        gh_api(
-            f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(CODEX_OK_LABEL, safe='')}",
-            method="DELETE",
+        record(
+            gh_api_write(
+                f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(CODEX_OK_LABEL, safe='')}",
+                method="DELETE",
+                tolerate_permission_errors=tolerate_permission_errors,
+                action=f"remove {CODEX_OK_LABEL} from {decision.repo}#{decision.number}",
+            )
         )
     if decision.needs_work_action == "add":
-        gh_api(
-            f"/repos/{decision.repo}/issues/{decision.number}/labels",
-            method="POST",
-            input_json={"labels": [CODEX_NEEDS_WORK_LABEL]},
+        record(
+            gh_api_write(
+                f"/repos/{decision.repo}/issues/{decision.number}/labels",
+                method="POST",
+                input_json={"labels": [CODEX_NEEDS_WORK_LABEL]},
+                tolerate_permission_errors=tolerate_permission_errors,
+                action=f"add {CODEX_NEEDS_WORK_LABEL} to {decision.repo}#{decision.number}",
+            )
         )
     elif decision.needs_work_action == "remove":
-        gh_api(
-            f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(CODEX_NEEDS_WORK_LABEL, safe='')}",
-            method="DELETE",
+        record(
+            gh_api_write(
+                f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(CODEX_NEEDS_WORK_LABEL, safe='')}",
+                method="DELETE",
+                tolerate_permission_errors=tolerate_permission_errors,
+                action=f"remove {CODEX_NEEDS_WORK_LABEL} from {decision.repo}#{decision.number}",
+            )
         )
     for label in decision.legacy_labels:
-        gh_api(
-            f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(label, safe='')}",
-            method="DELETE",
+        record(
+            gh_api_write(
+                f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(label, safe='')}",
+                method="DELETE",
+                tolerate_permission_errors=tolerate_permission_errors,
+                action=f"remove legacy {label} from {decision.repo}#{decision.number}",
+            )
         )
+    return tuple(warnings)
 
 
-def trigger_codex_review(decision: SyncDecision, *, body: str) -> None:
-    run_gh(
+def trigger_codex_review(
+    decision: SyncDecision,
+    *,
+    body: str,
+    tolerate_permission_errors: bool = False,
+) -> tuple[str, ...]:
+    warning = run_gh_write(
         [
             "api",
             "--method",
@@ -913,12 +1001,28 @@ def trigger_codex_review(decision: SyncDecision, *, body: str) -> None:
             f"body={body}",
         ],
         timeout_seconds=30,
+        tolerate_permission_errors=tolerate_permission_errors,
+        action=f"request Codex review on {decision.repo}#{decision.number}",
     )
+    return (warning,) if warning else ()
 
 
-def approve_workflow_runs(decision: SyncDecision) -> None:
+def approve_workflow_runs(
+    decision: SyncDecision,
+    *,
+    tolerate_permission_errors: bool = False,
+) -> tuple[str, ...]:
+    warnings: list[str] = []
     for run_id in decision.approve_workflow_run_ids:
-        gh_api(f"/repos/{decision.repo}/actions/runs/{run_id}/approve", method="POST")
+        warning = gh_api_write(
+            f"/repos/{decision.repo}/actions/runs/{run_id}/approve",
+            method="POST",
+            tolerate_permission_errors=tolerate_permission_errors,
+            action=f"approve workflow run {run_id} for {decision.repo}#{decision.number}",
+        )
+        if warning:
+            warnings.append(warning)
+    return tuple(warnings)
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -953,6 +1057,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Ignore current-head CI state when deciding the ok label. Normally do not use this.",
     )
     parser.add_argument(
+        "--tolerate-write-permission-errors",
+        action="store_true",
+        help=(
+            "Log and continue when GitHub returns Resource not accessible by integration "
+            "for label/comment/approval writes. Read/classification errors still fail."
+        ),
+    )
+    parser.add_argument(
         "--reviewer-login",
         action="append",
         default=[],
@@ -968,20 +1080,29 @@ def main(argv: list[str] | None = None) -> int:
     had_error = False
 
     for repo in repos:
-        ensure_label(
-            repo,
-            CODEX_OK_LABEL,
-            color="0e8a16",
-            description="Current PR head has green CI and a clean Codex review",
-            apply=args.apply,
+        setup_warnings: list[str] = []
+        setup_warnings.extend(
+            ensure_label(
+                repo,
+                CODEX_OK_LABEL,
+                color="0e8a16",
+                description="Current PR head has green CI and a clean Codex review",
+                apply=args.apply,
+                tolerate_permission_errors=args.tolerate_write_permission_errors,
+            )
         )
-        ensure_label(
-            repo,
-            CODEX_NEEDS_WORK_LABEL,
-            color="d93f0b",
-            description="Codex raised issues on the current PR head that still need work",
-            apply=args.apply,
+        setup_warnings.extend(
+            ensure_label(
+                repo,
+                CODEX_NEEDS_WORK_LABEL,
+                color="d93f0b",
+                description="Codex raised issues on the current PR head that still need work",
+                apply=args.apply,
+                tolerate_permission_errors=args.tolerate_write_permission_errors,
+            )
         )
+        for warning in setup_warnings:
+            print(f"warning: {warning}", file=sys.stderr, flush=True)
         numbers = list_open_pr_numbers(repo) if args.all_open else list(args.pr or [])
         if not numbers:
             print(f"{repo}: no PRs selected; pass --pr or --all-open", file=sys.stderr)
@@ -996,12 +1117,31 @@ def main(argv: list[str] | None = None) -> int:
                     allowed_authors=allowed_authors,
                     ignore_checks=args.ignore_checks,
                 )
+                write_warnings: tuple[str, ...] = ()
                 if args.apply:
-                    apply_decision(decision)
+                    accumulated_warnings: list[str] = []
+                    accumulated_warnings.extend(
+                        apply_decision(
+                            decision,
+                            tolerate_permission_errors=args.tolerate_write_permission_errors,
+                        )
+                    )
                     if decision.approve_workflow_run_ids and not args.no_approve_workflow_runs:
-                        approve_workflow_runs(decision)
+                        accumulated_warnings.extend(
+                            approve_workflow_runs(
+                                decision,
+                                tolerate_permission_errors=args.tolerate_write_permission_errors,
+                            )
+                        )
                     if decision.trigger_codex_review and not args.no_trigger_missing_codex:
-                        trigger_codex_review(decision, body=args.codex_review_command)
+                        accumulated_warnings.extend(
+                            trigger_codex_review(
+                                decision,
+                                body=args.codex_review_command,
+                                tolerate_permission_errors=args.tolerate_write_permission_errors,
+                            )
+                        )
+                    write_warnings = tuple(accumulated_warnings)
                 mode = "apply" if args.apply else "dry-run"
                 print(
                     f"{mode} {repo}#{number}: "
@@ -1018,6 +1158,8 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 if decision.review_url:
                     print(f"  review_url={decision.review_url}", flush=True)
+                for warning in write_warnings:
+                    print(f"  write_warning={warning}", flush=True)
             except Exception as exc:  # noqa: BLE001
                 had_error = True
                 print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)

--- a/.github/workflows/codex-review-labels.yml
+++ b/.github/workflows/codex-review-labels.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Sync labels
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -51,7 +51,7 @@ jobs:
             echo ".github/scripts/sync_codex_ok_labels.py is not available on the default branch yet; skipping bootstrap run"
             exit 0
           fi
-          python3 .github/scripts/sync_codex_ok_labels.py --repo "$REPO" --pr "$PR_NUMBER" --apply
+          python3 .github/scripts/sync_codex_ok_labels.py --repo "$REPO" --pr "$PR_NUMBER" --apply --tolerate-write-permission-errors
 
   sync-after-ci:
     name: Sync Codex labels after CI
@@ -71,11 +71,11 @@ jobs:
 
       - name: Sync labels
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
           REPO: ${{ github.repository }}
         run: |
           if [ ! -f .github/scripts/sync_codex_ok_labels.py ]; then
             echo ".github/scripts/sync_codex_ok_labels.py is not available on the default branch yet; skipping bootstrap run"
             exit 0
           fi
-          python3 .github/scripts/sync_codex_ok_labels.py --repo "$REPO" --all-open --apply
+          python3 .github/scripts/sync_codex_ok_labels.py --repo "$REPO" --all-open --apply --tolerate-write-permission-errors

--- a/openspec/changes/fix-codex-review-label-token/proposal.md
+++ b/openspec/changes/fix-codex-review-label-token/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+The `Codex review labels` workflow is failing repeatedly even though the label classifier itself can read PR state. The failing runs all stop on write operations such as adding/removing `🤖 codex:*` labels or posting `@codex review`, with GitHub returning `Resource not accessible by integration (HTTP 403)` from the workflow token.
+
+## What Changes
+
+- Prefer a repository-provided write token (`CODEX_LABEL_SYNC_TOKEN`, then existing `RELEASE_PLEASE_TOKEN`) before falling back to `github.token`.
+- Keep the workflow on the trusted default-branch checkout so privileged tokens are not exposed to PR code.
+- Add an explicit tolerant-write mode: read/classification errors still fail, but GitHub App write-denial responses are logged as per-PR warnings and the workflow continues processing the remaining PRs.
+- Add unit coverage for tolerated label/comment write denials and workflow token selection.
+
+## Impact
+
+- Repeated red `Codex review labels` runs caused by token write-denial should stop.
+- When a privileged token is available, labels/comments are written normally.
+- If the workflow falls back to a read-only token, it reports the skipped write in logs instead of making every CI completion red.

--- a/openspec/changes/fix-codex-review-label-token/specs/github-automation/spec.md
+++ b/openspec/changes/fix-codex-review-label-token/specs/github-automation/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Codex review label sync write-token fallback
+
+The `Codex review labels` workflow MUST execute the label synchronization script from the trusted default branch and MUST prefer a repository-provided write token before falling back to the default `github.token`.
+
+#### Scenario: Privileged token is configured
+
+- **WHEN** the workflow synchronizes Codex review labels
+- **THEN** it uses `CODEX_LABEL_SYNC_TOKEN` when present
+- **AND** it falls back to `RELEASE_PLEASE_TOKEN` before `github.token`
+- **AND** it checks out the default branch with persisted checkout credentials disabled
+
+### Requirement: Codex review label sync write-denial resilience
+
+The Codex label synchronization script MUST distinguish GitHub write-permission denials from classification/read failures.
+
+#### Scenario: GitHub App token cannot mutate a PR resource
+
+- **WHEN** a label, comment, or workflow-run approval write returns `Resource not accessible by integration (HTTP 403)`
+- **THEN** the workflow logs a per-PR warning for the skipped mutation
+- **AND** it continues processing remaining selected PRs
+- **AND** it exits successfully if no read/classification errors occurred
+
+#### Scenario: PR state cannot be read or classified
+
+- **WHEN** the script cannot read required PR state, check state, merge state, or Codex review evidence
+- **THEN** the workflow fails rather than silently treating the PR as synchronized

--- a/openspec/changes/fix-codex-review-label-token/tasks.md
+++ b/openspec/changes/fix-codex-review-label-token/tasks.md
@@ -1,0 +1,18 @@
+## 1. Workflow token
+
+- [x] 1.1 Prefer `CODEX_LABEL_SYNC_TOKEN` for Codex label synchronization writes.
+- [x] 1.2 Fall back to the existing `RELEASE_PLEASE_TOKEN`, then `github.token`.
+- [x] 1.3 Keep checkout pinned to the trusted default branch with persisted credentials disabled.
+
+## 2. Write-denial handling
+
+- [x] 2.1 Add a script flag to tolerate GitHub App `Resource not accessible by integration (HTTP 403)` write denials.
+- [x] 2.2 Apply the tolerant path only to label/comment/workflow-approval writes; read/classification failures still fail the run.
+- [x] 2.3 Log per-PR write warnings so skipped mutations remain visible.
+
+## 3. Verification
+
+- [x] 3.1 Add unit tests for tolerated label write denials.
+- [x] 3.2 Add unit tests for tolerated Codex review comment denials.
+- [x] 3.3 Add unit coverage for workflow token precedence and tolerant apply invocation.
+- [x] 3.4 Run focused tests, lint, and OpenSpec validation.

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+def load_sync_module() -> ModuleType:
+    script_path = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "sync_codex_ok_labels.py"
+    spec = importlib.util.spec_from_file_location("sync_codex_ok_labels", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def decision(module: ModuleType, **overrides: Any) -> Any:
+    values = {
+        "repo": "Soju06/codex-lb",
+        "number": 714,
+        "head_sha": "a" * 40,
+        "has_ok_label": True,
+        "wants_ok_label": False,
+        "ok_action": "remove",
+        "has_needs_work_label": False,
+        "wants_needs_work_label": False,
+        "needs_work_action": "keep",
+        "legacy_labels": frozenset(),
+        "reason": "checks are pending",
+        "review_url": None,
+        "review_state": "clean",
+        "checks_state": "pending",
+        "merge_state": "CLEAN",
+        "trigger_codex_review": False,
+        "approve_workflow_run_ids": (),
+    }
+    values.update(overrides)
+    return module.SyncDecision(**values)
+
+
+def test_apply_decision_tolerates_github_app_write_denial(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+
+    def deny_write(*_args: Any, **_kwargs: Any) -> None:
+        raise module.GhError("gh: Resource not accessible by integration (HTTP 403)")
+
+    monkeypatch.setattr(module, "gh_api", deny_write)
+
+    warnings = module.apply_decision(decision(module), tolerate_permission_errors=True)
+
+    assert len(warnings) == 1
+    assert "remove 🤖 codex: ok from Soju06/codex-lb#714" in warnings[0]
+    assert "Resource not accessible by integration" in warnings[0]
+
+
+def test_apply_decision_still_fails_on_write_denial_without_tolerance(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+
+    def deny_write(*_args: Any, **_kwargs: Any) -> None:
+        raise module.GhError("gh: Resource not accessible by integration (HTTP 403)")
+
+    monkeypatch.setattr(module, "gh_api", deny_write)
+
+    with pytest.raises(module.GhError):
+        module.apply_decision(decision(module), tolerate_permission_errors=False)
+
+
+def test_trigger_codex_review_tolerates_github_app_write_denial(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+
+    def deny_write(*_args: Any, **_kwargs: Any) -> None:
+        raise module.GhError("gh: Resource not accessible by integration (HTTP 403)")
+
+    monkeypatch.setattr(module, "run_gh", deny_write)
+    request_review = decision(module, trigger_codex_review=True, ok_action="keep")
+
+    warnings = module.trigger_codex_review(
+        request_review,
+        body="@codex review",
+        tolerate_permission_errors=True,
+    )
+
+    assert len(warnings) == 1
+    assert "request Codex review on Soju06/codex-lb#714" in warnings[0]
+
+
+def test_workflow_prefers_privileged_token_and_enables_tolerant_apply() -> None:
+    workflow = Path(".github/workflows/codex-review-labels.yml").read_text(encoding="utf-8")
+
+    assert "secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token" in workflow
+    assert workflow.count("--tolerate-write-permission-errors") == 2


### PR DESCRIPTION
## Summary
- Root cause: `Codex review labels` was using the default workflow token for label/comment writes, and GitHub returned `Resource not accessible by integration (HTTP 403)` on mutations like `🤖 codex: ok` removal and `@codex review` comments.
- Prefer a repository write token for the trusted default-branch label sync job: `CODEX_LABEL_SYNC_TOKEN`, then the existing `RELEASE_PLEASE_TOKEN`, then `github.token`.
- Add tolerant write-denial handling so read/classification errors still fail, but token write denials are logged per PR and do not make every CI completion red.
- Add OpenSpec change + unit coverage for label/comment write-denial handling and workflow token precedence.

## Test Plan
- `uv run --frozen pytest tests/unit/test_sync_codex_ok_labels.py -q`
- `uv run --frozen ruff check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- `uv run --frozen ty check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- `python3 .github/scripts/sync_codex_ok_labels.py --repo Soju06/codex-lb --pr 714`
- `openspec validate fix-codex-review-label-token --strict`
- `openspec validate --specs`
