### PR TITLE
fix(proxy): classify stale Codex websocket anchors

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -43,6 +43,8 @@ class ResponseFailedEvent(TypedDict):
 
 
 PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE = "Upstream websocket closed before response.completed"
+PREVIOUS_RESPONSE_STALE_CODE = "codex_previous_response_stale"
+PREVIOUS_RESPONSE_STALE_MESSAGE = "Upstream previous response anchor expired; retry without previous_response_id."
 
 
 def openai_error(code: str, message: str, error_type: str = "server_error") -> OpenAIErrorEnvelope:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7388,6 +7388,13 @@ class ProxyService:
 
         if len(grouped_previous_response_request_states) > 1:
             session.upstream_control.reconnect_requested = True
+            grouped_error_reason = (
+                "previous_response_not_found"
+                if is_previous_response_not_found_event
+                else "missing_tool_output"
+                if is_missing_tool_output_event
+                else "stream_incomplete"
+            )
             for grouped_request_state in grouped_previous_response_request_states:
                 grouped_request_state.error_http_status_override = 502
                 (
@@ -7398,7 +7405,7 @@ class ProxyService:
                     grouped_event_type,
                 ) = _build_stream_incomplete_terminal_event_for_request(
                     grouped_request_state,
-                    reason="previous_response_not_found",
+                    reason=grouped_error_reason,
                 )
                 if grouped_request_state.event_queue is not None:
                     await grouped_request_state.event_queue.put(grouped_event_block)
@@ -8299,6 +8306,13 @@ class ProxyService:
         if len(grouped_previous_response_request_states) > 1:
             upstream_control.reconnect_requested = True
             downstream_texts: list[str] = []
+            grouped_error_reason = (
+                "previous_response_not_found"
+                if is_previous_response_not_found_event
+                else "missing_tool_output"
+                if is_missing_tool_output_event
+                else "stream_incomplete"
+            )
             for grouped_request_state in grouped_previous_response_request_states:
                 (
                     grouped_downstream_text,
@@ -8308,7 +8322,7 @@ class ProxyService:
                     grouped_event_type,
                 ) = _build_stream_incomplete_terminal_event_for_request(
                     grouped_request_state,
-                    reason="previous_response_not_found",
+                    reason=grouped_error_reason,
                 )
                 downstream_texts.append(grouped_downstream_text)
                 await self._finalize_websocket_request_state(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -71,6 +71,8 @@ from app.core.config.settings import DEFAULT_HOME_DIR, Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
+    PREVIOUS_RESPONSE_STALE_CODE,
+    PREVIOUS_RESPONSE_STALE_MESSAGE,
     PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
     OpenAIErrorDetail,
     OpenAIErrorEnvelope,
@@ -3551,6 +3553,7 @@ class ProxyService:
                                     error_code="upstream_error",
                                     error_message="Upstream error",
                                     surface="websocket_connect",
+                                    expose_stale_previous_response_classifier=codex_session_affinity,
                                 )
                                 async with client_send_lock:
                                     await websocket.send_text(
@@ -4018,6 +4021,7 @@ class ProxyService:
         except ProxyResponseError:
             await self._release_websocket_reservation(reservation)
             raise
+        request_state.expose_stale_previous_response_classifier = codex_session_affinity
         if session_anchor is not None:
             request_state.proxy_injected_previous_response_id = True
             request_state.input_item_count = original_input_item_count or request_state.input_item_count
@@ -7392,7 +7396,10 @@ class ProxyService:
                     grouped_event,
                     grouped_payload,
                     grouped_event_type,
-                ) = _build_stream_incomplete_terminal_event_for_request(grouped_request_state)
+                ) = _build_stream_incomplete_terminal_event_for_request(
+                    grouped_request_state,
+                    reason="previous_response_not_found",
+                )
                 if grouped_request_state.event_queue is not None:
                     await grouped_request_state.event_queue.put(grouped_event_block)
                     await grouped_request_state.event_queue.put(None)
@@ -7934,6 +7941,7 @@ class ProxyService:
                         upstream_control=upstream_control,
                         response_create_gate=response_create_gate,
                         continuity_state=continuity_state,
+                        codex_session_affinity=codex_session_affinity,
                     )
                     suppress_downstream_event = upstream_control.suppress_downstream_event
                     downstream_texts = upstream_control.downstream_texts
@@ -8122,6 +8130,7 @@ class ProxyService:
         upstream_control: _WebSocketUpstreamControl,
         response_create_gate: asyncio.Semaphore,
         continuity_state: "_WebSocketContinuityState | None" = None,
+        codex_session_affinity: bool = False,
     ) -> str:
         event_block = f"data: {text}\n\n"
         payload = parse_sse_data_json(event_block)
@@ -8297,7 +8306,10 @@ class ProxyService:
                     grouped_event,
                     grouped_payload,
                     grouped_event_type,
