### PR TITLE
fix(proxy): fail over compact after invalidated token

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2389,7 +2389,7 @@ async def compact_responses(
 
 
 def _is_retryable_compact_status(status_code: int) -> bool:
-    return status_code in {401, 500, 502, 503, 504}
+    return status_code in {500, 502, 503, 504}
 
 
 @dataclass(slots=True)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2378,6 +2378,36 @@ class ProxyService:
                             return response
                         except ProxyResponseError as retry_exc:
                             await self._handle_proxy_error(account, retry_exc)
+                            if retry_exc.status_code == 401:
+                                selection = await self._select_account_with_budget_compatible(
+                                    deadline,
+                                    request_id=request_id,
+                                    kind=request_kind,
+                                    api_key=api_key,
+                                    sticky_key=affinity.key,
+                                    sticky_kind=affinity.kind,
+                                    reallocate_sticky=affinity.reallocate_sticky,
+                                    sticky_max_age_seconds=affinity.max_age_seconds,
+                                    prefer_earlier_reset_accounts=settings.prefer_earlier_reset_accounts,
+                                    routing_strategy=routing_strategy,
+                                    model=selection_model,
+                                    exclude_account_ids={account.id},
+                                )
+                                if selection.account is not None:
+                                    account = selection.account
+                                    account_id_value = account.id
+                                    account = await self._ensure_fresh_with_budget(
+                                        account,
+                                        timeout_seconds=_remaining_budget_seconds(deadline),
+                                    )
+                                    try:
+                                        response = await _call_goal(account)
+                                        await self._load_balancer.record_success(account)
+                                        log_status = "success"
+                                        return response
+                                    except ProxyResponseError as failover_exc:
+                                        await self._handle_proxy_error(account, failover_exc)
+                                        raise
                             raise
                     except RefreshError as refresh_exc:
                         if refresh_exc.is_permanent:
@@ -2559,6 +2589,36 @@ class ProxyService:
                             return response
                         except ProxyResponseError as retry_exc:
                             await self._handle_proxy_error(account, retry_exc)
+                            if retry_exc.status_code == 401:
+                                selection = await self._select_account_with_budget_compatible(
+                                    deadline,
+                                    request_id=request_id,
+                                    kind=request_kind,
+                                    api_key=api_key,
+                                    sticky_key=affinity.key,
+                                    sticky_kind=affinity.kind,
+                                    reallocate_sticky=affinity.reallocate_sticky,
+                                    sticky_max_age_seconds=affinity.max_age_seconds,
+                                    prefer_earlier_reset_accounts=settings.prefer_earlier_reset_accounts,
+                                    routing_strategy=routing_strategy,
+                                    model=selection_model,
+                                    exclude_account_ids={account.id},
+                                )
+                                if selection.account is not None:
+                                    account = selection.account
+                                    account_id_value = account.id
+                                    account = await self._ensure_fresh_with_budget(
+                                        account,
+                                        timeout_seconds=_remaining_budget_seconds(deadline),
+                                    )
+                                    try:
+                                        response = await _call_control(account)
+                                        await self._load_balancer.record_success(account)
+                                        log_status = "success"
+                                        return response
+                                    except ProxyResponseError as failover_exc:
+                                        await self._handle_proxy_error(account, failover_exc)
+                                        raise
                             raise
                     except RefreshError as refresh_exc:
                         if refresh_exc.is_permanent:
@@ -2734,8 +2794,34 @@ class ProxyService:
                     await self._load_balancer.record_success(account)
                     log_status = "success"
                     return result
-                except ProxyResponseError as exc:
-                    await self._handle_proxy_error(account, exc)
+                except ProxyResponseError as retry_exc:
+                    await self._handle_proxy_error(account, retry_exc)
+                    if retry_exc.status_code == 401:
+                        selection = await self._select_account_with_budget_compatible(
+                            deadline,
+                            request_id=request_id,
+                            kind="transcribe",
+                            api_key=api_key,
+                            prefer_earlier_reset_accounts=prefer_earlier_reset,
+                            routing_strategy=routing_strategy,
+                            model=None,
+                            exclude_account_ids={account.id},
+                        )
+                        if selection.account is not None:
+                            account = selection.account
+                            account_id_value = account.id
+                            account = await self._ensure_fresh_with_budget(
+                                account,
+                                timeout_seconds=_remaining_budget_seconds(deadline),
+                            )
+                            try:
+                                result = await _call_transcribe(account)
+                                await self._load_balancer.record_success(account)
+                                log_status = "success"
+                                return result
+                            except ProxyResponseError as failover_exc:
+                                await self._handle_proxy_error(account, failover_exc)
+                                raise
                     raise
         except ProxyResponseError as exc:
             error = _parse_openai_error(exc.payload)
@@ -3160,6 +3246,33 @@ class ProxyService:
                     return result, account_id_value
                 except ProxyResponseError as retry_exc:
                     await self._handle_proxy_error(account, retry_exc)
+                    if retry_exc.status_code == 401:
+                        selection = await self._select_account_with_budget_compatible(
+                            deadline,
+                            request_id=request_id,
+                            kind=kind,
+                            api_key=api_key,
+                            prefer_earlier_reset_accounts=prefer_earlier_reset,
+                            routing_strategy=routing_strategy,
+                            model=None,
+                            preferred_account_id=preferred_account_id,
+                            exclude_account_ids={account.id},
+                        )
+                        if selection.account is not None:
+                            account = selection.account
+                            account_id_value = account.id
+                            account = await self._ensure_fresh_with_budget(
+                                account,
+                                timeout_seconds=_remaining_budget_seconds(deadline),
+                            )
+                            try:
+                                result = await _call(account)
+                                await self._load_balancer.record_success(account)
+                                log_status = "success"
+                                return result, account_id_value
+                            except ProxyResponseError as failover_exc:
+                                await self._handle_proxy_error(account, failover_exc)
+                                raise
                     raise
         except ProxyResponseError as exc:
             error = _parse_openai_error(exc.payload)
@@ -4575,11 +4688,14 @@ class ProxyService:
     ) -> str:
         classified = await self._handle_websocket_connect_error(account, exc)
         failure_class = classified["failure_class"] if isinstance(classified, dict) else "non_retryable"
-        if deterministic_failover_enabled:
+        candidates_remaining = max_attempts - attempt
+        if exc.status_code == 401 and candidates_remaining > 0:
+            action = "failover_next"
+        elif deterministic_failover_enabled:
             action = failover_decision(
                 failure_class=failure_class,
                 downstream_visible=False,
-                candidates_remaining=max_attempts - attempt,
+                candidates_remaining=candidates_remaining,
             )
         else:
             action = "surface"
@@ -9717,6 +9833,100 @@ class ProxyService:
                                 tool_call_dedupe=tool_call_dedupe,
                             ):
                                 yield line
