### PR TITLE
fix(codex_version): fall back to npm registry when GitHub is rate-limited

### DIFF
--- a/app/core/clients/codex_version.py
+++ b/app/core/clients/codex_version.py
@@ -12,6 +12,7 @@ from app.core.config.settings import get_settings
 logger = logging.getLogger(__name__)
 
 _GITHUB_RELEASES_URL = "https://api.github.com/repos/openai/codex/releases/latest"
+_NPM_REGISTRY_URL = "https://registry.npmjs.org/@openai/codex/latest"
 _FETCH_TIMEOUT_SECONDS = 10.0
 _VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
@@ -43,12 +44,18 @@ class CodexVersionCache:
 
             # Fallback: stale cache value
             if self._cached_version is not None:
-                logger.warning("GitHub fetch failed; using stale cached version %s", self._cached_version)
+                logger.warning(
+                    "Upstream version sources failed; using stale cached version %s",
+                    self._cached_version,
+                )
                 return self._cached_version
 
             # Fallback: settings default
             fallback = get_settings().model_registry_client_version
-            logger.warning("GitHub fetch failed and no cached version; falling back to settings default %s", fallback)
+            logger.warning(
+                "Upstream version sources failed and no cached version; falling back to settings default %s",
+                fallback,
+            )
             return fallback
 
     async def invalidate(self) -> None:
@@ -57,15 +64,30 @@ class CodexVersionCache:
             self._cached_at = 0.0
 
     async def _fetch_latest_version(self) -> str | None:
+        timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
         try:
-            timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
             async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
-                headers = {"Accept": "application/vnd.github+json"}
-                async with session.get(_GITHUB_RELEASES_URL, headers=headers) as resp:
-                    if resp.status != 200:
-                        logger.warning("GitHub releases API returned HTTP %d", resp.status)
-                        return None
-                    data = await resp.json(content_type=None)
+                version = await self._fetch_from_github(session)
+                if version is not None:
+                    return version
+
+                version = await self._fetch_from_npm(session)
+                if version is not None:
+                    return version
+        except Exception:
+            logger.warning("Failed to fetch latest Codex release from upstream sources", exc_info=True)
+            return None
+
+        return None
+
+    async def _fetch_from_github(self, session: aiohttp.ClientSession) -> str | None:
+        try:
+            headers = {"Accept": "application/vnd.github+json"}
+            async with session.get(_GITHUB_RELEASES_URL, headers=headers) as resp:
+                if resp.status != 200:
+                    logger.warning("GitHub releases API returned HTTP %d", resp.status)
+                    return None
+                data = await resp.json(content_type=None)
         except Exception:
             logger.warning("Failed to fetch latest Codex release from GitHub", exc_info=True)
             return None
@@ -77,6 +99,29 @@ class CodexVersionCache:
 
         logger.info("Fetched latest Codex version from GitHub: %s", name)
         return name
+
+    async def _fetch_from_npm(self, session: aiohttp.ClientSession) -> str | None:
+        # npm registry is not anonymously rate-limited the way the GitHub
+        # API is, so it is a reliable secondary source when GitHub returns
+        # 403 / 5xx (see issue #664).
+        try:
+            headers = {"Accept": "application/json"}
+            async with session.get(_NPM_REGISTRY_URL, headers=headers) as resp:
+                if resp.status != 200:
+                    logger.warning("npm registry returned HTTP %d for @openai/codex", resp.status)
+                    return None
+                data = await resp.json(content_type=None)
+        except Exception:
+            logger.warning("Failed to fetch latest Codex release from npm registry", exc_info=True)
+            return None
+
+        version = data.get("version") if isinstance(data, dict) else None
+        if not isinstance(version, str) or not _VERSION_RE.match(version):
+            logger.warning("Unexpected version from npm registry: %r", version)
+            return None
+
+        logger.info("Fetched latest Codex version from npm registry: %s", version)
+        return version
 
 
 _codex_version_cache = CodexVersionCache()

--- a/tests/unit/test_codex_version.py
+++ b/tests/unit/test_codex_version.py
@@ -26,6 +26,21 @@ def _mock_session(response: MagicMock) -> MagicMock:
     return session
 
 
+def _mock_session_per_url(responses: dict[str, MagicMock]) -> MagicMock:
+    session = MagicMock()
+
+    def _get(url, **_kwargs):
+        for key, resp in responses.items():
+            if key in url:
+                return resp
+        raise AssertionError(f"unexpected URL: {url}")
+
+    session.get = MagicMock(side_effect=_get)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
 @pytest.mark.asyncio
 async def test_fetches_version_from_github():
     cache = CodexVersionCache(ttl_seconds=60)
