### PR TITLE
fix(proxy): mask codex chatgpt previous-response websocket errors

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11724,12 +11724,20 @@ def _websocket_event_error_payload(
         return None
     if event_type == "error":
         error = payload.get("error")
-    elif event_type == "response.failed":
+        if isinstance(error, dict):
+            return cast(dict[str, JsonValue], error)
+        # The ChatGPT-backed Codex websocket can emit OpenAI-style error
+        # details directly on the event frame instead of under an ``error``
+        # envelope. Treat those frames as errors so continuity masking sees
+        # ``previous_response_not_found`` instead of relaying the raw frame.
+        if any(isinstance(payload.get(field), str) for field in ("code", "message", "param")):
+            return payload
+        return None
+    if event_type == "response.failed":
         response = payload.get("response")
         error = response.get("error") if isinstance(response, dict) else None
-    else:
-        return None
-    return cast(dict[str, JsonValue], error) if isinstance(error, dict) else None
+        return cast(dict[str, JsonValue], error) if isinstance(error, dict) else None
+    return None
 
 
 def _maybe_rewrite_websocket_previous_response_not_found_event(

--- a/openspec/changes/mask-codex-chatgpt-previous-response-error/proposal.md
+++ b/openspec/changes/mask-codex-chatgpt-previous-response-error/proposal.md
@@ -1,0 +1,17 @@
+# Mask Codex ChatGPT previous-response WebSocket errors
+
+## Why
+
+Codex clients using the ChatGPT-backed `/backend-api/codex/responses` WebSocket path can still receive a raw upstream `previous_response_not_found` invalid-request error when the backend emits an error frame in a top-level error-field shape instead of the nested OpenAI error envelope shape already covered by the proxy.
+
+Raw `previous_response_not_found` is a continuity-loss implementation detail. Surfacing it to Codex clients is harmful because clients may drop `previous_response_id` and resend full conversation history, causing runaway context growth.
+
+## What Changes
+
+- Treat top-level WebSocket error fields (`code`, `message`, `param`) as an upstream error payload for `type: "error"` frames.
+- Reuse the existing continuity masking/rewrite path so Codex-native WebSocket clients receive `stream_incomplete`, not raw `previous_response_not_found`.
+- Add regression coverage for `/backend-api/codex/responses` with a ChatGPT-style top-level previous-response-miss error frame.
+
+## Impact
+
+Codex ChatGPT-backend WebSocket sessions fail closed with a retryable continuity error when upstream loses a previous-response anchor. Existing nested error envelopes and public `/v1/responses` behavior remain unchanged.

--- a/openspec/changes/mask-codex-chatgpt-previous-response-error/specs/responses-api-compat/spec.md
+++ b/openspec/changes/mask-codex-chatgpt-previous-response-error/specs/responses-api-compat/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Codex WebSocket top-level previous-response errors are masked
+When serving the Codex-native `/backend-api/codex/responses` WebSocket route, the proxy MUST treat upstream `type: "error"` frames with top-level error fields as upstream error envelopes if the frame does not contain a nested `error` object. If those fields describe a `previous_response_not_found` continuity miss, the proxy MUST use the existing continuity fail-closed behavior and MUST NOT forward raw `previous_response_not_found` or the missing response id to the downstream Codex client.
+
+#### Scenario: ChatGPT backend emits top-level previous-response miss on Codex websocket
+- **WHEN** a `/backend-api/codex/responses` WebSocket follow-up has `previous_response_id`
+- **AND** the ChatGPT backend emits `{"type":"error","code":"previous_response_not_found","param":"previous_response_id",...}` without a nested `error` object
+- **THEN** the downstream event is a retryable continuity failure such as `stream_incomplete`
+- **AND** the downstream payload does not contain `previous_response_not_found`
+- **AND** the downstream payload does not expose the missing previous response id

--- a/openspec/changes/mask-codex-chatgpt-previous-response-error/tasks.md
+++ b/openspec/changes/mask-codex-chatgpt-previous-response-error/tasks.md
@@ -1,0 +1,14 @@
+## 1. Specification
+- [x] Add a responses-api-compat delta for top-level Codex ChatGPT WebSocket previous-response errors.
+
+## 2. Tests
+- [x] Add regression coverage for `/backend-api/codex/responses` receiving a top-level `previous_response_not_found` WebSocket error frame.
+- [x] Verify existing nested previous-response masking regressions remain green.
+
+## 3. Implementation
+- [x] Broaden WebSocket error payload extraction to treat top-level `type: "error"` fields as an error payload when no nested `error` object exists.
+- [x] Reuse existing `stream_incomplete` continuity masking behavior.
+
+## 4. Verification
+- [x] Run focused WebSocket previous-response regression tests.
+- [x] Run OpenSpec validation.

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -2455,6 +2455,123 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
     assert fake_upstream.closed is True
 
 
+def test_backend_responses_websocket_masks_top_level_previous_response_not_found_from_chatgpt_backend(
+    app_instance,
+    monkeypatch,
+):
+    fake_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "error",
+                            "status": 400,
+                            "error_type": "invalid_request_error",
+                            "code": "previous_response_not_found",
+                            "message": "Previous response with id 'resp_chatgpt_prev_anchor' not found.",
+                            "param": "previous_response_id",
+                        },
+                        separators=(",", ":"),
+                    ),
+                )
+            ],
+        ],
+    )
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return SimpleNamespace(id="acct_ws_chatgpt_prev_top_level"), fake_upstream
+
+    async def fake_resolve_previous_response_owner(
+        self,
+        *,
+        previous_response_id,
+        api_key,
+        session_id=None,
+        surface,
+    ):
+        del self, previous_response_id, api_key, session_id, surface
+        return None
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_resolve_websocket_previous_response_owner",
+        fake_resolve_previous_response_owner,
+    )
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={"Authorization": "Bearer external-token"},
+        ) as websocket:
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "instructions": "",
+                        "previous_response_id": "resp_chatgpt_prev_anchor",
+                        "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
+                        "stream": True,
+                    }
+                )
+            )
+            failed_event = json.loads(websocket.receive_text())
+
+    assert failed_event["type"] == "response.failed"
+    assert failed_event["response"]["error"]["code"] == "stream_incomplete"
+    assert failed_event["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    serialized = json.dumps(failed_event)
+    assert "previous_response_not_found" not in serialized
+    assert "resp_chatgpt_prev_anchor" not in serialized
+
+
 def test_backend_responses_websocket_masks_previous_response_not_found_when_message_omits_response_id(
     app_instance,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Mask ChatGPT-backed Codex WebSocket `previous_response_not_found` frames that put error fields at the top level instead of under `error`.
- Route those frames through the existing continuity fail-closed path so clients receive `stream_incomplete` without the missing response id.
- Add an OpenSpec delta and regression coverage for `/backend-api/codex/responses`.

## Test Plan
- `uv run pytest -q tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_top_level_previous_response_not_found_from_chatgpt_backend tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_anonymous_previous_response_not_found_with_inflight_request tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_previous_response_not_found_when_message_omits_response_id tests/integration/test_proxy_websocket_responses.py::test_v1_responses_websocket_masks_short_previous_response_not_found_without_retry tests/unit/test_bridge_context_blowup.py::TestMidRequestFailurePreservesPreviousResponseId::test_mid_request_failure_with_previous_response_id_raises_502`
- `uv run ruff check app/modules/proxy/service.py tests/integration/test_proxy_websocket_responses.py`
- `openspec validate mask-codex-chatgpt-previous-response-error --strict`
