### PR TITLE
docs(readme): lowercase codex provider name to match Codex 2026-05-23 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ model_reasoning_effort = "xhigh"
 model_provider = "codex-lb"
 
 [model_providers.codex-lb]
-name = "OpenAI"  # required — enables remote /responses/compact
+name = "openai"  # required — enables remote /responses/compact. Lowercase since Codex 2026-05-23; older "OpenAI" stops resolving gpt-5.5
 base_url = "http://127.0.0.1:2455/backend-api/codex"
 wire_api = "responses"
 supports_websockets = true
@@ -146,7 +146,7 @@ match Codex CLI's native transport.
 
 ```toml
 [model_providers.codex-lb]
-name = "OpenAI"
+name = "openai"
 base_url = "http://127.0.0.1:2455/backend-api/codex"
 wire_api = "responses"
 env_key = "CODEX_LB_API_KEY"


### PR DESCRIPTION
## Why

After Codex 2026-05-23, the canonical model provider name flipped from `OpenAI` to lowercase `openai`. The two `model_providers.codex-lb` snippets in `README.md` still showed the old casing, so users copy-pasting the documented config hit "model not resolved" failures on `gpt-5.5`.

Reported and confirmed by two users in [#783](https://github.com/Soju06/codex-lb/issues/783): switching `name` to `"openai"` restores resolution.

## What

- Both `[model_providers.codex-lb]` snippets in `README.md` now use `name = "openai"`.
- The lead snippet's inline comment records when the change landed upstream so future readers know why it is lowercase.

Closes #783