### PR TITLE
feat(api-ui): add account pool window usage remaining bar

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -216,7 +216,8 @@ def get_api_keys_context(
     session: AsyncSession = Depends(get_session),
 ) -> ApiKeysContext:
     repository = ApiKeysRepository(session)
-    service = ApiKeysService(repository)
+    usage_repository = UsageRepository(session)
+    service = ApiKeysService(repository, usage_repository=usage_repository)
     return ApiKeysContext(session=session, repository=repository, service=service)
 
 

--- a/app/modules/api_keys/api.py
+++ b/app/modules/api_keys/api.py
@@ -71,15 +71,11 @@ def _to_response(row: ApiKeyData) -> ApiKeyResponse:
             if row.usage_summary is not None
             else None
         ),
-        pooled_remaining_percent_primary=(
-            row.pooled_credits.remaining_percent_primary if row.pooled_credits else None
-        ),
+        pooled_remaining_percent_primary=(row.pooled_credits.remaining_percent_primary if row.pooled_credits else None),
         pooled_remaining_percent_secondary=(
             row.pooled_credits.remaining_percent_secondary if row.pooled_credits else None
         ),
-        pooled_capacity_credits_primary=(
-            row.pooled_credits.capacity_credits_primary if row.pooled_credits else 0.0
-        ),
+        pooled_capacity_credits_primary=(row.pooled_credits.capacity_credits_primary if row.pooled_credits else 0.0),
     )
 
 

--- a/app/modules/api_keys/api.py
+++ b/app/modules/api_keys/api.py
@@ -71,6 +71,15 @@ def _to_response(row: ApiKeyData) -> ApiKeyResponse:
             if row.usage_summary is not None
             else None
         ),
