### PR TITLE
feat(quota): add reset-confirmed limit warm-up

### DIFF
--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -5,7 +5,7 @@ import contextlib
 import importlib
 import logging
 from dataclasses import dataclass, field
-from typing import Protocol, cast
+from typing import AsyncIterator, Protocol, cast
 
 from app.core.config.settings import get_settings
 from app.db.models import Account, AccountStatus, UsageHistory
@@ -113,7 +113,10 @@ class UsageRefreshScheduler:
                         warmup_service = LimitWarmupService(
                             warmup_repo,
                             request_logs_repo,
-                            sender=StreamingLimitWarmupSender(accounts_repo),
+                            sender=StreamingLimitWarmupSender(
+                                accounts_repo,
+                                accounts_repo_factory=_background_accounts_repo,
+                            ),
                         )
                         refreshed_accounts = await accounts_repo.list_accounts(refresh_existing=True)
                         await warmup_service.run_after_usage_refresh(
@@ -141,6 +144,12 @@ def build_usage_refresh_scheduler() -> UsageRefreshScheduler:
         interval_seconds=settings.usage_refresh_interval_seconds,
         enabled=settings.usage_refresh_enabled,
     )
+
+
+@contextlib.asynccontextmanager
+async def _background_accounts_repo() -> AsyncIterator[AccountsRepository]:
+    async with get_background_session() as session:
+        yield AccountsRepository(session)
 
 
 async def reconcile_recoverable_account_statuses(

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -373,7 +373,7 @@ class LimitWarmupService:
                         error_message=(
                             "Limit warm-up cancelled after another warm-up completion failed"
                             if isinstance(drained_result, asyncio.CancelledError)
-                            else _truncate(str(drained_result))
+                            else (_truncate(str(drained_result)) or "Limit warm-up send failed")
                         ),
                     )
 

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -215,7 +215,10 @@ class StreamingLimitWarmupSender:
         if self._accounts_repo_factory is None:
             return await self._auth_manager.ensure_fresh(account)
         async with self._accounts_repo_factory() as accounts_repo:
-            return await AuthManager(accounts_repo).ensure_fresh(account)
+            return await AuthManager(
+                accounts_repo,
+                refresh_repo_factory=self._accounts_repo_factory,
+            ).ensure_fresh(account)
 
 
 class LimitWarmupService:

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -347,29 +347,34 @@ class LimitWarmupService:
                     raise completion_error
         finally:
             if pending_send_tasks:
-                finished_send_tasks = {send_task for send_task in pending_send_tasks if send_task.done()}
-                pending_send_tasks -= finished_send_tasks
-                for send_task in finished_send_tasks:
-                    try:
-                        outcome = await send_task
-                        completed = await self._complete_warmup(outcome)
-                    except Exception:
-                        await self._mark_aborted_warmup(
-                            send_tasks[send_task],
-                            error_code="warmup_completion_failed",
-                            error_message="Limit warm-up completion failed",
-                        )
-                        continue
-                    latest_attempts[outcome.account.id] = completed or outcome.attempt
-
                 for send_task in pending_send_tasks:
                     send_task.cancel()
-                await asyncio.gather(*pending_send_tasks, return_exceptions=True)
-                for send_task in pending_send_tasks:
+                drained_results = await asyncio.gather(*pending_send_tasks, return_exceptions=True)
+                for send_task, drained_result in zip(pending_send_tasks, drained_results, strict=True):
+                    if isinstance(drained_result, LimitWarmupSendOutcome):
+                        try:
+                            completed = await self._complete_warmup(drained_result)
+                        except Exception:
+                            await self._mark_aborted_warmup(
+                                drained_result.attempt,
+                                error_code="warmup_completion_failed",
+                                error_message="Limit warm-up completion failed",
+                            )
+                            continue
+                        latest_attempts[drained_result.account.id] = completed or drained_result.attempt
+                        continue
                     await self._mark_aborted_warmup(
                         send_tasks[send_task],
-                        error_code="warmup_cancelled",
-                        error_message="Limit warm-up cancelled after another warm-up completion failed",
+                        error_code=(
+                            "warmup_cancelled"
+                            if isinstance(drained_result, asyncio.CancelledError)
+                            else "warmup_send_failed"
+                        ),
+                        error_message=(
+                            "Limit warm-up cancelled after another warm-up completion failed"
+                            if isinstance(drained_result, asyncio.CancelledError)
+                            else _truncate(str(drained_result))
+                        ),
                     )
 
     def _resolve_model(self, configured_model: str, account: Account) -> str | None:

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -30,6 +31,7 @@ LIMIT_WARMUP_HEADER = "x-codex-lb-limit-warmup"
 _DEFAULT_WARMUP_INSTRUCTIONS = "Reply with OK only."
 _TERMINAL_ERROR_EVENTS = {"response.failed", "response.incomplete", "error"}
 _QUOTA_ERROR_CODES = {"insufficient_quota", "quota_exceeded", "rate_limit_exceeded", "usage_limit_reached"}
