### PR TITLE
chore: release v1.19.0-beta.2

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.19.0-beta.1"  # x-release-please-version
+__version__ = "1.19.0-beta.2"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.19.0-beta.1
-appVersion: 1.19.0-beta.1
+version: 1.19.0-beta.2
+appVersion: 1.19.0-beta.2
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.19.0-beta.1",
+  "version": "1.19.0-beta.2",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/frontend/src/features/apis/components/apis-page.tsx
+++ b/frontend/src/features/apis/components/apis-page.tsx
@@ -9,6 +9,7 @@ import type {
 	ApiKeyCreateRequest,
 	ApiKeyUpdateRequest,
 } from "@/features/api-keys/schemas";
+import { ApiKeyCreatedDialog } from "@/features/api-keys/components/api-key-created-dialog";
 import { ApiDetail } from "@/features/apis/components/api-detail";
 import { ApiList } from "@/features/apis/components/api-list";
 import { ApisSkeleton } from "@/features/apis/components/apis-skeleton";
@@ -28,11 +29,6 @@ const ApiKeyCreateDialog = lazy(() =>
 const ApiKeyEditDialog = lazy(() =>
 	import("@/features/api-keys/components/api-key-edit-dialog").then((m) => ({
 		default: m.ApiKeyEditDialog,
-	})),
-);
-const ApiKeyCreatedDialog = lazy(() =>
-	import("@/features/api-keys/components/api-key-created-dialog").then((m) => ({
-		default: m.ApiKeyCreatedDialog,
 	})),
 );
 
@@ -193,13 +189,13 @@ export function ApisPage() {
 					onOpenChange={editDialog.onOpenChange}
 					onSubmit={handleUpdate}
 				/>
-
-				<ApiKeyCreatedDialog
-					open={createdDialog.open}
-					apiKey={createdDialog.data}
-					onOpenChange={createdDialog.onOpenChange}
-				/>
 			</Suspense>
+
+			<ApiKeyCreatedDialog
+				open={createdDialog.open}
+				apiKey={createdDialog.data}
+				onOpenChange={createdDialog.onOpenChange}
+			/>
 
 			<ConfirmDialog
 				open={deleteDialog.open}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
   build: {
     outDir: "../app/static",
     emptyOutDir: true,
+    chunkSizeWarningLimit: 600,
     rollupOptions: {
       output: {
         manualChunks,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.19.0-beta.1"
+version = "1.19.0-beta.2"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/unit/test_bridge_context_blowup.py
+++ b/tests/unit/test_bridge_context_blowup.py
@@ -311,7 +311,7 @@ class TestContextGrowthScenarios:
     - Apr 13 (broken):   17 turns, 70K tok/turn, max 853K, 2 compactions
     """
 
-    def test_healthy_growth_rate_stays_within_budget(self):
+    async def test_healthy_growth_rate_stays_within_budget(self):
         """With previous_response_id preserved, each turn adds only new content."""
         system_prompt_tokens = 50_000
         content_per_turn = 2_300  # avg from Apr 11 sessions
@@ -330,7 +330,7 @@ class TestContextGrowthScenarios:
 
         assert context < context_window
 
-    def test_broken_growth_rate_fills_window_fast(self):
+    async def test_broken_growth_rate_fills_window_fast(self):
         """Without previous_response_id, context fills in <20 turns."""
         system_prompt_tokens = 50_000
         growth_per_turn = 70_000  # avg from Apr 13 sessions (broken)
@@ -347,7 +347,7 @@ class TestContextGrowthScenarios:
         assert compaction_turn is not None
         assert compaction_turn < 20
 
-    def test_error_code_determines_growth_rate(self):
+    async def test_error_code_determines_growth_rate(self):
         """502 -> CLI retries with previous_response_id -> healthy growth
         400 previous_response_not_found -> CLI drops it -> broken growth"""
         error_502 = ProxyResponseError(

--- a/tests/unit/test_graceful_degradation.py
+++ b/tests/unit/test_graceful_degradation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Iterator, cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -125,7 +125,11 @@ async def test_health_ready_succeeds_when_degraded() -> None:
 
     set_degraded("all upstream accounts are unavailable")
     mock_session = AsyncMock()
-    mock_session.execute = AsyncMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = []
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
 
     with patch("app.core.draining._draining", False), patch("app.modules.health.api.get_session") as mock_get_session:
 

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.19.0-beta.1"
+version = "1.19.0-beta.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.19.0-beta.2 for the 1.19.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.19.0-beta.2 as a GitHub prerelease and trigger package/image/chart publishing.
- Synced automatically from release-please PR #714; no manual beta workflow dispatch is required.

## Install after publish
```bash
uvx --from "codex-lb==1.19.0b2" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.19.0-beta.2
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.19.0-beta.2 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.19.0.
