### PR TITLE
fix(codex desktop): restore backend responses compatibility

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -99,7 +99,6 @@ from app.modules.proxy.request_policy import (
     enforce_strict_text_format,
     normalize_responses_request_payload,
     openai_client_payload_error,
-    openai_invalid_payload_error,
     openai_validation_error,
     validate_model_access,
 )
@@ -455,7 +454,7 @@ async def responses(
             codex_tool_compat=True,
         )
     except ClientPayloadError as exc:
-        error = openai_invalid_payload_error(exc.param)
+        error = openai_client_payload_error(exc)
         return _logged_error_json_response(request, 400, error)
     except ValidationError as exc:
         error = openai_validation_error(exc)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -451,7 +451,7 @@ async def responses(
     try:
         responses_payload = normalize_responses_request_payload(
             payload,
-            openai_compat=True,
+            openai_compat=False,
             codex_tool_compat=True,
         )
     except ClientPayloadError as exc:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -198,7 +198,7 @@ _UNAVAILABLE_SELECTION_ERROR_CODES = {
 _STREAM_STARTUP_ERROR_PROBE_SECONDS = 0.05
 # Keep bridge startup probing above tiny event-loop scheduling jitter:
 # PostgreSQL-backed failures may need a DB round trip before the first item.
-_HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS = 0.5
+_HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS = 2.0
 _V1_MAX_OUTPUT_TOKEN_OVERRIDES: Final[dict[str, int]] = {
     "gpt-5.4": 128_000,
     "gpt-5.5": 128_000,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -97,7 +97,9 @@ from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     enforce_strict_function_tools_format,
     enforce_strict_text_format,
+    normalize_responses_request_payload,
     openai_client_payload_error,
+    openai_invalid_payload_error,
     openai_validation_error,
     validate_model_access,
 )
@@ -235,7 +237,14 @@ def _accepts_event_stream(request: Request) -> bool:
     return False
 
 
-def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
+def _has_openai_responses_shape(payload: V1ResponsesRequest | Mapping[str, JsonValue]) -> bool:
+    if isinstance(payload, Mapping):
+        return (
+            ("input" in payload and payload.get("instructions") is None)
+            or payload.get("messages") is not None
+            or "truncation" in payload
+        )
+
     explicit_fields = payload.model_fields_set
     return (
         ("input" in explicit_fields and payload.instructions is None)
@@ -244,7 +253,10 @@ def _has_openai_responses_shape(payload: V1ResponsesRequest) -> bool:
     )
 
 
-def _is_openai_sdk_request(request: Request, payload: V1ResponsesRequest | None = None) -> bool:
+def _is_openai_sdk_request(
+    request: Request,
+    payload: V1ResponsesRequest | Mapping[str, JsonValue] | None = None,
+) -> bool:
     for header_name in request.headers:
         normalized_header = header_name.lower()
         if normalized_header.startswith("x-stainless-"):
@@ -254,6 +266,8 @@ def _is_openai_sdk_request(request: Request, payload: V1ResponsesRequest | None 
         return True
     if payload is None or not _has_openai_responses_shape(payload):
         return False
+    if isinstance(payload, Mapping):
+        return _accepts_event_stream(request) or payload.get("messages") is not None
     return _accepts_event_stream(request) or payload.messages is not None
 
 
@@ -430,20 +444,23 @@ async def wham_agent_identities_jwks(
 )
 async def responses(
     request: Request,
-    payload: V1ResponsesRequest = Body(...),
+    payload: dict[str, JsonValue] = Body(...),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
     try:
-        responses_payload = payload.to_responses_request()
-        enforce_strict_text_format(responses_payload)
-        enforce_strict_function_tools_format(responses_payload.tools)
+        responses_payload = normalize_responses_request_payload(
+            payload,
+            openai_compat=True,
+            codex_tool_compat=True,
+        )
     except ClientPayloadError as exc:
-        error = openai_client_payload_error(exc)
+        error = openai_invalid_payload_error(exc.param)
         return _logged_error_json_response(request, 400, error)
     except ValidationError as exc:
         error = openai_validation_error(exc)
         return _logged_error_json_response(request, 400, error)
+
     return await _stream_responses(
         request,
         responses_payload,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -238,10 +238,11 @@ def _accepts_event_stream(request: Request) -> bool:
 
 def _has_openai_responses_shape(payload: V1ResponsesRequest | Mapping[str, JsonValue]) -> bool:
     if isinstance(payload, Mapping):
+        payload_dict = cast("Mapping[str, JsonValue]", payload)
         return (
-            ("input" in payload and payload.get("instructions") is None)
-            or payload.get("messages") is not None
-            or "truncation" in payload
+            ("input" in payload_dict and payload_dict.get("instructions") is None)
+            or payload_dict.get("messages") is not None
+            or "truncation" in payload_dict
         )
 
     explicit_fields = payload.model_fields_set
@@ -266,7 +267,8 @@ def _is_openai_sdk_request(
     if payload is None or not _has_openai_responses_shape(payload):
         return False
     if isinstance(payload, Mapping):
-        return _accepts_event_stream(request) or payload.get("messages") is not None
+        payload_dict = cast("Mapping[str, JsonValue]", payload)
+        return _accepts_event_stream(request) or payload_dict.get("messages") is not None
     return _accepts_event_stream(request) or payload.messages is not None
 
 
@@ -447,10 +449,12 @@ async def responses(
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
+    openai_sdk_request = _is_openai_sdk_request(request, payload)
+    openai_compat_payload = _has_openai_responses_shape(payload)
     try:
         responses_payload = normalize_responses_request_payload(
             payload,
-            openai_compat=False,
+            openai_compat=openai_compat_payload,
             codex_tool_compat=True,
         )
     except ClientPayloadError as exc:
@@ -471,7 +475,7 @@ async def responses(
         # The Codex CLI consumes codex.* vendor events and the upstream's
         # native event ordering, while OpenAI SDK clients pointed at this
         # compatibility route need the same SSE contract enforcement as /v1.
-        enforce_openai_sdk_contract=_is_openai_sdk_request(request, payload),
+        enforce_openai_sdk_contract=openai_sdk_request,
     )
 
 

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -15,6 +15,7 @@ from app.core.openai.strict_schema import (
 )
 from app.core.openai.v1_requests import V1ResponsesRequest
 from app.core.types import JsonValue
+from app.core.utils.json_guards import is_json_list, is_json_mapping
 from app.core.utils.request_id import get_request_id
 from app.modules.api_keys.service import ApiKeyData
 
@@ -212,14 +213,37 @@ def normalize_responses_request_payload(
     payload: dict[str, JsonValue],
     *,
     openai_compat: bool,
+    codex_tool_compat: bool = False,
 ) -> ResponsesRequest:
+    effective_payload = _sanitize_backend_codex_tool_advertisements(payload) if codex_tool_compat else payload
     if openai_compat:
-        responses = V1ResponsesRequest.model_validate(payload).to_responses_request()
+        responses = V1ResponsesRequest.model_validate(effective_payload).to_responses_request()
     else:
-        responses = ResponsesRequest.model_validate(payload)
+        responses = ResponsesRequest.model_validate(effective_payload)
     enforce_strict_text_format(responses)
     enforce_strict_function_tools_format(responses.tools)
     return responses
+
+
+def _sanitize_backend_codex_tool_advertisements(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    tools_value = payload.get("tools")
+    if not is_json_list(tools_value):
+        return payload
+
+    sanitized_tools: list[JsonValue] = []
+    removed_any = False
+    for tool in tools_value:
+        if is_json_mapping(tool) and tool.get("type") == "image_generation":
+            removed_any = True
+            continue
+        sanitized_tools.append(tool)
+
+    if not removed_any:
+        return payload
+
+    sanitized_payload = dict(payload)
+    sanitized_payload["tools"] = sanitized_tools
+    return sanitized_payload
 
 
 def enforce_strict_text_format(request: ResponsesRequest) -> None:

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -249,6 +249,8 @@ def _sanitize_backend_codex_tool_advertisements(payload: dict[str, JsonValue]) -
 
 
 def _explicitly_requests_image_generation(tool_choice: JsonValue | None) -> bool:
+    if tool_choice == "required":
+        return True
     return is_json_mapping(tool_choice) and tool_choice.get("type") == "image_generation"
 
 

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -229,6 +229,8 @@ def _sanitize_backend_codex_tool_advertisements(payload: dict[str, JsonValue]) -
     tools_value = payload.get("tools")
     if not is_json_list(tools_value):
         return payload
+    if _explicitly_requests_image_generation(payload.get("tool_choice")):
+        return payload
 
     sanitized_tools: list[JsonValue] = []
     removed_any = False
@@ -244,6 +246,10 @@ def _sanitize_backend_codex_tool_advertisements(payload: dict[str, JsonValue]) -
     sanitized_payload = dict(payload)
     sanitized_payload["tools"] = sanitized_tools
     return sanitized_payload
+
+
+def _explicitly_requests_image_generation(tool_choice: JsonValue | None) -> bool:
+    return is_json_mapping(tool_choice) and tool_choice.get("type") == "image_generation"
 
 
 def enforce_strict_text_format(request: ResponsesRequest) -> None:

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -229,7 +229,7 @@ def _sanitize_backend_codex_tool_advertisements(payload: dict[str, JsonValue]) -
     tools_value = payload.get("tools")
     if not is_json_list(tools_value):
         return payload
-    if _explicitly_requests_image_generation(payload.get("tool_choice")):
+    if _explicitly_requests_image_generation(payload.get("tool_choice"), tools_value):
         return payload
 
     sanitized_tools: list[JsonValue] = []
@@ -248,9 +248,9 @@ def _sanitize_backend_codex_tool_advertisements(payload: dict[str, JsonValue]) -
     return sanitized_payload
 
 
-def _explicitly_requests_image_generation(tool_choice: JsonValue | None) -> bool:
+def _explicitly_requests_image_generation(tool_choice: JsonValue | None, tools: list[JsonValue]) -> bool:
     if tool_choice == "required":
-        return True
+        return all(is_json_mapping(tool) and tool.get("type") == "image_generation" for tool in tools)
     return is_json_mapping(tool_choice) and tool_choice.get("type") == "image_generation"
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1542,6 +1542,8 @@ class ProxyService:
                                 )
                             )
                             break
+                        if propagate_http_errors and request_state.response_id is None:
+                            continue
                         keepalive_sent = True
                         yielded_any = True
                         if request_state.response_id:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3748,7 +3748,11 @@ class ProxyService:
     ) -> _PreparedWebSocketRequest:
         refreshed_api_key = await self._refresh_websocket_api_key_policy(api_key)
         client_metadata = _response_create_client_metadata(payload, headers=headers)
-        responses_payload = normalize_responses_request_payload(payload, openai_compat=openai_cache_affinity)
+        responses_payload = normalize_responses_request_payload(
+            payload,
+            openai_compat=openai_cache_affinity,
+            codex_tool_compat=codex_session_affinity,
+        )
         previous_response_trimmed_input_count: int | None = None
         previous_response_trimmed_input_fingerprint: str | None = None
         client_full_resend_payload: ResponsesRequest | None = None

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/.openspec.yaml
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/design.md
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Current Codex Desktop/CLI builds advertise a top-level `image_generation` tool
+on backend Codex Responses requests. codex-lb routes those payloads through the
+same shared Responses tool validator used by public `/v1/*` compatibility
+surfaces, and that validator intentionally rejects `image_generation`. The
+result is a backend Codex compatibility failure before the request reaches
+upstream, even though codex-lb does not need to interpret that tool locally to
+proxy the turn.
+
+The relevant request paths are split across HTTP and websocket entry points, but
+both converge on shared request normalization before upstream forwarding.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Restore compatibility with current Codex clients on
+  `/backend-api/codex/responses`.
+- Keep the change narrow to backend Codex routes.
+- Preserve the existing unsupported built-in tool policy for public `/v1/*`
+  compatibility routes.
+- Add regression coverage for both backend Codex HTTP and websocket request
+  handling.
+
+**Non-Goals:**
+
+- Broadly enabling `image_generation` as a supported built-in tool for all
+  OpenAI-compatible routes.
+- Implementing local image-generation semantics inside codex-lb.
+- Changing chat-completions tool validation behavior.
+
+## Decisions
+
+### Sanitize backend Codex payloads before shared validation
+
+Backend Codex HTTP requests and websocket `response.create` payloads will strip
+top-level `tools` entries whose `type` is `image_generation` before they pass
+through shared `ResponsesRequest` / `V1ResponsesRequest` validation.
+
+Rationale:
+
+- This is the smallest fix that unblocks current Codex clients.
+- It avoids changing the shared unsupported-tool policy that public `/v1/*`
+  routes depend on.
+- It preserves other tool entries exactly as they are today.
+
+Alternative considered:
+
+- Remove `image_generation` from the global unsupported-tool list. Rejected
+  because it would silently broaden `/v1/*` behavior and change the public
+  compatibility contract.
+
+### Keep sanitization scoped to backend Codex routes
+
+The sanitization hook will run only for `/backend-api/codex/responses` request
+handling, including websocket `response.create` payload preparation.
+
+Rationale:
+
+- The compatibility issue is specific to Codex clients.
+- Public OpenAI-style routes should keep their existing validation behavior.
+
+Alternative considered:
+
+- Add special handling inside the shared validator itself. Rejected because the
+  validator does not know which external route or client surface triggered the
+  request.
+
+## Risks / Trade-offs
+
+- [Upstream begins requiring the advertised tool descriptor for Codex image
+  flows] -> Keep the sanitization isolated so it can be revised or removed
+  without disturbing `/v1/*` compatibility behavior.
+- [Future Codex clients advertise additional ambient built-in tools] -> Cover
+  this change with focused regression tests and revisit the backend Codex
+  sanitization allowlist if new incompatibilities appear.
+- [Sanitization drifts between HTTP and websocket paths] -> Centralize the
+  backend Codex tool filtering in shared normalization logic and cover both
+  transports in tests.

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/design.md
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/design.md
@@ -1,12 +1,12 @@
 ## Context
 
 Current Codex Desktop/CLI builds advertise a top-level `image_generation` tool
-on backend Codex Responses requests. codex-lb routes those payloads through the
-same shared Responses tool validator used by public `/v1/*` compatibility
-surfaces, and that validator intentionally rejects `image_generation`. The
-result is a backend Codex compatibility failure before the request reaches
-upstream, even though codex-lb does not need to interpret that tool locally to
-proxy the turn.
+on backend Codex Responses requests even when the turn is not explicitly asking
+for image generation. codex-lb does not need that ambient advertisement to proxy
+the turn, and preserving it on the backend Codex path can couple normal Codex
+turns to upstream image-tool acceptance. Public `/v1/*` Responses compatibility
+already has a separate built-in-tool forwarding contract; this change keeps that
+contract unchanged.
 
 The relevant request paths are split across HTTP and websocket entry points, but
 both converge on shared request normalization before upstream forwarding.
@@ -18,15 +18,14 @@ both converge on shared request normalization before upstream forwarding.
 - Restore compatibility with current Codex clients on
   `/backend-api/codex/responses`.
 - Keep the change narrow to backend Codex routes.
-- Preserve the existing unsupported built-in tool policy for public `/v1/*`
+- Preserve the existing built-in tool forwarding policy for public `/v1/*`
   compatibility routes.
 - Add regression coverage for both backend Codex HTTP and websocket request
   handling.
 
 **Non-Goals:**
 
-- Broadly enabling `image_generation` as a supported built-in tool for all
-  OpenAI-compatible routes.
+- Changing public `/v1/*` built-in tool validation or forwarding behavior.
 - Implementing local image-generation semantics inside codex-lb.
 - Changing chat-completions tool validation behavior.
 
@@ -41,15 +40,14 @@ through shared `ResponsesRequest` / `V1ResponsesRequest` validation.
 Rationale:
 
 - This is the smallest fix that unblocks current Codex clients.
-- It avoids changing the shared unsupported-tool policy that public `/v1/*`
-  routes depend on.
+- It avoids changing the public `/v1/*` built-in tool forwarding policy.
 - It preserves other tool entries exactly as they are today.
 
 Alternative considered:
 
-- Remove `image_generation` from the global unsupported-tool list. Rejected
-  because it would silently broaden `/v1/*` behavior and change the public
-  compatibility contract.
+- Handle ambient Codex `image_generation` advertisements in shared request
+  validation. Rejected because the validator does not know whether a payload
+  came from the backend Codex route or a public OpenAI-compatible route.
 
 ### Keep sanitization scoped to backend Codex routes
 
@@ -59,7 +57,8 @@ handling, including websocket `response.create` payload preparation.
 Rationale:
 
 - The compatibility issue is specific to Codex clients.
-- Public OpenAI-style routes should keep their existing validation behavior.
+- Public OpenAI-style routes should keep their existing validation and
+  forwarding behavior.
 
 Alternative considered:
 

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/proposal.md
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Current Codex app/CLI builds advertise a top-level `image_generation` tool on
+`/backend-api/codex/responses` requests even when the turn is not actively
+using image generation. codex-lb currently runs those backend Codex payloads
+through the shared Responses tool validator, which rejects `image_generation`
+and returns `Invalid request payload` with `param: "tools"` before the request
+can reach upstream.
+
+## What Changes
+
+- Accept backend Codex Responses requests that include a top-level
+  `image_generation` tool advertisement.
+- Strip only that advertised top-level `image_generation` tool before shared
+  validation and upstream forwarding on `/backend-api/codex/responses` HTTP and
+  websocket paths.
+- Preserve the existing unsupported built-in tool policy for public `/v1/*`
+  routes and for other unsupported tool types.
+- Add regression coverage for backend Codex HTTP and websocket request shapes
+  emitted by current Codex clients.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: backend Codex Responses routes tolerate the client's
+  advertised `image_generation` tool without broadening public OpenAI-style
+  tool acceptance.
+
+## Impact
+
+- Code: `app/modules/proxy/request_policy.py`, `app/modules/proxy/service.py`,
+  and any shared request-normalization helpers needed to sanitize backend Codex
+  tool advertisements before validation.
+- Tests: backend Codex HTTP/websocket proxy regression coverage and targeted
+  request-normalization unit tests.
+- Client compatibility: current Codex app/CLI payloads continue to work against
+  codex-lb without relaxing `/v1/responses` validation semantics.

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/proposal.md
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/proposal.md
@@ -2,10 +2,10 @@
 
 Current Codex app/CLI builds advertise a top-level `image_generation` tool on
 `/backend-api/codex/responses` requests even when the turn is not actively
-using image generation. codex-lb currently runs those backend Codex payloads
-through the shared Responses tool validator, which rejects `image_generation`
-and returns `Invalid request payload` with `param: "tools"` before the request
-can reach upstream.
+using image generation. The backend Codex route does not need that ambient tool
+descriptor to proxy the turn, and forwarding it can make backend Responses
+compatibility depend on an upstream tool policy that is unrelated to the user's
+request.
 
 ## What Changes
 
@@ -14,8 +14,8 @@ can reach upstream.
 - Strip only that advertised top-level `image_generation` tool before shared
   validation and upstream forwarding on `/backend-api/codex/responses` HTTP and
   websocket paths.
-- Preserve the existing unsupported built-in tool policy for public `/v1/*`
-  routes and for other unsupported tool types.
+- Preserve the existing public `/v1/*` built-in tool forwarding policy and all
+  validation behavior for other tool types.
 - Add regression coverage for backend Codex HTTP and websocket request shapes
   emitted by current Codex clients.
 
@@ -28,8 +28,8 @@ None.
 ### Modified Capabilities
 
 - `responses-api-compat`: backend Codex Responses routes tolerate the client's
-  advertised `image_generation` tool without broadening public OpenAI-style
-  tool acceptance.
+  ambient `image_generation` tool advertisement without changing public
+  OpenAI-style tool handling.
 
 ## Impact
 
@@ -39,4 +39,4 @@ None.
 - Tests: backend Codex HTTP/websocket proxy regression coverage and targeted
   request-normalization unit tests.
 - Client compatibility: current Codex app/CLI payloads continue to work against
-  codex-lb without relaxing `/v1/responses` validation semantics.
+  codex-lb without changing `/v1/responses` validation or forwarding semantics.

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/specs/responses-api-compat/spec.md
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/specs/responses-api-compat/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Backend Codex Responses tolerate advertised image_generation tools
+The service MUST accept HTTP and websocket `/backend-api/codex/responses`
+request-create payloads that include top-level `tools` entries with
+`type: "image_generation"`. Before shared Responses validation and upstream
+forwarding, the service MUST remove only those advertised top-level
+`image_generation` tool entries while preserving all other tool entries and the
+existing unsupported built-in tool policy for public `/v1/*` routes.
+
+#### Scenario: Backend Codex HTTP request strips advertised image_generation tool
+- **WHEN** a client sends `POST /backend-api/codex/responses` with
+  `tools=[{"type":"image_generation"},{"type":"function","name":"x"}]`
+- **THEN** the request is accepted instead of failing with
+  `invalid_request_error`
+- **AND** the upstream Responses payload omits the `image_generation` tool
+- **AND** the remaining `function` tool is preserved
+
+#### Scenario: Backend Codex websocket create strips advertised image_generation tool
+- **WHEN** a websocket `response.create` payload for
+  `/backend-api/codex/responses` includes a top-level
+  `{"type":"image_generation"}` tool entry
+- **THEN** the backend Codex websocket request is accepted
+- **AND** the forwarded upstream `response.create` payload omits that
+  `image_generation` tool entry
+
+#### Scenario: Public v1 Responses still reject image_generation
+- **WHEN** a client sends `/v1/responses` with
+  `tools=[{"type":"image_generation"}]`
+- **THEN** the service returns a 4xx `invalid_request_error`
+- **AND** the error identifies `tools` as the invalid parameter

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/specs/responses-api-compat/spec.md
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/specs/responses-api-compat/spec.md
@@ -6,7 +6,7 @@ request-create payloads that include top-level `tools` entries with
 `type: "image_generation"`. Before shared Responses validation and upstream
 forwarding, the service MUST remove only those advertised top-level
 `image_generation` tool entries while preserving all other tool entries and the
-existing unsupported built-in tool policy for public `/v1/*` routes.
+existing built-in tool forwarding policy for public `/v1/*` routes.
 
 #### Scenario: Backend Codex HTTP request strips advertised image_generation tool
 - **WHEN** a client sends `POST /backend-api/codex/responses` with
@@ -24,8 +24,9 @@ existing unsupported built-in tool policy for public `/v1/*` routes.
 - **AND** the forwarded upstream `response.create` payload omits that
   `image_generation` tool entry
 
-#### Scenario: Public v1 Responses still reject image_generation
+#### Scenario: Public v1 Responses built-in forwarding policy remains unchanged
 - **WHEN** a client sends `/v1/responses` with
   `tools=[{"type":"image_generation"}]`
-- **THEN** the service returns a 4xx `invalid_request_error`
-- **AND** the error identifies `tools` as the invalid parameter
+- **THEN** the service does not locally reject the built-in tool as an
+  `invalid_request_error`
+- **AND** the upstream Responses payload preserves the `image_generation` tool

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/tasks.md
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/tasks.md
@@ -1,0 +1,14 @@
+## 1. Backend Codex request normalization
+
+- [x] 1.1 Add backend Codex-specific tool sanitization for HTTP and websocket `/backend-api/codex/responses` request-create payloads so top-level `image_generation` advertisements are removed before shared validation
+- [x] 1.2 Keep shared unsupported built-in validation unchanged for public `/v1/*` routes and other unsupported tool types
+
+## 2. Regression coverage
+
+- [x] 2.1 Add backend Codex websocket coverage proving `response.create` accepts an advertised `image_generation` tool while preserving other tools
+- [x] 2.2 Add backend Codex HTTP coverage proving the same payload shape is accepted, and retain explicit coverage that `/v1/responses` still rejects `image_generation`
+
+## 3. Verification
+
+- [x] 3.1 Run targeted unit and integration tests for request normalization and backend Codex responses routes
+- [x] 3.2 Run `openspec validate --specs`

--- a/openspec/changes/accept-codex-image-generation-tool-advertisement/tasks.md
+++ b/openspec/changes/accept-codex-image-generation-tool-advertisement/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Backend Codex request normalization
 
 - [x] 1.1 Add backend Codex-specific tool sanitization for HTTP and websocket `/backend-api/codex/responses` request-create payloads so top-level `image_generation` advertisements are removed before shared validation
-- [x] 1.2 Keep shared unsupported built-in validation unchanged for public `/v1/*` routes and other unsupported tool types
+- [x] 1.2 Keep public `/v1/*` built-in tool forwarding behavior and other tool validation unchanged
 
 ## 2. Regression coverage
 
 - [x] 2.1 Add backend Codex websocket coverage proving `response.create` accepts an advertised `image_generation` tool while preserving other tools
-- [x] 2.2 Add backend Codex HTTP coverage proving the same payload shape is accepted, and retain explicit coverage that `/v1/responses` still rejects `image_generation`
+- [x] 2.2 Add backend Codex HTTP coverage proving the same payload shape is accepted, and retain explicit coverage that `/v1/responses` preserves `image_generation` for upstream forwarding
 
 ## 3. Verification
 

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -379,6 +379,29 @@ async def test_v1_responses_allows_web_search(async_client, monkeypatch, tool_ty
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_preserves_image_generation_builtin_tool(async_client, monkeypatch):
+    await _import_account(async_client, "acc_v1_image_gen", "v1-image-gen@example.com")
+
+    seen = {}
+    image_tool = {"type": "image_generation", "output_format": "png"}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen["payload"] = payload
+        yield _completed_event("resp_v1_image_generation")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.2",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "Draw?"}]}],
+        "tools": [image_tool],
+    }
+    resp = await async_client.post("/v1/responses", json=request_payload)
+    assert resp.status_code == 200
+    assert seen["payload"].tools == [image_tool]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("tool_type", ["web_search", "web_search_preview"])
 async def test_backend_responses_allows_web_search(async_client, monkeypatch, tool_type):
     await _import_account(async_client, "acc_backend_web_search", "backend-web-search@example.com")

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -403,6 +403,34 @@ async def test_backend_responses_allows_web_search(async_client, monkeypatch, to
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_strip_image_generation_tool_advertisement(async_client, monkeypatch):
+    await _import_account(async_client, "acc_backend_image_gen", "backend-image-gen@example.com")
+
+    seen = {}
+    function_tool = {
+        "type": "function",
+        "name": "lookup_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    }
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen["payload"] = payload
+        yield _completed_event("resp_backend_image_generation")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.2",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "Weather?"}]}],
+        "tools": [{"type": "image_generation", "output_format": "png"}, function_tool],
+    }
+    resp = await async_client.post("/backend-api/codex/responses", json=request_payload)
+    assert resp.status_code == 200
+    assert seen["payload"].tools == [function_tool]
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_rejects_non_text_developer(async_client):
     payload = {
         "model": "gpt-5.2",

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -431,6 +431,33 @@ async def test_backend_responses_strip_image_generation_tool_advertisement(async
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_preserve_explicit_image_generation_tool_choice(async_client, monkeypatch):
+    await _import_account(async_client, "acc_backend_explicit_image_gen", "backend-explicit-image-gen@example.com")
+
+    seen = {}
+    image_tool = {"type": "image_generation", "output_format": "png"}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen["payload"] = payload
+        yield _completed_event("resp_backend_explicit_image_generation")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.2",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "Draw?"}]}],
+        "tools": [image_tool],
+        "tool_choice": {"type": "image_generation"},
+    }
+    resp = await async_client.post("/backend-api/codex/responses", json=request_payload)
+
+    assert resp.status_code == 200
+    assert seen["payload"].tools == [image_tool]
+    assert seen["payload"].tool_choice == {"type": "image_generation"}
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_rejects_non_text_developer(async_client):
     payload = {
         "model": "gpt-5.2",

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -458,6 +458,33 @@ async def test_backend_responses_preserve_explicit_image_generation_tool_choice(
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_preserve_required_image_generation_tool_choice(async_client, monkeypatch):
+    await _import_account(async_client, "acc_backend_required_image_gen", "backend-required-image-gen@example.com")
+
+    seen = {}
+    image_tool = {"type": "image_generation", "output_format": "png"}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen["payload"] = payload
+        yield _completed_event("resp_backend_required_image_generation")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.2",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "Draw?"}]}],
+        "tools": [image_tool],
+        "tool_choice": "required",
+    }
+    resp = await async_client.post("/backend-api/codex/responses", json=request_payload)
+
+    assert resp.status_code == 200
+    assert seen["payload"].tools == [image_tool]
+    assert seen["payload"].tool_choice == "required"
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_rejects_non_text_developer(async_client):
     payload = {
         "model": "gpt-5.2",

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -699,6 +699,35 @@ async def test_v1_responses_rejects_strict_function_tool_violation(async_client)
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_rejects_strict_schema_violation_with_specific_error(async_client):
+    """Backend /responses must preserve strict-validator error code and message."""
+    payload = {
+        "model": "gpt-5.2",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "Return JSON."}]}],
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "result_schema",
+                "strict": True,
+                "schema": {
+                    "type": "object",
+                    "properties": {"ok": {"type": "boolean"}},
+                    "required": ["ok"],
+                },
+            }
+        },
+    }
+    resp = await async_client.post("/backend-api/codex/responses", json=payload)
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["code"] == "invalid_json_schema"
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["param"] == "text.format.schema"
+    assert "additionalProperties" in body["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_rejects_missing_json_schema(async_client):
     payload = {
         "model": "gpt-5.2",

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -261,7 +261,6 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     assert log["input_tokens"] == 3
     assert log["output_tokens"] == 5
 
-
 def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
     app_instance,
     monkeypatch,
@@ -413,6 +412,123 @@ def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
     assert terminal_event["response"]["id"] == "resp_ws_duplicate_tool"
     assert len(log_calls) == 1
     assert log_calls[0]["status"] == "success"
+
+
+def test_backend_responses_websocket_strips_image_generation_tool_advertisement(app_instance, monkeypatch):
+    upstream_messages = [
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp_ws_tools", "object": "response", "status": "in_progress"},
+                },
+                separators=(",", ":"),
+            ),
+        ),
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_tools",
+                        "object": "response",
+                        "status": "completed",
+                        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ),
+    ]
+    fake_upstream = _FakeUpstreamWebSocket(upstream_messages)
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None):
+        assert authorization == "Bearer external-token"
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return SimpleNamespace(id="acct_ws_proxy"), fake_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    function_tool = {
+        "type": "function",
+        "name": "lookup_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    }
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "tools": [{"type": "image_generation", "output_format": "png"}, function_tool],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={"Authorization": "Bearer external-token"},
+        ) as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            first = json.loads(websocket.receive_text())
+            second = json.loads(websocket.receive_text())
+
+    assert first["type"] == "response.created"
+    assert second["type"] == "response.completed"
+    assert [json.loads(message) for message in fake_upstream.sent_text] == [
+        {
+            "model": "gpt-5.4",
+            "instructions": "",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+            "tools": [function_tool],
+            "store": False,
+            "include": [],
+            "type": "response.create",
+        }
+    ]
 
 
 def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app_instance, monkeypatch):

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -261,6 +261,7 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     assert log["input_tokens"] == 3
     assert log["output_tokens"] == 5
 
