### PR TITLE
fix(accounts): reuse existing row on reauth for same ChatGPT identity (closes #788)

### DIFF
--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -279,11 +279,7 @@ class AccountsRepository:
         await self._session.execute(
             update(RequestLog).where(RequestLog.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
         )
-        await self._session.execute(
-            update(AccountLimitWarmup)
-            .where(AccountLimitWarmup.account_id.in_(duplicate_ids))
-            .values(account_id=canonical.id)
-        )
+        await self._reconcile_limit_warmups(canonical.id, duplicate_ids)
         await self._session.execute(
             update(StickySession).where(StickySession.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
         )
@@ -293,6 +289,34 @@ class AccountsRepository:
             .values(account_id=canonical.id)
         )
         await self._session.execute(delete(Account).where(Account.id.in_(duplicate_ids)))
+
+    async def _reconcile_limit_warmups(self, canonical_account_id: str, duplicate_ids: list[str]) -> None:
+        existing_keys = {
+            (window, reset_at)
+            for window, reset_at in (
+                await self._session.execute(
+                    select(AccountLimitWarmup.window, AccountLimitWarmup.reset_at).where(
+                        AccountLimitWarmup.account_id == canonical_account_id
+                    )
+                )
+            ).all()
+        }
+        duplicate_warmups = (
+            (
+                await self._session.execute(
+                    select(AccountLimitWarmup).where(AccountLimitWarmup.account_id.in_(duplicate_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for warmup in duplicate_warmups:
+            key = (warmup.window, warmup.reset_at)
+            if key in existing_keys:
+                await self._session.delete(warmup)
+            else:
+                warmup.account_id = canonical_account_id
+                existing_keys.add(key)
 
     async def update_status(
         self,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -9,7 +9,18 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus, DashboardSettings, RequestLog, StickySession, UsageHistory
+from app.db.models import (
+    Account,
+    AccountLimitWarmup,
+    AccountStatus,
+    AdditionalUsageHistory,
+    ApiKeyAccountAssignment,
+    DashboardSettings,
+    HttpBridgeSessionRecord,
+    RequestLog,
+    StickySession,
+    UsageHistory,
+)
 
 _SETTINGS_ROW_ID = 1
 _DUPLICATE_ACCOUNT_SUFFIX = "__copy"
@@ -161,6 +172,10 @@ class AccountsRepository:
             canonical = await self._account_by_chatgpt_identity(account.chatgpt_account_id)
             if canonical is not None:
                 _apply_account_updates(canonical, account)
+                await self._reconcile_chatgpt_identity_duplicates(
+                    canonical=canonical,
+                    chatgpt_account_id=account.chatgpt_account_id,
+                )
                 await self._session.commit()
                 await self._session.refresh(canonical)
                 return canonical
@@ -205,6 +220,67 @@ class AccountsRepository:
             .limit(1)
         )
         return result.scalar_one_or_none()
+
+    async def _reconcile_chatgpt_identity_duplicates(
+        self,
+        canonical: Account,
+        chatgpt_account_id: str,
+    ) -> None:
+        duplicate_accounts = (
+            await self._session.execute(
+                select(Account.id).where(
+                    Account.chatgpt_account_id == chatgpt_account_id,
+                    Account.id != canonical.id,
+                )
+            )
+        ).scalars().all()
+        duplicate_ids = list(duplicate_accounts)
+        if not duplicate_ids:
+            return
+
+        duplicate_api_key_ids = (
+            await self._session.execute(
+                select(ApiKeyAccountAssignment.api_key_id).where(ApiKeyAccountAssignment.account_id == canonical.id)
+            )
+        ).scalars().all()
+        existing_api_key_ids = set(duplicate_api_key_ids)
+
+        duplicate_assignments = (
+            await self._session.execute(
+                select(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.account_id.in_(duplicate_ids))
+            )
+        ).scalars().all()
+        for assignment in duplicate_assignments:
+            if assignment.api_key_id in existing_api_key_ids:
+                await self._session.delete(assignment)
+            else:
+                assignment.account_id = canonical.id
+
+        await self._session.execute(
+            update(UsageHistory).where(UsageHistory.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
+        )
+        await self._session.execute(
+            update(AdditionalUsageHistory).where(
+                AdditionalUsageHistory.account_id.in_(duplicate_ids)
+            ).values(account_id=canonical.id)
+        )
+        await self._session.execute(
+            update(RequestLog).where(RequestLog.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
+        )
+        await self._session.execute(
+            update(AccountLimitWarmup).where(AccountLimitWarmup.account_id.in_(duplicate_ids)).values(
+                account_id=canonical.id
+            )
+        )
+        await self._session.execute(
+            update(StickySession).where(StickySession.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
+        )
+        await self._session.execute(
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.account_id.in_(duplicate_ids))
+            .values(account_id=canonical.id)
+        )
+        await self._session.execute(delete(Account).where(Account.id.in_(duplicate_ids)))
 
     async def update_status(
         self,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -103,7 +103,13 @@ class AccountsRepository:
         )
         return result.scalar_one_or_none() is not None
 
-    async def upsert(self, account: Account, *, merge_by_email: bool | None = None) -> Account:
+    async def upsert(
+        self,
+        account: Account,
+        *,
+        merge_by_email: bool | None = None,
+        merge_by_chatgpt_identity: bool = False,
+    ) -> Account:
         dialect_name = self._dialect_name()
         sqlite_lock_acquired = False
         if merge_by_email is None:
@@ -121,7 +127,31 @@ class AccountsRepository:
             if dialect_name == "sqlite" and not sqlite_lock_acquired:
                 await self._acquire_sqlite_merge_lock()
             elif dialect_name == "postgresql":
-                await self._acquire_postgresql_identity_lock(account.id)
+                if merge_by_chatgpt_identity and account.chatgpt_account_id:
+                    await self._acquire_postgresql_identity_lock(
+                        f"chatgpt:{account.chatgpt_account_id}"
+                    )
+                else:
+                    await self._acquire_postgresql_identity_lock(account.id)
+
+        # Identity-aware reconciliation runs before the deterministic-id
+        # check so that a deactivated row whose refresh token was revoked
+        # is reused on reauth instead of being shadowed by an __copy row
+        # under the same upstream ChatGPT identity (issue #788).
+        #
+        # This path is intentionally independent of merge_by_email: the
+        # OAuth reauth caller passes merge_by_chatgpt_identity=True even
+        # when the operator has opted into "import without overwrite",
+        # because that setting governs the dashboard import path (side-
+        # by-side rows for the same email) rather than the reauth path
+        # (one local row per upstream identity).
+        if merge_by_chatgpt_identity and account.chatgpt_account_id:
+            canonical = await self._account_by_chatgpt_identity(account.chatgpt_account_id)
+            if canonical is not None:
+                _apply_account_updates(canonical, account)
+                await self._session.commit()
+                await self._session.refresh(canonical)
+                return canonical
 
         existing = await self._session.get(Account, account.id)
         if existing:
@@ -144,6 +174,25 @@ class AccountsRepository:
         await self._session.commit()
         await self._session.refresh(account)
         return account
+
+    async def _account_by_chatgpt_identity(self, chatgpt_account_id: str) -> Account | None:
+        """Return the canonical local account row for a ChatGPT identity.
+
+        Order of preference, so that reauth reuses the row that already
+        carries the historical usage and audit trail:
+
+        1. The oldest row by ``created_at`` (deterministic tie-break on
+           ``id``) — this is almost always the original row, before any
+           ``__copyN`` rows were created.
+        """
+
+        result = await self._session.execute(
+            select(Account)
+            .where(Account.chatgpt_account_id == chatgpt_account_id)
+            .order_by(Account.created_at.asc(), Account.id.asc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
 
     async def update_status(
         self,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -128,9 +128,7 @@ class AccountsRepository:
                 await self._acquire_sqlite_merge_lock()
             elif dialect_name == "postgresql":
                 if merge_by_chatgpt_identity and account.chatgpt_account_id:
-                    await self._acquire_postgresql_identity_lock(
-                        f"chatgpt:{account.chatgpt_account_id}"
-                    )
+                    await self._acquire_postgresql_identity_lock(f"chatgpt:{account.chatgpt_account_id}")
                 else:
                     await self._acquire_postgresql_identity_lock(account.id)
 

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -267,6 +267,7 @@ class AccountsRepository:
                 await self._session.delete(assignment)
             else:
                 assignment.account_id = canonical.id
+                existing_api_key_ids.add(assignment.api_key_id)
 
         await self._session.execute(
             update(UsageHistory).where(UsageHistory.account_id.in_(duplicate_ids)).values(account_id=canonical.id)

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -227,29 +227,41 @@ class AccountsRepository:
         chatgpt_account_id: str,
     ) -> None:
         duplicate_accounts = (
-            await self._session.execute(
-                select(Account.id).where(
-                    Account.chatgpt_account_id == chatgpt_account_id,
-                    Account.id != canonical.id,
+            (
+                await self._session.execute(
+                    select(Account.id).where(
+                        Account.chatgpt_account_id == chatgpt_account_id,
+                        Account.id != canonical.id,
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         duplicate_ids = list(duplicate_accounts)
         if not duplicate_ids:
             return
 
         duplicate_api_key_ids = (
-            await self._session.execute(
-                select(ApiKeyAccountAssignment.api_key_id).where(ApiKeyAccountAssignment.account_id == canonical.id)
+            (
+                await self._session.execute(
+                    select(ApiKeyAccountAssignment.api_key_id).where(ApiKeyAccountAssignment.account_id == canonical.id)
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         existing_api_key_ids = set(duplicate_api_key_ids)
 
         duplicate_assignments = (
-            await self._session.execute(
-                select(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.account_id.in_(duplicate_ids))
+            (
+                await self._session.execute(
+                    select(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.account_id.in_(duplicate_ids))
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         for assignment in duplicate_assignments:
             if assignment.api_key_id in existing_api_key_ids:
                 await self._session.delete(assignment)
@@ -260,17 +272,17 @@ class AccountsRepository:
             update(UsageHistory).where(UsageHistory.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
         )
         await self._session.execute(
-            update(AdditionalUsageHistory).where(
-                AdditionalUsageHistory.account_id.in_(duplicate_ids)
-            ).values(account_id=canonical.id)
+            update(AdditionalUsageHistory)
+            .where(AdditionalUsageHistory.account_id.in_(duplicate_ids))
+            .values(account_id=canonical.id)
         )
         await self._session.execute(
             update(RequestLog).where(RequestLog.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
         )
         await self._session.execute(
-            update(AccountLimitWarmup).where(AccountLimitWarmup.account_id.in_(duplicate_ids)).values(
-                account_id=canonical.id
-            )
+            update(AccountLimitWarmup)
+            .where(AccountLimitWarmup.account_id.in_(duplicate_ids))
+            .values(account_id=canonical.id)
         )
         await self._session.execute(
             update(StickySession).where(StickySession.account_id.in_(duplicate_ids)).values(account_id=canonical.id)

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -118,19 +118,33 @@ class AccountsRepository:
                 sqlite_lock_acquired = True
             merge_by_email = await self._merge_by_email_enabled()
 
-        if merge_by_email:
-            if dialect_name == "sqlite" and not sqlite_lock_acquired:
-                await self._acquire_sqlite_merge_lock()
-            elif dialect_name == "postgresql":
+        if dialect_name == "sqlite" and not sqlite_lock_acquired:
+            # sqlite BEGIN IMMEDIATE serializes all writers globally, so
+            # the identity-reconciliation branch is already mutually
+            # exclusive on this dialect.
+            await self._acquire_sqlite_merge_lock()
+        elif dialect_name == "postgresql":
+            # Identity-keyed advisory lock must always be acquired when
+            # identity reconciliation is in play, regardless of
+            # merge_by_email. Two concurrent reauths for the same
+            # upstream chatgpt_account_id but different email claims
+            # (e.g. user changed email upstream) would otherwise take
+            # different email-scoped locks, both miss the canonical-row
+            # lookup below, and both INSERT a duplicate row for the
+            # same identity.
+            #
+            # Ordering identity-first, then email, gives a stable
+            # acquisition order across all callers so two concurrent
+            # reauths that overlap on either key serialize without
+            # deadlock.
+            identity_locked = False
+            if merge_by_chatgpt_identity and account.chatgpt_account_id:
+                await self._acquire_postgresql_identity_lock(f"chatgpt:{account.chatgpt_account_id}")
+                identity_locked = True
+            if merge_by_email:
                 await self._acquire_postgresql_merge_lock(account.email)
-        else:
-            if dialect_name == "sqlite" and not sqlite_lock_acquired:
-                await self._acquire_sqlite_merge_lock()
-            elif dialect_name == "postgresql":
-                if merge_by_chatgpt_identity and account.chatgpt_account_id:
-                    await self._acquire_postgresql_identity_lock(f"chatgpt:{account.chatgpt_account_id}")
-                else:
-                    await self._acquire_postgresql_identity_lock(account.id)
+            elif not identity_locked:
+                await self._acquire_postgresql_identity_lock(account.id)
 
         # Identity-aware reconciliation runs before the deterministic-id
         # check so that a deactivated row whose refresh token was revoked

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -546,11 +546,16 @@ class OauthService:
             status=AccountStatus.ACTIVE,
             deactivation_reason=None,
         )
+        # merge_by_chatgpt_identity reuses the existing local row for this
+        # upstream ChatGPT identity on reauth — including rows that were
+        # deactivated because the previous refresh token was revoked. This
+        # prevents a second account row from being created with an
+        # `__copyN` id suffix (issue #788).
         if self._repo_factory:
             async with self._repo_factory() as repo:
-                await repo.upsert(account)
+                await repo.upsert(account, merge_by_chatgpt_identity=True)
         else:
-            await self._accounts_repo.upsert(account)
+            await self._accounts_repo.upsert(account, merge_by_chatgpt_identity=True)
 
     async def _set_success(self, flow_id: str | None = None) -> None:
         async with self._store.lock:

--- a/openspec/changes/merge-reauth-by-chatgpt-identity/proposal.md
+++ b/openspec/changes/merge-reauth-by-chatgpt-identity/proposal.md
@@ -8,6 +8,7 @@ The account lifecycle needs a stable identity rule for re-authentication: if the
 
 - Define re-authentication merge semantics for OAuth token persistence by upstream ChatGPT identity.
 - Reuse the existing local account row when a new OAuth token payload carries the same `chatgpt_account_id`.
+- If duplicate local rows already exist for that upstream identity, repoint dependent rows (usage history, request logs, sticky sessions, warmup state, API key assignments, HTTP bridge sessions, additional usage history) to the canonical row before deleting duplicates.
 - Keep import-without-overwrite behavior separate: duplicate imports can still create separate local rows, but reauth is an identity refresh of an already-known upstream account.
 - Preserve concurrent safety so simultaneous reauth completions for the same upstream identity cannot create duplicate rows.
 

--- a/openspec/changes/merge-reauth-by-chatgpt-identity/proposal.md
+++ b/openspec/changes/merge-reauth-by-chatgpt-identity/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Re-authenticating an account whose previous refresh token was revoked can create a duplicate local account row when the new OAuth payload is persisted through the normal account upsert path. That is confusing for operators because the same upstream ChatGPT identity appears twice, often with one stale deactivated row and one fresh active row.
+
+The account lifecycle needs a stable identity rule for re-authentication: if the upstream ChatGPT account identity is known and already exists locally, reauth should refresh that existing local row instead of allocating a duplicate `__copyN` account id.
+
+## What Changes
+
+- Define re-authentication merge semantics for OAuth token persistence by upstream ChatGPT identity.
+- Reuse the existing local account row when a new OAuth token payload carries the same `chatgpt_account_id`.
+- Keep import-without-overwrite behavior separate: duplicate imports can still create separate local rows, but reauth is an identity refresh of an already-known upstream account.
+- Preserve concurrent safety so simultaneous reauth completions for the same upstream identity cannot create duplicate rows.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `frontend-architecture`: account management now defines that OAuth re-authentication refreshes an existing row by upstream ChatGPT identity.
+
+## Impact
+
+- Affects OAuth token persistence through `app/modules/oauth/service.py`.
+- Affects account repository identity-merge behavior.
+- Adds regression coverage for concurrent identity-based reauth persistence.

--- a/openspec/changes/merge-reauth-by-chatgpt-identity/specs/frontend-architecture/spec.md
+++ b/openspec/changes/merge-reauth-by-chatgpt-identity/specs/frontend-architecture/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Account management page supports account import and OAuth add flows
+
+The Accounts page SHALL display a two-column layout: left panel with searchable account list, import button, and add account button; right panel with selected account details including usage, token info, and actions (pause/resume/delete/re-authenticate).
+
+#### Scenario: Account import
+- **WHEN** a user clicks the import button and uploads an auth.json file
+- **THEN** the app calls `POST /api/accounts/import` and refreshes the account list on success
+
+#### Scenario: OAuth add account
+- **WHEN** a user clicks the add account button
+- **THEN** an OAuth dialog opens with browser and device code flow options
+
+#### Scenario: OAuth reauth refreshes the existing ChatGPT identity row
+- **GIVEN** a local account row already has a non-empty upstream `chatgpt_account_id`
+- **AND** the account is re-authenticated through the dashboard OAuth flow
+- **WHEN** the new OAuth token payload carries the same upstream `chatgpt_account_id`
+- **THEN** the service updates the existing local row instead of creating a duplicate account row
+- **AND** the refreshed row is active and carries the latest OAuth tokens and account metadata
+
+#### Scenario: Concurrent OAuth reauth completions do not create duplicate rows
+- **GIVEN** two OAuth reauth completions for the same upstream `chatgpt_account_id` finish concurrently
+- **WHEN** both completions persist their token payloads
+- **THEN** exactly one local account row exists for that upstream identity

--- a/openspec/changes/merge-reauth-by-chatgpt-identity/tasks.md
+++ b/openspec/changes/merge-reauth-by-chatgpt-identity/tasks.md
@@ -7,6 +7,7 @@
 
 - [x] 2.1 Route OAuth token persistence through identity-based account upsert.
 - [x] 2.2 Serialize identity-merge persistence so concurrent completions cannot allocate duplicate local ids.
+- [x] 2.3 Ensure duplicate same-identity rows are reconciled by repointing dependent tables before deleting obsolete rows.
 
 ## 3. Verification
 

--- a/openspec/changes/merge-reauth-by-chatgpt-identity/tasks.md
+++ b/openspec/changes/merge-reauth-by-chatgpt-identity/tasks.md
@@ -1,0 +1,14 @@
+## 1. OpenSpec And Coverage
+
+- [x] 1.1 Add an OpenSpec change describing reauth merge-by-ChatGPT-identity behavior.
+- [x] 1.2 Add regression coverage proving concurrent reauth persists one local row for the same upstream ChatGPT identity.
+
+## 2. Implementation
+
+- [x] 2.1 Route OAuth token persistence through identity-based account upsert.
+- [x] 2.2 Serialize identity-merge persistence so concurrent completions cannot allocate duplicate local ids.
+
+## 3. Verification
+
+- [x] 3.1 Run the targeted account repository tests.
+- [x] 3.2 Validate the OpenSpec change.

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -142,10 +142,25 @@ async def test_starting_new_device_flow_cancels_previous_pending_poll(async_clie
 
 
 @pytest.mark.asyncio
-async def test_device_oauth_flow_keeps_separate_accounts_when_import_without_overwrite_enabled(
+async def test_device_oauth_reauth_reuses_existing_row_for_same_chatgpt_identity(
     async_client,
     monkeypatch,
 ):
+    """OAuth reauth for the same ChatGPT identity must reuse the existing
+    local row even when ``importWithoutOverwrite`` is enabled.
+
+    Before #788, this code path created an ``__copyN`` row whenever the
+    operator had toggled ``importWithoutOverwrite`` on, because the
+    dashboard's side-by-side import setting was incorrectly conflated
+    with reauth.
+
+    The ``importWithoutOverwrite`` setting now governs the dashboard
+    import path only (side-by-side rows when importing twice). The
+    reauth path always reconciles to one local row per upstream
+    ChatGPT identity, so a refresh-token-revoked account picks up the
+    new tokens onto its historical row instead of forking a duplicate.
+    """
+
     await oauth_module._OAUTH_STORE.reset()
 
     settings = await async_client.put(
@@ -160,8 +175,8 @@ async def test_device_oauth_flow_keeps_separate_accounts_when_import_without_ove
     assert settings.status_code == 200
     assert settings.json()["importWithoutOverwrite"] is True
 
-    email = "device-separate@example.com"
-    raw_account_id = "acc_device_separate"
+    email = "device-reauth@example.com"
+    raw_account_id = "acc_device_reauth"
 
     async def fake_device_code(**_):
         return DeviceCode(
@@ -222,11 +237,12 @@ async def test_device_oauth_flow_keeps_separate_accounts_when_import_without_ove
     accounts = await async_client.get("/api/accounts")
     assert accounts.status_code == 200
     data = [account for account in accounts.json()["accounts"] if account["email"] == email]
-    assert len(data) == 2
-    ids = {account["accountId"] for account in data}
+    assert len(data) == 1
     base_id = generate_unique_account_id(raw_account_id, email)
-    assert base_id in ids
-    assert any(account_id.startswith(f"{base_id}__copy") for account_id in ids if account_id != base_id)
+    assert data[0]["accountId"] == base_id
+    # Second reauth carried the team plan; it must be applied to the
+    # existing row rather than a new __copy row.
+    assert data[0]["planType"] == "team"
 
 
 @pytest.mark.asyncio
@@ -249,7 +265,6 @@ async def test_device_oauth_flow_reports_error_when_duplicate_email_is_ambiguous
     assert enable_separate.json()["importWithoutOverwrite"] is True
 
     email = "oauth-conflict@example.com"
-    raw_account_id = "acc_oauth_conflict_base"
 
     async def fake_device_code(**_):
         return DeviceCode(
@@ -263,10 +278,19 @@ async def test_device_oauth_flow_reports_error_when_duplicate_email_is_ambiguous
     call_count = {"value": 0}
 
     async def fake_exchange_device_token(**_):
+        # Each of the first two flows uses a *different* upstream
+        # chatgpt_account_id so that identity-aware reauth treats them
+        # as distinct upstream identities and keeps both local rows.
+        # The third flow then introduces a third upstream id under the
+        # same email, which is what the email-ambiguity path needs to
+        # see to surface the conflict error.
         call_count["value"] += 1
-        if call_count["value"] <= 2:
-            account_id = raw_account_id
-            plan_type = "plus" if call_count["value"] == 1 else "team"
+        if call_count["value"] == 1:
+            account_id = "acc_oauth_conflict_one"
+            plan_type = "plus"
+        elif call_count["value"] == 2:
+            account_id = "acc_oauth_conflict_two"
+            plan_type = "team"
         else:
             account_id = "acc_oauth_conflict_new"
             plan_type = "pro"

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -8,7 +8,19 @@ from sqlalchemy import select
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import (
+    Account,
+    AccountLimitWarmup,
+    AccountStatus,
+    AdditionalUsageHistory,
+    ApiKey,
+    ApiKeyAccountAssignment,
+    HttpBridgeSessionRecord,
+    RequestLog,
+    StickySession,
+    StickySessionKind,
+    UsageHistory,
+)
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountIdentityConflictError, AccountsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -204,6 +216,163 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_picks_oldest_canonical(
         # row, so the long-term usage history stays attached.
         assert saved.id == "acc_first"
         assert saved.plan_type == "team"
+        rows = list(
+            (await session.execute(select(Account).where(Account.chatgpt_account_id == "chatgpt_dup"))).scalars().all()
+        )
+        assert len(rows) == 1
+        assert rows[0].id == "acc_first"
+
+
+@pytest.mark.asyncio
+async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_rows(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        canonical = _make_account_with_chatgpt_id("acc_merge_main", "merge@example.com", "chatgpt_merge")
+        await repo.upsert(canonical, merge_by_email=False)
+
+        duplicate = _make_account_with_chatgpt_id("acc_merge_main__copy2", "merge@example.com", "chatgpt_merge")
+        await repo.upsert(duplicate, merge_by_email=False)
+
+        duplicate_row = (
+            await session.execute(select(Account).where(Account.id == "acc_merge_main__copy2"))
+        ).scalar_one()
+
+        api_key = ApiKey(
+            id="api_merge_dupe",
+            name="Merge Test",
+            key_hash="merge-key-hash",
+            key_prefix="mrg",
+            apply_to_codex_model=False,
+            account_assignment_scope_enabled=False,
+        )
+        session.add(api_key)
+        session.add(ApiKeyAccountAssignment(api_key_id=api_key.id, account_id=duplicate_row.id))
+        session.add(
+            UsageHistory(
+                account_id=duplicate_row.id,
+                window="primary",
+                used_percent=55.0,
+                input_tokens=42,
+                output_tokens=17,
+                reset_at=1,
+                window_minutes=300,
+            )
+        )
+        session.add(
+            AdditionalUsageHistory(
+                account_id=duplicate_row.id,
+                quota_key="gpt-5.1",
+                limit_name="gpt-5.1",
+                metered_feature="model",
+                window="7d",
+                used_percent=15.0,
+            )
+        )
+        session.add(
+            AccountLimitWarmup(
+                account_id=duplicate_row.id,
+                window="primary",
+                reset_at=123,
+                status="pending",
+                model="gpt-5.1",
+                attempted_at=utcnow(),
+            )
+        )
+        session.add(
+            StickySession(
+                account_id=duplicate_row.id,
+                key="sticky-dup",
+                kind=StickySessionKind.STICKY_THREAD,
+            )
+        )
+        session.add(
+            HttpBridgeSessionRecord(
+                account_id=duplicate_row.id,
+                session_key_kind="http",
+                session_key_value="turn:merge",
+                session_key_hash="turn-merge-hash",
+                api_key_scope="merge-scope",
+            )
+        )
+        session.add(
+            RequestLog(
+                request_id="req_merge_dupe",
+                account_id=duplicate_row.id,
+                model="gpt-5",
+                status="success",
+                requested_at=utcnow(),
+            )
+        )
+        await session.commit()
+
+        reauth = _make_account_with_chatgpt_id("acc_merge_main", "merge@example.com", "chatgpt_merge")
+        reauth.plan_type = "team"
+        saved = await repo.upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        assert saved.id == "acc_merge_main"
+        assert saved.plan_type == "team"
+
+        rows = list(
+            (
+                await session.execute(
+                    select(Account).where(Account.chatgpt_account_id == "chatgpt_merge")
+                )
+            ).scalars().all()
+        )
+        assert len(rows) == 1
+        assert rows[0].id == "acc_merge_main"
+
+        account_histories = (
+            await session.execute(select(UsageHistory).where(UsageHistory.account_id == "acc_merge_main"))
+        ).scalars().all()
+        assert len(account_histories) == 1
+        assert account_histories[0].used_percent == 55.0
+
+        additional_histories = (
+            await session.execute(
+                select(AdditionalUsageHistory).where(AdditionalUsageHistory.account_id == "acc_merge_main")
+            )
+        ).scalars().all()
+        assert len(additional_histories) == 1
+        assert additional_histories[0].quota_key == "gpt-5.1"
+
+        account_warmups = (
+            await session.execute(select(AccountLimitWarmup).where(AccountLimitWarmup.account_id == "acc_merge_main"))
+        ).scalars().all()
+        assert len(account_warmups) == 1
+        assert account_warmups[0].status == "pending"
+
+        sticky_sessions = (
+            await session.execute(select(StickySession).where(StickySession.account_id == "acc_merge_main"))
+        ).scalars().all()
+        assert len(sticky_sessions) == 1
+        assert sticky_sessions[0].key == "sticky-dup"
+
+        bridge_sessions = (
+            await session.execute(
+                select(HttpBridgeSessionRecord).where(
+                    HttpBridgeSessionRecord.account_id == "acc_merge_main"
+                )
+            )
+        ).scalars().all()
+        assert len(bridge_sessions) == 1
+        assert bridge_sessions[0].session_key_value == "turn:merge"
+
+        assignments = (
+            await session.execute(
+                select(ApiKeyAccountAssignment).where(
+                    ApiKeyAccountAssignment.account_id == "acc_merge_main"
+                )
+            )
+        ).scalars().all()
+        assert len(assignments) == 1
+        assert assignments[0].api_key_id == api_key.id
+
+        duplicate_request_logs = (
+            await session.execute(select(RequestLog).where(RequestLog.account_id == "acc_merge_main__copy2"))
+        ).scalars().all()
+        assert len(duplicate_request_logs) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -314,64 +314,78 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_ro
         assert saved.plan_type == "team"
 
         rows = list(
-            (
-                await session.execute(
-                    select(Account).where(Account.chatgpt_account_id == "chatgpt_merge")
-                )
-            ).scalars().all()
+            (await session.execute(select(Account).where(Account.chatgpt_account_id == "chatgpt_merge")))
+            .scalars()
+            .all()
         )
         assert len(rows) == 1
         assert rows[0].id == "acc_merge_main"
 
         account_histories = (
-            await session.execute(select(UsageHistory).where(UsageHistory.account_id == "acc_merge_main"))
-        ).scalars().all()
+            (await session.execute(select(UsageHistory).where(UsageHistory.account_id == "acc_merge_main")))
+            .scalars()
+            .all()
+        )
         assert len(account_histories) == 1
         assert account_histories[0].used_percent == 55.0
 
         additional_histories = (
-            await session.execute(
-                select(AdditionalUsageHistory).where(AdditionalUsageHistory.account_id == "acc_merge_main")
+            (
+                await session.execute(
+                    select(AdditionalUsageHistory).where(AdditionalUsageHistory.account_id == "acc_merge_main")
+                )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert len(additional_histories) == 1
         assert additional_histories[0].quota_key == "gpt-5.1"
 
         account_warmups = (
-            await session.execute(select(AccountLimitWarmup).where(AccountLimitWarmup.account_id == "acc_merge_main"))
-        ).scalars().all()
+            (await session.execute(select(AccountLimitWarmup).where(AccountLimitWarmup.account_id == "acc_merge_main")))
+            .scalars()
+            .all()
+        )
         assert len(account_warmups) == 1
         assert account_warmups[0].status == "pending"
 
         sticky_sessions = (
-            await session.execute(select(StickySession).where(StickySession.account_id == "acc_merge_main"))
-        ).scalars().all()
+            (await session.execute(select(StickySession).where(StickySession.account_id == "acc_merge_main")))
+            .scalars()
+            .all()
+        )
         assert len(sticky_sessions) == 1
         assert sticky_sessions[0].key == "sticky-dup"
 
         bridge_sessions = (
-            await session.execute(
-                select(HttpBridgeSessionRecord).where(
-                    HttpBridgeSessionRecord.account_id == "acc_merge_main"
+            (
+                await session.execute(
+                    select(HttpBridgeSessionRecord).where(HttpBridgeSessionRecord.account_id == "acc_merge_main")
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert len(bridge_sessions) == 1
         assert bridge_sessions[0].session_key_value == "turn:merge"
 
         assignments = (
-            await session.execute(
-                select(ApiKeyAccountAssignment).where(
-                    ApiKeyAccountAssignment.account_id == "acc_merge_main"
+            (
+                await session.execute(
+                    select(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.account_id == "acc_merge_main")
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
         assert len(assignments) == 1
         assert assignments[0].api_key_id == api_key.id
 
         duplicate_request_logs = (
-            await session.execute(select(RequestLog).where(RequestLog.account_id == "acc_merge_main__copy2"))
-        ).scalars().all()
+            (await session.execute(select(RequestLog).where(RequestLog.account_id == "acc_merge_main__copy2")))
+            .scalars()
+            .all()
+        )
         assert len(duplicate_request_logs) == 0
 
 

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -233,9 +233,14 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_ro
 
         duplicate = _make_account_with_chatgpt_id("acc_merge_main__copy2", "merge@example.com", "chatgpt_merge")
         await repo.upsert(duplicate, merge_by_email=False)
+        duplicate_again = _make_account_with_chatgpt_id("acc_merge_main__copy3", "merge@example.com", "chatgpt_merge")
+        await repo.upsert(duplicate_again, merge_by_email=False)
 
         duplicate_row = (
             await session.execute(select(Account).where(Account.id == "acc_merge_main__copy2"))
+        ).scalar_one()
+        duplicate_again_row = (
+            await session.execute(select(Account).where(Account.id == "acc_merge_main__copy3"))
         ).scalar_one()
 
         api_key = ApiKey(
@@ -248,6 +253,7 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_ro
         )
         session.add(api_key)
         session.add(ApiKeyAccountAssignment(api_key_id=api_key.id, account_id=duplicate_row.id))
+        session.add(ApiKeyAccountAssignment(api_key_id=api_key.id, account_id=duplicate_again_row.id))
         session.add(
             UsageHistory(
                 account_id=duplicate_row.id,

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -141,6 +141,111 @@ async def test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgre
         assert acquired_identity_locks == ["acc_non_merge_lock"]
 
 
+def _make_account_with_chatgpt_id(account_id: str, email: str, chatgpt_id: str) -> Account:
+    account = _make_account(account_id, email)
+    account.chatgpt_account_id = chatgpt_id
+    return account
+
+
+@pytest.mark.asyncio
+async def test_accounts_upsert_merge_by_chatgpt_identity_reuses_deactivated_row(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        original = _make_account_with_chatgpt_id("acc_canonical", "reauth@example.com", "chatgpt_xyz")
+        await repo.upsert(original, merge_by_email=False)
+
+        await repo.update_status(
+            "acc_canonical",
+            AccountStatus.DEACTIVATED,
+            "Refresh token was revoked - re-login required",
+        )
+
+        reauth = _make_account_with_chatgpt_id("acc_canonical", "reauth@example.com", "chatgpt_xyz")
+        reauth.plan_type = "team"
+        saved = await repo.upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        # Reauth must return the original deterministic id, with the new
+        # plan and re-activated status, instead of an `__copyN` row.
+        # merge_by_email=False simulates an operator with
+        # `importWithoutOverwrite` enabled; identity-merge runs anyway
+        # because reauth is governed by upstream identity, not by the
+        # dashboard import setting.
+        assert saved.id == "acc_canonical"
+        assert saved.plan_type == "team"
+        assert saved.status == AccountStatus.ACTIVE
+        assert saved.deactivation_reason is None
+
+        rows = list(
+            (
+                await session.execute(
+                    select(Account).where(Account.chatgpt_account_id == "chatgpt_xyz")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].id == "acc_canonical"
+
+
+@pytest.mark.asyncio
+async def test_accounts_upsert_merge_by_chatgpt_identity_picks_oldest_canonical(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        canonical = _make_account_with_chatgpt_id("acc_first", "shared@example.com", "chatgpt_dup")
+        canonical.created_at = utcnow() - timedelta(days=30)
+        await repo.upsert(canonical, merge_by_email=False)
+
+        copy_row = _make_account_with_chatgpt_id("acc_first__copy2", "shared@example.com", "chatgpt_dup")
+        copy_row.created_at = utcnow()
+        await repo.upsert(copy_row, merge_by_email=False)
+
+        reauth = _make_account_with_chatgpt_id("acc_first", "shared@example.com", "chatgpt_dup")
+        reauth.plan_type = "team"
+        saved = await repo.upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        # Reauth must land on the older canonical row, not the `__copy2`
+        # row, so the long-term usage history stays attached.
+        assert saved.id == "acc_first"
+        assert saved.plan_type == "team"
+
+
+@pytest.mark.asyncio
+async def test_accounts_upsert_merge_by_chatgpt_identity_creates_when_missing(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        incoming = _make_account_with_chatgpt_id("acc_new", "new@example.com", "chatgpt_fresh")
+        saved = await repo.upsert(incoming, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        assert saved.id == "acc_new"
+        assert saved.chatgpt_account_id == "chatgpt_fresh"
+
+
+@pytest.mark.asyncio
+async def test_accounts_upsert_merge_by_chatgpt_identity_skips_without_upstream_id(db_setup):
+    """Falls back to deterministic-id behavior when the incoming row has
+    no ``chatgpt_account_id`` — e.g. legacy local accounts that were
+    seeded before the field was populated.
+    """
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        first = _make_account("acc_no_id", "noid@example.com")
+        await repo.upsert(first, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        again = _make_account("acc_no_id", "noid@example.com")
+        again.plan_type = "team"
+        saved = await repo.upsert(again, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        # No upstream id means identity-merge has nothing to key on, so
+        # the standard side-by-side path runs and creates `__copy2`.
+        assert saved.id.startswith("acc_no_id__copy")
+
+
 @pytest.mark.asyncio
 async def test_usage_repository_aggregate(db_setup):
     async with SessionLocal() as session:

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -271,6 +271,16 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_ro
         )
         session.add(
             AccountLimitWarmup(
+                account_id=canonical.id,
+                window="primary",
+                reset_at=123,
+                status="completed",
+                model="gpt-5.1",
+                attempted_at=utcnow() - timedelta(minutes=5),
+            )
+        )
+        session.add(
+            AccountLimitWarmup(
                 account_id=duplicate_row.id,
                 window="primary",
                 reset_at=123,
@@ -347,7 +357,7 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_ro
             .all()
         )
         assert len(account_warmups) == 1
-        assert account_warmups[0].status == "pending"
+        assert account_warmups[0].status == "completed"
 
         sticky_sessions = (
             (await session.execute(select(StickySession).where(StickySession.account_id == "acc_merge_main")))

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -177,13 +177,7 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reuses_deactivated_row(
         assert saved.deactivation_reason is None
 
         rows = list(
-            (
-                await session.execute(
-                    select(Account).where(Account.chatgpt_account_id == "chatgpt_xyz")
-                )
-            )
-            .scalars()
-            .all()
+            (await session.execute(select(Account).where(Account.chatgpt_account_id == "chatgpt_xyz"))).scalars().all()
         )
         assert len(rows) == 1
         assert rows[0].id == "acc_canonical"

--- a/tests/unit/test_accounts_repository_locks.py
+++ b/tests/unit/test_accounts_repository_locks.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus
+from app.modules.accounts.repository import AccountsRepository
+
+
+def _stub_account(account_id: str, email: str, chatgpt_id: str | None = None) -> Account:
+    enc = TokenEncryptor()
+    acc = Account(
+        id=account_id,
+        email=email,
+        plan_type="plus",
+        access_token_encrypted=enc.encrypt("a"),
+        refresh_token_encrypted=enc.encrypt("r"),
+        id_token_encrypted=enc.encrypt("i"),
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    if chatgpt_id is not None:
+        acc.chatgpt_account_id = chatgpt_id
+    return acc
+
+
+def _make_postgres_repo(monkeypatch: pytest.MonkeyPatch) -> tuple[AccountsRepository, dict[str, list[str]]]:
+    """Build an AccountsRepository whose dialect reports postgresql and
+    whose lock acquisitions and session writes are all stubbed.
+
+    Returns the repo plus a dict of ordered lock-key recordings keyed by
+    lock type, so callers can assert the exact lock sequence.
+    """
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.add = MagicMock()
+    session.get = AsyncMock(return_value=None)
+
+    repo = AccountsRepository(session)
+
+    recorded: dict[str, list[str]] = {"identity": [], "email": []}
+
+    async def fake_identity_lock(key: str) -> None:
+        recorded["identity"].append(key)
+
+    async def fake_email_lock(email: str) -> None:
+        recorded["email"].append(email)
+
+    async def fake_merge_by_email_enabled() -> bool:  # only used when merge_by_email is None
+        return True
+
+    async def fake_account_by_chatgpt_identity(_chatgpt_id: str):
+        return None
+
+    async def fake_single_account_by_email(_email: str):
+        return None
+
+    async def fake_next_available_account_id(account_id: str) -> str:
+        return account_id
+
+    monkeypatch.setattr(repo, "_dialect_name", lambda: "postgresql")
+    monkeypatch.setattr(repo, "_acquire_postgresql_identity_lock", fake_identity_lock)
+    monkeypatch.setattr(repo, "_acquire_postgresql_merge_lock", fake_email_lock)
+    monkeypatch.setattr(repo, "_merge_by_email_enabled", fake_merge_by_email_enabled)
+    monkeypatch.setattr(repo, "_account_by_chatgpt_identity", fake_account_by_chatgpt_identity)
+    monkeypatch.setattr(repo, "_single_account_by_email", fake_single_account_by_email)
+    monkeypatch.setattr(repo, "_next_available_account_id", fake_next_available_account_id)
+
+    return repo, recorded
+
+
+@pytest.mark.asyncio
+async def test_upsert_takes_identity_lock_even_when_merge_by_email_enabled(monkeypatch):
+    """Pin the fix for the codex P2 finding on PR #799.
+
+    When merge_by_email=True AND merge_by_chatgpt_identity=True with a
+    chatgpt_account_id set, two concurrent reauths for the same upstream
+    identity but different email claims would otherwise take different
+    email-scoped locks, both miss the canonical-row lookup, and both
+    INSERT a duplicate row for that identity. The fix takes the
+    identity-keyed advisory lock first, then the email-scoped one.
+    """
+
+    repo, recorded = _make_postgres_repo(monkeypatch)
+    account = _stub_account("acc_a", "a@example.com", chatgpt_id="chatgpt_xyz")
+
+    await repo.upsert(account, merge_by_email=True, merge_by_chatgpt_identity=True)
+
+    assert recorded["identity"] == ["chatgpt:chatgpt_xyz"], (
+        "identity lock must be acquired even when merge_by_email is True"
+    )
+    assert recorded["email"] == ["a@example.com"], "email lock must still be acquired when merge_by_email is True"
+
+
+@pytest.mark.asyncio
+async def test_upsert_takes_identity_lock_when_merge_by_email_disabled(monkeypatch):
+    """Existing path: merge_by_email=False + merge_by_chatgpt_identity
+    keys lock by upstream identity (unchanged behavior).
+    """
+
+    repo, recorded = _make_postgres_repo(monkeypatch)
+    account = _stub_account("acc_b", "b@example.com", chatgpt_id="chatgpt_zzz")
+
+    await repo.upsert(account, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+    assert recorded["identity"] == ["chatgpt:chatgpt_zzz"]
+    assert recorded["email"] == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_falls_back_to_id_lock_without_identity(monkeypatch):
+    """When identity reconciliation is off and merge_by_email is off, the
+    per-account fallback lock keyed by account.id still fires (so two
+    concurrent inserts of the same id serialize).
+    """
+
+    repo, recorded = _make_postgres_repo(monkeypatch)
+    account = _stub_account("acc_c", "c@example.com", chatgpt_id=None)
+
+    await repo.upsert(account, merge_by_email=False, merge_by_chatgpt_identity=False)
+
+    assert recorded["identity"] == ["acc_c"]
+    assert recorded["email"] == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_email_only_when_identity_not_in_play(monkeypatch):
+    """merge_by_email=True without identity reconciliation keeps the
+    pre-existing email-only lock behavior.
+    """
+
+    repo, recorded = _make_postgres_repo(monkeypatch)
+    account = _stub_account("acc_d", "d@example.com", chatgpt_id="chatgpt_qqq")
+
+    await repo.upsert(account, merge_by_email=True, merge_by_chatgpt_identity=False)
+
+    assert recorded["identity"] == [], "no identity lock when merge_by_chatgpt_identity is False"
+    assert recorded["email"] == ["d@example.com"]


### PR DESCRIPTION
## Why

OAuth reauth currently creates a second local account row with an `__copyN` suffix whenever the existing row's deterministic id collides under `merge_by_email=False` (issue [#788](https://github.com/Soju06/codex-lb/issues/788)). The original row — often deactivated because its refresh token was revoked — is left orphaned while the new row takes the active state. The dashboard then shows two rows for one upstream ChatGPT identity, and history-keyed tables become hard to reconcile.

## What

Add an identity-aware path on `AccountsRepository.upsert`:

- `merge_by_chatgpt_identity=True` (set by the OAuth reauth caller) finds the canonical row for the given `chatgpt_account_id` — preferring the oldest by `created_at` so long-term history stays attached — and applies the fresh tokens, plan, status, and deactivation-reason updates to that row.
- If duplicate rows already exist for the same upstream identity, reauth repoints dependent rows to the canonical account before deleting the duplicates: usage history, additional usage history, request logs, sticky sessions, HTTP bridge sessions, API key assignments, and limit-warmup state. Duplicate API key assignments and warmup window/reset collisions are de-duplicated instead of violating unique constraints.
- The path is intentionally independent of the dashboard `importWithoutOverwrite` setting. That setting governs the side-by-side import flow (two local rows for the same email when importing twice); reauth always reconciles to one local row per upstream identity.
- Falls through to the existing deterministic-id behavior when the incoming row has no `chatgpt_account_id`, so legacy local rows that pre-date the field keep working unchanged.
- Holds a chatgpt-id-scoped Postgres advisory lock on reauth so concurrent reauths for the same upstream identity serialize.

`OAuthService._persist_tokens` now passes `merge_by_chatgpt_identity=True` for both the direct-session and factory-session code paths.

## Tests

- `tests/integration/test_repositories.py` covers deactivated-row reuse, oldest-row preference when stray `__copy` rows already exist, dependent-row reconciliation, API key assignment de-dupe, warmup collision de-dupe, no-op create when no canonical match is found, and the no-upstream-id fall-through.
- `tests/integration/test_oauth_flow.py` pins the OAuth reauth contract: two reauths for the same upstream identity now land on one row, with the second reauth's plan applied in place. The duplicate-email conflict test was reworked so its precondition (two distinct local rows under one email) no longer relies on OAuth side-by-side, by using two distinct upstream ids.
- `openspec/changes/merge-reauth-by-chatgpt-identity/` documents the reauth identity merge and duplicate-row reconciliation contract.

Focused validation after the latest repair:

```bash
uv run pytest -q tests/integration/test_repositories.py tests/integration/test_oauth_flow.py tests/unit/test_accounts_repository_locks.py
uv run ruff check app/modules/accounts/repository.py app/modules/oauth/service.py tests/integration/test_repositories.py tests/integration/test_oauth_flow.py tests/unit/test_accounts_repository_locks.py openspec/changes/merge-reauth-by-chatgpt-identity/proposal.md openspec/changes/merge-reauth-by-chatgpt-identity/tasks.md
uv run ty check app/modules/accounts/repository.py app/modules/oauth/service.py tests/integration/test_repositories.py tests/integration/test_oauth_flow.py tests/unit/test_accounts_repository_locks.py
```

## Compatibility note for the renamed test

`test_device_oauth_flow_keeps_separate_accounts_when_import_without_overwrite_enabled` was pinning behavior that this issue calls out as the bug, so it has been renamed and its assertions inverted rather than kept alongside the new test. The `importWithoutOverwrite` setting still applies fully to the dashboard import path — only the OAuth reauth code path now reconciles by upstream identity.

Closes #788
