### PR TITLE
fix(accounts): own DB session in detached token-refresh task

### DIFF
--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable, Coroutine
+from contextlib import AbstractAsyncContextManager
 from datetime import datetime
 from hashlib import sha256
 from typing import Protocol, TypeAlias
@@ -138,18 +139,49 @@ class AuthManager:
         repo: AccountsRepositoryPort,
         *,
         acquire_refresh_admission: Callable[[], Awaitable[RefreshAdmissionLeasePort]] | None = None,
+        refresh_repo_factory: Callable[[], AbstractAsyncContextManager[AccountsRepositoryPort]] | None = None,
     ) -> None:
         self._repo = repo
         self._encryptor = TokenEncryptor()
         self._acquire_refresh_admission = acquire_refresh_admission
+        # Optional factory yielding a *fresh* accounts repo (own DB session) for
+        # the detached, shielded refresh task. When set, the singleflight body
+        # runs against this session instead of the request-scoped `repo`, so a
+        # caller cancelled by a client disconnect cannot close the session out
+        # from under the still-running refresh task and strand a pooled
+        # connection. See _run_refresh.
+        self._refresh_repo_factory = refresh_repo_factory
 
     async def ensure_fresh(self, account: Account, *, force: bool = False) -> Account:
         if force or should_refresh(account.last_refresh):
             account = await _REFRESH_SINGLEFLIGHT.run(
                 _refresh_singleflight_key(self._encryptor, account),
-                lambda: self.refresh_account(account),
+                lambda: self._run_refresh(account),
             )
         return await self._ensure_chatgpt_account_id(account)
+
+    async def _run_refresh(self, account: Account) -> Account:
+        """Singleflight body for token refresh.
+
+        Runs inside a detached task that the singleflight keeps alive with
+        ``asyncio.shield`` (so concurrent waiters share one refresh and a
+        cancelled waiter does not abort it). Because the task outlives the
+        caller, it MUST NOT use the caller's request-scoped session: when a
+        client disconnects, the caller is cancelled and its
+        ``async with get_background_session()`` closes that session, while this
+        shielded task keeps running and would then touch a closed,
+        concurrently-finalized ``AsyncSession`` (not safe for concurrent use) —
+        stranding a pooled connection that never returns. When a
+        ``refresh_repo_factory`` is provided, open a fresh session here so the
+        refresh write is fully self-contained; otherwise fall back to the bound
+        repo (callers whose session is not client-cancellable, e.g. the usage
+        refresh scheduler).
+        """
+        if self._refresh_repo_factory is None:
+            return await self.refresh_account(account)
+        async with self._refresh_repo_factory() as repo:
+            owned = AuthManager(repo, acquire_refresh_admission=self._acquire_refresh_admission)
+            return await owned.refresh_account(account)
 
     async def refresh_account(self, account: Account) -> Account:
         refresh_token = self._encryptor.decrypt(account.refresh_token_encrypted)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10,6 +10,7 @@ import re
 import time
 from collections import deque
 from collections.abc import AsyncGenerator, Awaitable, Callable, Collection, Coroutine, Sequence
+from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -119,7 +120,7 @@ from app.db.models import (
     UsageHistory,
 )
 from app.db.session import SessionLocal