+_MAX_CONCURRENT_WARMUP_SENDS = 4
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +41,15 @@ class LimitWarmupSendResult:
     latency_ms: int
     usage: ResponseUsage | None = None
     error_code: str | None = None
+    error_message: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LimitWarmupSendOutcome:
+    attempt: AccountLimitWarmup
+    account: Account
+    model: str
+    result: LimitWarmupSendResult | None
     error_message: str | None = None
 
 
@@ -104,12 +115,16 @@ class StreamingLimitWarmupSender:
         self._accounts_repo = accounts_repo
         self._auth_manager = AuthManager(accounts_repo)
         self._encryptor = TokenEncryptor()
+        self._auth_lock = asyncio.Lock()
 
     async def send(self, account: Account, *, model: str, prompt: str) -> LimitWarmupSendResult:
         request_id = f"limit-warmup-{uuid.uuid4().hex}"
         started = time.monotonic()
         try:
-            fresh_account = await self._auth_manager.ensure_fresh(account)
+            async with self._auth_lock:
+                fresh_account = await self._auth_manager.ensure_fresh(account)
+                access_token = self._encryptor.decrypt(fresh_account.access_token_encrypted)
+                chatgpt_account_id = fresh_account.chatgpt_account_id
         except RefreshError as exc:
             return LimitWarmupSendResult(
                 request_id=request_id,
@@ -145,7 +160,6 @@ class StreamingLimitWarmupSender:
             LIMIT_WARMUP_HEADER: "1",
             "user-agent": "codex-lb-limit-warmup",
         }
-        access_token = self._encryptor.decrypt(fresh_account.access_token_encrypted)
         usage: ResponseUsage | None = None
         with override_stream_timeouts(
             connect_timeout_seconds=5.0,
@@ -156,7 +170,7 @@ class StreamingLimitWarmupSender:
                 payload,
                 headers,
                 access_token,
-                fresh_account.chatgpt_account_id,
+                chatgpt_account_id,
                 upstream_stream_transport_override="http",
             ):
                 event = parse_sse_event(event_block)
@@ -225,6 +239,8 @@ class LimitWarmupService:
         sender = self._sender
         if sender is None:
             raise RuntimeError("LimitWarmupService requires a sender")
+        send_tasks: list[asyncio.Task[LimitWarmupSendOutcome]] = []
+        send_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_WARMUP_SENDS)
 
         for account in accounts:
             if not _account_is_safe_candidate(account):
@@ -281,14 +297,23 @@ class LimitWarmupService:
                 if attempt is None:
                     continue
 
