### PR TITLE
perf(dashboard): load projections in background

### DIFF
--- a/app/modules/dashboard/api.py
+++ b/app/modules/dashboard/api.py
@@ -5,7 +5,11 @@ from fastapi import APIRouter, Depends, Query
 from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
 from app.core.openai.model_registry import get_model_registry, is_public_model
 from app.dependencies import DashboardContext, get_dashboard_context
-from app.modules.dashboard.schemas import DashboardOverviewResponse, DashboardOverviewTimeframeKey
+from app.modules.dashboard.schemas import (
+    DashboardOverviewResponse,
+    DashboardOverviewTimeframeKey,
+    DashboardProjectionsResponse,
+)
 
 router = APIRouter(
     prefix="/api",
@@ -20,6 +24,13 @@ async def get_overview(
     context: DashboardContext = Depends(get_dashboard_context),
 ) -> DashboardOverviewResponse:
     return await context.service.get_overview(timeframe)
+
+
+@router.get("/dashboard/projections", response_model=DashboardProjectionsResponse)
+async def get_projections(
+    context: DashboardContext = Depends(get_dashboard_context),
+) -> DashboardProjectionsResponse:
+    return await context.service.get_projections()
 
 
 @router.get("/models")

--- a/app/modules/dashboard/schemas.py
+++ b/app/modules/dashboard/schemas.py
@@ -96,3 +96,9 @@ class DashboardOverviewResponse(DashboardModel):
     depletion_primary: DepletionResponse | None = None
     depletion_secondary: DepletionResponse | None = None
     weekly_credit_pace: WeeklyCreditPaceResponse | None = None
+
+
+class DashboardProjectionsResponse(DashboardModel):
+    depletion_primary: DepletionResponse | None = None
+    depletion_secondary: DepletionResponse | None = None
+    weekly_credit_pace: WeeklyCreditPaceResponse | None = None

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -18,6 +18,7 @@ from app.modules.dashboard.repository import DashboardRepository
 from app.modules.dashboard.schemas import (
     DashboardOverviewResponse,
     DashboardOverviewTimeframeKey,
+    DashboardProjectionsResponse,
     DashboardUsageWindows,
     DepletionResponse,
 )
@@ -115,109 +116,34 @@ class DashboardService:
             ),
         )
 