@@ -185,3 +200,95 @@ def test_ttl_must_be_positive():
         CodexVersionCache(ttl_seconds=0)
     with pytest.raises(ValueError, match="ttl_seconds must be positive"):
         CodexVersionCache(ttl_seconds=-1)
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_npm_when_github_rate_limited():
+    cache = CodexVersionCache(ttl_seconds=60)
+    github_resp = _mock_response(status=403, json_data=None)
+    npm_resp = _mock_response(json_data={"version": "0.130.0"})
+    session = _mock_session_per_url({"api.github.com": github_resp, "registry.npmjs.org": npm_resp})
+
+    with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
+        version = await cache.get_version()
+
+    assert version == "0.130.0"
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_npm_when_github_returns_invalid_name():
+    cache = CodexVersionCache(ttl_seconds=60)
+    github_resp = _mock_response(json_data={"name": "rust-v0.130.0"})
+    npm_resp = _mock_response(json_data={"version": "0.130.0"})
+    session = _mock_session_per_url({"api.github.com": github_resp, "registry.npmjs.org": npm_resp})
+
+    with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
+        version = await cache.get_version()
+
+    assert version == "0.130.0"
+
+
+@pytest.mark.asyncio
+async def test_npm_invalid_version_falls_back_to_settings_default():
+    cache = CodexVersionCache(ttl_seconds=60)
+    github_resp = _mock_response(status=403, json_data=None)
+    npm_resp = _mock_response(json_data={"version": "0.130.0-rc.1"})
+    session = _mock_session_per_url({"api.github.com": github_resp, "registry.npmjs.org": npm_resp})
+
+    with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
+        version = await cache.get_version()
+
+    assert version == "0.101.0"
+
+
+@pytest.mark.asyncio
+async def test_npm_missing_version_field_falls_back_to_settings_default():
+    cache = CodexVersionCache(ttl_seconds=60)
+    github_resp = _mock_response(status=403, json_data=None)
+    npm_resp = _mock_response(json_data={"name": "@openai/codex"})
+    session = _mock_session_per_url({"api.github.com": github_resp, "registry.npmjs.org": npm_resp})
+
+    with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
+        version = await cache.get_version()
+
+    assert version == "0.101.0"
+
+
+@pytest.mark.asyncio
+async def test_github_skipped_when_returning_valid_version():
+    cache = CodexVersionCache(ttl_seconds=60)
+    github_resp = _mock_response(json_data={"name": "0.130.0"})
+    npm_resp = _mock_response(json_data={"version": "9.9.9"})
+    session = _mock_session_per_url({"api.github.com": github_resp, "registry.npmjs.org": npm_resp})
+
+    with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
+        version = await cache.get_version()
+
+    # GitHub wins; npm is not consulted.
+    assert version == "0.130.0"
+    urls = [call.args[0] for call in session.get.call_args_list]
+    assert any("api.github.com" in u for u in urls)
+    assert not any("registry.npmjs.org" in u for u in urls)
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_stale_cache_when_both_sources_fail():
+    cache = CodexVersionCache(ttl_seconds=60)
+
+    # Populate cache via GitHub
+    github_ok = _mock_response(json_data={"name": "1.5.0"})
+    npm_unused = _mock_response(json_data={"version": "9.9.9"})
+    session_ok = _mock_session_per_url({"api.github.com": github_ok, "registry.npmjs.org": npm_unused})
+    with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session_ok):
+        v1 = await cache.get_version()
+    assert v1 == "1.5.0"
+
+    # Expire the cache and make both sources fail
+    cache._cached_at = time.monotonic() - 120
+    github_fail = _mock_response(status=403, json_data=None)
+    npm_fail = _mock_response(status=503, json_data=None)
+    session_fail = _mock_session_per_url({"api.github.com": github_fail, "registry.npmjs.org": npm_fail})
+    with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session_fail):
+        v2 = await cache.get_version()
+
+    assert v2 == "1.5.0"


### PR DESCRIPTION
## Summary

Adds the npm registry (`https://registry.npmjs.org/@openai/codex/latest`) as a secondary upstream source for `CodexVersionCache`, so a 403 from the anonymous GitHub API no longer poisons the model registry into rejecting any model gated behind a newer Codex client version.

## Why

When `app/core/clients/codex_version.py` cannot reach
`api.github.com/repos/openai/codex/releases/latest` (e.g. anonymous
rate-limit on a shared VPS / Docker host), it falls back to the baked-in
`Settings.model_registry_client_version` (currently `0.101.0`). The
model refresh then calls
`/codex/models?client_version=0.101.0`, which excludes any slug
upstream gates behind newer versions (e.g. `gpt-5.5`), and every proxy
request for those models is rejected with:

```
proxy_error_response status=503 code=no_plan_support_for_model
  message=No accounts with a plan supporting model 'gpt-5.5'
```

…even though the user is on a current Codex CLI and the account does
support the model. The reporter confirmed that bumping
`CODEX_LB_MODEL_REGISTRY_CLIENT_VERSION` manually fully resolves the
symptom.

## Approach

`https://registry.npmjs.org/@openai/codex/latest` is the cleanest alternate
source (option 2 in the issue) — it is not anonymously rate-limited the
way the GitHub API is and tracks the same release cadence (the npm
publish ships with the GitHub release). Order is now:

1. GitHub releases (existing primary source).
2. npm registry (new secondary source).
3. Stale cached value, if any.
4. Settings default (`model_registry_client_version`).

`_fetch_from_github` and `_fetch_from_npm` share the same aiohttp
session and 10s total timeout, and both apply the strict
`^\d+\.\d+\.\d+$` version regex so prerelease tags from npm (e.g.
`0.130.0-rc.1`) cannot poison the cache.

## Tests

`uv run pytest tests/unit/test_codex_version.py -x` — 17 passed.
Full unit suite: `uv run pytest tests/unit -x -q` — 1895 passed, 39 skipped.

New cases in `tests/unit/test_codex_version.py`:

- GitHub 403 → npm wins.
- GitHub returns invalid name → npm wins.
- GitHub 403 + npm prerelease version → settings default.
- GitHub 403 + npm payload missing `version` field → settings default.
- GitHub OK → npm is not consulted.
- GitHub failure + npm failure + previously populated cache → stale cache.

Updated the failure-path warning message to reflect the multi-source
fallback. Existing single-source tests still pass because they share
one mock response across all calls, which matches both the original
single-source behaviour when GitHub succeeds and the multi-source no-op
when it fails.

## Test plan

- [x] `uv run pytest tests/unit/test_codex_version.py -x`
- [x] `uv run pytest tests/unit -x -q`
- [x] `uv run ruff check app/core/clients/codex_version.py tests/unit/test_codex_version.py`
- [x] `uv run ruff format --check app/core/clients/codex_version.py tests/unit/test_codex_version.py`

Closes #664