-                completed = await self._send_and_complete(
-                    attempt,
-                    account=account,
-                    model=model,
-                    prompt=settings.limit_warmup_prompt,
-                    sender=sender,
+                send_tasks.append(
+                    asyncio.create_task(
+                        self._send_warmup(
+                            attempt,
+                            account=account,
+                            model=model,
+                            prompt=settings.limit_warmup_prompt,
+                            sender=sender,
+                            semaphore=send_semaphore,
+                        )
+                    )
                 )
-                latest_attempts[account.id] = completed or attempt
+
+        for send_task in asyncio.as_completed(send_tasks):
+            outcome = await send_task
+            completed = await self._complete_warmup(outcome)
+            latest_attempts[outcome.account.id] = completed or outcome.attempt
 
     def _resolve_model(self, configured_model: str, account: Account) -> str | None:
         normalized = configured_model.strip()
@@ -314,7 +339,7 @@ class LimitWarmupService:
             return None
         return min(candidates, key=lambda item: (item[0], item[1]))[1]
 
-    async def _send_and_complete(
+    async def _send_warmup(
         self,
         attempt: AccountLimitWarmup,
         *,
@@ -322,25 +347,39 @@ class LimitWarmupService:
         model: str,
         prompt: str,
         sender: LimitWarmupSender,
-    ) -> AccountLimitWarmup | None:
+        semaphore: asyncio.Semaphore,
+    ) -> LimitWarmupSendOutcome:
         try:
-            result = await sender.send(account, model=model, prompt=prompt)
+            async with semaphore:
+                result = await sender.send(account, model=model, prompt=prompt)
         except Exception as exc:
             logger.warning(
                 "Limit warm-up send failed account_id=%s window=%s", account.id, attempt.window, exc_info=True
             )
-            completed_at = utcnow()
-            return await self._warmup_repo.complete_attempt(
-                attempt.id,
-                status="failed",
-                completed_at=completed_at,
-                error_code="warmup_send_failed",
-                error_message=_truncate(str(exc)),
+            return LimitWarmupSendOutcome(
+                attempt=attempt,
+                account=account,
+                model=model,
+                result=None,
+                error_message=str(exc),
             )
 
+        return LimitWarmupSendOutcome(attempt=attempt, account=account, model=model, result=result)
+
+    async def _complete_warmup(self, outcome: LimitWarmupSendOutcome) -> AccountLimitWarmup | None:
+        if outcome.result is None:
+            return await self._warmup_repo.complete_attempt(
+                outcome.attempt.id,
+                status="failed",
+                completed_at=utcnow(),
+                error_code="warmup_send_failed",
+                error_message=_truncate(outcome.error_message),
+            )
+
+        result = outcome.result
         await self._record_request_log(
-            account=account,
-            model=model,
+            account=outcome.account,
+            model=outcome.model,
             result=result,
         )
         status = "succeeded" if result.success else "failed"
@@ -348,7 +387,7 @@ class LimitWarmupService:
         if error_code in _QUOTA_ERROR_CODES:
             error_code = "quota_still_exhausted"
         return await self._warmup_repo.complete_attempt(
-            attempt.id,
+            outcome.attempt.id,
             status=status,
             completed_at=utcnow(),
             error_code=error_code,

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -289,7 +289,6 @@ class LimitWarmupService:
                     sender=sender,
                 )
                 latest_attempts[account.id] = completed or attempt
-                break
 
     def _resolve_model(self, configured_model: str, account: Account) -> str | None:
         normalized = configured_model.strip()

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -316,21 +316,30 @@ class LimitWarmupService:
                     pending_send_tasks,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
+                completion_error: BaseException | None = None
                 for send_task in completed_send_tasks:
                     outcome = await send_task
-                    completed = await self._complete_warmup(outcome)
+                    try:
+                        completed = await self._complete_warmup(outcome)
+                    except Exception as exc:
+                        completion_error = completion_error or exc
+                        await self._mark_aborted_warmup(
+                            outcome.attempt,
+                            error_code="warmup_completion_failed",
+                            error_message="Limit warm-up completion failed",
+                        )
+                        continue
                     latest_attempts[outcome.account.id] = completed or outcome.attempt
+                if completion_error is not None:
+                    raise completion_error
         finally:
             if pending_send_tasks:
                 for send_task in pending_send_tasks:
                     send_task.cancel()
                 await asyncio.gather(*pending_send_tasks, return_exceptions=True)
                 for send_task in pending_send_tasks:
-                    attempt = send_tasks[send_task]
-                    await self._warmup_repo.complete_attempt(
-                        attempt.id,
-                        status="failed",
-                        completed_at=utcnow(),
+                    await self._mark_aborted_warmup(
+                        send_tasks[send_task],
                         error_code="warmup_cancelled",
                         error_message="Limit warm-up cancelled after another warm-up completion failed",
                     )
@@ -413,6 +422,29 @@ class LimitWarmupService:
             error_code=error_code,
             error_message=_truncate(result.error_message),
         )
+
+    async def _mark_aborted_warmup(
+        self,
+        attempt: AccountLimitWarmup,
+        *,
+        error_code: str,
+        error_message: str,
+    ) -> None:
+        try:
+            await self._warmup_repo.complete_attempt(
+                attempt.id,
+                status="failed",
+                completed_at=utcnow(),
+                error_code=error_code,
+                error_message=error_message,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to mark aborted limit warm-up attempt_id=%s error_code=%s",
+                attempt.id,
+                error_code,
+                exc_info=True,
+            )
 
     async def _record_request_log(
         self,

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Protocol
+from typing import AsyncContextManager, Callable, Protocol
 
 from app.core import usage as usage_core
 from app.core.auth.refresh import RefreshError
@@ -111,8 +111,14 @@ class LimitWarmupRequestLogRepository(Protocol):
 
 
 class StreamingLimitWarmupSender:
-    def __init__(self, accounts_repo: AccountsRepository) -> None:
+    def __init__(
+        self,
+        accounts_repo: AccountsRepository,
+        *,
+        accounts_repo_factory: Callable[[], AsyncContextManager[AccountsRepository]] | None = None,
+    ) -> None:
         self._accounts_repo = accounts_repo
+        self._accounts_repo_factory = accounts_repo_factory
         self._auth_manager = AuthManager(accounts_repo)
         self._encryptor = TokenEncryptor()
         self._auth_lock = asyncio.Lock()
@@ -122,7 +128,7 @@ class StreamingLimitWarmupSender:
         started = time.monotonic()
         try:
             async with self._auth_lock:
-                fresh_account = await self._auth_manager.ensure_fresh(account)
+                fresh_account = await self._ensure_fresh(account)
                 access_token = self._encryptor.decrypt(fresh_account.access_token_encrypted)
                 chatgpt_account_id = fresh_account.chatgpt_account_id
         except RefreshError as exc:
@@ -204,6 +210,12 @@ class StreamingLimitWarmupSender:
             error_code="stream_incomplete",
             error_message="Warm-up stream ended without a terminal event",
         )
+
+    async def _ensure_fresh(self, account: Account) -> Account:
+        if self._accounts_repo_factory is None:
+            return await self._auth_manager.ensure_fresh(account)
+        async with self._accounts_repo_factory() as accounts_repo:
+            return await AuthManager(accounts_repo).ensure_fresh(account)
 
 
 class LimitWarmupService:
@@ -305,7 +317,8 @@ class LimitWarmupService:
                         prompt=settings.limit_warmup_prompt,
                         sender=sender,
                         semaphore=send_semaphore,
-                    )
+                    ),
+                    name=f"limit-warmup:{attempt.id}",
                 )
                 send_tasks[send_task] = attempt
 
