### PR TITLE
fix(api-keys): backfill new limit usage

### DIFF
--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import Integer, cast, delete, func, select, true, update
+from sqlalchemy import BigInteger, Integer, cast, delete, func, select, true, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -257,7 +257,7 @@ class ApiKeysRepository:
         elif limit_type == LimitType.OUTPUT_TOKENS:
             value_expr = func.coalesce(RequestLog.output_tokens, RequestLog.reasoning_tokens, 0)
         elif limit_type == LimitType.COST_USD:
-            value_expr = cast(func.floor(func.coalesce(RequestLog.cost_usd, 0.0) * 1_000_000), Integer)
+            value_expr = cast(func.floor(func.coalesce(RequestLog.cost_usd, 0.0) * 1_000_000), BigInteger)
         else:
             return 0
 

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -234,6 +234,48 @@ class ApiKeysRepository:
             total_cost_usd=round(float(row.total_cost_usd or 0.0), 6),
         )
 
+    async def get_limit_usage_value(
+        self,
+        key_id: str,
+        *,
+        limit_type: LimitType,
+        since: datetime,
+        until: datetime,
+        model_filter: str | None,
+    ) -> int:
+        if limit_type == LimitType.CREDITS:
+            return 0
+
+        if limit_type == LimitType.TOTAL_TOKENS:
+            value_expr = func.coalesce(RequestLog.input_tokens, 0) + func.coalesce(
+                RequestLog.output_tokens,
+                RequestLog.reasoning_tokens,
+                0,
+            )
+        elif limit_type == LimitType.INPUT_TOKENS:
+            value_expr = func.coalesce(RequestLog.input_tokens, 0)
+        elif limit_type == LimitType.OUTPUT_TOKENS:
+            value_expr = func.coalesce(RequestLog.output_tokens, RequestLog.reasoning_tokens, 0)
+        elif limit_type == LimitType.COST_USD:
+            value_expr = func.coalesce(RequestLog.cost_usd, 0.0)
+        else:
+            return 0
+
+        stmt = select(func.coalesce(func.sum(value_expr), 0)).where(
+            RequestLog.api_key_id == key_id,
+            RequestLog.status == "success",
+            RequestLog.requested_at >= since,
+            RequestLog.requested_at < until,
+        )
+        if model_filter is not None:
+            stmt = stmt.where(RequestLog.model == model_filter)
+
+        result = await self._session.execute(stmt)
+        value = result.scalar_one()
+        if limit_type == LimitType.COST_USD:
+            return int(round(float(value or 0.0) * 1_000_000))
+        return int(value or 0)
+
     async def update(
         self,
         key_id: str,

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -257,7 +257,7 @@ class ApiKeysRepository:
         elif limit_type == LimitType.OUTPUT_TOKENS:
             value_expr = func.coalesce(RequestLog.output_tokens, RequestLog.reasoning_tokens, 0)
         elif limit_type == LimitType.COST_USD:
-            value_expr = func.coalesce(RequestLog.cost_usd, 0.0)
+            value_expr = cast(func.floor(func.coalesce(RequestLog.cost_usd, 0.0) * 1_000_000), Integer)
         else:
             return 0
 
@@ -272,8 +272,6 @@ class ApiKeysRepository:
 
         result = await self._session.execute(stmt)
         value = result.scalar_one()
-        if limit_type == LimitType.COST_USD:
-            return int(round(float(value or 0.0) * 1_000_000))
         return int(value or 0)
 
     async def update(

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -22,7 +22,7 @@ from app.core.usage.pricing import (
 from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import Account, ApiKey, ApiKeyLimit, LimitType, LimitWindow
 from app.db.session import sqlite_writer_section
-from app.modules.api_keys.limit_windows import advance_limit_reset, next_limit_reset
+from app.modules.api_keys.limit_windows import advance_limit_reset, limit_window_delta, next_limit_reset
 from app.modules.api_keys.repository import (
     _UNSET,
     ApiKeyTrendBucket,
@@ -55,6 +55,15 @@ class ApiKeysRepositoryProtocol(Protocol):
     async def list_all(self) -> list[ApiKey]: ...
     async def list_usage_summary_by_key(self) -> dict[str, ApiKeyUsageSummary]: ...
     async def get_usage_summary_by_key_id(self, key_id: str) -> ApiKeyUsageSummary: ...
+    async def get_limit_usage_value(
+        self,
+        key_id: str,
+        *,
+        limit_type: LimitType,
+        since: datetime,
+        until: datetime,
+        model_filter: str | None,
+    ) -> int: ...
     async def list_accounts_by_ids(self, account_ids: list[str]) -> list[Account]: ...
 
     async def update(
@@ -436,12 +445,13 @@ class ApiKeysService:
             now = utcnow()
             existing_limits = await self._repository.get_limits_by_key(key_id)
             submitted_limits = payload.limits or []
-            limit_rows = _build_limit_rows_for_update(
+            limit_rows = await _build_limit_rows_for_update(
                 key_id=key_id,
                 now=now,
                 submitted_limits=submitted_limits,
                 existing_limits=existing_limits,
                 reset_usage=payload.reset_usage,
+                repository=self._repository,
             )
         elif payload.reset_usage:
             now = utcnow()
@@ -1396,13 +1406,14 @@ def _limit_input_to_row(
     )
 
 
-def _build_limit_rows_for_update(
+async def _build_limit_rows_for_update(
     *,
     key_id: str,
     now: datetime,
     submitted_limits: list[LimitRuleInput],
     existing_limits: list[ApiKeyLimit],
     reset_usage: bool,
+    repository: ApiKeysRepositoryProtocol,
 ) -> list[ApiKeyLimit]:
     existing_by_key = {_limit_identity_from_row(limit): limit for limit in existing_limits}
     submitted_by_key = {_limit_identity_from_input(limit): limit for limit in submitted_limits}
@@ -1413,8 +1424,11 @@ def _build_limit_rows_for_update(
     for submitted in submitted_limits:
         identity = _limit_identity_from_input(submitted)
         matched = existing_by_key.get(identity)
-        if matched is None or reset_usage:
+        if reset_usage:
             rows.append(_limit_input_to_row(submitted, key_id, now))
+            continue
+        if matched is None:
+            rows.append(await _new_limit_input_to_backfilled_row(submitted, key_id, now, repository))
             continue
         rows.append(
             _limit_input_to_row(
@@ -1426,6 +1440,32 @@ def _build_limit_rows_for_update(
             )
         )
     return rows
+
+
+async def _new_limit_input_to_backfilled_row(
+    submitted: LimitRuleInput,
+    key_id: str,
+    now: datetime,
+    repository: ApiKeysRepositoryProtocol,
+) -> ApiKeyLimit:
+    limit_type = LimitType(submitted.limit_type)
+    window = LimitWindow(submitted.limit_window)
+    reset_at = next_limit_reset(now, window)
+    since = now - limit_window_delta(window)
+    current_value = await repository.get_limit_usage_value(
+        key_id,
+        limit_type=limit_type,
+        since=since,
+        until=now,
+        model_filter=submitted.model_filter,
+    )
+    return _limit_input_to_row(
+        submitted,
+        key_id,
+        now,
+        current_value=current_value,
+        reset_at=reset_at,
+    )
 
 
 def _build_reset_limit_rows(

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -1413,7 +1413,7 @@ async def _build_limit_rows_for_update(
     submitted_limits: list[LimitRuleInput],
     existing_limits: list[ApiKeyLimit],
     reset_usage: bool,
-    repository: ApiKeysRepositoryProtocol,
+    repository: ApiKeysRepositoryProtocol | None = None,
 ) -> list[ApiKeyLimit]:
     existing_by_key = {_limit_identity_from_row(limit): limit for limit in existing_limits}
     submitted_by_key = {_limit_identity_from_input(limit): limit for limit in submitted_limits}
@@ -1428,6 +1428,8 @@ async def _build_limit_rows_for_update(
             rows.append(_limit_input_to_row(submitted, key_id, now))
             continue
         if matched is None:
+            if repository is None:
+                raise TypeError("repository is required to backfill new API key limit usage")
             rows.append(await _new_limit_input_to_backfilled_row(submitted, key_id, now, repository))
             continue
         rows.append(

--- a/openspec/changes/backfill-api-key-limit-current-usage/.openspec.yaml
+++ b/openspec/changes/backfill-api-key-limit-current-usage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/backfill-api-key-limit-current-usage/design.md
+++ b/openspec/changes/backfill-api-key-limit-current-usage/design.md
@@ -8,6 +8,6 @@ The lookback window is derived from the same duration used for the new limit:
 - `since = now - limit_window_delta(limit_window)`
 - `until = now`
 
-The repository computes usage from `request_logs` scoped to the API key, the time window, and the optional model filter. Token limits use token columns; cost limits use `cost_usd` converted to microdollars. Credit limits are not derived from request logs and remain zero.
+The repository computes usage from `request_logs` scoped to the API key, the time window, and the optional model filter. Token limits use token columns; cost limits convert each `cost_usd` row to truncated integer microdollars before summing, matching live cost-limit accrual. Credit limits are not derived from request logs and remain zero.
 
 Existing limit rows keep their current value, preserving the established update behavior. `resetUsage=true` still forces all submitted limit rows to zero.

--- a/openspec/changes/backfill-api-key-limit-current-usage/design.md
+++ b/openspec/changes/backfill-api-key-limit-current-usage/design.md
@@ -1,0 +1,13 @@
+## Design
+
+New limit rules are initialized in the API key service during update. For each submitted rule without an existing `(limit_type, limit_window, model_filter)` match and without `resetUsage`, the service asks the repository to aggregate usage for the key inside the new rule's active window.
+
+The lookback window is derived from the same duration used for the new limit:
+
+- `reset_at = next_limit_reset(now, limit_window)`
+- `since = now - limit_window_delta(limit_window)`
+- `until = now`
+
+The repository computes usage from `request_logs` scoped to the API key, the time window, and the optional model filter. Token limits use token columns; cost limits use `cost_usd` converted to microdollars. Credit limits are not derived from request logs and remain zero.
+
+Existing limit rows keep their current value, preserving the established update behavior. `resetUsage=true` still forces all submitted limit rows to zero.

--- a/openspec/changes/backfill-api-key-limit-current-usage/proposal.md
+++ b/openspec/changes/backfill-api-key-limit-current-usage/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+When an API key has existing request-log usage and an admin later adds a limit rule, the new limit starts at `0`. This makes the dashboard and enforcement state disagree with actual usage in the current limit window.
+
+Issue #518 reports the visible case: a key has already used about 10k tokens, then a 100k daily token limit is added, but the limit shows `0/100k` instead of `10k/100k`.
+
+## What Changes
+
+- Backfill newly-added API key limit rules from existing request logs in the active window.
+- Preserve current values for existing matching limits unless the admin explicitly resets usage.
+- Keep `resetUsage=true` as the explicit way to start all submitted limits from zero.
+
+## Impact
+
+- Admins can add limits to an already-used API key without losing current-window usage visibility.
+- Enforcement immediately accounts for current-window usage on newly-added rules.
+- No schema, API shape, or frontend contract changes are required.

--- a/openspec/changes/backfill-api-key-limit-current-usage/specs/api-keys/spec.md
+++ b/openspec/changes/backfill-api-key-limit-current-usage/specs/api-keys/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: API Key update
+The system SHALL allow updating key properties via `PATCH /api/api-keys/{id}`. Updatable fields: `name`, `allowedModels`, `weeklyTokenLimit`, `expiresAt`, `isActive`. The key hash and prefix MUST NOT be modifiable. The system MUST accept timezone-aware ISO 8601 datetimes for `expiresAt` and normalize them to UTC naive before persistence.
+
+When a submitted API key limit rule does not match an existing rule by `limit_type`, `limit_window`, and `model_filter`, the system MUST initialize the new rule's `current_value` from the API key's successful existing request-log usage in that rule's current window. If `resetUsage` is true, the system MUST initialize submitted limits with `current_value: 0`.
+
+#### Scenario: Update key with timezone-aware expiration
+- **WHEN** admin submits `PATCH /api/api-keys/{id}` with `{ "expiresAt": "2025-12-31T00:00:00Z" }`
+- **THEN** the system persists the expiration successfully without PostgreSQL datetime binding errors
+- **AND** the response returns `expiresAt` representing the same UTC instant
+
+#### Scenario: Update non-existent key
+
+- **WHEN** admin submits `PATCH /api/api-keys/{id}` with an unknown ID
+- **THEN** the system returns 404
+
+#### Scenario: Add token limit after current-window usage exists
+
+- **WHEN** an API key has successful request-log token usage in the active daily window
+- **AND** the API key has error or incomplete request-log token usage in the same window
+- **AND** admin submits `PATCH /api/api-keys/{id}` adding a daily `total_tokens` limit without `resetUsage`
+- **THEN** the new limit's `current_value` includes only the successful current-window token usage
+
+#### Scenario: Reset usage when adding a limit
+
+- **WHEN** an API key has request-log usage in the active window
+- **AND** admin submits `PATCH /api/api-keys/{id}` adding a limit with `resetUsage: true`
+- **THEN** the new limit's `current_value` is `0`

--- a/openspec/changes/backfill-api-key-limit-current-usage/specs/api-keys/spec.md
+++ b/openspec/changes/backfill-api-key-limit-current-usage/specs/api-keys/spec.md
@@ -22,6 +22,12 @@ When a submitted API key limit rule does not match an existing rule by `limit_ty
 - **AND** admin submits `PATCH /api/api-keys/{id}` adding a daily `total_tokens` limit without `resetUsage`
 - **THEN** the new limit's `current_value` includes only the successful current-window token usage
 
+#### Scenario: Add cost limit after current-window usage exists
+
+- **WHEN** an API key has successful request-log costs in the active daily window
+- **AND** admin submits `PATCH /api/api-keys/{id}` adding a daily `cost_usd` limit without `resetUsage`
+- **THEN** the new limit's `current_value` is the sum of each successful request log's `cost_usd` converted to truncated integer microdollars
+
 #### Scenario: Reset usage when adding a limit
 
 - **WHEN** an API key has request-log usage in the active window

--- a/openspec/changes/backfill-api-key-limit-current-usage/specs/api-keys/spec.md
+++ b/openspec/changes/backfill-api-key-limit-current-usage/specs/api-keys/spec.md
@@ -1,5 +1,47 @@
 ## MODIFIED Requirements
 
+### Requirement: Limit update with usage state preservation
+When updating API key limits, the system SHALL preserve existing usage state (`current_value`, `reset_at`) for unchanged limit rules. Limit comparison key is `(limit_type, limit_window, model_filter)`.
+
+- Matching existing rule: `current_value` and `reset_at` SHALL be preserved; only `max_value` is updated
+- New rule (no match) without `resetUsage`: `current_value` SHALL be initialized from the API key's successful existing request-log usage in the new rule's current window, with a fresh `reset_at`
+- New rule (no match) with `resetUsage`: `current_value=0` and fresh `reset_at`
+- Removed rule (in existing but not in update): row is deleted
+
+Usage reset SHALL only occur via an explicit action (`resetUsage` field or dedicated endpoint), never as a side-effect of metadata or policy edits.
+
+#### Scenario: Metadata-only edit preserves usage state
+
+- **WHEN** an API key PATCH updates only name or is_active
+- **AND** `limits` field is not included in the payload
+- **THEN** existing `current_value` and `reset_at` are unchanged
+
+#### Scenario: Same policy re-submission preserves usage state
+
+- **WHEN** an API key PATCH includes `limits` with identical rules (same type/window/filter/max_value)
+- **THEN** existing `current_value` and `reset_at` are unchanged
+
+#### Scenario: max_value adjustment preserves counters
+
+- **WHEN** an API key PATCH changes only `max_value` for an existing matched limit rule
+- **THEN** that rule's existing `current_value` and `reset_at` are unchanged
+
+#### Scenario: Adding a new limit backfills current-window usage
+
+- **WHEN** an API key has successful request-log usage in the active window
+- **AND** an API key PATCH adds a limit rule that does not match any existing rule
+- **AND** `resetUsage` is not true
+- **THEN** the new rule's `current_value` reflects successful existing request-log usage for that rule's current window
+- **AND** the new rule receives a fresh `reset_at`
+
+#### Scenario: resetUsage keeps new limits at zero
+
+- **WHEN** an API key has request-log usage in the active window
+- **AND** an API key PATCH adds a limit rule that does not match any existing rule
+- **AND** `resetUsage` is true
+- **THEN** the new rule's `current_value` is `0`
+- **AND** the new rule receives a fresh `reset_at`
+
 ### Requirement: API Key update
 The system SHALL allow updating key properties via `PATCH /api/api-keys/{id}`. Updatable fields: `name`, `allowedModels`, `weeklyTokenLimit`, `expiresAt`, `isActive`. The key hash and prefix MUST NOT be modifiable. The system MUST accept timezone-aware ISO 8601 datetimes for `expiresAt` and normalize them to UTC naive before persistence.
 

--- a/openspec/changes/backfill-api-key-limit-current-usage/tasks.md
+++ b/openspec/changes/backfill-api-key-limit-current-usage/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specs
+
+- [x] 1.1 Add an API-key update requirement for backfilling newly-added limit rules from current-window request logs.
+- [x] 1.2 Validate OpenSpec changes.
+
+## 2. Implementation
+
+- [x] 2.1 Add repository support for aggregating API-key usage by limit type, window, and optional model filter.
+- [x] 2.2 Initialize newly-added API key limit rules from the aggregate when `resetUsage` is false.
+- [x] 2.3 Preserve existing matching limit values and explicit reset behavior.
+
+## 3. Verification
+
+- [x] 3.1 Add regression coverage for adding a total-token daily limit after existing usage.
+- [x] 3.2 Add regression coverage for model-filtered limit backfill.
+- [x] 3.3 Add regression coverage that `resetUsage=true` keeps new limits at zero.
+- [x] 3.4 Run targeted tests and static checks.

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -325,7 +325,7 @@ The service contract SHALL be typed explicitly: `enforce_limits_for_request(key_
 When updating API key limits, the system SHALL preserve existing usage state (`current_value`, `reset_at`) for unchanged limit rules. Limit comparison key is `(limit_type, limit_window, model_filter)`.
 
 - Matching existing rule: `current_value` and `reset_at` SHALL be preserved; only `max_value` is updated
-- New rule (no match): `current_value=0` and fresh `reset_at`
+- New rule (no match): when `resetUsage` is false, `current_value` is initialized from successful request-log usage in the new rule's current window; when `resetUsage` is true, `current_value=0`; always with a fresh `reset_at`
 - Removed rule (in existing but not in update): row is deleted
 
 Usage reset SHALL only occur via an explicit action (`reset_usage` field or dedicated endpoint), never as a side-effect of metadata or policy edits.
@@ -567,4 +567,3 @@ The dashboard API key CRUD surface MUST allow callers to persist an optional enf
 - **WHEN** a dashboard client updates an API key with `enforcedServiceTier: "flex"`
 - **THEN** the persisted API key stores `flex`
 - **AND** subsequent reads return `flex`
-

--- a/tests/integration/test_api_keys_trends_api.py
+++ b/tests/integration/test_api_keys_trends_api.py
@@ -18,6 +18,12 @@ async def _create_api_key(async_client, *, name: str) -> str:
     return response.json()["id"]
 
 
+def _only_limit(payload: dict) -> dict:
+    limits = payload["limits"]
+    assert len(limits) == 1
+    return limits[0]
+
+
 async def _insert_request_logs(*rows: RequestLog) -> None:
     async with SessionLocal() as session:
         session.add_all(rows)
@@ -41,6 +47,181 @@ def _hour_bucket(value: datetime) -> datetime:
 async def test_api_key_detail_endpoints_return_404_for_missing_key(async_client, endpoint: str):
     response = await async_client.get(f"/api/api-keys/missing-key/{endpoint}")
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_adding_limit_backfills_current_window_usage(async_client, monkeypatch: pytest.MonkeyPatch):
+    key_id = await _create_api_key(async_client, name="limit-backfill-key")
+    other_key_id = await _create_api_key(async_client, name="limit-backfill-other-key")
+    now = datetime(2026, 4, 30, 12, 0, 0)
+    monkeypatch.setattr("app.modules.api_keys.service.utcnow", lambda: now)
+
+    await _insert_request_logs(
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-limit-backfill-a",
+            requested_at=now - timedelta(hours=2),
+            model="gpt-5.1",
+            status="success",
+            input_tokens=8_000,
+            output_tokens=1_500,
+            cached_input_tokens=200,
+            cost_usd=0.25,
+        ),
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-limit-backfill-b",
+            requested_at=now - timedelta(minutes=30),
+            model="gpt-5.1",
+            status="success",
+            input_tokens=300,
+            output_tokens=None,
+            reasoning_tokens=200,
+            cached_input_tokens=20,
+            cost_usd=0.03,
+        ),
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-limit-backfill-error",
+            requested_at=now - timedelta(minutes=20),
+            model="gpt-5.1",
+            status="error",
+            error_code="response.incomplete",
+            input_tokens=40_000,
+            output_tokens=10_000,
+            cached_input_tokens=0,
+            cost_usd=5.0,
+        ),
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-limit-backfill-old",
+            requested_at=now - timedelta(days=2),
+            model="gpt-5.1",
+            status="success",
+            input_tokens=10_000,
+            output_tokens=10_000,
+            cached_input_tokens=0,
+            cost_usd=2.0,
+        ),
+        RequestLog(
+            api_key_id=other_key_id,
+            request_id="req-limit-backfill-other-key",
+            requested_at=now - timedelta(minutes=10),
+            model="gpt-5.1",
+            status="success",
+            input_tokens=50_000,
+            output_tokens=50_000,
+            cached_input_tokens=0,
+            cost_usd=10.0,
+        ),
+    )
+
+    response = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={
+            "limits": [
+                {
+                    "limitType": "total_tokens",
+                    "limitWindow": "daily",
+                    "maxValue": 100_000,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    limit = _only_limit(response.json())
+    assert limit["currentValue"] == 10_000
+    assert limit["maxValue"] == 100_000
+
+
+@pytest.mark.asyncio
+async def test_adding_model_scoped_limit_backfills_only_matching_model(async_client, monkeypatch: pytest.MonkeyPatch):
+    key_id = await _create_api_key(async_client, name="limit-model-backfill-key")
+    now = datetime(2026, 4, 30, 12, 0, 0)
+    monkeypatch.setattr("app.modules.api_keys.service.utcnow", lambda: now)
+
+    await _insert_request_logs(
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-limit-model-match",
+            requested_at=now - timedelta(hours=1),
+            model="gpt-5.1",
+            status="success",
+            input_tokens=400,
+            output_tokens=100,
+            cached_input_tokens=0,
+            cost_usd=0.04,
+        ),
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-limit-model-other",
+            requested_at=now - timedelta(minutes=45),
+            model="gpt-5.4",
+            status="success",
+            input_tokens=9_000,
+            output_tokens=1_000,
+            cached_input_tokens=0,
+            cost_usd=0.5,
+        ),
+    )
+
+    response = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={
+            "limits": [
+                {
+                    "limitType": "total_tokens",
+                    "limitWindow": "daily",
+                    "maxValue": 50_000,
+                    "modelFilter": "gpt-5.1",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    limit = _only_limit(response.json())
+    assert limit["currentValue"] == 500
+    assert limit["modelFilter"] == "gpt-5.1"
+
+
+@pytest.mark.asyncio
+async def test_adding_limit_with_reset_usage_keeps_current_value_zero(async_client, monkeypatch: pytest.MonkeyPatch):
+    key_id = await _create_api_key(async_client, name="limit-reset-backfill-key")
+    now = datetime(2026, 4, 30, 12, 0, 0)
+    monkeypatch.setattr("app.modules.api_keys.service.utcnow", lambda: now)
+
+    await _insert_request_logs(
+        RequestLog(
+            api_key_id=key_id,
+            request_id="req-limit-reset-existing",
+            requested_at=now - timedelta(hours=2),
+            model="gpt-5.1",
+            status="success",
+            input_tokens=2_000,
+            output_tokens=500,
+            cached_input_tokens=0,
+            cost_usd=0.1,
+        )
+    )
+
+    response = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={
+            "resetUsage": True,
+            "limits": [
+                {
+                    "limitType": "total_tokens",
+                    "limitWindow": "daily",
+                    "maxValue": 100_000,
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert _only_limit(response.json())["currentValue"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_api_keys_trends_api.py
+++ b/tests/integration/test_api_keys_trends_api.py
@@ -187,6 +187,96 @@ async def test_adding_model_scoped_limit_backfills_only_matching_model(async_cli
 
 
 @pytest.mark.asyncio
+async def test_adding_cost_limit_uses_per_request_truncation(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    key_id = await _create_api_key(async_client, name="cost-truncation-zero-key")
+    now = datetime(2026, 4, 30, 12, 0, 0)
+    monkeypatch.setattr("app.modules.api_keys.service.utcnow", lambda: now)
+
+    await _insert_request_logs(
+        *[
+            RequestLog(
+                api_key_id=key_id,
+                request_id=f"req-cost-truncation-zero-{index}",
+                requested_at=now - timedelta(minutes=index),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=1,
+                output_tokens=1,
+                cached_input_tokens=0,
+                cost_usd=0.0000005,
+            )
+            for index in range(1, 101)
+        ]
+    )
+
+    response = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={
+            "limits": [
+                {
+                    "limitType": "cost_usd",
+                    "limitWindow": "daily",
+                    "maxValue": 1_000_000,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    limit = _only_limit(response.json())
+    assert limit["currentValue"] == 0
+    assert limit["maxValue"] == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_adding_cost_limit_backfills_truncated_microdollars(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    key_id = await _create_api_key(async_client, name="cost-truncation-total-key")
+    now = datetime(2026, 4, 30, 12, 0, 0)
+    monkeypatch.setattr("app.modules.api_keys.service.utcnow", lambda: now)
+
+    await _insert_request_logs(
+        *[
+            RequestLog(
+                api_key_id=key_id,
+                request_id=f"req-cost-truncation-total-{index}",
+                requested_at=now - timedelta(minutes=index),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=1,
+                output_tokens=1,
+                cached_input_tokens=0,
+                cost_usd=0.0000015,
+            )
+            for index in range(1, 101)
+        ]
+    )
+
+    response = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={
+            "limits": [
+                {
+                    "limitType": "cost_usd",
+                    "limitWindow": "daily",
+                    "maxValue": 1_000_000,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    limit = _only_limit(response.json())
+    assert limit["currentValue"] == 100
+    assert limit["maxValue"] == 1_000_000
+
+
+@pytest.mark.asyncio
 async def test_adding_limit_with_reset_usage_keeps_current_value_zero(async_client, monkeypatch: pytest.MonkeyPatch):
     key_id = await _create_api_key(async_client, name="limit-reset-backfill-key")
     now = datetime(2026, 4, 30, 12, 0, 0)

--- a/tests/unit/test_api_keys_repository.py
+++ b/tests/unit/test_api_keys_repository.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
 
 from app.db.models import LimitType, LimitWindow
 from app.modules.api_keys.repository import ApiKeyAccountCost, ApiKeysRepository
@@ -210,11 +211,20 @@ async def test_cost_limit_backfill_uses_bigint_cast_for_microdollars() -> None:
     repo = ApiKeysRepository(session)
     since = datetime(2026, 5, 1, 0, 0, 0)
     until = datetime(2026, 5, 8, 0, 0, 0)
+    int32_max = 2_147_483_647
+    overflow_total = int32_max + 100
     executed_sql: list[str] = []
 
     async def _execute(statement):
-        executed_sql.append(str(statement.compile(compile_kwargs={"literal_binds": True})))
-        return SimpleNamespace(scalar_one=lambda: 3_000_000_000)
+        executed_sql.append(
+            str(
+                statement.compile(
+                    dialect=postgresql_dialect(),
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+        )
+        return SimpleNamespace(scalar_one=lambda: overflow_total)
 
     session.execute.side_effect = _execute
 
@@ -226,6 +236,7 @@ async def test_cost_limit_backfill_uses_bigint_cast_for_microdollars() -> None:
         model_filter=None,
     )
 
-    assert value == 3_000_000_000
+    assert value == overflow_total
+    assert value > int32_max
     assert "BIGINT" in executed_sql[0]
-    assert "INTEGER" not in executed_sql[0]
+    assert "sum(CAST(floor(coalesce(request_logs.cost_usd, 0.0) * 1000000) AS BIGINT))" in executed_sql[0]

--- a/tests/unit/test_api_keys_repository.py
+++ b/tests/unit/test_api_keys_repository.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.db.models import LimitWindow
+from app.db.models import LimitType, LimitWindow
 from app.modules.api_keys.repository import ApiKeyAccountCost, ApiKeysRepository
 
 pytestmark = pytest.mark.unit
@@ -202,3 +202,30 @@ class TestUsage7d:
             ),
         ]
         session.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cost_limit_backfill_uses_bigint_cast_for_microdollars() -> None:
+    session = AsyncMock()
+    repo = ApiKeysRepository(session)
+    since = datetime(2026, 5, 1, 0, 0, 0)
+    until = datetime(2026, 5, 8, 0, 0, 0)
+    executed_sql: list[str] = []
+
+    async def _execute(statement):
+        executed_sql.append(str(statement.compile(compile_kwargs={"literal_binds": True})))
+        return SimpleNamespace(scalar_one=lambda: 3_000_000_000)
+
+    session.execute.side_effect = _execute
+
+    value = await repo.get_limit_usage_value(
+        "key_1",
+        limit_type=LimitType.COST_USD,
+        since=since,
+        until=until,
+        model_filter=None,
+    )
+
+    assert value == 3_000_000_000
+    assert "BIGINT" in executed_sql[0]
+    assert "INTEGER" not in executed_sql[0]

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -95,6 +95,18 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
     async def list_usage_summary_by_key(self) -> dict[str, ApiKeyUsageSummary]:
         return {}
 
+    async def get_limit_usage_value(
+        self,
+        key_id: str,
+        *,
+        limit_type: LimitType,
+        since: datetime,
+        until: datetime,
+        model_filter: str | None,
+    ) -> int:
+        del key_id, limit_type, since, until, model_filter
+        return 0
+
     async def update(
         self,
         key_id: str,

--- a/tests/unit/test_api_keys_validation_error.py
+++ b/tests/unit/test_api_keys_validation_error.py
@@ -60,7 +60,8 @@ def test_limit_input_to_row_raises_typed_validation_error_for_credits_with_model
     assert "credits" in str(info.value).lower()
 
 
-def test_build_limit_rows_for_update_raises_typed_validation_error_on_duplicate_rules() -> None:
+@pytest.mark.asyncio
+async def test_build_limit_rows_for_update_raises_typed_validation_error_on_duplicate_rules() -> None:
     rule = LimitRuleInput(
         limit_type=LimitType.TOTAL_TOKENS.value,
         limit_window=LimitWindow.DAILY.value,
@@ -68,7 +69,7 @@ def test_build_limit_rows_for_update_raises_typed_validation_error_on_duplicate_
         model_filter=None,
     )
     with pytest.raises(ApiKeyValidationError) as info:
-        _build_limit_rows_for_update(
+        await _build_limit_rows_for_update(
             key_id="key-1",
             now=__import__("datetime").datetime(2026, 5, 15),
             submitted_limits=[rule, rule],


### PR DESCRIPTION
## Summary
Revives #522 on a maintainer-owned branch because the original PR head has `maintainerCanModify=false`.

Credit: original implementation by @mgwals in #522; this branch rebases and updates that work on current `main`.

- Backfills newly added API key limits from successful request-log usage in the active lookback window.
- Preserves explicit `resetUsage` behavior and updates the backfill to sum per-request truncated microdollars so historical cost counters match stored request accounting.

## Validation
- `uv run pytest tests/integration/test_api_keys_trends_api.py -q` passed: 13 passed
- `uv run pytest tests/unit/test_api_keys_service.py -q` passed: 47 passed
- `uv run pytest tests/unit/test_api_keys_repository.py -q` passed: 6 passed
- `uv run ruff check app/modules/api_keys tests/integration/test_api_keys_trends_api.py tests/unit/test_api_keys_service.py` passed
- `git diff --check origin/main...HEAD` passed

## OpenSpec
- `backfill-api-key-limit-current-usage` remains included and updated.

Revives #522


Fixes #518
