### PR TITLE
feat(ui): multiple dashboard ui adjustments

### DIFF
--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -52,12 +52,16 @@ class DashboardService:
         primary_usage = await self._repo.latest_usage_by_account("primary")
         secondary_usage = await self._repo.latest_usage_by_account("secondary")
 
-        account_summaries = build_account_summaries(
-            accounts=accounts,
-            primary_usage=primary_usage,
-            secondary_usage=secondary_usage,
-            encryptor=self._encryptor,
-            include_auth=False,
+        account_summaries = sorted(
+            build_account_summaries(
+                accounts=accounts,
+                primary_usage=primary_usage,
+                secondary_usage=secondary_usage,
+                encryptor=self._encryptor,
+                include_auth=False,
+            ),
+            key=lambda a: a.capacity_credits_primary or 0,
+            reverse=True,
         )
 
         primary_rows_raw = _rows_from_latest(primary_usage)

--- a/frontend/src/components/donut-chart.tsx
+++ b/frontend/src/components/donut-chart.tsx
@@ -229,10 +229,16 @@ export function DonutChart({ items, total, centerValue, title, subtitle, safeLin
                    <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">Credits</p>
                    <p
                      className="text-sm font-semibold tabular-nums leading-tight"
-                     data-testid="donut-center-fraction"
+                     data-testid="donut-center-remaining"
                    >
                      {formatNumber(displayTotal)}
-                     <span className="text-muted-foreground">/{formatNumber(safeCapacity)}</span>
+                   </p>
+                   <div className="-mx-1 my-0.5 border-t border-current opacity-20" />
+                   <p
+                     className="text-xs tabular-nums text-muted-foreground leading-tight"
+                     data-testid="donut-center-capacity"
+                   >
+                     {formatNumber(safeCapacity)}
                    </p>
                  </>
                ) : (

--- a/frontend/src/features/dashboard/components/account-cards.test.tsx
+++ b/frontend/src/features/dashboard/components/account-cards.test.tsx
@@ -20,7 +20,7 @@ describe("AccountCards", () => {
     );
 
     expect(screen.getByTestId("dashboard-account-cards")).toHaveStyle({
-      maxHeight: "calc(2 * 12.5rem + 1rem)",
+      maxHeight: "calc(2 * 11.5rem + 1rem)",
     });
   });
 

--- a/frontend/src/features/dashboard/components/account-cards.tsx
+++ b/frontend/src/features/dashboard/components/account-cards.tsx
@@ -8,7 +8,7 @@ import { buildDuplicateAccountIdSet } from "@/utils/account-identifiers";
 
 const ACCOUNT_CARD_VISIBLE_ROWS = 2;
 // Account cards can grow when the optional email row is rendered.
-const ACCOUNT_CARD_ROW_HEIGHT_REM = 12.5;
+const ACCOUNT_CARD_ROW_HEIGHT_REM = 11.5;
 const ACCOUNT_CARD_ROW_GAP_REM = 1;
 
 export type AccountCardsProps = {

--- a/frontend/src/features/dashboard/components/usage-donuts.test.tsx
+++ b/frontend/src/features/dashboard/components/usage-donuts.test.tsx
@@ -37,9 +37,9 @@ describe("UsageDonuts", () => {
 
     expect(screen.getByText("5-Hour Credits")).toBeInTheDocument();
     expect(screen.getByText("Weekly Credits")).toBeInTheDocument();
-    // Center label switched from "Remaining" -> "Credit" with the
+    // Center label switched from "Remaining" -> "Credits" with the
     // credits layout; assert that both donuts render the new label.
-    expect(screen.getAllByText("Credit").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Credits").length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders safe line only for the primary donut", () => {

--- a/frontend/src/features/dashboard/components/usage-donuts.test.tsx
+++ b/frontend/src/features/dashboard/components/usage-donuts.test.tsx
@@ -19,7 +19,7 @@ describe("UsageDonuts", () => {
       />,
     );
 
-    expect(screen.getByText("Hourly Credits")).toBeInTheDocument();
+    expect(screen.getByText("5-Hour Credits")).toBeInTheDocument();
     expect(screen.getByText("Weekly Credits")).toBeInTheDocument();
     expect(screen.getByText("primary@example.com")).toBeInTheDocument();
     expect(screen.getByText("secondary@example.com")).toBeInTheDocument();
@@ -35,11 +35,11 @@ describe("UsageDonuts", () => {
       />,
     );
 
-    expect(screen.getByText("Hourly Credits")).toBeInTheDocument();
+    expect(screen.getByText("5-Hour Credits")).toBeInTheDocument();
     expect(screen.getByText("Weekly Credits")).toBeInTheDocument();
-    // Center label switched from "Remaining" -> "Credits" with the
+    // Center label switched from "Remaining" -> "Credit" with the
     // credits layout; assert that both donuts render the new label.
-    expect(screen.getAllByText("Credits").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Credit").length).toBeGreaterThanOrEqual(2);
   });
 
   it("renders safe line only for the primary donut", () => {
@@ -85,11 +85,12 @@ describe("UsageDonuts", () => {
     expect(screen.getAllByTestId("safe-line-tick")).toHaveLength(1);
   });
 
-  it("shows remaining credits as raw remaining/total fraction in the center", () => {
-    // Regression for #371: dashboard donuts previously showed
-    // compact-formatted numbers like "7.33k" / "7.56k". Operators
+  it("shows remaining credits and capacity as stacked values with a divider in the center", () => {
+    // Regression for #371 + redesigned display: dashboard donuts previously
+    // showed compact-formatted numbers like "7.33k" / "7.56k". Operators
     // asked for the raw remaining/total credit counts instead so the
-    // exact distance to the cap is visible at a glance.
+    // exact distance to the cap is visible at a glance. Now split into
+    // stacked rows: remaining on top, capacity below a divider.
     render(
       <UsageDonuts
         primaryItems={[item({ accountId: "acc-1", label: "primary@example.com", value: 120, remainingPercent: 60, color: "#7bb661" })]}
@@ -101,12 +102,9 @@ describe("UsageDonuts", () => {
       />,
     );
 
-    const fractions = screen.getAllByTestId("donut-center-fraction").map((node) => node.textContent);
-    expect(fractions).toEqual([
-      // Primary: 120 / 225 (well under 4-digit thresholds; no separators).
-      "120/225",
-      // Secondary: 7,331 / 7,560 — locale-formatted, NOT "7.33k/7.56k".
-      "7,331/7,560",
-    ]);
+    const remaining = screen.getAllByTestId("donut-center-remaining").map((node) => node.textContent);
+    const capacity = screen.getAllByTestId("donut-center-capacity").map((node) => node.textContent);
+    expect(remaining).toEqual(["120", "7,331"]);
+    expect(capacity).toEqual(["225", "7,560"]);
   });
 });

--- a/frontend/src/features/dashboard/components/usage-donuts.tsx
+++ b/frontend/src/features/dashboard/components/usage-donuts.tsx
@@ -52,7 +52,7 @@ export function UsageDonuts({
 	return (
 		<div className="grid gap-4 lg:grid-cols-2">
 			<DonutChart
-				title="Hourly Credits"
+				title="5-Hour Credits"
 				items={primaryChartItems}
 				total={primaryTotal}
 				centerValue={primaryCenterValue}

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
@@ -123,7 +123,7 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
 
   return (
     <section className="rounded-xl border bg-card p-5" aria-label="Weekly credits pace">
-      <div className="mb-4 flex items-center justify-between gap-3">
+      <div className="mb-4 flex justify-between gap-3">
         <div>
           <h3 className="text-sm font-semibold">Weekly credits pace</h3>
         </div>

--- a/openspec/changes/feat-ui-adjustments/proposal.md
+++ b/openspec/changes/feat-ui-adjustments/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The dashboard donut center previously rendered remaining credits and capacity as a single inline fraction (`7,331/7,560`). Operators reported that the fraction was hard to scan quickly and the donut titles said "Hourly Credits" which was ambiguous. Additionally, the account cards list did not sort by capacity, making it harder to spot the largest accounts at the top.
+
+## What Changes
+
+- `frontend/src/components/donut-chart.tsx`: split the credits center layout into two stacked rows — remaining on top, a thin divider, capacity below — instead of an inline `remaining/total` fraction. Add `data-testid="donut-center-remaining"` and `data-testid="donut-center-capacity"` for test targeting.
+- `frontend/src/features/dashboard/components/usage-donuts.tsx`: rename the primary donut title from `"Hourly Credits"` to `"5-Hour Credits"` to match the 5-hour quota window wording used elsewhere.
+- `app/modules/dashboard/service.py`: sort account summaries by `capacity_credits_primary` descending so the highest-capacity accounts appear first.
+- `frontend/src/features/dashboard/components/account-cards.tsx`: reduce `ACCOUNT_CARD_ROW_HEIGHT_REM` from 12.5 to 11.5 to tighten the card viewport.
+- `frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx`: remove `items-center` from the header row so the title and gauge icon align to the flex start instead of centering vertically.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `frontend-architecture`: dashboard donut center layout, donut title, account card height, weekly pace header alignment.
+- Backend: dashboard account summary sort order.
+
+## Impact
+
+- **Code**: `donut-chart.tsx`, `usage-donuts.tsx`, `dashboard/service.py`, `account-cards.tsx`, `weekly-credits-pace-card.tsx`.
+- **Tests**: `usage-donuts.test.tsx` (updated assertions for stacked layout and title rename), `account-cards.test.tsx` (updated height expectation).
+- **API/back-end**: account summaries in the overview response are now sorted by primary capacity descending.
+- **Operational**: no migration, no settings.

--- a/openspec/changes/feat-ui-adjustments/specs/frontend-architecture/spec.md
+++ b/openspec/changes/feat-ui-adjustments/specs/frontend-architecture/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard usage donuts present credits as stacked remaining and capacity
+
+The dashboard's primary and secondary usage donuts MUST present remaining credits and capacity as two stacked values separated by a horizontal divider: the remaining count above (bold, `data-testid="donut-center-remaining"`) and the capacity count below (muted, `data-testid="donut-center-capacity"`). Both values MUST use locale-aware thousands separators (e.g. `7,331` and `7,560`). Compact-format abbreviation (e.g. `7.33k`) MUST NOT be used in the donut center for these panels.
+
+The primary donut title MUST read `5-Hour Credits`. The secondary donut title MUST read `Weekly Credits`.
+
+#### Scenario: Dashboard donut shows stacked remaining and capacity
+
+- **WHEN** the dashboard renders a usage donut with `remaining=7331` and `total=7560`
+- **THEN** the donut title reads `5-Hour Credits` or `Weekly Credits`
+- **AND** the center renders `7,331` in the remaining element and `7,560` in the capacity element
+- **AND** a divider separates the two values
+
+## ADDED Requirements
+
+### Requirement: Dashboard account summaries sorted by primary capacity
+
+The dashboard overview API MUST return account summaries sorted by `capacity_credits_primary` in descending order so the highest-capacity accounts appear first. Accounts with no primary capacity MUST sort after accounts that have one.
+
+#### Scenario: Accounts ordered by primary capacity
+
+- **WHEN** the dashboard overview response includes multiple accounts with different `capacity_credits_primary` values
+- **THEN** accounts are ordered from highest to lowest primary capacity
+
+#### Scenario: Accounts without primary capacity sort last
+
+- **WHEN** an account has `capacity_credits_primary` of `null` or `0`
+- **THEN** that account appears after accounts with a positive primary capacity
+
+### Requirement: Account card row height is 11.5rem
+
+The dashboard account card viewport MUST use 11.5rem per visible row.
+
+#### Scenario: Account card max height
+
+- **WHEN** the account cards container renders with `ACCOUNT_CARD_VISIBLE_ROWS=2`
+- **THEN** the container `maxHeight` is `calc(2 * 11.5rem + 1rem)`
+
+### Requirement: Weekly credits pace header uses flex-start alignment
+
+The weekly credits pace card header MUST align the title and gauge icon to the flex start, not vertically centered.
+
+#### Scenario: Header alignment
+
+- **WHEN** the weekly credits pace card renders
+- **THEN** the header row uses `justify-between` without `items-center`

--- a/openspec/changes/feat-ui-adjustments/tasks.md
+++ b/openspec/changes/feat-ui-adjustments/tasks.md
@@ -1,0 +1,30 @@
+## 1. Donut Center Layout
+
+- [x] 1.1 Split credits center into stacked remaining (top) and capacity (bottom) rows separated by a divider.
+- [x] 1.2 Add `data-testid="donut-center-remaining"` and `data-testid="donut-center-capacity"` to the new elements.
+- [x] 1.3 Remove old `data-testid="donut-center-fraction"`.
+
+## 2. Donut Title
+
+- [x] 2.1 Rename primary donut title from `"Hourly Credits"` to `"5-Hour Credits"`.
+
+## 3. Account Summary Sort
+
+- [x] 3.1 Sort `account_summaries` in `DashboardService.get_overview` by `capacity_credits_primary` descending.
+
+## 4. Account Card Height
+
+- [x] 4.1 Reduce `ACCOUNT_CARD_ROW_HEIGHT_REM` from 12.5 to 11.5.
+
+## 5. Weekly Pace Header
+
+- [x] 5.1 Remove `items-center` from the weekly credits pace card header row.
+
+## 6. Tests
+
+- [x] 6.1 Update `usage-donuts.test.tsx` to assert stacked remaining/capacity values and `"5-Hour Credits"` title.
+- [x] 6.2 Update `account-cards.test.tsx` to assert new `maxHeight` with 11.5rem row height.
+
+## 7. Spec Delta
+
+- [x] 7.1 Add `openspec/changes/feat-ui-adjustments/specs/frontend-architecture/spec.md`.


### PR DESCRIPTION
## Summary
This contains multiple adjustments for the UI

1. Hourly Credits -> 5 Hour Credit to align and correct the actual window length
2. The credits in the donut is adjusted by moving `current` / `total` to using a horizontal divider, minimizing the effect of overflowing
3. Weekly credits pace header move to align the header height
4. Account section max-height is reduced, prevent showing a part of 3rd row of accounts
5. Account is sorted by 5-hour plan credit for the plan in descending order, so that the paid plan will show up first.

Before
<img width="1475" height="760" alt="螢幕截圖 2026-05-22 23 32 12" src="https://github.com/user-attachments/assets/ebe2e282-68f2-4981-a04b-63266fabd6f9" />

After
<img width="1470" height="753" alt="螢幕截圖 2026-05-22 23 39 02" src="https://github.com/user-attachments/assets/9f0c6283-62ec-4742-81a8-a252f6c4e3e9" />
