### PR TITLE
fix(usage): ignore stale usage after account reset

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -162,6 +162,7 @@ def select_account(
         if state.status == AccountStatus.RATE_LIMITED:
             if state.reset_at and current >= state.reset_at:
                 state.status = AccountStatus.ACTIVE
+                state.used_percent = 0.0
                 state.error_count = 0
                 state.reset_at = None
             else:
@@ -170,6 +171,7 @@ def select_account(
             if state.reset_at and current >= state.reset_at:
                 state.status = AccountStatus.ACTIVE
                 state.used_percent = 0.0
+                state.secondary_used_percent = 0.0
                 state.reset_at = None
             else:
                 continue

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1044,6 +1044,20 @@ def _state_from_account(
     secondary_used = effective_secondary_entry.used_percent if effective_secondary_entry else None
     secondary_reset = effective_secondary_entry.reset_at if effective_secondary_entry else None
 
+    # If the usage window has reset (reset_at is in the past) but the last
+    # recorded sample still shows 100 % usage, the data is stale.  Zero it
+    # out so the account is not incorrectly blocked or deprioritised while
+    # waiting for the next usage refresh to fetch fresh numbers.
+    now_epoch = int(time.time())
+    if primary_used is not None and primary_used >= 100.0:
+        if primary_reset is not None and primary_reset <= now_epoch:
+            primary_used = 0.0
+            primary_reset = None
+    if secondary_used is not None and secondary_used >= 100.0:
+        if secondary_reset is not None and secondary_reset <= now_epoch:
+            secondary_used = 0.0
+            secondary_reset = None
+
     # Use account.reset_at from DB as the authoritative source for runtime reset
     # and to survive process restarts.
     db_reset_at = float(account.reset_at) if account.reset_at else None

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -748,10 +748,20 @@ def _latest_usage_is_fresh(
     now: datetime,
     interval_seconds: int,
 ) -> bool:
-    return latest is not None and (now - latest.recorded_at).total_seconds() < interval_seconds
+    if latest is None:
+        return False
+    if (now - latest.recorded_at).total_seconds() >= interval_seconds:
+        return False
+    if latest.reset_at is not None:
+        now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+        if now_epoch >= latest.reset_at:
+            return False
+    return True
 
 
 def _quota_recovery_should_bypass_freshness(account: Account, *, latest: UsageHistory | None) -> bool:
+    if _account_needs_post_reset_refresh(account):
+        return True
     if account.status != AccountStatus.QUOTA_EXCEEDED:
         return False
     if account.blocked_at is None:
@@ -765,6 +775,14 @@ def _quota_recovery_should_bypass_freshness(account: Account, *, latest: UsageHi
     if recorded_at.tzinfo is None:
         recorded_at = recorded_at.replace(tzinfo=timezone.utc)
     return recorded_at.timestamp() < cooldown_expires_at
+
+
+def _account_needs_post_reset_refresh(account: Account) -> bool:
+    if account.status not in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED):
+        return False
+    if account.reset_at is None:
+        return False
+    return time.time() >= account.reset_at
 
 
 def _parse_credits_balance(value: str | int | float | None) -> float | None:

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -760,7 +760,7 @@ def _latest_usage_is_fresh(
 
 
 def _quota_recovery_should_bypass_freshness(account: Account, *, latest: UsageHistory | None) -> bool:
-    if _account_needs_post_reset_refresh(account):
+    if _account_needs_post_reset_refresh(account, latest=latest):
         return True
     if account.status != AccountStatus.QUOTA_EXCEEDED:
         return False
@@ -777,12 +777,19 @@ def _quota_recovery_should_bypass_freshness(account: Account, *, latest: UsageHi
     return recorded_at.timestamp() < cooldown_expires_at
 
 
-def _account_needs_post_reset_refresh(account: Account) -> bool:
+def _account_needs_post_reset_refresh(account: Account, *, latest: UsageHistory | None) -> bool:
     if account.status not in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED):
         return False
     if account.reset_at is None:
         return False
-    return time.time() >= account.reset_at
+    if time.time() < account.reset_at:
+        return False
+    if latest is None:
+        return True
+    recorded_at = latest.recorded_at
+    if recorded_at.tzinfo is None:
+        recorded_at = recorded_at.replace(tzinfo=timezone.utc)
+    return recorded_at.timestamp() < float(account.reset_at)
 
 
 def _parse_credits_balance(value: str | int | float | None) -> float | None:

--- a/openspec/changes/fix-stale-post-reset-usage/proposal.md
+++ b/openspec/changes/fix-stale-post-reset-usage/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+Accounts can stay deprioritised or blocked after an upstream quota/rate-limit window has already reset when codex-lb still has a fresh-looking usage row from the previous window. The freshness gate should not trust rows whose `reset_at` is already in the past, and blocked accounts with an expired persisted reset deadline need one immediate post-reset usage fetch even if the latest primary row is still within the normal refresh interval.
+
+## What Changes
+
+- Treat latest usage rows with past `reset_at` values as stale.
+- Bypass the normal freshness interval for `RATE_LIMITED` and `QUOTA_EXCEEDED` accounts whose persisted reset deadline has elapsed.
+- Clear stale exhausted usage percentages when account selection observes an expired reset deadline, so selection does not keep ranking the account as exhausted while waiting for the next refresh.
+
+## Impact
+
+- Accounts become eligible for recovery promptly after their real upstream reset deadline.
+- Normal freshness throttling still applies to active accounts and blocked accounts whose reset time is still in the future.

--- a/openspec/changes/fix-stale-post-reset-usage/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/fix-stale-post-reset-usage/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Usage refresh does not trust elapsed reset windows
+
+Background usage refresh MUST treat a latest usage row as stale when that row's `reset_at` timestamp is in the past, even when the row's `recorded_at` timestamp is still within the normal refresh interval.
+
+#### Scenario: Past reset_at bypasses freshness
+
+- **GIVEN** the latest usage row was recorded within the normal refresh interval
+- **AND** that row's `reset_at` timestamp has already elapsed
+- **WHEN** background usage refresh evaluates the account
+- **THEN** the row is treated as stale
+- **AND** codex-lb attempts a fresh upstream usage fetch
+
+### Requirement: Blocked accounts refresh once their reset deadline elapses
+
+When an account is `RATE_LIMITED` or `QUOTA_EXCEEDED` and its persisted `reset_at` timestamp has elapsed, background usage refresh MUST bypass the normal freshness interval so the account can recover from the upstream post-reset state. The bypass MUST NOT apply before the persisted reset deadline elapses.
+
+#### Scenario: Quota-exceeded account with fresh primary row reaches reset deadline
+
+- **GIVEN** an account is marked `QUOTA_EXCEEDED`
+- **AND** the account's persisted `reset_at` timestamp has elapsed
+- **AND** the latest primary usage row is still within the normal refresh interval
+- **WHEN** background usage refresh evaluates the account
+- **THEN** codex-lb performs an upstream usage fetch instead of waiting for the primary row to age out
+
+#### Scenario: Rate-limited account reaches reset deadline
+
+- **GIVEN** an account is marked `RATE_LIMITED`
+- **AND** the account's persisted `reset_at` timestamp has elapsed
+- **WHEN** background usage refresh evaluates the account
+- **THEN** codex-lb performs an upstream usage fetch instead of waiting for the normal refresh interval

--- a/openspec/changes/fix-stale-post-reset-usage/tasks.md
+++ b/openspec/changes/fix-stale-post-reset-usage/tasks.md
@@ -1,0 +1,4 @@
+- [x] Treat usage rows whose reset window has elapsed as stale for refresh freshness checks.
+- [x] Force one post-reset usage refresh for rate-limited and quota-exceeded accounts.
+- [x] Clear stale exhausted usage percentages during selection after an elapsed reset.
+- [x] Add regression coverage for rate-limit reset, quota reset with a fresh primary row, and selection from stale exhausted rows.

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -401,6 +401,42 @@ def test_apply_usage_quota_resets_to_active_if_runtime_reset_expired(monkeypatch
     assert reset_at is None
 
 
+def test_select_account_resets_used_percent_when_rate_limit_expires():
+    now = 1_700_000_000.0
+    state = AccountState(
+        "a",
+        AccountStatus.RATE_LIMITED,
+        used_percent=100.0,
+        reset_at=now - 10,
+    )
+
+    result = select_account([state], now=now)
+
+    assert result.account is not None
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent == 0.0
+    assert state.reset_at is None
+
+
+def test_select_account_resets_secondary_used_percent_when_quota_exceeded_expires():
+    now = 1_700_000_000.0
+    state = AccountState(
+        "a",
+        AccountStatus.QUOTA_EXCEEDED,
+        used_percent=100.0,
+        secondary_used_percent=100.0,
+        reset_at=now - 10,
+    )
+
+    result = select_account([state], now=now)
+
+    assert result.account is not None
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent == 0.0
+    assert state.secondary_used_percent == 0.0
+    assert state.reset_at is None
+
+
 def test_apply_usage_quota_clears_quota_exceeded_when_runtime_reset_is_none(monkeypatch):
     now = 1_700_000_000.0
     monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
@@ -505,6 +541,48 @@ def _epoch_to_naive_utc(epoch: float) -> datetime:
     from datetime import timezone
 
     return datetime.fromtimestamp(epoch, timezone.utc).replace(tzinfo=None)
+
+
+def test_state_from_account_zeroes_stale_exhausted_primary_usage_after_reset(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE),
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=100.0,
+            reset_at=int(now - 10),
+            recorded_at=_epoch_to_naive_utc(now - 30),
+        ),
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    assert state.used_percent == 0.0
+    assert state.reset_at is None
+
+
+def test_state_from_account_zeroes_stale_exhausted_secondary_usage_after_reset(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE),
+        primary_entry=None,
+        secondary_entry=_make_test_usage(
+            window="secondary",
+            used_percent=100.0,
+            reset_at=int(now - 10),
+            recorded_at=_epoch_to_naive_utc(now - 30),
+        ),
+        runtime=RuntimeState(),
+    )
+
+    assert state.secondary_used_percent == 0.0
+    assert state.secondary_reset_at is None
 
 
 def test_state_from_account_recovers_quota_exceeded_on_restart_without_blocked_at_when_usage_shows_new_reset_window(

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -2255,3 +2255,129 @@ async def test_additional_rate_limits_no_credits_passed(monkeypatch) -> None:
     assert not hasattr(entry, "credits_has")
     assert not hasattr(entry, "credits_unlimited")
     assert not hasattr(entry, "credits_balance")
+
+
+def test_latest_usage_is_fresh_returns_false_when_reset_at_has_passed() -> None:
+    now = datetime(2024, 6, 1, 12, 0, 30)
+    reset_epoch = int(datetime(2024, 6, 1, 12, 0, 25, tzinfo=timezone.utc).timestamp())
+    entry = UsageHistory(
+        id=1,
+        account_id="a",
+        used_percent=100.0,
+        recorded_at=datetime(2024, 6, 1, 12, 0, 20),
+        window="primary",
+        reset_at=reset_epoch,
+        window_minutes=300,
+    )
+
+    assert usage_updater_module._latest_usage_is_fresh(entry, now=now, interval_seconds=60) is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_accounts_forces_fetch_after_rate_limit_reset_despite_fresh_usage(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+    from app.core.utils.time import utcnow
+
+    get_settings.cache_clear()
+    now_epoch = 1_700_000_000
+    monkeypatch.setattr("app.modules.usage.updater.time.time", lambda: now_epoch)
+
+    fetch_calls = 0
+
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 5.0,
+                        "reset_at": now_epoch + 3600,
+                        "limit_window_seconds": 3600,
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository()
+    await usage_repo.add_entry(
+        "acc_reset",
+        100.0,
+        recorded_at=utcnow(),
+        window="primary",
+        reset_at=now_epoch - 1,
+        window_minutes=60,
+    )
+    latest = await usage_repo.latest_entry_for_account("acc_reset", window="primary")
+    assert latest is not None
+
+    acc = _make_account("acc_reset", "workspace_reset", email="reset@example.com")
+    acc.status = AccountStatus.RATE_LIMITED
+    acc.reset_at = now_epoch - 1
+
+    updater = UsageUpdater(usage_repo, accounts_repo=None)
+    await updater.refresh_accounts([acc], latest_usage={"acc_reset": latest})
+
+    assert fetch_calls == 1
+    assert usage_repo.entries[-1].used_percent == 5.0
+
+
+@pytest.mark.asyncio
+async def test_refresh_accounts_forces_fetch_after_quota_reset_despite_fresh_primary_usage(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+    from app.core.utils.time import utcnow
+
+    get_settings.cache_clear()
+    now_epoch = 1_700_000_000
+    monkeypatch.setattr("app.modules.usage.updater.time.time", lambda: now_epoch)
+
+    fetch_calls = 0
+
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 10.0,
+                        "reset_at": now_epoch + 3600,
+                        "limit_window_seconds": 3600,
+                    },
+                    "secondary_window": {
+                        "used_percent": 15.0,
+                        "reset_at": now_epoch + 7 * 24 * 3600,
+                        "limit_window_seconds": 7 * 24 * 3600,
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository()
+    await usage_repo.add_entry(
+        "acc_quota_reset",
+        50.0,
+        recorded_at=utcnow(),
+        window="primary",
+        reset_at=now_epoch + 3600,
+        window_minutes=60,
+    )
+    latest = await usage_repo.latest_entry_for_account("acc_quota_reset", window="primary")
+    assert latest is not None
+
+    acc = _make_account("acc_quota_reset", "workspace_quota_reset", email="quota-reset@example.com")
+    acc.status = AccountStatus.QUOTA_EXCEEDED
+    acc.reset_at = now_epoch - 1
+
+    updater = UsageUpdater(usage_repo, accounts_repo=None)
+    await updater.refresh_accounts([acc], latest_usage={"acc_quota_reset": latest})
+
+    assert fetch_calls == 1
+    assert usage_repo.entries[-2].used_percent == 10.0
+    assert usage_repo.entries[-1].used_percent == 15.0

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -2326,6 +2326,40 @@ async def test_refresh_accounts_forces_fetch_after_rate_limit_reset_despite_fres
 
 
 @pytest.mark.asyncio
+async def test_refresh_accounts_does_not_repeat_post_reset_rate_limit_probe(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_INTERVAL_SECONDS", "3600")
+    from app.core.config.settings import get_settings
+    from app.core.utils.time import utcnow
+
+    get_settings.cache_clear()
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    monkeypatch.setattr("app.modules.usage.updater.time.time", lambda: now_epoch)
+
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        raise AssertionError("post-reset rate-limit probe should not repeat while usage is fresh")
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    latest = UsageHistory(
+        id=1,
+        account_id="acc_rate_limited_post_reset",
+        used_percent=5.0,
+        recorded_at=now,
+        window="primary",
+        reset_at=now_epoch + 3600,
+        window_minutes=60,
+    )
+    acc = _make_account("acc_rate_limited_post_reset", "workspace_rate_limited_post_reset")
+    acc.status = AccountStatus.RATE_LIMITED
+    acc.reset_at = now_epoch - 1
+
+    updater = UsageUpdater(StubUsageRepository(), accounts_repo=None)
+    await updater.refresh_accounts([acc], latest_usage={acc.id: latest})
+
+
+@pytest.mark.asyncio
 async def test_refresh_accounts_forces_fetch_after_quota_reset_despite_fresh_primary_usage(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings
@@ -2381,3 +2415,37 @@ async def test_refresh_accounts_forces_fetch_after_quota_reset_despite_fresh_pri
     assert fetch_calls == 1
     assert usage_repo.entries[-2].used_percent == 10.0
     assert usage_repo.entries[-1].used_percent == 15.0
+
+
+@pytest.mark.asyncio
+async def test_refresh_accounts_does_not_repeat_post_reset_quota_probe(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_INTERVAL_SECONDS", "3600")
+    from app.core.config.settings import get_settings
+    from app.core.utils.time import utcnow
+
+    get_settings.cache_clear()
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    monkeypatch.setattr("app.modules.usage.updater.time.time", lambda: now_epoch)
+
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        raise AssertionError("post-reset quota probe should not repeat while usage is fresh")
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    latest = UsageHistory(
+        id=1,
+        account_id="acc_quota_post_reset",
+        used_percent=10.0,
+        recorded_at=now,
+        window="primary",
+        reset_at=now_epoch + 3600,
+        window_minutes=60,
+    )
+    acc = _make_account("acc_quota_post_reset", "workspace_quota_post_reset")
+    acc.status = AccountStatus.QUOTA_EXCEEDED
+    acc.reset_at = now_epoch - 1
+
+    updater = UsageUpdater(StubUsageRepository(), accounts_repo=None)
+    await updater.refresh_accounts([acc], latest_usage={acc.id: latest})


### PR DESCRIPTION
## Summary
Revives #272 on a maintainer-owned branch because the original PR head has `maintainerCanModify=false`.

Credit: original implementation by @XavLimSG in #272; this branch rebases and updates that work on current `main`.

- Fixes backend stale-usage-after-reset handling so reset accounts are not selected using old usage snapshots.
- Adds OpenSpec coverage for the reset freshness behavior and keeps adjacent load-balancer/account selection tests current.

## Validation
- `.venv/bin/ruff check ...` passed
- `.venv/bin/pytest -q tests/unit/test_load_balancer.py tests/unit/test_usage_updater.py --durations=20` passed: 119 passed
- `.venv/bin/openspec validate fix-stale-post-reset-usage --strict` passed
- `git diff --check origin/main..HEAD` passed

## OpenSpec
- `fix-stale-post-reset-usage` remains included and valid.

Revives #272
