### PR TITLE
feat(api): add app version response header

### DIFF
--- a/app/core/middleware/__init__.py
+++ b/app/core/middleware/__init__.py
@@ -1,3 +1,4 @@
+from app.core.middleware.app_version import add_app_version_middleware
 from app.core.middleware.api_firewall import add_api_firewall_middleware
 from app.core.middleware.dashboard_auth_proxy import add_dashboard_auth_proxy_middleware
 from app.core.middleware.path_rewrite import add_backend_api_codex_v1_alias_middleware
@@ -5,6 +6,7 @@ from app.core.middleware.request_decompression import add_request_decompression_
 from app.core.middleware.request_id import add_request_id_middleware
 
 __all__ = [
+    "add_app_version_middleware",
     "add_api_firewall_middleware",
     "add_backend_api_codex_v1_alias_middleware",
     "add_dashboard_auth_proxy_middleware",

--- a/app/core/middleware/__init__.py
+++ b/app/core/middleware/__init__.py
@@ -1,5 +1,5 @@
-from app.core.middleware.app_version import add_app_version_middleware
 from app.core.middleware.api_firewall import add_api_firewall_middleware
+from app.core.middleware.app_version import add_app_version_middleware
 from app.core.middleware.dashboard_auth_proxy import add_dashboard_auth_proxy_middleware
 from app.core.middleware.path_rewrite import add_backend_api_codex_v1_alias_middleware
 from app.core.middleware.request_decompression import add_request_decompression_middleware

--- a/app/core/middleware/app_version.py
+++ b/app/core/middleware/app_version.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from fastapi import FastAPI, Request
+from fastapi.responses import Response
+
+from app import __version__
+
+
+def add_app_version_middleware(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def app_version_middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        response = await call_next(request)
+        if 200 <= response.status_code < 500:
+            response.headers.setdefault("X-App-Version", __version__)
+        return response

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.core.handlers import add_exception_handlers
 from app.core.metrics.middleware import MetricsMiddleware
 from app.core.metrics.prometheus import MULTIPROCESS_MODE, PROMETHEUS_AVAILABLE, make_scrape_registry, mark_process_dead
 from app.core.middleware import (
+    add_app_version_middleware,
     add_api_firewall_middleware,
     add_backend_api_codex_v1_alias_middleware,
     add_dashboard_auth_proxy_middleware,
@@ -348,6 +349,7 @@ def create_app() -> FastAPI:
         ),
     )
     add_backend_api_codex_v1_alias_middleware(app)
+    add_app_version_middleware(app)
     add_exception_handlers(app)
 
     app.include_router(proxy_api.router)

--- a/app/main.py
+++ b/app/main.py
@@ -25,8 +25,8 @@ from app.core.handlers import add_exception_handlers
 from app.core.metrics.middleware import MetricsMiddleware
 from app.core.metrics.prometheus import MULTIPROCESS_MODE, PROMETHEUS_AVAILABLE, make_scrape_registry, mark_process_dead
 from app.core.middleware import (
-    add_app_version_middleware,
     add_api_firewall_middleware,
+    add_app_version_middleware,
     add_backend_api_codex_v1_alias_middleware,
     add_dashboard_auth_proxy_middleware,
     add_request_decompression_middleware,

--- a/openspec/changes/add-app-version-response-header/.openspec.yaml
+++ b/openspec/changes/add-app-version-response-header/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/add-app-version-response-header/design.md
+++ b/openspec/changes/add-app-version-response-header/design.md
@@ -1,0 +1,64 @@
+## Context
+
+codex-lb already adds some cross-cutting response headers through HTTP middleware, such as `x-request-id`. The requested version header has the same scope: it should apply broadly to HTTP responses regardless of whether the route returns JSON, a static file, or a handled framework/domain error.
+
+The repo currently has two possible version sources: FastAPI app metadata in `app/main.py` and the package release version in `app/__init__.py`. The FastAPI metadata is stale (`0.1.0`), while the package version is the maintained release value.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `X-App-Version` to HTTP responses with status codes in the `200-499` range.
+- Use the package release version as the header value.
+- Cover success and handled client-error responses without touching individual route handlers.
+- Preserve route-specific headers and avoid overwriting an explicit `X-App-Version` if one is ever set downstream.
+
+**Non-Goals:**
+
+- Changing response bodies or OpenAI/dashboard error envelope shapes.
+- Adding the version header to `5xx` responses.
+- Adding the version header to websocket handshakes, websocket frames, or other non-HTTP response paths.
+- Normalizing or correcting the existing FastAPI app metadata version as part of this change.
+
+## Decisions
+
+### Add the header in global HTTP middleware
+
+The change will add a dedicated HTTP middleware that runs after `call_next(request)` returns a response object. If the response status code is between `200` and `499`, inclusive of `200` and exclusive of `500`, the middleware will attach `X-App-Version`.
+
+Rationale:
+
+- A middleware is the narrowest way to cover JSON responses, `FileResponse`, and handled framework/domain errors with one change.
+- It avoids duplicating header logic across route handlers and exception handlers.
+- It naturally excludes websocket traffic because the middleware is HTTP-only.
+
+Alternative considered:
+
+- Attach the header inside each exception handler and selected routes. Rejected because it is easy to miss non-JSON responses and future routes.
+
+### Source the header from `app.__version__`
+
+The middleware will import `__version__` from `app` and use that value directly for `X-App-Version`.
+
+Rationale:
+
+- `app.__version__` is the maintained release value and matches the existing release/version tests.
+- The FastAPI metadata version in `app/main.py` is stale and would expose incorrect runtime information.
+
+Alternative considered:
+
+- Reuse `app.version` from the FastAPI instance. Rejected because it currently reports the wrong version.
+
+### Preserve explicit downstream overrides
+
+The middleware will use `response.headers.setdefault("X-App-Version", __version__)` rather than overwriting the header unconditionally.
+
+Rationale:
+
+- This keeps the behavior safe if a future route or proxy path needs to set a more specific version header explicitly.
+
+## Risks / Trade-offs
+
+- [Unhandled exceptions bypass the intended status range] -> Cover a representative `5xx` path to prove the header is absent on server-error responses.
+- [Route-specific header behavior regresses on static files or fallback 404s] -> Include at least one integration assertion against a non-JSON or framework-generated response path.
+- [Future developers accidentally source the wrong version field] -> Keep the spec explicit that the runtime header value comes from the package release version.

--- a/openspec/changes/add-app-version-response-header/proposal.md
+++ b/openspec/changes/add-app-version-response-header/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Operators and client integrations need a stable way to identify which codex-lb build produced a successful or client-error HTTP response. Today the service exposes request identifiers and some route-specific headers, but it does not expose the running application version on normal HTTP responses.
+
+Adding a version header improves debugging and rollout verification without changing any response body contracts. The header should be present on successful and client-error HTTP responses, but it should not be attached to 5xx responses where the server did not complete the request successfully.
+
+## What Changes
+
+- Add a global HTTP response metadata contract that returns `X-App-Version` on HTTP responses with status codes in the `200-499` range.
+- Define the header value as the running codex-lb package version rather than the stale FastAPI metadata version.
+- Exclude the header from `5xx` responses and websocket traffic.
+- Add regression coverage for success, client-error, and server-error response paths.
+
+## Capabilities
+
+### New Capabilities
+
+- `api-response-metadata`: global HTTP response headers that codex-lb adds across route families.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- **Code**: `app/main.py`, `app/core/middleware/*`
+- **Tests**: focused middleware unit coverage plus integration coverage on representative `2xx`, `4xx`, and `5xx` routes
+- **Behavior**: HTTP `200-499` responses now include `X-App-Version` with the running codex-lb package version

--- a/openspec/changes/add-app-version-response-header/specs/api-response-metadata/spec.md
+++ b/openspec/changes/add-app-version-response-header/specs/api-response-metadata/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: HTTP 2xx-4xx responses include the running app version header
+The system MUST attach `X-App-Version` to HTTP responses whose final status code is in the `200-499` range. The header value MUST equal the running codex-lb package version. This requirement applies across dashboard, health, proxy, and static-file HTTP routes, including handled framework or domain `4xx` responses. If a response already sets `X-App-Version`, the system MUST preserve the explicit value rather than overwrite it.
+
+#### Scenario: Successful health response includes app version header
+- **WHEN** a client sends `GET /health`
+- **THEN** the response status is `200`
+- **AND** the response includes `X-App-Version`
+- **AND** the header value equals the running codex-lb package version
+
+#### Scenario: Handled client error includes app version header
+- **WHEN** a client sends a request that the service rejects with a handled `4xx` HTTP response
+- **THEN** the response includes `X-App-Version`
+- **AND** the header value equals the running codex-lb package version
+
+#### Scenario: Existing explicit app version header is preserved
+- **GIVEN** an HTTP response already sets `X-App-Version`
+- **WHEN** the global response metadata policy runs
+- **THEN** the existing `X-App-Version` value is preserved unchanged
+
+### Requirement: HTTP 5xx and websocket responses omit the app version header
+The system MUST NOT add `X-App-Version` to HTTP responses whose final status code is `500` or greater. The system MUST NOT add this header to websocket accept paths or websocket message traffic.
+
+#### Scenario: Server error response omits app version header
+- **WHEN** a request ends in an HTTP `503` response
+- **THEN** the response does not include `X-App-Version`
+
+#### Scenario: Websocket route does not gain app version response metadata
+- **WHEN** a client connects to a websocket route
+- **THEN** the global HTTP app-version response-header policy does not apply to websocket traffic

--- a/openspec/changes/add-app-version-response-header/tasks.md
+++ b/openspec/changes/add-app-version-response-header/tasks.md
@@ -1,0 +1,17 @@
+## 1. HTTP middleware
+
+- [x] 1.1 Add a dedicated HTTP middleware that attaches `X-App-Version` to responses whose `status_code` is in the `200-499` range
+- [x] 1.2 Source the header value from `app.__version__` and preserve any explicit downstream override with `setdefault`
+- [x] 1.3 Register the middleware in the shared FastAPI app wiring so it covers dashboard, health, proxy, and static HTTP responses
+
+## 2. Regression coverage
+
+- [x] 2.1 Add focused unit coverage for the middleware on a `2xx` response and a `5xx` response
+- [x] 2.2 Add integration coverage proving a representative `2xx` route returns `X-App-Version`
+- [x] 2.3 Add integration coverage proving representative handled `4xx` responses return `X-App-Version`
+- [x] 2.4 Add integration coverage proving a representative `5xx` response does not return `X-App-Version`
+
+## 3. Spec delta and verification
+
+- [x] 3.1 Add the `api-response-metadata` capability requirements for the `X-App-Version` header contract
+- [x] 3.2 Validate the OpenSpec change with `openspec validate add-app-version-response-header --strict`

--- a/tests/integration/test_health_and_errors.py
+++ b/tests/integration/test_health_and_errors.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from app import __version__
+
 pytestmark = pytest.mark.integration
 
 _STATIC_DIR = Path(__file__).resolve().parent.parent.parent / "app" / "static"
@@ -14,6 +16,7 @@ async def test_health_endpoint_ok(async_client):
     response = await async_client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+    assert response.headers["X-App-Version"] == __version__
 
 
 @pytest.mark.asyncio
@@ -23,6 +26,7 @@ async def test_api_validation_error_returns_dashboard_payload(async_client):
     payload = response.json()
     assert payload["error"]["code"] == "validation_error"
     assert payload["error"]["message"] == "Invalid request payload"
+    assert response.headers["X-App-Version"] == __version__
 
 
 @pytest.mark.asyncio
@@ -32,6 +36,7 @@ async def test_api_not_found_returns_dashboard_payload(async_client):
     payload = response.json()
     assert payload["error"]["code"] == "http_404"
     assert payload["error"]["message"] == "Not Found"
+    assert response.headers["X-App-Version"] == __version__
 
 
 @pytest.mark.asyncio
@@ -45,6 +50,7 @@ async def test_spa_route_path_returns_index_html(async_client, tmp_path):
         response = await async_client.get("/dashboard/settings")
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("text/html")
+        assert response.headers["X-App-Version"] == __version__
     finally:
         if created:
             index.unlink(missing_ok=True)
@@ -55,3 +61,4 @@ async def test_missing_static_asset_returns_not_found(async_client):
     response = await async_client.get("/assets/missing.js")
     assert response.status_code == 404
     assert response.json()["detail"] == "Not Found"
+    assert response.headers["X-App-Version"] == __version__

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -666,6 +666,7 @@ async def test_codex_control_retry_failure_after_forced_refresh_updates_account_
     )
 
     assert response.status_code == 503
+    assert "X-App-Version" not in response.headers
     assert calls == 2
     assert len(handled) == 1
     assert handled[0][0].startswith("acc_codex_retry_error")

--- a/tests/unit/test_app_version_middleware.py
+++ b/tests/unit/test_app_version_middleware.py
@@ -129,7 +129,9 @@ async def test_app_version_middleware_adds_header_to_short_circuited_4xx_respons
         return {"ok": True}
 
     work_route = app.router.routes.pop()
-    fallback_index = next(index for index, route in enumerate(app.router.routes) if getattr(route, "path", None) == "/{path:path}")
+    fallback_index = next(
+        index for index, route in enumerate(app.router.routes) if getattr(route, "path", None) == "/{path:path}"
+    )
     app.router.routes.insert(fallback_index, work_route)
 
     transport = ASGITransport(app=app)

--- a/tests/unit/test_app_version_middleware.py
+++ b/tests/unit/test_app_version_middleware.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import cast
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
+from httpx import ASGITransport, AsyncClient
+from starlette.types import Message
+
+import app.main as main
+from app import __version__
+from app.core.config.settings import Settings
+from app.core.middleware.app_version import add_app_version_middleware
+
+pytestmark = pytest.mark.unit
+
+_Dispatch = Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]
+
+
+@pytest.mark.asyncio
+async def test_app_version_middleware_adds_header_to_2xx_response():
+    app = FastAPI()
+    add_app_version_middleware(app)
+    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
+
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/health",
+            "raw_path": b"/health",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+        },
+        receive=_empty_receive,
+    )
+
+    async def call_next(_: Request) -> JSONResponse:
+        return JSONResponse({"ok": True}, status_code=204)
+
+    response = await dispatch(request, call_next)
+
+    assert response.headers["X-App-Version"] == __version__
+
+
+@pytest.mark.asyncio
+async def test_app_version_middleware_skips_header_on_5xx_response():
+    app = FastAPI()
+    add_app_version_middleware(app)
+    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
+
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/health",
+            "raw_path": b"/health",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+        },
+        receive=_empty_receive,
+    )
+
+    async def call_next(_: Request) -> JSONResponse:
+        return JSONResponse({"error": "boom"}, status_code=503)
+
+    response = await dispatch(request, call_next)
+
+    assert "X-App-Version" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_app_version_middleware_preserves_existing_header_value():
+    app = FastAPI()
+    add_app_version_middleware(app)
+    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
+
+    request = Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/health",
+            "raw_path": b"/health",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [],
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+        },
+        receive=_empty_receive,
+    )
+
+    async def call_next(_: Request) -> Response:
+        return Response(status_code=200, headers={"X-App-Version": "route-owned-version"})
+
+    response = await dispatch(request, call_next)
+
+    assert response.headers["X-App-Version"] == "route-owned-version"
+
+
+@pytest.mark.asyncio
+async def test_app_version_middleware_adds_header_to_short_circuited_4xx_response_from_create_app(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(main, "get_settings", lambda: Settings(backpressure_max_concurrent_requests=1))
+    app = main.create_app()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    @app.get("/work")
+    async def work():
+        entered.set()
+        await release.wait()
+        return {"ok": True}
+
+    work_route = app.router.routes.pop()
+    fallback_index = next(index for index, route in enumerate(app.router.routes) if getattr(route, "path", None) == "/{path:path}")
+    app.router.routes.insert(fallback_index, work_route)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        first_request = asyncio.create_task(client.get("/work"))
+        await entered.wait()
+
+        overloaded = await client.get("/work")
+        release.set()
+        await first_request
+
+    assert overloaded.status_code == 429
+    assert overloaded.headers["X-App-Version"] == __version__
+
+
+async def _empty_receive() -> Message:
+    return {"type": "http.request", "body": b"", "more_body": False}


### PR DESCRIPTION
  ## Summary

  Add a global `X-App-Version` response header for HTTP responses with status codes in the `200-499` range, sourced from `app.__version__`. This gives
  operators and clients a stable way to identify the running codex-lb build without changing any response-body contracts.

  ## Type of change

  - [ ] `fix:` — bug fix (no behavior change beyond the bug)
  - [x] `feat:` — new user-facing feature or capability
  - [ ] `refactor:` — internal refactor (no behavior change, no API change)
  - [ ] `docs:` — documentation only
  - [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
  - [ ] `test:` — test-only change
  - [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

  Linked issue: None provided

  ## OpenSpec

  - [x] This PR includes / updates an OpenSpec change
  - [ ] Not applicable — bug fix that matches the existing spec
  - [ ] Not applicable — docs / CI / chore only
  - [ ] This PR touches a codex-faithful path (image pipeline, request/response
        shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

  Change directory: `openspec/changes/add-app-version-response-header/`

  ## Changes

  - Add `app/core/middleware/app_version.py` to attach `X-App-Version` to HTTP `200-499` responses, using `app.__version__` and preserving any explicit
  downstream header value with `setdefault`.
  - Register the middleware in `app/main.py` so the header applies across normal app routes, handled framework/domain `4xx` responses, and static/dashboard
  responses, while leaving `5xx` responses unchanged.
  - Add focused regression coverage in `tests/unit/test_app_version_middleware.py`, `tests/integration/test_health_and_errors.py`, and `tests/integration/
  test_proxy_api_extended.py`.
  - Add the OpenSpec change artifacts and new `api-response-metadata` capability requirements for the response-header contract.

  ## Test plan

  ```bash
  uv run pytest tests/unit/test_app_version_middleware.py -q
  # 4 passed in 0.06s

  uv run pytest tests/integration/test_health_and_errors.py tests/integration/test_proxy_api_extended.py -q
  # 37 passed in 3.73s

  openspec validate add-app-version-response-header --strict
  # Change 'add-app-version-response-header' is valid

  openspec validate --specs
  # Totals: 21 passed, 0 failed (21 items)
```
 ## Screenshots / output (optional)

<img width="566" height="181" alt="螢幕截圖 2026-05-25 18 16 57" src="https://github.com/user-attachments/assets/95fc6452-54fb-493d-9225-1df1de8ad7a3" />

