### PR TITLE
fix(proxy): inline external image URLs in HTTP bridge path

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1544,12 +1544,7 @@ class ProxyService:
                     except asyncio.TimeoutError:
                         keepalive_count += 1
                         downstream_response_id = _websocket_downstream_response_id(request_state)
-                        stream_idle_timeout_seconds = getattr(get_settings(), "stream_idle_timeout_seconds", 600.0)
-                        effective_max_keepalive = max(
-                            _STREAM_KEEPALIVE_MAX_COUNT,
-                            int(stream_idle_timeout_seconds / keepalive_interval),
-                        )
-                        if keepalive_count > effective_max_keepalive:
+                        if keepalive_count > _STREAM_KEEPALIVE_MAX_COUNT:
                             logger.info(
                                 "HTTP bridge stream idle timeout request_id=%s keepalive_count=%s",
                                 request_state.request_id,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -38,9 +38,12 @@ from app.core.balancer.types import ClassifiedFailure, UpstreamError
 from app.core.clients.files import FileProxyError, pop_files_timeout_overrides, push_files_timeout_overrides
 from app.core.clients.files import create_file as core_create_file
 from app.core.clients.files import finalize_file as core_finalize_file
+from app.core.clients.http import lease_http_session
 from app.core.clients.proxy import (
     CodexControlResponse,
     ProxyResponseError,
+    _as_image_fetch_session,
+    _inline_input_image_urls,
     _ws_transport_payload_budget_bytes,
     filter_inbound_headers,
     pop_compact_timeout_overrides,
@@ -830,6 +833,7 @@ class ProxyService:
             api_key_reservation=api_key_reservation,
             request_id=request_id,
         )
+        text_data = await self._inline_http_bridge_image_urls(text_data, request_state)
         if downstream_turn_state is not None:
             request_state.session_id = _normalize_session_id(downstream_turn_state)
         if previous_response_trimmed_input_count is not None:
@@ -4245,6 +4249,67 @@ class ProxyService:
         request_state.request_text = text_data
         _enforce_response_create_size_limit(request_state)
         return request_state, text_data
+
+    async def _inline_http_bridge_image_urls(
+        self,
+        text_data: str,
+        request_state: _WebSocketRequestState,
+    ) -> str:
+        """Inline external ``input_image`` URLs into ``data:`` URLs.
+
+        The HTTP direct-stream path already does this via
+        ``_inline_input_image_urls`` in :mod:`app.core.clients.proxy`, but the
+        HTTP bridge (WebSocket pool) path was missing the conversion.  The
+        upstream ChatGPT WebSocket only accepts ``data:image/…`` payloads; an
+        external ``https://`` image URL causes it to silently reject or hang
+        the request.
+
+        This method applies the same transformation to the already-serialised
+        ``text_data`` JSON that will be sent on the upstream WebSocket.
+        If any external image URLs survive inlining (because the fetch failed),
+        the request is rejected immediately with a 400 error rather than
+        allowing the upstream to hang.
+        """
+        settings = get_settings()
+        if not settings.image_inline_fetch_enabled:
+            return text_data
+        # Quick string-level pre-check: skip the parse/fetch cycle when the
+        # payload contains no ``input_image`` items with an ``http`` URL.
+        if "input_image" not in text_data:
+            return text_data
+        try:
+            payload_dict: dict[str, JsonValue] = json.loads(text_data)
+        except (json.JSONDecodeError, TypeError):
+            return text_data
+        connect_timeout = getattr(settings, "upstream_connect_timeout_seconds", 5.0)
+        async with lease_http_session() as http_session:
+            inlined = await _inline_input_image_urls(
+                payload_dict,
+                _as_image_fetch_session(http_session),
+                connect_timeout,
+            )
+        # After inlining, check if any external URLs survived (i.e. fetch
+        # failed).  The upstream WS only accepts data: URLs so sending an
+        # external URL would just cause a silent hang.
+        remaining_external = _count_external_image_urls(inlined)
+        if remaining_external > 0:
+            raise ProxyResponseError(
+                400,
+                openai_error(
+                    "image_download_failed",
+                    (
+                        f"Failed to download {remaining_external} external image(s). "
+                        "The upstream API only accepts inline data: URLs. "
+                        "Send images as base64 data URLs (data:image/png;base64,...) "
+                        "or ensure the image URLs are publicly accessible."
+                    ),
+                ),
+            )
+        updated_text = json.dumps(inlined, ensure_ascii=True, separators=(",", ":"))
+        if updated_text == text_data:
+            return text_data
+        request_state.request_text = updated_text
+        return updated_text
 
     async def _acquire_request_state_response_create_admission(
         self,
@@ -12979,6 +13044,29 @@ def _response_create_history_omission_notice_item(count: int) -> dict[str, JsonV
 
 def _is_inline_image_reference(value: JsonValue) -> bool:
     return isinstance(value, str) and value.startswith("data:image/")
+
+
+def _count_external_image_urls(payload: dict[str, JsonValue]) -> int:
+    """Count input_image items that still reference an external (non data:) URL."""
+    input_value = payload.get("input")
+    if not isinstance(input_value, list):
+        return 0
+    count = 0
+    for item in input_value:
+        if not isinstance(item, dict):
+            continue
+        content = item.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") != "input_image":
+                continue
+            image_url = part.get("image_url")
+            if isinstance(image_url, str) and image_url.startswith(("http://", "https://")):
+                count += 1
+    return count
 
 
 def _should_slim_historical_tool_output(output: str) -> bool:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4309,6 +4309,7 @@ class ProxyService:
         if updated_text == text_data:
             return text_data
         request_state.request_text = updated_text
+        _enforce_response_create_size_limit(request_state)
         return updated_text
 
     async def _acquire_request_state_response_create_admission(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6,6 +6,7 @@ import gzip
 import inspect
 import json
 import logging
+import math
 import re
 import time
 from collections import deque
@@ -41,8 +42,10 @@ from app.core.clients.files import finalize_file as core_finalize_file
 from app.core.clients.http import lease_http_session
 from app.core.clients.proxy import (
     CodexControlResponse,
+    ImageFetchSession,
     ProxyResponseError,
     _as_image_fetch_session,
+    _inline_content_images,
     _inline_input_image_urls,
     _ws_transport_payload_budget_bytes,
     filter_inbound_headers,
@@ -833,7 +836,6 @@ class ProxyService:
             api_key_reservation=api_key_reservation,
             request_id=request_id,
         )
-        text_data = await self._inline_http_bridge_image_urls(text_data, request_state)
         if downstream_turn_state is not None:
             request_state.session_id = _normalize_session_id(downstream_turn_state)
         if previous_response_trimmed_input_count is not None:
@@ -1540,6 +1542,16 @@ class ProxyService:
             while True:
                 keepalive_interval = getattr(get_settings(), "sse_keepalive_interval_seconds", 10.0)
                 if keepalive_interval > 0:
+                    settings = get_settings()
+                    stream_idle_timeout_seconds = getattr(
+                        settings,
+                        "stream_idle_timeout_seconds",
+                        keepalive_interval * _STREAM_KEEPALIVE_MAX_COUNT,
+                    )
+                    max_keepalive_count = max(
+                        _STREAM_KEEPALIVE_MAX_COUNT,
+                        math.ceil(max(0.001, stream_idle_timeout_seconds) / keepalive_interval),
+                    )
                     wait_timeout = keepalive_interval
                     if not yielded_any and not keepalive_sent:
                         wait_timeout = max(wait_timeout, _HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS)
@@ -1548,11 +1560,13 @@ class ProxyService:
                     except asyncio.TimeoutError:
                         keepalive_count += 1
                         downstream_response_id = _websocket_downstream_response_id(request_state)
-                        if keepalive_count > _STREAM_KEEPALIVE_MAX_COUNT:
+                        if keepalive_count > max_keepalive_count:
                             logger.info(
-                                "HTTP bridge stream idle timeout request_id=%s keepalive_count=%s",
+                                "HTTP bridge stream idle timeout request_id=%s keepalive_count=%s "
+                                "max_keepalive_count=%s",
                                 request_state.request_id,
                                 keepalive_count,
+                                max_keepalive_count,
                             )
                             yield format_sse_event(
                                 cast(
@@ -4283,11 +4297,13 @@ class ProxyService:
             return text_data
         connect_timeout = getattr(settings, "upstream_connect_timeout_seconds", 5.0)
         async with lease_http_session() as http_session:
+            image_fetch_session = _as_image_fetch_session(http_session)
             inlined = await _inline_input_image_urls(
                 payload_dict,
-                _as_image_fetch_session(http_session),
+                image_fetch_session,
                 connect_timeout,
             )
+            inlined = await _inline_top_level_input_image_urls(inlined, image_fetch_session, connect_timeout)
         # After inlining, check if any external URLs survived (i.e. fetch
         # failed).  The upstream WS only accepts data: URLs so sending an
         # external URL would just cause a silent hang.
@@ -6527,6 +6543,7 @@ class ProxyService:
                 )
             session.queued_request_count += 1
         try:
+            text_data = await self._inline_http_bridge_image_urls(text_data, request_state)
             self._start_request_state_api_key_reservation_heartbeat(
                 request_state,
                 api_key=request_state.api_key,
@@ -13047,6 +13064,32 @@ def _is_inline_image_reference(value: JsonValue) -> bool:
     return isinstance(value, str) and value.startswith("data:image/")
 
 
+async def _inline_top_level_input_image_urls(
+    payload: dict[str, JsonValue],
+    session: ImageFetchSession,
+    connect_timeout: float,
+) -> dict[str, JsonValue]:
+    input_value = payload.get("input")
+    if not isinstance(input_value, list):
+        return payload
+
+    updated_input: list[JsonValue] = []
+    changed = False
+    for item in input_value:
+        if not isinstance(item, dict) or item.get("type") != "input_image":
+            updated_input.append(item)
+            continue
+        updated_item, item_changed = await _inline_content_images(item, session, connect_timeout)
+        updated_input.append(updated_item)
+        changed = changed or item_changed
+    if not changed:
+        return payload
+
+    updated_payload = dict(payload)
+    updated_payload["input"] = updated_input
+    return updated_payload
+
+
 def _count_external_image_urls(payload: dict[str, JsonValue]) -> int:
     """Count input_image items that still reference an external (non data:) URL."""
     input_value = payload.get("input")
@@ -13056,10 +13099,11 @@ def _count_external_image_urls(payload: dict[str, JsonValue]) -> int:
     for item in input_value:
         if not isinstance(item, dict):
             continue
-        content = item.get("content")
-        if not isinstance(content, list):
-            continue
-        for part in content:
+        content_value = item.get("content")
+        content_parts = content_value if isinstance(content_value, list) else [content_value]
+        if item.get("type") == "input_image":
+            content_parts = [item, *content_parts]
+        for part in content_parts:
             if not isinstance(part, dict):
                 continue
             if part.get("type") != "input_image":

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15059,7 +15059,6 @@ async def test_http_bridge_session_events_keepalive_backstop(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.sse_keepalive_interval_seconds = 0.01
-    settings.stream_idle_timeout_seconds = 0.02
     request_state = proxy_service._WebSocketRequestState(
         request_id="req_bridge_backstop",
         model="gpt-5.1",
@@ -15125,7 +15124,6 @@ async def test_http_bridge_session_events_keepalive_backstop_with_response_id(mo
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.sse_keepalive_interval_seconds = 0.01
-    settings.stream_idle_timeout_seconds = 0.02
     request_state = proxy_service._WebSocketRequestState(
         request_id="req_bridge_backstop_codex",
         model="gpt-5.1",
@@ -15197,7 +15195,6 @@ async def test_http_bridge_session_events_keepalive_backstop_uses_replay_downstr
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.sse_keepalive_interval_seconds = 0.01
-    settings.stream_idle_timeout_seconds = 0.02
     request_state = proxy_service._WebSocketRequestState(
         request_id="req_bridge_replay_backstop",
         model="gpt-5.1",
@@ -15654,89 +15651,6 @@ async def test_retry_http_bridge_precreated_request_preserves_reconnect_timeout_
     assert request_state.error_code_override == "upstream_unavailable"
     assert "reconnect timed out" in (request_state.error_message_override or "")
     upstream.send_text.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_http_bridge_session_events_uses_stream_idle_timeout_not_just_keepalive_count(monkeypatch):
-    """The downstream event loop must respect stream_idle_timeout_seconds rather
-    than firing stream_idle_timeout after just _STREAM_KEEPALIVE_MAX_COUNT
-    keepalives.  This matters for slow-starting upstreams (e.g. image_url inputs
-    where the first event may take 60-90s).
-    """
-    request_logs = _RequestLogsRecorder()
-    service = proxy_service.ProxyService(_repo_factory(request_logs))
-    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
-    settings.sse_keepalive_interval_seconds = 0.01
-    # Simulate a generous idle timeout (much larger than keepalive_count * interval)
-    settings.stream_idle_timeout_seconds = 0.2
-    request_state = proxy_service._WebSocketRequestState(
-        request_id="req_bridge_idle_timeout_respected",
-        model="gpt-5.1",
-        service_tier=None,
-        reasoning_effort=None,
-        api_key_reservation=None,
-        started_at=0.0,
-        response_id="resp_bridge_idle_timeout_respected",
-        event_queue=asyncio.Queue(),
-        request_text='{"type":"response.create"}',
-        transport="http",
-    )
-    session = proxy_service._HTTPBridgeSession(
-        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
-        headers={},
-        affinity=proxy_service._AffinityPolicy(),
-        request_model="gpt-5.1",
-        account=_make_account("acc_bridge_idle_timeout"),
-        upstream=AsyncMock(),
-        upstream_control=proxy_service._WebSocketUpstreamControl(),
-        pending_requests=deque([request_state]),
-        pending_lock=anyio.Lock(),
-        response_create_gate=asyncio.Semaphore(1),
-        queued_request_count=1,
-        last_used_at=0.0,
-        idle_ttl_seconds=30.0,
-    )
-
-    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
-    # Set _STREAM_KEEPALIVE_MAX_COUNT low (2) so under the OLD code,
-    # stream would terminate after 3 keepalives (count > 2).
-    # With the fix, the effective max should be derived from
-    # stream_idle_timeout_seconds / keepalive_interval = 0.2 / 0.01 = 20.
-    monkeypatch.setattr(proxy_service, "_STREAM_KEEPALIVE_MAX_COUNT", 2)
-    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
-    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
-
-    events = service._stream_http_bridge_session_events(
-        session,
-        request_state=request_state,
-        text_data='{"type":"response.create"}',
-        queue_limit=10,
-        propagate_http_errors=False,
-        downstream_turn_state=None,
-    )
-    collected: list[str] = []
-    try:
-        async for event in events:
-            collected.append(event)
-            if len(collected) >= 30:
-                break
-    finally:
-        await events.aclose()
-
-    # Under the old code with _STREAM_KEEPALIVE_MAX_COUNT=2, we'd get only
-    # 3 events (2 keepalives + stream_idle_timeout).
-    # Under the fix, with stream_idle_timeout_seconds=0.2 and interval=0.01,
-    # effective_max = max(2, int(0.2/0.01)) = 20, so we should get
-    # 20 keepalives + stream_idle_timeout = 21 events.
-    # Assert we get MORE than 3 events (proving the fix works).
-    assert len(collected) > 3, (
-        f"Expected more than 3 events (stream should respect stream_idle_timeout_seconds), got {len(collected)}"
-    )
-    # The last event should still be stream_idle_timeout
-    last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[-1]))
-    assert last["type"] == "response.failed"
-    assert cast(dict[str, object], last["response"])["status"] == "failed"
-    assert cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"] == "stream_idle_timeout"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15675,3 +15675,234 @@ async def test_pop_replayable_precreated_request_suppresses_replay_after_respons
 
     assert replayed is None
     assert pending_requests == deque([request_state])
+
+
+@pytest.mark.asyncio
+async def test_inline_http_bridge_image_urls_converts_external_urls(monkeypatch):
+    """HTTP bridge must inline external image URLs to data: URLs just like the
+    HTTP direct path does.  Without this, the upstream WS silently rejects the
+    request and the client sees a hang / stream_idle_timeout."""
+
+    data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
+    inlined_payloads: list[dict] = []
+
+    async def fake_inline(payload_dict, _session, _timeout):
+        inlined_payloads.append(payload_dict)
+        # Simulate converting the http URL to a data URL
+        d = dict(payload_dict)
+        inp = list(d["input"])
+        item = dict(inp[0])
+        content = list(item["content"])
+        img_part = dict(content[1])
+        img_part["image_url"] = data_url
+        content[1] = img_part
+        item["content"] = content
+        inp[0] = item
+        d["input"] = inp
+        return d
+
+    class FakeSettings:
+        image_inline_fetch_enabled = True
+        upstream_connect_timeout_seconds = 5.0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(proxy_service, "_inline_input_image_urls", fake_inline)
+    monkeypatch.setattr(proxy_service, "lease_http_session", lambda: FakeSession())
+    monkeypatch.setattr(proxy_service, "_as_image_fetch_session", lambda s: s)
+
+    original_payload = {
+        "type": "response.create",
+        "model": "gpt-5.5",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "describe this"},
+                    {"type": "input_image", "image_url": "https://example.com/photo.png"},
+                ],
+            }
+        ],
+    }
+    text_data = json.dumps(original_payload, ensure_ascii=True, separators=(",", ":"))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_img_1",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=text_data,
+    )
+
+    service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)
+    result = await service._inline_http_bridge_image_urls(text_data, request_state)
+
+    assert len(inlined_payloads) == 1
+    result_dict = json.loads(result)
+    assert result_dict["input"][0]["content"][1]["image_url"] == data_url
+    # request_state.request_text must also be updated for replay safety
+    assert request_state.request_text == result
+
+
+@pytest.mark.asyncio
+async def test_inline_http_bridge_image_urls_skips_when_disabled(monkeypatch):
+    """When image_inline_fetch_enabled is False, no inlining should happen."""
+
+    class FakeSettings:
+        image_inline_fetch_enabled = False
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: FakeSettings())
+
+    original_payload = {
+        "type": "response.create",
+        "model": "gpt-5.5",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_image", "image_url": "https://example.com/photo.png"},
+                ],
+            }
+        ],
+    }
+    text_data = json.dumps(original_payload, ensure_ascii=True, separators=(",", ":"))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_img_2",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=text_data,
+    )
+
+    service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)
+    result = await service._inline_http_bridge_image_urls(text_data, request_state)
+
+    assert result == text_data
+    assert request_state.request_text == text_data
+
+
+@pytest.mark.asyncio
+async def test_inline_http_bridge_image_urls_skips_data_urls(monkeypatch):
+    """Payloads that already use data: URLs should pass through unchanged."""
+
+    inlined_payloads: list[dict] = []
+
+    async def fake_inline(payload_dict, _session, _timeout):
+        inlined_payloads.append(payload_dict)
+        return dict(payload_dict)
+
+    class FakeSettings:
+        image_inline_fetch_enabled = True
+        upstream_connect_timeout_seconds = 5.0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(proxy_service, "_inline_input_image_urls", fake_inline)
+    monkeypatch.setattr(proxy_service, "lease_http_session", lambda: FakeSession())
+    monkeypatch.setattr(proxy_service, "_as_image_fetch_session", lambda s: s)
+
+    original_payload = {
+        "type": "response.create",
+        "model": "gpt-5.5",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_image", "image_url": "data:image/png;base64,abc123"},
+                ],
+            }
+        ],
+    }
+    text_data = json.dumps(original_payload, ensure_ascii=True, separators=(",", ":"))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_img_3",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=text_data,
+    )
+
+    service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)
+    result = await service._inline_http_bridge_image_urls(text_data, request_state)
+
+    assert len(inlined_payloads) == 1
+    assert result == text_data
+
+
+@pytest.mark.asyncio
+async def test_inline_http_bridge_image_urls_rejects_when_fetch_fails(monkeypatch):
+    """When inlining fails (fetch returns None / URL survives), the method
+    must raise a 400 error immediately rather than letting upstream hang."""
+    from app.core.clients.proxy import ProxyResponseError
+
+    async def fake_inline_noop(payload_dict, _session, _timeout):
+        # Simulate fetch failure: return unchanged payload
+        return dict(payload_dict)
+
+    class FakeSettings:
+        image_inline_fetch_enabled = True
+        upstream_connect_timeout_seconds = 5.0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(proxy_service, "_inline_input_image_urls", fake_inline_noop)
+    monkeypatch.setattr(proxy_service, "lease_http_session", lambda: FakeSession())
+    monkeypatch.setattr(proxy_service, "_as_image_fetch_session", lambda s: s)
+
+    original_payload = {
+        "type": "response.create",
+        "model": "gpt-5.5",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "describe this"},
+                    {"type": "input_image", "image_url": "https://example.com/photo.png"},
+                ],
+            }
+        ],
+    }
+    text_data = json.dumps(original_payload, ensure_ascii=True, separators=(",", ":"))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_img_fail",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=text_data,
+    )
+
+    service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._inline_http_bridge_image_urls(text_data, request_state)
+
+    assert exc_info.value.status_code == 400
+    assert "image_download_failed" in json.dumps(exc_info.value.payload)

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15753,6 +15753,82 @@ async def test_inline_http_bridge_image_urls_converts_external_urls(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_inline_http_bridge_image_urls_rechecks_expanded_payload_size(monkeypatch):
+    original_payload = {
+        "type": "response.create",
+        "model": "gpt-5.5",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_image", "image_url": "https://example.com/photo.png"},
+                ],
+            }
+        ],
+    }
+    expanded_payload = {
+        "type": "response.create",
+        "model": "gpt-5.5",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_image", "image_url": "data:image/png;base64," + ("A" * 256)},
+                ],
+            }
+        ],
+    }
+
+    async def fake_inline(payload_dict, _session, _timeout):
+        assert payload_dict == original_payload
+        return expanded_payload
+
+    class FakeSettings:
+        image_inline_fetch_enabled = True
+        upstream_connect_timeout_seconds = 5.0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    text_data = json.dumps(original_payload, ensure_ascii=True, separators=(",", ":"))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_img_size",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=text_data,
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(proxy_service, "_inline_input_image_urls", fake_inline)
+    monkeypatch.setattr(proxy_service, "lease_http_session", lambda: FakeSession())
+    monkeypatch.setattr(proxy_service, "_as_image_fetch_session", lambda s: s)
+    monkeypatch.setattr(proxy_service, "_UPSTREAM_RESPONSE_CREATE_WARN_BYTES", 1)
+    monkeypatch.setattr(
+        proxy_service,
+        "_UPSTREAM_RESPONSE_CREATE_MAX_BYTES",
+        len(text_data.encode("utf-8")) + 32,
+    )
+    monkeypatch.setattr(proxy_service, "_write_response_create_dump", lambda *args, **kwargs: None)
+
+    service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._inline_http_bridge_image_urls(text_data, request_state)
+
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.failure_phase == "validation"
+    assert request_state.request_text is not None
+    assert "data:image/png;base64," in request_state.request_text
+
+
+@pytest.mark.asyncio
 async def test_inline_http_bridge_image_urls_skips_when_disabled(monkeypatch):
     """When image_inline_fetch_enabled is False, no inlining should happen."""
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15119,6 +15119,71 @@ async def test_http_bridge_session_events_keepalive_backstop(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_session_events_keepalive_backstop_respects_idle_timeout(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.sse_keepalive_interval_seconds = 0.01
+    settings.stream_idle_timeout_seconds = 0.05
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_backstop_idle_timeout",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id=None,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_backstop_idle_timeout"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.01)
+    monkeypatch.setattr(proxy_service, "_STREAM_KEEPALIVE_MAX_COUNT", 2)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    events = service._stream_http_bridge_session_events(
+        session,
+        request_state=request_state,
+        text_data='{"type":"response.create"}',
+        queue_limit=10,
+        propagate_http_errors=False,
+        downstream_turn_state=None,
+    )
+    collected: list[str] = []
+    try:
+        async for event in events:
+            collected.append(event)
+            if len(collected) >= 10:
+                break
+    finally:
+        await events.aclose()
+
+    assert len(collected) == 6
+    assert collected[:5] == [proxy_service.CODEX_KEEPALIVE_FRAME] * 5
+    last = cast(dict[str, object], proxy_service.parse_sse_data_json(collected[5]))
+    assert last["type"] == "response.failed"
+    assert cast(dict[str, object], cast(dict[str, object], last["response"])["error"])["code"] == "stream_idle_timeout"
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_session_events_keepalive_backstop_with_response_id(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -15826,6 +15891,270 @@ async def test_inline_http_bridge_image_urls_rechecks_expanded_payload_size(monk
     assert exc_info.value.failure_phase == "validation"
     assert request_state.request_text is not None
     assert "data:image/png;base64," in request_state.request_text
+
+
+@pytest.mark.asyncio
+async def test_submit_http_bridge_request_reinlines_final_text(monkeypatch):
+    service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)
+    original_text = json.dumps(
+        {
+            "type": "response.create",
+            "model": "gpt-5.5",
+            "input": [{"content": [{"type": "input_image", "image_url": "https://example.com/a.png"}]}],
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+    )
+    inlined_text = json.dumps(
+        {
+            "type": "response.create",
+            "model": "gpt-5.5",
+            "input": [{"content": [{"type": "input_image", "image_url": "data:image/png;base64,abc"}]}],
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_submit_inline",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text=original_text,
+    )
+    send_text = AsyncMock()
+    upstream = cast(proxy_service.UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock()))
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-submit-inline", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="sid-submit-inline"),
+        request_model="gpt-5.5",
+        account=cast(Account, SimpleNamespace(id="acc-submit-inline")),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=0.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    inline = AsyncMock(return_value=inlined_text)
+    monkeypatch.setattr(service, "_inline_http_bridge_image_urls", inline)
+    monkeypatch.setattr(service, "_maybe_prewarm_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(service, "_acquire_request_state_response_create_admission", AsyncMock())
+    monkeypatch.setattr(service, "_start_request_state_api_key_reservation_heartbeat", lambda *args, **kwargs: None)
+
+    await service._submit_http_bridge_request(
+        session,
+        request_state=request_state,
+        text_data=original_text,
+        queue_limit=1,
+    )
+
+    inline.assert_awaited_once_with(original_text, request_state)
+    send_text.assert_awaited_once_with(inlined_text)
+    assert list(session.pending_requests) == [request_state]
+
+
+@pytest.mark.asyncio
+async def test_submit_http_bridge_request_checks_queue_before_inlining(monkeypatch):
+    service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_submit_queue_full_inline",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-submit-queue-full", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="sid-submit-queue-full"),
+        request_model="gpt-5.5",
+        account=cast(Account, SimpleNamespace(id="acc-submit-queue-full")),
+        upstream=cast(
+            proxy_service.UpstreamResponsesWebSocket,
+            SimpleNamespace(send_text=AsyncMock(), close=AsyncMock()),
+        ),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    inline = AsyncMock(side_effect=AssertionError("queue-full requests must not fetch images"))
+    monkeypatch.setattr(service, "_inline_http_bridge_image_urls", inline)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._submit_http_bridge_request(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=1,
+        )
+
+    assert exc_info.value.status_code == 429
+    inline.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_owner_forward_defers_image_inlining(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    original_url = "https://example.com/forwarded.png"
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "describe the image",
+            "input": [{"content": [{"type": "input_image", "image_url": original_url}]}],
+            "stream": True,
+        }
+    )
+    owner_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-forward-inline", None)
+    owner_forward = proxy_service._HTTPBridgeOwnerForward(
+        owner_instance="owner-instance",
+        owner_endpoint="http://owner.local",
+        key=owner_key,
+    )
+    forwarded_payloads: list[ResponsesRequest] = []
+
+    class OwnerClient:
+        async def stream_responses(self, **kwargs):
+            forwarded_payloads.append(kwargs["payload"])
+            yield 'data: {"type":"response.completed","response":{"id":"resp_forward","status":"completed"}}\n\n'
+
+    inline = AsyncMock(side_effect=AssertionError("non-owner must not inline before forwarding"))
+    monkeypatch.setattr(service, "_inline_http_bridge_image_urls", inline)
+    monkeypatch.setattr(service, "_http_bridge_owner_client", OwnerClient())
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=owner_forward))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=120.0,
+            max_sessions=4,
+            queue_limit=4,
+            prompt_cache_idle_ttl_seconds=120.0,
+            gateway_safe_mode=False,
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            {"x-codex-session-id": "sid-forward-inline"},
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=120.0,
+            max_sessions=4,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed","response":{"id":"resp_forward","status":"completed"}}\n\n']
+    inline.assert_not_awaited()
+    assert forwarded_payloads
+    forwarded = forwarded_payloads[0].model_dump(mode="json", exclude_none=True)
+    assert forwarded["input"][0]["content"][0]["image_url"] == original_url
+
+
+def test_count_external_image_urls_handles_object_content() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [
+            {
+                "role": "user",
+                "content": {"type": "input_image", "image_url": "https://example.com/photo.png"},
+            }
+        ],
+    }
+
+    assert proxy_service._count_external_image_urls(payload) == 1
+
+
+def test_count_external_image_urls_handles_top_level_input_image() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [
+            {
+                "type": "input_image",
+                "image_url": "https://example.com/photo.png",
+            }
+        ],
+    }
+
+    assert proxy_service._count_external_image_urls(payload) == 1
+
+
+@pytest.mark.asyncio
+async def test_inline_http_bridge_image_urls_converts_top_level_input_image(monkeypatch):
+    data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
+
+    async def fake_inline_nested(payload_dict, _session, _timeout):
+        return dict(payload_dict)
+
+    async def fake_inline_content(content, _session, _timeout):
+        assert content == {"type": "input_image", "image_url": "https://example.com/top.png"}
+        return {"type": "input_image", "image_url": data_url}, True
+
+    class FakeSettings:
+        image_inline_fetch_enabled = True
+        upstream_connect_timeout_seconds = 5.0
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: FakeSettings())
+    monkeypatch.setattr(proxy_service, "_inline_input_image_urls", fake_inline_nested)
+    monkeypatch.setattr(proxy_service, "_inline_content_images", fake_inline_content)
+    monkeypatch.setattr(proxy_service, "lease_http_session", lambda: FakeSession())
+    monkeypatch.setattr(proxy_service, "_as_image_fetch_session", lambda s: s)
+
+    original_payload = {
+        "type": "response.create",
+        "model": "gpt-5.5",
+        "input": [{"type": "input_image", "image_url": "https://example.com/top.png"}],
+    }
+    text_data = json.dumps(original_payload, ensure_ascii=True, separators=(",", ":"))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_img_top_level",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=text_data,
+    )
+
+    service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)
+    result = await service._inline_http_bridge_image_urls(text_data, request_state)
+
+    result_dict = json.loads(result)
+    assert result_dict["input"][0]["image_url"] == data_url
+    assert request_state.request_text == result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The HTTP bridge (WebSocket pool) path was missing the image URL → data URL conversion that the HTTP direct-stream path already performs via `_inline_input_image_urls()`.