-                ) = _build_stream_incomplete_terminal_event_for_request(grouped_request_state)
+                ) = _build_stream_incomplete_terminal_event_for_request(
+                    grouped_request_state,
+                    reason="previous_response_not_found",
+                )
                 downstream_texts.append(grouped_downstream_text)
                 await self._finalize_websocket_request_state(
                     grouped_request_state,
@@ -8322,12 +8334,16 @@ class ProxyService:
         if request_state is None:
             if is_previous_response_not_found_event:
                 upstream_control.reconnect_requested = True
+                fallback_error_code, fallback_error_message = _websocket_continuity_error_fields(
+                    reason="previous_response_not_found",
+                    expose_stale_previous_response_classifier=codex_session_affinity,
+                )
                 downstream_text = json.dumps(
                     cast(
                         dict[str, JsonValue],
                         response_failed_event(
-                            "stream_incomplete",
-                            "Upstream websocket closed before response.completed",
+                            fallback_error_code,
+                            fallback_error_message,
                             error_type="server_error",
                             response_id=get_request_id(),
                         ),
@@ -11441,6 +11457,7 @@ class _WebSocketRequestState:
     previous_response_id: str | None = None
     session_id: str | None = None
     proxy_injected_previous_response_id: bool = False
+    expose_stale_previous_response_classifier: bool = False
     fresh_upstream_request_text: str | None = None
     # True only when ``fresh_upstream_request_text`` contains a *safe* pre-
     # injection form of this request that can be replayed as a fresh turn.
@@ -12347,6 +12364,16 @@ def _maybe_rewrite_websocket_previous_response_not_found_event(
     )
 
 
+def _websocket_continuity_error_fields(
+    *,
+    reason: str,
+    expose_stale_previous_response_classifier: bool,
+) -> tuple[str, str]:
+    if reason == "previous_response_not_found" and expose_stale_previous_response_classifier:
+        return PREVIOUS_RESPONSE_STALE_CODE, PREVIOUS_RESPONSE_STALE_MESSAGE
+    return "stream_incomplete", PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE
+
+
 def _rewrite_websocket_continuity_corruption_event(
     *,
     request_state: _WebSocketRequestState,
@@ -12364,9 +12391,13 @@ def _rewrite_websocket_continuity_corruption_event(
         previous_response_id=request_state.previous_response_id,
         session_id=request_state.session_id,
     )
+    rewritten_code, rewritten_message = _websocket_continuity_error_fields(
+        reason=reason,
+        expose_stale_previous_response_classifier=request_state.expose_stale_previous_response_classifier,
+    )
     rewritten_event_payload = response_failed_event(
-        "stream_incomplete",
-        PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+        rewritten_code,
+        rewritten_message,
         error_type="server_error",
         response_id=_websocket_downstream_response_id(request_state),
     )
@@ -12436,6 +12467,7 @@ def _sanitize_websocket_connect_failure(
         error_code=error_code,
         error_message=error_message,
         surface="websocket_connect",
+        expose_stale_previous_response_classifier=request_state.expose_stale_previous_response_classifier,
     )
 
 
@@ -12448,6 +12480,7 @@ def _sanitize_websocket_previous_response_error(
     error_code: str,
     error_message: str,
     surface: str,
+    expose_stale_previous_response_classifier: bool = False,
 ) -> tuple[int, OpenAIErrorEnvelope, str, str]:
     if previous_response_id is None:
         return status_code, payload, error_code, error_message
@@ -12473,7 +12506,10 @@ def _sanitize_websocket_previous_response_error(
     if not should_rewrite:
         return status_code, payload, error_code, error_message
 
-    rewritten_message = PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE
+    rewritten_code, rewritten_message = _websocket_continuity_error_fields(
+        reason=reason,
+        expose_stale_previous_response_classifier=expose_stale_previous_response_classifier,
+    )
     _record_continuity_fail_closed(
         surface=surface,
         reason=reason,
@@ -12484,11 +12520,11 @@ def _sanitize_websocket_previous_response_error(
     return (
         502,
         openai_error(
-            "stream_incomplete",
+            rewritten_code,
             rewritten_message,
             error_type="server_error",
         ),
-        "stream_incomplete",
+        rewritten_code,
         rewritten_message,
     )
 
@@ -12515,9 +12551,13 @@ def _sanitize_websocket_terminal_error_fields(
         session_id=request_state.session_id,
         upstream_error_code=normalized_code,
     )
+    rewritten_code, rewritten_message = _websocket_continuity_error_fields(
+        reason="previous_response_not_found",
+        expose_stale_previous_response_classifier=request_state.expose_stale_previous_response_classifier,
+    )
     return (
-        "stream_incomplete",
-        PREVIOUS_RESPONSE_STREAM_INCOMPLETE_MESSAGE,
+        rewritten_code,
+        rewritten_message,
         "server_error",
         None,
     )
@@ -12872,18 +12912,24 @@ def _pop_matching_websocket_request_states(
 
 def _build_stream_incomplete_terminal_event_for_request(
     request_state: _WebSocketRequestState,
+    *,
+    reason: str = "stream_incomplete",
 ) -> tuple[str, str, OpenAIEvent | None, dict[str, JsonValue] | None, str | None]:
+    error_code, error_message = _websocket_continuity_error_fields(
+        reason=reason,
+        expose_stale_previous_response_classifier=request_state.expose_stale_previous_response_classifier,
+    )
     event_block, event, payload, event_type = _build_rewritten_stream_response_failed_event(
         response_id=_websocket_downstream_response_id(request_state),
-        error_code="stream_incomplete",
-        error_message="Upstream websocket closed before response.completed",
+        error_code=error_code,
+        error_message=error_message,
     )
     downstream_text = json.dumps(
         cast(
             dict[str, JsonValue],
             response_failed_event(
-                "stream_incomplete",
-                "Upstream websocket closed before response.completed",
+                error_code,
+                error_message,
                 error_type="server_error",
                 response_id=_websocket_downstream_response_id(request_state),
             ),

--- a/openspec/changes/stabilize-codex-ws-continuity-sot/design.md
+++ b/openspec/changes/stabilize-codex-ws-continuity-sot/design.md
@@ -1,0 +1,72 @@
+# Design: Codex WebSocket long-wait continuity
+
+## Problem model
+
+Observed failure shape:
+
+1. Codex CLI sends `response.create` over `wss://.../backend-api/codex/responses`.
+2. The model emits a tool call, e.g. background terminal wait.
+3. The client waits for a long-running command.
+4. Upstream ChatGPT invalidates the previous Responses anchor while the local Codex turn is still semantically active.
+5. When the tool returns, Codex sends a follow-up `response.create` with `previous_response_id` plus tool output / delta input.
+6. Same account/session routing can still receive upstream `previous_response_not_found`.
+
+The key insight is that the upstream anchor is not durable. However, the minimal recovery point is probably the Codex client, not a large proxy-owned conversation ledger.
+
+## Official Codex client behavior
+
+Current upstream Codex client behavior, verified against `openai/codex`:
+
+- `prepare_websocket_request` builds incremental WebSocket requests by comparing the new full conversation-history request against the previous request plus the previous response output items. If the prefix matches, it sends only the delta plus `previous_response_id`.
+- `response.failed` becomes an `ApiError` in `process_responses_event`.
+- `run_turn` treats that `ApiError` as a hard `EventMsg::Error` and ends the current turn.
+- After that failure, the next user prompt is sent as a full `response.create` without `previous_response_id`, because the previous `last_response` has been consumed/cleared. This matches the observed behavior: typing any text after the hard error restarts with full session context and works.
+
+Therefore, the direct minimal fix is to make that same full-create reset happen automatically inside the failed turn:
+
+1. Detect a stale-anchor continuity error (`previous_response_not_found` or codex-lb's sanitized equivalent) as recoverable.
+2. Reset/clear the incremental WebSocket session state for the current `ModelClientSession`.
+3. Rebuild the sampling request from conversation history.
+4. Retry once as a full `response.create` without `previous_response_id`.
+5. Do not surface a hard turn-ending error unless that retry fails.
+
+This is the "soft error" behavior Soju previously identified in the Codex client analysis.
+
+## Primary invariant
+
+For Codex-native WebSocket long-wait continuity, the active invariant is:
+
+> A stale upstream `previous_response_id` during a tool-output continuation must not hard-end the turn before Codex has attempted one full-context retry without `previous_response_id`.
+
+This is a client/session retry invariant. The proxy's primary responsibility is to expose the failure in a shape the client can classify without leaking raw upstream internals.
+
+## Proxy responsibilities
+
+codex-lb should still enforce these narrower proxy-side invariants:
+
+- Never leak raw `previous_response_not_found` or the missing `resp_...` id downstream.
+- Preserve enough error identity for Codex to classify the event as stale-anchor continuity loss. If `stream_incomplete` is too generic for the client, add a sanitized stable code/detail such as `codex_previous_response_stale` without exposing the upstream response id.
+- Do not convert stale-anchor errors into unrelated hard failures such as owner unavailable, quota, or generic invalid request.
+- Keep direct `/backend-api/codex/responses` WebSocket tests separate from HTTP bridge tests.
+
+## Server-side replay fallback
+
+A proxy-owned local replay ledger can still be useful for clients we cannot change, but it is not the primary canonical fix when the Codex client is patchable.
+
+If implemented, keep it narrow:
+
+- only one replay attempt;
+- only before downstream-visible output for the failed follow-up;
+- only when the proxy has verified self-contained replay state;
+- no broad DB-backed conversation reconstruction until a client-side fix is ruled out.
+
+Do not make the proxy a second full conversation-state owner by default.
+
+## Source-of-truth cleanup
+
+This change is the active SoT for this failure mode. Existing older changes remain historical unless their requirements are explicitly copied here. Do not add another branch-local previous-response patch without updating this change first.
+
+Implementation should now be split into two tracks:
+
+1. **Client soft-reset retry track** — preferred if we can patch the Codex client/fork used by Soju.
+2. **codex-lb compatibility track** — sanitize/classify errors so the client can trigger the soft reset; optionally keep narrow proxy replay only as fallback.

--- a/openspec/changes/stabilize-codex-ws-continuity-sot/notes.md
+++ b/openspec/changes/stabilize-codex-ws-continuity-sot/notes.md
@@ -1,0 +1,70 @@
+# Continuity source-of-truth cleanup note
+
+This note records why `stabilize-codex-ws-continuity-sot` is the active source of truth for the long background-terminal `previous_response_id` failure mode.
+
+## Branch audit snapshot
+
+A local branch scan found 36 branch refs whose names mention Codex, Responses, WebSocket, bridge, continuity, terminal, or previous-response behavior. Notable overlapping branches include:
+
+- `komzpa/codex/mask-single-previous-response-miss`
+- `komzpa/fix/durable-http-bridge-full-resend-trim`
+- `komzpa/fix/partial-previous-response-stream-errors`
+- `komzpa/fix/responses-continuity-and-large-bodies`
+- `komzpa/fix/stream-incomplete-long-codex-turns`
+- `komzpa/fix/websocket-codex-full-replay-trim`
+- `komzpa/fix/websocket-created-drop-replay`
+- `komzpa/fix/websocket-prev-response-sanitize`
+- `komzpa/fix/websocket-stream-error-statuses`
+- `komzpa/live/previous-response-dns-plan-plus-prs`
+- `komzpa/split/555-continuity-core`
+- `komzpa/split/555-ws-prev-trim`
+
+These names show the previous work was split across masking, trimming, full replay, partial stream errors, and continuity core branches. That split is exactly the problem: no single normative requirement explained how long-wait tool-output continuations recover when upstream invalidates an otherwise correctly routed anchor.
+
+## Active source of truth
+
+The active source of truth is now:
+
+- `openspec/changes/stabilize-codex-ws-continuity-sot/proposal.md`
+- `openspec/changes/stabilize-codex-ws-continuity-sot/design.md`
+- `openspec/changes/stabilize-codex-ws-continuity-sot/tasks.md`
+- `openspec/changes/stabilize-codex-ws-continuity-sot/specs/responses-api-compat/spec.md`
+
+## Superseded framing
+
+This change supersedes the following framings for the long-wait failure mode:
+
+- “Just mask the raw upstream error.” Masking is required but not recovery.
+- “Just retry the client request.” Retrying the same anchor-dependent delta repeats the failure.
+- “Just route to the owner account/session.” Correct routing is necessary but insufficient; the observed case failed on the same account/session.
+- “Just keep the WebSocket alive.” A live socket does not make the upstream Responses anchor durable.
+- “Fix each WebSocket envelope shape independently.” Envelope parsing is necessary, but the invariant must be path-wide.
+
+## Retained requirements from older work
+
+Older work remains useful where it provides:
+
+- raw-error masking and response-id redaction;
+- direct `/backend-api/codex/responses` WebSocket tests;
+- replay trimming / size-guard helpers;
+- stream-incomplete fail-closed behavior;
+- HTTP bridge learnings, as long as they are not mistaken for direct WebSocket coverage.
+
+Those requirements should be copied into this change as tests or helper behavior when implementation starts. Do not create another previous-response branch without updating this SoT first.
+
+## Implemented codex-lb contract
+
+This change now implements the codex-lb side of the contract for direct
+`/backend-api/codex/responses` WebSockets:
+
+- stale upstream `previous_response_id` errors are still fail-closed and never
+  leak raw `previous_response_not_found` or the missing upstream `resp_...` id;
+- Codex-native direct WebSocket clients receive the sanitized classifier
+  `codex_previous_response_stale` with the retry hint "retry without
+  previous_response_id";
+- OpenAI-compatible `/v1/responses` WebSocket clients keep the older generic
+  `stream_incomplete` masking so this Codex-only classifier does not become a
+  public OpenAI-compatible error code;
+- proxy-side conversation replay remains out of the primary path. Compatible
+  clients should use the classifier to soft-reset incremental WebSocket state
+  and retry once from full conversation history.

--- a/openspec/changes/stabilize-codex-ws-continuity-sot/proposal.md
+++ b/openspec/changes/stabilize-codex-ws-continuity-sot/proposal.md
@@ -1,0 +1,24 @@
+# Stabilize Codex WebSocket continuity and source of truth
+
+## Why
+
+Codex CLI sessions that run long background terminal commands can sit idle long enough for the upstream ChatGPT Responses `previous_response_id` anchor to expire. When the terminal eventually returns, Codex sends a follow-up `response.create` that is usually a delta around the previous response, often tool output tied to the prior model tool call. Re-sending that delta with the same `previous_response_id` is not recovery; it repeats the failing dependency on an expired upstream anchor.
+
+Official Codex client behavior shows the minimal recovery shape: after a WebSocket stream error, the current turn hard-ends, but the next user prompt is sent as a full `response.create` without `previous_response_id` and the session continues. The failure is that this reset happens only after user intervention instead of as a soft automatic retry inside the same turn.
+
+Prior fixes treated `previous_response_not_found` as a path-specific routing, masking, or proxy replay bug. Those patches were necessary but insufficient because the source-of-truth invariant was missing: stale upstream anchors need a full-context retry/reset path, and raw upstream errors must not hard-end the user turn before that retry is attempted.
+
+The current repository also has too many branch-level / change-level partial fixes around this problem. This change becomes the active source of truth for Codex WebSocket long-wait continuity, superseding one-off previous-response masking/retry changes for this failure mode.
+
+## What Changes
+
+- Define upstream `previous_response_id` as an ephemeral anchor, not durable state.
+- Prefer the Codex client soft-reset fix: classify stale-anchor continuity loss, reset incremental WebSocket session state, rebuild from conversation history, and retry once without `previous_response_id` before surfacing an error.
+- Keep codex-lb focused on sanitized/classifiable error semantics for direct `/backend-api/codex/responses` WebSocket traffic.
+- Do not leak raw `previous_response_not_found` or missing response ids downstream.
+- Treat proxy-side anchorless replay ledgers as optional compatibility fallback for clients that cannot be patched, not the primary design.
+- Consolidate the source of truth: OpenSpec delta + context docs + focused regression tests for long background-terminal waits on the Codex-native direct WebSocket path.
+
+## Impact
+
+Long-running background terminal waits become recoverable by automatically triggering the same full-session restart behavior that currently works only after the user types another message. codex-lb remains responsible for safe masking/classification, while the client owns the turn-level retry semantics.

--- a/openspec/changes/stabilize-codex-ws-continuity-sot/specs/responses-api-compat/spec.md
+++ b/openspec/changes/stabilize-codex-ws-continuity-sot/specs/responses-api-compat/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Codex WebSocket stale-anchor failures remain recoverable by a full-context retry
+When serving or consuming the Codex-native `/backend-api/codex/responses` WebSocket route, upstream `previous_response_id` MUST be treated as an ephemeral optimization rather than durable conversation state. A stale-anchor continuity failure during a long-wait tool-output continuation MUST NOT hard-end the user turn before one full-context retry without `previous_response_id` has been attempted.
+
+#### Scenario: Long-running terminal wait invalidates the upstream previous response anchor
+- **GIVEN** a Codex-native WebSocket session has completed a response with id `resp_old`
+- **AND** the client later sends a `response.create` frame with `previous_response_id: "resp_old"` and tool-output or other delta input after a long idle period
+- **WHEN** the upstream rejects `resp_old` with a stale-anchor error such as `previous_response_not_found`
+- **THEN** the failure is classified as stale-anchor continuity loss
+- **AND** the client-side recovery path retries once using full conversation history without `previous_response_id` before surfacing a turn-ending error
+- **AND** the downstream/user-visible error path does not expose raw `previous_response_not_found` or the missing upstream response id
+
+#### Scenario: codex-lb sanitizes stale-anchor errors for client classification
+- **WHEN** upstream emits a direct WebSocket stale-anchor error
+- **THEN** codex-lb MUST NOT forward raw `previous_response_not_found`
+- **AND** codex-lb MUST NOT expose the missing upstream response id downstream
+- **AND** codex-lb SHOULD preserve a stable sanitized classifier that lets a compatible Codex client distinguish stale-anchor continuity loss from quota, policy, auth, and generic invalid-request failures
+
+#### Scenario: Non-stale-anchor failures do not trigger full-context retry
+- **WHEN** the upstream failure is quota, policy, auth, context-window, or another non-continuity error
+- **THEN** the client MUST NOT convert it into a stale-anchor full-context retry
+- **AND** codex-lb MUST preserve the original error class as much as safely possible
+
+### Requirement: Codex WebSocket continuity source of truth is centralized
+The behavior for Codex-native WebSocket previous-response continuity MUST be specified in this OpenSpec change rather than route-local or branch-local ad hoc patches. Future changes to this behavior MUST update the OpenSpec requirements before modifying code.
+
+#### Scenario: Previous-response fix changes behavior
+- **WHEN** a patch changes routing, replay, masking, retry, or failure behavior for Codex-native WebSocket `previous_response_id`
+- **THEN** the patch includes an OpenSpec delta or updates the active continuity source of truth
+- **AND** direct `/backend-api/codex/responses` WebSocket tests or Codex client WebSocket tests cover the changed behavior

--- a/openspec/changes/stabilize-codex-ws-continuity-sot/specs/responses-api-compat/spec.md
+++ b/openspec/changes/stabilize-codex-ws-continuity-sot/specs/responses-api-compat/spec.md
@@ -15,7 +15,7 @@ When serving or consuming the Codex-native `/backend-api/codex/responses` WebSoc
 - **WHEN** upstream emits a direct WebSocket stale-anchor error
 - **THEN** codex-lb MUST NOT forward raw `previous_response_not_found`
 - **AND** codex-lb MUST NOT expose the missing upstream response id downstream
-- **AND** codex-lb SHOULD preserve a stable sanitized classifier that lets a compatible Codex client distinguish stale-anchor continuity loss from quota, policy, auth, and generic invalid-request failures
+- **AND** codex-lb MUST preserve a stable sanitized classifier that lets a compatible Codex client distinguish stale-anchor continuity loss from quota, policy, auth, and generic invalid-request failures
 
 #### Scenario: Non-stale-anchor failures do not trigger full-context retry
 - **WHEN** the upstream failure is quota, policy, auth, context-window, or another non-continuity error

--- a/openspec/changes/stabilize-codex-ws-continuity-sot/tasks.md
+++ b/openspec/changes/stabilize-codex-ws-continuity-sot/tasks.md
@@ -1,0 +1,23 @@
+## 1. Source of truth
+- [x] Create this OpenSpec change as the active source of truth for Codex-native WebSocket long-wait continuity.
+- [x] Audit existing previous-response / WebSocket continuity changes and mark which requirements are superseded or retained here.
+- [x] Re-check official Codex client behavior and reclassify proxy ledger as fallback, not primary fix.
+- [x] Sync stable context back to `openspec/specs/responses-api-compat/context.md` after implementation is verified.
+
+## 2. Tests first
+- [ ] Add/port a Codex client regression where a long-wait tool-output continuation receives stale-anchor continuity failure and the same turn retries once as full `response.create` without `previous_response_id`.
+- [x] Add a direct `/backend-api/codex/responses` WebSocket regression proving codex-lb returns a sanitized/classifiable stale-anchor error and never leaks raw `previous_response_not_found` or the missing response id.
+- [ ] Add a regression proving stale-anchor auto-retry is attempted at most once per failed sampling request.
+- [ ] Add a regression proving non-stale-anchor errors still surface normally and do not trigger full-context retry.
+
+## 3. Implementation
+- [ ] Prefer Codex client soft-reset retry: detect stale-anchor continuity errors, clear incremental WebSocket session state, rebuild from conversation history, and retry once without `previous_response_id` before emitting `EventMsg::Error`.
+- [x] In codex-lb, preserve direct WebSocket masking and add a stable sanitized error classifier if `stream_incomplete` is too generic for the client.
+- [x] Keep proxy-side local replay ledger work out of the primary path unless the client cannot be patched; if needed, implement it as a narrow compatibility fallback.
+- [x] Keep direct WebSocket route logic centralized and covered by OpenSpec before adding more branch-local previous-response patches.
+
+## 4. Verification
+- [ ] Run focused Codex client WebSocket continuity tests if the client/fork is in scope.
+- [x] Run codex-lb direct WebSocket previous-response masking/classification tests.
+- [x] Run OpenSpec validation with `openspec validate --specs`.
+- [x] Produce a short branch/SoT cleanup note listing superseded older changes/branches and the canonical change id.

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -30,6 +30,7 @@ See `openspec/specs/responses-api-compat/spec.md` for normative requirements.
 - Compact transport may use bounded same-contract retries only for safe pre-body transport failures and `401 -> refresh -> retry`.
 - `/v1/responses/compact` is supported only when the upstream implements it.
 - `prompt_cache_key` affinity on OpenAI-style routes is intentionally bounded by a dashboard-managed freshness window, unlike durable backend `session_id` or dashboard sticky-thread routing.
+- Codex-native direct websocket `/backend-api/codex/responses` treats upstream `previous_response_id` as an ephemeral anchor. If that anchor goes stale, the proxy must mask raw `previous_response_not_found` details and emit a sanitized `codex_previous_response_stale` classifier so compatible Codex clients can soft-reset and retry without `previous_response_id`.
 
 ## Include Allowlist (Reference)
 
@@ -49,6 +50,7 @@ See `openspec/specs/responses-api-compat/spec.md` for normative requirements.
 - **HTTP bridge session closes or expires:** The next compatible HTTP `/v1/responses` or `/backend-api/codex/responses` request recreates a fresh upstream websocket bridge session; continuity is guaranteed only within the lifetime of one active bridged session.
 - **Multi-instance routing without bridge owner policy:** if operators do not configure a bridge ring or front-door affinity, continuity can still fragment across replicas. With a configured bridge ring, hard continuity keys still fail closed on the wrong replica, while gateway-safe prompt-cache requests may accept locality misses instead of failing.
 - **Codex websocket reconnects:** Reconnect continuity now depends on the client replaying the accepted `x-codex-turn-state`; generated turn-state is emitted on accept for backend Codex routes and echoed back when the client already supplies one.
+- **Codex websocket stale previous-response anchors:** Direct backend Codex websocket stale-anchor failures are surfaced as `response.failed` / `codex_previous_response_stale` without the raw upstream code or missing `resp_...` id; OpenAI-compatible `/v1/responses` websocket clients continue to receive generic `stream_incomplete` masking.
 - **Websocket handshake forbidden/not-found:** Auto transport now fails loud on `403` / `404` instead of silently hiding the websocket regression behind HTTP fallback.
 - **Invalid request payloads:** Return 4xx with `invalid_request_error`.
 
@@ -83,4 +85,5 @@ Non-streaming request/response:
 - Post-deploy: monitor `capacity_exhausted_active_sessions`, Codex-session bridge reuse/evict counts, websocket handshake 403/404 rates after the narrower auto-fallback policy, and backend Codex HTTP vs websocket cache-ratio gaps.
 - When tracing compact incidents, confirm that request logs and upstream logs show direct `/codex/responses/compact` usage without surrogate `/codex/responses` fallback.
 - Post-deploy: monitor `no_accounts`, `stream_incomplete`, and `upstream_unavailable`.
+- Post-deploy: monitor `codex_previous_response_stale` on `/backend-api/codex/responses`; recurring spikes mean clients are still relying on stale upstream anchors and should perform the documented full-context retry without `previous_response_id`.
 - Websocket/Codex CLI tier verification runbook: `openspec/specs/responses-api-compat/ops.md`

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -16,6 +16,11 @@ import app.modules.proxy.service as proxy_module
 pytestmark = pytest.mark.integration
 
 
+def _assert_codex_previous_response_stale_error(error: dict[str, object]) -> None:
+    assert error["code"] == proxy_module.PREVIOUS_RESPONSE_STALE_CODE
+    assert error["message"] == proxy_module.PREVIOUS_RESPONSE_STALE_MESSAGE
+
+
 @pytest.fixture(autouse=True)
 def _stub_request_logging(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_write_request_log(self, **kwargs):
@@ -2216,8 +2221,7 @@ def test_backend_responses_websocket_connect_failure_masks_previous_response_not
 
     assert event["type"] == "error"
     assert event["status"] == 502
-    assert event["error"]["code"] == "stream_incomplete"
-    assert event["error"]["message"] == "Upstream websocket closed before response.completed"
+    _assert_codex_previous_response_stale_error(event["error"])
 
 
 def test_backend_responses_websocket_masks_short_previous_response_not_found_without_retry(
@@ -2399,8 +2403,7 @@ def test_backend_responses_websocket_masks_short_previous_response_not_found_wit
             failed_2 = json.loads(websocket.receive_text())
 
     assert failed_2["type"] == "response.failed"
-    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    _assert_codex_previous_response_stale_error(failed_2["response"]["error"])
     assert "previous_response_not_found" not in json.dumps(failed_2)
     assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
     assert connect_count == 1
@@ -2562,12 +2565,14 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
     assert created_event["type"] == "response.created"
     assert created_event["response"]["id"] == "resp_ws_inflight"
     assert failed_event["type"] == "response.failed"
-    assert failed_event["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_event["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    _assert_codex_previous_response_stale_error(failed_event["response"]["error"])
     assert "previous_response_not_found" not in json.dumps(failed_event)
     assert completed_event["type"] == "response.completed"
     assert completed_event["response"]["id"] == "resp_ws_inflight"
-    assert any(call["status"] == "error" and call["error_code"] == "stream_incomplete" for call in log_calls)
+    assert any(
+        call["status"] == "error" and call["error_code"] == proxy_module.PREVIOUS_RESPONSE_STALE_CODE
+        for call in log_calls
+    )
     assert any(call["status"] == "success" and call["request_id"] == "resp_ws_inflight" for call in log_calls)
     assert fake_upstream.closed is True
 
@@ -2682,8 +2687,7 @@ def test_backend_responses_websocket_masks_top_level_previous_response_not_found
             failed_event = json.loads(websocket.receive_text())
 
     assert failed_event["type"] == "response.failed"
-    assert failed_event["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_event["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    _assert_codex_previous_response_stale_error(failed_event["response"]["error"])
     serialized = json.dumps(failed_event)
     assert "previous_response_not_found" not in serialized
     assert "resp_chatgpt_prev_anchor" not in serialized
@@ -2858,8 +2862,7 @@ def test_backend_responses_websocket_masks_previous_response_not_found_when_mess
             failed_2 = json.loads(websocket.receive_text())
 
     assert failed_2["type"] == "response.failed"
-    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    _assert_codex_previous_response_stale_error(failed_2["response"]["error"])
     assert "previous_response_not_found" not in json.dumps(failed_2)
     assert "resp_ws_prev_anchor" not in json.dumps(failed_2)
     assert connect_count == 1
@@ -3073,8 +3076,7 @@ def test_backend_responses_websocket_keeps_session_alive_after_foreign_previous_
     assert created_2["response"]["id"] == "resp_ws_followup_created"
     assert failed_2["type"] == "response.failed"
     assert failed_2["response"]["id"] == "resp_ws_followup_created"
-    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_2["response"]["error"]["message"] == "Upstream websocket closed before response.completed"
+    _assert_codex_previous_response_stale_error(failed_2["response"]["error"])
     assert "previous_response_not_found" not in json.dumps(failed_2)
     assert created_3["type"] == "response.created"
     assert completed_3["type"] == "response.completed"
@@ -3326,7 +3328,7 @@ def test_backend_responses_websocket_keeps_session_alive_after_anonymous_prev_nf
     assert created_3["response"]["id"] == "resp_ws_followup_created"
     assert failed_3["type"] == "response.failed"
     assert failed_3["response"]["id"] == "resp_ws_followup_created"
-    assert failed_3["response"]["error"]["code"] == "stream_incomplete"
+    _assert_codex_previous_response_stale_error(failed_3["response"]["error"])
     assert "previous_response_not_found" not in json.dumps(failed_3)
     assert completed_2["type"] == "response.completed"
     assert completed_2["response"]["id"] == "resp_ws_inflight"
@@ -3589,7 +3591,7 @@ def test_backend_responses_websocket_matches_previous_response_error_to_anchor_w
     assert created_4["response"]["id"] == "resp_ws_followup_b"
     assert failed_3["type"] == "response.failed"
     assert failed_3["response"]["id"] == "resp_ws_followup_a"
-    assert failed_3["response"]["error"]["code"] == "stream_incomplete"
+    _assert_codex_previous_response_stale_error(failed_3["response"]["error"])
     assert "previous_response_not_found" not in json.dumps(failed_3)
     assert completed_4["type"] == "response.completed"
     assert completed_4["response"]["id"] == "resp_ws_followup_b"
@@ -3814,8 +3816,8 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
     assert failed_3["type"] == "response.failed"
     assert failed_2["response"]["id"] == "resp_ws_followup_same_anchor_a"
     assert failed_3["response"]["id"] == "resp_ws_followup_same_anchor_b"
-    assert failed_2["response"]["error"]["code"] == "stream_incomplete"
-    assert failed_3["response"]["error"]["code"] == "stream_incomplete"
+    _assert_codex_previous_response_stale_error(failed_2["response"]["error"])
+    _assert_codex_previous_response_stale_error(failed_3["response"]["error"])
     assert "previous_response_not_found" not in json.dumps(failed_2)
     assert "previous_response_not_found" not in json.dumps(failed_3)
     assert created_4["response"]["id"] == "resp_ws_after_same_anchor_error"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9037,6 +9037,7 @@ async def test_process_upstream_websocket_text_masks_anonymous_missing_tool_outp
         started_at=0.0,
         previous_response_id="resp_anchor",
         request_text='{"type":"response.create","previous_response_id":"resp_anchor"}',
+        expose_stale_previous_response_classifier=True,
     )
     followup_request_b = proxy_service._WebSocketRequestState(
         request_id="ws_req_missing_tool_same_anchor_b",
@@ -9047,6 +9048,7 @@ async def test_process_upstream_websocket_text_masks_anonymous_missing_tool_outp
         started_at=0.0,
         previous_response_id="resp_anchor",
         request_text='{"type":"response.create","previous_response_id":"resp_anchor"}',
+        expose_stale_previous_response_classifier=True,
     )
     pending_requests = deque([followup_request_a, followup_request_b])
     upstream_control = proxy_service._WebSocketUpstreamControl()
@@ -9080,6 +9082,7 @@ async def test_process_upstream_websocket_text_masks_anonymous_missing_tool_outp
     for emitted_text in upstream_control.downstream_texts:
         assert '"type":"response.failed"' in emitted_text
         assert '"code":"stream_incomplete"' in emitted_text
+        assert "codex_previous_response_stale" not in emitted_text
         assert "call_missing_output" not in emitted_text
     assert finalize_request_state.await_count == 2
     finalized_requests = [call.args[0] for call in finalize_request_state.await_args_list]


### PR DESCRIPTION
## Summary
- Adds an OpenSpec change that centralizes the source of truth for Codex-native WebSocket `previous_response_id` continuity failures.
- Implements a sanitized Codex-native direct WebSocket stale-anchor classifier: `codex_previous_response_stale`.
- Preserves raw upstream masking: downstream never receives raw `previous_response_not_found` or the missing upstream `resp_...` id.
- Keeps grouped `missing_tool_output` terminal failures on the generic `stream_incomplete` path, even when Codex stale-anchor classification is enabled.
- Keeps `/v1/responses` WebSocket compatibility on the existing generic `stream_incomplete` masking, while `/backend-api/codex/responses` gets the Codex-specific classifier that clients can use for soft-reset retry.
- Records stable context in `openspec/specs/responses-api-compat/context.md` and keeps proxy-side replay ledger out of the primary path.

## Context
Long background terminal waits can expire the upstream Responses anchor while the local Codex turn is still active. Retrying the same delta with the stale `previous_response_id` repeats the failure. The desired recovery is for a compatible Codex client to classify the stale-anchor failure, reset incremental WebSocket state, and retry once from full conversation history without `previous_response_id`.

## Implementation
- Adds `PREVIOUS_RESPONSE_STALE_CODE` / `PREVIOUS_RESPONSE_STALE_MESSAGE`.
- Marks Codex-native direct WebSocket request state as eligible to expose the stale-anchor classifier.
- Routes previous-response stale rewrites through a single helper so nested, top-level, grouped, connect-failure, and terminal-error paths share the same sanitized behavior.
- Preserves non-stale continuity errors, including grouped missing-tool-output failures, as generic `stream_incomplete` failures.
- Leaves OpenAI-compatible `/v1/responses` WebSocket behavior unchanged.

## Verification
```bash
uv run pytest tests/unit/test_proxy_utils.py::test_process_upstream_websocket_text_masks_anonymous_missing_tool_output_for_same_anchor_followups tests/unit/test_proxy_utils.py::test_process_upstream_websocket_text_masks_anonymous_previous_response_not_found_for_same_anchor_followups tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_anonymous_previous_response_not_found_for_same_anchor_followups_and_recovers tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_short_previous_response_not_found_without_retry tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_masks_previous_response_not_found_when_message_omits_response_id -q
uv run ruff check app/core/errors.py app/modules/proxy/service.py tests/integration/test_proxy_websocket_responses.py tests/unit/test_proxy_utils.py
uv run ty check app/core/errors.py app/modules/proxy/service.py tests/integration/test_proxy_websocket_responses.py tests/unit/test_proxy_utils.py
uv run openspec validate stabilize-codex-ws-continuity-sot --strict
uv run openspec validate --specs
git diff --check
```
