### PR TITLE
perf(db): add raw window usage latest index

### DIFF
--- a/app/db/alembic/versions/20260525_000000_add_usage_raw_window_latest_index.py
+++ b/app/db/alembic/versions/20260525_000000_add_usage_raw_window_latest_index.py
@@ -1,0 +1,31 @@
+"""add raw window latest usage index
+
+Revision ID: 20260525_000000_add_usage_raw_window_latest_index
+Revises: 20260513_000000_add_accounts_alias
+Create Date: 2026-05-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260525_000000_add_usage_raw_window_latest_index"
+down_revision = "20260513_000000_add_accounts_alias"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            CREATE INDEX IF NOT EXISTS idx_usage_window_raw_account_latest
+            ON usage_history ("window", account_id, recorded_at DESC, id DESC)
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP INDEX IF EXISTS idx_usage_window_raw_account_latest"))

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -67,7 +67,13 @@ _BRANCHED_ENFORCEMENT_DESCENDANT_REVISIONS = frozenset(
     }
 )
 _MANUAL_DRIFT_INDEX_REQUIREMENTS: dict[str, frozenset[str]] = {
-    "usage_history": frozenset({"idx_usage_window_account_latest", "idx_usage_window_account_time"}),
+    "usage_history": frozenset(
+        {
+            "idx_usage_window_account_latest",
+            "idx_usage_window_account_time",
+            "idx_usage_window_raw_account_latest",
+        }
+    ),
     "request_logs": frozenset(
         {
             "idx_logs_requested_at_id",

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -711,6 +711,13 @@ Index(
     UsageHistory.recorded_at.desc(),
     UsageHistory.id.desc(),
 )
+Index(
+    "idx_usage_window_raw_account_latest",
+    UsageHistory.window,
+    UsageHistory.account_id,
+    UsageHistory.recorded_at.desc(),
+    UsageHistory.id.desc(),
+)
 Index("idx_accounts_email", Account.email)
 Index("idx_api_keys_name", ApiKey.name)
 Index("idx_logs_account_time", RequestLog.account_id, RequestLog.requested_at)

--- a/openspec/changes/add-dashboard-usage-raw-window-index/proposal.md
+++ b/openspec/changes/add-dashboard-usage-raw-window-index/proposal.md
@@ -1,0 +1,19 @@
+## Why
+`GET /api/dashboard/overview?timeframe=7d` performs latest-usage lookups for both primary and secondary usage windows. On SQLite, the secondary-window lookup filters on the raw `usage_history.window` column, but the existing latest-usage index is built on `coalesce("window", 'primary')`. With larger `usage_history` tables this causes SQLite to choose a slower scan path for secondary latest usage.
+
+## What Changes
+- Add a forward-only Alembic migration that creates `idx_usage_window_raw_account_latest` on `usage_history ("window", account_id, recorded_at DESC, id DESC)`.
+- Add the index to SQLAlchemy metadata and migration drift checks so it remains part of the managed schema.
+- Keep the migration idempotent with `CREATE INDEX IF NOT EXISTS`, matching the live database hotfix path where the index may already exist before the migration is applied.
+- Add regression coverage for drift detection, idempotent migration application, and the SQLite query plan for secondary latest usage.
+
+## Impact
+- Improves the dashboard overview secondary latest-usage query on SQLite without changing dashboard response semantics.
+- A live SQLite hotfix with this index reduced the secondary latest-usage query from about 2300 ms to about 720 ms,
+  roughly a 3.2x improvement for that database read path.
+- The same live probe reduced total SQL time inside `DashboardService.get_overview("7d")` from about 4.6 seconds
+  to about 3.0 seconds, roughly a 1.5x improvement for the measured SQL portion.
+- The full dashboard overview remained around 12 seconds in the direct service probe because most remaining time is
+  spent loading and processing large secondary usage-history windows for depletion and weekly pace calculations.
+- Increases SQLite write/index maintenance by one additional index on `usage_history`.
+- Does not address the remaining overview cost from loading and processing large usage-history windows for depletion and weekly pace.

--- a/openspec/changes/add-dashboard-usage-raw-window-index/specs/database-backends/spec.md
+++ b/openspec/changes/add-dashboard-usage-raw-window-index/specs/database-backends/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+### Requirement: SQLite usage history supports raw-window latest lookups
+SQLite deployments MUST maintain an index that supports latest `usage_history` lookup by raw usage window, account id, and newest recorded sample ordering.
+
+#### Scenario: Secondary usage lookup uses the raw-window latest index
+- **GIVEN** the database backend is SQLite
+- **AND** `usage_history` contains rows for the `secondary` window
+- **WHEN** the dashboard overview asks for latest usage by account for the `secondary` window
+- **THEN** SQLite MUST be able to satisfy the raw `window='secondary'` filter with `idx_usage_window_raw_account_latest`
+- **AND** the query result MUST remain semantically identical to the previous latest-usage lookup
+
+#### Scenario: Migration is safe after a live hotfix
+- **GIVEN** `idx_usage_window_raw_account_latest` was already created manually as a live SQLite hotfix
+- **WHEN** the schema migration is applied
+- **THEN** the migration MUST complete without failing on duplicate index creation

--- a/openspec/changes/add-dashboard-usage-raw-window-index/tasks.md
+++ b/openspec/changes/add-dashboard-usage-raw-window-index/tasks.md
@@ -1,0 +1,5 @@
+- [x] Add an Alembic migration for the raw-window latest usage index.
+- [x] Register the index in ORM metadata and migration drift policy.
+- [x] Add regression tests for idempotent migration behavior and SQLite secondary latest-usage query planning.
+- [x] Validate migration, drift checks, and relevant usage repository tests locally.
+- [ ] Run OpenSpec validation once the `openspec` CLI is available in the workspace.

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -157,6 +157,49 @@ async def test_latest_by_account_primary_query_plan_uses_normalized_window_index
 
 
 @pytest.mark.asyncio
+async def test_latest_by_account_secondary_query_plan_uses_raw_window_index(db_setup):
+    now = utcnow()
+    async with SessionLocal() as session:
+        if _dialect_name(session) != "sqlite":
+            pytest.skip("SQLite-only query plan test")
+
+        accounts_repo = AccountsRepository(session)
+        repo = UsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc1"))
+        await accounts_repo.upsert(_make_account("acc2"))
+
+        await repo.add_entry("acc1", 10.0, window="secondary", recorded_at=now - timedelta(hours=2))
+        await repo.add_entry("acc1", 20.0, window="secondary", recorded_at=now)
+        await repo.add_entry("acc2", 30.0, window="primary", recorded_at=now - timedelta(hours=1))
+        await repo.add_entry("acc2", 40.0, window="secondary", recorded_at=now)
+
+        plan_rows = (
+            await session.execute(
+                text(
+                    """
+                    EXPLAIN QUERY PLAN
+                    SELECT uh.id
+                    FROM usage_history AS uh
+                    JOIN (
+                        SELECT id AS usage_id,
+                               row_number() OVER (
+                                   PARTITION BY account_id
+                                   ORDER BY recorded_at DESC, id DESC
+                               ) AS row_number
+                        FROM usage_history
+                        WHERE "window" = 'secondary'
+                    ) AS ranked ON uh.id = ranked.usage_id
+                    WHERE ranked.row_number = 1
+                    """
+                )
+            )
+        ).fetchall()
+
+    details = " ".join(str(row[-1]) for row in plan_rows)
+    assert "idx_usage_window_raw_account_latest" in details
+
+
+@pytest.mark.asyncio
 async def test_latest_by_account_primary_query_plan_uses_normalized_window_index_postgresql(db_setup):
     now = utcnow()
     async with SessionLocal() as session:

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -285,10 +285,40 @@ def test_check_schema_drift_detects_missing_manual_performance_index(tmp_path: P
     sync_url = to_sync_database_url(url)
     with create_engine(sync_url, future=True).connect() as connection:
         connection.execute(text("DROP INDEX idx_usage_window_account_latest"))
+        connection.execute(text("DROP INDEX idx_usage_window_raw_account_latest"))
         connection.commit()
 
     drift = check_schema_drift(url)
     assert any("idx_usage_window_account_latest" in diff for diff in drift)
+    assert any("idx_usage_window_raw_account_latest" in diff for diff in drift)
+
+
+def test_raw_usage_window_latest_index_migration_is_idempotent(tmp_path: Path) -> None:
+    db_path = tmp_path / "raw-window-latest-index.db"
+    url = _db_url(db_path)
+    pre_revision = "20260513_000000_add_accounts_alias"
+    target_revision = "20260525_000000_add_usage_raw_window_latest_index"
+
+    run_upgrade(url, pre_revision, bootstrap_legacy=False)
+
+    sync_url = to_sync_database_url(url)
+    with create_engine(sync_url, future=True).connect() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE INDEX idx_usage_window_raw_account_latest
+                ON usage_history ("window", account_id, recorded_at DESC, id DESC)
+                """
+            )
+        )
+        connection.commit()
+
+    result = run_upgrade(url, target_revision, bootstrap_legacy=False)
+    assert result.current_revision == target_revision
+
+    with create_engine(sync_url, future=True).connect() as connection:
+        index_names = {index["name"] for index in inspect(connection).get_indexes("usage_history")}
+        assert "idx_usage_window_raw_account_latest" in index_names
 
 
 def test_check_schema_drift_detects_missing_dashboard_read_indexes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a managed SQLite index for raw-window latest usage lookups. In the live hotfix, the targeted secondary latest-usage query improved from ~2300 ms to ~720 ms (~3.2x), while the full dashboard overview remains dominated by bulk usage-history processing for depletion and weekly pace.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: N/A

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/add-dashboard-usage-raw-window-index/`

## Changes

- Add `idx_usage_window_raw_account_latest` on `usage_history (window, account_id, recorded_at DESC, id DESC)`.
- Register the index in SQLAlchemy metadata and manual drift requirements.
- Add an idempotent Alembic migration for environments where the live hotfix index may already exist.
- Add regression coverage for migration idempotency, drift detection, and SQLite secondary latest-usage query planning.

## Test plan

- `python -m ruff format --check app/db/alembic/versions/20260525_000000_add_usage_raw_window_latest_index.py app/db/models.py app/db/migrate.py tests/unit/test_db_migrate.py tests/integration/test_usage_repository.py`
- `python -m ruff check app/db/alembic/versions/20260525_000000_add_usage_raw_window_latest_index.py app/db/models.py app/db/migrate.py tests/unit/test_db_migrate.py tests/integration/test_usage_repository.py`
- `python -m pytest tests/unit/test_db_migrate.py -q`
- `python -m pytest tests/integration/test_usage_repository.py -q`
- `python -m app.db.migrate --db-url <tmp-sqlite-url> upgrade head`
- `python -m app.db.migrate --db-url <tmp-sqlite-url> check`

Note: `openspec validate --specs` was not run locally because the OpenSpec CLI is not installed in this workspace.

## Screenshots / output

Live SQLite hotfix measurements:

- Secondary latest-usage query: ~2300 ms -> ~720 ms (~3.2x faster).
- Total SQL time inside `DashboardService.get_overview(7d)`: ~4.6s -> ~3.0s (~1.5x faster for the measured SQL portion).
- Full direct `DashboardService.get_overview(7d)` probe still measured around 12s because most remaining time is spent loading and processing large secondary usage-history windows for depletion and weekly pace calculations.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local ruff, migration, unit, and integration subsets.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is not edited by hand (release-please handles it).