### PR TITLE
chore(openspec): mark add-v1-api-key-usage tasks complete

### DIFF
--- a/openspec/changes/archive/2026-05-17-add-v1-api-key-usage/tasks.md
+++ b/openspec/changes/archive/2026-05-17-add-v1-api-key-usage/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Specs
 
-- [ ] 1.1 Add an API-key self-usage requirement for `GET /v1/usage`.
-- [ ] 1.2 Validate OpenSpec changes.
+- [x] 1.1 Add an API-key self-usage requirement for `GET /v1/usage`.
+- [x] 1.2 Validate OpenSpec changes.
 
 ## 2. Tests
 
-- [ ] 2.1 Add integration coverage for missing/invalid API keys.
-- [ ] 2.2 Add integration coverage for zero-usage responses, per-key usage scoping, and returned limit state.
-- [ ] 2.3 Add integration coverage that `GET /v1/usage` still works when global proxy API-key auth is disabled.
-- [ ] 2.4 Add integration coverage that upstream Codex aggregate limits are returned separately from API-key limits.
+- [x] 2.1 Add integration coverage for missing/invalid API keys.
+- [x] 2.2 Add integration coverage for zero-usage responses, per-key usage scoping, and returned limit state.
+- [x] 2.3 Add integration coverage that `GET /v1/usage` still works when global proxy API-key auth is disabled.
+- [x] 2.4 Add integration coverage that upstream Codex aggregate limits are returned separately from API-key limits.
 
 ## 3. Implementation
 
-- [ ] 3.1 Add self-usage API-key validation that always requires a valid Bearer key.
-- [ ] 3.2 Add `GET /v1/usage` and return usage totals plus current limits for the authenticated key.
-- [ ] 3.3 Reuse API-key repository/service aggregation instead of scanning all keys.
-- [ ] 3.4 Include upstream aggregate Codex credit windows without replacing authenticated key limits.
+- [x] 3.1 Add self-usage API-key validation that always requires a valid Bearer key.
+- [x] 3.2 Add `GET /v1/usage` and return usage totals plus current limits for the authenticated key.
+- [x] 3.3 Reuse API-key repository/service aggregation instead of scanning all keys.
+- [x] 3.4 Include upstream aggregate Codex credit windows without replacing authenticated key limits.


### PR DESCRIPTION
## Summary

Reconciles the archived `add-v1-api-key-usage` OpenSpec change so its
task list matches the project's archive convention (every shipped
task checked).

`openspec/changes/archive/2026-05-17-add-v1-api-key-usage/tasks.md`
had every checkbox unchecked even though the change was archived on
2026-05-17. Other archived changes in the same folder (e.g.
`2026-02-12-admin-auth-and-api-keys`,
`2026-03-03-add-optional-postgresql-backend`) record their tasks as
`[x]` once shipped.

## Evidence each task is implemented

**Spec (1.1, 1.2)**
- `openspec/specs/api-keys/spec.md:500` — "API keys can read their own `/v1/usage`" with normative requirements and scenarios. The change was archived, so OpenSpec validation already accepted it.

**Tests (2.1-2.4)** — all in `tests/integration/test_v1_usage.py`:
- 2.1 missing/invalid bearer → `test_v1_usage_requires_valid_bearer_key_when_global_auth_disabled` (L270)
- 2.2 zero-usage / per-key scoping / limit state → `test_v1_usage_returns_zero_usage_for_key_without_logs` (L280), `test_v1_usage_scopes_usage_and_limits_to_authenticated_key` (L297)
- 2.3 works when global proxy api-key auth disabled → `test_v1_usage_still_works_when_global_api_key_auth_is_disabled` (L426)
- 2.4 upstream Codex aggregate limits returned separately from API-key limits → `test_v1_usage_returns_aggregate_credit_limits_when_upstream_usage_exists` (L435), `test_v1_usage_returns_api_key_and_upstream_credit_limits_separately` (L470)

**Implementation (3.1-3.4)**
- 3.1 `validate_usage_api_key` at `app/core/auth/dependencies.py:98` — always requires a valid Bearer key.
- 3.2 `GET /v1/usage` handler at `app/modules/proxy/api.py:592` — returns `V1UsageResponse` with totals + limits.
- 3.3 Handler reuses `ApiKeysService(ApiKeysRepository).get_key_usage_summary_for_self` instead of scanning all keys.
- 3.4 `_build_aggregate_credit_limits` feeds `upstream_limits` on the response without replacing the per-key `limits` list.

## Test plan

- [x] Diff is checkbox-only inside an archived `tasks.md`; no code or spec text changed.
- [x] Cross-checked each task against the cited route, dependency, service method, and integration test.

Closes #627