### PR TITLE
fix(ci): tolerate transient Codex label read failures

### DIFF
--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -744,6 +744,13 @@ def write_warning(action: str, exc: BaseException) -> str:
     return f"{action}: skipped because the GitHub token cannot write this resource ({exc})"
 
 
+def is_missing_issue_label(exc: BaseException) -> bool:
+    """Return True when GitHub reports that an issue label is already absent."""
+
+    text = str(exc)
+    return "HTTP 404" in text and "Label does not exist" in text
+
+
 def gh_api_write(
     path: str,
     *,
@@ -756,7 +763,7 @@ def gh_api_write(
     try:
         gh_api(path, method=method, input_json=input_json)
     except GhError as exc:
-        if tolerate_missing and "HTTP 404" in str(exc):
+        if tolerate_missing and is_missing_issue_label(exc):
             return None
         if tolerate_permission_errors and is_github_app_write_denial(exc):
             return write_warning(action, exc)
@@ -1123,6 +1130,7 @@ def main(argv: list[str] | None = None) -> int:
             had_error = True
             continue
 
+        classified_count = 0
         for number in sorted(set(numbers)):
             try:
                 decision = decide_pr(
@@ -1141,6 +1149,7 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
                 continue
 
+            classified_count += 1
             try:
                 write_warnings: tuple[str, ...] = ()
                 if args.apply:
@@ -1188,6 +1197,14 @@ def main(argv: list[str] | None = None) -> int:
             except Exception as exc:  # noqa: BLE001
                 had_error = True
                 print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
+
+        if args.tolerate_read_errors and classified_count == 0:
+            had_error = True
+            print(
+                f"{repo}: all selected PRs failed classification; refusing a false-green tolerant run",
+                file=sys.stderr,
+                flush=True,
+            )
 
     return 1 if had_error else 0
 

--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -1125,6 +1125,17 @@ def main(argv: list[str] | None = None) -> int:
                     allowed_authors=allowed_authors,
                     ignore_checks=args.ignore_checks,
                 )
+            except GhError as exc:
+                if not args.tolerate_read_errors:
+                    had_error = True
+                print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
+                continue
+            except Exception as exc:  # noqa: BLE001
+                had_error = True
+                print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
+                continue
+
+            try:
                 write_warnings: tuple[str, ...] = ()
                 if args.apply:
                     accumulated_warnings: list[str] = []
@@ -1169,8 +1180,7 @@ def main(argv: list[str] | None = None) -> int:
                 for warning in write_warnings:
                     print(f"  write_warning={warning}", flush=True)
             except Exception as exc:  # noqa: BLE001
-                if not args.tolerate_read_errors:
-                    had_error = True
+                had_error = True
                 print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
 
     return 1 if had_error else 0

--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -750,11 +750,14 @@ def gh_api_write(
     method: str = "GET",
     input_json: Any | None = None,
     tolerate_permission_errors: bool,
+    tolerate_missing: bool = False,
     action: str,
 ) -> str | None:
     try:
         gh_api(path, method=method, input_json=input_json)
     except GhError as exc:
+        if tolerate_missing and "HTTP 404" in str(exc):
+            return None
         if tolerate_permission_errors and is_github_app_write_denial(exc):
             return write_warning(action, exc)
         raise
@@ -951,6 +954,7 @@ def apply_decision(decision: SyncDecision, *, tolerate_permission_errors: bool =
                 f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(CODEX_OK_LABEL, safe='')}",
                 method="DELETE",
                 tolerate_permission_errors=tolerate_permission_errors,
+                tolerate_missing=True,
                 action=f"remove {CODEX_OK_LABEL} from {decision.repo}#{decision.number}",
             )
         )
@@ -970,6 +974,7 @@ def apply_decision(decision: SyncDecision, *, tolerate_permission_errors: bool =
                 f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(CODEX_NEEDS_WORK_LABEL, safe='')}",
                 method="DELETE",
                 tolerate_permission_errors=tolerate_permission_errors,
+                tolerate_missing=True,
                 action=f"remove {CODEX_NEEDS_WORK_LABEL} from {decision.repo}#{decision.number}",
             )
         )
@@ -979,6 +984,7 @@ def apply_decision(decision: SyncDecision, *, tolerate_permission_errors: bool =
                 f"/repos/{decision.repo}/issues/{decision.number}/labels/{quote(label, safe='')}",
                 method="DELETE",
                 tolerate_permission_errors=tolerate_permission_errors,
+                tolerate_missing=True,
                 action=f"remove legacy {label} from {decision.repo}#{decision.number}",
             )
         )

