### PR TITLE
refactor(proxy): extract affinity routing helpers

### DIFF
--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -1,0 +1,327 @@
+"""Sticky-affinity and prompt-cache key helpers for proxy routing.
+
+This module owns the pure request/header policy used by ``ProxyService`` to
+choose a sticky session family. Keeping it outside ``service.py`` makes the
+routing decisions testable without adding more responsibility to the proxy
+orchestration class.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import cast
+from uuid import uuid4
+
+from app.core.config.settings import get_settings
+from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+from app.db.models import StickySessionKind
+from app.modules.api_keys.service import ApiKeyData
+
+
+@dataclass(frozen=True, slots=True)
+class _AffinityPolicy:
+    key: str | None = None
+    kind: StickySessionKind | None = None
+    reallocate_sticky: bool = False
+    max_age_seconds: int | None = None
+
+
+def _prompt_cache_key_from_request_model(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
+    typed_value = getattr(payload, "prompt_cache_key", None)
+    if isinstance(typed_value, str) and typed_value:
+        return typed_value
+    if not payload.model_extra:
+        return None
+    extra_value = payload.model_extra.get("prompt_cache_key")
+    if isinstance(extra_value, str) and extra_value:
+        return extra_value
+    camel_value = payload.model_extra.get("promptCacheKey")
+    if isinstance(camel_value, str) and camel_value:
+        return camel_value
+    return None
+
+
+def _extract_model_class(model: str) -> str:
+    """Extract model class from model name for cache key prefix.
+
+    Classification:
+    - "mini" for gpt-5.4-mini
+    - "codex" for gpt-5.3-codex* (any variant)
+    - "std" for all others
+    """
+    if "codex" in model:
+        return "codex"
+    if "mini" in model:
+        return "mini"
+    return "std"
+
+
+def _derive_prompt_cache_key(
+    payload: ResponsesRequest | ResponsesCompactRequest,
+    api_key: ApiKeyData | None,
+) -> str:
+    """Derive a stable, session-scoped prompt_cache_key when the client does not provide one.
+
+    The generated key is scoped to (model-class, api-key, instructions-prefix,
+    instruction-role input, first-user-input) so that:
+    - Different model classes get *different* keys (prevents cache pollution).
+    - Parallel sessions from the same API key get *different* keys (different first input).
+    - Successive turns within one session get the *same* key (first input stays constant).
+    - Different API keys never collide.
+    """
+    parts: list[str] = []
+    model = getattr(payload, "model", None)
+    model_class = _extract_model_class(model) if isinstance(model, str) and model else None
+
+    if api_key is not None:
+        parts.append(api_key.id[:12])
+
+    instructions = getattr(payload, "instructions", None)
+    if isinstance(instructions, str) and instructions:
+        parts.append(sha256(instructions[:512].encode()).hexdigest()[:12])
+
+    instruction_input_text = _extract_instruction_input(payload)
+    if instruction_input_text:
+        parts.append(sha256(instruction_input_text[:512].encode()).hexdigest()[:12])
+
+    first_user_text = _extract_first_user_input(payload)
+    if first_user_text:
+        parts.append(sha256(first_user_text[:512].encode()).hexdigest()[:12])
+
+    if not parts:
+        random_suffix = uuid4().hex[:24]
+        return f"{model_class}-{random_suffix}" if model_class is not None else random_suffix
+
+    return "-".join([model_class, *parts]) if model_class is not None else "-".join(parts)
+
+
+def _extract_instruction_input(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
+    input_value = getattr(payload, "input", None)
+    if not isinstance(input_value, list):
+        return None
+    parts: list[str] = []
+    for item in input_value:
+        if not isinstance(item, dict):
+            continue
+        if item.get("role") not in ("system", "developer"):
+            continue
+        content_text = _extract_message_content_text(item.get("content"))
+        if content_text:
+            parts.append(content_text)
+        else:
+            parts.append(json.dumps(item, sort_keys=True, ensure_ascii=False))
+        if sum(len(part) for part in parts) >= 512:
+            break
+    if not parts:
+        return None
+    return "\n".join(parts)[:512]
+
+
+def _extract_first_user_input(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
+    """Return a text representation of the first user input item for cache key derivation."""
+    input_value = getattr(payload, "input", None)
+    if isinstance(input_value, str):
+        return input_value[:512]
+    if not isinstance(input_value, list):
+        return None
+    for item in input_value:
+        if not isinstance(item, dict):
+            continue
+        role = item.get("role")
+        if role == "user":
+            content = item.get("content")
+            content_text = _extract_message_content_text(content)
+            if content_text:
+                return content_text[:512]
+            return json.dumps(item, sort_keys=True, ensure_ascii=False)[:512]
+    return None
+
+
+def _extract_message_content_text(content: object) -> str | None:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        content_mapping = cast(Mapping[str, object], content)
+        text = content_mapping.get("text")
+        return text if isinstance(text, str) else None
+    if not isinstance(content, list):
+        return None
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, str):
+            parts.append(part)
+            continue
+        if not isinstance(part, dict):
+            continue
+        part_mapping = cast(Mapping[str, object], part)
+        text = part_mapping.get("text")
+        if isinstance(text, str):
+            parts.append(text)
+    return "".join(parts) if parts else None
+
+
+def _sticky_key_from_payload(payload: ResponsesRequest) -> str | None:
+    value = _prompt_cache_key_from_request_model(payload)
+    if not value:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _sticky_key_from_session_header(headers: Mapping[str, str]) -> str | None:
+    normalized = {key.lower(): value for key, value in headers.items()}
+    for key in ("session_id", "x-codex-session-id", "x-codex-conversation-id"):
+        value = normalized.get(key)
+        if not isinstance(value, str):
+            continue
+        stripped = value.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _sticky_key_from_turn_state_header(headers: Mapping[str, str]) -> str | None:
+    normalized = {key.lower(): value for key, value in headers.items()}
+    value = normalized.get("x-codex-turn-state")
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _sticky_key_for_codex_control_request(
+    headers: Mapping[str, str],
+    *,
+    codex_session_affinity: bool,
+) -> _AffinityPolicy:
+    turn_state_key = _sticky_key_from_turn_state_header(headers)
+    if turn_state_key:
+        return _AffinityPolicy(
+            key=turn_state_key,
+            kind=StickySessionKind.CODEX_SESSION,
+        )
+    if codex_session_affinity:
+        session_key = _sticky_key_from_session_header(headers)
+        if session_key:
+            return _AffinityPolicy(
+                key=session_key,
+                kind=StickySessionKind.CODEX_SESSION,
+            )
+    return _AffinityPolicy()
+
+
+def _owner_lookup_session_id_from_headers(headers: Mapping[str, str]) -> str | None:
+    # `x-codex-turn-state` is per conversation turn/thread and is more specific
+    # than `session_id`, which may be shared across multiple terminals.
+    turn_state = _sticky_key_from_turn_state_header(headers)
+    if turn_state is not None:
+        return turn_state
+    return _sticky_key_from_session_header(headers)
+
+
+# Pattern matching turn-state values synthesized by the helpers below.
+# A 32-char lowercase hex (uuid4().hex) suffix follows the prefix.
+_SYNTHESIZED_TURN_STATE_PATTERN = re.compile(r"^(?:http_)?turn_[0-9a-f]{32}$")
+
+
+def _is_synthesized_turn_state(value: str) -> bool:
+    """True when ``value`` matches a turn-state synthesized by codex-lb itself.
+
+    Used by the file-pin resolver to distinguish a client-supplied
+    continuation marker from a synthesizer-generated placeholder so
+    first-turn upload-then-converse requests still benefit from
+    file_id pin routing on the websocket / HTTP entry points.
+    """
+    return bool(_SYNTHESIZED_TURN_STATE_PATTERN.match(value))
+
+
+def ensure_downstream_turn_state(headers: Mapping[str, str]) -> str:
+    existing = _sticky_key_from_turn_state_header(headers)
+    if existing is not None:
+        return existing
+    return f"turn_{uuid4().hex}"
+
+
+def ensure_http_downstream_turn_state(headers: Mapping[str, str]) -> str:
+    existing = _sticky_key_from_turn_state_header(headers)
+    if existing is not None:
+        return existing
+    return f"http_turn_{uuid4().hex}"
+
+
+def build_downstream_turn_state_accept_headers(turn_state: str) -> list[tuple[bytes, bytes]]:
+    return [(b"x-codex-turn-state", turn_state.encode("utf-8"))]
+
+
+def build_downstream_turn_state_response_headers(turn_state: str) -> dict[str, str]:
+    return {"x-codex-turn-state": turn_state}
+
+
+def _resolve_prompt_cache_key(
+    payload: ResponsesRequest | ResponsesCompactRequest,
+    *,
+    openai_cache_affinity: bool,
+    api_key: ApiKeyData | None,
+) -> tuple[str | None, str]:
+    cache_key = _prompt_cache_key_from_request_model(payload)
+    if isinstance(cache_key, str):
+        stripped = cache_key.strip()
+        if stripped:
+            if stripped != cache_key:
+                payload.prompt_cache_key = stripped
+            return stripped, "payload"
+    if not openai_cache_affinity:
+        return None, "none"
+    settings = get_settings()
+    if not settings.openai_prompt_cache_key_derivation_enabled:
+        return None, "none"
+    cache_key = _derive_prompt_cache_key(payload, api_key)
+    payload.prompt_cache_key = cache_key
+    return cache_key, "derived"
+
+
+def _sticky_key_for_responses_request(
+    payload: ResponsesRequest,
+    headers: Mapping[str, str],
+    *,
+    codex_session_affinity: bool,
+    openai_cache_affinity: bool,
+    openai_cache_affinity_max_age_seconds: int,
+    sticky_threads_enabled: bool,
+    api_key: ApiKeyData | None = None,
+) -> _AffinityPolicy:
+    cache_key, _ = _resolve_prompt_cache_key(
+        payload,
+        openai_cache_affinity=openai_cache_affinity,
+        api_key=api_key,
+    )
+    turn_state_key = _sticky_key_from_turn_state_header(headers)
+    if turn_state_key:
+        return _AffinityPolicy(
+            key=turn_state_key,
+            kind=StickySessionKind.CODEX_SESSION,
+        )
+    if codex_session_affinity:
+        session_key = _sticky_key_from_session_header(headers)
+        if session_key:
+            return _AffinityPolicy(
+                key=session_key,
+                kind=StickySessionKind.CODEX_SESSION,
+            )
+    if openai_cache_affinity:
+        return _AffinityPolicy(
+            key=cache_key,
+            kind=StickySessionKind.PROMPT_CACHE,
+            max_age_seconds=openai_cache_affinity_max_age_seconds,
+        )
+    if sticky_threads_enabled:
+        return _AffinityPolicy(
+            key=cache_key,
+            kind=StickySessionKind.STICKY_THREAD,
+            reallocate_sticky=True,
+        )
+    return _AffinityPolicy()

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -87,6 +87,7 @@ from app.modules.api_keys.service import (
 )
 from app.modules.firewall.repository import FirewallRepository
 from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
+from app.modules.proxy import affinity as proxy_affinity_module
 from app.modules.proxy import images_service as images_service_module
 from app.modules.proxy import service as proxy_service_module
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
@@ -428,8 +429,8 @@ async def responses_websocket(
     if denial is not None:
         await websocket.send_denial_response(denial)
         return
-    turn_state = proxy_service_module.ensure_downstream_turn_state(websocket.headers)
-    await websocket.accept(headers=proxy_service_module.build_downstream_turn_state_accept_headers(turn_state))
+    turn_state = proxy_affinity_module.ensure_downstream_turn_state(websocket.headers)
+    await websocket.accept(headers=proxy_affinity_module.build_downstream_turn_state_accept_headers(turn_state))
     forwarded_headers = dict(websocket.headers)
     forwarded_headers.setdefault("x-codex-turn-state", turn_state)
     await context.service.proxy_responses_websocket(
@@ -561,8 +562,8 @@ async def v1_responses_websocket(
     if denial is not None:
         await websocket.send_denial_response(denial)
         return
-    turn_state = proxy_service_module.ensure_downstream_turn_state(websocket.headers)
-    await websocket.accept(headers=proxy_service_module.build_downstream_turn_state_accept_headers(turn_state))
+    turn_state = proxy_affinity_module.ensure_downstream_turn_state(websocket.headers)
+    await websocket.accept(headers=proxy_affinity_module.build_downstream_turn_state_accept_headers(turn_state))
     forwarded_headers = dict(websocket.headers)
     forwarded_headers.setdefault("x-codex-turn-state", turn_state)
     await context.service.proxy_responses_websocket(
@@ -1828,12 +1829,12 @@ async def _stream_responses(
     downstream_turn_state = (
         forwarded_downstream_turn_state
         if bridge_active and forwarded_downstream_turn_state is not None
-        else proxy_service_module.ensure_http_downstream_turn_state(effective_headers)
+        else proxy_affinity_module.ensure_http_downstream_turn_state(effective_headers)
         if bridge_active
         else None
     )
     turn_state_headers = (
-        proxy_service_module.build_downstream_turn_state_response_headers(downstream_turn_state)
+        proxy_affinity_module.build_downstream_turn_state_response_headers(downstream_turn_state)
         if downstream_turn_state is not None
         else {}
     )
@@ -1924,10 +1925,10 @@ async def _collect_responses(
     rate_limit_headers = await context.service.rate_limit_headers()
     bridge_active = prefer_http_bridge and proxy_service_module.get_settings().http_responses_session_bridge_enabled
     downstream_turn_state = (
-        proxy_service_module.ensure_http_downstream_turn_state(request.headers) if bridge_active else None
+        proxy_affinity_module.ensure_http_downstream_turn_state(request.headers) if bridge_active else None
     )
     turn_state_headers = (
-        proxy_service_module.build_downstream_turn_state_response_headers(downstream_turn_state)
+        proxy_affinity_module.build_downstream_turn_state_response_headers(downstream_turn_state)
         if downstream_turn_state is not None
         else {}
     )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -128,6 +128,18 @@ from app.modules.api_keys.service import (
     ApiKeysService,
     ApiKeyUsageReservationData,
 )
+from app.modules.proxy.affinity import (
+    _AffinityPolicy,
+    _extract_model_class,
+    _is_synthesized_turn_state,
+    _owner_lookup_session_id_from_headers,
+    _prompt_cache_key_from_request_model,
+    _resolve_prompt_cache_key,
+    _sticky_key_for_codex_control_request,
+    _sticky_key_for_responses_request,
+    _sticky_key_from_session_header,
+    _sticky_key_from_turn_state_header,
+)
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.durable_bridge_coordinator import (
     DurableBridgeLookup,
@@ -326,14 +338,6 @@ _WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
 _WEBSOCKET_CONTINUITY_CACHE_LIMIT = 4096
 _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS = 20
 _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS = 0.05
-
-
-@dataclass(frozen=True, slots=True)
-class _AffinityPolicy:
-    key: str | None = None
-    kind: StickySessionKind | None = None
-    reallocate_sticky: bool = False
-    max_age_seconds: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -13172,190 +13176,6 @@ def _interesting_header_keys(headers: Mapping[str, str]) -> list[str]:
     return sorted({key.lower() for key in headers.keys() if key.lower() in allowlist})
 
 
-def _prompt_cache_key_from_request_model(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
-    typed_value = getattr(payload, "prompt_cache_key", None)
-    if isinstance(typed_value, str) and typed_value:
-        return typed_value
-    if not payload.model_extra:
-        return None
-    extra_value = payload.model_extra.get("prompt_cache_key")
-    if isinstance(extra_value, str) and extra_value:
-        return extra_value
-    camel_value = payload.model_extra.get("promptCacheKey")
-    if isinstance(camel_value, str) and camel_value:
-        return camel_value
-    return None
-
-
-def _extract_model_class(model: str) -> str:
-    """Extract model class from model name for cache key prefix.
-
-    Classification:
-    - "mini" for gpt-5.4-mini
-    - "codex" for gpt-5.3-codex* (any variant)
-    - "std" for all others
-    """
-    if "codex" in model:
-        return "codex"
-    if "mini" in model:
-        return "mini"
-    return "std"
-
-
-def _derive_prompt_cache_key(
-    payload: ResponsesRequest | ResponsesCompactRequest,
-    api_key: ApiKeyData | None,
-) -> str:
-    """Derive a stable, session-scoped prompt_cache_key when the client does not provide one.
-
-    The generated key is scoped to (model-class, api-key, instructions-prefix,
-    instruction-role input, first-user-input) so that:
-    - Different model classes get *different* keys (prevents cache pollution).
-    - Parallel sessions from the same API key get *different* keys (different first input).
-    - Successive turns within one session get the *same* key (first input stays constant).
-    - Different API keys never collide.
-    """
-    parts: list[str] = []
-    model = getattr(payload, "model", None)
-    model_class = _extract_model_class(model) if isinstance(model, str) and model else None
-
-    if api_key is not None:
-        parts.append(api_key.id[:12])
-
-    instructions = getattr(payload, "instructions", None)
-    if isinstance(instructions, str) and instructions:
-        parts.append(sha256(instructions[:512].encode()).hexdigest()[:12])
-
-    instruction_input_text = _extract_instruction_input(payload)
-    if instruction_input_text:
-        parts.append(sha256(instruction_input_text[:512].encode()).hexdigest()[:12])
-
-    first_user_text = _extract_first_user_input(payload)
-    if first_user_text:
-        parts.append(sha256(first_user_text[:512].encode()).hexdigest()[:12])
-
-    if not parts:
-        random_suffix = uuid4().hex[:24]
-        return f"{model_class}-{random_suffix}" if model_class is not None else random_suffix
-
-    return "-".join([model_class, *parts]) if model_class is not None else "-".join(parts)
-
-
-def _extract_instruction_input(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
-    input_value = getattr(payload, "input", None)
-    if not isinstance(input_value, list):
-        return None
-    parts: list[str] = []
-    for item in input_value:
-        if not isinstance(item, dict):
-            continue
-        if item.get("role") not in ("system", "developer"):
-            continue
-        content_text = _extract_message_content_text(item.get("content"))
-        if content_text:
-            parts.append(content_text)
-        else:
-            parts.append(json.dumps(item, sort_keys=True, ensure_ascii=False))
-        if sum(len(part) for part in parts) >= 512:
-            break
-    if not parts:
-        return None
-    return "\n".join(parts)[:512]
-
-
-def _extract_first_user_input(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
-    """Return a text representation of the first user input item for cache key derivation."""
-    input_value = getattr(payload, "input", None)
-    if isinstance(input_value, str):
-        return input_value[:512]
-    if not isinstance(input_value, list):
-        return None
-    for item in input_value:
-        if not isinstance(item, dict):
-            continue
-        role = item.get("role")
-        if role == "user":
-            content = item.get("content")
-            content_text = _extract_message_content_text(content)
-            if content_text:
-                return content_text[:512]
-            return json.dumps(item, sort_keys=True, ensure_ascii=False)[:512]
-    return None
-
-
-def _extract_message_content_text(content: object) -> str | None:
-    if isinstance(content, str):
-        return content
-    if isinstance(content, dict):
-        content_mapping = cast(Mapping[str, object], content)
-        text = content_mapping.get("text")
-        return text if isinstance(text, str) else None
-    if not isinstance(content, list):
-        return None
-    parts: list[str] = []
-    for part in content:
-        if isinstance(part, str):
-            parts.append(part)
-            continue
-        if not isinstance(part, dict):
-            continue
-        part_mapping = cast(Mapping[str, object], part)
-        text = part_mapping.get("text")
-        if isinstance(text, str):
-            parts.append(text)
-    return "".join(parts) if parts else None
-
-
-def _sticky_key_from_payload(payload: ResponsesRequest) -> str | None:
-    value = _prompt_cache_key_from_request_model(payload)
-    if not value:
-        return None
-    stripped = value.strip()
-    return stripped or None
-
-
-def _sticky_key_from_session_header(headers: Mapping[str, str]) -> str | None:
-    normalized = {key.lower(): value for key, value in headers.items()}
-    for key in ("session_id", "x-codex-session-id", "x-codex-conversation-id"):
-        value = normalized.get(key)
-        if not isinstance(value, str):
-            continue
-        stripped = value.strip()
-        if stripped:
-            return stripped
-    return None
-
-
-def _sticky_key_from_turn_state_header(headers: Mapping[str, str]) -> str | None:
-    normalized = {key.lower(): value for key, value in headers.items()}
-    value = normalized.get("x-codex-turn-state")
-    if not isinstance(value, str):
-        return None
-    stripped = value.strip()
-    return stripped or None
-
-
-def _sticky_key_for_codex_control_request(
-    headers: Mapping[str, str],
-    *,
-    codex_session_affinity: bool,
-) -> _AffinityPolicy:
-    turn_state_key = _sticky_key_from_turn_state_header(headers)
-    if turn_state_key:
-        return _AffinityPolicy(
-            key=turn_state_key,
-            kind=StickySessionKind.CODEX_SESSION,
-        )
-    if codex_session_affinity:
-        session_key = _sticky_key_from_session_header(headers)
-        if session_key:
-            return _AffinityPolicy(
-                key=session_key,
-                kind=StickySessionKind.CODEX_SESSION,
-            )
-    return _AffinityPolicy()
-
-
 def _is_missing_thread_goal_protocol_error(exc: ProxyResponseError) -> bool:
     if exc.status_code not in {404, 405}:
         return False
@@ -13373,53 +13193,6 @@ def _is_missing_thread_goal_protocol_error(exc: ProxyResponseError) -> bool:
 def _detached_account_copy(account: Account) -> Account:
     data = {column.name: getattr(account, column.name) for column in Account.__table__.columns}
     return Account(**data)
-
-
-def _owner_lookup_session_id_from_headers(headers: Mapping[str, str]) -> str | None:
-    # `x-codex-turn-state` is per conversation turn/thread and is more specific
-    # than `session_id`, which may be shared across multiple terminals.
-    turn_state = _sticky_key_from_turn_state_header(headers)
-    if turn_state is not None:
-        return turn_state
-    return _sticky_key_from_session_header(headers)
-
-
-# Pattern matching turn-state values synthesized by the helpers below.
-# A 32-char lowercase hex (uuid4().hex) suffix follows the prefix.
-_SYNTHESIZED_TURN_STATE_PATTERN = re.compile(r"^(?:http_)?turn_[0-9a-f]{32}$")
-
-
-def _is_synthesized_turn_state(value: str) -> bool:
-    """True when ``value`` matches a turn-state synthesized by codex-lb itself.
-
-    Used by the file-pin resolver to distinguish a client-supplied
-    continuation marker from a synthesizer-generated placeholder so
-    first-turn upload-then-converse requests still benefit from
-    file_id pin routing on the websocket / HTTP entry points.
-    """
-    return bool(_SYNTHESIZED_TURN_STATE_PATTERN.match(value))
-
-
-def ensure_downstream_turn_state(headers: Mapping[str, str]) -> str:
-    existing = _sticky_key_from_turn_state_header(headers)
-    if existing is not None:
-        return existing
-    return f"turn_{uuid4().hex}"
-
-
-def ensure_http_downstream_turn_state(headers: Mapping[str, str]) -> str:
-    existing = _sticky_key_from_turn_state_header(headers)
-    if existing is not None:
-        return existing
-    return f"http_turn_{uuid4().hex}"
-
-
-def build_downstream_turn_state_accept_headers(turn_state: str) -> list[tuple[bytes, bytes]]:
-    return [(b"x-codex-turn-state", turn_state.encode("utf-8"))]
-
-
-def build_downstream_turn_state_response_headers(turn_state: str) -> dict[str, str]:
-    return {"x-codex-turn-state": turn_state}
 
 
 def _upstream_turn_state_from_socket(upstream: UpstreamResponsesWebSocket | None) -> str | None:
@@ -13514,72 +13287,6 @@ def _http_bridge_session_matches_preferred_account(
     if previous_response_id is None or preferred_account_id is None:
         return True
     return session.account.id == preferred_account_id
-
-
-def _resolve_prompt_cache_key(
-    payload: ResponsesRequest | ResponsesCompactRequest,
-    *,
-    openai_cache_affinity: bool,
-    api_key: ApiKeyData | None,
-) -> tuple[str | None, str]:
-    cache_key = _prompt_cache_key_from_request_model(payload)
-    if isinstance(cache_key, str):
-        stripped = cache_key.strip()
-        if stripped:
-            if stripped != cache_key:
-                payload.prompt_cache_key = stripped
-            return stripped, "payload"
-    if not openai_cache_affinity:
-        return None, "none"
-    settings = get_settings()
-    if not settings.openai_prompt_cache_key_derivation_enabled:
-        return None, "none"
-    cache_key = _derive_prompt_cache_key(payload, api_key)
-    payload.prompt_cache_key = cache_key
-    return cache_key, "derived"
-
-
-def _sticky_key_for_responses_request(
-    payload: ResponsesRequest,
-    headers: Mapping[str, str],
-    *,
-    codex_session_affinity: bool,
-    openai_cache_affinity: bool,
-    openai_cache_affinity_max_age_seconds: int,
-    sticky_threads_enabled: bool,
-    api_key: ApiKeyData | None = None,
-) -> _AffinityPolicy:
-    cache_key, _ = _resolve_prompt_cache_key(
-        payload,
-        openai_cache_affinity=openai_cache_affinity,
-        api_key=api_key,
-    )
-    turn_state_key = _sticky_key_from_turn_state_header(headers)
-    if turn_state_key:
-        return _AffinityPolicy(
-            key=turn_state_key,
-            kind=StickySessionKind.CODEX_SESSION,
-        )
-    if codex_session_affinity:
-        session_key = _sticky_key_from_session_header(headers)
-        if session_key:
-            return _AffinityPolicy(
-                key=session_key,
-                kind=StickySessionKind.CODEX_SESSION,
-            )
-    if openai_cache_affinity:
-        return _AffinityPolicy(
-            key=cache_key,
-            kind=StickySessionKind.PROMPT_CACHE,
-            max_age_seconds=openai_cache_affinity_max_age_seconds,
-        )
-    if sticky_threads_enabled:
-        return _AffinityPolicy(
-            key=cache_key,
-            kind=StickySessionKind.STICKY_THREAD,
-            reallocate_sticky=True,
-        )
-    return _AffinityPolicy()
 
 
 def _make_http_bridge_session_key(

--- a/tests/integration/test_cache_locality_fix.py
+++ b/tests/integration/test_cache_locality_fix.py
@@ -54,7 +54,7 @@ def test_mini_and_large_requests_use_different_cache_keys():
     """Verify that gpt-5.4-mini and gpt-5.3-codex requests produce different prompt_cache_keys
     due to model-class prefix separation."""
     from app.core.openai.requests import ResponsesRequest
-    from app.modules.proxy.service import _derive_prompt_cache_key
+    from app.modules.proxy.affinity import _derive_prompt_cache_key
 
     mini_payload = ResponsesRequest(
         model="gpt-5.4-mini",
@@ -79,7 +79,7 @@ def test_mini_and_large_requests_use_different_cache_keys():
 def test_same_model_class_produces_same_cache_key():
     """Verify that two requests with the same model class produce the same cache key."""
     from app.core.openai.requests import ResponsesRequest
-    from app.modules.proxy.service import _derive_prompt_cache_key
+    from app.modules.proxy.affinity import _derive_prompt_cache_key
 
     payload = ResponsesRequest(
         model="gpt-5.3-codex",
@@ -135,7 +135,7 @@ def test_codex_session_idle_ttl_unchanged():
 
 def test_model_class_extraction_for_all_model_types():
     """Verify model class extraction works correctly for mini, codex, and standard models."""
-    from app.modules.proxy.service import _extract_model_class
+    from app.modules.proxy.affinity import _extract_model_class
 
     assert _extract_model_class("gpt-5.4-mini") == "mini"
     assert _extract_model_class("gpt-4-mini") == "mini"

--- a/tests/integration/test_proxy_files.py
+++ b/tests/integration/test_proxy_files.py
@@ -491,7 +491,7 @@ async def test_synthesized_turn_state_does_not_block_file_id_pin(async_client):
 
     from app.core.openai.requests import ResponsesRequest
     from app.dependencies import get_proxy_service_for_app
-    from app.modules.proxy.service import ensure_downstream_turn_state
+    from app.modules.proxy.affinity import ensure_downstream_turn_state
 
     service = get_proxy_service_for_app(async_client._transport.app)
     await service._pin_file_account("file_synth_ts", "acc_ts_a")

--- a/tests/unit/test_prompt_cache_key_derivation.py
+++ b/tests/unit/test_prompt_cache_key_derivation.py
@@ -8,7 +8,7 @@ import pytest
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
 from app.core.types import JsonValue
 from app.modules.api_keys.service import ApiKeyData
-from app.modules.proxy.service import (
+from app.modules.proxy.affinity import (
     _derive_prompt_cache_key,
     _extract_first_user_input,
     _extract_instruction_input,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36,6 +36,7 @@ from app.modules.accounts import auth_manager as auth_manager_module
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyData
+from app.modules.proxy import affinity as proxy_affinity
 from app.modules.proxy import api as proxy_api
 from app.modules.proxy import request_policy as proxy_request_policy
 from app.modules.proxy import service as proxy_service
@@ -1309,6 +1310,7 @@ def _install_default_proxy_runtime_settings(monkeypatch: pytest.MonkeyPatch) -> 
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_affinity, "get_settings", lambda: settings)
 
 
 def _make_account(account_id: str) -> Account:
@@ -1851,6 +1853,7 @@ def test_log_proxy_request_shape_reports_derived_key_after_affinity_resolution(m
         openai_prompt_cache_key_derivation_enabled = True
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_affinity, "get_settings", lambda: Settings())
 
     payload = ResponsesRequest.model_validate(
         {
@@ -4483,6 +4486,7 @@ def test_sticky_key_for_responses_request_respects_prompt_cache_derivation_flag(
         openai_prompt_cache_key_derivation_enabled = False
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_affinity, "get_settings", lambda: Settings())
 
     payload = ResponsesRequest.model_validate(
         {
@@ -4511,6 +4515,7 @@ def test_sticky_key_for_responses_request_preserves_client_supplied_prompt_cache
         openai_prompt_cache_key_derivation_enabled = False
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_affinity, "get_settings", lambda: Settings())
 
     payload = ResponsesRequest.model_validate(
         {


### PR DESCRIPTION
## Summary
- Extract prompt-cache and sticky-session affinity routing helpers from `ProxyService` into `app.modules.proxy.affinity`
- Route API-layer turn-state header helpers through the new affinity module instead of the proxy service monolith
- Update prompt-cache / sticky-affinity tests to import the pure helper seam directly and patch the moved settings seam

## Analysis
- Current hotspot audit found `app/modules/proxy/service.py` at ~13k non-comment LOC with `ProxyService` carrying HTTP bridge lifecycle, websocket relay, request logging, API-key settlement, sticky routing, and stream retry responsibilities.
- This PR takes the safest first slice: move pure affinity/prompt-cache policy out of the 14k-line service file without touching async bridge locking, owner forwarding, or retry behavior.
- No OpenSpec change: behavior-preserving internal refactor only.

## Test Plan
- `uv run ruff check app/modules/proxy/service.py app/modules/proxy/affinity.py app/modules/proxy/api.py tests/unit/test_prompt_cache_key_derivation.py tests/unit/test_proxy_utils.py tests/integration/test_cache_locality_fix.py tests/integration/test_proxy_files.py`
- `uv run ty check app/modules/proxy/affinity.py app/modules/proxy/service.py app/modules/proxy/api.py tests/unit/test_prompt_cache_key_derivation.py tests/unit/test_proxy_utils.py tests/integration/test_cache_locality_fix.py tests/integration/test_proxy_files.py`
- `uv run pytest tests/unit/test_prompt_cache_key_derivation.py tests/unit/test_proxy_utils.py -q -k 'prompt_cache or sticky_key or AffinityPolicy or downstream_turn_state'`
- `uv run pytest tests/integration/test_cache_locality_fix.py tests/integration/test_proxy_files.py tests/integration/test_http_responses_bridge.py tests/integration/test_multi_instance_bridge.py -q`

## Review Notes
- Independent review passed after fixing the moved `get_settings` monkeypatch seam in `tests/unit/test_proxy_utils.py`.
