### PR TITLE
chore: clean up beta-2 test and build warnings

### DIFF
--- a/frontend/src/features/apis/components/apis-page.tsx
+++ b/frontend/src/features/apis/components/apis-page.tsx
@@ -9,6 +9,7 @@ import type {
 	ApiKeyCreateRequest,
 	ApiKeyUpdateRequest,
 } from "@/features/api-keys/schemas";
+import { ApiKeyCreatedDialog } from "@/features/api-keys/components/api-key-created-dialog";
 import { ApiDetail } from "@/features/apis/components/api-detail";
 import { ApiList } from "@/features/apis/components/api-list";
 import { ApisSkeleton } from "@/features/apis/components/apis-skeleton";
@@ -28,11 +29,6 @@ const ApiKeyCreateDialog = lazy(() =>
 const ApiKeyEditDialog = lazy(() =>
 	import("@/features/api-keys/components/api-key-edit-dialog").then((m) => ({
 		default: m.ApiKeyEditDialog,
-	})),
-);
-const ApiKeyCreatedDialog = lazy(() =>
-	import("@/features/api-keys/components/api-key-created-dialog").then((m) => ({
-		default: m.ApiKeyCreatedDialog,
 	})),
 );
 
@@ -193,13 +189,13 @@ export function ApisPage() {
 					onOpenChange={editDialog.onOpenChange}
 					onSubmit={handleUpdate}
 				/>
-
-				<ApiKeyCreatedDialog
-					open={createdDialog.open}
-					apiKey={createdDialog.data}
-					onOpenChange={createdDialog.onOpenChange}
-				/>
 			</Suspense>
+
+			<ApiKeyCreatedDialog
+				open={createdDialog.open}
+				apiKey={createdDialog.data}
+				onOpenChange={createdDialog.onOpenChange}
+			/>
 
 			<ConfirmDialog
 				open={deleteDialog.open}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
   build: {
     outDir: "../app/static",
     emptyOutDir: true,
+    chunkSizeWarningLimit: 600,
     rollupOptions: {
       output: {
         manualChunks,

--- a/tests/unit/test_bridge_context_blowup.py
+++ b/tests/unit/test_bridge_context_blowup.py
@@ -311,7 +311,7 @@ class TestContextGrowthScenarios:
     - Apr 13 (broken):   17 turns, 70K tok/turn, max 853K, 2 compactions
     """
 
-    def test_healthy_growth_rate_stays_within_budget(self):
+    async def test_healthy_growth_rate_stays_within_budget(self):
         """With previous_response_id preserved, each turn adds only new content."""
         system_prompt_tokens = 50_000
         content_per_turn = 2_300  # avg from Apr 11 sessions
@@ -330,7 +330,7 @@ class TestContextGrowthScenarios:
 
         assert context < context_window
 
-    def test_broken_growth_rate_fills_window_fast(self):
+    async def test_broken_growth_rate_fills_window_fast(self):
         """Without previous_response_id, context fills in <20 turns."""
         system_prompt_tokens = 50_000
         growth_per_turn = 70_000  # avg from Apr 13 sessions (broken)
@@ -347,7 +347,7 @@ class TestContextGrowthScenarios:
         assert compaction_turn is not None
         assert compaction_turn < 20
 
-    def test_error_code_determines_growth_rate(self):
+    async def test_error_code_determines_growth_rate(self):
         """502 -> CLI retries with previous_response_id -> healthy growth
         400 previous_response_not_found -> CLI drops it -> broken growth"""
         error_502 = ProxyResponseError(

--- a/tests/unit/test_graceful_degradation.py
+++ b/tests/unit/test_graceful_degradation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Iterator, cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -125,7 +125,11 @@ async def test_health_ready_succeeds_when_degraded() -> None:
 
     set_degraded("all upstream accounts are unavailable")
     mock_session = AsyncMock()
-    mock_session.execute = AsyncMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = []
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute = AsyncMock(return_value=mock_result)
 
     with patch("app.core.draining._draining", False), patch("app.modules.health.api.get_session") as mock_get_session:
 


### PR DESCRIPTION
## Summary

Clean up all non-blocking warnings from the beta-2 e2e verification run.

### Changes

**Python test warnings (4 → 0):**
- `test_bridge_context_blowup.py`: Convert 3 sync `TestContextGrowthScenarios` methods to `async def` — these are pure arithmetic tests but the module-level `pytestmark = [pytest.mark.asyncio]` caused PytestWarning on non-async functions
- `test_graceful_degradation.py`: Properly chain `mock_session.execute` return value with `.scalars().all()` to prevent unawaited `AsyncMock` coroutine RuntimeWarning

**Vite build warnings (2 → 0):**
- `apis-page.tsx`: Convert `ApiKeyCreatedDialog` from `lazy()` to static import — it is already statically imported by `api-keys-section.tsx` so the dynamic import is ineffective (same chunk)
- `vite.config.ts`: Raise `chunkSizeWarningLimit` to 600 kB — main bundle is 526 kB with manual chunk splitting already applied for vendor packages

### Verification
- Full pytest suite: **2819 passed, 7 skipped, 0 warnings** (was 4 warnings)
- Frontend: **431 tests passed**, `bun run lint` clean, `bun run build` warning-free
- `ruff check` clean