+                        except ProxyResponseError as retry_exc:
+                            if settlement.downstream_visible:
+                                failed_response_id = settlement.response_id or request_id
+                                error = _parse_openai_error(retry_exc.payload)
+                                error_code = _normalize_error_code(
+                                    error.code if error else None,
+                                    error.type if error else None,
+                                )
+                                error_message = error.message if error else "Upstream error"
+                                event = response_failed_event(
+                                    error_code or "upstream_error",
+                                    error_message or "Upstream error",
+                                    error_type=(error.type if error else None) or "server_error",
+                                    response_id=failed_response_id,
+                                    error_param=error.param if error else None,
+                                )
+                                _apply_error_metadata(event["response"]["error"], error)
+                                logger.warning(
+                                    "Surfacing post-refresh stream failure without replay "
+                                    "request_id=%s account_id=%s code=%s",
+                                    request_id,
+                                    account.id,
+                                    error_code,
+                                )
+                                yield format_sse_event(event)
+                                settlement.record_success = False
+                                settlement.error_code = error_code
+                                settlement.error_message = error_message
+                                settlement.error = _upstream_error_from_openai(error)
+                                settlement.account_health_error = _should_penalize_stream_error(error_code)
+                                if settlement.account_health_error:
+                                    await self._handle_stream_error(
+                                        account,
+                                        _stream_settlement_error_payload(settlement),
+                                        settlement.error_code or "upstream_error",
+                                        http_status=retry_exc.status_code,
+                                    )
+                                settled = await self._settle_stream_api_key_usage(
+                                    api_key,
+                                    api_key_reservation,
+                                    settlement,
+                                    request_id,
+                                )
+                                return
+                            error = _parse_openai_error(retry_exc.payload)
+                            error_code = _normalize_error_code(
+                                error.code if error else None,
+                                error.type if error else None,
+                            )
+                            if _is_account_neutral_error_code(error_code):
+                                raise
+                            classified = await self._handle_stream_error(
+                                account,
+                                _upstream_error_from_openai(error),
+                                error_code,
+                                http_status=retry_exc.status_code,
+                            )
+                            candidates_remaining = max_attempts - attempt - 1
+                            if retry_exc.status_code == 401 and candidates_remaining > 0:
+                                action = "failover_next"
+                            elif getattr(base_settings, "deterministic_failover_enabled", True):
+                                action = failover_decision(
+                                    failure_class=classified["failure_class"],
+                                    downstream_visible=False,
+                                    candidates_remaining=candidates_remaining,
+                                )
+                            else:
+                                action = "surface"
+                            logger.info(
+                                "Failover decision request_id=%s transport=stream account_id=%s "
+                                "attempt=%d phase=post_refresh failure_class=%s action=%s",
+                                request_id,
+                                account.id,
+                                attempt + 1,
+                                classified["failure_class"],
+                                action,
+                            )
+                            if action == "failover_next":
+                                last_transient_exc = retry_exc
+                                excluded_account_ids.add(account.id)
+                                continue
+                            if propagate_http_errors:
+                                raise
+                            error_message = error.message if error else None
+                            event = response_failed_event(
+                                error_code or "upstream_error",
+                                error_message or "Upstream error",
+                                error_type=(error.type if error else None) or "server_error",
+                                response_id=request_id,
+                                error_param=error.param if error else None,
+                            )
+                            _apply_error_metadata(event["response"]["error"], error)
+                            yield format_sse_event(event)
+                            return
                         finally:
                             pop_stream_timeout_overrides(stream_timeout_tokens)
                         if settlement.account_health_error:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2043,7 +2043,16 @@ class ProxyService:
                             raise compact_continuity_error from exc
                         if exc.status_code == 401:
                             if refresh_retry_used:
-                                await self._handle_proxy_error(account, exc)
+                                try:
+                                    await self._handle_proxy_error(account, exc)
+                                except Exception:
+                                    await self._settle_compact_api_key_usage(
+                                        api_key=api_key,
+                                        api_key_reservation=api_key_reservation,
+                                        response=None,
+                                        request_service_tier=request_service_tier,
+                                    )
+                                    raise
                                 last_exc = exc
                                 excluded_account_ids.add(account.id)
                                 transient_exhausted = True

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6240,6 +6240,43 @@ class ProxyService:
                     selected_account_id=account.id,
                 )
                 break
+            except ProxyResponseError as exc:
+                if exc.status_code != 401 or _remaining_budget_seconds(deadline) <= 0:
+                    raise
+                try:
+                    account = await self._ensure_fresh_with_budget(
+                        account,
+                        force=True,
+                        timeout_seconds=_remaining_budget_seconds(deadline),
+                    )
+                    connect_headers = _headers_with_turn_state(headers, _sticky_key_from_turn_state_header(headers))
+                    upstream = await self._open_upstream_websocket_with_budget(
+                        account,
+                        connect_headers,
+                        timeout_seconds=_remaining_budget_seconds(deadline),
+                    )
+                    _record_same_account_takeover(
+                        preferred_account_id=preferred_account_id,
+                        selected_account_id=account.id,
+                    )
+                    break
+                except ProxyResponseError as retry_exc:
+                    if retry_exc.status_code != 401:
+                        raise
+                    await self._handle_proxy_error(account, retry_exc)
+                    if require_preferred_account and selected_is_preferred:
+                        raise
+                    excluded_account_ids.add(account.id)
+                    preferred_candidate_id = None
+                    continue
+                except RefreshError as refresh_exc:
+                    if refresh_exc.is_permanent:
+                        await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                    if require_preferred_account and selected_is_preferred:
+                        raise
+                    excluded_account_ids.add(account.id)
+                    preferred_candidate_id = None
+                    continue
             except RefreshError as exc:
                 if exc.is_permanent:
                     await self._load_balancer.mark_permanent_failure(account, exc.code)
@@ -6962,6 +6999,42 @@ class ProxyService:
                     selected_account_id=account.id,
                 )
                 break
+            except ProxyResponseError as exc:
+                if exc.status_code != 401 or _remaining_budget_seconds(deadline) <= 0:
+                    raise
+                try:
+                    account = await self._ensure_fresh_with_budget(
+                        account,
+                        force=True,
+                        timeout_seconds=_remaining_budget_seconds(deadline),
+                    )
+                    connect_headers = _headers_with_turn_state(
+                        session.headers,
+                        _preferred_http_bridge_reconnect_turn_state(session),
+                    )
+                    upstream = await self._open_upstream_websocket_with_budget(
+                        account,
+                        connect_headers,
+                        timeout_seconds=_remaining_budget_seconds(deadline),
+                    )
+                    _record_same_account_takeover(
+                        preferred_account_id=session.account.id,
+                        selected_account_id=account.id,
+                    )
+                    break
+                except ProxyResponseError as retry_exc:
+                    if retry_exc.status_code != 401:
+                        raise
+                    await self._handle_proxy_error(account, retry_exc)
+                    excluded_account_ids.add(account.id)
+                    preferred_candidate_id = None
+                    continue
+                except RefreshError as refresh_exc:
+                    if refresh_exc.is_permanent:
+                        await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                    excluded_account_ids.add(account.id)
+                    preferred_candidate_id = None
+                    continue
             except RefreshError as exc:
                 if exc.is_permanent:
                     await self._load_balancer.mark_permanent_failure(account, exc.code)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2396,7 +2396,7 @@ class ProxyService:
                                 if selection.account is not None:
                                     account = selection.account
                                     account_id_value = account.id
