### PR TITLE
feat: show update indicator for stale runtime version

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -58,6 +58,7 @@ from app.modules.proxy.ring_membership import (
     RingMembershipService,
 )
 from app.modules.request_logs import api as request_logs_api
+from app.modules.runtime import api as runtime_api
 from app.modules.settings import api as settings_api
 from app.modules.sticky_sessions import api as sticky_sessions_api
 from app.modules.sticky_sessions.cleanup_scheduler import build_sticky_session_cleanup_scheduler
@@ -365,6 +366,7 @@ def create_app() -> FastAPI:
     app.include_router(usage_api.router)
     app.include_router(request_logs_api.router)
     app.include_router(conversation_archive_api.router)
+    app.include_router(runtime_api.router)
     app.include_router(oauth_api.router)
     app.include_router(dashboard_auth_api.router)
     app.include_router(settings_api.router)

--- a/app/modules/runtime/__init__.py
+++ b/app/modules/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime metadata APIs."""

--- a/app/modules/runtime/api.py
+++ b/app/modules/runtime/api.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.modules.runtime.schemas import RuntimeVersionResponse
+from app.modules.runtime.service import get_runtime_version_service
+
+router = APIRouter(
+    prefix="/api/runtime",
+    tags=["runtime"],
+    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+)
+
+
+@router.get("/version", response_model=RuntimeVersionResponse)
+async def get_runtime_version() -> RuntimeVersionResponse:
+    return await get_runtime_version_service().get_version_status()

--- a/app/modules/runtime/schemas.py
+++ b/app/modules/runtime/schemas.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.modules.shared.schemas import DashboardModel
+
+
+class RuntimeVersionResponse(DashboardModel):
+    current_version: str
+    latest_version: str | None = None
+    update_available: bool = False
+    checked_at: datetime
+    source: str | None = None
+    release_url: str = "https://github.com/Soju06/codex-lb/releases/latest"

--- a/app/modules/runtime/service.py
+++ b/app/modules/runtime/service.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime
+
+import aiohttp
+
+from app import __version__
+from app.core.utils.time import utcnow
+from app.modules.runtime.schemas import RuntimeVersionResponse
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_LATEST_RELEASE_URL = "https://api.github.com/repos/Soju06/codex-lb/releases/latest"
+_LATEST_RELEASE_PAGE_URL = "https://github.com/Soju06/codex-lb/releases/latest"
+_VERSION_RE = re.compile(
+    r"^v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _RuntimeVersionSnapshot:
+    current_version: str
+    latest_version: str | None
+    update_available: bool
+    checked_at: datetime
+    source: str | None
+
+
+class RuntimeVersionService:
+    def __init__(
+        self,
+        *,
+        current_version: str = __version__,
+        ttl_seconds: float = 6 * 60 * 60,
+        failure_ttl_seconds: float = 15 * 60,
+        github_token_env_var: str = "GITHUB_TOKEN",
+    ) -> None:
+        self._current_version = current_version
+        self._ttl_seconds = ttl_seconds
+        self._failure_ttl_seconds = failure_ttl_seconds
+        self._github_token_env_var = github_token_env_var
+        self._cached_snapshot: _RuntimeVersionSnapshot | None = None
+        self._cached_at = 0.0
+        self._lock = asyncio.Lock()
+
+    async def get_version_status(self) -> RuntimeVersionResponse:
+        now = time.monotonic()
+        if self._cached_snapshot is not None and now - self._cached_at < self._cache_ttl_for(self._cached_snapshot):
+            return _to_response(self._cached_snapshot)
+
+        async with self._lock:
+            now = time.monotonic()
+            if self._cached_snapshot is not None and now - self._cached_at < self._cache_ttl_for(self._cached_snapshot):
+                return _to_response(self._cached_snapshot)
+
+            snapshot = await self._fetch_snapshot()
+            self._cached_snapshot = snapshot
+            self._cached_at = time.monotonic()
+            return _to_response(snapshot)
+
+    async def invalidate(self) -> None:
+        async with self._lock:
+            self._cached_snapshot = None
+            self._cached_at = 0.0
+
+    async def _fetch_snapshot(self) -> _RuntimeVersionSnapshot:
+        checked_at = utcnow()
+        try:
+            latest_version = await self._fetch_latest_release_version()
+        except Exception:
+            logger.warning("Failed to fetch latest codex-lb release from GitHub", exc_info=True)
+            return _RuntimeVersionSnapshot(
+                current_version=self._current_version,
+                latest_version=None,
+                update_available=False,
+                checked_at=checked_at,
+                source=None,
+            )
+
+        update_available = _is_newer_version(latest_version, self._current_version)
+        return _RuntimeVersionSnapshot(
+            current_version=self._current_version,
+            latest_version=latest_version,
+            update_available=update_available,
+            checked_at=checked_at,
+            source="github",
+        )
+
+    async def _fetch_latest_release_version(self) -> str:
+        timeout = aiohttp.ClientTimeout(total=10, sock_connect=5, sock_read=5)
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": f"codex-lb/{self._current_version}",
+        }
+        github_token = os.getenv(self._github_token_env_var, "").strip()
+        if github_token:
+            headers["Authorization"] = f"Bearer {github_token}"
+        async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
+            async with session.get(_GITHUB_LATEST_RELEASE_URL, headers=headers) as response:
+                if response.status != 200:
+                    raise RuntimeError(f"GitHub releases API returned HTTP {response.status}")
+                data = await response.json()
+
+        raw_version = data.get("tag_name") if isinstance(data, dict) else None
+        if not isinstance(raw_version, str):
+            raise RuntimeError(f"GitHub release tag_name is not a string: {raw_version!r}")
+        version = _normalize_version(raw_version)
+        if version is None:
+            raise RuntimeError(f"GitHub release tag_name is not a stable semver: {raw_version!r}")
+        return version
+
+    def _cache_ttl_for(self, snapshot: _RuntimeVersionSnapshot) -> float:
+        if snapshot.source is None:
+            return self._failure_ttl_seconds
+        return self._ttl_seconds
+
+
+def _to_response(snapshot: _RuntimeVersionSnapshot) -> RuntimeVersionResponse:
+    return RuntimeVersionResponse(
+        current_version=snapshot.current_version,
+        latest_version=snapshot.latest_version,
+        update_available=snapshot.update_available,
+        checked_at=snapshot.checked_at,
+        source=snapshot.source,
+        release_url=_LATEST_RELEASE_PAGE_URL,
+    )
+
+
+def _normalize_version(value: str) -> str | None:
+    match = _VERSION_RE.match(value.strip())
+    if match is None:
+        return None
+    core = ".".join(match.group(part) for part in ("major", "minor", "patch"))
+    prerelease = match.group("prerelease")
+    return f"{core}-{prerelease}" if prerelease else core
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedVersion:
+    major: int
+    minor: int
+    patch: int
+    prerelease: str | None
+
+
+def _parse_version(value: str) -> _ParsedVersion | None:
+    match = _VERSION_RE.match(value.strip())
+    if match is None:
+        return None
+    return _ParsedVersion(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=match.group("prerelease"),
+    )
+
+
+def _is_newer_version(candidate: str, current: str) -> bool:
+    candidate_version = _parse_version(candidate)
+    current_version = _parse_version(current)
+    if candidate_version is None or current_version is None:
+        return False
+    candidate_core = (candidate_version.major, candidate_version.minor, candidate_version.patch)
+    current_core = (current_version.major, current_version.minor, current_version.patch)
+    if candidate_core != current_core:
+        return candidate_core > current_core
+    if candidate_version.prerelease is None and current_version.prerelease is not None:
+        return True
+    if candidate_version.prerelease is not None and current_version.prerelease is None:
+        return False
+    if candidate_version.prerelease is None and current_version.prerelease is None:
+        return False
+    return _compare_prerelease(candidate_version.prerelease, current_version.prerelease) > 0
+
+
+def _compare_prerelease(candidate: str | None, current: str | None) -> int:
+    if candidate is None and current is None:
+        return 0
+    if candidate is None:
+        return 1
+    if current is None:
+        return -1
+
+    candidate_parts = candidate.split(".")
+    current_parts = current.split(".")
+    for candidate_part, current_part in zip(candidate_parts, current_parts, strict=False):
+        if candidate_part == current_part:
+            continue
+        candidate_numeric = candidate_part.isdigit()
+        current_numeric = current_part.isdigit()
+        if candidate_numeric and current_numeric:
+            candidate_number = int(candidate_part)
+            current_number = int(current_part)
+            if candidate_number != current_number:
+                return 1 if candidate_number > current_number else -1
+            continue
+        if candidate_numeric:
+            return -1
+        if current_numeric:
+            return 1
+        return 1 if candidate_part > current_part else -1
+    if len(candidate_parts) == len(current_parts):
+        return 0
+    return 1 if len(candidate_parts) > len(current_parts) else -1
+
+
+_runtime_version_service = RuntimeVersionService()
+
+
+def get_runtime_version_service() -> RuntimeVersionService:
+    return _runtime_version_service

--- a/frontend/src/components/layout/status-bar.test.tsx
+++ b/frontend/src/components/layout/status-bar.test.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
 import { StatusBar } from "@/components/layout/status-bar";
+import { server } from "@/test/mocks/server";
 
 function renderStatusBar() {
   const queryClient = new QueryClient({
@@ -29,5 +31,47 @@ describe("StatusBar", () => {
     expect(link).toHaveAttribute("href", "https://github.com/soju06/codex-lb");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noreferrer");
+  });
+
+  it("links to release notes when a newer version is available", async () => {
+    server.use(
+      http.get("/api/runtime/version", () =>
+        HttpResponse.json({
+          currentVersion: "1.19.0",
+          latestVersion: "1.20.0",
+          updateAvailable: true,
+          checkedAt: "2026-05-26T00:00:00Z",
+          source: "github",
+          releaseUrl: "https://github.com/Soju06/codex-lb/releases/latest",
+        }),
+      ),
+    );
+
+    renderStatusBar();
+
+    const link = await screen.findByRole("link", {
+      name: "New version available: 1.20.0. Open release notes.",
+    });
+
+    expect(link).toHaveAttribute("href", "https://github.com/Soju06/codex-lb/releases/latest");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noreferrer");
+  });
+
+  it("does not show an update link when the runtime version check fails", async () => {
+    server.use(
+      http.get("/api/runtime/version", () =>
+        HttpResponse.json({ error: "upstream unavailable" }, { status: 503 }),
+      ),
+    );
+
+    renderStatusBar();
+
+    expect(await screen.findByText("Version:")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", {
+        name: /New version available/,
+      }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/layout/status-bar.tsx
+++ b/frontend/src/components/layout/status-bar.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { Activity, ArrowRightLeft, Tag } from "lucide-react";
+import { Activity, ArrowRightLeft, ArrowUpCircle, Tag } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getDashboardOverview } from "@/features/dashboard/api";
 import { DEFAULT_OVERVIEW_TIMEFRAME } from "@/features/dashboard/schemas";
+import { getRuntimeVersion } from "@/features/runtime/api";
 import { getSettings } from "@/features/settings/api";
 import { formatTimeLong } from "@/utils/formatters";
 
@@ -38,6 +39,12 @@ export function StatusBar() {
     queryKey: ["settings", "detail"],
     queryFn: getSettings,
   });
+  const { data: runtimeVersion } = useQuery({
+    queryKey: ["runtime", "version"],
+    queryFn: getRuntimeVersion,
+    retry: false,
+    staleTime: 6 * 60 * 60 * 1000,
+  });
   const lastSync = formatTimeLong(lastSyncAt);
   const [isLive, setIsLive] = useState(false);
   useEffect(() => {
@@ -52,6 +59,12 @@ export function StatusBar() {
   const routingLabel = settings
     ? getRoutingLabel(settings.routingStrategy, settings.stickyThreadsEnabled, settings.preferEarlierResetAccounts)
     : "—";
+  const currentVersion = runtimeVersion?.currentVersion ?? __APP_VERSION__;
+  const latestVersion = runtimeVersion?.latestVersion ?? null;
+  const showUpdateAvailable = runtimeVersion?.updateAvailable === true && latestVersion;
+  const updateLabel = latestVersion
+    ? `New version available: ${latestVersion}. Open release notes.`
+    : "New version available. Open release notes.";
 
   return (
     <footer className="fixed bottom-0 left-0 right-0 z-50 border-t border-white/[0.08] bg-background/50 px-4 py-2 shadow-[0_-1px_12px_rgba(0,0,0,0.06)] backdrop-blur-xl backdrop-saturate-[1.8] supports-[backdrop-filter]:bg-background/40 dark:shadow-[0_-1px_12px_rgba(0,0,0,0.25)]">
@@ -71,7 +84,19 @@ export function StatusBar() {
           </span>
           <span className="inline-flex items-center gap-1.5">
             <Tag className="h-3 w-3" aria-hidden="true" />
-            <span className="font-medium">Version:</span> {__APP_VERSION__}
+            <span className="font-medium">Version:</span> {currentVersion}
+            {showUpdateAvailable ? (
+              <a
+                aria-label={updateLabel}
+                className="inline-flex h-4 w-4 items-center justify-center rounded-full text-amber-500 transition-colors hover:text-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-2"
+                href={runtimeVersion.releaseUrl}
+                rel="noreferrer"
+                target="_blank"
+                title={updateLabel}
+              >
+                <ArrowUpCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              </a>
+            ) : null}
           </span>
         </div>
         <a

--- a/frontend/src/features/runtime/api.ts
+++ b/frontend/src/features/runtime/api.ts
@@ -1,0 +1,9 @@
+import { get } from "@/lib/api-client";
+
+import { RuntimeVersionSchema } from "@/features/runtime/schemas";
+
+const RUNTIME_VERSION_PATH = "/api/runtime/version";
+
+export function getRuntimeVersion() {
+  return get(RUNTIME_VERSION_PATH, RuntimeVersionSchema);
+}

--- a/frontend/src/features/runtime/schemas.ts
+++ b/frontend/src/features/runtime/schemas.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const RuntimeVersionSchema = z.object({
+  currentVersion: z.string(),
+  latestVersion: z.string().nullable().optional(),
+  updateAvailable: z.boolean(),
+  checkedAt: z.string(),
+  source: z.string().nullable().optional(),
+  releaseUrl: z.string().url(),
+});
+
+export type RuntimeVersion = z.infer<typeof RuntimeVersionSchema>;

--- a/frontend/src/test/mocks/handler-coverage.test.ts
+++ b/frontend/src/test/mocks/handler-coverage.test.ts
@@ -22,6 +22,8 @@ function extractHandlerPaths(): string[] {
 const EXPECTED_ENDPOINTS = [
 	// health
 	"GET /health",
+	// runtime
+	"GET /api/runtime/version",
 	// dashboard
 	"GET /api/dashboard/overview",
 	"GET /api/request-logs",

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -319,6 +319,17 @@ export const handlers = [
 		return HttpResponse.json({ status: "ok" });
 	}),
 
+	http.get("/api/runtime/version", () => {
+		return HttpResponse.json({
+			currentVersion: "1.19.0",
+			latestVersion: "1.19.0",
+			updateAvailable: false,
+			checkedAt: "2026-05-26T00:00:00Z",
+			source: "github",
+			releaseUrl: "https://github.com/Soju06/codex-lb/releases/latest",
+		});
+	}),
+
 	http.get("/api/dashboard/overview", () => {
 		return HttpResponse.json(
 			createDashboardOverview({

--- a/openspec/changes/add-version-update-indicator/proposal.md
+++ b/openspec/changes/add-version-update-indicator/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+Operators can see the running codex-lb version in the dashboard footer, but there is no visible signal when the deployed version falls behind the latest GitHub release. This makes small self-hosted deployments easy to leave stale.
+
+## What Changes
+
+- Add a backend runtime version status endpoint that compares the running app version with the latest GitHub release.
+- Cache GitHub release lookups and degrade silently when the lookup fails.
+- Show a compact update-available icon beside the footer version when a newer release exists.
+- Link the icon to the latest GitHub release notes.
+
+## Impact
+
+- New dashboard-auth protected support API under `/api/runtime/version`.
+- New outbound HTTP call to GitHub releases API with in-process caching.
+- Footer UI gets one optional icon and tooltip when update information is available.

--- a/openspec/changes/add-version-update-indicator/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-version-update-indicator/specs/frontend-architecture/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Footer version update indicator
+
+The dashboard footer SHALL show the running application version and SHALL display a compact update-available icon next to that version only when the runtime version API confirms a newer stable GitHub release exists.
+
+#### Scenario: Newer release is available
+
+- **WHEN** `GET /api/runtime/version` returns `updateAvailable: true` with a `latestVersion`
+- **THEN** the footer renders an accessible update icon beside the current version
+- **AND** the icon links to `https://github.com/Soju06/codex-lb/releases/latest`
+- **AND** the icon title or accessible label includes the latest version
+
+#### Scenario: Version lookup is unavailable
+
+- **WHEN** `GET /api/runtime/version` fails or returns no newer version
+- **THEN** the footer continues showing the current version without an update indicator

--- a/openspec/changes/add-version-update-indicator/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/add-version-update-indicator/specs/outbound-http-clients/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Runtime version status checks latest GitHub release
+
+The service SHALL expose a dashboard-auth protected runtime version status API that reports the running codex-lb version, the latest known GitHub release version when available, whether an update is available, and the time of the latest lookup attempt. The lookup MUST be cached in-process to avoid per-request GitHub traffic, and lookup failures MUST NOT cause the API to fail.
+
+#### Scenario: Latest release is newer than current version
+
+- **WHEN** the running version is `1.19.0`
+- **AND** the GitHub latest release tag is `v1.20.0`
+- **THEN** the runtime version status reports `currentVersion: "1.19.0"`, `latestVersion: "1.20.0"`, and `updateAvailable: true`
+
+#### Scenario: GitHub lookup fails
+
+- **WHEN** the GitHub latest release lookup fails
+- **THEN** the runtime version status API still returns the current version
+- **AND** `updateAvailable` is `false`

--- a/openspec/changes/add-version-update-indicator/tasks.md
+++ b/openspec/changes/add-version-update-indicator/tasks.md
@@ -1,0 +1,22 @@
+## 1. Specs
+
+- [x] 1.1 Add runtime version status API requirements.
+- [x] 1.2 Add dashboard footer update-indicator requirements.
+
+## 2. Backend
+
+- [x] 2.1 Add a runtime version service that fetches and caches the latest GitHub release.
+- [x] 2.2 Add `/api/runtime/version` response schema and route.
+- [x] 2.3 Cover version comparison, cache behavior, and failure degradation.
+
+## 3. Frontend
+
+- [x] 3.1 Add runtime version API client/schema.
+- [x] 3.2 Render a linked update icon beside the footer version only when an update is available.
+- [x] 3.3 Cover footer link behavior and the no-update/no-error fallback.
+
+## 4. Verification
+
+- [x] 4.1 Run focused backend unit tests.
+- [x] 4.2 Run focused frontend component tests.
+- [x] 4.3 Validate OpenSpec specs.

--- a/tests/integration/test_runtime_api.py
+++ b/tests/integration/test_runtime_api.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.modules.runtime.schemas import RuntimeVersionResponse
+
+pytestmark = pytest.mark.integration
+
+
+class _RuntimeVersionServiceStub:
+    async def get_version_status(self) -> RuntimeVersionResponse:
+        return RuntimeVersionResponse(
+            current_version="1.19.0",
+            latest_version="1.20.0",
+            update_available=True,
+            checked_at=datetime(2026, 5, 26, 0, 0, 0),
+            source="github",
+            release_url="https://github.com/Soju06/codex-lb/releases/latest",
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_endpoint_returns_camel_case_contract(async_client, monkeypatch) -> None:
+    from app.modules.runtime import api as runtime_api
+
+    monkeypatch.setattr(runtime_api, "get_runtime_version_service", lambda: _RuntimeVersionServiceStub())
+
+    response = await async_client.get("/api/runtime/version")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "currentVersion": "1.19.0",
+        "latestVersion": "1.20.0",
+        "updateAvailable": True,
+        "checkedAt": "2026-05-26T00:00:00Z",
+        "source": "github",
+        "releaseUrl": "https://github.com/Soju06/codex-lb/releases/latest",
+    }
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_endpoint_requires_dashboard_auth_for_remote_clients(app_instance) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("203.0.113.11", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
+            response = await remote_client.get("/api/runtime/version")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "bootstrap_required"

--- a/tests/unit/test_runtime_version.py
+++ b/tests/unit/test_runtime_version.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.modules.runtime.service import RuntimeVersionService
+
+
+def _mock_response(*, status: int = 200, json_data: object = None) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_data)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+    return response
+
+
+def _mock_session(response: MagicMock) -> MagicMock:
+    session = MagicMock()
+    session.get = MagicMock(return_value=response)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_reports_update_available_for_newer_github_release() -> None:
+    service = RuntimeVersionService(current_version="1.19.0", ttl_seconds=60)
+    session = _mock_session(_mock_response(json_data={"tag_name": "v1.20.0"}))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=session):
+        status = await service.get_version_status()
+
+    assert status.current_version == "1.19.0"
+    assert status.latest_version == "1.20.0"
+    assert status.update_available is True
+    assert status.source == "github"
+    assert status.release_url == "https://github.com/Soju06/codex-lb/releases/latest"
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_does_not_report_update_for_same_release() -> None:
+    service = RuntimeVersionService(current_version="1.19.0", ttl_seconds=60)
+    session = _mock_session(_mock_response(json_data={"tag_name": "v1.19.0"}))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=session):
+        status = await service.get_version_status()
+
+    assert status.latest_version == "1.19.0"
+    assert status.update_available is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_reports_stable_release_as_update_for_current_beta() -> None:
+    service = RuntimeVersionService(current_version="1.20.0-beta.1", ttl_seconds=60)
+    session = _mock_session(_mock_response(json_data={"tag_name": "v1.20.0"}))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=session):
+        status = await service.get_version_status()
+
+    assert status.latest_version == "1.20.0"
+    assert status.update_available is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_compares_prerelease_identifiers() -> None:
+    service = RuntimeVersionService(current_version="1.20.0-beta.1", ttl_seconds=60)
+    session = _mock_session(_mock_response(json_data={"tag_name": "v1.20.0-beta.2"}))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=session):
+        status = await service.get_version_status()
+
+    assert status.latest_version == "1.20.0-beta.2"
+    assert status.update_available is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_degrades_silently_on_github_failure() -> None:
+    service = RuntimeVersionService(current_version="1.19.0", ttl_seconds=60)
+    session = _mock_session(_mock_response(status=503, json_data=None))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=session):
+        status = await service.get_version_status()
+
+    assert status.current_version == "1.19.0"
+    assert status.latest_version is None
+    assert status.update_available is False
+    assert status.source is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_caches_failed_lookup() -> None:
+    service = RuntimeVersionService(current_version="1.19.0", ttl_seconds=60)
+    session = _mock_session(_mock_response(status=503, json_data=None))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=session):
+        first = await service.get_version_status()
+        second = await service.get_version_status()
+
+    assert first.update_available is False
+    assert second.update_available is False
+    session.get.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_uses_github_token_when_available(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "github-secret")
+    service = RuntimeVersionService(current_version="1.19.0", ttl_seconds=60)
+    session = _mock_session(_mock_response(json_data={"tag_name": "v1.20.0"}))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=session):
+        status = await service.get_version_status()
+
+    assert status.update_available is True
+    headers = session.get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer github-secret"
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_omits_github_token_when_unavailable(monkeypatch) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    service = RuntimeVersionService(current_version="1.19.0", ttl_seconds=60)
+    session = _mock_session(_mock_response(json_data={"tag_name": "v1.20.0"}))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=session):
+        await service.get_version_status()
+
+    headers = session.get.call_args.kwargs["headers"]
+    assert "Authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_runtime_version_refetches_failed_lookup_after_failure_ttl() -> None:
+    service = RuntimeVersionService(current_version="1.19.0", ttl_seconds=60, failure_ttl_seconds=1)
+    failed_session = _mock_session(_mock_response(status=503, json_data=None))
+
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=failed_session):
+        failed = await service.get_version_status()
+
+    assert failed.update_available is False
+    service._cached_at = time.monotonic() - 2
+
+    successful_session = _mock_session(_mock_response(json_data={"tag_name": "v1.20.0"}))
+    with patch("app.modules.runtime.service.aiohttp.ClientSession", return_value=successful_session):
+        recovered = await service.get_version_status()
+
+    assert recovered.latest_version == "1.20.0"
+    assert recovered.update_available is True


### PR DESCRIPTION
## Summary

Adds a dashboard footer update indicator for stale codex-lb deployments. The backend exposes a dashboard-auth protected runtime version endpoint that caches GitHub latest-release lookups and degrades silently when the lookup fails.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: N/A — requested directly, no existing issue.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/add-version-update-indicator/`

## Changes

- Adds `GET /api/runtime/version`, protected by dashboard auth, returning current version, latest GitHub release version, update availability, lookup timestamp, and release URL.
- Adds cached GitHub latest-release lookup with silent failure degradation and semver/prerelease comparison support.
- Updates the footer status bar to show a linked update icon beside the version only when a newer release is confirmed.
- Adds backend unit/integration coverage and frontend component coverage for the new behavior.

## Test plan

```bash
uv run pytest tests/unit/test_runtime_version.py tests/integration/test_runtime_api.py
uv run ruff check app/modules/runtime app/main.py tests/unit/test_runtime_version.py tests/integration/test_runtime_api.py
bun run test -- status-bar.test.tsx
bun run typecheck
openspec validate add-version-update-indicator --strict
openspec validate --specs
git diff --check
```

Full `uv run pre-commit run local-ci --hook-stage manual --all-files` was not run; the focused backend/frontend/spec subset above covers the changed runtime endpoint and footer UI.

## Screenshots / output (optional)

N/A — compact footer icon behavior is covered by component tests.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above, or marked N/A because none exists.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local validation subset listed in the test plan.
- [x] If touching specs: `openspec validate --specs` passes.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