@@ -334,6 +347,21 @@ class LimitWarmupService:
                     raise completion_error
         finally:
             if pending_send_tasks:
+                finished_send_tasks = {send_task for send_task in pending_send_tasks if send_task.done()}
+                pending_send_tasks -= finished_send_tasks
+                for send_task in finished_send_tasks:
+                    try:
+                        outcome = await send_task
+                        completed = await self._complete_warmup(outcome)
+                    except Exception:
+                        await self._mark_aborted_warmup(
+                            send_tasks[send_task],
+                            error_code="warmup_completion_failed",
+                            error_message="Limit warm-up completion failed",
+                        )
+                        continue
+                    latest_attempts[outcome.account.id] = completed or outcome.attempt
+
                 for send_task in pending_send_tasks:
                     send_task.cancel()
                 await asyncio.gather(*pending_send_tasks, return_exceptions=True)

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -445,8 +445,10 @@ def _build_candidate(
         return None
     if before.used_percent < 100.0:
         return None
-    available_percent = max(0.0, 100.0 - after.used_percent)
-    if available_percent < min_available_percent:
+    if after.used_percent >= 100.0:
+        return None
+    available_percent = 100.0 - after.used_percent
+    if min_available_percent < 100.0 and available_percent < min_available_percent:
         return None
     if after.reset_at <= before.reset_at:
         return None

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -239,7 +239,7 @@ class LimitWarmupService:
         sender = self._sender
         if sender is None:
             raise RuntimeError("LimitWarmupService requires a sender")
-        send_tasks: list[asyncio.Task[LimitWarmupSendOutcome]] = []
+        send_tasks: dict[asyncio.Task[LimitWarmupSendOutcome], AccountLimitWarmup] = {}
         send_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_WARMUP_SENDS)
 
         for account in accounts:
@@ -297,23 +297,43 @@ class LimitWarmupService:
                 if attempt is None:
                     continue
 
