### PR TITLE
fix(proxy): make Codex Spark quota gating plan-aware

### DIFF
--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -36,7 +36,10 @@ from app.db.models import Account, AccountStatus, AdditionalUsageHistory, Sticky
 from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.additional_model_limits import get_additional_quota_key_for_model_id
 from app.modules.proxy.repo_bundle import ProxyRepoFactory, ProxyRepositories
-from app.modules.usage.additional_quota_keys import canonicalize_additional_quota_key
+from app.modules.usage.additional_quota_keys import (
+    canonicalize_additional_quota_key,
+    get_additional_quota_definition,
+)
 from app.modules.usage.mappers import usage_history_to_window_row
 
 if TYPE_CHECKING:
@@ -553,6 +556,8 @@ class LoadBalancer:
         for account in accounts:
             eligibility = _additional_quota_eligibility(
                 account_id=account.id,
+                account_plan_type=account.plan_type,
+                quota_key=limit_name,
                 latest_primary=latest_primary,
                 latest_secondary=latest_secondary,
                 fresh_primary=fresh_primary,
@@ -1271,6 +1276,8 @@ def _additional_usage_fresh_since(now: datetime | None = None) -> datetime:
 def _additional_quota_eligibility(
     *,
     account_id: str,
+    account_plan_type: str | None,
+    quota_key: str | None,
     latest_primary: dict[str, AdditionalUsageHistory],
     latest_secondary: dict[str, AdditionalUsageHistory],
     fresh_primary: dict[str, AdditionalUsageHistory],
@@ -1280,6 +1287,9 @@ def _additional_quota_eligibility(
     latest_secondary_entry = latest_secondary.get(account_id)
     primary_entry = fresh_primary.get(account_id)
     secondary_entry = fresh_secondary.get(account_id)
+
+    if not _additional_quota_applies_to_plan(quota_key=quota_key, plan_type=account_plan_type):
+        return "eligible"
 
     if latest_primary_entry is None and latest_secondary_entry is None:
         return "data_unavailable"
@@ -1293,6 +1303,14 @@ def _additional_quota_eligibility(
     if secondary_entry is not None and _additional_usage_is_exhausted(secondary_entry):
         return "quota_exhausted"
     return "eligible"
+
+
+def _additional_quota_applies_to_plan(*, quota_key: str | None, plan_type: str | None) -> bool:
+    definition = get_additional_quota_definition(quota_key)
+    if definition is None or definition.applies_to_plans is None:
+        return True
+    normalized_plan = plan_type.strip().lower() if plan_type is not None else None
+    return normalized_plan in definition.applies_to_plans
 
 
 def _additional_usage_is_exhausted(entry: AdditionalUsageHistory) -> bool:

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -62,6 +62,7 @@ _RECOVERABLE_STATUSES = frozenset(
 NO_PLAN_SUPPORT_FOR_MODEL = "no_plan_support_for_model"
 ADDITIONAL_QUOTA_DATA_UNAVAILABLE = "additional_quota_data_unavailable"
 NO_ADDITIONAL_QUOTA_ELIGIBLE_ACCOUNTS = "no_additional_quota_eligible_accounts"
+_ADDITIONAL_QUOTA_EXEMPT_PLAN_TYPES = frozenset({"free", "plus"})
 
 
 @dataclass
@@ -1312,7 +1313,9 @@ def _additional_quota_applies_to_plan(*, quota_key: str | None, plan_type: str |
     normalized_plan = normalize_account_plan_type(plan_type)
     if normalized_plan is None:
         return True
-    return normalized_plan in definition.applies_to_plans
+    if normalized_plan in definition.applies_to_plans:
+        return True
+    return normalized_plan not in _ADDITIONAL_QUOTA_EXEMPT_PLAN_TYPES
 
 
 def _additional_usage_is_exhausted(entry: AdditionalUsageHistory) -> bool:

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -26,7 +26,7 @@ from app.core.balancer import (
 from app.core.balancer.types import UpstreamError
 from app.core.config.settings import get_settings
 from app.core.openai.model_registry import get_model_registry
-from app.core.plan_types import account_plan_matches_allowed
+from app.core.plan_types import account_plan_matches_allowed, normalize_account_plan_type
 from app.core.resilience.circuit_breaker import are_all_account_circuit_breakers_open
 from app.core.resilience.degradation import get_status as get_degradation_status
 from app.core.resilience.degradation import set_degraded, set_normal
@@ -1309,7 +1309,9 @@ def _additional_quota_applies_to_plan(*, quota_key: str | None, plan_type: str |
     definition = get_additional_quota_definition(quota_key)
     if definition is None or definition.applies_to_plans is None:
         return True
-    normalized_plan = plan_type.strip().lower() if plan_type is not None else None
+    normalized_plan = normalize_account_plan_type(plan_type)
+    if normalized_plan is None:
+        return True
     return normalized_plan in definition.applies_to_plans
 
 

--- a/app/modules/usage/additional_quota_keys.py
+++ b/app/modules/usage/additional_quota_keys.py
@@ -23,6 +23,7 @@ class AdditionalQuotaDefinition:
     quota_key: str
     display_label: str
     model_ids: frozenset[str] = frozenset()
+    applies_to_plans: frozenset[str] | None = None
     quota_key_aliases: frozenset[str] = frozenset()
     limit_name_aliases: frozenset[str] = frozenset()
     metered_feature_aliases: frozenset[str] = frozenset()
@@ -48,6 +49,7 @@ class AdditionalQuotaRegistryEntry(TypedDict, total=False):
     quota_key: str
     display_label: str
     model_ids: list[str]
+    applies_to_plans: list[str]
     quota_key_aliases: list[str]
     limit_name_aliases: list[str]
     metered_feature_aliases: list[str]
@@ -81,6 +83,14 @@ def _definition_from_json(item: AdditionalQuotaRegistryEntry) -> AdditionalQuota
         for normalized in (_normalize_identifier(str(value)) for value in item.get("model_ids", []))
         if normalized is not None
     )
+    raw_applies_to_plans = item.get("applies_to_plans")
+    applies_to_plans = None
+    if raw_applies_to_plans is not None:
+        applies_to_plans = frozenset(
+            normalized
+            for normalized in (_normalize_identifier(str(value)) for value in raw_applies_to_plans)
+            if normalized is not None
+        )
     quota_key_aliases = frozenset(
         normalized
         for normalized in (_normalize_identifier(str(value)) for value in item.get("quota_key_aliases", []))
@@ -100,6 +110,7 @@ def _definition_from_json(item: AdditionalQuotaRegistryEntry) -> AdditionalQuota
         quota_key=quota_key,
         display_label=display_label,
         model_ids=model_ids,
+        applies_to_plans=applies_to_plans,
         quota_key_aliases=quota_key_aliases,
         limit_name_aliases=limit_name_aliases,
         metered_feature_aliases=metered_feature_aliases,

--- a/config/additional_quota_registry.json
+++ b/config/additional_quota_registry.json
@@ -3,6 +3,7 @@
     "quota_key": "codex_spark",
     "display_label": "GPT-5.3-Codex-Spark",
     "model_ids": ["gpt-5.3-codex-spark"],
+    "applies_to_plans": ["pro", "prolite", "team", "business", "enterprise"],
     "limit_name_aliases": ["codex_other", "GPT-5.3-Codex-Spark", "gpt-5.3-codex-spark"],
     "metered_feature_aliases": ["codex_bengalfox"]
   }

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -29,11 +29,11 @@ def _encode_jwt(payload: dict) -> str:
     return f"header.{body}.sig"
 
 
-def _make_auth_json(account_id: str, email: str) -> dict:
+def _make_auth_json(account_id: str, email: str, *, plan_type: str = "plus") -> dict:
     payload = {
         "email": email,
         "chatgpt_account_id": account_id,
-        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+        "https://api.openai.com/auth": {"chatgpt_plan_type": plan_type},
     }
     return {
         "tokens": {
@@ -143,7 +143,7 @@ async def test_proxy_compact_strips_tool_fields_before_upstream(async_client, mo
 async def test_proxy_compact_surfaces_no_additional_quota_eligible_accounts(async_client):
     email = "compact-gated@example.com"
     raw_account_id = "acc_compact_gated"
-    auth_json = _make_auth_json(raw_account_id, email)
+    auth_json = _make_auth_json(raw_account_id, email, plan_type="pro")
     files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
     response = await async_client.post("/api/accounts/import", files=files)
     assert response.status_code == 200

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -26,11 +26,11 @@ def _encode_jwt(payload: dict) -> str:
     return f"header.{body}.sig"
 
 
-def _make_auth_json(account_id: str, email: str) -> dict:
+def _make_auth_json(account_id: str, email: str, *, plan_type: str = "plus") -> dict:
     payload = {
         "email": email,
         "chatgpt_account_id": account_id,
-        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+        "https://api.openai.com/auth": {"chatgpt_plan_type": plan_type},
     }
     return {
         "tokens": {
@@ -172,7 +172,7 @@ async def test_proxy_responses_no_accounts(async_client):
 async def test_proxy_responses_stream_surfaces_additional_quota_data_unavailable(async_client):
     email = "gated-unavailable@example.com"
     raw_account_id = "acc_gated_unavailable"
-    auth_json = _make_auth_json(raw_account_id, email)
+    auth_json = _make_auth_json(raw_account_id, email, plan_type="pro")
     files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
     response = await async_client.post("/api/accounts/import", files=files)
     assert response.status_code == 200

--- a/tests/unit/test_additional_model_limits.py
+++ b/tests/unit/test_additional_model_limits.py
@@ -13,6 +13,7 @@ from app.modules.proxy.additional_model_limits import (
 from app.modules.usage.additional_quota_keys import (
     canonicalize_additional_quota_key,
     clear_additional_quota_registry_cache,
+    get_additional_quota_definition_for_model,
     reload_additional_quota_registry,
 )
 
@@ -26,6 +27,13 @@ def test_get_additional_model_limit_returns_seeded_mapping() -> None:
     assert resolved.model == "gpt-5.3-codex-spark"
     assert resolved.quota_key == "codex_spark"
     assert resolved.display_label == "GPT-5.3-Codex-Spark"
+
+
+def test_seeded_codex_spark_quota_is_plan_applicable() -> None:
+    resolved = get_additional_quota_definition_for_model("gpt-5.3-codex-spark")
+
+    assert resolved is not None
+    assert resolved.applies_to_plans == frozenset({"pro", "prolite", "team", "business", "enterprise"})
 
 
 def test_get_additional_model_limit_normalizes_case_and_whitespace() -> None:

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1157,8 +1157,8 @@ def test_select_account_capacity_weighted_unknown_plan_uses_conservative_fallbac
     assert counts["plus"] > counts["unknown-plan"]
 
 
-@pytest.mark.parametrize("plan_type", ["pro", "prolite", "team", "business", "enterprise", "unknown", None])
-def test_additional_quota_applies_to_quota_enforced_and_unknown_plans(plan_type):
+@pytest.mark.parametrize("plan_type", ["pro", "prolite", "team", "business", "enterprise", "edu", "unknown", None])
+def test_additional_quota_applies_to_quota_enforced_and_unmapped_plans(plan_type):
     assert _additional_quota_applies_to_plan(quota_key="codex_spark", plan_type=plan_type) is True
 
 

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -18,6 +18,7 @@ from app.core.usage.quota import apply_usage_quota
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.proxy.load_balancer import (
     RuntimeState,
+    _additional_quota_applies_to_plan,
     _select_account_preferring_budget_safe,
     _state_above_sticky_budget_threshold,
     _state_from_account,
@@ -1154,6 +1155,16 @@ def test_select_account_capacity_weighted_unknown_plan_uses_conservative_fallbac
     unknown_ratio = counts["unknown-plan"] / n
     assert 0.05 <= unknown_ratio <= 0.25
     assert counts["plus"] > counts["unknown-plan"]
+
+
+@pytest.mark.parametrize("plan_type", ["pro", "prolite", "team", "business", "enterprise", "unknown", None])
+def test_additional_quota_applies_to_quota_enforced_and_unknown_plans(plan_type):
+    assert _additional_quota_applies_to_plan(quota_key="codex_spark", plan_type=plan_type) is True
+
+
+@pytest.mark.parametrize("plan_type", ["free", "plus"])
+def test_additional_quota_does_not_apply_to_known_non_additional_quota_plans(plan_type):
+    assert _additional_quota_applies_to_plan(quota_key="codex_spark", plan_type=plan_type) is False
 
 
 def test_select_account_capacity_weighted_education_alias_uses_edu_capacity():

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -2339,6 +2339,7 @@ async def test_select_account_retries_no_accounts_after_runtime_recovery(monkeyp
 @pytest.mark.asyncio
 async def test_select_account_returns_data_unavailable_error_for_mapped_model(monkeypatch) -> None:
     account = _make_account("acc-gated-stale", "gated-stale@example.com")
+    account.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     primary_entry = UsageHistory(
@@ -2367,7 +2368,7 @@ async def test_select_account_returns_data_unavailable_error_for_mapped_model(mo
 
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_model_registry",
-        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"plus"})),
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"pro"})),
     )
 
     balancer = LoadBalancer(
@@ -2385,8 +2386,48 @@ async def test_select_account_returns_data_unavailable_error_for_mapped_model(mo
 
 
 @pytest.mark.asyncio
+async def test_select_account_allows_plus_plan_without_additional_quota_rows(monkeypatch) -> None:
+    account = _make_account("acc-plus-no-gated-rows", "plus-no-gated-rows@example.com")
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    primary_entry = UsageHistory(
+        id=1,
+        account_id=account.id,
+        recorded_at=now,
+        window="primary",
+        used_percent=5.0,
+        reset_at=now_epoch + 300,
+        window_minutes=5,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(primary={account.id: primary_entry}, secondary={})
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(primary={}, secondary={})
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"plus"})),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+
+    assert selection.account is not None
+    assert selection.account.id == account.id
+    assert selection.error_code is None
+
+
+@pytest.mark.asyncio
 async def test_select_account_returns_data_unavailable_when_secondary_window_is_stale(monkeypatch) -> None:
     account = _make_account("acc-gated-stale-secondary", "gated-stale-secondary@example.com")
+    account.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     primary_entry = UsageHistory(
@@ -2426,7 +2467,7 @@ async def test_select_account_returns_data_unavailable_when_secondary_window_is_
 
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_model_registry",
-        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"plus"})),
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"pro"})),
     )
 
     balancer = LoadBalancer(
@@ -2449,6 +2490,8 @@ async def test_select_account_allows_primary_only_account_when_other_account_has
 ) -> None:
     primary_only_account = _make_account("acc-primary-only", "primary-only@example.com")
     stale_secondary_account = _make_account("acc-stale-secondary", "stale-secondary@example.com")
+    primary_only_account.plan_type = "pro"
+    stale_secondary_account.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     usage_rows = {
@@ -2507,7 +2550,7 @@ async def test_select_account_allows_primary_only_account_when_other_account_has
 
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_model_registry",
-        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"plus"})),
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"pro"})),
     )
 
     balancer = LoadBalancer(
@@ -2528,6 +2571,7 @@ async def test_select_account_allows_primary_only_account_when_other_account_has
 @pytest.mark.asyncio
 async def test_select_account_returns_no_eligible_error_for_mapped_model(monkeypatch) -> None:
     account = _make_account("acc-gated-exhausted", "gated-exhausted@example.com")
+    account.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     primary_entry = UsageHistory(
@@ -2567,7 +2611,7 @@ async def test_select_account_returns_no_eligible_error_for_mapped_model(monkeyp
 
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_model_registry",
-        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"plus"})),
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"pro"})),
     )
 
     balancer = LoadBalancer(
@@ -2587,6 +2631,7 @@ async def test_select_account_returns_no_eligible_error_for_mapped_model(monkeyp
 @pytest.mark.asyncio
 async def test_select_account_additional_limit_filter_does_not_mutate_account_status(monkeypatch) -> None:
     account = _make_account("acc-gated-status-stable", "status-stable@example.com")
+    account.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     primary_entry = UsageHistory(
@@ -2616,7 +2661,7 @@ async def test_select_account_additional_limit_filter_does_not_mutate_account_st
 
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_model_registry",
-        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"plus"})),
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"pro"})),
     )
 
     balancer = LoadBalancer(

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -2425,6 +2425,45 @@ async def test_select_account_allows_plus_plan_without_additional_quota_rows(mon
 
 
 @pytest.mark.asyncio
+async def test_select_account_fails_closed_for_unknown_plan_without_additional_quota_rows(monkeypatch) -> None:
+    account = _make_account("acc-unknown-no-gated-rows", "unknown-no-gated-rows@example.com")
+    account.plan_type = "chatgpt_pro_preview"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    primary_entry = UsageHistory(
+        id=1,
+        account_id=account.id,
+        recorded_at=now,
+        window="primary",
+        used_percent=5.0,
+        reset_at=now_epoch + 300,
+        window_minutes=5,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(primary={account.id: primary_entry}, secondary={})
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(primary={}, secondary={})
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"chatgpt_pro_preview"})),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+
+    assert selection.account is None
+    assert selection.error_code == ADDITIONAL_QUOTA_DATA_UNAVAILABLE
+
+
+@pytest.mark.asyncio
 async def test_select_account_returns_data_unavailable_when_secondary_window_is_stale(monkeypatch) -> None:
     account = _make_account("acc-gated-stale-secondary", "gated-stale-secondary@example.com")
     account.plan_type = "pro"

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -2425,9 +2425,9 @@ async def test_select_account_allows_plus_plan_without_additional_quota_rows(mon
 
 
 @pytest.mark.asyncio
-async def test_select_account_fails_closed_for_unknown_plan_without_additional_quota_rows(monkeypatch) -> None:
-    account = _make_account("acc-unknown-no-gated-rows", "unknown-no-gated-rows@example.com")
-    account.plan_type = "chatgpt_pro_preview"
+async def test_select_account_fails_closed_for_unmapped_plan_without_additional_quota_rows(monkeypatch) -> None:
+    account = _make_account("acc-unmapped-no-gated-rows", "unmapped-no-gated-rows@example.com")
+    account.plan_type = "edu"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     primary_entry = UsageHistory(
@@ -2446,7 +2446,7 @@ async def test_select_account_fails_closed_for_unknown_plan_without_additional_q
 
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_model_registry",
-        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"chatgpt_pro_preview"})),
+        lambda: SimpleNamespace(plan_types_for_model=lambda _model: frozenset({"edu"})),
     )
 
     balancer = LoadBalancer(


### PR DESCRIPTION
## Summary
Revives #513 on a maintainer-owned branch because the original PR head has `maintainerCanModify=false`.

Credit: original implementation by @nguyendkn in #513; this branch rebases and updates that work on current `main`.

- Keeps `codex_spark` in the quota registry, but makes model quota eligibility plan-aware.
- Allows Plus-like plans that do not provide additional quota data while keeping Pro/Team-style accounts fail-closed when their additional quota data is missing or stale.

## Validation
- Focused backend/unit/integration suite passed: 54 passed, 3 skipped
- `uv run ruff check ...` passed
- `uv run ty check ...` passed
- `git diff --check origin/main...HEAD` passed

Revives #513