--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -1065,6 +1065,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--tolerate-read-errors",
+        action="store_true",
+        help=(
+            "Log and continue when a selected PR cannot be classified because of a GitHub "
+            "read/API error. Intended for broad --all-open best-effort maintenance runs."
+        ),
+    )
+    parser.add_argument(
         "--reviewer-login",
         action="append",
         default=[],
@@ -1161,7 +1169,8 @@ def main(argv: list[str] | None = None) -> int:
                 for warning in write_warnings:
                     print(f"  write_warning={warning}", flush=True)
             except Exception as exc:  # noqa: BLE001
-                had_error = True
+                if not args.tolerate_read_errors:
+                    had_error = True
                 print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
 
     return 1 if had_error else 0

--- a/.github/workflows/codex-review-labels.yml
+++ b/.github/workflows/codex-review-labels.yml
@@ -78,4 +78,4 @@ jobs:
             echo ".github/scripts/sync_codex_ok_labels.py is not available on the default branch yet; skipping bootstrap run"
             exit 0
           fi
-          python3 .github/scripts/sync_codex_ok_labels.py --repo "$REPO" --all-open --apply --tolerate-write-permission-errors
+          python3 .github/scripts/sync_codex_ok_labels.py --repo "$REPO" --all-open --apply --tolerate-write-permission-errors --tolerate-read-errors

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -71,6 +71,28 @@ def test_apply_decision_still_fails_on_write_denial_without_tolerance(monkeypatc
         module.apply_decision(decision(module), tolerate_permission_errors=False)
 
 
+def test_apply_decision_treats_missing_label_delete_as_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+
+    calls: list[tuple[str, str]] = []
+
+    def missing_label(path: str, *, method: str = "GET", **_kwargs: Any) -> None:
+        calls.append((method, path))
+        raise module.GhError("gh: Not Found (HTTP 404)")
+
+    monkeypatch.setattr(module, "gh_api", missing_label)
+
+    warnings = module.apply_decision(decision(module), tolerate_permission_errors=False)
+
+    assert warnings == ()
+    assert calls == [
+        (
+            "DELETE",
+            "/repos/Soju06/codex-lb/issues/714/labels/%F0%9F%A4%96%20codex%3A%20ok",
+        )
+    ]
+
+
 def test_trigger_codex_review_tolerates_github_app_write_denial(monkeypatch: pytest.MonkeyPatch) -> None:
     module = load_sync_module()
 

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -134,3 +134,25 @@ def test_main_fails_read_errors_without_tolerance(monkeypatch: pytest.MonkeyPatc
     )
 
     assert module.main(["--repo", "Soju06/codex-lb", "--all-open"]) == 1
+
+
+def test_main_fails_apply_errors_even_with_read_error_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [714])
+    monkeypatch.setattr(module, "decide_pr", lambda *_args, **_kwargs: decision(module))
+
+    def fail_apply(*_args: Any, **_kwargs: Any) -> tuple[str, ...]:
+        raise module.GhError("gh: HTTP 500 while writing labels")
+
+    monkeypatch.setattr(module, "apply_decision", fail_apply)
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply", "--tolerate-read-errors"])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Soju06/codex-lb#714: gh: HTTP 500 while writing labels" in captured.err

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -95,3 +95,42 @@ def test_workflow_prefers_privileged_token_and_enables_tolerant_apply() -> None:
 
     assert "secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token" in workflow
     assert workflow.count("--tolerate-write-permission-errors") == 2
+    assert workflow.count("--tolerate-read-errors") == 1
+
+
+def test_main_tolerates_read_errors_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
+
+    def fake_decide_pr(_repo: str, number: int, **_kwargs: Any) -> Any:
+        if number == 710:
+            raise module.GhError("gh: HTTP 502")
+        return decision(module, number=number)
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--tolerate-read-errors"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Soju06/codex-lb#710: gh: HTTP 502" in captured.err
+    assert "dry-run Soju06/codex-lb#714" in captured.out
+
+
+def test_main_fails_read_errors_without_tolerance(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710])
+    monkeypatch.setattr(
+        module,
+        "decide_pr",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(module.GhError("gh: HTTP 502")),
+    )
+
+    assert module.main(["--repo", "Soju06/codex-lb", "--all-open"]) == 1

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -78,7 +78,7 @@ def test_apply_decision_treats_missing_label_delete_as_done(monkeypatch: pytest.
 
     def missing_label(path: str, *, method: str = "GET", **_kwargs: Any) -> None:
         calls.append((method, path))
-        raise module.GhError("gh: Not Found (HTTP 404)")
+        raise module.GhError("gh: Label does not exist (HTTP 404)")
 
     monkeypatch.setattr(module, "gh_api", missing_label)
 
@@ -91,6 +91,18 @@ def test_apply_decision_treats_missing_label_delete_as_done(monkeypatch: pytest.
             "/repos/Soju06/codex-lb/issues/714/labels/%F0%9F%A4%96%20codex%3A%20ok",
         )
     ]
+
+
+def test_apply_decision_does_not_swallow_unrelated_delete_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+
+    def missing_resource(*_args: Any, **_kwargs: Any) -> None:
+        raise module.GhError("gh: Not Found (HTTP 404)")
+
+    monkeypatch.setattr(module, "gh_api", missing_resource)
+
+    with pytest.raises(module.GhError):
+        module.apply_decision(decision(module), tolerate_permission_errors=False)
 
 
 def test_trigger_codex_review_tolerates_github_app_write_denial(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -142,6 +154,27 @@ def test_main_tolerates_read_errors_when_requested(
     assert result == 0
     assert "Soju06/codex-lb#710: gh: HTTP 502" in captured.err
     assert "dry-run Soju06/codex-lb#714" in captured.out
+
+
+def test_main_fails_tolerant_run_when_every_pr_read_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
+    monkeypatch.setattr(
+        module,
+        "decide_pr",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(module.GhError("gh: HTTP 502")),
+    )
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--tolerate-read-errors"])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "all selected PRs failed classification" in captured.err
 
 
 def test_main_fails_read_errors_without_tolerance(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- keep PR-specific Codex label sync strict, but let broad `--all-open` maintenance runs continue when one PR hits a GitHub read/API failure
- enable that tolerant read mode only for the workflow_run/all-open Codex label job
- add unit coverage for both tolerant and strict read-error behavior

## Why
The workflow_run job failed on a transient GitHub GraphQL 502 while scanning review threads for one PR:
https://github.com/Soju06/codex-lb/actions/runs/26230176759/job/77188036878

That should not make the whole all-open label sweep red. It should log the affected PR and continue processing the rest.

## Validation
- `uv run pytest tests/unit/test_sync_codex_ok_labels.py -q`
- `uv run ruff check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- `uv run ruff format --check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- `git diff --check`
