### PR TITLE
ci: label pull requests with database migrations

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+db migration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - app/db/alembic/versions/**

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,19 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v6.0.1
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR labeler
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] labels fork PRs without checking out PR code
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Apply path-based labels
-        uses: actions/labeler@v6.0.1
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false


### PR DESCRIPTION
Supersedes #766 with the same workflow-labeler diff on an in-repository branch. The original fork PR is stuck in GitHub mergeStateStatus=BLOCKED despite all required checks passing and a clean Codex review, likely because it modifies workflow files from a fork.\n\nThis keeps the code review surface identical:\n- add db migration labeler rule for Alembic migrations\n- add PR labeler workflow pinned to a full action SHA\n\nValidation already run on #766 before replacement:\n- all required CI checks passed on f1357bf1203c609b27d92502c3ced45535a07d12\n- Codex review clean\n\nCloses #766.