### PR TITLE
ci: label pull requests with database migrations

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+db migration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - app/db/alembic/versions/**

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v6.0.1
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR labeler
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] labels fork PRs without checking out PR code
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Apply path-based labels
-        uses: actions/labeler@v6.0.1
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false


### PR DESCRIPTION
## Summary
- add a `db migration` path label for Alembic revision changes
- run `actions/labeler` on pull requests from forks without checking out PR code
- keep manual labels stable by disabling label sync/removal

## Why
Merging several green PRs that each add database migrations needs maintainer ordering/oversight even when CI is green.

## Test plan
- `git diff --check`
- Created/updated the `db migration` repository label
- Manually applied `db migration` to the currently open migration PRs: #759, #761, #762
