### PR TITLE
fix(acc): free account should hide 5h bar in account

### DIFF
--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -78,7 +78,12 @@ def _account_to_summary(
     if primary_remaining_percent is None and not weekly_only_usage:
         primary_remaining_percent = 100.0
 
+    status_primary_usage = effective_primary_usage
+    status_primary_used_percent = primary_used_percent
     if usage_core.capacity_for_plan(plan_type, "primary") == 0.0:
+        if account.status != AccountStatus.RATE_LIMITED:
+            status_primary_usage = None
+            status_primary_used_percent = None
         effective_primary_usage = None
         primary_used_percent = None
         primary_remaining_percent = None
@@ -105,8 +110,8 @@ def _account_to_summary(
     )
     effective_status = _effective_status_from_usage(
         account,
-        effective_primary_usage,
-        primary_used_percent,
+        status_primary_usage,
+        status_primary_used_percent,
         effective_secondary_usage,
         secondary_used_percent,
     )

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -62,6 +62,7 @@ def _account_to_summary(
         primary_usage,
         secondary_usage,
     )
+
     weekly_only_usage = (
         effective_primary_usage is None
         and primary_usage is not None
@@ -76,6 +77,11 @@ def _account_to_summary(
 
     if primary_remaining_percent is None and not weekly_only_usage:
         primary_remaining_percent = 100.0
+
+    if usage_core.capacity_for_plan(plan_type, "primary") == 0.0:
+        effective_primary_usage = None
+        primary_remaining_percent = None
+
     reset_at_primary = (
         from_epoch_seconds(effective_primary_usage.reset_at) if effective_primary_usage is not None else None
     )

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -80,6 +80,7 @@ def _account_to_summary(
 
     if usage_core.capacity_for_plan(plan_type, "primary") == 0.0:
         effective_primary_usage = None
+        primary_used_percent = None
         primary_remaining_percent = None
 
     reset_at_primary = (

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -575,6 +575,44 @@ async def test_accounts_list_ignores_hidden_zero_capacity_primary_for_status(asy
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_recovers_zero_capacity_rate_limited_status(async_client, db_setup):
+    expired_reset = int((utcnow() - timedelta(minutes=5)).timestamp())
+    account = _make_account("acc_free_recovered_primary", "free-recovered@example.com", plan_type="free")
+    account.status = AccountStatus.RATE_LIMITED
+    account.reset_at = expired_reset
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(account)
+        await usage_repo.add_entry(
+            "acc_free_recovered_primary",
+            24.0,
+            window="primary",
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            "acc_free_recovered_primary",
+            24.0,
+            window="secondary",
+            window_minutes=10080,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account_payload = accounts["acc_free_recovered_primary"]
+    assert account_payload["status"] == "active"
+    assert account_payload["usage"]["primaryRemainingPercent"] is None
+    assert account_payload["usage"]["secondaryRemainingPercent"] == pytest.approx(76.0)
+    assert account_payload["windowMinutesPrimary"] is None
+    assert account_payload["windowMinutesSecondary"] == 10080
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_prefers_newer_weekly_primary_over_stale_secondary(async_client, db_setup):
     now = utcnow()
     stale_reset = 1735689600

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -542,6 +542,39 @@ async def test_accounts_list_maps_weekly_only_primary_to_secondary(async_client,
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_ignores_hidden_zero_capacity_primary_for_status(async_client, db_setup):
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_free_dirty_primary", "free-dirty@example.com", plan_type="free"))
+        await usage_repo.add_entry(
+            "acc_free_dirty_primary",
+            100.0,
+            window="primary",
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            "acc_free_dirty_primary",
+            24.0,
+            window="secondary",
+            window_minutes=10080,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account = accounts["acc_free_dirty_primary"]
+    assert account["status"] == "active"
+    assert account["usage"]["primaryRemainingPercent"] is None
+    assert account["usage"]["secondaryRemainingPercent"] == pytest.approx(76.0)
+    assert account["windowMinutesPrimary"] is None
+    assert account["windowMinutesSecondary"] == 10080
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_prefers_newer_weekly_primary_over_stale_secondary(async_client, db_setup):
     now = utcnow()
     stale_reset = 1735689600


### PR DESCRIPTION
## Summary
Force 5h Plan credit = 0.0 to remove the 5h bar in the account card due to unclean data in the database.

## Type of change

<!-- Check the box that matches your PR. Commit titles must follow Conventional Commits. -->

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

<img width="311" height="109" alt="螢幕截圖 2026-05-22 00 39 54" src="https://github.com/user-attachments/assets/ce384a4b-92ba-48fc-aaa3-3930133deeed" />
Before

<img width="315" height="98" alt="螢幕截圖 2026-05-22 01 17 51" src="https://github.com/user-attachments/assets/f0f7fd14-dfb6-4c20-8df9-956e293b93b7" />
After

This also fixes the account selection card in the edit API to hide the 5h usage info.