### PR TITLE
fix(proxy): allow larger compressed responses bodies

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -186,6 +186,7 @@ class Settings(BaseSettings):
     conversation_archive_dir: Path = DEFAULT_HOME_DIR / "conversation-archive"
     conversation_archive_queue_max_bytes: int = Field(default=8 * 1024 * 1024, gt=0)
     max_decompressed_body_bytes: int = Field(default=32 * 1024 * 1024, gt=0)
+    max_decompressed_responses_body_bytes: int = Field(default=128 * 1024 * 1024, gt=0)
     image_inline_fetch_enabled: bool = True
     image_inline_allowed_hosts: Annotated[list[str], NoDecode] = Field(default_factory=list)
     # OpenAI Images API compatibility (POST /v1/images/{generations,edits})

--- a/app/core/middleware/request_decompression.py
+++ b/app/core/middleware/request_decompression.py
@@ -14,6 +14,13 @@ from starlette.requests import ClientDisconnect
 from app.core.config.settings import get_settings
 from app.core.errors import dashboard_error
 
+_RESPONSES_DECOMPRESSION_PATHS = frozenset(
+    {
+        "/backend-api/codex/responses",
+        "/v1/responses",
+    }
+)
+
 
 class _DecompressedBodyTooLarge(Exception):
     def __init__(self, max_size: int) -> None:
@@ -114,6 +121,13 @@ def _replace_request_body(request: Request, body: bytes) -> None:
     request.__dict__.pop("_headers", None)
 
 
+def _max_decompressed_body_bytes_for_request(request: Request) -> int:
+    settings = get_settings()
+    if request.url.path.rstrip("/") in _RESPONSES_DECOMPRESSION_PATHS:
+        return max(settings.max_decompressed_body_bytes, settings.max_decompressed_responses_body_bytes)
+    return settings.max_decompressed_body_bytes
+
+
 def add_request_decompression_middleware(app: FastAPI) -> None:
     @app.middleware("http")
     async def request_decompression_middleware(
@@ -126,8 +140,7 @@ def add_request_decompression_middleware(app: FastAPI) -> None:
         encodings = [enc.strip().lower() for enc in content_encoding.split(",") if enc.strip()]
         if not encodings:
             return await call_next(request)
-        settings = get_settings()
-        max_size = settings.max_decompressed_body_bytes
+        max_size = _max_decompressed_body_bytes_for_request(request)
         try:
             body = await request.body()
         except ClientDisconnect:

--- a/tests/unit/test_request_decompression_middleware.py
+++ b/tests/unit/test_request_decompression_middleware.py
@@ -36,6 +36,16 @@ def _build_echo_app(*, touch_headers: bool = False) -> FastAPI:
         data = await request.json()
         return {"content_encoding": request.headers.get("content-encoding"), "data": data}
 
+    @app.post("/backend-api/codex/responses")
+    async def responses(request: Request):
+        data = await request.json()
+        return {"content_encoding": request.headers.get("content-encoding"), "data": data}
+
+    @app.post("/backend-api/codex/responses/")
+    async def responses_slash(request: Request):
+        data = await request.json()
+        return {"content_encoding": request.headers.get("content-encoding"), "data": data}
+
     return app
 
 
@@ -169,6 +179,80 @@ async def test_request_decompression_rejects_unsupported_encoding():
     response_data = resp.json()
     assert response_data["error"]["code"] == "invalid_request"
     assert response_data["error"]["message"] == "Unsupported Content-Encoding"
+
+
+@pytest.mark.asyncio
+async def test_request_decompression_allows_larger_responses_payload(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "128")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "2048")
+
+    app = _build_echo_app()
+
+    payload = {"input": "x" * 512}
+    body = json.dumps(payload).encode("utf-8")
+    compressed = zstd.ZstdCompressor().compress(body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/backend-api/codex/responses",
+            content=compressed,
+            headers={"Content-Encoding": "zstd", "Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 200
+    response_data = resp.json()
+    assert response_data["content_encoding"] is None
+    assert response_data["data"] == payload
+
+
+@pytest.mark.asyncio
+async def test_request_decompression_allows_larger_trailing_slash_responses_payload(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "128")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "2048")
+
+    app = _build_echo_app()
+
+    payload = {"input": "x" * 512}
+    body = json.dumps(payload).encode("utf-8")
+    compressed = zstd.ZstdCompressor().compress(body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/backend-api/codex/responses/",
+            content=compressed,
+            headers={"Content-Encoding": "zstd", "Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 200
+    response_data = resp.json()
+    assert response_data["content_encoding"] is None
+    assert response_data["data"] == payload
+
+
+@pytest.mark.asyncio
+async def test_request_decompression_keeps_default_limit_for_other_routes(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "128")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "2048")
+
+    app = _build_echo_app()
+
+    payload = {"input": "x" * 512}
+    body = json.dumps(payload).encode("utf-8")
+    compressed = zstd.ZstdCompressor().compress(body)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/echo",
+            content=compressed,
+            headers={"Content-Encoding": "zstd", "Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 413
+    response_data = resp.json()
+    assert response_data["error"]["code"] == "payload_too_large"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a Responses-specific decompressed request body limit
- keep the existing generic decompression limit for non-Responses routes
- cover both the raised Responses limit and the unchanged generic-route rejection in middleware tests

## Why
Large Codex Responses requests can be sent compressed and legitimately decompress above the generic API body limit before the Responses route has a chance to validate or slim the `response.create` payload. This makes the proxy return a pre-route `413 payload_too_large` for requests that should continue into the normal Responses handling path.

This keeps the conservative default for ordinary API routes while allowing larger compressed bodies on `/backend-api/codex/responses` and `/v1/responses`.

## Tests
```bash
uv run python -m py_compile app/core/config/settings.py app/core/middleware/request_decompression.py
uv run pytest tests/unit/test_request_decompression_middleware.py tests/integration/test_request_decompression.py -q
git diff --check origin/main..HEAD
```