-from app.modules.accounts.auth_manager import AuthManager
+from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManager
 from app.modules.api_keys.service import (
     ApiKeyData,
     ApiKeyInvalidError,
@@ -10598,6 +10599,16 @@ class ProxyService:
 
         return additional_limits
 
+    @asynccontextmanager
+    async def _accounts_refresh_scope(self) -> AsyncIterator[AccountsRepositoryPort]:
+        # Fresh, self-contained accounts repo (own DB session) for AuthManager's
+        # detached/shielded token-refresh task. A client disconnect cancels the
+        # request and closes the request-scoped session below; without this the
+        # still-running refresh task would touch that closed session and strand
+        # a background-pool connection (the codex-lb pool-exhaustion leak).
+        async with self._repo_factory() as repos:
+            yield repos.accounts
+
     async def _ensure_fresh(
         self,
         account: Account,
@@ -10611,6 +10622,7 @@ class ProxyService:
                 auth_manager = AuthManager(
                     repos.accounts,
                     acquire_refresh_admission=self._get_work_admission().acquire_token_refresh,
+                    refresh_repo_factory=self._accounts_refresh_scope,
                 )
                 return await auth_manager.ensure_fresh(account, force=force)
         finally:

--- a/openspec/changes/fix-auth-refresh-detached-session-leak/proposal.md
+++ b/openspec/changes/fix-auth-refresh-detached-session-leak/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`AuthManager.ensure_fresh` runs the OAuth token refresh as a **detached task** that the singleflight (`_RefreshSingleflight`) keeps alive with `asyncio.shield` — so concurrent waiters share one refresh and a cancelled waiter does not abort it. `AuthManager.refresh_account` then persists the rotated tokens through the manager's bound repo (`update_tokens`, and on permanent failure `get_by_id` / `update_status`).
+
+When the manager is constructed on a **request-scoped** session, that detached task can outlive its session. The proxy path does exactly this: `ProxyService._ensure_fresh` opens `async with self._repo_factory() as repos` (→ `get_background_session()`) and builds `AuthManager(repos.accounts, ...)`.
+
+On client disconnect mid-refresh, the request task is cancelled at `await asyncio.shield(task)`. The shield keeps the refresh task running, but the caller unwinds and the `async with` closes the request-scoped session in its `finally`. The still-running refresh task then calls `update_tokens` against that closed, concurrently-finalized `AsyncSession` (which is not safe for concurrent use). The connection it checks out is never returned to the pool.
+
+Over time these stranded checkouts exhaust the background engine pool. Once exhausted, every request that needs a background session (e.g. the firewall allowlist lookup on `/v1/*` and `/backend-api/codex/*`) blocks for the full `database_pool_timeout_seconds` and then returns HTTP 500 (`sqlalchemy.exc.TimeoutError: QueuePool limit ... connection timed out`), and client retries pile more load on the dead pool.
+
+Observed in a production multi-agent deployment: thousands of `QueuePool limit` 500s accumulating over hours, onset only after days of uptime (a slow leak of roughly one connection per refresh-interrupted-by-disconnect), strongly correlated with client reconnect storms, and not per-request — consistent with this detached-refresh path rather than the per-request firewall/auth reads.
+
+## What Changes
+
+- `AuthManager.__init__` gains an optional `refresh_repo_factory: Callable[[], AbstractAsyncContextManager[AccountsRepositoryPort]]`. A new `AuthManager._run_refresh` becomes the singleflight body: when a factory is provided it opens a **fresh** accounts repo (its own session) for the refresh write, so the detached task's session lifetime is independent of the caller's cancellation. When no factory is provided it falls back to the bound repo (callers whose session is not client-cancellable, e.g. the usage refresh scheduler).
+- `ProxyService._ensure_fresh` passes `refresh_repo_factory=self._accounts_refresh_scope`, a new `@asynccontextmanager` that yields a fresh `repos.accounts` from the existing `self._repo_factory()`.
+- Regression test in `tests/unit/test_auth_manager.py`: with a refresh in flight, the caller is cancelled (simulating a client disconnect) and the test asserts the refresh wrote through its own session (opened and closed) and never the request-scoped repo. Fails before the change, passes after.
+- `ADDED Requirements` delta to the `database-backends` capability codifying that detached/shielded background tasks own their DB session lifetime.
+
+## Impact
+
+- Fixes the background-pool connection leak that, once the pool is exhausted, surfaces as `QueuePool limit ... connection timed out` 500s on all pool-backed paths until a restart.
+- No env var, config, API, or migration change. Token-refresh behavior is unchanged on the happy path and for non-cancelled callers; the only change is that a refresh triggered from the proxy path uses its own DB session.
+- Singleflight dedup, refresh admission control, recent-failure cooldown, and `_ensure_chatgpt_account_id` are unchanged. The usage refresh scheduler path is unchanged (it passes no factory).

--- a/openspec/changes/fix-auth-refresh-detached-session-leak/specs/database-backends/spec.md
+++ b/openspec/changes/fix-auth-refresh-detached-session-leak/specs/database-backends/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Detached background tasks own their database session lifetime
+
+A background task that is intentionally decoupled from its caller's lifetime — for example a singleflight refresh kept alive with `asyncio.shield` so concurrent waiters share one in-flight operation — MUST NOT perform database work through a session whose lifetime is owned by the (cancellable) caller. Such a task MUST acquire its own session (via `get_background_session()` or an equivalent caller-independent factory), use it, and release it entirely within the task. This prevents the caller's cancellation (e.g. a client disconnect) from closing a session that the still-running detached task then touches, which — because `AsyncSession` is not safe for concurrent use — strands a pooled connection that never returns and, accumulated over time, exhausts the background engine pool.
+
+#### Scenario: Client disconnect during token refresh does not strand a connection
+
+- **GIVEN** a proxy request triggers an account token refresh through `AuthManager.ensure_fresh`
+- **AND** the refresh runs as a detached singleflight task held alive by `asyncio.shield`
+- **AND** the request that initiated it is bound to a request-scoped background session
+- **WHEN** the client disconnects mid-refresh and the request task is cancelled
+- **THEN** the refresh task MUST complete its token/status writes against its own session, acquired independently of the cancelled request
+- **AND** the request-scoped session MUST close without being used by the refresh task after close
+- **AND** no background-pool connection is left checked out after the refresh task finishes
+
+#### Scenario: Non-cancellable callers retain the bound-session path
+
+- **GIVEN** a caller whose session is not tied to a client-cancellable request (for example the usage refresh scheduler holding its own loop-scoped session)
+- **AND** that caller invokes `AuthManager.ensure_fresh` without supplying a refresh session factory
+- **WHEN** a token refresh runs
+- **THEN** the refresh MAY use the caller's bound session
+- **AND** behavior is unchanged from before this requirement (no new session is opened)
+
+#### Scenario: Accumulated leak no longer exhausts the background pool
+
+- **GIVEN** repeated client disconnects during token refreshes over an extended period
+- **WHEN** each disconnect-during-refresh occurs
+- **THEN** each refresh task releases its connection back to the background pool
+- **AND** the background engine pool (`database_background_pool_size` + `database_background_max_overflow`) is not driven to exhaustion by stranded refresh connections
+- **AND** `/backend-api/codex/*` requests do not begin returning `500` from `QueuePool limit ... connection timed out` as a result of this path

--- a/openspec/changes/fix-auth-refresh-detached-session-leak/tasks.md
+++ b/openspec/changes/fix-auth-refresh-detached-session-leak/tasks.md
@@ -1,0 +1,8 @@
+- [x] Add optional `refresh_repo_factory` to `AuthManager.__init__` (`Callable[[], AbstractAsyncContextManager[AccountsRepositoryPort]] | None`).
+- [x] Add `AuthManager._run_refresh` as the singleflight body and point `ensure_fresh` at it. When `refresh_repo_factory` is set, open a fresh repo (`async with self._refresh_repo_factory() as repo`) and run `refresh_account` via a temporary `AuthManager(repo, acquire_refresh_admission=...)`; otherwise fall back to `self.refresh_account(account)`.
+- [x] Add `ProxyService._accounts_refresh_scope` (`@asynccontextmanager`) yielding `repos.accounts` from `self._repo_factory()`, and pass `refresh_repo_factory=self._accounts_refresh_scope` where `_ensure_fresh` builds `AuthManager`.
+- [x] Add `test_ensure_fresh_detached_refresh_owns_session_on_caller_cancel` to `tests/unit/test_auth_manager.py`: refresh in flight, cancel the caller, assert the refresh wrote via the owned session (opened + closed) and never the request-scoped repo. Verify it fails before the fix and passes after.
+- [x] `uv run pytest tests/unit/test_auth_manager.py -q` green.
+- [x] `uvx ruff check` + `uvx ruff format --check` on touched files clean; `uv run ty check` on touched files clean.
+- [x] Add `ADDED Requirements` delta to `openspec/changes/fix-auth-refresh-detached-session-leak/specs/database-backends/spec.md`.
+- [ ] Run `openspec validate --specs` where the OpenSpec CLI is available.

--- a/openspec/changes/fix-auth-refresh-detached-session-leak/tasks.md
+++ b/openspec/changes/fix-auth-refresh-detached-session-leak/tasks.md
@@ -5,4 +5,4 @@
 - [x] `uv run pytest tests/unit/test_auth_manager.py -q` green.
 - [x] `uvx ruff check` + `uvx ruff format --check` on touched files clean; `uv run ty check` on touched files clean.
 - [x] Add `ADDED Requirements` delta to `openspec/changes/fix-auth-refresh-detached-session-leak/specs/database-backends/spec.md`.
-- [ ] Run `openspec validate --specs` where the OpenSpec CLI is available.
+- [x] Run `openspec validate --specs` where the OpenSpec CLI is available.

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime
 from types import SimpleNamespace
 from typing import cast
@@ -68,6 +70,82 @@ class _DummyRepo:
             "chatgpt_account_id": chatgpt_account_id,
         }
         return True
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_detached_refresh_owns_session_on_caller_cancel(monkeypatch):
+    """Regression: a client disconnect during a forced token refresh must not
+    strand a background-pool connection. The shielded refresh task must write
+    via its OWN session (from refresh_repo_factory), never the request-scoped
+    repo that the cancelled caller closes. Pre-fix this leaked one pooled
+    connection per disconnect-during-refresh (codex-lb pool-exhaustion spiral).
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _fake_refresh(_: str) -> TokenRefreshResult:
+        started.set()
+        await release.wait()
+        return TokenRefreshResult(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            id_token="new-id",
+            account_id="acc_disconnect",
+            plan_type="plus",
+            email=None,
+        )
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+
+    request_repo = _DummyRepo()
+    owned_repo = _DummyRepo()
+    scope_state = {"opened": False, "closed": False}
+
+    @asynccontextmanager
+    async def _refresh_scope() -> AsyncIterator[AccountsRepositoryPort]:
+        scope_state["opened"] = True
+        try:
+            yield cast(AccountsRepositoryPort, owned_repo)
+        finally:
+            scope_state["closed"] = True
+
+    encryptor = TokenEncryptor()
+    account = Account(
+        id="acc_disconnect",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    manager = AuthManager(
+        cast(AccountsRepositoryPort, request_repo),
+        refresh_repo_factory=_refresh_scope,
+    )
+
+    caller = asyncio.create_task(manager.ensure_fresh(account, force=True))
+    await started.wait()  # refresh is in-flight
+    caller.cancel()  # simulate the client disconnecting mid-refresh
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    # The shielded refresh task survives the caller's cancellation; let it finish.
+    release.set()
+    for _ in range(200):
+        if owned_repo.tokens_payload is not None and scope_state["closed"]:
+            break
+        await asyncio.sleep(0.005)
+
+    # The refresh wrote through its OWN session and never the request-scoped one.
+    assert owned_repo.tokens_payload is not None
+    assert owned_repo.tokens_payload["account_id"] == "acc_disconnect"
+    assert request_repo.tokens_payload is None
+    # The owned session was opened and deterministically closed (connection returned).
+    assert scope_state["opened"] is True
+    assert scope_state["closed"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes a background DB connection-pool leak: the detached, shielded token-refresh task can keep using a request-scoped `AsyncSession` after the originating request is cancelled (client disconnect), stranding a pooled connection. Accumulated, this exhausts the background pool and surfaces as `QueuePool limit ... connection timed out` 500s on every pool-backed path until restart.

## Root cause
`AuthManager.ensure_fresh` submits `refresh_account` to `_RefreshSingleflight`, which runs it as `asyncio.create_task(...)` then `await asyncio.shield(task)`. `refresh_account` writes via the manager's bound repo. In the proxy path that repo is bound to the request-scoped background session opened by `ProxyService._ensure_fresh` (`async with self._repo_factory()` -> `get_background_session()`).

On client disconnect mid-refresh, the request is cancelled at `await asyncio.shield(task)`; the shield keeps the refresh task alive, but the caller unwinds and the `async with` closes the session. The still-running task then calls `update_tokens` on the closed, concurrently-finalized `AsyncSession` (not safe for concurrent use), checking out a connection that is never returned to the pool.

Observed signature in a production multi-agent deployment: thousands of `QueuePool limit` 500s over hours, onset only after days of uptime (~1 leak per disconnect-interrupted refresh), correlated with client reconnect storms, and not per-request.

## Fix
- `AuthManager` gains an optional `refresh_repo_factory`. New `_run_refresh` (the singleflight body) opens its **own** session for the refresh write when the factory is set, decoupling the detached task from the caller's cancellation. Falls back to the bound repo when no factory is given (callers whose session is not client-cancellable, e.g. the usage refresh scheduler).
- `ProxyService._ensure_fresh` passes `refresh_repo_factory=self._accounts_refresh_scope` (a fresh accounts repo from the existing `_repo_factory`).

## Test
`tests/unit/test_auth_manager.py::test_ensure_fresh_detached_refresh_owns_session_on_caller_cancel`: refresh in flight -> cancel the caller -> assert the refresh wrote via its own session (opened + closed), never the request-scoped repo. Fails before the change, passes after.

## Verification
- `uv run pytest tests/unit/test_auth_manager.py -q` -> passes
- `uvx ruff check` / `uvx ruff format --check` (touched files) -> clean
- `uv run ty check` (touched files) -> clean

Includes an OpenSpec change under `database-backends` documenting the invariant (detached/shielded tasks own their DB session lifetime). No env/config/API/migration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
