### PR TITLE
fix(proxy): align Codex websocket error parsing

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11200,9 +11200,10 @@ async def _websocket_full_replay_should_wait_for_continuity(
 def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
     if not isinstance(payload, dict):
         return None
-    status = payload.get("status")
-    if isinstance(status, int):
-        return status
+    for status_field in ("status", "status_code"):
+        status = payload.get(status_field)
+        if isinstance(status, int) and not isinstance(status, bool):
+            return status
     return None
 
 
@@ -11369,6 +11370,8 @@ def _normalize_http_bridge_error_event(
             explicit_error_code = True
     elif isinstance(payload, dict):
         payload_error = payload.get("error")
+        if not isinstance(payload_error, dict):
+            payload_error = _websocket_top_level_error_payload(payload)
         if isinstance(payload_error, dict):
             code_value = payload_error.get("code")
             if isinstance(code_value, str):
@@ -11394,6 +11397,8 @@ def _normalize_http_bridge_error_event(
 
     if isinstance(payload, dict):
         raw_error = payload.get("error")
+        if not isinstance(raw_error, dict):
+            raw_error = _websocket_top_level_error_payload(payload)
         if isinstance(raw_error, dict):
             plan_type = raw_error.get("plan_type")
             if isinstance(plan_type, str):
@@ -11728,6 +11733,24 @@ def _refresh_websocket_request_input_fingerprint_from_text(request_state: _WebSo
     request_state.input_full_fingerprint = _fingerprint_input_items(cast(list[JsonValue], input_items))
 
 
+def _websocket_top_level_error_payload(payload: dict[str, JsonValue]) -> dict[str, JsonValue] | None:
+    if payload.get("type") != "error":
+        return None
+    error: dict[str, JsonValue] = {}
+    for error_field in ("code", "message", "param"):
+        value = payload.get(error_field)
+        if isinstance(value, str) and value.strip():
+            error[error_field] = value.strip()
+    error_type = payload.get("error_type")
+    if isinstance(error_type, str) and error_type.strip():
+        error["type"] = error_type.strip()
+    for metadata_field in ("plan_type", "resets_at", "resets_in_seconds"):
+        value = payload.get(metadata_field)
+        if isinstance(value, str | int | float) and not isinstance(value, bool):
+            error[metadata_field] = value
+    return error or None
+
+
 def _websocket_event_error_payload(
     event_type: str | None,
     payload: dict[str, JsonValue] | None,
@@ -11740,11 +11763,10 @@ def _websocket_event_error_payload(
             return cast(dict[str, JsonValue], error)
         # The ChatGPT-backed Codex websocket can emit OpenAI-style error
         # details directly on the event frame instead of under an ``error``
-        # envelope. Treat those frames as errors so continuity masking sees
-        # ``previous_response_not_found`` instead of relaying the raw frame.
-        if any(isinstance(payload.get(field), str) for field in ("code", "message", "param")):
-            return payload
-        return None
+        # envelope. Normalize those fields into an error-detail object so the
+        # event discriminator ``type: error`` is not mistaken for the upstream
+        # error type.
+        return _websocket_top_level_error_payload(payload)
     if event_type == "response.failed":
         response = payload.get("response")
         error = response.get("error") if isinstance(response, dict) else None

--- a/openspec/changes/align-codex-websocket-error-parity/proposal.md
+++ b/openspec/changes/align-codex-websocket-error-parity/proposal.md
@@ -1,0 +1,37 @@
+# Align Codex WebSocket error parity
+
+## Why
+
+Official Codex's ChatGPT-backed Responses WebSocket client treats `type: "error"` frames with `status` or `status_code` as wrapped upstream HTTP errors and keeps the original frame body for error parsing. The proxy already masks nested and top-level `previous_response_not_found` frames, but its helper path still treats the event discriminator (`type: "error"`) as the error type when top-level fields are present and only reads `status`, not the official client's `status_code` alias.
+
+That leaves parity gaps for ChatGPT backend error frames that arrive without a nested `error` object, especially when downstream classification depends on error type/status metadata.
+
+## What changes
+
+- Normalize top-level ChatGPT WebSocket error fields into an error-detail shape before classification.
+- Accept `status_code` as an alias for `status` on wrapped WebSocket error frames.
+- Preserve existing fail-closed masking for `previous_response_not_found` so raw anchors do not leak to Codex clients.
+- Add regression coverage pinned to the official Codex client's observed wrapped-error contract.
+
+## Official Codex reference
+
+Analysis source: `openai/codex` at `7d47056ea42636271ac020b86347fbbef49490aa`.
+
+Relevant files:
+
+- `codex-rs/core/src/client.rs`
+  - `ModelClientSession` is per turn.
+  - It reuses one Responses WebSocket connection during the turn.
+  - Incremental `response.create` payloads include `previous_response_id` only after a completed prior response id is available and the new input is an incremental extension of the previous request + output baseline.
+  - Reconnect resets `last_request` and `last_response_rx`, so previous-response anchors are connection/session scoped optimizations, not durable resume tokens.
+- `codex-rs/codex-api/src/endpoint/responses_websocket.rs`
+  - Handshake uses `provider.websocket_url_for_path("responses")`, `OpenAI-Beta: responses_websockets=2026-02-06`, `x-codex-turn-state`, session headers, and optional compression/custom CA support.
+  - Request frames are JSON text frames (`response.create` / `response.processed`).
+  - `parse_wrapped_websocket_error_event` accepts only `type: "error"` frames.
+  - `WrappedWebsocketErrorEvent.status` has `#[serde(alias = "status_code")]`.
+  - Non-2xx wrapped errors map to `TransportError::Http` with the original frame body preserved.
+  - `websocket_connection_limit_reached` maps to retryable so a new WebSocket can be opened.
+
+## Impact
+
+This is a narrow compatibility fix for the Responses WebSocket proxy path. It does not change account selection, durable bridge ownership, or public OpenAI-compatible SSE contracts except for more accurate wrapped-error normalization.

--- a/openspec/changes/align-codex-websocket-error-parity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/align-codex-websocket-error-parity/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Codex WebSocket wrapped errors follow official client shape
+
+When serving `/backend-api/codex/responses` or bridge-backed Responses WebSocket traffic, the service MUST classify upstream `type: "error"` frames using the same wrapped-error shape that the official Codex client accepts: a non-2xx `status` or `status_code` field indicates an upstream HTTP-style error, and the error detail MAY appear either in a nested `error` object or in top-level fields such as `code`, `message`, `param`, and `error_type`.
+
+Top-level error normalization MUST NOT treat the event discriminator `type: "error"` as the upstream error type. If the frame provides `error_type`, the service MUST use that value as the error type for classification/rewrites. Existing continuity protection remains authoritative: frames describing `previous_response_not_found` MUST be rewritten or recovered through the established `stream_incomplete` continuity path instead of exposing the raw upstream code or missing response id.
+
+#### Scenario: status_code alias is classified as upstream error status
+
+- **WHEN** an upstream Codex WebSocket frame is `{"type":"error","status_code":400,...}`
+- **THEN** the service treats the HTTP-style error status as `400`
+- **AND** applies the same error classification path as for `status: 400`
+
+#### Scenario: top-level error_type is used for classification
+
+- **WHEN** an upstream Codex WebSocket frame is `{"type":"error","status":400,"error_type":"invalid_request_error","code":"previous_response_not_found",...}`
+- **THEN** the normalized error detail has `type = "invalid_request_error"`
+- **AND** the event discriminator `type = "error"` is not used as the upstream error type
+
+#### Scenario: top-level previous-response miss remains masked
+
+- **WHEN** a `/backend-api/codex/responses` WebSocket follow-up has `previous_response_id`
+- **AND** upstream emits a top-level `previous_response_not_found` wrapped-error frame using `status_code`
+- **THEN** the downstream event is a retryable continuity failure such as `stream_incomplete`
+- **AND** the downstream payload does not contain `previous_response_not_found`
+- **AND** the downstream payload does not expose the missing previous response id

--- a/openspec/changes/align-codex-websocket-error-parity/tasks.md
+++ b/openspec/changes/align-codex-websocket-error-parity/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+- [x] Add a responses-api-compat delta for Codex ChatGPT WebSocket wrapped-error parity.
+
+## 2. Tests
+- [x] Add unit coverage for top-level WebSocket error-detail normalization (`error_type` must not be confused with the event discriminator).
+- [x] Add unit coverage for `status_code` alias handling.
+- [x] Add/extend backend WebSocket previous-response masking coverage for official wrapped-error shapes.
+
+## 3. Implementation
+- [x] Normalize top-level `type: "error"` frames into an error-detail mapping before classification.
+- [x] Accept `status_code` as a wrapped WebSocket HTTP status alias.
+- [x] Preserve existing `stream_incomplete` masking for previous-response continuity misses.
+
+## 4. Verification
+- [x] Run focused websocket/error regression tests.
+- [x] Run OpenSpec validation.
+- [x] Run lint/format checks for changed files.

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -2468,7 +2468,7 @@ def test_backend_responses_websocket_masks_top_level_previous_response_not_found
                     text=json.dumps(
                         {
                             "type": "error",
-                            "status": 400,
+                            "status_code": 400,
                             "error_type": "invalid_request_error",
                             "code": "previous_response_not_found",
                             "message": "Previous response with id 'resp_chatgpt_prev_anchor' not found.",

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -82,6 +82,38 @@ def _make_api_key(
     )
 
 
+def test_websocket_top_level_error_payload_uses_error_type_not_event_type() -> None:
+    payload: dict[str, proxy_service.JsonValue] = {
+        "type": "error",
+        "status": 400,
+        "error_type": "invalid_request_error",
+        "code": "previous_response_not_found",
+        "message": "Previous response with id 'resp_missing' not found.",
+        "param": "previous_response_id",
+    }
+
+    error = proxy_service._websocket_event_error_payload("error", payload)
+
+    assert error == {
+        "type": "invalid_request_error",
+        "code": "previous_response_not_found",
+        "message": "Previous response with id 'resp_missing' not found.",
+        "param": "previous_response_id",
+    }
+    assert proxy_service._websocket_event_error_type("error", payload) == "invalid_request_error"
+    assert proxy_service._websocket_event_error_code("error", payload) == "previous_response_not_found"
+
+
+def test_http_error_status_from_payload_accepts_official_status_code_alias() -> None:
+    payload: dict[str, proxy_service.JsonValue] = {
+        "type": "error",
+        "status_code": 400,
+        "error": {"message": "bad request"},
+    }
+
+    assert proxy_service._http_error_status_from_payload(payload) == 400
+
+
 @pytest.mark.asyncio
 async def test_http_bridge_precreated_completed_terminal_falls_back_to_unresolved_request(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Align Codex-native WebSocket wrapped-error parsing with the official Codex client contract (`status`/`status_code`, nested or top-level error detail).
- Normalize top-level `type: "error"` frames so `error_type` is used as the upstream error type instead of the event discriminator.
- Preserve existing `stream_incomplete` masking for `previous_response_not_found` continuity misses.

## Official Codex reference
- Inspected `openai/codex` at `7d47056ea42636271ac020b86347fbbef49490aa`.
- Official client maps `type: "error"` frames with non-2xx `status`/`status_code` into HTTP-style transport errors and preserves the original frame body.
- Official per-turn WebSocket state treats `previous_response_id` as an in-turn/in-connection optimization, not a durable resume token.

## Test Plan
- `uv run pytest tests/unit/test_proxy_http_bridge.py::test_websocket_top_level_error_payload_uses_error_type_not_event_type tests/unit/test_proxy_http_bridge.py::test_http_error_status_from_payload_accepts_official_status_code_alias tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_top_level_previous_response_not_found_from_chatgpt_backend -q`
- `uv run pytest tests/integration/test_proxy_websocket_responses.py -k 'previous_response_not_found or top_level' -q`
- `openspec validate align-codex-websocket-error-parity --strict`
- `openspec validate --specs`
- `uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_http_bridge.py tests/integration/test_proxy_websocket_responses.py`
- `uv run ruff format --check app/modules/proxy/service.py tests/unit/test_proxy_http_bridge.py tests/integration/test_proxy_websocket_responses.py`