-                send_tasks.append(
-                    asyncio.create_task(
-                        self._send_warmup(
-                            attempt,
-                            account=account,
-                            model=model,
-                            prompt=settings.limit_warmup_prompt,
-                            sender=sender,
-                            semaphore=send_semaphore,
-                        )
+                send_task = asyncio.create_task(
+                    self._send_warmup(
+                        attempt,
+                        account=account,
+                        model=model,
+                        prompt=settings.limit_warmup_prompt,
+                        sender=sender,
+                        semaphore=send_semaphore,
                     )
                 )
+                send_tasks[send_task] = attempt
 
-        for send_task in asyncio.as_completed(send_tasks):
-            outcome = await send_task
-            completed = await self._complete_warmup(outcome)
-            latest_attempts[outcome.account.id] = completed or outcome.attempt
+        pending_send_tasks = set(send_tasks)
+        try:
+            while pending_send_tasks:
+                completed_send_tasks, pending_send_tasks = await asyncio.wait(
+                    pending_send_tasks,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for send_task in completed_send_tasks:
+                    outcome = await send_task
+                    completed = await self._complete_warmup(outcome)
+                    latest_attempts[outcome.account.id] = completed or outcome.attempt
+        finally:
+            if pending_send_tasks:
+                for send_task in pending_send_tasks:
+                    send_task.cancel()
+                await asyncio.gather(*pending_send_tasks, return_exceptions=True)
+                for send_task in pending_send_tasks:
+                    attempt = send_tasks[send_task]
+                    await self._warmup_repo.complete_attempt(
+                        attempt.id,
+                        status="failed",
+                        completed_at=utcnow(),
+                        error_code="warmup_cancelled",
+                        error_message="Limit warm-up cancelled after another warm-up completion failed",
+                    )
 
     def _resolve_model(self, configured_model: str, account: Account) -> str | None:
         normalized = configured_model.strip()

--- a/frontend/src/features/accounts/components/account-list-item.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.tsx
@@ -36,7 +36,7 @@ export function AccountListItem({ account, selected, showAccountId = false, onSe
   const visibleQuotaRows = Number(showPrimaryRow) + Number(showSecondaryRow);
   const warmupLabel = account.limitWarmupEnabled ? "Warm-up on" : "Warm-up off";
   const warmupMeta = account.limitWarmup
-    ? `${formatSlug(account.limitWarmup.status)} | ${formatDateTimeInline(account.limitWarmup.completedAt ?? account.limitWarmup.attemptedAt)}`
+    ? `${formatSlug(account.limitWarmup.status)} | ${formatSlug(account.limitWarmup.model)} | ${formatDateTimeInline(account.limitWarmup.completedAt ?? account.limitWarmup.attemptedAt)}`
     : "No attempts";
 
   return (

--- a/frontend/src/features/dashboard/components/account-card.tsx
+++ b/frontend/src/features/dashboard/components/account-card.tsx
@@ -86,7 +86,7 @@ export function AccountCard({ account, showAccountId = false, onAction }: Accoun
   const warmupStatus = account.limitWarmupEnabled ? "Warm-up on" : "Warm-up off";
   const warmupToggleLabel = `${account.limitWarmupEnabled ? "Disable" : "Enable"} limit warm-up for ${title}`;
   const warmupDetail = account.limitWarmup
-    ? `${formatSlug(account.limitWarmup.status)} | ${account.limitWarmup.window === "primary" ? "5h" : "weekly"} | ${formatDateTimeInline(account.limitWarmup.completedAt ?? account.limitWarmup.attemptedAt)}`
+    ? `${formatSlug(account.limitWarmup.status)} | ${account.limitWarmup.window === "primary" ? "5h" : "weekly"} | ${formatSlug(account.limitWarmup.model)} | ${formatDateTimeInline(account.limitWarmup.completedAt ?? account.limitWarmup.attemptedAt)}`
     : "No attempts";
 
   return (

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 
@@ -187,6 +188,29 @@ class FakeSender:
         )
 
 
+class TrackingSender:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.active = 0
+        self.max_active = 0
+        self.release = asyncio.Event()
+
+    async def send(self, account: Account, *, model: str, prompt: str) -> LimitWarmupSendResult:
+        self.calls.append((account.id, model))
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        if self.max_active >= 4:
+            self.release.set()
+        await self.release.wait()
+        await asyncio.sleep(0)
+        self.active -= 1
+        return LimitWarmupSendResult(
+            request_id=f"warmup-{len(self.calls)}",
+            success=True,
+            latency_ms=12,
+        )
+
+
 @pytest.mark.asyncio
 async def test_reset_confirmed_candidate_sends_one_warmup() -> None:
     repo = FakeWarmupRepo()
@@ -216,6 +240,29 @@ async def test_reset_confirmed_candidate_sends_one_warmup() -> None:
     assert len(repo.rows) == 1
     assert repo.rows[0].status == "succeeded"
     assert logs.logs[0]["source"] == "limit_warmup"
+
+
+@pytest.mark.asyncio
+async def test_warmup_sends_use_bounded_concurrency() -> None:
+    repo = FakeWarmupRepo()
+    logs = FakeRequestLogsRepo()
+    sender = TrackingSender()
+    service = LimitWarmupService(repo, logs, sender=sender)
+    accounts = [_account(f"acc_{index}") for index in range(6)]
+
+    await service.run_after_usage_refresh(
+        accounts=accounts,
+        settings=_settings(),
+        before_primary={account.id: _usage(account.id, used_percent=100, reset_at=1000) for account in accounts},
+        before_secondary={},
+        after_primary={account.id: _usage(account.id, used_percent=0, reset_at=2000) for account in accounts},
+        after_secondary={},
+    )
+
+    assert len(sender.calls) == 6
+    assert sender.max_active == 4
+    assert len(logs.logs) == 6
+    assert [row.status for row in repo.rows] == ["succeeded"] * 6
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -118,6 +118,7 @@ class FailingCompletionWarmupRepo(FakeWarmupRepo):
     def __init__(self, *, fail_attempt_id: int) -> None:
         super().__init__()
         self.fail_attempt_id = fail_attempt_id
+        self.failed_once = False
 
     async def complete_attempt(
         self,
@@ -128,7 +129,8 @@ class FailingCompletionWarmupRepo(FakeWarmupRepo):
         error_code: str | None = None,
         error_message: str | None = None,
     ) -> AccountLimitWarmup | None:
-        if attempt_id == self.fail_attempt_id:
+        if attempt_id == self.fail_attempt_id and not self.failed_once:
+            self.failed_once = True
             raise RuntimeError("completion failed")
         return await super().complete_attempt(
             attempt_id,
@@ -252,6 +254,24 @@ class BlockingSecondSender:
         )
 
 
+class CoordinatedSender:
+    def __init__(self, expected: int) -> None:
+        self.expected = expected
+        self.started = 0
+        self.release = asyncio.Event()
+
+    async def send(self, account: Account, *, model: str, prompt: str) -> LimitWarmupSendResult:
+        self.started += 1
+        if self.started >= self.expected:
+            self.release.set()
+        await self.release.wait()
+        return LimitWarmupSendResult(
+            request_id=f"warmup-{account.id}",
+            success=True,
+            latency_ms=12,
+        )
+
+
 @pytest.mark.asyncio
 async def test_reset_confirmed_candidate_sends_one_warmup() -> None:
     repo = FakeWarmupRepo()
@@ -323,8 +343,32 @@ async def test_warmup_completion_failure_cancels_pending_sends() -> None:
             after_secondary={},
         )
 
-    assert [row.status for row in repo.rows] == ["pending", "failed"]
+    assert [row.status for row in repo.rows] == ["failed", "failed"]
+    assert repo.rows[0].error_code == "warmup_completion_failed"
     assert repo.rows[1].error_code == "warmup_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_warmup_completion_failure_finalizes_same_batch_sends() -> None:
+    repo = FailingCompletionWarmupRepo(fail_attempt_id=1)
+    sender = CoordinatedSender(expected=2)
+    service = LimitWarmupService(repo, FakeRequestLogsRepo(), sender=sender)
+    accounts = [_account("acc_1"), _account("acc_2")]
+
+    with pytest.raises(RuntimeError, match="completion failed"):
+        await service.run_after_usage_refresh(
+            accounts=accounts,
+            settings=_settings(),
+            before_primary={account.id: _usage(account.id, used_percent=100, reset_at=1000) for account in accounts},
+            before_secondary={},
+            after_primary={account.id: _usage(account.id, used_percent=0, reset_at=2000) for account in accounts},
+            after_secondary={},
+        )
+
+    statuses_by_account = {row.account_id: row.status for row in repo.rows}
+    assert statuses_by_account == {"acc_1": "failed", "acc_2": "succeeded"}
+    failed = next(row for row in repo.rows if row.account_id == "acc_1")
+    assert failed.error_code == "warmup_completion_failed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -276,6 +276,29 @@ async def test_min_available_quota_threshold_uses_remaining_percent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_both_selected_windows_warm_primary_and_secondary_resets() -> None:
+    repo = FakeWarmupRepo()
+    sender = FakeSender()
+    service = LimitWarmupService(repo, FakeRequestLogsRepo(), sender=sender)
+    account = _account()
+
+    await service.run_after_usage_refresh(
+        accounts=[account],
+        settings=_settings(limit_warmup_windows="both"),
+        before_primary={account.id: _usage(account.id, used_percent=100, reset_at=1000)},
+        before_secondary={account.id: _usage(account.id, used_percent=100, reset_at=10_000, window="secondary")},
+        after_primary={account.id: _usage(account.id, used_percent=0, reset_at=2000)},
+        after_secondary={account.id: _usage(account.id, used_percent=0, reset_at=20_000, window="secondary")},
+    )
+
+    assert sender.calls == [(account.id, "gpt-5.1-codex-mini"), (account.id, "gpt-5.1-codex-mini")]
+    assert [(row.window, row.reset_at, row.status) for row in repo.rows] == [
+        ("primary", 2000, "succeeded"),
+        ("secondary", 20_000, "succeeded"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_unsafe_account_state_does_not_send() -> None:
     repo = FakeWarmupRepo()
     sender = FakeSender()

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -114,6 +114,31 @@ class FakeWarmupRepo:
         return row
 
 
+class FailingCompletionWarmupRepo(FakeWarmupRepo):
+    def __init__(self, *, fail_attempt_id: int) -> None:
+        super().__init__()
+        self.fail_attempt_id = fail_attempt_id
+
+    async def complete_attempt(
+        self,
+        attempt_id: int,
+        *,
+        status: str,
+        completed_at,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> AccountLimitWarmup | None:
+        if attempt_id == self.fail_attempt_id:
+            raise RuntimeError("completion failed")
+        return await super().complete_attempt(
+            attempt_id,
+            status=status,
+            completed_at=completed_at,
+            error_code=error_code,
+            error_message=error_message,
+        )
+
+
 class FakeRequestLogsRepo:
     def __init__(self) -> None:
         self.logs: list[dict[str, object]] = []
@@ -211,6 +236,22 @@ class TrackingSender:
         )
 
 
+class BlockingSecondSender:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.block = asyncio.Event()
+
+    async def send(self, account: Account, *, model: str, prompt: str) -> LimitWarmupSendResult:
+        self.calls.append(account.id)
+        if account.id == "acc_2":
+            await self.block.wait()
+        return LimitWarmupSendResult(
+            request_id=f"warmup-{account.id}",
+            success=True,
+            latency_ms=12,
+        )
+
+
 @pytest.mark.asyncio
 async def test_reset_confirmed_candidate_sends_one_warmup() -> None:
     repo = FakeWarmupRepo()
@@ -263,6 +304,27 @@ async def test_warmup_sends_use_bounded_concurrency() -> None:
     assert sender.max_active == 4
     assert len(logs.logs) == 6
     assert [row.status for row in repo.rows] == ["succeeded"] * 6
+
+
+@pytest.mark.asyncio
+async def test_warmup_completion_failure_cancels_pending_sends() -> None:
+    repo = FailingCompletionWarmupRepo(fail_attempt_id=1)
+    sender = BlockingSecondSender()
+    service = LimitWarmupService(repo, FakeRequestLogsRepo(), sender=sender)
+    accounts = [_account("acc_1"), _account("acc_2")]
+
+    with pytest.raises(RuntimeError, match="completion failed"):
+        await service.run_after_usage_refresh(
+            accounts=accounts,
+            settings=_settings(),
+            before_primary={account.id: _usage(account.id, used_percent=100, reset_at=1000) for account in accounts},
+            before_secondary={},
+            after_primary={account.id: _usage(account.id, used_percent=0, reset_at=2000) for account in accounts},
+            after_secondary={},
+        )
+
+    assert [row.status for row in repo.rows] == ["pending", "failed"]
+    assert repo.rows[1].error_code == "warmup_cancelled"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -248,6 +248,26 @@ async def test_disabled_or_account_opt_out_does_not_send() -> None:
 
 
 @pytest.mark.asyncio
+async def test_default_available_threshold_accepts_nonzero_reset_usage() -> None:
+    repo = FakeWarmupRepo()
+    sender = FakeSender()
+    service = LimitWarmupService(repo, FakeRequestLogsRepo(), sender=sender)
+    account = _account()
+
+    await service.run_after_usage_refresh(
+        accounts=[account],
+        settings=_settings(),
+        before_primary={account.id: _usage(account.id, used_percent=100, reset_at=1000)},
+        before_secondary={},
+        after_primary={account.id: _usage(account.id, used_percent=1, reset_at=2000)},
+        after_secondary={},
+    )
+
+    assert len(sender.calls) == 1
+    assert len(repo.rows) == 1
+
+
+@pytest.mark.asyncio
 async def test_min_available_quota_threshold_uses_remaining_percent() -> None:
     repo = FakeWarmupRepo()
     sender = FakeSender()

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountLimitWarmup, AccountStatus, DashboardSettings, UsageHistory
+from app.modules.limit_warmup import service as limit_warmup_service
 from app.modules.limit_warmup.service import LimitWarmupSendResult, LimitWarmupService
 
 pytestmark = pytest.mark.unit
@@ -369,6 +370,42 @@ async def test_warmup_completion_failure_finalizes_same_batch_sends() -> None:
     assert statuses_by_account == {"acc_1": "failed", "acc_2": "succeeded"}
     failed = next(row for row in repo.rows if row.account_id == "acc_1")
     assert failed.error_code == "warmup_completion_failed"
+
+
+@pytest.mark.asyncio
+async def test_warmup_completion_failure_drains_finished_pending_sends(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = FailingCompletionWarmupRepo(fail_attempt_id=1)
+    sender = FakeSender()
+    service = LimitWarmupService(repo, FakeRequestLogsRepo(), sender=sender)
+    accounts = [_account("acc_1"), _account("acc_2")]
+
+    async def wait_with_finished_pending(
+        tasks,
+        *,
+        return_when,
+    ):
+        await asyncio.sleep(0)
+        failed_task = {task for task in tasks if task.get_name() == "limit-warmup:1"}
+        assert failed_task
+        pending = set(tasks) - failed_task
+        assert pending
+        assert all(task.done() for task in pending)
+        return failed_task, pending
+
+    monkeypatch.setattr(limit_warmup_service.asyncio, "wait", wait_with_finished_pending)
+
+    with pytest.raises(RuntimeError, match="completion failed"):
+        await service.run_after_usage_refresh(
+            accounts=accounts,
+            settings=_settings(),
+            before_primary={account.id: _usage(account.id, used_percent=100, reset_at=1000) for account in accounts},
+            before_secondary={},
+            after_primary={account.id: _usage(account.id, used_percent=0, reset_at=2000) for account in accounts},
+            after_secondary={},
+        )
+
+    statuses_by_account = {row.account_id: row.status for row in repo.rows}
+    assert statuses_by_account == {"acc_1": "failed", "acc_2": "succeeded"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -248,30 +248,31 @@ async def test_disabled_or_account_opt_out_does_not_send() -> None:
 
 
 @pytest.mark.asyncio
-async def test_min_available_threshold_uses_available_quota_percent() -> None:
+async def test_min_available_quota_threshold_uses_remaining_percent() -> None:
     repo = FakeWarmupRepo()
     sender = FakeSender()
     service = LimitWarmupService(repo, FakeRequestLogsRepo(), sender=sender)
-    eligible_account = _account("acc_available_enough")
-    below_threshold_account = _account("acc_available_low")
+    account = _account()
 
     await service.run_after_usage_refresh(
-        accounts=[eligible_account, below_threshold_account],
-        settings=_settings(limit_warmup_min_available_percent=20.0),
-        before_primary={
-            eligible_account.id: _usage(eligible_account.id, used_percent=100, reset_at=1000),
-            below_threshold_account.id: _usage(below_threshold_account.id, used_percent=100, reset_at=1000),
-        },
+        accounts=[account],
+        settings=_settings(limit_warmup_min_available_percent=99.0),
+        before_primary={account.id: _usage(account.id, used_percent=100, reset_at=1000)},
         before_secondary={},
-        after_primary={
-            eligible_account.id: _usage(eligible_account.id, used_percent=75, reset_at=2000),
-            below_threshold_account.id: _usage(below_threshold_account.id, used_percent=85, reset_at=2000),
-        },
+        after_primary={account.id: _usage(account.id, used_percent=98, reset_at=2000)},
+        after_secondary={},
+    )
+    await service.run_after_usage_refresh(
+        accounts=[account],
+        settings=_settings(limit_warmup_min_available_percent=99.0),
+        before_primary={account.id: _usage(account.id, used_percent=100, reset_at=1000)},
+        before_secondary={},
+        after_primary={account.id: _usage(account.id, used_percent=1, reset_at=2000)},
         after_secondary={},
     )
 
-    assert sender.calls == [(eligible_account.id, "gpt-5.1-codex-mini")]
-    assert [row.account_id for row in repo.rows] == [eligible_account.id]
+    assert len(sender.calls) == 1
+    assert len(repo.rows) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Draft repair branch for #773. The original fork branch has maintainer edits disabled, so this branch carries the same reset-confirmed limit warm-up work plus follow-up fixes needed for CI and review findings.\n\nFollow-up fixes included here:\n- remove the unsupported typed ResponsesRequest max_output_tokens constructor argument\n- type LimitWarmupService against structural repository ports so test doubles pass ty\n- compare configured available-quota thresholds against remaining quota\n- warm all selected reset windows when primary and secondary reset in the same refresh\n- keep the default 100 setting as any reset-confirmed availability rather than requiring exactly 0% used\n\nVerification run locally:\n- make lint\n- make typecheck\n- uv run pytest tests/unit/test_limit_warmup.py\n- codex review --base origin/main, three-pass capped review loop with findings addressed\n\nReferences #773.