### PR TITLE
perf(dashboard): memoize per-account depletion EWMA state

### DIFF
--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -32,6 +32,7 @@ from app.modules.usage.depletion_service import (
     compute_aggregate_depletion,
     compute_depletion_for_account,
     filter_depletion_history_since,
+    prune_depletion_cache,
 )
 from app.modules.usage.mappers import usage_history_to_window_row
 
@@ -247,6 +248,8 @@ def _build_depletion_by_window(
     now,
 ) -> tuple[DepletionResponse | None, DepletionResponse | None]:
     """Compute depletion independently per window."""
+    active_cache_keys = {(account_id, "standard", "primary") for account_id in primary_history}
+    active_cache_keys.update((account_id, "standard", "secondary") for account_id in secondary_history)
 
     def _aggregate(history: dict[str, list[UsageHistory]], window: str) -> DepletionResponse | None:
         metrics = []
@@ -271,7 +274,10 @@ def _build_depletion_by_window(
             seconds_until_exhaustion=agg.seconds_until_exhaustion,
         )
 
-    return _aggregate(primary_history, "primary"), _aggregate(secondary_history, "secondary")
+    primary_depletion = _aggregate(primary_history, "primary")
+    secondary_depletion = _aggregate(secondary_history, "secondary")
+    prune_depletion_cache(active_cache_keys)
+    return primary_depletion, secondary_depletion
 
 
 def _rows_from_latest(latest: dict[str, UsageHistory]) -> list[UsageWindowRow]:

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -31,6 +31,7 @@ from app.modules.usage.builders import (
 from app.modules.usage.depletion_service import (
     compute_aggregate_depletion,
     compute_depletion_for_account,
+    filter_depletion_history_since,
 )
 from app.modules.usage.mappers import usage_history_to_window_row
 
@@ -192,27 +193,27 @@ class DashboardService:
         for account_id in all_account_ids:
             if account_id in normalized_primary_ids:
                 cutoff = pri_cutoffs[account_id]
-                rows = [r for r in all_pri_rows.get(account_id, []) if r.recorded_at >= cutoff]
+                rows = filter_depletion_history_since(all_pri_rows.get(account_id, []), cutoff)
                 if rows:
                     primary_history[account_id] = rows
                 if account_id in sec_cutoffs:
                     s_cutoff = sec_cutoffs[account_id]
-                    s_rows = [r for r in all_sec_rows.get(account_id, []) if r.recorded_at >= s_cutoff]
+                    s_rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), s_cutoff)
                     if s_rows:
                         secondary_history[account_id] = s_rows
             elif account_id in weekly_only_ids:
                 source = weekly_only_history_sources[account_id]
                 if source == "primary":
                     cutoff = pri_cutoffs[account_id]
-                    rows = [r for r in all_pri_rows.get(account_id, []) if r.recorded_at >= cutoff]
+                    rows = filter_depletion_history_since(all_pri_rows.get(account_id, []), cutoff)
                 else:
                     cutoff = sec_cutoffs[account_id]
-                    rows = [r for r in all_sec_rows.get(account_id, []) if r.recorded_at >= cutoff]
+                    rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), cutoff)
                 if rows:
                     secondary_history[account_id] = rows
             else:
                 cutoff = sec_cutoffs[account_id]
-                rows = [r for r in all_sec_rows.get(account_id, []) if r.recorded_at >= cutoff]
+                rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), cutoff)
                 if rows:
                     secondary_history[account_id] = rows
 

--- a/app/modules/usage/depletion_service.py
+++ b/app/modules/usage/depletion_service.py
@@ -14,9 +14,20 @@ from app.core.usage.depletion import (
 )
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 
+# Per-account cache key: (account_id, limit_name, window).
+_StateKey = tuple[str, str, str]
+# Signature of the history slice that produced a cached EWMAState. Includes the
+# window endpoints and length so any change in the in-window history (new row,
+# aged-out row, or replaced row) invalidates the cache and forces a rebuild.
+_HistorySignature = tuple[datetime, datetime, int]
+
 # In-memory EWMA state: keyed by (account_id, limit_name, window)
 # Persists across requests; resets on process restart.
-_ewma_states: dict[tuple[str, str, str], EWMAState] = {}
+_ewma_states: dict[_StateKey, EWMAState] = {}
+# Parallel signature map used to memoize EWMA rebuilds across dashboard polls
+# (issue #537). When the in-window history is unchanged between requests we
+# reuse the cached EWMAState instead of replaying the full history.
+_history_signatures: dict[_StateKey, _HistorySignature] = {}
 
 
 @dataclass