+        pooled_remaining_percent_primary=(
+            row.pooled_credits.remaining_percent_primary if row.pooled_credits else None
+        ),
+        pooled_remaining_percent_secondary=(
+            row.pooled_credits.remaining_percent_secondary if row.pooled_credits else None
+        ),
+        pooled_capacity_credits_primary=(
+            row.pooled_credits.capacity_credits_primary if row.pooled_credits else 0.0
+        ),
     )
 
 

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -7,7 +7,7 @@ from enum import Enum
 
 from sqlalchemy import Integer, cast, delete, func, select, true, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import load_only, selectinload
 
 from app.core.utils.time import utcnow
 from app.db.models import (
@@ -165,11 +165,15 @@ class ApiKeysRepository:
     async def list_accounts_by_ids(self, account_ids: list[str]) -> list[Account]:
         if not account_ids:
             return []
-        result = await self._session.execute(select(Account).where(Account.id.in_(account_ids)))
+        result = await self._session.execute(
+            select(Account)
+            .options(load_only(Account.id, Account.plan_type))
+            .where(Account.id.in_(account_ids))
+        )
         return list(result.scalars().all())
 
     async def list_all_accounts(self) -> list[Account]:
-        result = await self._session.execute(select(Account))
+        result = await self._session.execute(select(Account).options(load_only(Account.id, Account.plan_type)))
         return list(result.scalars().all())
 
     async def list_usage_summary_by_key(self) -> dict[str, ApiKeyUsageSummary]:

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import load_only, selectinload
 from app.core.utils.time import utcnow
 from app.db.models import (
     Account,
+    AccountStatus,
     ApiKey,
     ApiKeyAccountAssignment,
     ApiKeyLimit,
@@ -166,12 +167,18 @@ class ApiKeysRepository:
         if not account_ids:
             return []
         result = await self._session.execute(
-            select(Account).options(load_only(Account.id, Account.plan_type)).where(Account.id.in_(account_ids))
+            select(Account)
+            .options(load_only(Account.id, Account.plan_type, Account.status))
+            .where(Account.id.in_(account_ids))
         )
         return list(result.scalars().all())
 
     async def list_all_accounts(self) -> list[Account]:
-        result = await self._session.execute(select(Account).options(load_only(Account.id, Account.plan_type)))
+        result = await self._session.execute(
+            select(Account)
+            .options(load_only(Account.id, Account.plan_type))
+            .where(~Account.status.in_((AccountStatus.DEACTIVATED, AccountStatus.PAUSED)))
+        )
         return list(result.scalars().all())
 
     async def list_usage_summary_by_key(self) -> dict[str, ApiKeyUsageSummary]:

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -166,9 +166,7 @@ class ApiKeysRepository:
         if not account_ids:
             return []
         result = await self._session.execute(
-            select(Account)
-            .options(load_only(Account.id, Account.plan_type))
-            .where(Account.id.in_(account_ids))
+            select(Account).options(load_only(Account.id, Account.plan_type)).where(Account.id.in_(account_ids))
         )
         return list(result.scalars().all())
 

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -168,6 +168,10 @@ class ApiKeysRepository:
         result = await self._session.execute(select(Account).where(Account.id.in_(account_ids)))
         return list(result.scalars().all())
 
+    async def list_all_accounts(self) -> list[Account]:
+        result = await self._session.execute(select(Account))
+        return list(result.scalars().all())
+
     async def list_usage_summary_by_key(self) -> dict[str, ApiKeyUsageSummary]:
         stmt = (
             select(

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -176,7 +176,7 @@ class ApiKeysRepository:
     async def list_all_accounts(self) -> list[Account]:
         result = await self._session.execute(
             select(Account)
-            .options(load_only(Account.id, Account.plan_type))
+            .options(load_only(Account.id, Account.plan_type, Account.status))
             .where(~Account.status.in_((AccountStatus.DEACTIVATED, AccountStatus.PAUSED)))
         )
         return list(result.scalars().all())

--- a/app/modules/api_keys/schemas.py
+++ b/app/modules/api_keys/schemas.py
@@ -76,6 +76,9 @@ class ApiKeyResponse(DashboardModel):
     last_used_at: datetime | None
     limits: list[LimitRuleResponse] = Field(default_factory=list)
     usage_summary: ApiKeyUsageSummaryResponse | None = None
+    pooled_remaining_percent_primary: float | None = None
+    pooled_remaining_percent_secondary: float | None = None
+    pooled_capacity_credits_primary: float = 0.0
 
 
 class ApiKeyCreateResponse(ApiKeyResponse):

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -20,7 +20,7 @@ from app.core.usage.pricing import (
     get_pricing_for_model,
 )
 from app.core.utils.time import to_utc_naive, utcnow
-from app.db.models import Account, ApiKey, ApiKeyLimit, LimitType, LimitWindow
+from app.db.models import Account, ApiKey, ApiKeyLimit, LimitType, LimitWindow, UsageHistory
 from app.db.session import sqlite_writer_section
 from app.modules.api_keys.limit_windows import advance_limit_reset, next_limit_reset
 from app.modules.api_keys.repository import (
@@ -33,6 +33,7 @@ from app.modules.api_keys.repository import (
     UsageReservationItemData,
     _Unset,
 )
+from app.modules.usage.repository import UsageRepository
 
 _SQLITE_BUSY_RETRY_ATTEMPTS = 4
 _SQLITE_BUSY_RETRY_BASE_SECONDS = 0.1
@@ -56,6 +57,7 @@ class ApiKeysRepositoryProtocol(Protocol):
     async def list_usage_summary_by_key(self) -> dict[str, ApiKeyUsageSummary]: ...
     async def get_usage_summary_by_key_id(self, key_id: str) -> ApiKeyUsageSummary: ...
     async def list_accounts_by_ids(self, account_ids: list[str]) -> list[Account]: ...
+    async def list_all_accounts(self) -> list[Account]: ...
 
     async def update(
         self,
@@ -297,6 +299,7 @@ class ApiKeyData:
     usage_summary: "ApiKeyUsageSummaryData | None" = None
     account_assignment_scope_enabled: bool = False
     assigned_account_ids: list[str] = field(default_factory=list)
+    pooled_credits: "PooledCreditData | None" = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -313,6 +316,61 @@ class ApiKeyUsageSummaryData:
 
 
 @dataclass(frozen=True, slots=True)
+class PooledCreditData:
+    remaining_percent_primary: float | None = None
+    remaining_percent_secondary: float | None = None
+    capacity_credits_primary: float = 0.0
+
+
+def _compute_pooled_credits(
+    *,
+    assigned_account_ids: list[str],
+    all_accounts: list[Account],
+    primary_usage: dict[str, UsageHistory],
+    secondary_usage: dict[str, UsageHistory],
+) -> PooledCreditData:
+    import app.core.usage as usage_core
+    from app.modules.usage.mappers import usage_history_to_window_row
+
+    if assigned_account_ids:
+        account_ids = set(assigned_account_ids)
+    else:
+        account_ids = {a.id for a in all_accounts}
+
+    account_map = {a.id: a for a in all_accounts if a.id in account_ids}
+
+    primary_rows_raw = [
+        usage_history_to_window_row(entry)
+        for entry in primary_usage.values()
+        if entry.account_id in account_ids
+    ]
+    secondary_rows_raw = [
+        usage_history_to_window_row(entry)
+        for entry in secondary_usage.values()
+        if entry.account_id in account_ids
+    ]
+
+    primary_rows, secondary_rows = usage_core.normalize_weekly_only_rows(
+        primary_rows_raw, secondary_rows_raw,
+    )
+
+    primary_summary = usage_core.summarize_usage_window(primary_rows, account_map, "primary")
+    secondary_summary = usage_core.summarize_usage_window(secondary_rows, account_map, "secondary")
+
+    primary_remaining = usage_core.remaining_percent_from_used(primary_summary.used_percent)
+    secondary_remaining = usage_core.remaining_percent_from_used(secondary_summary.used_percent)
+
+    if primary_summary.capacity_credits == 0.0:
+        primary_remaining = None
+
+    return PooledCreditData(
+        remaining_percent_primary=primary_remaining,
+        remaining_percent_secondary=secondary_remaining,
+        capacity_credits_primary=primary_summary.capacity_credits,
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class ApiKeyUsageReservationData:
     reservation_id: str
     key_id: str
@@ -320,8 +378,9 @@ class ApiKeyUsageReservationData:
 
 
 class ApiKeysService:
-    def __init__(self, repository: ApiKeysRepositoryProtocol) -> None:
+    def __init__(self, repository: ApiKeysRepositoryProtocol, usage_repository: UsageRepository | None = None) -> None:
         self._repository = repository
+        self._usage_repository = usage_repository
 
     async def create_key(self, payload: ApiKeyCreateData) -> ApiKeyCreatedData:
         now = utcnow()
@@ -373,8 +432,30 @@ class ApiKeysService:
     async def list_keys(self) -> list[ApiKeyData]:
         rows = await self._repository.list_all()
         usage_summary_by_key = await self._repository.list_usage_summary_by_key()
+
+        all_accounts = await self._repository.list_all_accounts()
+
+        pooled_by_key: dict[str, PooledCreditData] = {}
+        if self._usage_repository is not None:
+            primary_usage = await self._usage_repository.latest_by_account("primary")
+            secondary_usage = await self._usage_repository.latest_by_account("secondary")
+
+            for row in rows:
+                account_assignments = getattr(row, "account_assignments", [])
+                assigned_ids = [a.account_id for a in account_assignments]
+                pooled_by_key[row.id] = _compute_pooled_credits(
+                    assigned_account_ids=assigned_ids,
+                    all_accounts=all_accounts,
+                    primary_usage=primary_usage,
+                    secondary_usage=secondary_usage,
+                )
+
         return [
-            _to_api_key_data(row, usage_summary=_to_usage_summary_data(usage_summary_by_key.get(row.id)))
+            _to_api_key_data(
+                row,
+                usage_summary=_to_usage_summary_data(usage_summary_by_key.get(row.id)),
+                pooled_credits=pooled_by_key.get(row.id),
+            )
             for row in rows
         ]
 
@@ -1340,7 +1421,12 @@ def _to_created_data(data: ApiKeyData, key: str) -> ApiKeyCreatedData:
     )
 
 
-def _to_api_key_data(row: ApiKey, *, usage_summary: ApiKeyUsageSummaryData | None = None) -> ApiKeyData:
+def _to_api_key_data(
+    row: ApiKey,
+    *,
+    usage_summary: ApiKeyUsageSummaryData | None = None,
+    pooled_credits: PooledCreditData | None = None,
+) -> ApiKeyData:
     limits = [_to_limit_rule_data(limit) for limit in row.limits] if row.limits else []
     account_assignments = getattr(row, "account_assignments", [])
     return ApiKeyData(
@@ -1360,6 +1446,7 @@ def _to_api_key_data(row: ApiKey, *, usage_summary: ApiKeyUsageSummaryData | Non
         usage_summary=usage_summary,
         account_assignment_scope_enabled=getattr(row, "account_assignment_scope_enabled", False),
         assigned_account_ids=[assignment.account_id for assignment in account_assignments],
+        pooled_credits=pooled_credits,
     )
 
 

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -21,7 +21,7 @@ from app.core.usage.pricing import (
 )
 from app.core.usage.types import UsageWindowRow
 from app.core.utils.time import to_utc_naive, utcnow
-from app.db.models import Account, ApiKey, ApiKeyLimit, LimitType, LimitWindow, UsageHistory
+from app.db.models import Account, AccountStatus, ApiKey, ApiKeyLimit, LimitType, LimitWindow, UsageHistory
 from app.db.session import sqlite_writer_section
 from app.modules.api_keys.limit_windows import advance_limit_reset, next_limit_reset
 from app.modules.api_keys.repository import (
@@ -334,11 +334,16 @@ def _compute_pooled_credits(
     from app.modules.usage.mappers import usage_history_to_window_row
 
     if assigned_account_ids:
-        account_ids = set(assigned_account_ids)
+        requested_account_ids = set(assigned_account_ids)
     else:
-        account_ids = {a.id for a in all_accounts}
+        requested_account_ids = {a.id for a in all_accounts}
 
-    account_map = {a.id: a for a in all_accounts if a.id in account_ids}
+    account_map = {
+        a.id: a
+        for a in all_accounts
+        if a.id in requested_account_ids and a.status not in (AccountStatus.DEACTIVATED, AccountStatus.PAUSED)
+    }
+    account_ids = set(account_map)
 
     primary_rows_raw = [
         usage_history_to_window_row(entry) for entry in primary_usage.values() if entry.account_id in account_ids

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -19,6 +19,7 @@ from app.core.usage.pricing import (
     calculate_cost_from_usage,
     get_pricing_for_model,
 )
+from app.core.usage.types import UsageWindowRow
 from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import Account, ApiKey, ApiKeyLimit, LimitType, LimitWindow, UsageHistory
 from app.db.session import sqlite_writer_section
@@ -353,6 +354,8 @@ def _compute_pooled_credits(
     primary_rows, secondary_rows = usage_core.normalize_weekly_only_rows(
         primary_rows_raw, secondary_rows_raw,
     )
+    primary_rows = _seed_missing_usage_rows(primary_rows, account_ids)
+    secondary_rows = _seed_missing_usage_rows(secondary_rows, account_ids)
 
     primary_summary = usage_core.summarize_usage_window(primary_rows, account_map, "primary")
     secondary_summary = usage_core.summarize_usage_window(secondary_rows, account_map, "secondary")
@@ -368,6 +371,20 @@ def _compute_pooled_credits(
         remaining_percent_secondary=secondary_remaining,
         capacity_credits_primary=primary_summary.capacity_credits,
     )
+
+
+def _seed_missing_usage_rows(
+    rows: list[UsageWindowRow],
+    account_ids: set[str],
+) -> list[UsageWindowRow]:
+    present_account_ids = {row.account_id for row in rows}
+    missing_account_ids = account_ids - present_account_ids
+    if not missing_account_ids:
+        return rows
+    return rows + [
+        UsageWindowRow(account_id=account_id, used_percent=0.0)
+        for account_id in sorted(missing_account_ids)
+    ]
 
 
 @dataclass(frozen=True, slots=True)
@@ -433,18 +450,28 @@ class ApiKeysService:
         rows = await self._repository.list_all()
         usage_summary_by_key = await self._repository.list_usage_summary_by_key()
 
-        all_accounts = await self._repository.list_all_accounts()
-
         pooled_by_key: dict[str, PooledCreditData] = {}
         if self._usage_repository is not None:
-            primary_usage = await self._usage_repository.latest_by_account("primary")
-            secondary_usage = await self._usage_repository.latest_by_account("secondary")
-
+            assigned_ids_by_key = {
+                row.id: [a.account_id for a in getattr(row, "account_assignments", [])]
+                for row in rows
+            }
+            needs_all_accounts = any(not assigned_ids for assigned_ids in assigned_ids_by_key.values())
+            if needs_all_accounts:
+                all_accounts = await self._repository.list_all_accounts()
+                primary_usage = await self._usage_repository.latest_by_account("primary")
+                secondary_usage = await self._usage_repository.latest_by_account("secondary")
+            else:
+                all_account_ids = sorted({account_id for ids in assigned_ids_by_key.values() for account_id in ids})
+                all_accounts = await self._repository.list_accounts_by_ids(all_account_ids)
+                primary_usage = await self._usage_repository.latest_by_account("primary", account_ids=all_account_ids)
+                secondary_usage = await self._usage_repository.latest_by_account(
+                    "secondary",
+                    account_ids=all_account_ids,
+                )
             for row in rows:
-                account_assignments = getattr(row, "account_assignments", [])
-                assigned_ids = [a.account_id for a in account_assignments]
                 pooled_by_key[row.id] = _compute_pooled_credits(
-                    assigned_account_ids=assigned_ids,
+                    assigned_account_ids=assigned_ids_by_key[row.id],
                     all_accounts=all_accounts,
                     primary_usage=primary_usage,
                     secondary_usage=secondary_usage,

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -341,18 +341,15 @@ def _compute_pooled_credits(
     account_map = {a.id: a for a in all_accounts if a.id in account_ids}
 
     primary_rows_raw = [
-        usage_history_to_window_row(entry)
-        for entry in primary_usage.values()
-        if entry.account_id in account_ids
+        usage_history_to_window_row(entry) for entry in primary_usage.values() if entry.account_id in account_ids
     ]
     secondary_rows_raw = [
-        usage_history_to_window_row(entry)
-        for entry in secondary_usage.values()
-        if entry.account_id in account_ids
+        usage_history_to_window_row(entry) for entry in secondary_usage.values() if entry.account_id in account_ids
     ]
 
     primary_rows, secondary_rows = usage_core.normalize_weekly_only_rows(
-        primary_rows_raw, secondary_rows_raw,
+        primary_rows_raw,
+        secondary_rows_raw,
     )
     primary_rows = _seed_missing_usage_rows(primary_rows, account_ids)
     secondary_rows = _seed_missing_usage_rows(secondary_rows, account_ids)
@@ -382,8 +379,7 @@ def _seed_missing_usage_rows(
     if not missing_account_ids:
         return rows
     return rows + [
-        UsageWindowRow(account_id=account_id, used_percent=0.0)
-        for account_id in sorted(missing_account_ids)
+        UsageWindowRow(account_id=account_id, used_percent=0.0) for account_id in sorted(missing_account_ids)
     ]
 
 
@@ -453,8 +449,7 @@ class ApiKeysService:
         pooled_by_key: dict[str, PooledCreditData] = {}
         if self._usage_repository is not None:
             assigned_ids_by_key = {
-                row.id: [a.account_id for a in getattr(row, "account_assignments", [])]
-                for row in rows
+                row.id: [a.account_id for a in getattr(row, "account_assignments", [])] for row in rows
             }
             needs_all_accounts = any(not assigned_ids for assigned_ids in assigned_ids_by_key.values())
             if needs_all_accounts:

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -160,12 +160,24 @@ class UsageRepository:
             for row in rows
         ]
 
-    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+    async def latest_by_account(
+        self,
+        window: str | None = None,
+        *,
+        account_ids: Collection[str] | None = None,
+    ) -> dict[str, UsageHistory]:
         conditions = _window_clause(window)
+        if account_ids is not None and not account_ids:
+            return {}
+        if account_ids is not None:
+            conditions = and_(conditions, UsageHistory.account_id.in_(account_ids))
         bind = self._session.get_bind()
         dialect = bind.dialect.name if bind else "sqlite"
         if dialect == "postgresql":
-            acct_subq = select(Account.id).subquery("accts")
+            acct_stmt = select(Account.id)
+            if account_ids is not None:
+                acct_stmt = acct_stmt.where(Account.id.in_(account_ids))
+            acct_subq = acct_stmt.subquery("accts")
             lateral = (
                 select(UsageHistory.id)
                 .where(

--- a/frontend/src/components/mini-quota-bar.tsx
+++ b/frontend/src/components/mini-quota-bar.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+import { quotaBarColor, quotaBarTrack } from "@/utils/account-status";
+
+export function MiniQuotaBar({ percent, testId }: { percent: number | null; testId: string }) {
+  if (percent === null) {
+    return <div data-testid={testId} className="h-1 flex-1 overflow-hidden rounded-full bg-muted" />;
+  }
+  const clamped = Math.max(0, Math.min(100, percent));
+  return (
+    <div data-testid={testId} className={cn("h-1 flex-1 overflow-hidden rounded-full", quotaBarTrack(clamped))}>
+      <div
+        data-testid={`${testId}-fill`}
+        className={cn("h-full rounded-full", quotaBarColor(clamped))}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/mini-quota-bar.tsx
+++ b/frontend/src/components/mini-quota-bar.tsx
@@ -1,13 +1,27 @@
 import { cn } from "@/lib/utils";
 import { quotaBarColor, quotaBarTrack } from "@/utils/account-status";
 
-export function MiniQuotaBar({ percent, testId }: { percent: number | null; testId: string }) {
+type MiniQuotaBarProps = {
+  percent: number | null;
+  testId: string;
+  "aria-label"?: string;
+};
+
+export function MiniQuotaBar({ percent, testId, "aria-label": ariaLabel }: MiniQuotaBarProps) {
   if (percent === null) {
-    return <div data-testid={testId} className="h-1 flex-1 overflow-hidden rounded-full bg-muted" />;
+    return <div aria-hidden="true" data-testid={testId} className="h-1 flex-1 overflow-hidden rounded-full bg-muted" />;
   }
   const clamped = Math.max(0, Math.min(100, percent));
   return (
-    <div data-testid={testId} className={cn("h-1 flex-1 overflow-hidden rounded-full", quotaBarTrack(clamped))}>
+    <div
+      role="progressbar"
+      aria-label={ariaLabel}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={clamped}
+      data-testid={testId}
+      className={cn("h-1 flex-1 overflow-hidden rounded-full", quotaBarTrack(clamped))}
+    >
       <div
         data-testid={`${testId}-fill`}
         className={cn("h-full rounded-full", quotaBarColor(clamped))}

--- a/frontend/src/features/accounts/components/account-list-item.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.tsx
@@ -80,7 +80,11 @@ function MiniQuotaRow({
         <span className="text-muted-foreground">{label}</span>
         <span className="tabular-nums font-medium">{formatPercentNullable(percent)}</span>
       </div>
-      <MiniQuotaBar percent={percent} testId={`mini-quota-track-${label.toLowerCase()}`} />
+      <MiniQuotaBar
+        aria-label={`${label} credits remaining`}
+        percent={percent}
+        testId={`mini-quota-track-${label.toLowerCase()}`}
+      />
       <div className="text-[10px] text-muted-foreground">{formatMiniQuotaResetLabel(resetAt ?? null)}</div>
     </div>
   );

--- a/frontend/src/features/accounts/components/account-list-item.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.tsx
@@ -3,8 +3,9 @@ import { isEmailLabel } from "@/components/blur-email";
 import { usePrivacyStore } from "@/hooks/use-privacy";
 import { useAccountQuotaDisplayStore } from "@/hooks/use-account-quota-display";
 import { StatusBadge } from "@/components/status-badge";
+import { MiniQuotaBar } from "@/components/mini-quota-bar";
 import type { AccountSummary } from "@/features/accounts/schemas";
-import { normalizeStatus, quotaBarColor, quotaBarTrack } from "@/utils/account-status";
+import { normalizeStatus } from "@/utils/account-status";
 import { formatCompactAccountId } from "@/utils/account-identifiers";
 import { formatPercentNullable, formatQuotaResetLabel, formatSlug } from "@/utils/formatters";
 
@@ -14,22 +15,6 @@ export type AccountListItemProps = {
   showAccountId?: boolean;
   onSelect: (accountId: string) => void;
 };
-
-function MiniQuotaBar({ percent, testId }: { percent: number | null; testId: string }) {
-  if (percent === null) {
-    return <div data-testid={testId} className="h-1 flex-1 overflow-hidden rounded-full bg-muted" />;
-  }
-  const clamped = Math.max(0, Math.min(100, percent));
-  return (
-    <div data-testid={testId} className={cn("h-1 flex-1 overflow-hidden rounded-full", quotaBarTrack(clamped))}>
-      <div
-        data-testid={`${testId}-fill`}
-        className={cn("h-full rounded-full", quotaBarColor(clamped))}
-        style={{ width: `${clamped}%` }}
-      />
-    </div>
-  );
-}
 
 export function AccountListItem({ account, selected, showAccountId = false, onSelect }: AccountListItemProps) {
   const blurred = usePrivacyStore((s) => s.blurred);

--- a/frontend/src/features/api-keys/schemas.test.ts
+++ b/frontend/src/features/api-keys/schemas.test.ts
@@ -56,6 +56,29 @@ describe("ApiKeySchema", () => {
 
     expect(parsed.limits).toEqual([]);
     expect(parsed.applyToCodexModel).toBe(false);
+    expect(parsed.pooledRemainingPercentPrimary).toBeNull();
+    expect(parsed.pooledRemainingPercentSecondary).toBeNull();
+    expect(parsed.pooledCapacityCreditsPrimary).toBe(0);
+  });
+
+  it("parses pooled credit fields", () => {
+    const parsed = ApiKeySchema.parse({
+      id: "key-1",
+      name: "Service Key",
+      keyPrefix: "sk-live",
+      allowedModels: null,
+      expiresAt: null,
+      isActive: true,
+      createdAt: ISO,
+      lastUsedAt: null,
+      pooledRemainingPercentPrimary: 67.5,
+      pooledRemainingPercentSecondary: 85.0,
+      pooledCapacityCreditsPrimary: 225.0,
+    });
+
+    expect(parsed.pooledRemainingPercentPrimary).toBe(67.5);
+    expect(parsed.pooledRemainingPercentSecondary).toBe(85.0);
+    expect(parsed.pooledCapacityCreditsPrimary).toBe(225.0);
   });
 });
 

--- a/frontend/src/features/api-keys/schemas.ts
+++ b/frontend/src/features/api-keys/schemas.ts
@@ -56,6 +56,9 @@ export const ApiKeySchema = z.object({
   lastUsedAt: z.string().datetime({ offset: true }).nullable(),
   limits: z.array(LimitRuleSchema).default([]),
   usageSummary: ApiKeyUsageSummarySchema.nullable().default(null),
+  pooledRemainingPercentPrimary: z.number().nullable().default(null),
+  pooledRemainingPercentSecondary: z.number().nullable().default(null),
+  pooledCapacityCreditsPrimary: z.number().default(0),
 });
 
 export const ApiKeyCreateRequestSchema = z.object({

--- a/frontend/src/features/apis/components/api-list-item.tsx
+++ b/frontend/src/features/apis/components/api-list-item.tsx
@@ -4,11 +4,45 @@ import { MiniQuotaBar } from "@/components/mini-quota-bar";
 import type { ApiKey } from "@/features/api-keys/schemas";
 import { formatPercentNullable } from "@/utils/formatters";
 
+function limitBarColor(percent: number): string {
+  if (percent >= 90) return "bg-red-500";
+  if (percent >= 70) return "bg-orange-500";
+  if (percent >= 40) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+function MiniUsageBar({ percent }: { percent: number | null }) {
+  if (percent === null) {
+    return <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted" />;
+  }
+  const clamped = Math.max(0, Math.min(100, percent));
+  return (
+    <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted">
+      <div
+        className={cn("h-full rounded-full", limitBarColor(clamped))}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}
+
 export type ApiListItemProps = {
   apiKey: ApiKey;
   selected: boolean;
   onSelect: (keyId: string) => void;
 };
+
+function formatLimitPercent(apiKey: ApiKey): number | null {
+  if (apiKey.limits.length === 0) return null;
+  let maxPercent = 0;
+  for (const limit of apiKey.limits) {
+    if (limit.maxValue > 0) {
+      const pct = (limit.currentValue / limit.maxValue) * 100;
+      if (pct > maxPercent) maxPercent = pct;
+    }
+  }
+  return maxPercent;
+}
 
 function isExpired(apiKey: ApiKey): boolean {
   if (!apiKey.expiresAt) return false;
@@ -22,6 +56,7 @@ export function ApiListItem({ apiKey, selected, onSelect }: ApiListItemProps) {
   const hasPrimary = apiKey.pooledCapacityCreditsPrimary > 0 && primary !== null;
   const hasSecondary = secondary !== null;
   const visibleRows = Number(hasPrimary) + Number(hasSecondary);
+  const limitPct = formatLimitPercent(apiKey);
 
   return (
     <button
@@ -68,6 +103,11 @@ export function ApiListItem({ apiKey, selected, onSelect }: ApiListItemProps) {
               <MiniQuotaBar percent={secondary} testId="pooled-quota-track-weekly" />
             </div>
           ) : null}
+        </div>
+      ) : null}
+      {limitPct !== null ? (
+        <div className="mt-1.5">
+          <MiniUsageBar percent={limitPct} />
         </div>
       ) : null}
     </button>

--- a/frontend/src/features/apis/components/api-list-item.tsx
+++ b/frontend/src/features/apis/components/api-list-item.tsx
@@ -91,7 +91,11 @@ export function ApiListItem({ apiKey, selected, onSelect }: ApiListItemProps) {
                 <span className="text-muted-foreground">Pooled 5h</span>
                 <span className="tabular-nums font-medium">{formatPercentNullable(primary)}</span>
               </div>
-              <MiniQuotaBar percent={primary} testId="pooled-quota-track-5h" />
+              <MiniQuotaBar
+                aria-label="Pooled 5h credits remaining"
+                percent={primary}
+                testId="pooled-quota-track-5h"
+              />
             </div>
           ) : null}
           {hasSecondary ? (
@@ -100,7 +104,11 @@ export function ApiListItem({ apiKey, selected, onSelect }: ApiListItemProps) {
                 <span className="text-muted-foreground">Pooled Weekly</span>
                 <span className="tabular-nums font-medium">{formatPercentNullable(secondary)}</span>
               </div>
-              <MiniQuotaBar percent={secondary} testId="pooled-quota-track-weekly" />
+              <MiniQuotaBar
+                aria-label="Pooled weekly credits remaining"
+                percent={secondary}
+                testId="pooled-quota-track-weekly"
+              />
             </div>
           ) : null}
         </div>

--- a/frontend/src/features/apis/components/api-list-item.tsx
+++ b/frontend/src/features/apis/components/api-list-item.tsx
@@ -1,6 +1,8 @@
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
+import { MiniQuotaBar } from "@/components/mini-quota-bar";
 import type { ApiKey } from "@/features/api-keys/schemas";
+import { formatPercentNullable } from "@/utils/formatters";
 
 export type ApiListItemProps = {
   apiKey: ApiKey;
@@ -8,48 +10,18 @@ export type ApiListItemProps = {
   onSelect: (keyId: string) => void;
 };
 
-function formatLimitPercent(apiKey: ApiKey): number | null {
-  if (apiKey.limits.length === 0) return null;
-  let maxPercent = 0;
-  for (const limit of apiKey.limits) {
-    if (limit.maxValue > 0) {
-      const pct = (limit.currentValue / limit.maxValue) * 100;
-      if (pct > maxPercent) maxPercent = pct;
-    }
-  }
-  return maxPercent;
-}
-
-function limitBarColor(percent: number): string {
-  if (percent >= 90) return "bg-red-500";
-  if (percent >= 70) return "bg-orange-500";
-  if (percent >= 40) return "bg-amber-500";
-  return "bg-emerald-500";
-}
-
-function MiniUsageBar({ percent }: { percent: number | null }) {
-  if (percent === null) {
-    return <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted" />;
-  }
-  const clamped = Math.max(0, Math.min(100, percent));
-  return (
-    <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted">
-      <div
-        className={cn("h-full rounded-full", limitBarColor(clamped))}
-        style={{ width: `${clamped}%` }}
-      />
-    </div>
-  );
-}
-
 function isExpired(apiKey: ApiKey): boolean {
   if (!apiKey.expiresAt) return false;
   return new Date(apiKey.expiresAt).getTime() < Date.now();
 }
 
 export function ApiListItem({ apiKey, selected, onSelect }: ApiListItemProps) {
-  const limitPct = formatLimitPercent(apiKey);
   const expired = isExpired(apiKey);
+  const primary = apiKey.pooledRemainingPercentPrimary ?? null;
+  const secondary = apiKey.pooledRemainingPercentSecondary ?? null;
+  const hasPrimary = apiKey.pooledCapacityCreditsPrimary > 0 && primary !== null;
+  const hasSecondary = secondary !== null;
+  const visibleRows = Number(hasPrimary) + Number(hasSecondary);
 
   return (
     <button
@@ -76,9 +48,28 @@ export function ApiListItem({ apiKey, selected, onSelect }: ApiListItemProps) {
           {!apiKey.isActive ? "Disabled" : expired ? "Expired" : "Active"}
         </Badge>
       </div>
-      <div className="mt-1.5">
-        <MiniUsageBar percent={limitPct} />
-      </div>
+      {visibleRows > 0 ? (
+        <div className={cn("mt-2 grid gap-2", visibleRows > 1 ? "grid-cols-2" : "grid-cols-1")}>
+          {hasPrimary ? (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between text-[11px]">
+                <span className="text-muted-foreground">Pooled 5h</span>
+                <span className="tabular-nums font-medium">{formatPercentNullable(primary)}</span>
+              </div>
+              <MiniQuotaBar percent={primary} testId="pooled-quota-track-5h" />
+            </div>
+          ) : null}
+          {hasSecondary ? (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between text-[11px]">
+                <span className="text-muted-foreground">Pooled Weekly</span>
+                <span className="tabular-nums font-medium">{formatPercentNullable(secondary)}</span>
+              </div>
+              <MiniQuotaBar percent={secondary} testId="pooled-quota-track-weekly" />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </button>
   );
 }

--- a/frontend/src/features/apis/components/api-list-item.tsx
+++ b/frontend/src/features/apis/components/api-list-item.tsx
@@ -106,7 +106,11 @@ export function ApiListItem({ apiKey, selected, onSelect }: ApiListItemProps) {
         </div>
       ) : null}
       {limitPct !== null ? (
-        <div className="mt-1.5">
+        <div className="mt-1.5 space-y-1">
+          <div className="flex items-center justify-between text-[11px]">
+            <span className="text-muted-foreground">API Limit</span>
+            <span className="tabular-nums font-medium">{formatPercentNullable(limitPct)}</span>
+          </div>
           <MiniUsageBar percent={limitPct} />
         </div>
       ) : null}

--- a/frontend/src/features/apis/components/apis-page.test.tsx
+++ b/frontend/src/features/apis/components/apis-page.test.tsx
@@ -142,4 +142,20 @@ describe("ApisPage", () => {
 		expect(apiKeysQuery.refetch).toHaveBeenCalledTimes(1);
 		expect(screen.queryByText("Create API Key")).not.toBeInTheDocument();
 	});
+
+	it("labels the legacy limit bar as API Limit", () => {
+		renderApisPage({
+			apiKeys: [
+				createApiKey({
+					pooledRemainingPercentPrimary: 67.5,
+					pooledRemainingPercentSecondary: 85,
+					pooledCapacityCreditsPrimary: 225,
+				}),
+			],
+		});
+
+		expect(screen.getByText("Pooled 5h")).toBeInTheDocument();
+		expect(screen.getByText("Pooled Weekly")).toBeInTheDocument();
+		expect(screen.getByText("API Limit")).toBeInTheDocument();
+	});
 });

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/proposal.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-The APIs tab left sidebar shows each API key with a limit-usage bar, but operators could not see the pooled credit status of the accounts assigned to each key. This change adds "Pooled 5h" and "Pooled Weekly" credit bars to each API list item, computed server-side by aggregating usage across the key's assigned accounts (or all accounts if unscoped), rendered identically to the account credit bars in the Accounts tab.
+The APIs tab left sidebar shows each API key with pooled credit bars and, when limit rules exist, retains the legacy API Limit bar beneath them. This change ensures the list item continues to surface both the pooled status of the accounts assigned to each key and the key-specific limit usage, computed server-side by aggregating usage across the key's assigned accounts (or all accounts if unscoped), with pooled bars rendered identically to the account credit bars in the Accounts tab.
 
 ## What Changes
 
@@ -8,7 +8,7 @@ The APIs tab left sidebar shows each API key with a limit-usage bar, but operato
 - Extend `list_keys()` to compute pooled credits per key by filtering `summarize_usage_window()` to the key's assigned accounts (or all accounts if none assigned).
 - Add `pooled_remaining_percent_primary`, `pooled_remaining_percent_secondary`, and `pooled_capacity_credits_primary` to the `ApiKeyResponse` schema.
 - Extract `MiniQuotaBar` from `account-list-item.tsx` into a shared component.
-- Replace the limit-usage bar in `api-list-item.tsx` with pooled credit bars labeled "Pooled 5h" and "Pooled Weekly".
+- Keep the legacy limit-usage bar in `api-list-item.tsx` beneath pooled credit bars labeled "Pooled 5h" and "Pooled Weekly" when limit rules exist.
 - Hide the Pooled 5h bar when pooled primary capacity is 0.0 (e.g., all free-tier accounts).
 - No reset countdown labels on pooled bars.
 

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/proposal.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The APIs tab left sidebar shows each API key with a limit-usage bar, but operators could not see the pooled credit status of the accounts assigned to each key. This change adds "Pooled 5h" and "Pooled Weekly" credit bars to each API list item, computed server-side by aggregating usage across the key's assigned accounts (or all accounts if unscoped), rendered identically to the account credit bars in the Accounts tab.
+
+## What Changes
+
+- Add `PooledCreditData` dataclass to the API keys service layer with `remaining_percent_primary`, `remaining_percent_secondary`, and `capacity_credits_primary` fields.
+- Extend `list_keys()` to compute pooled credits per key by filtering `summarize_usage_window()` to the key's assigned accounts (or all accounts if none assigned).
+- Add `pooled_remaining_percent_primary`, `pooled_remaining_percent_secondary`, and `pooled_capacity_credits_primary` to the `ApiKeyResponse` schema.
+- Extract `MiniQuotaBar` from `account-list-item.tsx` into a shared component.
+- Replace the limit-usage bar in `api-list-item.tsx` with pooled credit bars labeled "Pooled 5h" and "Pooled Weekly".
+- Hide the Pooled 5h bar when pooled primary capacity is 0.0 (e.g., all free-tier accounts).
+- No reset countdown labels on pooled bars.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: API key list response now includes per-key pooled credit data computed from assigned accounts.
+- `frontend-architecture`: API sidebar list items now render pooled credit bars instead of limit-usage bars. `MiniQuotaBar` is extracted to a shared component.
+
+## Impact
+
+- Backend: `app/modules/api_keys/{service,repository,api,schemas}.py`, `app/dependencies.py`
+- Frontend: `frontend/src/components/mini-quota-bar.tsx` (new), `frontend/src/features/api-keys/schemas.ts`, `frontend/src/features/apis/components/api-list-item.tsx`, `frontend/src/features/accounts/components/account-list-item.tsx`
+- Tests: Unit tests for `_compute_pooled_credits`, integration tests for pooled fields in list response, frontend schema tests

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/api-keys/spec.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/api-keys/spec.md
@@ -1,3 +1,5 @@
+## ADDED Requirements
+
 ### Requirement: API key list includes pooled credit data
 
 The `GET /api/api-keys/` list endpoint SHALL include per-key pooled credit data computed by aggregating upstream usage across the accounts assigned to each key. When a key has no assigned accounts, the system SHALL pool across all accounts.

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/api-keys/spec.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/api-keys/spec.md
@@ -2,7 +2,9 @@
 
 ### Requirement: API key list includes pooled credit data
 
-The `GET /api/api-keys/` list endpoint SHALL include per-key pooled credit data computed by aggregating upstream usage across the accounts assigned to each key. When a key has no assigned accounts, the system SHALL pool across all accounts.
+The `GET /api/api-keys/` list endpoint SHALL include per-key pooled credit data computed by aggregating upstream usage across the selectable accounts assigned to each key. When a key has no assigned accounts, the system SHALL pool across all selectable accounts.
+
+Selectable accounts exclude accounts whose status is `paused` or `deactivated`, matching load-balancer routing eligibility.
 
 The response SHALL include `pooled_remaining_percent_primary` (float or null), `pooled_remaining_percent_secondary` (float or null), and `pooled_capacity_credits_primary` (float, default 0.0) on each key object.
 
@@ -24,3 +26,8 @@ When `pooled_capacity_credits_primary` is 0.0 (e.g., all assigned accounts are f
 - **WHEN** all assigned accounts have plan_type "free" (primary capacity = 0)
 - **THEN** `pooled_capacity_credits_primary` = 0.0
 - **AND** `pooled_remaining_percent_primary` = null
+
+#### Scenario: Paused and deactivated accounts are excluded
+
+- **WHEN** an API key has assigned accounts with active and paused statuses
+- **THEN** pooled credit fields reflect only the active selectable accounts

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/api-keys/spec.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/api-keys/spec.md
@@ -1,0 +1,24 @@
+### Requirement: API key list includes pooled credit data
+
+The `GET /api/api-keys/` list endpoint SHALL include per-key pooled credit data computed by aggregating upstream usage across the accounts assigned to each key. When a key has no assigned accounts, the system SHALL pool across all accounts.
+
+The response SHALL include `pooled_remaining_percent_primary` (float or null), `pooled_remaining_percent_secondary` (float or null), and `pooled_capacity_credits_primary` (float, default 0.0) on each key object.
+
+When `pooled_capacity_credits_primary` is 0.0 (e.g., all assigned accounts are free-tier), `pooled_remaining_percent_primary` SHALL be null.
+
+#### Scenario: Scoped key pools assigned accounts only
+
+- **WHEN** an API key has `assignedAccountIds` containing two accounts
+- **AND** those accounts have usage data
+- **THEN** `pooled_remaining_percent_primary` and `pooled_remaining_percent_secondary` reflect only those two accounts
+
+#### Scenario: Unscoped key pools all accounts
+
+- **WHEN** an API key has `assignedAccountIds` = []
+- **THEN** pooled credit fields reflect all accounts in the system
+
+#### Scenario: Free-tier accounts hide primary bar
+
+- **WHEN** all assigned accounts have plan_type "free" (primary capacity = 0)
+- **THEN** `pooled_capacity_credits_primary` = 0.0
+- **AND** `pooled_remaining_percent_primary` = null

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/frontend-architecture/spec.md
@@ -1,3 +1,5 @@
+## ADDED Requirements
+
 ### Requirement: API sidebar shows pooled credit bars
 
 The APIs page left sidebar SHALL render pooled credit bars on each API key list item. Each bar SHALL display a label, percentage, and colored progress bar using the same `MiniQuotaBar` component as the Accounts sidebar.

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/frontend-architecture/spec.md
@@ -1,0 +1,24 @@
+### Requirement: API sidebar shows pooled credit bars
+
+The APIs page left sidebar SHALL render pooled credit bars on each API key list item. Each bar SHALL display a label, percentage, and colored progress bar using the same `MiniQuotaBar` component as the Accounts sidebar.
+
+Labels SHALL be "Pooled 5h" for the primary window and "Pooled Weekly" for the secondary window. No reset countdown text SHALL be shown.
+
+When `pooledCapacityCreditsPrimary > 0` and `pooledRemainingPercentPrimary` is not null, the "Pooled 5h" bar SHALL be visible. Otherwise it SHALL be hidden. The "Pooled Weekly" bar SHALL be visible when `pooledRemainingPercentSecondary` is not null.
+
+When both bars are visible, they SHALL be laid out in a 2-column grid. When only one bar is visible, it SHALL use a 1-column layout.
+
+#### Scenario: Both pooled bars visible
+
+- **WHEN** an API key has both primary and secondary pooled credit data
+- **THEN** the sidebar item shows "Pooled 5h" and "Pooled Weekly" bars in a 2-column grid
+
+#### Scenario: Primary bar hidden for free-tier accounts
+
+- **WHEN** an API key's pooled primary capacity is 0
+- **THEN** only the "Pooled Weekly" bar is shown in a 1-column layout
+
+#### Scenario: No credit data hides bars
+
+- **WHEN** an API key has no pooled credit data
+- **THEN** no credit bars are rendered on that list item

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/specs/frontend-architecture/spec.md
@@ -8,6 +8,8 @@ When `pooledCapacityCreditsPrimary > 0` and `pooledRemainingPercentPrimary` is n
 
 When both bars are visible, they SHALL be laid out in a 2-column grid. When only one bar is visible, it SHALL use a 1-column layout.
 
+When API key limit rules exist, the sidebar SHALL also render the legacy limit progress bar below the pooled bars with an "API Limit" label and percentage value so it remains clearly distinct from the pooled-account bars.
+
 #### Scenario: Both pooled bars visible
 
 - **WHEN** an API key has both primary and secondary pooled credit data
@@ -22,3 +24,8 @@ When both bars are visible, they SHALL be laid out in a 2-column grid. When only
 
 - **WHEN** an API key has no pooled credit data
 - **THEN** no credit bars are rendered on that list item
+
+#### Scenario: API limit bar is labeled distinctly
+
+- **WHEN** an API key has configured limit rules
+- **THEN** the sidebar renders the legacy limit bar with an "API Limit" label below the pooled bars

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/tasks.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/tasks.md
@@ -10,7 +10,7 @@
 - [ ] 2.3 Add pooled credit fields to `ApiKeyResponse` schema and `_to_response()` mapping.
 - [ ] 2.4 Add pooled credit fields to frontend `ApiKeySchema`.
 - [ ] 2.5 Extract `MiniQuotaBar` to shared component.
-- [ ] 2.6 Replace limit-usage bar in `api-list-item.tsx` with pooled credit bars.
+- [ ] 2.6 Keep the legacy limit-usage bar in `api-list-item.tsx` beneath pooled credit bars when limit rules exist.
 
 ## 3. Verification
 

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/tasks.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/tasks.md
@@ -1,20 +1,20 @@
 ## 1. Spec Backfill
 
-- [ ] 1.1 Add the API-key pooled credit computation and response fields requirement to `api-keys/spec.md`.
-- [ ] 1.2 Add the API sidebar pooled credit bar rendering requirement to `frontend-architecture/spec.md`.
+- [x] 1.1 Add the API-key pooled credit computation and response fields requirement to `api-keys/spec.md`.
+- [x] 1.2 Add the API sidebar pooled credit bar rendering requirement to `frontend-architecture/spec.md`.
 
 ## 2. Implementation
 
-- [ ] 2.1 Add `PooledCreditData` dataclass and `_compute_pooled_credits` helper to the API keys service layer.
-- [ ] 2.2 Compute pooled credits per key in `list_keys()` by filtering `summarize_usage_window()` to assigned accounts.
-- [ ] 2.3 Add pooled credit fields to `ApiKeyResponse` schema and `_to_response()` mapping.
-- [ ] 2.4 Add pooled credit fields to frontend `ApiKeySchema`.
-- [ ] 2.5 Extract `MiniQuotaBar` to shared component.
-- [ ] 2.6 Keep the legacy limit-usage bar in `api-list-item.tsx` beneath pooled credit bars when limit rules exist.
+- [x] 2.1 Add `PooledCreditData` dataclass and `_compute_pooled_credits` helper to the API keys service layer.
+- [x] 2.2 Compute pooled credits per key in `list_keys()` by filtering `summarize_usage_window()` to assigned accounts.
+- [x] 2.3 Add pooled credit fields to `ApiKeyResponse` schema and `_to_response()` mapping.
+- [x] 2.4 Add pooled credit fields to frontend `ApiKeySchema`.
+- [x] 2.5 Extract `MiniQuotaBar` to shared component.
+- [x] 2.6 Keep the legacy limit-usage bar in `api-list-item.tsx` beneath pooled credit bars when limit rules exist.
 
 ## 3. Verification
 
-- [ ] 3.1 Unit test `_compute_pooled_credits` for assigned accounts, all accounts, and free-tier capacity-zero cases.
-- [ ] 3.2 Integration test verifying pooled credit fields in `GET /api/api-keys/` response.
-- [ ] 3.3 Frontend schema test for new pooled fields.
-- [ ] 3.4 Validate the OpenSpec change locally.
+- [x] 3.1 Unit test `_compute_pooled_credits` for assigned accounts, all accounts, and free-tier capacity-zero cases.
+- [x] 3.2 Integration test verifying pooled credit fields in `GET /api/api-keys/` response.
+- [x] 3.3 Frontend schema test for new pooled fields.
+- [x] 3.4 Validate the OpenSpec change locally.

--- a/openspec/changes/add-pooled-credit-bars-api-sidebar/tasks.md
+++ b/openspec/changes/add-pooled-credit-bars-api-sidebar/tasks.md
@@ -1,0 +1,20 @@
+## 1. Spec Backfill
+
+- [ ] 1.1 Add the API-key pooled credit computation and response fields requirement to `api-keys/spec.md`.
+- [ ] 1.2 Add the API sidebar pooled credit bar rendering requirement to `frontend-architecture/spec.md`.
+
+## 2. Implementation
+
+- [ ] 2.1 Add `PooledCreditData` dataclass and `_compute_pooled_credits` helper to the API keys service layer.
+- [ ] 2.2 Compute pooled credits per key in `list_keys()` by filtering `summarize_usage_window()` to assigned accounts.
+- [ ] 2.3 Add pooled credit fields to `ApiKeyResponse` schema and `_to_response()` mapping.
+- [ ] 2.4 Add pooled credit fields to frontend `ApiKeySchema`.
+- [ ] 2.5 Extract `MiniQuotaBar` to shared component.
+- [ ] 2.6 Replace limit-usage bar in `api-list-item.tsx` with pooled credit bars.
+
+## 3. Verification
+
+- [ ] 3.1 Unit test `_compute_pooled_credits` for assigned accounts, all accounts, and free-tier capacity-zero cases.
+- [ ] 3.2 Integration test verifying pooled credit fields in `GET /api/api-keys/` response.
+- [ ] 3.3 Frontend schema test for new pooled fields.
+- [ ] 3.4 Validate the OpenSpec change locally.

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -214,9 +214,7 @@ async def test_api_key_list_includes_pooled_credit_fields_for_selectable_assigne
 
     async with SessionLocal() as session:
         await session.execute(
-            update(Account)
-            .where(Account.id == paused_account_id)
-            .values(status=AccountStatus.PAUSED)
+            update(Account).where(Account.id == paused_account_id).values(status=AccountStatus.PAUSED)
         )
         session.add_all(
             [

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -17,7 +17,7 @@ from app.core.clients.proxy import ProxyResponseError
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
 from app.core.openai.models import OpenAIResponsePayload
 from app.core.utils.time import utcnow
-from app.db.models import ApiKeyUsageReservation, LimitWindow, RequestLog
+from app.db.models import Account, AccountStatus, ApiKeyUsageReservation, LimitWindow, RequestLog, UsageHistory
 from app.db.session import SessionLocal
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService, LimitRuleInput
@@ -205,6 +205,44 @@ async def test_api_key_create_persists_assigned_account_ids(async_client):
     assert listed.status_code == 200
     assert listed.json()[0]["accountAssignmentScopeEnabled"] is True
     assert listed.json()[0]["assignedAccountIds"] == [first_account_id, second_account_id]
+
+
+@pytest.mark.asyncio
+async def test_api_key_list_includes_pooled_credit_fields_for_selectable_assigned_accounts(async_client):
+    active_account_id = await _import_account(async_client, "acc-pooled-active", "pooled-active@example.com")
+    paused_account_id = await _import_account(async_client, "acc-pooled-paused", "pooled-paused@example.com")
+
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Account)
+            .where(Account.id == paused_account_id)
+            .values(status=AccountStatus.PAUSED)
+        )
+        session.add_all(
+            [
+                UsageHistory(account_id=active_account_id, window="primary", used_percent=25.0, window_minutes=300),
+                UsageHistory(account_id=active_account_id, window="secondary", used_percent=10.0, window_minutes=10080),
+                UsageHistory(account_id=paused_account_id, window="primary", used_percent=90.0, window_minutes=300),
+                UsageHistory(account_id=paused_account_id, window="secondary", used_percent=90.0, window_minutes=10080),
+            ]
+        )
+        await session.commit()
+
+    create = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "pooled-response-key",
+            "assignedAccountIds": [active_account_id, paused_account_id],
+        },
+    )
+    assert create.status_code == 200
+
+    listed = await async_client.get("/api/api-keys/")
+    assert listed.status_code == 200
+    [row] = listed.json()
+    assert row["pooledCapacityCreditsPrimary"] == 225.0
+    assert row["pooledRemainingPercentPrimary"] == 75.0
+    assert row["pooledRemainingPercentSecondary"] == 90.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_api_keys_repository.py
+++ b/tests/unit/test_api_keys_repository.py
@@ -146,6 +146,50 @@ class TestUsage7dByAccount:
         assert result == []
 
 
+class TestAccountLookupQueries:
+    @pytest.mark.asyncio
+    async def test_list_all_accounts_only_loads_identity_and_plan_type(self) -> None:
+        session = AsyncMock()
+        repo = ApiKeysRepository(session)
+        statements: list[str] = []
+
+        async def _execute(statement):
+            statements.append(str(statement))
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: []))
+
+        session.execute.side_effect = _execute
+
+        result = await repo.list_all_accounts()
+
+        assert result == []
+        assert len(statements) == 1
+        assert "access_token_encrypted" not in statements[0]
+        assert "refresh_token_encrypted" not in statements[0]
+        assert "id_token_encrypted" not in statements[0]
+        assert "plan_type" in statements[0]
+
+    @pytest.mark.asyncio
+    async def test_list_accounts_by_ids_only_loads_identity_and_plan_type(self) -> None:
+        session = AsyncMock()
+        repo = ApiKeysRepository(session)
+        statements: list[str] = []
+
+        async def _execute(statement):
+            statements.append(str(statement))
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: []))
+
+        session.execute.side_effect = _execute
+
+        result = await repo.list_accounts_by_ids(["acc_1", "acc_2"])
+
+        assert result == []
+        assert len(statements) == 1
+        assert "access_token_encrypted" not in statements[0]
+        assert "refresh_token_encrypted" not in statements[0]
+        assert "id_token_encrypted" not in statements[0]
+        assert "plan_type" in statements[0]
+
+
 class TestUsage7d:
     @pytest.mark.asyncio
     async def test_returns_totals_and_account_costs_from_single_execute(self) -> None:

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Collection
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 
@@ -430,7 +431,7 @@ class _FakeUsageRepository(UsageRepository):
         self,
         window: str | None = None,
         *,
-        account_ids: list[str] | None = None,
+        account_ids: Collection[str] | None = None,
     ) -> dict[str, UsageHistory]:
         self.calls.append((window, None if account_ids is None else list(account_ids)))
         source = self._secondary if window == "secondary" else self._primary

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy.exc import OperationalError
 
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus, ApiKey, ApiKeyAccountAssignment, ApiKeyLimit, LimitType
+from app.db.models import Account, AccountStatus, ApiKey, ApiKeyAccountAssignment, ApiKeyLimit, LimitType, UsageHistory
 from app.modules.api_keys.repository import (
     _UNSET,
     ApiKeyTrendBucket,
@@ -30,6 +30,7 @@ from app.modules.api_keys.service import (
     _build_api_key_trends,
     _is_sqlite_database_locked,
 )
+from app.modules.usage.repository import UsageRepository
 
 pytestmark = pytest.mark.unit
 
@@ -54,6 +55,8 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
         self._accounts: dict[str, Account] = {}
         self._limit_id_seq = 0
         self._reservations: dict[str, UsageReservationData] = {}
+        self.list_all_accounts_calls = 0
+        self.list_accounts_by_ids_calls: list[list[str]] = []
         self.commit_calls = 0
         self.rollback_calls = 0
         self.commit_count = 0
@@ -90,7 +93,12 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
         return result
 
     async def list_accounts_by_ids(self, account_ids: list[str]) -> list[Account]:
+        self.list_accounts_by_ids_calls.append(list(account_ids))
         return [self._accounts[account_id] for account_id in account_ids if account_id in self._accounts]
+
+    async def list_all_accounts(self) -> list[Account]:
+        self.list_all_accounts_calls += 1
+        return list(self._accounts.values())
 
     async def list_usage_summary_by_key(self) -> dict[str, ApiKeyUsageSummary]:
         return {}
@@ -407,6 +415,32 @@ class _FakeApiKeysRepository(ApiKeysRepositoryProtocol):
         return True
 
 
+class _FakeUsageRepository(UsageRepository):
+    def __init__(
+        self,
+        *,
+        primary: dict[str, UsageHistory],
+        secondary: dict[str, UsageHistory],
+    ) -> None:
+        self._primary = primary
+        self._secondary = secondary
+        self.calls: list[tuple[str | None, list[str] | None]] = []
+
+    async def latest_by_account(
+        self,
+        window: str | None = None,
+        *,
+        account_ids: list[str] | None = None,
+    ) -> dict[str, UsageHistory]:
+        self.calls.append((window, None if account_ids is None else list(account_ids)))
+        source = self._secondary if window == "secondary" else self._primary
+        rows = dict(source)
+        if account_ids is not None:
+            allowed = set(account_ids)
+            rows = {account_id: row for account_id, row in rows.items() if account_id in allowed}
+        return rows
+
+
 class _TransactionalAssignmentFailureRepo(_FakeApiKeysRepository):
     def __init__(self) -> None:
         super().__init__()
@@ -470,6 +504,23 @@ def _find_limit_by_id(
 
 async def _async_noop(*args, **kwargs) -> None:
     del args, kwargs
+
+
+def _make_usage_history(
+    account_id: str,
+    *,
+    used_percent: float,
+    reset_at: int | None = None,
+    window_minutes: int | None = None,
+    recorded_at: datetime | None = None,
+) -> UsageHistory:
+    return UsageHistory(
+        account_id=account_id,
+        used_percent=used_percent,
+        reset_at=reset_at,
+        window_minutes=window_minutes,
+        recorded_at=recorded_at or utcnow(),
+    )
 
 
 @pytest.mark.asyncio
@@ -735,6 +786,127 @@ async def test_create_key_rejects_unknown_assigned_accounts() -> None:
                 assigned_account_ids=["missing-account"],
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_list_keys_uses_only_assigned_accounts_for_pooled_credits() -> None:
+    repo = _FakeApiKeysRepository()
+    repo._accounts = {
+        "acc-a": Account(
+            id="acc-a",
+            chatgpt_account_id=None,
+            email="a@example.com",
+            plan_type="plus",
+            access_token_encrypted=b"access-a",
+            refresh_token_encrypted=b"refresh-a",
+            id_token_encrypted=b"id-a",
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        ),
+        "acc-b": Account(
+            id="acc-b",
+            chatgpt_account_id=None,
+            email="b@example.com",
+            plan_type="plus",
+            access_token_encrypted=b"access-b",
+            refresh_token_encrypted=b"refresh-b",
+            id_token_encrypted=b"id-b",
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        ),
+    }
+    service = ApiKeysService(
+        repo,
+        _FakeUsageRepository(
+            primary={
+                "acc-a": _make_usage_history("acc-a", used_percent=25.0),
+                "acc-b": _make_usage_history("acc-b", used_percent=75.0),
+            },
+            secondary={
+                "acc-a": _make_usage_history("acc-a", used_percent=10.0),
+                "acc-b": _make_usage_history("acc-b", used_percent=60.0),
+            },
+        ),
+    )
+
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="assigned-only",
+            allowed_models=None,
+            expires_at=None,
+            assigned_account_ids=["acc-a"],
+        )
+    )
+
+    account_calls_before_list = len(repo.list_accounts_by_ids_calls)
+    listed = await service.list_keys()
+    account_calls_after_list = repo.list_accounts_by_ids_calls[account_calls_before_list:]
+
+    assert listed[0].id == created.id
+    assert listed[0].pooled_credits is not None
+    assert repo.list_all_accounts_calls == 0
+    assert account_calls_after_list == [["acc-a"]]
+    assert cast(_FakeUsageRepository, service._usage_repository).calls == [
+        ("primary", ["acc-a"]),
+        ("secondary", ["acc-a"]),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_keys_falls_back_to_all_accounts_when_key_is_unassigned() -> None:
+    repo = _FakeApiKeysRepository()
+    repo._accounts = {
+        "acc-a": Account(
+            id="acc-a",
+            chatgpt_account_id=None,
+            email="a@example.com",
+            plan_type="plus",
+            access_token_encrypted=b"access-a",
+            refresh_token_encrypted=b"refresh-a",
+            id_token_encrypted=b"id-a",
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        ),
+        "acc-b": Account(
+            id="acc-b",
+            chatgpt_account_id=None,
+            email="b@example.com",
+            plan_type="plus",
+            access_token_encrypted=b"access-b",
+            refresh_token_encrypted=b"refresh-b",
+            id_token_encrypted=b"id-b",
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        ),
+    }
+    usage_repo = _FakeUsageRepository(
+        primary={
+            "acc-a": _make_usage_history("acc-a", used_percent=25.0),
+            "acc-b": _make_usage_history("acc-b", used_percent=75.0),
+        },
+        secondary={
+            "acc-a": _make_usage_history("acc-a", used_percent=10.0),
+            "acc-b": _make_usage_history("acc-b", used_percent=60.0),
+        },
+    )
+    service = ApiKeysService(repo, usage_repo)
+
+    await service.create_key(
+        ApiKeyCreateData(
+            name="unassigned",
+            allowed_models=None,
+            expires_at=None,
+        )
+    )
+
+    account_calls_before_list = len(repo.list_accounts_by_ids_calls)
+    listed = await service.list_keys()
+    account_calls_after_list = repo.list_accounts_by_ids_calls[account_calls_before_list:]
+
+    assert listed[0].pooled_credits is not None
+    assert repo.list_all_accounts_calls == 1
+    assert account_calls_after_list == []
+    assert usage_repo.calls == [("primary", None), ("secondary", None)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Collection
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -57,7 +57,13 @@ class _StubUsageRepository:
         self._primary = primary
         self._secondary = secondary
 
-    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+    async def latest_by_account(
+        self,
+        window: str | None = None,
+        *,
+        account_ids: Collection[str] | None = None,
+    ) -> dict[str, UsageHistory]:
+        del account_ids
         if window == "secondary":
             return self._secondary
         return self._primary

--- a/tests/unit/test_pooled_credits.py
+++ b/tests/unit/test_pooled_credits.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus, UsageHistory
+from app.modules.api_keys.service import PooledCreditData, _compute_pooled_credits
+
+pytestmark = pytest.mark.unit
+
+
+def _make_account(account_id: str, plan_type: str = "plus") -> Account:
+    return Account(
+        id=account_id,
+        chatgpt_account_id=f"workspace-{account_id}",
+        email=f"{account_id}@example.com",
+        plan_type=plan_type,
+        access_token_encrypted=b"a",
+        refresh_token_encrypted=b"b",
+        id_token_encrypted=b"c",
+        last_refresh=datetime.now(tz=timezone.utc),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+
+
+def _make_usage(
+    account_id: str,
+    window: str,
+    used_percent: float,
+    *,
+    window_minutes: int = 300,
+) -> UsageHistory:
+    now = utcnow()
+    return UsageHistory(
+        id=abs(hash(f"{account_id}-{window}")),
+        account_id=account_id,
+        recorded_at=now,
+        window=window,
+        used_percent=used_percent,
+        reset_at=int(now.timestamp()) + window_minutes * 60,
+        window_minutes=window_minutes,
+    )
+
+
+class TestComputePooledCredits:
+    def test_pools_assigned_accounts_only(self) -> None:
+        acc_a = _make_account("acc-a", "plus")
+        acc_b = _make_account("acc-b", "pro")
+        acc_unassigned = _make_account("acc-unassigned", "pro")
+
+        result = _compute_pooled_credits(
+            assigned_account_ids=["acc-a"],
+            all_accounts=[acc_a, acc_b, acc_unassigned],
+            primary_usage={
+                "acc-a": _make_usage("acc-a", "primary", 20.0),
+                "acc-b": _make_usage("acc-b", "primary", 50.0),
+                "acc-unassigned": _make_usage("acc-unassigned", "primary", 80.0),
+            },
+            secondary_usage={
+                "acc-a": _make_usage("acc-a", "secondary", 10.0, window_minutes=10080),
+                "acc-b": _make_usage("acc-b", "secondary", 30.0, window_minutes=10080),
+                "acc-unassigned": _make_usage("acc-unassigned", "secondary", 60.0, window_minutes=10080),
+            },
+        )
+
+        assert isinstance(result, PooledCreditData)
+        assert result.remaining_percent_primary == pytest.approx(80.0)
+        assert result.remaining_percent_secondary == pytest.approx(90.0)
+        assert result.capacity_credits_primary == 225.0
+
+    def test_pools_all_accounts_when_no_assignments(self) -> None:
+        acc_a = _make_account("acc-a", "plus")
+        acc_b = _make_account("acc-b", "pro")
+
+        result = _compute_pooled_credits(
+            assigned_account_ids=[],
+            all_accounts=[acc_a, acc_b],
+            primary_usage={
+                "acc-a": _make_usage("acc-a", "primary", 20.0),
+                "acc-b": _make_usage("acc-b", "primary", 50.0),
+            },
+            secondary_usage={
+                "acc-a": _make_usage("acc-a", "secondary", 10.0, window_minutes=10080),
+                "acc-b": _make_usage("acc-b", "secondary", 30.0, window_minutes=10080),
+            },
+        )
+
+        assert result.remaining_percent_primary is not None
+        assert result.remaining_percent_primary < 80.0
+        assert result.remaining_percent_secondary is not None
+        assert result.remaining_percent_secondary < 90.0
+        assert result.capacity_credits_primary == 225.0 + 1500.0
+
+    def test_free_tier_hides_primary_bar(self) -> None:
+        acc_free = _make_account("acc-free", "free")
+
+        result = _compute_pooled_credits(
+            assigned_account_ids=["acc-free"],
+            all_accounts=[acc_free],
+            primary_usage={
+                "acc-free": _make_usage("acc-free", "primary", 50.0),
+            },
+            secondary_usage={
+                "acc-free": _make_usage("acc-free", "secondary", 30.0, window_minutes=10080),
+            },
+        )
+
+        assert result.capacity_credits_primary == 0.0
+        assert result.remaining_percent_primary is None
+        assert result.remaining_percent_secondary is not None
+
+    def test_no_usage_data_returns_null_percents(self) -> None:
+        acc_a = _make_account("acc-a", "plus")
+
+        result = _compute_pooled_credits(
+            assigned_account_ids=["acc-a"],
+            all_accounts=[acc_a],
+            primary_usage={},
+            secondary_usage={},
+        )
+
+        assert result.remaining_percent_primary is None
+        assert result.remaining_percent_secondary is None
+        assert result.capacity_credits_primary == 0.0
+
+    def test_mixed_plans_sums_capacity(self) -> None:
+        acc_plus = _make_account("acc-plus", "plus")
+        acc_pro = _make_account("acc-pro", "pro")
+
+        result = _compute_pooled_credits(
+            assigned_account_ids=["acc-plus", "acc-pro"],
+            all_accounts=[acc_plus, acc_pro],
+            primary_usage={
+                "acc-plus": _make_usage("acc-plus", "primary", 50.0),
+                "acc-pro": _make_usage("acc-pro", "primary", 10.0),
+            },
+            secondary_usage={
+                "acc-plus": _make_usage("acc-plus", "secondary", 50.0, window_minutes=10080),
+                "acc-pro": _make_usage("acc-pro", "secondary", 10.0, window_minutes=10080),
+            },
+        )
+
+        assert result.capacity_credits_primary == 225.0 + 1500.0
+        assert result.remaining_percent_primary is not None
+        assert result.remaining_percent_primary > 0
+
+    def test_weekly_only_account_remapped(self) -> None:
+        acc_free = _make_account("acc-free", "free")
+
+        primary_with_weekly_minutes = _make_usage("acc-free", "primary", 50.0, window_minutes=10080)
+
+        result = _compute_pooled_credits(
+            assigned_account_ids=["acc-free"],
+            all_accounts=[acc_free],
+            primary_usage={"acc-free": primary_with_weekly_minutes},
+            secondary_usage={},
+        )
+
+        assert result.capacity_credits_primary == 0.0
+        assert result.remaining_percent_primary is None
+
+    def test_used_percent_100_means_zero_remaining(self) -> None:
+        acc_a = _make_account("acc-a", "plus")
+
+        result = _compute_pooled_credits(
+            assigned_account_ids=["acc-a"],
+            all_accounts=[acc_a],
+            primary_usage={"acc-a": _make_usage("acc-a", "primary", 100.0)},
+            secondary_usage={"acc-a": _make_usage("acc-a", "secondary", 100.0, window_minutes=10080)},
+        )
+
+        assert result.remaining_percent_primary == pytest.approx(0.0)
+        assert result.remaining_percent_secondary == pytest.approx(0.0)

--- a/tests/unit/test_pooled_credits.py
+++ b/tests/unit/test_pooled_credits.py
@@ -112,7 +112,19 @@ class TestComputePooledCredits:
         assert result.remaining_percent_primary is None
         assert result.remaining_percent_secondary is not None
 
-    def test_no_usage_data_returns_null_percents(self) -> None:
+    def test_no_accounts_returns_null_percents(self) -> None:
+        result = _compute_pooled_credits(
+            assigned_account_ids=[],
+            all_accounts=[],
+            primary_usage={},
+            secondary_usage={},
+        )
+
+        assert result.remaining_percent_primary is None
+        assert result.remaining_percent_secondary is None
+        assert result.capacity_credits_primary == 0.0
+
+    def test_assigned_accounts_without_usage_history_still_count_capacity(self) -> None:
         acc_a = _make_account("acc-a", "plus")
 
         result = _compute_pooled_credits(
@@ -122,9 +134,9 @@ class TestComputePooledCredits:
             secondary_usage={},
         )
 
-        assert result.remaining_percent_primary is None
-        assert result.remaining_percent_secondary is None
-        assert result.capacity_credits_primary == 0.0
+        assert result.remaining_percent_primary == pytest.approx(100.0)
+        assert result.remaining_percent_secondary == pytest.approx(100.0)
+        assert result.capacity_credits_primary == 225.0
 
     def test_mixed_plans_sums_capacity(self) -> None:
         acc_plus = _make_account("acc-plus", "plus")

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -136,7 +136,13 @@ class StubUsageRepository(UsageRepository):
         self.primary_calls = 0
         self.secondary_calls = 0
 
-    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+    async def latest_by_account(
+        self,
+        window: str | None = None,
+        *,
+        account_ids: Collection[str] | None = None,
+    ) -> dict[str, UsageHistory]:
+        del account_ids
         if window == "secondary":
             self.secondary_calls += 1
             return self._secondary


### PR DESCRIPTION
This feature is to add a usage bar to represent the overall usage of the account assigned to the API

And also added a Label for the original limit 

<img width="340" height="294" alt="螢幕截圖 2026-05-23 14 15 51" src="https://github.com/user-attachments/assets/55ae6992-ec4a-4323-aff7-bb7fe23d0dde" />