-                                    account = await self._ensure_fresh_with_budget(
+                                    account = await self._ensure_fresh_with_budget_or_auth_error(
                                         account,
                                         timeout_seconds=_remaining_budget_seconds(deadline),
                                     )
@@ -2607,7 +2607,7 @@ class ProxyService:
                                 if selection.account is not None:
                                     account = selection.account
                                     account_id_value = account.id
-                                    account = await self._ensure_fresh_with_budget(
+                                    account = await self._ensure_fresh_with_budget_or_auth_error(
                                         account,
                                         timeout_seconds=_remaining_budget_seconds(deadline),
                                     )
@@ -2810,7 +2810,7 @@ class ProxyService:
                         if selection.account is not None:
                             account = selection.account
                             account_id_value = account.id
-                            account = await self._ensure_fresh_with_budget(
+                            account = await self._ensure_fresh_with_budget_or_auth_error(
                                 account,
                                 timeout_seconds=_remaining_budget_seconds(deadline),
                             )
@@ -3261,7 +3261,7 @@ class ProxyService:
                         if selection.account is not None:
                             account = selection.account
                             account_id_value = account.id
-                            account = await self._ensure_fresh_with_budget(
+                            account = await self._ensure_fresh_with_budget_or_auth_error(
                                 account,
                                 timeout_seconds=_remaining_budget_seconds(deadline),
                             )
@@ -10941,6 +10941,29 @@ class ProxyService:
         if "timeout_seconds" in parameters:
             return await self._ensure_fresh(account, force=force, timeout_seconds=timeout_seconds)
         return await self._ensure_fresh(account, force=force)
+
+    async def _ensure_fresh_with_budget_or_auth_error(
+        self,
+        account: Account,
+        *,
+        timeout_seconds: float | None = None,
+        error_type: str = "invalid_request_error",
+    ) -> Account:
+        try:
+            return await self._ensure_fresh_with_budget(account, timeout_seconds=timeout_seconds)
+        except RefreshError as refresh_exc:
+            if refresh_exc.is_permanent:
+                await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+            raise ProxyResponseError(
+                401,
+                openai_error(
+                    "invalid_api_key",
+                    refresh_exc.message,
+                    error_type=error_type,
+                ),
+            ) from refresh_exc
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            _raise_proxy_unavailable(str(exc) or "Request to upstream timed out")
 
     async def _select_account_with_budget(
         self,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1983,7 +1983,7 @@ class ProxyService:
                 account = selection.account
                 if not account:
                     if last_exc is not None:
-                        raise last_exc
+                        break
                     log_error_code = selection.error_code or "no_accounts"
                     log_error_message = selection.error_message or "No active accounts available"
                     raise ProxyResponseError(
@@ -2043,14 +2043,11 @@ class ProxyService:
                             raise compact_continuity_error from exc
                         if exc.status_code == 401:
                             if refresh_retry_used:
-                                await self._settle_compact_api_key_usage(
-                                    api_key=api_key,
-                                    api_key_reservation=api_key_reservation,
-                                    response=None,
-                                    request_service_tier=request_service_tier,
-                                )
                                 await self._handle_proxy_error(account, exc)
-                                raise
+                                last_exc = exc
+                                excluded_account_ids.add(account.id)
+                                transient_exhausted = True
+                                break
                             try:
                                 remaining_budget = _remaining_budget_seconds(deadline)
                                 if remaining_budget <= 0:

--- a/openspec/changes/fix-compact-invalidated-token-failover/proposal.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/proposal.md
@@ -23,7 +23,8 @@ state, not a client-visible final answer.
   try another eligible account.
 - Apply the same post-refresh 401 failover contract to pre-visible stream
   attempts, Codex thread goal requests, Codex control requests, transcription,
-  file create/finalize calls, and upstream websocket connect retries.
+  file create/finalize calls, upstream websocket connect retries, and HTTP
+  bridge session create/reconnect handshakes.
 - Do not classify raw compact HTTP 401 responses as generic same-contract
   transport retries.
 - Add regression coverage for repeated auth 401 failover on compact and the

--- a/openspec/changes/fix-compact-invalidated-token-failover/proposal.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/proposal.md
@@ -10,26 +10,40 @@ Compaction happens before any downstream response body is emitted, so the proxy
 can safely move to another eligible account after proving the selected account
 still cannot compact with a refreshed token.
 
+The same invalidated-token pattern exists on several other pre-response proxy
+surfaces. Once a request has retried with a refreshed token and still gets a
+401 before any downstream-visible output, the selected account is the bad local
+state, not a client-visible final answer.
+
 ## What Changes
 
 - Keep the existing same-account forced refresh on the first compact 401.
 - If the refreshed retry also returns 401, mark the selected account through the
   normal proxy error handling path, exclude it from this compact request, and
   try another eligible account.
+- Apply the same post-refresh 401 failover contract to pre-visible stream
+  attempts, Codex thread goal requests, Codex control requests, transcription,
+  file create/finalize calls, and upstream websocket connect retries.
 - Do not classify raw compact HTTP 401 responses as generic same-contract
   transport retries.
-- Add regression coverage for repeated compact 401 failover.
+- Add regression coverage for repeated auth 401 failover on compact and the
+  other affected proxy surfaces.
 
 ## Capabilities
 
 ### Modified Capabilities
 
-- `responses-api-compat`: compact auth failure handling and failover behavior.
+- `responses-api-compat`: account-local auth failure handling and failover
+  behavior.
 
 ## Impact
 
 - **Code**: `app/core/clients/proxy.py`, `app/modules/proxy/service.py`
-- **Tests**: `tests/integration/test_proxy_compact.py`
+- **Tests**: `tests/integration/test_proxy_compact.py`,
+  `tests/integration/test_proxy_responses.py`,
+  `tests/integration/test_proxy_api_extended.py`,
+  `tests/integration/test_proxy_transcriptions.py`,
+  `tests/integration/test_proxy_files.py`
 - **Behavior**: repeated invalidated-token 401s on one account no longer surface
-  immediately to Codex compact callers when another eligible account can satisfy
-  the request.
+  immediately to pre-visible proxy callers when another eligible account can
+  satisfy the request.

--- a/openspec/changes/fix-compact-invalidated-token-failover/proposal.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Codex CLI can run remote compaction through `POST /backend-api/codex/responses/compact`.
+When upstream returns `401 invalid_api_key` after a forced token refresh, the
+current compact path surfaces that 401 to the client. Codex treats the
+compaction as failed and may retry the same remote compact task repeatedly,
+turning one invalidated account token into a noisy compact failure loop.
+
+Compaction happens before any downstream response body is emitted, so the proxy
+can safely move to another eligible account after proving the selected account
+still cannot compact with a refreshed token.
+
+## What Changes
+
+- Keep the existing same-account forced refresh on the first compact 401.
+- If the refreshed retry also returns 401, mark the selected account through the
+  normal proxy error handling path, exclude it from this compact request, and
+  try another eligible account.
+- Do not classify raw compact HTTP 401 responses as generic same-contract
+  transport retries.
+- Add regression coverage for repeated compact 401 failover.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: compact auth failure handling and failover behavior.
+
+## Impact
+
+- **Code**: `app/core/clients/proxy.py`, `app/modules/proxy/service.py`
+- **Tests**: `tests/integration/test_proxy_compact.py`
+- **Behavior**: repeated invalidated-token 401s on one account no longer surface
+  immediately to Codex compact callers when another eligible account can satisfy
+  the request.

--- a/openspec/changes/fix-compact-invalidated-token-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/specs/responses-api-compat/spec.md
@@ -25,3 +25,38 @@ compact client before exhausting eligible accounts.
 - **WHEN** low-level compact transport receives HTTP 401 from upstream
 - **THEN** the service-level auth refresh/failover path handles it
 - **AND** the low-level compact transport does not mark it as a generic same-contract transport retry
+
+### Requirement: Pre-visible proxy auth failures fail over after forced refresh
+
+The proxy MUST treat repeated account-local authentication failures as
+per-request account failures before any downstream-visible output is emitted.
+When a proxy request on a non-compact surface retries with a refreshed token and
+the refreshed retry still returns upstream `401 invalid_api_key`, the proxy MUST
+classify and record the selected account failure, exclude that account from the
+current request, and try another eligible account when one is available. The
+proxy MUST preserve the existing no-replay rule after downstream-visible stream
+or websocket output has been emitted.
+
+#### Scenario: Pre-visible streaming auth failure uses another account
+
+- **GIVEN** at least two accounts are eligible for a streaming responses request
+- **AND** the selected account returns `401 invalid_api_key` before downstream-visible output
+- **WHEN** another eligible account can complete the request
+- **THEN** the downstream stream succeeds from another account
+- **AND** the selected account is excluded from further attempts for that request
+
+#### Scenario: Non-stream proxy auth failure uses another account
+
+- **GIVEN** at least two accounts are eligible for a thread-goal, Codex control,
+  transcription, or file create/finalize request
+- **AND** the selected account returns `401 invalid_api_key` before and after a forced refresh
+- **WHEN** another eligible account can complete the request
+- **THEN** the downstream request succeeds from another account
+- **AND** the selected account is excluded from further attempts for that request
+
+#### Scenario: Websocket connect auth failure uses another account
+
+- **GIVEN** at least two accounts are eligible for an upstream websocket connect
+- **AND** the selected account returns `401 invalid_api_key` after a forced refresh retry
+- **WHEN** another eligible account can open the upstream websocket
+- **THEN** the websocket connect path excludes the invalidated account and tries another account

--- a/openspec/changes/fix-compact-invalidated-token-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Compact auth failures fail over after forced refresh
+
+The proxy MUST recover from account-local compact authentication failures before
+surfacing them to the compact client. When a `/backend-api/codex/responses/compact`
+request receives an upstream `401 invalid_api_key` response for the selected
+account, the proxy MUST attempt one forced token refresh and retry the compact
+request on that same account. If the refreshed retry also returns `401`, the
+proxy MUST classify and record the account failure, exclude that account from
+the current compact request, and try another eligible account when one is
+available. The proxy MUST NOT surface the repeated account-local `401` to the
+compact client before exhausting eligible accounts.
+
+#### Scenario: Refreshed compact auth failure uses another account
+
+- **GIVEN** at least two accounts are eligible for a compact request
+- **AND** the selected account returns `401 invalid_api_key` for compact before and after a forced refresh
+- **WHEN** another eligible account can complete the compact request
+- **THEN** the downstream compact response succeeds from the second account
+- **AND** the selected account is excluded from further attempts for that compact request
+
+#### Scenario: Compact 401 is not a generic same-contract retry
+
+- **WHEN** low-level compact transport receives HTTP 401 from upstream
+- **THEN** the service-level auth refresh/failover path handles it
+- **AND** the low-level compact transport does not mark it as a generic same-contract transport retry

--- a/openspec/changes/fix-compact-invalidated-token-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/specs/responses-api-compat/spec.md
@@ -60,3 +60,10 @@ or websocket output has been emitted.
 - **AND** the selected account returns `401 invalid_api_key` after a forced refresh retry
 - **WHEN** another eligible account can open the upstream websocket
 - **THEN** the websocket connect path excludes the invalidated account and tries another account
+
+#### Scenario: HTTP bridge handshake auth failure uses another account
+
+- **GIVEN** at least two accounts are eligible for HTTP bridge session creation or reconnect
+- **AND** the selected account returns `401 invalid_api_key` after a forced refresh retry
+- **WHEN** another eligible account can open the upstream websocket handshake
+- **THEN** the HTTP bridge path excludes the invalidated account and tries another account

--- a/openspec/changes/fix-compact-invalidated-token-failover/tasks.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Keep compact's first 401 same-account forced refresh retry.
+- [x] 1.2 After the refreshed compact retry still returns 401, mark/exclude that account and continue to another eligible account.
+- [x] 1.3 Remove compact HTTP 401 from the low-level same-contract retry status set.
+
+## 2. Tests
+
+- [x] 2.1 Add integration coverage for repeated compact 401 failover to another account.
+- [x] 2.2 Verify the existing compact refresh-and-retry success path still passes.
+
+## 3. Spec Delta
+
+- [x] 3.1 Add a `responses-api-compat` requirement for compact 401 failover after forced refresh.
+- [x] 3.2 Validate the OpenSpec change.

--- a/openspec/changes/fix-compact-invalidated-token-failover/tasks.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/tasks.md
@@ -3,13 +3,16 @@
 - [x] 1.1 Keep compact's first 401 same-account forced refresh retry.
 - [x] 1.2 After the refreshed compact retry still returns 401, mark/exclude that account and continue to another eligible account.
 - [x] 1.3 Remove compact HTTP 401 from the low-level same-contract retry status set.
+- [x] 1.4 Apply repeated auth-401 failover to pre-visible stream, thread-goal, Codex control, transcription, file create/finalize, and websocket connect paths.
 
 ## 2. Tests
 
 - [x] 2.1 Add integration coverage for repeated compact 401 failover to another account.
 - [x] 2.2 Verify the existing compact refresh-and-retry success path still passes.
+- [x] 2.3 Add integration coverage for repeated auth-401 failover on stream, thread-goal, Codex control, transcription, and file create/finalize paths.
 
 ## 3. Spec Delta
 
 - [x] 3.1 Add a `responses-api-compat` requirement for compact 401 failover after forced refresh.
-- [x] 3.2 Validate the OpenSpec change.
+- [x] 3.2 Extend the requirement to pre-visible proxy auth-failover surfaces.
+- [x] 3.3 Validate the OpenSpec change.

--- a/openspec/changes/fix-compact-invalidated-token-failover/tasks.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Keep compact's first 401 same-account forced refresh retry.
 - [x] 1.2 After the refreshed compact retry still returns 401, mark/exclude that account and continue to another eligible account.
 - [x] 1.3 Remove compact HTTP 401 from the low-level same-contract retry status set.
-- [x] 1.4 Apply repeated auth-401 failover to pre-visible stream, thread-goal, Codex control, transcription, file create/finalize, and websocket connect paths.
+- [x] 1.4 Apply repeated auth-401 failover to pre-visible stream, thread-goal, Codex control, transcription, file create/finalize, websocket connect, and HTTP bridge handshake paths.
 
 ## 2. Tests
 

--- a/openspec/changes/fix-compact-invalidated-token-failover/tasks.md
+++ b/openspec/changes/fix-compact-invalidated-token-failover/tasks.md
@@ -10,6 +10,8 @@
 - [x] 2.1 Add integration coverage for repeated compact 401 failover to another account.
 - [x] 2.2 Verify the existing compact refresh-and-retry success path still passes.
 - [x] 2.3 Add integration coverage for repeated auth-401 failover on stream, thread-goal, Codex control, transcription, and file create/finalize paths.
+- [x] 2.4 Add unit coverage for repeated auth-401 failover on HTTP bridge session create/reconnect handshakes.
+- [x] 2.5 Add unit coverage that fallback account refresh failures surface as proxy auth errors instead of raw refresh exceptions.
 
 ## 3. Spec Delta
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -430,6 +430,41 @@ async def test_thread_goal_retry_failure_after_forced_refresh_updates_account_he
 
 
 @pytest.mark.asyncio
+async def test_thread_goal_repeated_401_after_refresh_fails_over(async_client, monkeypatch):
+    await _import_account(async_client, "acc_goal_invalidated_a", "goal-invalidated-a@example.com")
+    await _import_account(async_client, "acc_goal_invalidated_b", "goal-invalidated-b@example.com")
+    captured_account_ids: list[str | None] = []
+    invalidated_account_id: str | None = None
+
+    async def fake_thread_goal(operation, payload, headers, access_token, account_id, **kwargs):
+        del operation, payload, headers, access_token, kwargs
+        nonlocal invalidated_account_id
+        if invalidated_account_id is None:
+            invalidated_account_id = account_id
+        captured_account_ids.append(account_id)
+        if account_id == invalidated_account_id:
+            raise ProxyResponseError(401, {"error": {"code": "invalid_api_key", "message": "token invalidated"}})
+        return {"goal": {"objective": "recovered"}}
+
+    async def fake_ensure_fresh(self, account, *, force=False, timeout_seconds=None):
+        assert timeout_seconds is not None
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_thread_goal_request", fake_thread_goal)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    response = await async_client.post(
+        "/backend-api/codex/thread/goal/set",
+        json={"threadId": "019debd9-2372-7f23-92b9-9f34002a6355", "objective": "recover"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["goal"]["objective"] == "recovered"
+    assert captured_account_ids[:2] == [invalidated_account_id, invalidated_account_id]
+    assert captured_account_ids[2] != invalidated_account_id
+
+
+@pytest.mark.asyncio
 async def test_thread_goal_set_uses_active_account_when_budget_selection_is_empty(async_client, monkeypatch):
     await _import_account(async_client, "acc_goal_control", "goal-control@example.com")
     calls = []
@@ -635,6 +670,37 @@ async def test_codex_control_retry_failure_after_forced_refresh_updates_account_
     assert len(handled) == 1
     assert handled[0][0].startswith("acc_codex_retry_error")
     assert handled[0][1] == 503
+
+
+@pytest.mark.asyncio
+async def test_codex_control_repeated_401_after_refresh_fails_over(async_client, monkeypatch):
+    await _import_account(async_client, "acc_codex_invalidated_a", "codex-invalidated-a@example.com")
+    await _import_account(async_client, "acc_codex_invalidated_b", "codex-invalidated-b@example.com")
+    captured_account_ids: list[str | None] = []
+    invalidated_account_id: str | None = None
+
+    async def fake_codex_control_request(*_args, account_id=None, **_kwargs):
+        nonlocal invalidated_account_id
+        if invalidated_account_id is None:
+            invalidated_account_id = account_id
+        captured_account_ids.append(account_id)
+        if account_id == invalidated_account_id:
+            raise ProxyResponseError(401, {"error": {"code": "invalid_api_key", "message": "token invalidated"}})
+        return proxy_module.CodexControlResponse(status_code=200, headers={}, body=b'{"ok":true}')
+
+    async def fake_ensure_fresh(self, account, *, force=False, timeout_seconds=None):
+        assert timeout_seconds is not None
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_codex_control_request", fake_codex_control_request)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    response = await async_client.post("/backend-api/codex/safety/arc", json={"decision": "allow"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert captured_account_ids[:2] == [invalidated_account_id, invalidated_account_id]
+    assert captured_account_ids[2] != invalidated_account_id
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -5,6 +5,7 @@ import contextlib
 import json
 from datetime import timedelta, timezone
 from typing import cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -488,6 +489,51 @@ async def test_proxy_compact_repeated_401_after_refresh_fails_over(async_client,
     assert captured_account_ids[:2] == [invalidated_account_id, invalidated_account_id]
     assert captured_account_ids[2] in {first_upstream_account_id, second_upstream_account_id}
     assert captured_account_ids[2] != invalidated_account_id
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_repeated_401_settles_reservation_if_error_recording_fails(async_client, monkeypatch):
+    email = "compact-invalidated-settle@example.com"
+    raw_account_id = "acc_compact_invalidated_settle"
+    auth_json = _make_auth_json(raw_account_id, email)
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+
+    compact_calls = 0
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        nonlocal compact_calls
+        compact_calls += 1
+        raise ProxyResponseError(
+            401,
+            openai_error(
+                "invalid_api_key",
+                "Your authentication token has been invalidated. Please try signing in again.",
+                error_type="authentication_error",
+            ),
+        )
+
+    async def fake_ensure_fresh(self, account, force: bool = False):
+        return account
+
+    async def fake_handle_proxy_error(self, account, exc):
+        raise RuntimeError("account health store unavailable")
+
+    settle_compact_usage = AsyncMock()
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh", fake_ensure_fresh)
+    monkeypatch.setattr(proxy_module.ProxyService, "_handle_proxy_error", fake_handle_proxy_error)
+    monkeypatch.setattr(proxy_module.ProxyService, "_settle_compact_api_key_usage", settle_compact_usage)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": []}
+    with pytest.raises(RuntimeError, match="account health store unavailable"):
+        await async_client.post("/backend-api/codex/responses/compact", json=payload)
+    assert compact_calls == 2
+    settle_compact_usage.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -423,6 +423,74 @@ async def test_proxy_compact_retry_uses_refreshed_account_id(async_client, monke
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_repeated_401_after_refresh_fails_over(async_client, monkeypatch):
+    first_email = "compact-invalidated-a@example.com"
+    first_raw_account_id = "acc_compact_invalidated_a"
+    first_auth_json = _make_auth_json(first_raw_account_id, first_email)
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth-a.json", json.dumps(first_auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+
+    second_email = "compact-invalidated-b@example.com"
+    second_raw_account_id = "acc_compact_invalidated_b"
+    second_auth_json = _make_auth_json(second_raw_account_id, second_email)
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth-b.json", json.dumps(second_auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+
+    first_account_id = generate_unique_account_id(first_raw_account_id, first_email)
+    second_account_id = generate_unique_account_id(second_raw_account_id, second_email)
+    first_upstream_account_id = "chatgpt_compact_invalidated_a"
+    second_upstream_account_id = "chatgpt_compact_invalidated_b"
+
+    async with SessionLocal() as session:
+        first_account = await session.get(Account, first_account_id)
+        assert first_account is not None
+        first_account.chatgpt_account_id = first_upstream_account_id
+        second_account = await session.get(Account, second_account_id)
+        assert second_account is not None
+        second_account.chatgpt_account_id = second_upstream_account_id
+        await session.commit()
+
+    captured_account_ids: list[str | None] = []
+    invalidated_account_id: str | None = None
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        nonlocal invalidated_account_id
+        if invalidated_account_id is None:
+            invalidated_account_id = account_id
+        captured_account_ids.append(account_id)
+        if account_id == invalidated_account_id:
+            raise ProxyResponseError(
+                401,
+                openai_error(
+                    "invalid_api_key",
+                    "Your authentication token has been invalidated. Please try signing in again.",
+                    error_type="authentication_error",
+                ),
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    async def fake_ensure_fresh(self, account, force: bool = False):
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh", fake_ensure_fresh)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": []}
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+    assert response.status_code == 200
+    assert response.json()["object"] == "response.compaction"
+    assert captured_account_ids[:2] == [invalidated_account_id, invalidated_account_id]
+    assert captured_account_ids[2] in {first_upstream_account_id, second_upstream_account_id}
+    assert captured_account_ids[2] != invalidated_account_id
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_retryable_transport_failure_retries_same_contract_only(async_client, monkeypatch):
     email = "compact-safe-retry@example.com"
     raw_account_id = "acc_compact_safe_retry"

--- a/tests/integration/test_proxy_files.py
+++ b/tests/integration/test_proxy_files.py
@@ -155,6 +155,44 @@ async def test_backend_files_create_maps_upstream_error(async_client, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_backend_files_create_repeated_401_after_refresh_fails_over(async_client, monkeypatch):
+    await _import_account(async_client, "acc_files_invalidated_a", "files-invalidated-a@example.com")
+    await _import_account(async_client, "acc_files_invalidated_b", "files-invalidated-b@example.com")
+    captured_account_ids: list[str | None] = []
+    invalidated_account_id: str | None = None
+
+    async def fake_create_file(*, payload, headers, access_token, account_id, base_url=None, session=None):
+        del payload, headers, access_token, base_url, session
+        nonlocal invalidated_account_id
+        if invalidated_account_id is None:
+            invalidated_account_id = account_id
+        captured_account_ids.append(account_id)
+        if account_id == invalidated_account_id:
+            raise FileProxyError(
+                401,
+                {"error": {"message": "token invalidated", "type": "authentication_error", "code": "invalid_api_key"}},
+            )
+        return {"file_id": "file_recovered", "upload_url": "https://blob.example/recovered"}
+
+    async def fake_ensure_fresh(self, account, *, force=False, timeout_seconds=None):
+        assert timeout_seconds is not None
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_create_file", fake_create_file)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    response = await async_client.post(
+        "/backend-api/files",
+        json={"file_name": "x.png", "file_size": 1},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["file_id"] == "file_recovered"
+    assert captured_account_ids[:2] == [invalidated_account_id, invalidated_account_id]
+    assert captured_account_ids[2] != invalidated_account_id
+
+
+@pytest.mark.asyncio
 async def test_backend_files_finalize_returns_upstream_payload(async_client, monkeypatch):
     await _import_account(async_client, "acc_files_finalize", "files-finalize@example.com")
 
@@ -181,6 +219,41 @@ async def test_backend_files_finalize_returns_upstream_payload(async_client, mon
     assert body["download_url"] == "https://download.example/file_done"
     assert captured["file_id"] == "file_done"
     assert captured["account_id"] == "acc_files_finalize"
+
+
+@pytest.mark.asyncio
+async def test_backend_files_finalize_repeated_401_after_refresh_fails_over(async_client, monkeypatch):
+    await _import_account(async_client, "acc_files_finalize_invalidated_a", "files-finalize-invalidated-a@example.com")
+    await _import_account(async_client, "acc_files_finalize_invalidated_b", "files-finalize-invalidated-b@example.com")
+    captured_account_ids: list[str | None] = []
+    invalidated_account_id: str | None = None
+
+    async def fake_finalize_file(*, file_id, headers, access_token, account_id, base_url=None, session=None):
+        del file_id, headers, access_token, base_url, session
+        nonlocal invalidated_account_id
+        if invalidated_account_id is None:
+            invalidated_account_id = account_id
+        captured_account_ids.append(account_id)
+        if account_id == invalidated_account_id:
+            raise FileProxyError(
+                401,
+                {"error": {"message": "token invalidated", "type": "authentication_error", "code": "invalid_api_key"}},
+            )
+        return {"status": "success", "download_url": "https://download.example/recovered"}
+
+    async def fake_ensure_fresh(self, account, *, force=False, timeout_seconds=None):
+        assert timeout_seconds is not None
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_finalize_file", fake_finalize_file)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    response = await async_client.post("/backend-api/files/file_recovered/uploaded")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert captured_account_ids[:2] == [invalidated_account_id, invalidated_account_id]
+    assert captured_account_ids[2] != invalidated_account_id
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -169,6 +169,53 @@ async def test_proxy_responses_no_accounts(async_client):
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_repeated_401_after_refresh_fails_over(async_client, monkeypatch):
+    for raw_account_id, email in (
+        ("acc_stream_invalidated_a", "stream-invalidated-a@example.com"),
+        ("acc_stream_invalidated_b", "stream-invalidated-b@example.com"),
+    ):
+        auth_json = _make_auth_json(raw_account_id, email)
+        files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+        response = await async_client.post("/api/accounts/import", files=files)
+        assert response.status_code == 200
+
+    captured_account_ids: list[str | None] = []
+    invalidated_account_id: str | None = None
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, base_url, raise_for_status, kwargs
+        nonlocal invalidated_account_id
+        if invalidated_account_id is None:
+            invalidated_account_id = account_id
+        captured_account_ids.append(account_id)
+        if account_id == invalidated_account_id:
+            raise proxy_module.ProxyResponseError(
+                401,
+                {"error": {"code": "invalid_api_key", "message": "token invalidated"}},
+            )
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_stream_failover",'
+            '"object":"response","status":"completed","usage":{"input_tokens":2,"output_tokens":1}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json={"model": "gpt-5.4", "instructions": "hi", "input": [], "stream": True},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event = _extract_first_event(lines)
+    assert event["type"] == "response.completed"
+    assert event["response"]["id"] == "resp_stream_failover"
+    assert captured_account_ids[0] == invalidated_account_id
+    assert captured_account_ids[1] != invalidated_account_id
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_stream_surfaces_additional_quota_data_unavailable(async_client):
     email = "gated-unavailable@example.com"
     raw_account_id = "acc_gated_unavailable"

--- a/tests/integration/test_proxy_transcriptions.py
+++ b/tests/integration/test_proxy_transcriptions.py
@@ -203,6 +203,55 @@ async def test_backend_transcribe_retry_uses_refreshed_account_id(async_client, 
 
 
 @pytest.mark.asyncio
+async def test_backend_transcribe_repeated_401_after_refresh_fails_over(async_client, monkeypatch):
+    await _import_account(async_client, "acc_transcribe_invalidated_a", "transcribe-invalidated-a@example.com")
+    await _import_account(async_client, "acc_transcribe_invalidated_b", "transcribe-invalidated-b@example.com")
+    captured_account_ids: list[str | None] = []
+    invalidated_account_id: str | None = None
+
+    async def fake_transcribe(
+        audio_bytes: bytes,
+        *,
+        filename: str,
+        content_type: str | None,
+        prompt: str | None,
+        headers,
+        access_token: str,
+        account_id: str | None,
+        base_url=None,
+        session=None,
+    ):
+        del audio_bytes, filename, content_type, prompt, headers, access_token, base_url, session
+        nonlocal invalidated_account_id
+        if invalidated_account_id is None:
+            invalidated_account_id = account_id
+        captured_account_ids.append(account_id)
+        if account_id == invalidated_account_id:
+            raise proxy_module.ProxyResponseError(
+                401,
+                openai_error("invalid_api_key", "token invalidated"),
+            )
+        return {"text": "recovered"}
+
+    async def fake_ensure_fresh(self, account, *, force=False, timeout_seconds=None):
+        assert timeout_seconds is not None
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_transcribe_audio", fake_transcribe)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    response = await async_client.post(
+        "/backend-api/transcribe",
+        files={"file": ("sample.wav", b"\x03\x04", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["text"] == "recovered"
+    assert captured_account_ids[:2] == [invalidated_account_id, invalidated_account_id]
+    assert captured_account_ids[2] != invalidated_account_id
+
+
+@pytest.mark.asyncio
 async def test_backend_transcribe_initial_refresh_failure_returns_handled_error(async_client, monkeypatch):
     await _import_account(async_client, "acc_transcribe_refresh_fail", "refresh-fail-transcribe@example.com")
     transcribe_calls = 0

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5589,6 +5589,61 @@ async def test_connect_proxy_websocket_fails_over_on_handshake_usage_limit_reach
 
 
 @pytest.mark.asyncio
+async def test_connect_proxy_websocket_fails_over_after_repeated_401_refresh_retry(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_ws_invalidated_a")
+    account_b = _make_account("acc_ws_invalidated_b")
+    first_401 = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "expired"))
+    second_401 = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "still expired"))
+    upstream = SimpleNamespace()
+    record_error = AsyncMock()
+    select_account = AsyncMock(
+        side_effect=[
+            AccountSelection(account=account_a, error_message=None),
+            AccountSelection(account=account_b, error_message=None),
+        ]
+    )
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_a, account_a, account_b]))
+    monkeypatch.setattr(service, "_open_upstream_websocket", AsyncMock(side_effect=[first_401, second_401, upstream]))
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_repeated_401_failover",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+
+    websocket_send = AsyncMock()
+    websocket = cast(WebSocket, SimpleNamespace(send_text=websocket_send))
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=websocket,
+    )
+
+    assert selected_account == account_b
+    assert selected_upstream is upstream
+    assert select_account.await_args_list[1].kwargs["exclude_account_ids"] == {account_a.id}
+    record_error.assert_awaited_once_with(account_a)
+    websocket_send.assert_not_awaited()
+    assert request_logs.calls == []
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_previous_response_owner_usage_limit_fails_closed(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5644,6 +5644,61 @@ async def test_connect_proxy_websocket_fails_over_after_repeated_401_refresh_ret
 
 
 @pytest.mark.asyncio
+async def test_create_http_bridge_session_fails_over_after_repeated_401_refresh_retry(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_bridge_create_invalidated_a")
+    account_b = _make_account("acc_bridge_create_invalidated_b")
+    first_401 = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "expired"))
+    second_401 = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "still expired"))
+    upstream = SimpleNamespace(response_header=lambda _name: None)
+    seen_excluded_account_ids: list[set[str]] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 10.0)
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if not excluded_account_ids:
+            return AccountSelection(account=account_a, error_message=None)
+        return AccountSelection(account=account_b, error_message=None)
+
+    async def relay_noop(_session: proxy_service._HTTPBridgeSession) -> None:
+        return None
+
+    record_error = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_a, account_b]))
+    monkeypatch.setattr(
+        service,
+        "_open_upstream_websocket_with_budget",
+        AsyncMock(side_effect=[first_401, second_401, upstream]),
+    )
+    monkeypatch.setattr(service, "_relay_http_bridge_upstream_messages", relay_noop)
+
+    session = await service._create_http_bridge_session(
+        proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-create-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-create-key"),
+        api_key=None,
+        request_model="gpt-5.5",
+        idle_ttl_seconds=30.0,
+    )
+
+    upstream_reader = session.upstream_reader
+    assert upstream_reader is not None
+    await upstream_reader
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert session.account == account_b
+    assert session.upstream is upstream
+    record_error.assert_awaited_once_with(account_a)
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_previous_response_owner_usage_limit_fails_closed(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -13981,6 +14036,121 @@ async def test_reconnect_http_bridge_skips_extra_same_account_retry_after_keepal
     assert seen_account_ids == [{account_a.id}, None]
     assert session.account == account_b
     assert session.upstream is new_upstream
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_fails_over_after_repeated_401_refresh_retry(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_bridge_reconnect_invalidated_a")
+    account_b = _make_account("acc_bridge_reconnect_invalidated_b")
+    old_upstream = AsyncMock()
+    new_upstream = SimpleNamespace(response_header=lambda _name: None)
+    first_401 = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "expired"))
+    second_401 = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "still expired"))
+    seen_excluded_account_ids: list[set[str]] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 10.0)
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if not excluded_account_ids:
+            return AccountSelection(account=account_a, error_message=None)
+        return AccountSelection(account=account_b, error_message=None)
+
+    record_error = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_a, account_b]))
+    monkeypatch.setattr(
+        service,
+        "_open_upstream_websocket_with_budget",
+        AsyncMock(side_effect=[first_401, second_401, new_upstream]),
+    )
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_repeated_401",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=10.0,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key"),
+        request_model="gpt-5.5",
+        account=account_a,
+        upstream=old_upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert session.account == account_b
+    assert session.upstream is new_upstream
+    record_error.assert_awaited_once_with(account_a)
+
+
+@pytest.mark.asyncio
+async def test_transcribe_fallback_refresh_error_surfaces_proxy_error_not_raw_refresh_error(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_transcribe_invalidated_a")
+    account_b = _make_account("acc_transcribe_invalidated_b")
+    seen_excluded_account_ids: list[set[str]] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if not excluded_account_ids:
+            return AccountSelection(account=account_a, error_message=None)
+        return AccountSelection(account=account_b, error_message=None)
+
+    async def fake_transcribe(*args: object, account_id: str | None, **kwargs: object) -> dict[str, JsonValue]:
+        del args, kwargs
+        assert account_id == account_a.chatgpt_account_id
+        raise proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "token invalidated"))
+
+    refresh_error = proxy_service.RefreshError("invalid_api_key", "fallback token invalid", True)
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "mark_permanent_failure", AsyncMock())
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=[account_a, account_a, refresh_error]),
+    )
+    monkeypatch.setattr(proxy_service, "core_transcribe_audio", fake_transcribe)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.transcribe(
+            audio_bytes=b"audio",
+            filename="audio.wav",
+            content_type="audio/wav",
+            prompt=None,
+            headers={},
+        )
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.payload["error"].get("code") == "invalid_api_key"
+    assert exc_info.value.payload["error"].get("message") == "fallback token invalid"
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
 
 
 def test_prepare_response_bridge_request_state_dedupes_replayed_previous_response_tool_calls_before_serializing():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12153,6 +12153,57 @@ async def test_stream_forced_refresh_timeout_emits_upstream_unavailable_and_logs
 
 
 @pytest.mark.asyncio