-        # Compute depletion separately for primary-window and secondary-window
-        # accounts so the aggregate is not skewed by mixing different window
-        # durations.  The response includes a "window" field that tells the
-        # frontend which donut to render the safe-line marker on.
-        normalized_primary_ids = {row.account_id for row in primary_rows}
-        all_account_ids = set(primary_usage.keys()) | set(secondary_usage.keys())
-
-        # Batch fetch: collect account IDs and determine the widest lookback
-        # per window so we can issue at most 2 bulk queries instead of O(N).
-        pri_fetch_ids: list[str] = []
-        sec_fetch_ids: list[str] = []
-        pri_since = now  # will be narrowed to the earliest needed
-        sec_since = now
-        # Per-account cutoffs for in-memory filtering after bulk fetch
-        pri_cutoffs: dict[str, datetime] = {}
-        sec_cutoffs: dict[str, datetime] = {}
-        weekly_only_ids: set[str] = set()
-        weekly_only_history_sources: dict[str, str] = {}
-
-        for account_id in all_account_ids:
-            if account_id in normalized_primary_ids:
-                usage_entry = primary_usage[account_id]
-                acct_window = usage_entry.window_minutes if usage_entry.window_minutes else 300
-                acct_since = now - timedelta(minutes=acct_window)
-                pri_fetch_ids.append(account_id)
-                pri_cutoffs[account_id] = acct_since
-                if acct_since < pri_since:
-                    pri_since = acct_since
-                if account_id in secondary_usage:
-                    sec_entry = secondary_usage[account_id]
-                    sec_window = sec_entry.window_minutes if sec_entry.window_minutes else 10080
-                    s_since = now - timedelta(minutes=sec_window)
-                    sec_fetch_ids.append(account_id)
-                    sec_cutoffs[account_id] = s_since
-                    if s_since < sec_since:
-                        sec_since = s_since
-            elif account_id in primary_usage:
-                weekly_only_ids.add(account_id)
-                primary_entry = primary_usage[account_id]
-                sec_entry = secondary_usage.get(account_id)
-                use_primary_stream = _should_use_weekly_primary_history(primary_entry, sec_entry)
-                weekly_only_history_sources[account_id] = "primary" if use_primary_stream else "secondary"
-                current_entry = primary_entry if use_primary_stream else sec_entry
-                acct_window = current_entry.window_minutes if current_entry and current_entry.window_minutes else 10080
-                acct_since = now - timedelta(minutes=acct_window)
-                if use_primary_stream:
-                    pri_fetch_ids.append(account_id)
-                    pri_cutoffs[account_id] = acct_since
-                    if acct_since < pri_since:
-                        pri_since = acct_since
-                else:
-                    sec_fetch_ids.append(account_id)
-                    sec_cutoffs[account_id] = acct_since
-                    if acct_since < sec_since:
-                        sec_since = acct_since
-            else:
-                sec_entry = secondary_usage[account_id]
-                acct_window = sec_entry.window_minutes if sec_entry.window_minutes else 10080
-                acct_since = now - timedelta(minutes=acct_window)
-                sec_fetch_ids.append(account_id)
-                sec_cutoffs[account_id] = acct_since
-                if acct_since < sec_since:
-                    sec_since = acct_since
-
-        # Issue at most 2 bulk queries
-        all_pri_rows = (
-            await self._repo.bulk_usage_history_since(pri_fetch_ids, "primary", pri_since) if pri_fetch_ids else {}
-        )
-        all_sec_rows = (
-            await self._repo.bulk_usage_history_since(sec_fetch_ids, "secondary", sec_since) if sec_fetch_ids else {}
+        additional_ts = await self._repo.latest_additional_recorded_at()
+        return DashboardOverviewResponse(
+            last_sync_at=_latest_recorded_at(primary_usage, secondary_usage, additional_ts),
+            timeframe=build_overview_timeframe(overview_timeframe),
+            accounts=account_summaries,
+            summary=summary,
+            windows=windows,
+            trends=trends,
         )
 
-        # Filter in-memory to each account's actual cutoff
-        primary_history: dict[str, list[UsageHistory]] = {}
-        secondary_history: dict[str, list[UsageHistory]] = {}
-
-        for account_id in all_account_ids:
-            if account_id in normalized_primary_ids:
-                cutoff = pri_cutoffs[account_id]
-                rows = filter_depletion_history_since(all_pri_rows.get(account_id, []), cutoff)
-                if rows:
-                    primary_history[account_id] = rows
-                if account_id in sec_cutoffs:
-                    s_cutoff = sec_cutoffs[account_id]
-                    s_rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), s_cutoff)
-                    if s_rows:
-                        secondary_history[account_id] = s_rows
-            elif account_id in weekly_only_ids:
-                source = weekly_only_history_sources[account_id]
-                if source == "primary":
-                    cutoff = pri_cutoffs[account_id]
-                    rows = filter_depletion_history_since(all_pri_rows.get(account_id, []), cutoff)
-                else:
-                    cutoff = sec_cutoffs[account_id]
-                    rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), cutoff)
-                if rows:
-                    secondary_history[account_id] = rows
-            else:
-                cutoff = sec_cutoffs[account_id]
-                rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), cutoff)
-                if rows:
-                    secondary_history[account_id] = rows
-
+    async def get_projections(self) -> DashboardProjectionsResponse:
+        now = utcnow()
+        accounts = await self._repo.list_accounts()
+        primary_usage = await self._repo.latest_usage_by_account("primary")
+        secondary_usage = await self._repo.latest_usage_by_account("secondary")
+        account_summaries = build_account_summaries(
+            accounts=accounts,
+            primary_usage=primary_usage,
+            secondary_usage=secondary_usage,
+            encryptor=self._encryptor,
+            include_auth=False,
+        )
+        primary_history, secondary_history = await _load_projection_histories(
+            self._repo,
+            primary_usage,
+            secondary_usage,
+            now,
+        )
         pri_depletion, sec_depletion = _build_depletion_by_window(primary_history, secondary_history, now)
         settings = get_settings()
         weekly_credit_pace = build_weekly_credit_pace(
@@ -227,19 +153,120 @@ class DashboardService:
             now=now,
             usage_refresh_interval_seconds=settings.usage_refresh_interval_seconds,
         )
