### PR TITLE
fix(quota): keep credit-backed accounts usable

### DIFF
--- a/app/core/usage/quota.py
+++ b/app/core/usage/quota.py
@@ -15,6 +15,9 @@ def apply_usage_quota(
     runtime_reset: float | None,
     secondary_used: float | None,
     secondary_reset: int | None,
+    credits_has: bool | None = None,
+    credits_unlimited: bool | None = None,
+    credits_balance: float | None = None,
 ) -> tuple[AccountStatus, float | None, float | None]:
     used_percent = primary_used
     reset_at = runtime_reset
@@ -24,12 +27,21 @@ def apply_usage_quota(
 
     if secondary_used is not None:
         if secondary_used >= 100.0:
-            status = AccountStatus.QUOTA_EXCEEDED
-            used_percent = 100.0
-            if secondary_reset is not None:
-                reset_at = secondary_reset
-            return status, used_percent, reset_at
-        if status == AccountStatus.QUOTA_EXCEEDED:
+            if _has_usable_credits(
+                credits_has=credits_has,
+                credits_unlimited=credits_unlimited,
+                credits_balance=credits_balance,
+            ):
+                if status == AccountStatus.QUOTA_EXCEEDED:
+                    status = AccountStatus.ACTIVE
+                    reset_at = None
+            else:
+                status = AccountStatus.QUOTA_EXCEEDED
+                used_percent = 100.0
+                if secondary_reset is not None:
+                    reset_at = secondary_reset
+                return status, used_percent, reset_at
+        elif status == AccountStatus.QUOTA_EXCEEDED:
             if runtime_reset and runtime_reset > time.time():
                 reset_at = runtime_reset
             else:
@@ -62,3 +74,21 @@ def _fallback_primary_reset(primary_window_minutes: int | None) -> float | None:
     if not window_minutes:
         return None
     return time.time() + float(window_minutes) * 60.0
+
+
+def _has_usable_credits(
+    *,
+    credits_has: bool | None,
+    credits_unlimited: bool | None,
+    credits_balance: float | None,
+) -> bool:
+    if credits_unlimited is True:
+        return True
+    if credits_has is True:
+        return True
+    if credits_balance is None:
+        return False
+    try:
+        return float(credits_balance) > 0.0
+    except (TypeError, ValueError):
+        return False

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -144,8 +144,21 @@ def _effective_status_from_usage(
         runtime_reset=float(account.reset_at) if account.reset_at else None,
         secondary_used=secondary_used_percent,
         secondary_reset=secondary_usage.reset_at if secondary_usage is not None else None,
+        credits_has=_first_not_none(primary_usage, secondary_usage, "credits_has"),
+        credits_unlimited=_first_not_none(primary_usage, secondary_usage, "credits_unlimited"),
+        credits_balance=_first_not_none(primary_usage, secondary_usage, "credits_balance"),
     )
     return status
+
+
+def _first_not_none(primary_usage: UsageHistory | None, secondary_usage: UsageHistory | None, field: str):
+    if primary_usage is not None:
+        value = getattr(primary_usage, field)
+        if value is not None:
+            return value
+    if secondary_usage is not None:
+        return getattr(secondary_usage, field)
+    return None
 
 
 def _effective_usage_windows(

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1043,6 +1043,9 @@ def _state_from_account(
 
     secondary_used = effective_secondary_entry.used_percent if effective_secondary_entry else None
     secondary_reset = effective_secondary_entry.reset_at if effective_secondary_entry else None
+    credits_has = _first_not_none(primary_entry, effective_secondary_entry, "credits_has")
+    credits_unlimited = _first_not_none(primary_entry, effective_secondary_entry, "credits_unlimited")
+    credits_balance = _first_not_none(primary_entry, effective_secondary_entry, "credits_balance")
 
     # Use account.reset_at from DB as the authoritative source for runtime reset
     # and to survive process restarts.
@@ -1100,6 +1103,9 @@ def _state_from_account(
         runtime_reset=effective_runtime_reset,
         secondary_used=secondary_used,
         secondary_reset=secondary_reset,
+        credits_has=credits_has,
+        credits_unlimited=credits_unlimited,
+        credits_balance=credits_balance,
     )
 
     next_blocked_at = (
@@ -1205,6 +1211,16 @@ def _mapped_model_has_registry_entry(model: str | None) -> bool:
 def _clone_account(account: Account) -> Account:
     data = {column.name: getattr(account, column.name) for column in Account.__table__.columns}
     return Account(**data)
+
+
+def _first_not_none(primary_entry: UsageHistory | None, secondary_entry: UsageHistory | None, field: str):
+    if primary_entry is not None:
+        value = getattr(primary_entry, field)
+        if value is not None:
+            return value
+    if secondary_entry is not None:
+        return getattr(secondary_entry, field)
+    return None
 
 
 def _clone_usage_history(entry: UsageHistory) -> UsageHistory:

--- a/openspec/changes/fix-credit-backed-quota-status/proposal.md
+++ b/openspec/changes/fix-credit-backed-quota-status/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Accounts can exhaust their weekly ChatGPT usage percentage while still having usable credit-backed capacity. The proxy routing path must keep those accounts selectable when the upstream usage snapshot reports usable credits, and the accounts/dashboard summary path must show the same effective status. If those paths disagree, operators see an account as `quota_exceeded` even though proxy selection treats it as usable.
+
+## What Changes
+
+- Treat exhausted secondary-window usage as usable when the selected usage snapshot reports `credits_unlimited`, `credits_has`, or a positive `credits_balance`.
+- Apply the same credit-aware quota interpretation in proxy account selection and account-summary status mapping.
+- Preserve existing primary-window precedence: exhausted primary usage still produces `rate_limited`.
+- Preserve operator-disabled states: paused or deactivated accounts are not reactivated by credit snapshots.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: effective account status derived from usage snapshots must honor usable credit fields consistently across routing and dashboard/account summaries.
+
+## Impact
+
+- **Code**: existing shared quota helper plus proxy/account-summary call sites.
+- **Tests**: unit coverage for credit-backed secondary exhaustion in proxy selection and account summaries.
+- **API/schema**: no database migration and no API field changes.

--- a/openspec/changes/fix-credit-backed-quota-status/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/fix-credit-backed-quota-status/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Credit-backed secondary quota remains usable
+
+When account status is derived from persisted usage snapshots, an exhausted secondary-window usage percentage MUST NOT by itself mark an account `quota_exceeded` if the governing usage snapshot reports usable credit-backed capacity. Usable credit-backed capacity is present when `credits_unlimited` is true, `credits_has` is true, or `credits_balance` is positive.
+
+This credit-aware interpretation MUST be shared by proxy account selection and account/dashboard summary status mapping so an account selected as usable by the proxy is not simultaneously displayed as `quota_exceeded` in the operator summary. Exhausted primary-window usage MUST still take precedence as `rate_limited`, and paused or deactivated accounts MUST NOT be reactivated solely because a usage snapshot reports usable credits.
+
+#### Scenario: Secondary quota exhausted with credits remains active
+
+- **GIVEN** an account is persisted as `quota_exceeded`
+- **AND** its governing secondary-window usage reports `used_percent >= 100`
+- **AND** the same usage snapshot reports usable credit-backed capacity
+- **WHEN** proxy selection or account-summary mapping derives the effective status
+- **THEN** the effective status is `active`
+
+#### Scenario: Exhausted primary window keeps rate-limit precedence
+
+- **GIVEN** an account has usable credit-backed capacity in its usage snapshot
+- **AND** its primary-window usage reports `used_percent >= 100`
+- **WHEN** proxy selection or account-summary mapping derives the effective status
+- **THEN** the effective status is `rate_limited`
+
+#### Scenario: Operator-disabled states are preserved
+
+- **GIVEN** an account is `paused` or `deactivated`
+- **AND** its usage snapshot reports usable credit-backed capacity
+- **WHEN** proxy selection or account-summary mapping derives the effective status
+- **THEN** the account remains `paused` or `deactivated`

--- a/openspec/changes/fix-credit-backed-quota-status/tasks.md
+++ b/openspec/changes/fix-credit-backed-quota-status/tasks.md
@@ -1,0 +1,11 @@
+## 1. Quota Status
+
+- [x] 1.1 Treat exhausted secondary-window usage as usable when credit fields show usable capacity.
+- [x] 1.2 Use the same credit-aware quota interpretation in proxy account state construction and account-summary status mapping.
+- [x] 1.3 Preserve primary-window `rate_limited` precedence and paused/deactivated state preservation.
+
+## 2. Tests and Validation
+
+- [x] 2.1 Add regression coverage for proxy selection with secondary credits.
+- [x] 2.2 Add regression coverage for account-summary effective status with secondary credits.
+- [x] 2.3 Run focused backend tests and OpenSpec validation.

--- a/tests/unit/test_account_mappers.py
+++ b/tests/unit/test_account_mappers.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from app.db.models import Account, AccountStatus, UsageHistory
+from app.modules.accounts.mappers import _effective_status_from_usage
+
+
+def _account(status: AccountStatus = AccountStatus.QUOTA_EXCEEDED) -> Account:
+    return Account(
+        id="account-1",
+        email="account@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"",
+        refresh_token_encrypted=b"",
+        id_token_encrypted=b"",
+        status=status,
+        reset_at=1_700_003_600,
+    )
+
+
+def _primary_usage(**overrides) -> UsageHistory:
+    values = {
+        "account_id": "account-1",
+        "window": "primary",
+        "used_percent": 40.0,
+        "reset_at": None,
+        "window_minutes": 300,
+    }
+    values.update(overrides)
+    return UsageHistory(**values)
+
+
+def _secondary_usage(**overrides) -> UsageHistory:
+    values = {
+        "account_id": "account-1",
+        "window": "secondary",
+        "used_percent": 100.0,
+        "reset_at": 1_700_003_600,
+        "window_minutes": 10080,
+    }
+    values.update(overrides)
+    return UsageHistory(**values)
+
+
+def test_effective_status_uses_secondary_credits_to_reactivate_quota_exceeded_account() -> None:
+    account = _account()
+    primary = _primary_usage()
+    secondary = _secondary_usage(
+        credits_has=False,
+        credits_unlimited=False,
+        credits_balance=25.0,
+    )
+
+    assert (
+        _effective_status_from_usage(
+            account,
+            primary,
+            primary.used_percent,
+            secondary,
+            secondary.used_percent,
+        )
+        == AccountStatus.ACTIVE
+    )
+
+
+def test_effective_status_uses_primary_credits_when_secondary_has_no_credit_fields() -> None:
+    account = _account()
+    primary = _primary_usage(credits_balance=25.0)
+    secondary = _secondary_usage()
+
+    assert (
+        _effective_status_from_usage(
+            account,
+            primary,
+            primary.used_percent,
+            secondary,
+            secondary.used_percent,
+        )
+        == AccountStatus.ACTIVE
+    )
+
+
+def test_effective_status_keeps_primary_rate_limit_precedence_with_usable_credits() -> None:
+    account = _account(AccountStatus.ACTIVE)
+    primary = _primary_usage(used_percent=100.0, reset_at=1_700_000_300, credits_balance=25.0)
+    secondary = _secondary_usage(used_percent=100.0, credits_balance=25.0)
+
+    assert (
+        _effective_status_from_usage(
+            account,
+            primary,
+            primary.used_percent,
+            secondary,
+            secondary.used_percent,
+        )
+        == AccountStatus.RATE_LIMITED
+    )
+
+
+def test_effective_status_keeps_paused_account_paused_with_usable_credits() -> None:
+    account = _account(AccountStatus.PAUSED)
+    primary = _primary_usage(credits_balance=25.0)
+    secondary = _secondary_usage(credits_balance=25.0)
+
+    assert (
+        _effective_status_from_usage(
+            account,
+            primary,
+            primary.used_percent,
+            secondary,
+            secondary.used_percent,
+        )
+        == AccountStatus.PAUSED
+    )

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -320,6 +320,44 @@ def test_apply_usage_quota_sets_fallback_reset_for_primary_window(monkeypatch):
     assert reset_at == pytest.approx(now + 60.0)
 
 
+def test_apply_usage_quota_secondary_exhausted_without_credits_sets_quota_exceeded():
+    secondary_reset = 1_700_000_000
+    status, used_percent, reset_at = apply_usage_quota(
+        status=AccountStatus.ACTIVE,
+        primary_used=40.0,
+        primary_reset=None,
+        primary_window_minutes=None,
+        runtime_reset=None,
+        secondary_used=100.0,
+        secondary_reset=secondary_reset,
+        credits_has=False,
+        credits_unlimited=False,
+        credits_balance=0.0,
+    )
+    assert status == AccountStatus.QUOTA_EXCEEDED
+    assert used_percent == 100.0
+    assert reset_at == secondary_reset
+
+
+def test_apply_usage_quota_secondary_exhausted_with_credits_reactivates_account():
+    future_reset = 1_700_000_000.0
+    status, used_percent, reset_at = apply_usage_quota(
+        status=AccountStatus.QUOTA_EXCEEDED,
+        primary_used=40.0,
+        primary_reset=None,
+        primary_window_minutes=None,
+        runtime_reset=future_reset,
+        secondary_used=100.0,
+        secondary_reset=int(future_reset),
+        credits_has=False,
+        credits_unlimited=False,
+        credits_balance=25.0,
+    )
+    assert status == AccountStatus.ACTIVE
+    assert used_percent == 40.0
+    assert reset_at is None
+
+
 def test_handle_quota_exceeded_sets_used_percent_and_cooldown():
     state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
     handle_quota_exceeded(state, {})
@@ -489,6 +527,9 @@ def _make_test_usage(
     used_percent: float = 10.0,
     reset_at: int | None = None,
     recorded_at: datetime | None = None,
+    credits_has: bool | None = None,
+    credits_unlimited: bool | None = None,
+    credits_balance: float | None = None,
 ) -> UsageHistory:
     return UsageHistory(
         id=1,
@@ -498,6 +539,9 @@ def _make_test_usage(
         used_percent=used_percent,
         reset_at=reset_at,
         window_minutes=10080,
+        credits_has=credits_has,
+        credits_unlimited=credits_unlimited,
+        credits_balance=credits_balance,
     )
 
 
@@ -531,6 +575,39 @@ def test_state_from_account_recovers_quota_exceeded_on_restart_without_blocked_a
         runtime=RuntimeState(),
     )
     assert state.status == AccountStatus.ACTIVE
+
+
+def test_state_from_account_uses_secondary_credits_when_primary_lacks_credit_fields(monkeypatch):
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_test_account(status=AccountStatus.QUOTA_EXCEEDED, reset_at=future_reset)
+    primary = _make_test_usage(
+        window="primary",
+        used_percent=40.0,
+        reset_at=None,
+        recorded_at=_epoch_to_naive_utc(now - 30),
+    )
+    secondary = _make_test_usage(
+        used_percent=100.0,
+        reset_at=future_reset,
+        recorded_at=_epoch_to_naive_utc(now - 30),
+        credits_balance=25.0,
+    )
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=primary,
+        secondary_entry=secondary,
+        runtime=RuntimeState(),
+    )
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent == 40.0
+    assert state.reset_at is None
+    assert state.blocked_at is None
 
 
 def test_state_from_account_keeps_quota_exceeded_on_restart_when_fresh_usage_is_missing_and_no_blocked_at(


### PR DESCRIPTION
## Summary
Revives the useful quota-handling slice of #237 on a maintainer-owned branch because the original PR head has `maintainerCanModify=false`.

Credit: original implementation by @mws-weekend-projects in #237; this branch keeps only the current-main-compatible credit-backed quota fix.

- Keeps credit-backed accounts usable when paid credits are present on secondary usage data.
- Drops the stale burn-rate/request-log stack that carried the old Codex needs-work comments.

## Validation
- `uv run pytest tests/unit/test_load_balancer.py -q` passed: 67 passed
- `uv run ruff check app/core/usage/quota.py app/modules/proxy/load_balancer.py tests/unit/test_load_balancer.py` passed
- `uv run ty check app/core/usage/quota.py app/modules/proxy/load_balancer.py tests/unit/test_load_balancer.py` passed
- `git diff --check origin/main..HEAD` passed

Revives #237
