### PR TITLE
fix(codex): accept OpenAI-style backend responses requests

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -248,6 +248,7 @@ def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
     explicit_fields = payload.model_fields_set
     return (
         isinstance(payload.input, str)
+        or ("input" in explicit_fields and "instructions" not in explicit_fields)
         or payload.messages is not None
         or "conversation" in explicit_fields
         or "truncation" in explicit_fields

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -246,10 +246,11 @@ def _accepts_event_stream(request: Request) -> bool:
 
 def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
     explicit_fields = payload.model_fields_set
+    if "instructions" in explicit_fields:
+        return payload.messages is not None or "conversation" in explicit_fields or "truncation" in explicit_fields
     return (
         isinstance(payload.input, str)
         or payload.messages is not None
-        or "instructions" not in explicit_fields
         or "conversation" in explicit_fields
         or "truncation" in explicit_fields
     )

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -246,8 +246,6 @@ def _accepts_event_stream(request: Request) -> bool:
 
 def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
     explicit_fields = payload.model_fields_set
-    if "instructions" in explicit_fields:
-        return payload.messages is not None or "conversation" in explicit_fields or "truncation" in explicit_fields
     return (
         isinstance(payload.input, str)
         or payload.messages is not None
@@ -266,7 +264,7 @@ def _is_openai_sdk_request(request: Request, payload: V1ResponsesRequest | None 
         return True
     if payload is None or not _has_openai_responses_shape(payload):
         return False
-    return _accepts_event_stream(request) or isinstance(payload.input, str) or payload.messages is not None
+    return _accepts_event_stream(request) or payload.messages is not None
 
 
 async def _thread_goal_payload_from_request(request: Request) -> dict[str, JsonValue]:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -227,6 +227,14 @@ _IMAGE_ERROR_CODE_STATUS: Final[dict[str, int]] = {
 }
 
 
+def _is_openai_sdk_request(request: Request) -> bool:
+    for header_name in request.headers:
+        if header_name.lower().startswith("x-stainless-"):
+            return True
+    user_agent = request.headers.get("user-agent", "").lower()
+    return "openai" in user_agent
+
+
 async def _thread_goal_payload_from_request(request: Request) -> dict[str, JsonValue]:
     if request.method.upper() == "GET":
         return {key: value for key, value in request.query_params.multi_items()}
@@ -400,23 +408,31 @@ async def wham_agent_identities_jwks(
 )
 async def responses(
     request: Request,
-    payload: ResponsesRequest = Body(...),
+    payload: V1ResponsesRequest = Body(...),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
+    try:
+        responses_payload = payload.to_responses_request()
+        enforce_strict_text_format(responses_payload)
+    except ClientPayloadError as exc:
+        error = openai_client_payload_error(exc)
+        return _logged_error_json_response(request, 400, error)
+    except ValidationError as exc:
+        error = openai_validation_error(exc)
+        return _logged_error_json_response(request, 400, error)
     return await _stream_responses(
         request,
-        payload,
+        responses_payload,
         context,
         api_key,
         codex_session_affinity=True,
         openai_cache_affinity=True,
         prefer_http_bridge=True,
         # The Codex CLI consumes codex.* vendor events and the upstream's
-        # native event ordering (it does not use the OpenAI Python SDK parser);
-        # forward the stream verbatim instead of enforcing the OpenAI SDK
-        # contract that /v1/responses applies.
-        enforce_openai_sdk_contract=False,
+        # native event ordering, while OpenAI SDK clients pointed at this
+        # compatibility route need the same SSE contract enforcement as /v1.
+        enforce_openai_sdk_contract=_is_openai_sdk_request(request),
     )
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -227,12 +227,45 @@ _IMAGE_ERROR_CODE_STATUS: Final[dict[str, int]] = {
 }
 
 
-def _is_openai_sdk_request(request: Request) -> bool:
+_OPENAI_CLIENT_HEADER_NAMES: Final[frozenset[str]] = frozenset(
+    {
+        "openai-organization",
+        "openai-project",
+        "openai-version",
+    }
+)
+
+
+def _accepts_event_stream(request: Request) -> bool:
+    for value in request.headers.getlist("accept"):
+        media_ranges = (part.split(";", 1)[0].strip().lower() for part in value.split(","))
+        if "text/event-stream" in media_ranges:
+            return True
+    return False
+
+
+def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
+    explicit_fields = payload.model_fields_set
+    return (
+        isinstance(payload.input, str)
+        or payload.messages is not None
+        or "instructions" not in explicit_fields
+        or "conversation" in explicit_fields
+        or "truncation" in explicit_fields
+    )
+
+
+def _is_openai_sdk_request(request: Request, payload: V1ResponsesRequest | None = None) -> bool:
     for header_name in request.headers:
-        if header_name.lower().startswith("x-stainless-"):
+        normalized_header = header_name.lower()
+        if normalized_header.startswith("x-stainless-") or normalized_header in _OPENAI_CLIENT_HEADER_NAMES:
             return True
     user_agent = request.headers.get("user-agent", "").lower()
-    return "openai" in user_agent
+    if "openai" in user_agent:
+        return True
+    if payload is None or not _has_openai_responses_shape(payload):
+        return False
+    return _accepts_event_stream(request) or isinstance(payload.input, str) or payload.messages is not None
 
 
 async def _thread_goal_payload_from_request(request: Request) -> dict[str, JsonValue]:
@@ -432,7 +465,7 @@ async def responses(
         # The Codex CLI consumes codex.* vendor events and the upstream's
         # native event ordering, while OpenAI SDK clients pointed at this
         # compatibility route need the same SSE contract enforcement as /v1.
-        enforce_openai_sdk_contract=_is_openai_sdk_request(request),
+        enforce_openai_sdk_contract=_is_openai_sdk_request(request, payload),
     )
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -249,7 +249,6 @@ def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
     return (
         ("input" in explicit_fields and "instructions" not in explicit_fields)
         or payload.messages is not None
-        or "conversation" in explicit_fields
         or "truncation" in explicit_fields
     )
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -238,7 +238,7 @@ def _accepts_event_stream(request: Request) -> bool:
 def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
     explicit_fields = payload.model_fields_set
     return (
-        ("input" in explicit_fields and "instructions" not in explicit_fields)
+        ("input" in explicit_fields and payload.instructions is None)
         or payload.messages is not None
         or "truncation" in explicit_fields
     )

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -437,6 +437,7 @@ async def responses(
     try:
         responses_payload = payload.to_responses_request()
         enforce_strict_text_format(responses_payload)
+        enforce_strict_function_tools_format(responses_payload.tools)
     except ClientPayloadError as exc:
         error = openai_client_payload_error(exc)
         return _logged_error_json_response(request, 400, error)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -227,15 +227,6 @@ _IMAGE_ERROR_CODE_STATUS: Final[dict[str, int]] = {
 }
 
 
-_OPENAI_CLIENT_HEADER_NAMES: Final[frozenset[str]] = frozenset(
-    {
-        "openai-organization",
-        "openai-project",
-        "openai-version",
-    }
-)
-
-
 def _accepts_event_stream(request: Request) -> bool:
     for value in request.headers.getlist("accept"):
         media_ranges = (part.split(";", 1)[0].strip().lower() for part in value.split(","))
@@ -256,7 +247,7 @@ def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
 def _is_openai_sdk_request(request: Request, payload: V1ResponsesRequest | None = None) -> bool:
     for header_name in request.headers:
         normalized_header = header_name.lower()
-        if normalized_header.startswith("x-stainless-") or normalized_header in _OPENAI_CLIENT_HEADER_NAMES:
+        if normalized_header.startswith("x-stainless-"):
             return True
     user_agent = request.headers.get("user-agent", "").lower()
     if "openai" in user_agent:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -247,8 +247,7 @@ def _accepts_event_stream(request: Request) -> bool:
 def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
     explicit_fields = payload.model_fields_set
     return (
-        isinstance(payload.input, str)
-        or ("input" in explicit_fields and "instructions" not in explicit_fields)
+        ("input" in explicit_fields and "instructions" not in explicit_fields)
         or payload.messages is not None
         or "conversation" in explicit_fields
         or "truncation" in explicit_fields

--- a/openspec/changes/accept-openai-style-backend-responses/proposal.md
+++ b/openspec/changes/accept-openai-style-backend-responses/proposal.md
@@ -1,0 +1,17 @@
+# Accept OpenAI-Style Backend Responses Requests
+
+## Why
+
+Clients that reuse a Codex CLI `base_url` such as `/backend-api/codex` with an OpenAI Responses SDK send `POST /responses` payloads where `instructions` is optional and `input` may be a plain string. The public `/v1/responses` route already accepts this shape, but `/backend-api/codex/responses` still requires the stricter Codex-native request shape, making OpenAI-compatible HTTP clients fail before they can consume the SSE Responses stream.
+
+## What Changes
+
+- Normalize `/backend-api/codex/responses` request bodies through the same OpenAI-compatible Responses request adapter used by `/v1/responses`.
+- Keep the route streaming SSE Responses events and preserve existing Codex-native fields such as `instructions`, `session_id` headers, and Codex affinity behavior.
+- Add regression coverage with the OpenAI Python SDK against `/backend-api/codex`.
+
+## Impact
+
+- Allows OpenAI-compatible Responses clients to use either `/v1` or `/backend-api/codex` as their base URL.
+- Reduces friction for clients that mirror Codex CLI provider configuration.
+- Does not change the WebSocket `/responses` contract.

--- a/openspec/changes/accept-openai-style-backend-responses/specs/responses-api-compat/spec.md
+++ b/openspec/changes/accept-openai-style-backend-responses/specs/responses-api-compat/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Backend Responses endpoint accepts OpenAI-compatible request shapes
+The `/backend-api/codex/responses` HTTP endpoint SHALL accept the OpenAI-compatible Responses request shape used by `/v1/responses`, including a plain string `input` and omitted `instructions`. The endpoint MUST normalize that request into the internal Responses request model before forwarding upstream, MUST continue returning `text/event-stream` SSE Responses events, and MUST preserve Codex-specific session/cache affinity behavior for the backend route.
+
+#### Scenario: OpenAI SDK streams through backend Responses path
+- **WHEN** an OpenAI-compatible client sends `POST /backend-api/codex/responses` with `stream=true`, a model, and a plain string `input`
+- **THEN** the proxy accepts the request without requiring `instructions`
+- **AND** the response is a `text/event-stream` stream containing Responses events such as `response.output_text.delta` and `response.completed`
+
+#### Scenario: Codex-private stream metadata is hidden from OpenAI SDK clients
+- **WHEN** upstream emits a Codex-private stream event such as `codex.rate_limits` before `response.created`
+- **THEN** the HTTP Responses stream omits the private event from the downstream SSE body
+- **AND** OpenAI SDK clients can consume the stream without failing their Responses event ordering checks
+
+#### Scenario: Codex-native backend Responses shape is preserved
+- **WHEN** a Codex client sends `POST /backend-api/codex/responses` with `instructions`, array-shaped `input`, and Codex affinity headers
+- **THEN** the proxy preserves the normalized request content and continues applying backend Codex session affinity

--- a/openspec/changes/accept-openai-style-backend-responses/specs/responses-api-compat/spec.md
+++ b/openspec/changes/accept-openai-style-backend-responses/specs/responses-api-compat/spec.md
@@ -1,7 +1,7 @@
 ## MODIFIED Requirements
 
 ### Requirement: Backend Responses endpoint accepts OpenAI-compatible request shapes
-The `/backend-api/codex/responses` HTTP endpoint SHALL accept the OpenAI-compatible Responses request shape used by `/v1/responses`, including a plain string `input` and omitted `instructions`. The endpoint MUST normalize that request into the internal Responses request model before forwarding upstream, MUST continue returning `text/event-stream` SSE Responses events, and MUST preserve Codex-specific session/cache affinity behavior for the backend route.
+The `/backend-api/codex/responses` HTTP endpoint SHALL accept the OpenAI-compatible Responses request shape used by `/v1/responses`, including a plain string `input` and omitted or explicit `null` `instructions`. The endpoint MUST normalize that request into the internal Responses request model before forwarding upstream, MUST continue returning `text/event-stream` SSE Responses events, and MUST preserve Codex-specific session/cache affinity behavior for the backend route.
 
 #### Scenario: OpenAI SDK streams through backend Responses path
 - **WHEN** an OpenAI-compatible client sends `POST /backend-api/codex/responses` with `stream=true`, a model, and a plain string `input`

--- a/openspec/changes/accept-openai-style-backend-responses/specs/responses-api-compat/spec.md
+++ b/openspec/changes/accept-openai-style-backend-responses/specs/responses-api-compat/spec.md
@@ -13,6 +13,10 @@ The `/backend-api/codex/responses` HTTP endpoint SHALL accept the OpenAI-compati
 - **THEN** the HTTP Responses stream omits the private event from the downstream SSE body
 - **AND** OpenAI SDK clients can consume the stream without failing their Responses event ordering checks
 
+#### Scenario: Strict function tool schemas are validated before streaming
+- **WHEN** an OpenAI-compatible client sends `POST /backend-api/codex/responses` with a strict function tool schema that violates the supported JSON Schema subset
+- **THEN** the proxy rejects the request with a deterministic 400 `invalid_function_parameters` error before opening the stream
+
 #### Scenario: Codex-native backend Responses shape is preserved
 - **WHEN** a Codex client sends `POST /backend-api/codex/responses` with `instructions`, array-shaped `input`, and Codex affinity headers
 - **THEN** the proxy preserves the normalized request content and continues applying backend Codex session affinity

--- a/openspec/changes/accept-openai-style-backend-responses/tasks.md
+++ b/openspec/changes/accept-openai-style-backend-responses/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+- [x] 1.1 Route `/backend-api/codex/responses` through OpenAI-compatible request normalization.
+- [x] 1.2 Preserve existing SSE streaming, Codex session affinity, and HTTP bridge behavior.
+
+## 2. Verification
+
+- [x] 2.1 Add regression coverage for OpenAI SDK streaming against `/backend-api/codex`.
+- [x] 2.2 Update backend Responses validation coverage for optional `instructions`.
+- [x] 2.3 Run focused pytest and lint.
+- [ ] 2.4 Validate OpenSpec once the OpenSpec CLI is available in the workspace.

--- a/openspec/changes/accept-openai-style-backend-responses/tasks.md
+++ b/openspec/changes/accept-openai-style-backend-responses/tasks.md
@@ -8,4 +8,4 @@
 - [x] 2.1 Add regression coverage for OpenAI SDK streaming against `/backend-api/codex`.
 - [x] 2.2 Update backend Responses validation coverage for optional `instructions`.
 - [x] 2.3 Run focused pytest and lint.
-- [ ] 2.4 Validate OpenSpec once the OpenSpec CLI is available in the workspace.
+- [x] 2.4 Validate OpenSpec once the OpenSpec CLI is available in the workspace.

--- a/tests/integration/test_openai_client_compat.py
+++ b/tests/integration/test_openai_client_compat.py
@@ -61,6 +61,58 @@ async def test_openai_client_responses_create(app_instance, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_openai_client_responses_stream_backend_codex_base_url(app_instance, monkeypatch):
+    seen: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del headers, access_token, account_id, base_url, raise_for_status, kwargs
+        seen["instructions"] = payload.instructions
+        seen["input"] = payload.input
+        yield (
+            'data: {"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":1}},'
+            '"response":{"id":"resp_backend_sdk"}}\n\n'
+        )
+        yield (
+            'data: {"type":"response.created","response":{"id":"resp_backend_sdk","object":"response",'
+            '"status":"in_progress","output":[]}}\n\n'
+        )
+        yield 'data: {"type":"response.output_text.delta","delta":"OK"}\n\n'
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_backend_sdk","object":"response",'
+            '"status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    transport = ASGITransport(app=app_instance)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as admin_client:
+        auth_json = _make_auth_json("acc_openai_backend_resp", "openai-backend-resp@example.com")
+        files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+        response = await admin_client.post("/api/accounts/import", files=files)
+        assert response.status_code == 200
+
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver/backend-api/codex",
+    ) as http_client:
+        client = openai.AsyncOpenAI(
+            api_key="test",
+            base_url="http://testserver/backend-api/codex",
+            http_client=http_client,
+        )
+        stream = await client.responses.create(model="gpt-5.5", input="hi", stream=True)
+        events = [event async for event in stream]
+
+    assert [event.type for event in events] == [
+        "response.created",
+        "response.output_text.delta",
+        "response.completed",
+    ]
+    assert seen["instructions"] == ""
+    assert seen["input"] == [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+
+
+@pytest.mark.asyncio
 async def test_openai_client_chat_completions_create(app_instance, monkeypatch):
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         yield 'data: {"type":"response.output_text.delta","delta":"hi"}\n\n'

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -188,11 +188,22 @@ async def test_proxy_responses_stream_surfaces_additional_quota_data_unavailable
 
 
 @pytest.mark.asyncio
-async def test_proxy_responses_requires_instructions(async_client):
-    payload = {"model": "gpt-5.1", "input": []}
-    resp = await async_client.post("/backend-api/codex/responses", json=payload)
+async def test_proxy_responses_accepts_openai_style_payload_without_instructions(async_client):
+    payload = {"model": "gpt-5.1", "input": "hi", "stream": True}
+    request_id = "req_backend_openai_style_123"
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"x-request-id": request_id},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
 
-    assert resp.status_code == 400
+    event = _extract_first_event(lines)
+    assert event["type"] == "response.failed"
+    assert event["response"]["id"] == request_id
+    assert event["response"]["error"]["code"] == "no_accounts"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -207,6 +207,36 @@ async def test_proxy_responses_accepts_openai_style_payload_without_instructions
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_rejects_strict_function_tool_violation(async_client):
+    payload = {
+        "model": "gpt-5.2",
+        "input": [{"role": "user", "content": "Weather in Seoul?"}],
+        "tools": [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "x",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+                "strict": True,
+            }
+        ],
+        "stream": True,
+    }
+    resp = await async_client.post("/backend-api/codex/responses", json=payload)
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_function_parameters"
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["param"] == "tools[0].parameters"
+    assert "get_weather" in body["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_openai_shape_custom_client_gets_sdk_sse_contract(async_client, monkeypatch):
     email = "backend-openai-shape@example.com"
     raw_account_id = "acc_backend_openai_shape"

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -279,6 +279,43 @@ async def test_proxy_responses_instructionless_array_input_gets_sdk_sse_contract
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_native_string_input_with_instructions_preserves_vendor_events(
+    async_client,
+    monkeypatch,
+):
+    email = "backend-native-string@example.com"
+    raw_account_id = "acc_backend_native_string"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield 'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+        yield (
+            'data: {"type":"response.completed","sequence_number":1,'
+            '"response":{"id":"resp_native_string","object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": "hello", "stream": True}
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"accept": "text/event-stream", "user-agent": "codex-cli/1.0"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event_types = [event["type"] for event in _iter_sse_events(lines)]
+    assert event_types[0] == "codex.rate_limits"
+    assert "response.created" not in event_types
+    assert "response.completed" in event_types
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_native_codex_shape_preserves_vendor_events(async_client, monkeypatch):
     email = "backend-native-codex@example.com"
     raw_account_id = "acc_backend_native_codex"

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -316,6 +316,46 @@ async def test_proxy_responses_native_string_input_with_instructions_preserves_v
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_native_conversation_preserves_vendor_events(async_client, monkeypatch):
+    email = "backend-native-conversation@example.com"
+    raw_account_id = "acc_backend_native_conversation"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield 'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+        yield (
+            'data: {"type":"response.completed","sequence_number":1,'
+            '"response":{"id":"resp_native_conversation","object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {
+        "model": "gpt-5.1",
+        "conversation": "conv_native_continuation",
+        "instructions": "continue",
+        "input": "hello",
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"accept": "text/event-stream", "user-agent": "custom-client/1.0"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event_types = [event["type"] for event in _iter_sse_events(lines)]
+    assert event_types[0] == "codex.rate_limits"
+    assert "response.created" not in event_types
+    assert "response.completed" in event_types
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_native_codex_shape_preserves_vendor_events(async_client, monkeypatch):
     email = "backend-native-codex@example.com"
     raw_account_id = "acc_backend_native_codex"

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -356,6 +356,46 @@ async def test_proxy_responses_native_conversation_preserves_vendor_events(async
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_native_openai_routing_headers_preserve_vendor_events(async_client, monkeypatch):
+    email = "backend-native-openai-headers@example.com"
+    raw_account_id = "acc_backend_native_openai_headers"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield 'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+        yield (
+            'data: {"type":"response.completed","sequence_number":1,'
+            '"response":{"id":"resp_native_openai_headers","object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": "hello", "stream": True}
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={
+            "accept": "text/event-stream",
+            "openai-organization": "org_native_route",
+            "openai-project": "proj_native_route",
+            "openai-version": "2020-10-01",
+            "user-agent": "custom-client/1.0",
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event_types = [event["type"] for event in _iter_sse_events(lines)]
+    assert event_types[0] == "codex.rate_limits"
+    assert "response.created" not in event_types
+    assert "response.completed" in event_types
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_native_codex_shape_preserves_vendor_events(async_client, monkeypatch):
     email = "backend-native-codex@example.com"
     raw_account_id = "acc_backend_native_codex"

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -207,6 +207,79 @@ async def test_proxy_responses_accepts_openai_style_payload_without_instructions
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_openai_shape_custom_client_gets_sdk_sse_contract(async_client, monkeypatch):
+    email = "backend-openai-shape@example.com"
+    raw_account_id = "acc_backend_openai_shape"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield 'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+        yield (
+            'data: {"type":"response.completed","sequence_number":1,'
+            '"response":{"id":"resp_custom_client","object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "input": "hi", "stream": True}
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"accept": "text/event-stream", "user-agent": "custom-client/1.0"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event_types = [event["type"] for event in _iter_sse_events(lines)]
+    assert event_types[0] == "response.created"
+    assert "codex.rate_limits" not in event_types
+    assert "response.completed" in event_types
+
+
+@pytest.mark.asyncio
+async def test_proxy_responses_native_codex_shape_preserves_vendor_events(async_client, monkeypatch):
+    email = "backend-native-codex@example.com"
+    raw_account_id = "acc_backend_native_codex"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield 'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+        yield (
+            'data: {"type":"response.completed","sequence_number":1,'
+            '"response":{"id":"resp_native_codex","object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"accept": "text/event-stream", "user-agent": "codex-cli/1.0"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event_types = [event["type"] for event in _iter_sse_events(lines)]
+    assert event_types[0] == "codex.rate_limits"
+    assert "response.created" not in event_types
+    assert "response.completed" in event_types
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_routes(async_client):
     payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
     request_id = "req_v1_stream_123"

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -241,6 +241,44 @@ async def test_proxy_responses_openai_shape_custom_client_gets_sdk_sse_contract(
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_instructionless_array_input_gets_sdk_sse_contract(async_client, monkeypatch):
+    email = "backend-openai-array@example.com"
+    raw_account_id = "acc_backend_openai_array"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield 'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+        yield (
+            'data: {"type":"response.completed","sequence_number":1,'
+            '"response":{"id":"resp_openai_array","object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {
+        "model": "gpt-5.1",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"accept": "text/event-stream", "user-agent": "custom-client/1.0"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event_types = [event["type"] for event in _iter_sse_events(lines)]
+    assert event_types[0] == "response.created"
+    assert "codex.rate_limits" not in event_types
+    assert "response.completed" in event_types
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_native_codex_shape_preserves_vendor_events(async_client, monkeypatch):
     email = "backend-native-codex@example.com"
     raw_account_id = "acc_backend_native_codex"

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -241,6 +241,41 @@ async def test_proxy_responses_openai_shape_custom_client_gets_sdk_sse_contract(
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_null_instructions_gets_sdk_sse_contract(async_client, monkeypatch):
+    email = "backend-openai-null-instructions@example.com"
+    raw_account_id = "acc_backend_openai_null_instructions"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        assert payload.instructions == ""
+        yield 'data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n'
+        yield (
+            'data: {"type":"response.completed","sequence_number":1,'
+            '"response":{"id":"resp_null_instructions","object":"response","status":"completed","output":[]}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": None, "input": "hi", "stream": True}
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"accept": "text/event-stream", "user-agent": "custom-client/1.0"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event_types = [event["type"] for event in _iter_sse_events(lines)]
+    assert event_types[0] == "response.created"
+    assert "codex.rate_limits" not in event_types
+    assert "response.completed" in event_types
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_instructionless_array_input_gets_sdk_sse_contract(async_client, monkeypatch):
     email = "backend-openai-array@example.com"
     raw_account_id = "acc_backend_openai_array"


### PR DESCRIPTION
## Summary
Revives #593 on a maintainer-owned branch because the original PR head has `maintainerCanModify=false`.

Credit: original implementation by @Mrhaizi in #593; this branch rebases and updates that work on current `main`.

- Keeps OpenAI-style `/backend-api/codex/responses` request parsing.
- Resolves the current-main streaming conflict so OpenAI SDK callers get SDK-safe SSE normalization while normal Codex CLI backend callers keep native `codex.*` events.

## Validation
- `ruff check app/modules/proxy/api.py tests/integration/test_openai_client_compat.py tests/integration/test_proxy_responses.py` passed
- `uv run --frozen ty check app/modules/proxy/api.py tests/integration/test_openai_client_compat.py tests/integration/test_proxy_responses.py` passed
- `uv run --frozen pytest ...` focused selection passed: 3 passed

## OpenSpec
- `accept-openai-style-backend-responses` remains included and updated.

Revives #593