-
-        additional_ts = await self._repo.latest_additional_recorded_at()
-        return DashboardOverviewResponse(
-            last_sync_at=_latest_recorded_at(primary_usage, secondary_usage, additional_ts),
-            timeframe=build_overview_timeframe(overview_timeframe),
-            accounts=account_summaries,
-            summary=summary,
-            windows=windows,
-            trends=trends,
+        return DashboardProjectionsResponse(
             depletion_primary=pri_depletion,
             depletion_secondary=sec_depletion,
             weekly_credit_pace=weekly_credit_pace,
         )
+
+
+async def _load_projection_histories(
+    repo: DashboardRepository,
+    primary_usage: dict[str, UsageHistory],
+    secondary_usage: dict[str, UsageHistory],
+    now: datetime,
+) -> tuple[dict[str, list[UsageHistory]], dict[str, list[UsageHistory]]]:
+    # Compute depletion separately for primary-window and secondary-window
+    # accounts so the aggregate is not skewed by mixing different window durations.
+    primary_rows_raw = _rows_from_latest(primary_usage)
+    secondary_rows_raw = _rows_from_latest(secondary_usage)
+    primary_rows, _ = usage_core.normalize_weekly_only_rows(
+        primary_rows_raw,
+        secondary_rows_raw,
+    )
+    normalized_primary_ids = {row.account_id for row in primary_rows}
+    all_account_ids = set(primary_usage.keys()) | set(secondary_usage.keys())
+
+    # Batch fetch: collect account IDs and determine the widest lookback per
+    # window so we can issue at most 2 bulk queries instead of O(N).
+    pri_fetch_ids: list[str] = []
+    sec_fetch_ids: list[str] = []
+    pri_since = now
+    sec_since = now
+    pri_cutoffs: dict[str, datetime] = {}
+    sec_cutoffs: dict[str, datetime] = {}
+    weekly_only_ids: set[str] = set()
+    weekly_only_history_sources: dict[str, str] = {}
+
+    for account_id in all_account_ids:
+        if account_id in normalized_primary_ids:
+            usage_entry = primary_usage[account_id]
+            acct_window = usage_entry.window_minutes if usage_entry.window_minutes else 300
+            acct_since = now - timedelta(minutes=acct_window)
+            pri_fetch_ids.append(account_id)
+            pri_cutoffs[account_id] = acct_since
+            if acct_since < pri_since:
+                pri_since = acct_since
+            if account_id in secondary_usage:
+                sec_entry = secondary_usage[account_id]
+                sec_window = sec_entry.window_minutes if sec_entry.window_minutes else 10080
+                s_since = now - timedelta(minutes=sec_window)
+                sec_fetch_ids.append(account_id)
+                sec_cutoffs[account_id] = s_since
+                if s_since < sec_since:
+                    sec_since = s_since
+        elif account_id in primary_usage:
+            weekly_only_ids.add(account_id)
+            primary_entry = primary_usage[account_id]
+            sec_entry = secondary_usage.get(account_id)
+            use_primary_stream = _should_use_weekly_primary_history(primary_entry, sec_entry)
+            weekly_only_history_sources[account_id] = "primary" if use_primary_stream else "secondary"
+            current_entry = primary_entry if use_primary_stream else sec_entry
+            acct_window = current_entry.window_minutes if current_entry and current_entry.window_minutes else 10080
+            acct_since = now - timedelta(minutes=acct_window)
+            if use_primary_stream:
+                pri_fetch_ids.append(account_id)
+                pri_cutoffs[account_id] = acct_since
+                if acct_since < pri_since:
+                    pri_since = acct_since
+            else:
+                sec_fetch_ids.append(account_id)
+                sec_cutoffs[account_id] = acct_since
+                if acct_since < sec_since:
+                    sec_since = acct_since
+        else:
+            sec_entry = secondary_usage[account_id]
+            acct_window = sec_entry.window_minutes if sec_entry.window_minutes else 10080
+            acct_since = now - timedelta(minutes=acct_window)
+            sec_fetch_ids.append(account_id)
+            sec_cutoffs[account_id] = acct_since
+            if acct_since < sec_since:
+                sec_since = acct_since
+
+    all_pri_rows = await repo.bulk_usage_history_since(pri_fetch_ids, "primary", pri_since) if pri_fetch_ids else {}
+    all_sec_rows = await repo.bulk_usage_history_since(sec_fetch_ids, "secondary", sec_since) if sec_fetch_ids else {}
+
+    primary_history: dict[str, list[UsageHistory]] = {}
+    secondary_history: dict[str, list[UsageHistory]] = {}
+
+    for account_id in all_account_ids:
+        if account_id in normalized_primary_ids:
+            cutoff = pri_cutoffs[account_id]
+            rows = filter_depletion_history_since(all_pri_rows.get(account_id, []), cutoff)
+            if rows:
+                primary_history[account_id] = rows
+            if account_id in sec_cutoffs:
+                s_cutoff = sec_cutoffs[account_id]
+                s_rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), s_cutoff)
+                if s_rows:
+                    secondary_history[account_id] = s_rows
+        elif account_id in weekly_only_ids:
+            source = weekly_only_history_sources[account_id]
+            if source == "primary":
+                cutoff = pri_cutoffs[account_id]
+                rows = filter_depletion_history_since(all_pri_rows.get(account_id, []), cutoff)
+            else:
+                cutoff = sec_cutoffs[account_id]
+                rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), cutoff)
+            if rows:
+                secondary_history[account_id] = rows
+        else:
+            cutoff = sec_cutoffs[account_id]
+            rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), cutoff)
+            if rows:
+                secondary_history[account_id] = rows
+
+    return primary_history, secondary_history
 
 
 def _build_depletion_by_window(

--- a/frontend/src/features/accounts/hooks/use-accounts.test.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.test.ts
@@ -45,6 +45,7 @@ describe("useAccounts", () => {
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "list"] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "projections"] });
     });
   });
 