@@ -58,7 +69,7 @@ def compute_depletion_for_account(
         return None
 
     now = now or utcnow()
-    key = (account_id, limit_name, window)
+    key: _StateKey = (account_id, limit_name, window)
 
     if len(history) < 2:
         # Only one in-window sample — seed the EWMA but don't compute
@@ -68,12 +79,24 @@ def compute_depletion_for_account(
         _ewma_states[key] = ewma_update(
             None, entry.used_percent, naive_utc_to_epoch(entry.recorded_at), reset_at=entry.reset_at
         )
+        _history_signatures[key] = (entry.recorded_at, entry.recorded_at, 1)
         return None
 
-    state = _rebuild_ewma_state(history)
+    signature: _HistorySignature = (history[0].recorded_at, history[-1].recorded_at, len(history))
+    cached_state = _ewma_states.get(key)
+    cached_signature = _history_signatures.get(key)
 
-    if state is not None:
-        _ewma_states[key] = state
+    if cached_state is not None and cached_signature == signature:
+        # Same in-window history as the last call — reuse the cached EWMA
+        # state instead of replaying every row.  Time-dependent fields below
+        # (risk, safe_usage_percent, projected_exhaustion_at) are still
+        # recomputed from `now`, so dashboard polls remain live.
+        state: EWMAState | None = cached_state
+    else:
+        state = _rebuild_ewma_state(history)
+        if state is not None:
+            _ewma_states[key] = state
+            _history_signatures[key] = signature
 
     if state is None or state.rate is None:
         return None
@@ -153,6 +176,7 @@ def compute_aggregate_depletion(
 def reset_ewma_state() -> None:
     """Clear all in-memory EWMA state. Used for testing."""
     _ewma_states.clear()
+    _history_signatures.clear()
 
 
 def _rebuild_ewma_state(history: list) -> EWMAState | None:

--- a/app/modules/usage/depletion_service.py
+++ b/app/modules/usage/depletion_service.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from hashlib import blake2b
+from typing import TypeAlias
 
 from app.core.usage.depletion import (
     EWMAState,
@@ -16,7 +17,7 @@ from app.core.usage.depletion import (
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 
 # Per-account cache key: (account_id, limit_name, window).
-_StateKey = tuple[str, str, str]
+_StateKey: TypeAlias = tuple[str, str, str]
 _RowEdgeSignature = tuple[int | None, datetime, float, float | None, int | None]
 
 
@@ -32,6 +33,7 @@ class _SignedHistory(list):
     def __init__(self, rows: Iterable, signature: _HistorySignature) -> None:
         super().__init__(rows)
         self.depletion_history_signature = signature
+
 
 # In-memory EWMA state: keyed by (account_id, limit_name, window)
 # Persists across requests; resets on process restart.
@@ -189,6 +191,15 @@ def reset_ewma_state() -> None:
     """Clear all in-memory EWMA state. Used for testing."""
     _ewma_states.clear()
     _history_signatures.clear()
+
+
+def prune_depletion_cache(active_keys: Iterable[tuple[str, str, str]]) -> None:
+    """Drop EWMA/signature cache entries outside the current account/window set."""
+    keep = set(active_keys)
+    for key in set(_ewma_states) | set(_history_signatures):
+        if key not in keep:
+            _ewma_states.pop(key, None)
+            _history_signatures.pop(key, None)
 
 
 def _rebuild_ewma_state(history: list) -> EWMAState | None:

--- a/app/modules/usage/depletion_service.py
+++ b/app/modules/usage/depletion_service.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from hashlib import blake2b
 
 from app.core.usage.depletion import (
     EWMAState,
@@ -16,16 +17,21 @@ from app.core.utils.time import naive_utc_to_epoch, utcnow
 
 # Per-account cache key: (account_id, limit_name, window).
 _StateKey = tuple[str, str, str]
-# Per-row content fingerprint: timestamp + value-bearing fields. Captured
-# row-by-row so an in-place correction to `used_percent` / `reset_at` /
-# `window_minutes` on an existing row invalidates the cache even when the
-# window endpoints and row count are unchanged.
-_RowSignature = tuple[datetime, float, float | None, int | None]
-# Signature of the history slice that produced a cached EWMAState. A tuple of
-# per-row fingerprints so any change in the in-window history (new row, aged-
-# out row, replaced row, or in-place value correction) invalidates the cache
-# and forces a rebuild.
-_HistorySignature = tuple[_RowSignature, ...]
+_RowEdgeSignature = tuple[int | None, datetime, float, float | None, int | None]
+
+
+@dataclass(frozen=True)
+class _HistorySignature:
+    row_count: int
+    first: _RowEdgeSignature
+    latest: _RowEdgeSignature
+    content_digest: str | None
+
+
+class _SignedHistory(list):
+    def __init__(self, rows: Iterable, signature: _HistorySignature) -> None:
+        super().__init__(rows)
+        self.depletion_history_signature = signature
 
 # In-memory EWMA state: keyed by (account_id, limit_name, window)
 # Persists across requests; resets on process restart.
@@ -85,14 +91,10 @@ def compute_depletion_for_account(
         _ewma_states[key] = ewma_update(
             None, entry.used_percent, naive_utc_to_epoch(entry.recorded_at), reset_at=entry.reset_at
         )
-        _history_signatures[key] = (
-            (entry.recorded_at, entry.used_percent, entry.reset_at, entry.window_minutes),
-        )
+        _history_signatures[key] = _history_signature_from_edges(history)
         return None
 
-    signature: _HistorySignature = tuple(
-        (e.recorded_at, e.used_percent, e.reset_at, e.window_minutes) for e in history
-    )
+    signature = _history_signature(history)
     cached_state = _ewma_states.get(key)
     cached_signature = _history_signatures.get(key)
 
@@ -195,3 +197,89 @@ def _rebuild_ewma_state(history: list) -> EWMAState | None:
         ts = naive_utc_to_epoch(entry.recorded_at)
         state = ewma_update(state, entry.used_percent, ts, reset_at=entry.reset_at)
     return state
+
+
+def attach_depletion_history_signature(history: Iterable) -> list:
+    """Return a list carrying a compact content signature for cache checks.
+
+    Dashboard code already iterates fetched rows while grouping/filtering them;
+    attaching the digest there keeps cache-hit checks O(1) and avoids retaining
+    a tuple per history row in the module-level cache.
+    """
+    rows = list(history)
+    return _signed_history_from_rows(rows)
+
+
+def filter_depletion_history_since(history: Iterable, cutoff: datetime) -> list:
+    """Filter rows by cutoff and attach the cache signature in the same pass."""
+    rows = []
+    digest = blake2b(digest_size=16)
+    for entry in history:
+        if entry.recorded_at < cutoff:
+            continue
+        rows.append(entry)
+        _update_history_digest(digest, entry)
+    if not rows:
+        return []
+    return _SignedHistory(
+        rows,
+        _HistorySignature(
+            row_count=len(rows),
+            first=_row_edge_signature(rows[0]),
+            latest=_row_edge_signature(rows[-1]),
+            content_digest=digest.hexdigest(),
+        ),
+    )
+
+
+def _history_signature(history: list) -> _HistorySignature:
+    attached = getattr(history, "depletion_history_signature", None)
+    if isinstance(attached, _HistorySignature):
+        return attached
+    return _history_signature_from_edges(history)
+
+
+def _history_signature_from_rows(history: list) -> _HistorySignature:
+    if not history:
+        raise ValueError("history must not be empty")
+    digest = blake2b(digest_size=16)
+    for entry in history:
+        _update_history_digest(digest, entry)
+    return _HistorySignature(
+        row_count=len(history),
+        first=_row_edge_signature(history[0]),
+        latest=_row_edge_signature(history[-1]),
+        content_digest=digest.hexdigest(),
+    )
+
+
+def _signed_history_from_rows(history: list) -> list:
+    return _SignedHistory(history, _history_signature_from_rows(history))
+
+
+def _history_signature_from_edges(history: Sequence) -> _HistorySignature:
+    if not history:
+        raise ValueError("history must not be empty")
+    return _HistorySignature(
+        row_count=len(history),
+        first=_row_edge_signature(history[0]),
+        latest=_row_edge_signature(history[-1]),
+        content_digest=None,
+    )
+
+
+def _row_edge_signature(entry) -> _RowEdgeSignature:
+    return (
+        getattr(entry, "id", None),
+        entry.recorded_at,
+        entry.used_percent,
+        entry.reset_at,
+        entry.window_minutes,
+    )
+
+
+def _update_history_digest(digest, entry) -> None:
+    for value in _row_edge_signature(entry):
+        digest.update(repr(value).encode("utf-8"))
+        digest.update(b"\0")
+    digest.update(b"\1")

--- a/app/modules/usage/depletion_service.py
+++ b/app/modules/usage/depletion_service.py
@@ -16,10 +16,16 @@ from app.core.utils.time import naive_utc_to_epoch, utcnow
 
 # Per-account cache key: (account_id, limit_name, window).
 _StateKey = tuple[str, str, str]
-# Signature of the history slice that produced a cached EWMAState. Includes the
-# window endpoints and length so any change in the in-window history (new row,
-# aged-out row, or replaced row) invalidates the cache and forces a rebuild.
-_HistorySignature = tuple[datetime, datetime, int]
+# Per-row content fingerprint: timestamp + value-bearing fields. Captured
+# row-by-row so an in-place correction to `used_percent` / `reset_at` /
+# `window_minutes` on an existing row invalidates the cache even when the
+# window endpoints and row count are unchanged.
+_RowSignature = tuple[datetime, float, float | None, int | None]
+# Signature of the history slice that produced a cached EWMAState. A tuple of
+# per-row fingerprints so any change in the in-window history (new row, aged-
+# out row, replaced row, or in-place value correction) invalidates the cache
+# and forces a rebuild.
+_HistorySignature = tuple[_RowSignature, ...]
 
 # In-memory EWMA state: keyed by (account_id, limit_name, window)
 # Persists across requests; resets on process restart.
@@ -79,10 +85,14 @@ def compute_depletion_for_account(
         _ewma_states[key] = ewma_update(
             None, entry.used_percent, naive_utc_to_epoch(entry.recorded_at), reset_at=entry.reset_at
         )
-        _history_signatures[key] = (entry.recorded_at, entry.recorded_at, 1)
+        _history_signatures[key] = (
+            (entry.recorded_at, entry.used_percent, entry.reset_at, entry.window_minutes),
+        )
         return None
 
-    signature: _HistorySignature = (history[0].recorded_at, history[-1].recorded_at, len(history))
+    signature: _HistorySignature = tuple(
+        (e.recorded_at, e.used_percent, e.reset_at, e.window_minutes) for e in history
+    )
     cached_state = _ewma_states.get(key)
     cached_signature = _history_signatures.get(key)
 

--- a/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
@@ -1,0 +1,18 @@
+## Why
+Issue #537 reports that `GET /api/dashboard/overview` is slow once `usage_history` grows because the depletion / EWMA section rebuilds depletion state from raw usage rows on every request. The reporter measured 120 accounts × 117,600 usage_history rows × 7 day timeframe:
+
+- dashboard with EWMA/depletion: median **2122.3 ms**
+- dashboard with EWMA history fetch disabled: median **197.6 ms**
+- EWMA/depletion share: **~90.7 %** of endpoint time
+
+Dashboard polls are issued much more frequently than new usage rows land, yet each poll currently re-walks the full per-account history through `ewma_update`.
+
+## What Changes
+- Memoize per-account EWMA state alongside a signature of the in-window history `(earliest_recorded_at, latest_recorded_at, len(history))` so dashboard polls reuse the cached state whenever the input is unchanged.
+- Invalidate the memoized state automatically when a new sample is appended, an older sample ages out of the window, or `reset_ewma_state()` is called.
+- Continue recomputing the time-dependent fields (`risk`, `safe_usage_percent`, `projected_exhaustion_at`, `seconds_until_exhaustion`) on every call so polls remain live.
+
+## Impact
+- Cuts the dominant cost of `GET /api/dashboard/overview` in steady state: subsequent polls within the inter-arrival time of usage_history rows skip the per-account history replay entirely.
+- No change to depletion semantics: the cache key captures the only inputs that influence EWMA rate, and any change to the in-window history forces a rebuild.
+- No schema or persistence changes; the cache lives next to the existing in-memory `_ewma_states` map and clears on process restart.

--- a/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
@@ -10,9 +10,10 @@ Dashboard polls are issued much more frequently than new usage rows land, yet ea
 ## What Changes
 - Memoize per-account EWMA state alongside a compact in-window history signature. The dashboard attaches a bounded signature containing row count, first/latest row metadata, and a full content digest built while rows are already being filtered, so the depletion cache hit path does not scan history again or retain per-row tuples.
 - Invalidate the memoized state automatically when a new sample is appended, an older sample ages out of the window, an existing row is corrected in place, or `reset_ewma_state()` is called.
+- Prune EWMA/signature cache entries for account/window keys that are absent from the current dashboard history set so account churn cannot retain stale state forever.
 - Continue recomputing the time-dependent fields (`risk`, `safe_usage_percent`, `projected_exhaustion_at`, `seconds_until_exhaustion`) on every call so polls remain live.
 
 ## Impact
 - Cuts the dominant cost of `GET /api/dashboard/overview` in steady state: subsequent polls within the inter-arrival time of usage_history rows skip the per-account history replay entirely.
 - No change to depletion semantics for dashboard requests: the attached digest captures the inputs that influence EWMA rate, and any change to the in-window history forces a rebuild.
-- No schema or persistence changes; the cache lives next to the existing in-memory `_ewma_states` map and clears on process restart.
+- No schema or persistence changes; the cache lives next to the existing in-memory `_ewma_states` map, is pruned during normal dashboard lifecycle, and clears on process restart.

--- a/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
@@ -8,8 +8,8 @@ Issue #537 reports that `GET /api/dashboard/overview` is slow once `usage_histor
 Dashboard polls are issued much more frequently than new usage rows land, yet each poll currently re-walks the full per-account history through `ewma_update`.
 
 ## What Changes
-- Memoize per-account EWMA state alongside a signature of the in-window history `(earliest_recorded_at, latest_recorded_at, len(history))` so dashboard polls reuse the cached state whenever the input is unchanged.
-- Invalidate the memoized state automatically when a new sample is appended, an older sample ages out of the window, or `reset_ewma_state()` is called.
+- Memoize per-account EWMA state alongside a full per-row content signature of the in-window history (`recorded_at`, `used_percent`, `reset_at`, `window_minutes`) so dashboard polls reuse the cached state whenever the input is unchanged.
+- Invalidate the memoized state automatically when a new sample is appended, an older sample ages out of the window, an existing row is corrected in place, or `reset_ewma_state()` is called.
 - Continue recomputing the time-dependent fields (`risk`, `safe_usage_percent`, `projected_exhaustion_at`, `seconds_until_exhaustion`) on every call so polls remain live.
 
 ## Impact

--- a/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/proposal.md
@@ -8,11 +8,11 @@ Issue #537 reports that `GET /api/dashboard/overview` is slow once `usage_histor
 Dashboard polls are issued much more frequently than new usage rows land, yet each poll currently re-walks the full per-account history through `ewma_update`.
 
 ## What Changes
-- Memoize per-account EWMA state alongside a full per-row content signature of the in-window history (`recorded_at`, `used_percent`, `reset_at`, `window_minutes`) so dashboard polls reuse the cached state whenever the input is unchanged.
+- Memoize per-account EWMA state alongside a compact in-window history signature. The dashboard attaches a bounded signature containing row count, first/latest row metadata, and a full content digest built while rows are already being filtered, so the depletion cache hit path does not scan history again or retain per-row tuples.
 - Invalidate the memoized state automatically when a new sample is appended, an older sample ages out of the window, an existing row is corrected in place, or `reset_ewma_state()` is called.
 - Continue recomputing the time-dependent fields (`risk`, `safe_usage_percent`, `projected_exhaustion_at`, `seconds_until_exhaustion`) on every call so polls remain live.
 
 ## Impact
 - Cuts the dominant cost of `GET /api/dashboard/overview` in steady state: subsequent polls within the inter-arrival time of usage_history rows skip the per-account history replay entirely.
-- No change to depletion semantics: the cache key captures the only inputs that influence EWMA rate, and any change to the in-window history forces a rebuild.
+- No change to depletion semantics for dashboard requests: the attached digest captures the inputs that influence EWMA rate, and any change to the in-window history forces a rebuild.
 - No schema or persistence changes; the cache lives next to the existing in-memory `_ewma_states` map and clears on process restart.

--- a/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+### Requirement: Dashboard overview memoizes per-account depletion EWMA state
+`GET /api/dashboard/overview` MUST cache per-account EWMA depletion state in memory so repeated polls do not re-walk the full in-window `usage_history` slice when its content is unchanged.
+
+#### Scenario: Repeated polls with unchanged history reuse cached EWMA state
+- **GIVEN** the dashboard service has previously computed depletion for an account
+- **AND** a subsequent request supplies the same in-window history slice for that account (same earliest `recorded_at`, same latest `recorded_at`, same row count)
+- **WHEN** depletion is recomputed for the dashboard response
+- **THEN** the service MUST reuse the cached EWMA state for that account instead of replaying every history row
+- **AND** the depletion metrics for that account MUST match the previously returned values for rate-bearing fields
+
+#### Scenario: Memoized EWMA state is invalidated when a new usage row is appended
+- **WHEN** a later dashboard request supplies the same account's in-window history with an additional row appended (a new `recorded_at` past the previous latest)
+- **THEN** the service MUST rebuild the EWMA state from the new history slice
+- **AND** the recomputed rate MUST reflect the newly observed sample
+
+#### Scenario: Memoized EWMA state is invalidated when an older row ages out of the window
+- **WHEN** a later dashboard request supplies the same account's in-window history with the earliest row dropped (because it has aged past the window cutoff)
+- **THEN** the service MUST rebuild the EWMA state from the narrowed history slice
+- **AND** the cached state from the wider window MUST NOT influence the recomputed rate

--- a/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
@@ -1,13 +1,14 @@
 ## ADDED Requirements
 ### Requirement: Dashboard overview memoizes per-account depletion EWMA state
-`GET /api/dashboard/overview` MUST cache per-account EWMA depletion state in memory so repeated polls do not re-walk the full in-window `usage_history` slice when its content is unchanged.
+`GET /api/dashboard/overview` MUST cache per-account EWMA depletion state in memory so repeated polls do not re-walk the full in-window `usage_history` slice in the depletion cache check when its content is unchanged.
 
 #### Scenario: Repeated polls with unchanged history reuse cached EWMA state
 - **GIVEN** the dashboard service has previously computed depletion for an account
-- **AND** a subsequent request supplies the same in-window history slice for that account (same per-row `recorded_at`, `used_percent`, `reset_at`, and `window_minutes` values)
+- **AND** a subsequent request supplies the same in-window history slice for that account with the same attached compact content signature
 - **WHEN** depletion is recomputed for the dashboard response
 - **THEN** the service MUST reuse the cached EWMA state for that account instead of replaying every history row
 - **AND** the depletion metrics for that account MUST match the previously returned values for rate-bearing fields
+- **AND** the cache hit check MUST use bounded signature metadata rather than building or retaining a per-row signature tuple
 
 #### Scenario: Memoized EWMA state is invalidated when a new usage row is appended
 - **WHEN** a later dashboard request supplies the same account's in-window history with an additional row appended (a new `recorded_at` past the previous latest)

--- a/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
@@ -9,6 +9,7 @@
 - **THEN** the service MUST reuse the cached EWMA state for that account instead of replaying every history row
 - **AND** the depletion metrics for that account MUST match the previously returned values for rate-bearing fields
 - **AND** the cache hit check MUST use bounded signature metadata rather than building or retaining a per-row signature tuple
+- **AND** the service MUST prune cached depletion state for account/window keys that are absent from the current dashboard history set
 
 #### Scenario: Memoized EWMA state is invalidated when a new usage row is appended
 - **WHEN** a later dashboard request supplies the same account's in-window history with an additional row appended (a new `recorded_at` past the previous latest)

--- a/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/specs/query-caching/spec.md
@@ -4,7 +4,7 @@
 
 #### Scenario: Repeated polls with unchanged history reuse cached EWMA state
 - **GIVEN** the dashboard service has previously computed depletion for an account
-- **AND** a subsequent request supplies the same in-window history slice for that account (same earliest `recorded_at`, same latest `recorded_at`, same row count)
+- **AND** a subsequent request supplies the same in-window history slice for that account (same per-row `recorded_at`, `used_percent`, `reset_at`, and `window_minutes` values)
 - **WHEN** depletion is recomputed for the dashboard response
 - **THEN** the service MUST reuse the cached EWMA state for that account instead of replaying every history row
 - **AND** the depletion metrics for that account MUST match the previously returned values for rate-bearing fields
@@ -18,3 +18,8 @@
 - **WHEN** a later dashboard request supplies the same account's in-window history with the earliest row dropped (because it has aged past the window cutoff)
 - **THEN** the service MUST rebuild the EWMA state from the narrowed history slice
 - **AND** the cached state from the wider window MUST NOT influence the recomputed rate
+
+#### Scenario: Memoized EWMA state is invalidated when an existing usage row is corrected
+- **WHEN** a later dashboard request supplies the same account's in-window history with the same row count and endpoints but a corrected `used_percent`, `reset_at`, or `window_minutes` value on an existing row
+- **THEN** the service MUST rebuild the EWMA state from the corrected history slice
+- **AND** the recomputed rate-bearing metrics MUST reflect the corrected row content

--- a/openspec/changes/memoize-dashboard-depletion-ewma/tasks.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/tasks.md
@@ -1,0 +1,4 @@
+- [x] Add a per-account history signature alongside `_ewma_states` and short-circuit `compute_depletion_for_account` when the signature matches a cached state.
+- [x] Invalidate the memoized state on appended rows, aged-out rows, and `reset_ewma_state()` calls.
+- [x] Add regression tests covering: cache hit on identical history (no rebuild), cache miss when a new row lands, cache miss when an old row ages out, and continued idempotency of the result for unchanged input.
+- [x] Document the memoization contract in the `query-caching` capability spec.

--- a/openspec/changes/memoize-dashboard-depletion-ewma/tasks.md
+++ b/openspec/changes/memoize-dashboard-depletion-ewma/tasks.md
@@ -1,4 +1,4 @@
 - [x] Add a per-account history signature alongside `_ewma_states` and short-circuit `compute_depletion_for_account` when the signature matches a cached state.
-- [x] Invalidate the memoized state on appended rows, aged-out rows, and `reset_ewma_state()` calls.
-- [x] Add regression tests covering: cache hit on identical history (no rebuild), cache miss when a new row lands, cache miss when an old row ages out, and continued idempotency of the result for unchanged input.
+- [x] Invalidate the memoized state on appended rows, aged-out rows, in-place value corrections, and `reset_ewma_state()` calls.
+- [x] Add regression tests covering: cache hit on identical history (no rebuild), cache miss when a new row lands, cache miss when an old row ages out, cache miss when existing row content changes, and continued idempotency of the result for unchanged input.
 - [x] Document the memoization contract in the `query-caching` capability spec.

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -278,6 +278,122 @@ def test_aged_out_samples_do_not_keep_stale_ewma_influence() -> None:
     assert in_window_result.rate_per_second < full_window_result.rate_per_second
 
 
+def test_repeated_call_with_unchanged_history_skips_rebuild(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #537: dashboard polls must reuse the cached EWMA state when the
+    in-window history is unchanged, instead of replaying every usage row."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    history = [
+        _entry(10.0, BASE_TIME),
+        _entry(20.0, BASE_TIME + timedelta(minutes=1)),
+        _entry(30.0, BASE_TIME + timedelta(minutes=2)),
+    ]
+    now = BASE_TIME + timedelta(minutes=3)
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    first = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert first is not None
+    assert rebuild_calls == 1
+
+    # Subsequent polls with the exact same in-window history must not re-walk
+    # the history. The result must remain identical.
+    second = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert second is not None
+    assert rebuild_calls == 1
+    assert second.rate_per_second == pytest.approx(first.rate_per_second)
+    assert second.risk == pytest.approx(first.risk)
+
+    third = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert third is not None
+    assert rebuild_calls == 1
+
+
+def test_new_history_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a new usage row lands the cache must rebuild so the rate reflects
+    the latest observations."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    history = [
+        _entry(10.0, BASE_TIME),
+        _entry(15.0, BASE_TIME + timedelta(minutes=1)),
+    ]
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    first = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", history, now=BASE_TIME + timedelta(minutes=2)
+    )
+    assert first is not None
+    assert rebuild_calls == 1
+
+    appended_history = history + [_entry(40.0, BASE_TIME + timedelta(minutes=2))]
+    second = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", appended_history, now=BASE_TIME + timedelta(minutes=3)
+    )
+    assert second is not None
+    # Signature changed (new row appended) -> rebuild executed.
+    assert rebuild_calls == 2
+    # Rate must rise to reflect the steeper observation.
+    assert second.rate_per_second > first.rate_per_second
+
+
+def test_aged_out_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the leading row of the in-window history drops away the cache must
+    rebuild so the rate does not retain influence from samples now outside the
+    window."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    full_history = [
+        _entry(10.0, BASE_TIME),
+        _entry(70.0, BASE_TIME + timedelta(minutes=1)),
+        _entry(80.0, BASE_TIME + timedelta(minutes=2)),
+    ]
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    full_result = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", full_history, now=BASE_TIME + timedelta(minutes=3)
+    )
+    assert full_result is not None
+    assert rebuild_calls == 1
+
+    in_window_history = full_history[1:]
+    truncated_result = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", in_window_history, now=BASE_TIME + timedelta(minutes=3)
+    )
+    assert truncated_result is not None
+    assert rebuild_calls == 2
+    assert truncated_result.rate_per_second != pytest.approx(full_result.rate_per_second)
+
+
 def test_post_reset_window_returns_none() -> None:
     """R30-F1: When reset_at is in the past, depletion should be None (window expired)."""
     reset_ewma_state()

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -10,6 +10,7 @@ from app.modules.usage.depletion_service import (
     attach_depletion_history_signature,
     compute_aggregate_depletion,
     compute_depletion_for_account,
+    prune_depletion_cache,
     reset_ewma_state,
 )
 
@@ -289,11 +290,13 @@ def test_repeated_call_with_unchanged_history_skips_rebuild(monkeypatch: pytest.
     from app.modules.usage import depletion_service
 
     reset_ewma_state()
-    history = _signed([
-        _entry(10.0, BASE_TIME),
-        _entry(20.0, BASE_TIME + timedelta(minutes=1)),
-        _entry(30.0, BASE_TIME + timedelta(minutes=2)),
-    ])
+    history = _signed(
+        [
+            _entry(10.0, BASE_TIME),
+            _entry(20.0, BASE_TIME + timedelta(minutes=1)),
+            _entry(30.0, BASE_TIME + timedelta(minutes=2)),
+        ]
+    )
     now = BASE_TIME + timedelta(minutes=3)
 
     rebuild_calls = 0
@@ -335,16 +338,75 @@ def test_repeated_call_with_unchanged_history_skips_rebuild(monkeypatch: pytest.
     assert digest_rebuild_calls == 0
 
 
+def test_signature_cache_stores_compact_digest_not_per_row_tuple() -> None:
+    """The retained cache signature should stay bounded for large histories."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    history = _signed([_entry(float(index), BASE_TIME + timedelta(minutes=index)) for index in range(100)])
+
+    result = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", history, now=BASE_TIME + timedelta(minutes=101)
+    )
+
+    assert result is not None
+    signature = depletion_service._history_signatures[("acc1", "codex_other", "primary")]
+    assert signature.row_count == 100
+    assert isinstance(signature.content_digest, str)
+    assert len(signature.content_digest) == 32
+
+
+def test_prune_depletion_cache_drops_absent_account_window_entries() -> None:
+    """Dashboard lifecycle pruning prevents churned account/window keys from
+    accumulating in the EWMA and signature caches."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    primary_history = _signed(
+        [
+            _entry(10.0, BASE_TIME, account_id="acc1"),
+            _entry(20.0, BASE_TIME + timedelta(minutes=1), account_id="acc1"),
+        ]
+    )
+    secondary_history = _signed(
+        [
+            _entry(30.0, BASE_TIME, account_id="acc2"),
+            _entry(40.0, BASE_TIME + timedelta(minutes=1), account_id="acc2"),
+        ]
+    )
+
+    primary = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", primary_history, now=BASE_TIME + timedelta(minutes=2)
+    )
+    secondary = compute_depletion_for_account(
+        "acc2", "codex_other", "secondary", secondary_history, now=BASE_TIME + timedelta(minutes=2)
+    )
+
+    assert primary is not None
+    assert secondary is not None
+    assert set(depletion_service._history_signatures) == {
+        ("acc1", "codex_other", "primary"),
+        ("acc2", "codex_other", "secondary"),
+    }
+
+    prune_depletion_cache({("acc1", "codex_other", "primary")})
+
+    assert set(depletion_service._history_signatures) == {("acc1", "codex_other", "primary")}
+    assert set(depletion_service._ewma_states) == {("acc1", "codex_other", "primary")}
+
+
 def test_new_history_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch) -> None:
     """When a new usage row lands the cache must rebuild so the rate reflects
     the latest observations."""
     from app.modules.usage import depletion_service
 
     reset_ewma_state()
-    history = _signed([
-        _entry(10.0, BASE_TIME),
-        _entry(15.0, BASE_TIME + timedelta(minutes=1)),
-    ])
+    history = _signed(
+        [
+            _entry(10.0, BASE_TIME),
+            _entry(15.0, BASE_TIME + timedelta(minutes=1)),
+        ]
+    )
 
     rebuild_calls = 0
     real_rebuild = depletion_service._rebuild_ewma_state
@@ -380,11 +442,13 @@ def test_aged_out_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch
     from app.modules.usage import depletion_service
 
     reset_ewma_state()
-    full_history = _signed([
-        _entry(10.0, BASE_TIME),
-        _entry(70.0, BASE_TIME + timedelta(minutes=1)),
-        _entry(80.0, BASE_TIME + timedelta(minutes=2)),
-    ])
+    full_history = _signed(
+        [
+            _entry(10.0, BASE_TIME),
+            _entry(70.0, BASE_TIME + timedelta(minutes=1)),
+            _entry(80.0, BASE_TIME + timedelta(minutes=2)),
+        ]
+    )
 
     rebuild_calls = 0
     real_rebuild = depletion_service._rebuild_ewma_state
@@ -420,11 +484,13 @@ def test_inplace_value_correction_invalidates_memoized_state(
     from app.modules.usage import depletion_service
 
     reset_ewma_state()
-    history = _signed([
-        _entry(10.0, BASE_TIME),
-        _entry(20.0, BASE_TIME + timedelta(minutes=1)),
-        _entry(30.0, BASE_TIME + timedelta(minutes=2)),
-    ])
+    history = _signed(
+        [
+            _entry(10.0, BASE_TIME),
+            _entry(20.0, BASE_TIME + timedelta(minutes=1)),
+            _entry(30.0, BASE_TIME + timedelta(minutes=2)),
+        ]
+    )
     now = BASE_TIME + timedelta(minutes=3)
 
     rebuild_calls = 0
@@ -446,14 +512,14 @@ def test_inplace_value_correction_invalidates_memoized_state(
     # the corrected series remains monotonically non-decreasing. Window-
     # endpoint-only signatures would treat this as unchanged and reuse the
     # stale EWMA state.
-    corrected_history = _signed([
-        history[0],
-        _entry(25.0, BASE_TIME + timedelta(minutes=1)),
-        history[2],
-    ])
-    second = compute_depletion_for_account(
-        "acc1", "codex_other", "primary", corrected_history, now=now
+    corrected_history = _signed(
+        [
+            history[0],
+            _entry(25.0, BASE_TIME + timedelta(minutes=1)),
+            history[2],
+        ]
     )
+    second = compute_depletion_for_account("acc1", "codex_other", "primary", corrected_history, now=now)
     assert second is not None
     assert rebuild_calls == 2
     # Rate must reflect the correction, not the stale cached state.
@@ -469,11 +535,13 @@ def test_inplace_reset_at_correction_invalidates_memoized_state(
 
     reset_ewma_state()
     reset_epoch = int((BASE_TIME + timedelta(minutes=30)).timestamp())
-    history = _signed([
-        _entry(10.0, BASE_TIME, reset_at=reset_epoch, window_minutes=60),
-        _entry(20.0, BASE_TIME + timedelta(minutes=1), reset_at=reset_epoch, window_minutes=60),
-        _entry(30.0, BASE_TIME + timedelta(minutes=2), reset_at=reset_epoch, window_minutes=60),
-    ])
+    history = _signed(
+        [
+            _entry(10.0, BASE_TIME, reset_at=reset_epoch, window_minutes=60),
+            _entry(20.0, BASE_TIME + timedelta(minutes=1), reset_at=reset_epoch, window_minutes=60),
+            _entry(30.0, BASE_TIME + timedelta(minutes=2), reset_at=reset_epoch, window_minutes=60),
+        ]
+    )
     now = BASE_TIME + timedelta(minutes=3)
 
     rebuild_calls = 0
@@ -494,13 +562,10 @@ def test_inplace_reset_at_correction_invalidates_memoized_state(
     # (per-row consistency keeps ewma_update from treating it as a mid-stream
     # window change and dropping the rate).
     extended_reset = int((BASE_TIME + timedelta(minutes=90)).timestamp())
-    corrected_history = _signed([
-        _entry(e.used_percent, e.recorded_at, reset_at=extended_reset, window_minutes=60)
-        for e in history
-    ])
-    second = compute_depletion_for_account(
-        "acc1", "codex_other", "primary", corrected_history, now=now
+    corrected_history = _signed(
+        [_entry(e.used_percent, e.recorded_at, reset_at=extended_reset, window_minutes=60) for e in history]
     )
+    second = compute_depletion_for_account("acc1", "codex_other", "primary", corrected_history, now=now)
     assert second is not None
     assert rebuild_calls == 2
     # Extending reset_at lengthens seconds_until_reset which lowers the

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.modules.usage.depletion_service import (
     DepletionMetrics,
+    attach_depletion_history_signature,
     compute_aggregate_depletion,
     compute_depletion_for_account,
     reset_ewma_state,
@@ -40,6 +41,10 @@ def _entry(
         reset_at=reset_at,
         window_minutes=window_minutes,
     )
+
+
+def _signed(history: list[_FakeEntry]) -> list[_FakeEntry]:
+    return attach_depletion_history_signature(history)
 
 
 def test_depletion_metrics_dataclass_shape() -> None:
@@ -284,38 +289,50 @@ def test_repeated_call_with_unchanged_history_skips_rebuild(monkeypatch: pytest.
     from app.modules.usage import depletion_service
 
     reset_ewma_state()
-    history = [
+    history = _signed([
         _entry(10.0, BASE_TIME),
         _entry(20.0, BASE_TIME + timedelta(minutes=1)),
         _entry(30.0, BASE_TIME + timedelta(minutes=2)),
-    ]
+    ])
     now = BASE_TIME + timedelta(minutes=3)
 
     rebuild_calls = 0
+    digest_rebuild_calls = 0
     real_rebuild = depletion_service._rebuild_ewma_state
+    real_digest_rebuild = depletion_service._history_signature_from_rows
 
     def _counting_rebuild(history_arg):
         nonlocal rebuild_calls
         rebuild_calls += 1
         return real_rebuild(history_arg)
 
+    def _counting_digest_rebuild(history_arg):
+        nonlocal digest_rebuild_calls
+        digest_rebuild_calls += 1
+        return real_digest_rebuild(history_arg)
+
     monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+    monkeypatch.setattr(depletion_service, "_history_signature_from_rows", _counting_digest_rebuild)
 
     first = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
     assert first is not None
     assert rebuild_calls == 1
+    assert digest_rebuild_calls == 0
 
     # Subsequent polls with the exact same in-window history must not re-walk
-    # the history. The result must remain identical.
+    # the history or rebuild a full-row signature. The result must remain
+    # identical.
     second = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
     assert second is not None
     assert rebuild_calls == 1
+    assert digest_rebuild_calls == 0
     assert second.rate_per_second == pytest.approx(first.rate_per_second)
     assert second.risk == pytest.approx(first.risk)
 
     third = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
     assert third is not None
     assert rebuild_calls == 1
+    assert digest_rebuild_calls == 0
 
 
 def test_new_history_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -324,10 +341,10 @@ def test_new_history_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPa
     from app.modules.usage import depletion_service
 
     reset_ewma_state()
-    history = [
+    history = _signed([
         _entry(10.0, BASE_TIME),
         _entry(15.0, BASE_TIME + timedelta(minutes=1)),
-    ]
+    ])
 
     rebuild_calls = 0
     real_rebuild = depletion_service._rebuild_ewma_state
@@ -345,7 +362,7 @@ def test_new_history_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPa
     assert first is not None
     assert rebuild_calls == 1
 
-    appended_history = history + [_entry(40.0, BASE_TIME + timedelta(minutes=2))]
+    appended_history = _signed([*history, _entry(40.0, BASE_TIME + timedelta(minutes=2))])
     second = compute_depletion_for_account(
         "acc1", "codex_other", "primary", appended_history, now=BASE_TIME + timedelta(minutes=3)
     )
@@ -363,11 +380,11 @@ def test_aged_out_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch
     from app.modules.usage import depletion_service
 
     reset_ewma_state()
-    full_history = [
+    full_history = _signed([
         _entry(10.0, BASE_TIME),
         _entry(70.0, BASE_TIME + timedelta(minutes=1)),
         _entry(80.0, BASE_TIME + timedelta(minutes=2)),
-    ]
+    ])
 
     rebuild_calls = 0
     real_rebuild = depletion_service._rebuild_ewma_state
@@ -385,7 +402,7 @@ def test_aged_out_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch
     assert full_result is not None
     assert rebuild_calls == 1
 
-    in_window_history = full_history[1:]
+    in_window_history = _signed(full_history[1:])
     truncated_result = compute_depletion_for_account(
         "acc1", "codex_other", "primary", in_window_history, now=BASE_TIME + timedelta(minutes=3)
     )
@@ -403,11 +420,11 @@ def test_inplace_value_correction_invalidates_memoized_state(
     from app.modules.usage import depletion_service
 
     reset_ewma_state()
-    history = [
+    history = _signed([
         _entry(10.0, BASE_TIME),
         _entry(20.0, BASE_TIME + timedelta(minutes=1)),
         _entry(30.0, BASE_TIME + timedelta(minutes=2)),
-    ]
+    ])
     now = BASE_TIME + timedelta(minutes=3)
 
     rebuild_calls = 0
@@ -429,11 +446,11 @@ def test_inplace_value_correction_invalidates_memoized_state(
     # the corrected series remains monotonically non-decreasing. Window-
     # endpoint-only signatures would treat this as unchanged and reuse the
     # stale EWMA state.
-    corrected_history = [
+    corrected_history = _signed([
         history[0],
         _entry(25.0, BASE_TIME + timedelta(minutes=1)),
         history[2],
-    ]
+    ])
     second = compute_depletion_for_account(
         "acc1", "codex_other", "primary", corrected_history, now=now
     )
@@ -452,11 +469,11 @@ def test_inplace_reset_at_correction_invalidates_memoized_state(
 
     reset_ewma_state()
     reset_epoch = int((BASE_TIME + timedelta(minutes=30)).timestamp())
-    history = [
+    history = _signed([
         _entry(10.0, BASE_TIME, reset_at=reset_epoch, window_minutes=60),
         _entry(20.0, BASE_TIME + timedelta(minutes=1), reset_at=reset_epoch, window_minutes=60),
         _entry(30.0, BASE_TIME + timedelta(minutes=2), reset_at=reset_epoch, window_minutes=60),
-    ]
+    ])
     now = BASE_TIME + timedelta(minutes=3)
 
     rebuild_calls = 0
@@ -477,10 +494,10 @@ def test_inplace_reset_at_correction_invalidates_memoized_state(
     # (per-row consistency keeps ewma_update from treating it as a mid-stream
     # window change and dropping the rate).
     extended_reset = int((BASE_TIME + timedelta(minutes=90)).timestamp())
-    corrected_history = [
+    corrected_history = _signed([
         _entry(e.used_percent, e.recorded_at, reset_at=extended_reset, window_minutes=60)
         for e in history
-    ]
+    ])
     second = compute_depletion_for_account(
         "acc1", "codex_other", "primary", corrected_history, now=now
     )

--- a/tests/unit/test_depletion_service.py
+++ b/tests/unit/test_depletion_service.py
@@ -394,6 +394,106 @@ def test_aged_out_row_invalidates_memoized_state(monkeypatch: pytest.MonkeyPatch
     assert truncated_result.rate_per_second != pytest.approx(full_result.rate_per_second)
 
 
+def test_inplace_value_correction_invalidates_memoized_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review on #588: when a row's `used_percent` is corrected in place
+    (same timestamps, same row count) the cache must rebuild — otherwise we
+    keep returning depletion metrics derived from the stale value."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    history = [
+        _entry(10.0, BASE_TIME),
+        _entry(20.0, BASE_TIME + timedelta(minutes=1)),
+        _entry(30.0, BASE_TIME + timedelta(minutes=2)),
+    ]
+    now = BASE_TIME + timedelta(minutes=3)
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    first = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert first is not None
+    assert rebuild_calls == 1
+
+    # Same window endpoints and row count, but the middle row's used_percent is
+    # corrected upward (e.g. backfill of a previously underreported sample) so
+    # the corrected series remains monotonically non-decreasing. Window-
+    # endpoint-only signatures would treat this as unchanged and reuse the
+    # stale EWMA state.
+    corrected_history = [
+        history[0],
+        _entry(25.0, BASE_TIME + timedelta(minutes=1)),
+        history[2],
+    ]
+    second = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", corrected_history, now=now
+    )
+    assert second is not None
+    assert rebuild_calls == 2
+    # Rate must reflect the correction, not the stale cached state.
+    assert second.rate_per_second != pytest.approx(first.rate_per_second)
+
+
+def test_inplace_reset_at_correction_invalidates_memoized_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review on #588: corrections to value-bearing non-`used_percent`
+    fields (here `reset_at`) must also invalidate the cache."""
+    from app.modules.usage import depletion_service
+
+    reset_ewma_state()
+    reset_epoch = int((BASE_TIME + timedelta(minutes=30)).timestamp())
+    history = [
+        _entry(10.0, BASE_TIME, reset_at=reset_epoch, window_minutes=60),
+        _entry(20.0, BASE_TIME + timedelta(minutes=1), reset_at=reset_epoch, window_minutes=60),
+        _entry(30.0, BASE_TIME + timedelta(minutes=2), reset_at=reset_epoch, window_minutes=60),
+    ]
+    now = BASE_TIME + timedelta(minutes=3)
+
+    rebuild_calls = 0
+    real_rebuild = depletion_service._rebuild_ewma_state
+
+    def _counting_rebuild(history_arg):
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+        return real_rebuild(history_arg)
+
+    monkeypatch.setattr(depletion_service, "_rebuild_ewma_state", _counting_rebuild)
+
+    first = compute_depletion_for_account("acc1", "codex_other", "primary", history, now=now)
+    assert first is not None
+    assert rebuild_calls == 1
+
+    # Upstream extended the window — reset_at moved later on every row
+    # (per-row consistency keeps ewma_update from treating it as a mid-stream
+    # window change and dropping the rate).
+    extended_reset = int((BASE_TIME + timedelta(minutes=90)).timestamp())
+    corrected_history = [
+        _entry(e.used_percent, e.recorded_at, reset_at=extended_reset, window_minutes=60)
+        for e in history
+    ]
+    second = compute_depletion_for_account(
+        "acc1", "codex_other", "primary", corrected_history, now=now
+    )
+    assert second is not None
+    assert rebuild_calls == 2
+    # Extending reset_at lengthens seconds_until_reset which lowers the
+    # sustainable_rate denominator in compute_burn_rate, so burn_rate must
+    # rise; the cached pre-correction state would have produced the old,
+    # lower burn_rate.
+    assert second.burn_rate != pytest.approx(first.burn_rate)
+    assert second.burn_rate > first.burn_rate
+
+
 def test_post_reset_window_returns_none() -> None:
     """R30-F1: When reset_at is in the past, depletion should be None (window expired)."""
     reset_ewma_state()


### PR DESCRIPTION
## Summary
Fixes #537

Revives #588 on a maintainer-owned branch because the original PR head has `maintainerCanModify=false`.

Credit: original implementation by @ozpool in #588; this branch rebases and updates that work on current `main`.

- Memoizes per-account depletion EWMA rebuilds behind a full-row usage-history signature.
- Keeps time-dependent dashboard fields recomputed on every request and invalidates cache on appends, aged-out rows, and reset.

## Validation
- `uv run pytest tests/unit/test_depletion_service.py tests/unit/test_depletion.py tests/integration/test_dashboard_overview.py tests/integration/test_usage_api.py` passed: 71 passed
- `uv run ruff check app/modules/dashboard app/modules/usage tests/unit/test_depletion_service.py tests/unit/test_depletion.py tests/integration/test_dashboard_overview.py tests/integration/test_usage_api.py` passed
- `git diff --check origin/main...HEAD` passed

## OpenSpec
- `memoize-dashboard-depletion-ewma` remains included and updated.

Fixes #537

Revives #588