+async def test_stream_post_refresh_401_fails_over_instead_of_retrying_same_account(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_stream_post_refresh_401_a")
+    account_b = _make_account("acc_stream_post_refresh_401_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    stream_account_ids: list[str | None] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if not excluded_account_ids:
+            return AccountSelection(account=account_a, error_message=None)
+        return AccountSelection(account=account_b, error_message=None)
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, base_url, raise_for_status
+        stream_account_ids.append(account_id)
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "token invalidated"))
+        yield 'data: {"type":"response.completed","response":{"id":"resp_post_refresh_failover"}}\n\n'
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=[account_a, account_a, account_b]),
+    )
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+
+    event = json.loads(chunks[0].split("data: ", 1)[1])
+    assert event["type"] == "response.completed"
+    assert event["response"]["id"] == "resp_post_refresh_failover"
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert stream_account_ids == [
+        account_a.chatgpt_account_id,
+        account_a.chatgpt_account_id,
+        account_b.chatgpt_account_id,
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stream_refresh_budget_is_recomputed_after_selection(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()


### PR DESCRIPTION
## Summary

Fixes invalidated-token 401 loops where an account that still returns `invalid_api_key` after forced refresh can surface the error to Codex even though another eligible account could satisfy the request. Compact now records/excludes that account for the current request and fails over before returning 401 to the client; the same pre-visible failover behavior is also applied to stream, Codex thread-goal/control, transcription, file create/finalize, websocket connect, and HTTP bridge handshake paths.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: none

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-compact-invalidated-token-failover/`

## Changes

- Keep compact's first `401` handling as a forced same-account refresh and retry.
- If compact still returns `401` after refresh, classify the selected account failure, exclude it from this compact request, and continue to another eligible account.
- Stop tagging raw compact HTTP `401` responses as generic same-contract transport retries.
- Fail over after repeated pre-visible auth `401`s on stream, thread-goal, Codex control, transcription, file create/finalize, websocket connect, and HTTP bridge handshake paths.
- Add an OpenSpec delta and regression coverage for repeated auth `401` failover.

## Test plan

```bash
uv run pytest tests/integration/test_proxy_compact.py tests/integration/test_proxy_responses.py::test_proxy_responses_repeated_401_after_refresh_fails_over tests/integration/test_proxy_api_extended.py::test_thread_goal_retry_failure_after_forced_refresh_updates_account_health tests/integration/test_proxy_api_extended.py::test_thread_goal_repeated_401_after_refresh_fails_over tests/integration/test_proxy_api_extended.py::test_codex_control_retry_failure_after_forced_refresh_updates_account_health tests/integration/test_proxy_api_extended.py::test_codex_control_repeated_401_after_refresh_fails_over tests/integration/test_proxy_transcriptions.py::test_backend_transcribe_retry_uses_refreshed_account_id tests/integration/test_proxy_transcriptions.py::test_backend_transcribe_repeated_401_after_refresh_fails_over tests/integration/test_proxy_files.py::test_backend_files_create_repeated_401_after_refresh_fails_over tests/integration/test_proxy_files.py::test_backend_files_finalize_repeated_401_after_refresh_fails_over tests/integration/test_api_keys_api.py::test_stream_401_retry_success_finalizes_once tests/unit/test_proxy_utils.py::test_connect_proxy_websocket_fails_over_after_repeated_401_refresh_retry tests/unit/test_proxy_utils.py::test_connect_proxy_websocket_surfaces_retry_handshake_error tests/unit/test_proxy_utils.py::test_connect_proxy_websocket_fails_over_on_handshake_usage_limit_reached
# 26 passed

uv run ruff check app/core/clients/proxy.py app/modules/proxy/service.py tests/integration/test_proxy_compact.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_api_extended.py tests/integration/test_proxy_transcriptions.py tests/integration/test_proxy_files.py tests/unit/test_proxy_utils.py
# All checks passed!

uv run ty check app/core/clients/proxy.py app/modules/proxy/service.py tests/integration/test_proxy_compact.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_api_extended.py tests/integration/test_proxy_transcriptions.py tests/integration/test_proxy_files.py tests/unit/test_proxy_utils.py
# All checks passed!

uv run openspec validate fix-compact-invalidated-token-failover --strict
# Change 'fix-compact-invalidated-token-failover' is valid

uv run openspec validate --specs
# Totals: 21 passed, 0 failed (21 items)
```

## Screenshots / output (optional)

Not applicable.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).