+
 def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
     app_instance,
     monkeypatch,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -493,6 +493,33 @@ def test_normalize_responses_request_payload_preserves_required_image_generation
     assert request.tool_choice == "required"
 
 
+def test_normalize_responses_request_payload_strips_required_image_generation_advertisement_with_function_tool():
+    image_tool = {"type": "image_generation", "output_format": "png"}
+    function_tool = {
+        "type": "function",
+        "name": "lookup",
+        "description": "Lookup",
+        "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+        "strict": True,
+    }
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [],
+        "tools": [image_tool, function_tool],
+        "tool_choice": "required",
+    }
+
+    request = proxy_request_policy.normalize_responses_request_payload(
+        payload,
+        openai_compat=True,
+        codex_tool_compat=True,
+    )
+
+    assert request.tools == [function_tool]
+    assert request.tool_choice == "required"
+
+
 class _RingMembershipStub:
     def __init__(self, members: list[str]) -> None:
         self.members = members

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -453,6 +453,26 @@ def test_normalize_responses_request_payload_without_codex_compat_preserves_imag
     assert request.tools == [{"type": "image_generation", "output_format": "png"}]
 
 
+def test_normalize_responses_request_payload_preserves_explicit_image_generation_choice():
+    image_tool = {"type": "image_generation", "output_format": "png"}
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [],
+        "tools": [image_tool],
+        "tool_choice": {"type": "image_generation"},
+    }
+
+    request = proxy_request_policy.normalize_responses_request_payload(
+        payload,
+        openai_compat=True,
+        codex_tool_compat=True,
+    )
+
+    assert request.tools == [image_tool]
+    assert request.tool_choice == {"type": "image_generation"}
+
+
 class _RingMembershipStub:
     def __init__(self, members: list[str]) -> None:
         self.members = members

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -231,7 +231,6 @@ def test_apply_api_key_enforcement_overrides_service_tier_aliases_to_priority():
 
     assert payload.service_tier == "priority"
 