@@ -93,6 +94,7 @@ describe("useAccounts", () => {
       expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-export");
       expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["accounts", "list"] });
       expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
+      expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "projections"] });
     } finally {
       clickSpy.mockRestore();
       Object.defineProperty(URL, "createObjectURL", {

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -14,6 +14,7 @@ import {
 function invalidateAccountRelatedQueries(queryClient: ReturnType<typeof useQueryClient>) {
   void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
   void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
+  void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
 }
 
 /**

--- a/frontend/src/features/dashboard/api.ts
+++ b/frontend/src/features/dashboard/api.ts
@@ -3,6 +3,7 @@ import { get } from "@/lib/api-client";
 import {
   DEFAULT_OVERVIEW_TIMEFRAME,
   DashboardOverviewSchema,
+  DashboardProjectionsSchema,
   RequestLogFilterOptionsSchema,
   RequestLogsResponseSchema,
   type OverviewTimeframe,
@@ -50,6 +51,10 @@ export function getDashboardOverview(params: DashboardOverviewParams = {}) {
   const query = new URLSearchParams();
   query.set("timeframe", params.timeframe ?? DEFAULT_OVERVIEW_TIMEFRAME);
   return get(`${DASHBOARD_PATH}/overview?${query.toString()}`, DashboardOverviewSchema);
+}
+
+export function getDashboardProjections() {
+  return get(`${DASHBOARD_PATH}/projections`, DashboardProjectionsSchema);
 }
 
 export function getRequestLogs(params: RequestLogsListFilters = {}) {

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -13,7 +13,7 @@ import { RecentRequestsTable } from "@/features/dashboard/components/recent-requ
 import { StatsGrid } from "@/features/dashboard/components/stats-grid";
 import { UsageDonuts } from "@/features/dashboard/components/usage-donuts";
 import { WeeklyCreditsPaceCard } from "@/features/dashboard/components/weekly-credits-pace-card";
-import { useDashboard } from "@/features/dashboard/hooks/use-dashboard";
+import { useDashboard, useDashboardProjections } from "@/features/dashboard/hooks/use-dashboard";
 import { useRequestLogs } from "@/features/dashboard/hooks/use-request-logs";
 import { buildDashboardView } from "@/features/dashboard/utils";
 import {
@@ -40,10 +40,11 @@ export function DashboardPage() {
     [searchParams],
   );
   const dashboardQuery = useDashboard(overviewTimeframe);
+  const projectionsQuery = useDashboardProjections(Boolean(dashboardQuery.data));
   const { filters, logsQuery, optionsQuery, updateFilters } = useRequestLogs();
   const { resumeMutation } = useAccountMutations();
 
-  const isRefreshing = dashboardQuery.isFetching || logsQuery.isFetching;
+  const isRefreshing = dashboardQuery.isFetching || projectionsQuery.isFetching || logsQuery.isFetching;
 
   const handleRefresh = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: ["dashboard"] });
@@ -86,11 +87,16 @@ export function DashboardPage() {
     if (!overview || !logPage) {
       return null;
     }
-    return buildDashboardView(overview, logPage.requests, {
-      isDark,
-      showAccountBurnrate,
-    });
-  }, [overview, logPage, isDark, showAccountBurnrate]);
+    return buildDashboardView(
+      overview,
+      logPage.requests,
+      {
+        isDark,
+        showAccountBurnrate,
+      },
+      projectionsQuery.data,
+    );
+  }, [overview, logPage, isDark, showAccountBurnrate, projectionsQuery.data]);
 
   const accountOptions = useMemo(() => {
     const entries = new Map<string, { label: string; isEmail: boolean }>();

--- a/frontend/src/features/dashboard/hooks/use-dashboard.ts
+++ b/frontend/src/features/dashboard/hooks/use-dashboard.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getDashboardOverview } from "@/features/dashboard/api";
+import { getDashboardOverview, getDashboardProjections } from "@/features/dashboard/api";
 import {
   DEFAULT_OVERVIEW_TIMEFRAME,
   type OverviewTimeframe,
@@ -10,6 +10,17 @@ export function useDashboard(timeframe: OverviewTimeframe = DEFAULT_OVERVIEW_TIM
   return useQuery({
     queryKey: ["dashboard", "overview", timeframe],
     queryFn: () => getDashboardOverview({ timeframe }),
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function useDashboardProjections(enabled = true) {
+  return useQuery({
+    queryKey: ["dashboard", "projections"],
+    queryFn: getDashboardProjections,
+    enabled,
     refetchInterval: 30_000,
     refetchIntervalInBackground: false,
     refetchOnWindowFocus: true,

--- a/frontend/src/features/dashboard/schemas.ts
+++ b/frontend/src/features/dashboard/schemas.ts
@@ -127,6 +127,12 @@ export const DashboardOverviewSchema = z.object({
   weeklyCreditPace: WeeklyCreditPaceSchema.nullable().optional(),
 });
 
+export const DashboardProjectionsSchema = z.object({
+  depletionPrimary: DepletionSchema.nullable().optional(),
+  depletionSecondary: DepletionSchema.nullable().optional(),
+  weeklyCreditPace: WeeklyCreditPaceSchema.nullable().optional(),
+});
+
 export const RequestLogCostBreakdownSchema = z.object({
   inputUsd: z.number().nullable().optional().default(null),
   cachedInputUsd: z.number().nullable().optional().default(null),
@@ -196,6 +202,7 @@ export const FilterStateSchema = z.object({
 
 export type DashboardMetrics = z.infer<typeof DashboardMetricsSchema>;
 export type DashboardOverview = z.infer<typeof DashboardOverviewSchema>;
+export type DashboardProjections = z.infer<typeof DashboardProjectionsSchema>;
 export type DashboardOverviewTimeframe = z.infer<typeof DashboardOverviewTimeframeSchema>;
 export type TrendPoint = z.infer<typeof TrendPointSchema>;
 export type MetricsTrends = z.infer<typeof MetricsTrendsSchema>;

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -3,6 +3,7 @@ import { Activity, AlertTriangle, Coins, DollarSign, Flame, type LucideIcon } fr
 import type {
   AccountSummary,
   DashboardOverview,
+  DashboardProjections,
   Depletion,
   RequestLog,
   TrendPoint,
@@ -698,6 +699,7 @@ export function buildDashboardView(
   overview: DashboardOverview,
   requestLogs: RequestLog[],
   optionsOrIsDark: DashboardViewOptions | boolean = false,
+  projections?: DashboardProjections,
 ): DashboardView {
   const { isDark, showAccountBurnrate } = resolveDashboardViewOptions(optionsOrIsDark);
   const primaryWindow = overview.windows.primary;
@@ -794,11 +796,13 @@ export function buildDashboardView(
     primaryTotal: sumRemaining(primaryUsageItems),
     secondaryTotal: sumRemaining(secondaryUsageItems),
     requestLogs,
-    safeLinePrimary: buildDepletionView(overview.depletionPrimary),
-    safeLineSecondary: buildDepletionView(overview.depletionSecondary),
+    safeLinePrimary: buildDepletionView(projections?.depletionPrimary ?? overview.depletionPrimary),
+    safeLineSecondary: buildDepletionView(projections?.depletionSecondary ?? overview.depletionSecondary),
     weeklyCreditPace:
-      overview.weeklyCreditPace !== undefined
-        ? overview.weeklyCreditPace
-        : buildWeeklyCreditPace(overview.accounts),
+      projections?.weeklyCreditPace !== undefined
+        ? projections.weeklyCreditPace
+        : overview.weeklyCreditPace !== undefined
+          ? overview.weeklyCreditPace
+          : buildWeeklyCreditPace(overview.accounts),
   };
 }

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -29,6 +29,7 @@ import type { AuthSession } from "@/features/auth/schemas";
 import { AuthSessionSchema } from "@/features/auth/schemas";
 import type {
 	DashboardOverview,
+	DashboardProjections,
 	RequestLog,
 	RequestLogFilterOptions,
 	RequestLogsResponse,
@@ -37,6 +38,7 @@ import type {
 import {
 	DEFAULT_OVERVIEW_TIMEFRAME,
 	DashboardOverviewSchema,
+	DashboardProjectionsSchema,
 	RequestLogFilterOptionsSchema,
 	RequestLogSchema,
 	RequestLogsResponseSchema,
@@ -53,6 +55,7 @@ export type {
 	AccountSummary,
 	AccountTrendsResponse,
 	DashboardOverview,
+	DashboardProjections,
 	RequestLogsResponse,
 	RequestLogFilterOptions,
 	DashboardSettings,
@@ -242,6 +245,31 @@ export function createDashboardOverview(
 		...overrides,
 	};
 	return DashboardOverviewSchema.parse(response);
+}
+
+export function createDashboardProjections(
+	overrides: Partial<DashboardProjections> = {},
+): DashboardProjections {
+	return DashboardProjectionsSchema.parse({
+		depletionPrimary: {
+			risk: 0.55,
+			riskLevel: "warning" as const,
+			burnRate: 1.1,
+			safeUsagePercent: 72.0,
+			projectedExhaustionAt: null,
+			secondsUntilExhaustion: null,
+		},
+		depletionSecondary: {
+			risk: 0.65,
+			riskLevel: "warning" as const,
+			burnRate: 1.4,
+			safeUsagePercent: 58.0,
+			projectedExhaustionAt: null,
+			secondsUntilExhaustion: null,
+		},
+		weeklyCreditPace: null,
+		...overrides,
+	});
 }
 
 export function createRequestLogEntry(

--- a/frontend/src/test/mocks/handler-coverage.test.ts
+++ b/frontend/src/test/mocks/handler-coverage.test.ts
@@ -24,6 +24,7 @@ const EXPECTED_ENDPOINTS = [
 	"GET /health",
 	// dashboard
 	"GET /api/dashboard/overview",
+	"GET /api/dashboard/projections",
 	"GET /api/request-logs",
 	"GET /api/request-logs/options",
 	// accounts

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -13,6 +13,7 @@ import {
 	createApiKeyUsage7Day,
 	createDashboardAuthSession,
 	createDashboardOverview,
+	createDashboardProjections,
 	createDashboardSettings,
 	createDefaultAccounts,
 	createDefaultApiKeys,
@@ -321,6 +322,10 @@ export const handlers = [
 				accounts: state.accounts,
 			}),
 		);
+	}),
+
+	http.get("/api/dashboard/projections", () => {
+		return HttpResponse.json(createDashboardProjections());
 	}),
 
 	http.get("/api/request-logs", ({ request }) => {

--- a/openspec/changes/lazy-dashboard-projections/proposal.md
+++ b/openspec/changes/lazy-dashboard-projections/proposal.md
@@ -1,0 +1,22 @@
+# lazy-dashboard-projections
+
+## Why
+
+Dashboard startup was blocked by quota projection work in `GET /api/dashboard/overview`.
+On live data, the heavy depletion and weekly-credit projection pass can take around 12
+seconds, even though the dashboard's primary cards, donuts, accounts, and request logs
+can render from cheaper queries much earlier.
+
+## What Changes
+
+- Keep `GET /api/dashboard/overview` focused on fast dashboard data.
+- Add `GET /api/dashboard/projections` for depletion safe-lines and weekly-credit pace.
+- Fetch projections in the SPA after overview data is available, so the web interface
+  can render first and fill projection-only elements in the background.
+- Keep frontend compatibility with older overview payloads that still include projection
+  fields.
+
+## Impact
+
+The dashboard can show its main interface before long-running projection calculations
+finish. Projection data still refreshes, but it no longer blocks initial page load.

--- a/openspec/changes/lazy-dashboard-projections/specs/frontend-architecture/spec.md
+++ b/openspec/changes/lazy-dashboard-projections/specs/frontend-architecture/spec.md
@@ -1,3 +1,5 @@
+## ADDED Requirements
+
 ### Requirement: Dashboard projections load after the primary dashboard data
 
 The dashboard SPA SHALL render primary dashboard content from `GET /api/dashboard/overview`

--- a/openspec/changes/lazy-dashboard-projections/specs/frontend-architecture/spec.md
+++ b/openspec/changes/lazy-dashboard-projections/specs/frontend-architecture/spec.md
@@ -1,0 +1,20 @@
+### Requirement: Dashboard projections load after the primary dashboard data
+
+The dashboard SPA SHALL render primary dashboard content from `GET /api/dashboard/overview`
+and recent request-log data without waiting for depletion or weekly-credit projection
+calculations. Projection-only data, including safe-line depletion markers and weekly-credit
+pace, SHALL be available from `GET /api/dashboard/projections` and fetched after overview
+data is available.
+
+#### Scenario: Main dashboard renders before projections finish
+
+- **GIVEN** an authenticated operator opens the dashboard
+- **WHEN** `GET /api/dashboard/overview` and request-log calls complete before `GET /api/dashboard/projections`
+- **THEN** the dashboard renders the primary cards, usage donuts, account list, and request-log surface
+- **AND** projection-only safe-line and weekly-credit fields may populate later when the projections response arrives
+
+#### Scenario: Projection endpoint exposes heavy dashboard calculations
+
+- **WHEN** the dashboard client requests `GET /api/dashboard/projections`
+- **THEN** the response includes depletion safe-line data and weekly-credit pace data when those calculations are available
+- **AND** the overview endpoint does not need to compute those fields for initial page render

--- a/openspec/changes/lazy-dashboard-projections/tasks.md
+++ b/openspec/changes/lazy-dashboard-projections/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [x] Split projection fields out of the overview backend path.
+- [x] Add an authenticated `/api/dashboard/projections` endpoint.
+- [x] Fetch projections from the dashboard SPA after overview data is present.
+- [x] Use projection payload data for safe-line and weekly-credit views while preserving
+  fallback behavior for older overview responses.
+
+## 2. Verification
+
+- [x] Cover projection endpoint behavior in dashboard integration tests.
+- [x] Cover frontend schemas, hooks, utilities, and mocks.
+- [x] Run targeted backend and frontend validation.

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -307,7 +307,7 @@ async def test_dashboard_overview_counts_prolite_capacity(async_client, db_setup
 
 
 @pytest.mark.asyncio
-async def test_dashboard_overview_weekly_credit_pace_excludes_inactive_and_stale_accounts(
+async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_stale_accounts(
     async_client,
     db_setup,
     monkeypatch: pytest.MonkeyPatch,
@@ -356,7 +356,7 @@ async def test_dashboard_overview_weekly_credit_pace_excludes_inactive_and_stale
             recorded_at=fixed_now - timedelta(minutes=1),
         )
 
-    response = await async_client.get("/api/dashboard/overview")
+    response = await async_client.get("/api/dashboard/projections")
     assert response.status_code == 200
     payload = response.json()
 
@@ -372,7 +372,7 @@ async def test_dashboard_overview_weekly_credit_pace_excludes_inactive_and_stale
 
 
 @pytest.mark.asyncio
-async def test_dashboard_overview_weekly_credit_pace_forecast_uses_recent_slope_not_full_window_average(
+async def test_dashboard_projections_weekly_credit_pace_forecast_uses_recent_slope_not_full_window_average(
     async_client,
     db_setup,
     monkeypatch: pytest.MonkeyPatch,
@@ -411,7 +411,7 @@ async def test_dashboard_overview_weekly_credit_pace_forecast_uses_recent_slope_
             recorded_at=fixed_now - timedelta(minutes=1),
         )
 
-    response = await async_client.get("/api/dashboard/overview")
+    response = await async_client.get("/api/dashboard/projections")
     assert response.status_code == 200
     payload = response.json()
 
@@ -428,7 +428,7 @@ async def test_dashboard_overview_weekly_credit_pace_forecast_uses_recent_slope_
 
 
 @pytest.mark.asyncio
-async def test_dashboard_overview_computes_depletion_from_recent_db_history(async_client, db_setup):
+async def test_dashboard_projections_compute_depletion_from_recent_db_history(async_client, db_setup):
     now = utcnow().replace(microsecond=0)
 
     async with SessionLocal() as session:
@@ -453,7 +453,7 @@ async def test_dashboard_overview_computes_depletion_from_recent_db_history(asyn
             recorded_at=now - timedelta(minutes=5),
         )
 
-    response = await async_client.get("/api/dashboard/overview")
+    response = await async_client.get("/api/dashboard/projections")
     assert response.status_code == 200
 
     payload = response.json()
@@ -463,7 +463,7 @@ async def test_dashboard_overview_computes_depletion_from_recent_db_history(asyn
 
 
 @pytest.mark.asyncio
-async def test_dashboard_overview_weekly_only_depletion_uses_current_stream(async_client, db_setup):
+async def test_dashboard_projections_weekly_only_depletion_uses_current_stream(async_client, db_setup):
     now = utcnow().replace(microsecond=0)
     reset_at = int(naive_utc_to_epoch(now + timedelta(minutes=30)))
 
@@ -506,7 +506,7 @@ async def test_dashboard_overview_weekly_only_depletion_uses_current_stream(asyn
             recorded_at=now - timedelta(minutes=1),
         )
 
-    response = await async_client.get("/api/dashboard/overview")
+    response = await async_client.get("/api/dashboard/projections")
     assert response.status_code == 200
 
     payload = response.json()


### PR DESCRIPTION
﻿## Summary

This PR moves the heavy dashboard projection work out of the initial overview request.

`GET /api/dashboard/overview` now returns the fast dashboard data needed for the main web UI, while `GET /api/dashboard/projections` returns depletion safe-lines and weekly-credit pace. The dashboard SPA starts loading `/api/dashboard/projections` in the background after overview data exists, so the web interface can render first instead of waiting for long-running projection calculations.

## Why

On live data, projection calculations were taking about 12 seconds and blocked the dashboard's first render. After this split, the primary dashboard surface can load from the faster overview and request-log calls, while projection-only widgets fill in later.

## Changes

- Add authenticated `GET /api/dashboard/projections` backend endpoint.
- Move depletion and weekly-credit pace calculation out of `GET /api/dashboard/overview`.
- Add frontend query/schema/API wiring for background projection loading.
- Use projection results for safe-line and weekly-credit UI data, with fallback support for older overview payloads.
- Update MSW mocks, frontend tests, backend integration tests, and OpenSpec change notes.

## Validation

- `python -m pytest tests/integration/test_dashboard_overview.py -q`
- `python -m ruff check app/modules/dashboard/api.py app/modules/dashboard/schemas.py app/modules/dashboard/service.py tests/integration/test_dashboard_overview.py`
- `bun run typecheck`
- `bun run test src/features/dashboard/hooks/use-dashboard.test.ts src/features/dashboard/utils.test.ts src/features/dashboard/schemas.test.ts src/test/mocks/handler-coverage.test.ts`
- `bun run build` was run during live Docker image validation

Note: `openspec` CLI was not available in the local PATH, so the OpenSpec change was added but not CLI-validated locally.

## Live validation

This change has also been smoke-tested on the live deployment. A Chrome DevTools trace after rollout showed the first dashboard render around 1 second LCP, with `/api/dashboard/projections` continuing in the background.