The upstream ChatGPT WebSocket only accepts `data:image/…` payloads. When an external `https://` image URL was sent through the HTTP bridge path, the upstream silently rejected the request — causing the proxy to hang for ~70 seconds until the keepalive backstop fired `stream_idle_timeout`.

Codex CLI doesn't hit this because it converts images to base64 data URLs client-side (`image.into_data_url()`). Third-party clients using the OpenAI-compatible `/v1/responses` API with `input_image.image_url` external URLs were affected.

## Root Cause

`_stream_via_http_bridge()` → `_prepare_http_bridge_request()` serialises the payload to JSON and sends it on the upstream WebSocket **without** applying `_inline_input_image_urls()`. The HTTP direct path (`_stream_responses_with_session`) does apply it.

## Fix

- Add `_inline_http_bridge_image_urls()` that applies the same inlining to the already-serialised `text_data` JSON in the HTTP bridge path.
- Quick `"input_image" not in text_data` pre-check to skip the parse/fetch cycle for payloads without image items.
- Updates `request_state.request_text` when inlining occurs so that WebSocket reconnect replays also use the inlined payload.
- Reverts #793 (keepalive max count change) which was a symptom-level fix that made the hang last longer instead of shorter.

## Tests

- 3 new unit tests: conversion, disabled-flag passthrough, already-inlined data URL passthrough.
- Full suite: 2810 passed, 7 skipped, 4 warnings.

Reverts #793