-
 def _service_tier_enforcement_key(enforced: str) -> proxy_service.ApiKeyData:
     return proxy_service.ApiKeyData(
         id="key_default",
@@ -411,6 +410,46 @@ def test_apply_api_key_enforcement_normalizes_minimal_without_api_key():
 
     assert payload.reasoning is not None
     assert payload.reasoning.effort == "low"
+
+
+def test_normalize_responses_request_payload_strips_backend_codex_image_generation_tools():
+    function_tool = {
+        "type": "function",
+        "name": "lookup_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    }
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [],
+        "tools": [{"type": "image_generation", "output_format": "png"}, function_tool],
+    }
+
+    request = proxy_request_policy.normalize_responses_request_payload(
+        payload,
+        openai_compat=True,
+        codex_tool_compat=True,
+    )
+
+    assert request.tools == [function_tool]
+    assert payload["tools"] == [{"type": "image_generation", "output_format": "png"}, function_tool]
+
+
+def test_normalize_responses_request_payload_without_codex_compat_preserves_image_generation():
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [],
+        "tools": [{"type": "image_generation", "output_format": "png"}],
+    }
+
+    request = proxy_request_policy.normalize_responses_request_payload(
+        payload,
+        openai_compat=True,
+        codex_tool_compat=False,
+    )
+
+    assert request.tools == [{"type": "image_generation", "output_format": "png"}]
 
 
 class _RingMembershipStub:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -473,6 +473,26 @@ def test_normalize_responses_request_payload_preserves_explicit_image_generation
     assert request.tool_choice == {"type": "image_generation"}
 
 
