### PR TITLE
docs: backfill missing contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -532,6 +532,26 @@
         "doc",
         "bug"
       ]
+    },
+    {
+      "login": "timefox",
+      "name": "timefox",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5635109?v=4",
+      "profile": "https://github.com/timefox",
+      "contributions": [
+        "code",
+        "test"
+      ]
+    },
+    {
+      "login": "datfooldive",
+      "name": "hikki",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110718021?v=4",
+      "profile": "https://datfooldive.github.io/",
+      "contributions": [
+        "code",
+        "design"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -517,6 +517,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/linusmixson"><img src="https://avatars.githubusercontent.com/u/7087013?v=4?s=100" width="100px;" alt="Linus Mixson"/><br /><sub><b>Linus Mixson</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=linusmixson" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=linusmixson" title="Tests">⚠️</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Lotfree618"><img src="https://avatars.githubusercontent.com/u/91266981?v=4?s=100" width="100px;" alt="Lotfree"/><br /><sub><b>Lotfree</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=Lotfree618" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=Lotfree618" title="Tests">⚠️</a> <a href="https://github.com/Soju06/codex-lb/commits?author=Lotfree618" title="Documentation">📖</a> <a href="https://github.com/Soju06/codex-lb/issues?q=author%3ALotfree618" title="Bug reports">🐛</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/timefox"><img src="https://avatars.githubusercontent.com/u/5635109?v=4?s=100" width="100px;" alt="timefox"/><br /><sub><b>timefox</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=timefox" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=timefox" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://datfooldive.github.io/"><img src="https://avatars.githubusercontent.com/u/110718021?v=4?s=100" width="100px;" alt="hikki"/><br /><sub><b>hikki</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=datfooldive" title="Code">💻</a> <a href="#design-datfooldive" title="Design">🎨</a></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Summary
- Backfills missing all-contributors entries for `timefox` and `datfooldive`.
- Regenerates the README contributors table from `.all-contributorsrc`.

## Audit
| Contributor | Evidence | Contribution types |
| --- | --- | --- |
| `timefox` | Merged PR #412 (`feat(accounts): add export action with audit and no-store safeguards`) changed backend/frontend code and tests | `code`, `test` |
| `datfooldive` | Merged PR #629 (`style(dashboard): use monochrome dark theme with muted steel-slate accents`) changed dashboard styling/UI | `code`, `design` |

Automation-only authors from the raw audit (`github-actions[bot]` / all-contributors app) were excluded.

## Validation
- `.all-contributorsrc` parses as JSON; contributor count is 51.
- README contributor row widths preserved: final rows `[7, 7, 7, 7, 2]`.
- Diff scope verified: only `.all-contributorsrc` and `README.md` changed.
- `git diff --check origin/main..HEAD` passed.