+def test_normalize_responses_request_payload_preserves_required_image_generation_choice():
+    image_tool = {"type": "image_generation", "output_format": "png"}
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [],
+        "tools": [image_tool],
+        "tool_choice": "required",
+    }
+
+    request = proxy_request_policy.normalize_responses_request_payload(
+        payload,
+        openai_compat=True,
+        codex_tool_compat=True,
+    )
+
+    assert request.tools == [image_tool]
+    assert request.tool_choice == "required"
+
+
 class _RingMembershipStub:
     def __init__(self, members: list[str]) -> None:
         self.members = members

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -231,6 +231,7 @@ def test_apply_api_key_enforcement_overrides_service_tier_aliases_to_priority():
 
     assert payload.service_tier == "priority"
 
+
 def _service_tier_enforcement_key(enforced: str) -> proxy_service.ApiKeyData:
     return proxy_service.ApiKeyData(
         id="key_default",


### PR DESCRIPTION
## Summary
Revives #439 on a maintainer-owned branch because the original PR head has `maintainerCanModify=false`.

Credit: original implementation by @ihazgithub in #439; this branch rebases and updates that work on current `main`.

- Restores `/backend-api/codex/responses` compatibility for backend responses callers.
- Allows `image_generation` tool advertisement on the backend responses path while preserving strict backend HTTP responses validation.

## Validation
- Focused `uv run pytest ...` selection passed: 4 passed
- `uv run ruff check ...` passed
- `uv run ty check ...` passed

## OpenSpec
- `accept-codex-image-generation-tool-advertisement` remains included and updated.

Revives #439
