### PR TITLE
fix(proxy): recover websocket terminal auth failures

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -20,6 +20,8 @@ PERMANENT_FAILURE_CODES = {
     # returned a fresh token pair instead. Treat it as a permanent failure so
     # the account stops being routed to until it is re-authenticated.
     "token_expired": "Authentication token expired - re-login required",
+    "account_session_expired": "ChatGPT session ended - re-login required",
+    "account_auth_invalidated": "Authentication failed after token refresh - re-login required",
     "account_deactivated": "Account has been deactivated",
     "account_suspended": "Account has been suspended",
     "account_deleted": "Account has been deleted",

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2391,7 +2391,7 @@ async def _validate_proxy_api_key_authorization_for_connection(
 
 def _is_legacy_proxy_auth_override_type_error(exc: TypeError) -> bool:
     message = str(exc)
-    return "request" in message and "unexpected keyword argument" in message
+    return "unexpected keyword argument 'request'" in message
 
 
 async def _validate_proxy_websocket_request(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
@@ -2385,13 +2384,10 @@ async def _validate_proxy_websocket_request(
     if denial is not None:
         return None, denial
     try:
-        if "request" in inspect.signature(validate_proxy_api_key_authorization).parameters:
-            api_key = await validate_proxy_api_key_authorization(
-                websocket.headers.get("authorization"),
-                request=websocket,
-            )
-        else:
-            api_key = await validate_proxy_api_key_authorization(websocket.headers.get("authorization"))
+        api_key = await validate_proxy_api_key_authorization(
+            websocket.headers.get("authorization"),
+            request=websocket,
+        )
     except ProxyAuthError as exc:
         return None, JSONResponse(
             status_code=exc.status_code,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2377,6 +2377,23 @@ def _error_details_from_content(
     return code if isinstance(code, str) else None, message if isinstance(message, str) else None
 
 
+async def _validate_proxy_api_key_authorization_for_connection(
+    authorization: str | None,
+    connection: Request | WebSocket,
+) -> ApiKeyData | None:
+    try:
+        return await validate_proxy_api_key_authorization(authorization, request=connection)
+    except TypeError as exc:
+        if not _is_legacy_proxy_auth_override_type_error(exc):
+            raise
+    return await validate_proxy_api_key_authorization(authorization)
+
+
+def _is_legacy_proxy_auth_override_type_error(exc: TypeError) -> bool:
+    message = str(exc)
+    return "request" in message and "unexpected keyword argument" in message
+
+
 async def _validate_proxy_websocket_request(
     websocket: WebSocket,
 ) -> tuple[ApiKeyData | None, JSONResponse | None]:
@@ -2384,9 +2401,9 @@ async def _validate_proxy_websocket_request(
     if denial is not None:
         return None, denial
     try:
-        api_key = await validate_proxy_api_key_authorization(
+        api_key = await _validate_proxy_api_key_authorization_for_connection(
             websocket.headers.get("authorization"),
-            request=websocket,
+            websocket,
         )
     except ProxyAuthError as exc:
         return None, JSONResponse(
@@ -2403,9 +2420,9 @@ async def _validate_internal_bridge_api_key(
     if not dashboard_settings.api_key_auth_enabled:
         return None, None
     try:
-        api_key = await validate_proxy_api_key_authorization(
+        api_key = await _validate_proxy_api_key_authorization_for_connection(
             request.headers.get("authorization"),
-            request=request,
+            request,
         )
     except ProxyAuthError as exc:
         return None, JSONResponse(

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1346,14 +1346,7 @@ async def _latest_additional_by_key(
     )
     if resolved_quota_key is None:
         return {}
-    if hasattr(additional_usage_repo, "latest_by_quota_key"):
-        return await additional_usage_repo.latest_by_quota_key(
-            resolved_quota_key,
-            window,
-            account_ids=account_ids,
-            since=since,
-        )
-    return await additional_usage_repo.latest_by_account(
+    return await additional_usage_repo.latest_by_quota_key(
         resolved_quota_key,
         window,
         account_ids=account_ids,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4467,7 +4467,6 @@ class ProxyService:
                     last_failover_exc = exc
                     last_failover_account = account
                     excluded_account_ids.add(account.id)
-                    request_state.excluded_account_ids.add(account.id)
                     continue
                 error = _parse_openai_error(exc.payload)
                 error_code = _normalize_error_code(error.code if error else None, error.type if error else None)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4689,7 +4689,7 @@ class ProxyService:
                     request_state=request_state,
                 )
                 return None
-            if exc.status_code != 401:
+            if exc.status_code != 401 or force_refresh:
                 raise
             return await self._retry_websocket_connect_after_401(
                 account,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8480,7 +8480,8 @@ class ProxyService:
 
         if _websocket_auth_failure_requires_reauth(error_message):
             failure_code = _WEBSOCKET_SESSION_EXPIRED_FAILURE_CODE
-        elif request_state.auth_replay_count <= 1:
+        elif request_state.auth_replay_counts_by_account.get(account.id, 0) == 0:
+            request_state.auth_replay_counts_by_account[account.id] = 1
             request_state.force_refresh_account_id = account.id
             request_state.preferred_account_id = account.id
             upstream_control.reconnect_requested = True
@@ -11494,6 +11495,7 @@ class _WebSocketRequestState:
     request_text: str | None = None
     replay_count: int = 0
     auth_replay_count: int = 0
+    auth_replay_counts_by_account: dict[str, int] = field(default_factory=dict)
     force_refresh_account_id: str | None = None
     excluded_account_ids: set[str] = field(default_factory=set)
     skip_request_log: bool = False

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -370,6 +370,17 @@ _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES = frozenset(
         "quota_exceeded",
     }
 )
+_WEBSOCKET_AUTH_FAILURE_CODES = frozenset({"invalid_api_key", "invalid_authentication"})
+_WEBSOCKET_REAUTH_REQUIRED_MESSAGE_MARKERS = (
+    "session has ended",
+    "session expired",
+    "log in again",
+    "login again",
+    "reauth",
+    "re-auth",
+)
+_WEBSOCKET_SESSION_EXPIRED_FAILURE_CODE = "account_session_expired"
+_WEBSOCKET_AUTH_INVALIDATED_FAILURE_CODE = "account_auth_invalidated"
 _SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE = (
     "Suppressed duplicate side-effect tool call; upstream response cannot be continued safely."
 )
@@ -4384,11 +4395,13 @@ class ProxyService:
         deadline = _websocket_connect_deadline(request_state, get_settings().proxy_request_budget_seconds)
         base_settings = get_settings()
         max_attempts = _WEBSOCKET_MAX_ACCOUNT_ATTEMPTS
-        excluded_account_ids: set[str] = set()
+        excluded_account_ids: set[str] = set(request_state.excluded_account_ids)
         last_failover_exc: ProxyResponseError | None = None
         last_failover_account: Account | None = None
         for attempt in range(max_attempts):
             is_retry = attempt > 0
+            forced_refresh_account_id = request_state.force_refresh_account_id
+            preferred_account_id = forced_refresh_account_id or request_state.preferred_account_id
             require_preferred_account = (
                 request_state.previous_response_id is not None and request_state.preferred_account_id is not None
             )
@@ -4405,7 +4418,7 @@ class ProxyService:
                 "reallocate_sticky": True if is_retry else reallocate_sticky,
                 "sticky_max_age_seconds": sticky_max_age_seconds,
                 "exclude_account_ids": excluded_account_ids,
-                "preferred_account_id": request_state.preferred_account_id,
+                "preferred_account_id": preferred_account_id,
                 "require_preferred_account": require_preferred_account,
             }
             if "defer_no_account_error" in inspect.signature(self._select_websocket_connect_account).parameters:
@@ -4435,14 +4448,19 @@ class ProxyService:
                 return None, None
 
             try:
+                try_open_kwargs: dict[str, Any] = {
+                    "deadline": deadline,
+                    "api_key": api_key,
+                    "request_state": request_state,
+                    "client_send_lock": client_send_lock,
+                    "websocket": websocket,
+                }
+                if "force_refresh" in inspect.signature(self._try_open_websocket_connect_attempt).parameters:
+                    try_open_kwargs["force_refresh"] = forced_refresh_account_id == account.id
                 connect_result = await self._try_open_websocket_connect_attempt(
                     account,
                     headers,
-                    deadline=deadline,
-                    api_key=api_key,
-                    request_state=request_state,
-                    client_send_lock=client_send_lock,
-                    websocket=websocket,
+                    **try_open_kwargs,
                 )
             except ProxyResponseError as exc:
                 action = await self._decide_websocket_failover_action(
@@ -4457,6 +4475,7 @@ class ProxyService:
                     last_failover_exc = exc
                     last_failover_account = account
                     excluded_account_ids.add(account.id)
+                    request_state.excluded_account_ids.add(account.id)
                     continue
                 error = _parse_openai_error(exc.payload)
                 error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
@@ -4632,6 +4651,7 @@ class ProxyService:
         request_state: _WebSocketRequestState,
         client_send_lock: anyio.Lock,
         websocket: WebSocket,
+        force_refresh: bool = False,
     ) -> tuple[Account, UpstreamResponsesWebSocket] | None:
         try:
             remaining_budget = _remaining_budget_seconds(deadline)
@@ -4644,7 +4664,13 @@ class ProxyService:
                     request_state=request_state,
                 )
                 return None
-            account = await self._ensure_fresh_with_budget(account, timeout_seconds=remaining_budget)
+            account = await self._ensure_fresh_with_budget(
+                account,
+                force=force_refresh,
+                timeout_seconds=remaining_budget,
+            )
+            if force_refresh and request_state.force_refresh_account_id == account.id:
+                request_state.force_refresh_account_id = None
 
             remaining_budget = _remaining_budget_seconds(deadline)
             if remaining_budget <= 0:
@@ -8384,6 +8410,21 @@ class ProxyService:
             payload=payload,
             has_other_pending_requests=has_other_pending_requests,
         )
+        auth_error_code = _websocket_precreated_auth_error_code(
+            request_state,
+            event_type=event_type,
+            payload=payload,
+            has_other_pending_requests=has_other_pending_requests,
+        )
+        if auth_error_code is not None:
+            handled_auth_failure = await self._handle_precreated_websocket_auth_failure(
+                account=account,
+                request_state=request_state,
+                upstream_control=upstream_control,
+                error_message=_websocket_event_error_message(event_type, payload),
+            )
+            if handled_auth_failure:
+                return text
         event, payload, event_type, downstream_text = _maybe_rewrite_websocket_previous_response_not_found_event(
             request_state=request_state,
             event=event,
@@ -8469,6 +8510,38 @@ class ProxyService:
             response_create_gate=response_create_gate,
         )
         return downstream_text
+
+    async def _handle_precreated_websocket_auth_failure(
+        self,
+        *,
+        account: Account,
+        request_state: "_WebSocketRequestState",
+        upstream_control: "_WebSocketUpstreamControl",
+        error_message: str | None,
+    ) -> bool:
+        if _prepare_websocket_request_state_for_auth_replay(request_state) is None:
+            return False
+
+        if _websocket_auth_failure_requires_reauth(error_message):
+            failure_code = _WEBSOCKET_SESSION_EXPIRED_FAILURE_CODE
+        elif request_state.auth_replay_count <= 1:
+            request_state.force_refresh_account_id = account.id
+            request_state.preferred_account_id = account.id
+            upstream_control.reconnect_requested = True
+            upstream_control.suppress_downstream_event = True
+            upstream_control.replay_request_state = request_state
+            return True
+        else:
+            failure_code = _WEBSOCKET_AUTH_INVALIDATED_FAILURE_CODE
+
+        await self._load_balancer.mark_permanent_failure(account, failure_code)
+        request_state.force_refresh_account_id = None
+        request_state.preferred_account_id = None
+        request_state.excluded_account_ids.add(account.id)
+        upstream_control.reconnect_requested = True
+        upstream_control.suppress_downstream_event = True
+        upstream_control.replay_request_state = request_state
+        return True
 
     async def _next_websocket_receive_timeout(
         self,
@@ -11467,6 +11540,9 @@ class _WebSocketRequestState:
     api_key: ApiKeyData | None = None
     request_text: str | None = None
     replay_count: int = 0
+    auth_replay_count: int = 0
+    force_refresh_account_id: str | None = None
+    excluded_account_ids: set[str] = field(default_factory=set)
     skip_request_log: bool = False
     previous_response_id: str | None = None
     session_id: str | None = None
@@ -12159,6 +12235,84 @@ def _websocket_precreated_retry_error_code(
     if error_code not in _WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
         return None
     return error_code
+
+
+def _websocket_precreated_auth_error_code(
+    request_state: _WebSocketRequestState | None,
+    *,
+    event_type: str | None,
+    payload: dict[str, JsonValue] | None,
+    has_other_pending_requests: bool,
+) -> str | None:
+    if request_state is None:
+        return None
+    if has_other_pending_requests:
+        return None
+    if request_state.response_id is not None:
+        return None
+    if request_state.response_event_count > 0:
+        return None
+    if not request_state.awaiting_response_created:
+        return None
+    if not request_state.request_text:
+        return None
+    if request_state.downstream_visible:
+        return None
+    if event_type not in {"error", "response.failed"}:
+        return None
+
+    error_code = _normalize_error_code(
+        _websocket_event_error_code(event_type, payload),
+        _websocket_event_error_type(event_type, payload),
+    )
+    error_type = _websocket_event_error_type(event_type, payload)
+    if error_code in _WEBSOCKET_AUTH_FAILURE_CODES or error_type == "authentication_error":
+        return "invalid_api_key"
+    return None
+
+
+def _websocket_auth_failure_requires_reauth(message: str | None) -> bool:
+    if not isinstance(message, str):
+        return False
+    lowered = message.lower()
+    return any(marker in lowered for marker in _WEBSOCKET_REAUTH_REQUIRED_MESSAGE_MARKERS)
+
+
+def _websocket_auth_request_can_switch_account(request_state: _WebSocketRequestState) -> bool:
+    if request_state.previous_response_id is None or request_state.preferred_account_id is None:
+        return True
+    return bool(
+        request_state.proxy_injected_previous_response_id
+        and request_state.fresh_upstream_request_is_retry_safe
+        and request_state.fresh_upstream_request_text
+    )
+
+
+def _prepare_websocket_request_state_for_auth_replay(
+    request_state: _WebSocketRequestState,
+) -> str | None:
+    if not _websocket_auth_request_can_switch_account(request_state):
+        return None
+    if (
+        request_state.proxy_injected_previous_response_id
+        and request_state.fresh_upstream_request_is_retry_safe
+        and request_state.fresh_upstream_request_text
+    ):
+        request_state.request_text = request_state.fresh_upstream_request_text
+        request_state.previous_response_id = None
+        request_state.preferred_account_id = None
+        request_state.proxy_injected_previous_response_id = False
+        request_state.fresh_upstream_request_is_retry_safe = False
+        _refresh_websocket_request_input_fingerprint_from_text(request_state)
+    request_text = request_state.request_text
+    if not isinstance(request_text, str):
+        return None
+    request_state.replay_count += 1
+    request_state.auth_replay_count += 1
+    request_state.awaiting_response_created = True
+    request_state.response_id = None
+    request_state.response_event_count = 0
+    return request_text
 
 
 def _websocket_owner_pinned_quota_error_code(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4448,19 +4448,15 @@ class ProxyService:
                 return None, None
 
             try:
-                try_open_kwargs: dict[str, Any] = {
-                    "deadline": deadline,
-                    "api_key": api_key,
-                    "request_state": request_state,
-                    "client_send_lock": client_send_lock,
-                    "websocket": websocket,
-                }
-                if "force_refresh" in inspect.signature(self._try_open_websocket_connect_attempt).parameters:
-                    try_open_kwargs["force_refresh"] = forced_refresh_account_id == account.id
                 connect_result = await self._try_open_websocket_connect_attempt(
                     account,
                     headers,
-                    **try_open_kwargs,
+                    deadline=deadline,
+                    api_key=api_key,
+                    request_state=request_state,
+                    client_send_lock=client_send_lock,
+                    websocket=websocket,
+                    force_refresh=forced_refresh_account_id == account.id,
                 )
             except ProxyResponseError as exc:
                 action = await self._decide_websocket_failover_action(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -4442,6 +4442,10 @@ class ProxyService:
                 if last_failover_exc is not None and not require_preferred_account:
                     break
                 return None, None
+            if forced_refresh_account_id is not None and account.id != forced_refresh_account_id:
+                request_state.force_refresh_account_id = None
+                if request_state.preferred_account_id == forced_refresh_account_id:
+                    request_state.preferred_account_id = None
 
             try:
                 connect_result = await self._try_open_websocket_connect_attempt(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import gzip
-import inspect
 import json
 import logging
 import math
@@ -2017,7 +2016,7 @@ class ProxyService:
             last_exc: ProxyResponseError | None = None
             excluded_account_ids: set[str] = set()
             for _account_attempt in range(_COMPACT_MAX_ACCOUNT_ATTEMPTS):
-                selection = await self._select_account_with_budget_compatible(
+                selection = await self._select_account_with_budget(
                     deadline,
                     request_id=request_id,
                     kind="compact",
@@ -2329,7 +2328,7 @@ class ProxyService:
         request_kind = f"thread_goal_{operation}"
 
         try:
-            selection = await self._select_account_with_budget_compatible(
+            selection = await self._select_account_with_budget(
                 deadline,
                 request_id=request_id,
                 kind=request_kind,
@@ -2441,7 +2440,7 @@ class ProxyService:
                         except ProxyResponseError as retry_exc:
                             await self._handle_proxy_error(account, retry_exc)
                             if retry_exc.status_code == 401:
-                                selection = await self._select_account_with_budget_compatible(
+                                selection = await self._select_account_with_budget(
                                     deadline,
                                     request_id=request_id,
                                     kind=request_kind,
@@ -2540,7 +2539,7 @@ class ProxyService:
         request_kind = f"codex_control_{path.strip('/').replace('/', '_')}"
 
         try:
-            selection = await self._select_account_with_budget_compatible(
+            selection = await self._select_account_with_budget(
                 deadline,
                 request_id=request_id,
                 kind=request_kind,
@@ -2652,7 +2651,7 @@ class ProxyService:
                         except ProxyResponseError as retry_exc:
                             await self._handle_proxy_error(account, retry_exc)
                             if retry_exc.status_code == 401:
-                                selection = await self._select_account_with_budget_compatible(
+                                selection = await self._select_account_with_budget(
                                     deadline,
                                     request_id=request_id,
                                     kind=request_kind,
@@ -2743,7 +2742,7 @@ class ProxyService:
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
         routing_strategy = _routing_strategy(settings)
         try:
-            selection = await self._select_account_with_budget_compatible(
+            selection = await self._select_account_with_budget(
                 deadline,
                 request_id=request_id,
                 kind="transcribe",
@@ -2859,7 +2858,7 @@ class ProxyService:
                 except ProxyResponseError as retry_exc:
                     await self._handle_proxy_error(account, retry_exc)
                     if retry_exc.status_code == 401:
-                        selection = await self._select_account_with_budget_compatible(
+                        selection = await self._select_account_with_budget(
                             deadline,
                             request_id=request_id,
                             kind="transcribe",
@@ -3184,7 +3183,7 @@ class ProxyService:
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
         routing_strategy = _routing_strategy(settings)
         try:
-            selection = await self._select_account_with_budget_compatible(
+            selection = await self._select_account_with_budget(
                 deadline,
                 request_id=request_id,
                 kind=kind,
@@ -3309,7 +3308,7 @@ class ProxyService:
                 except ProxyResponseError as retry_exc:
                     await self._handle_proxy_error(account, retry_exc)
                     if retry_exc.status_code == 401:
-                        selection = await self._select_account_with_budget_compatible(
+                        selection = await self._select_account_with_budget(
                             deadline,
                             request_id=request_id,
                             kind=kind,
@@ -4405,28 +4404,25 @@ class ProxyService:
             require_preferred_account = (
                 request_state.previous_response_id is not None and request_state.preferred_account_id is not None
             )
-            select_kwargs: dict[str, Any] = {
-                "sticky_key": sticky_key,
-                "sticky_kind": sticky_kind,
-                "prefer_earlier_reset": prefer_earlier_reset,
-                "routing_strategy": routing_strategy,
-                "model": model,
-                "request_state": request_state,
-                "api_key": api_key,
-                "client_send_lock": client_send_lock,
-                "websocket": websocket,
-                "reallocate_sticky": True if is_retry else reallocate_sticky,
-                "sticky_max_age_seconds": sticky_max_age_seconds,
-                "exclude_account_ids": excluded_account_ids,
-                "preferred_account_id": preferred_account_id,
-                "require_preferred_account": require_preferred_account,
-            }
-            if "defer_no_account_error" in inspect.signature(self._select_websocket_connect_account).parameters:
-                select_kwargs["defer_no_account_error"] = (
-                    last_failover_exc is not None and not require_preferred_account
-                )
             try:
-                account = await self._select_websocket_connect_account(deadline, **select_kwargs)
+                account = await self._select_websocket_connect_account(
+                    deadline,
+                    sticky_key=sticky_key,
+                    sticky_kind=sticky_kind,
+                    prefer_earlier_reset=prefer_earlier_reset,
+                    routing_strategy=routing_strategy,
+                    model=model,
+                    request_state=request_state,
+                    api_key=api_key,
+                    client_send_lock=client_send_lock,
+                    websocket=websocket,
+                    reallocate_sticky=True if is_retry else reallocate_sticky,
+                    sticky_max_age_seconds=sticky_max_age_seconds,
+                    exclude_account_ids=excluded_account_ids,
+                    preferred_account_id=preferred_account_id,
+                    require_preferred_account=require_preferred_account,
+                    defer_no_account_error=last_failover_exc is not None and not require_preferred_account,
+                )
             except _WebSocketConnectFailureEmitted:
                 return None, None
             if account is None:
@@ -4531,7 +4527,7 @@ class ProxyService:
         defer_no_account_error: bool = False,
     ) -> Account | None:
         try:
-            selection = await self._select_account_with_budget_compatible(
+            selection = await self._select_account_with_budget(
                 deadline,
                 request_id=request_state.request_log_id or request_state.request_id,
                 kind="websocket",
@@ -4907,24 +4903,6 @@ class ProxyService:
             )
             return max(visible_pending_count, session.queued_request_count)
 
-    async def _select_account_with_budget_compatible(
-        self,
-        deadline: float,
-        **kwargs: object,
-    ) -> AccountSelection:
-        select_account = self._select_account_with_budget
-        select_account_any = cast(Any, select_account)
-        try:
-            signature = inspect.signature(select_account)
-        except (TypeError, ValueError):
-            return await select_account_any(deadline, **kwargs)
-
-        if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()):
-            return await select_account_any(deadline, **kwargs)
-
-        supported_kwargs = {name: value for name, value in kwargs.items() if name in signature.parameters}
-        return await select_account_any(deadline, **supported_kwargs)
-
     async def _select_codex_control_account_without_budget(
         self,
         *,
@@ -4948,24 +4926,6 @@ class ProxyService:
         if selection.account is None:
             return None
         return _detached_account_copy(selection.account)
-
-    async def _create_http_bridge_session_compatible(
-        self,
-        key: "_HTTPBridgeSessionKey",
-        **kwargs: object,
-    ) -> "_HTTPBridgeSession":
-        create_session = self._create_http_bridge_session
-        create_session_any = cast(Any, create_session)
-        try:
-            signature = inspect.signature(create_session)
-        except (TypeError, ValueError):
-            return await create_session_any(key, **kwargs)
-
-        if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()):
-            return await create_session_any(key, **kwargs)
-
-        supported_kwargs = {name: value for name, value in kwargs.items() if name in signature.parameters}
-        return await create_session_any(key, **supported_kwargs)
 
     async def _fail_http_bridge_inflight_session_creation(
         self,
@@ -5919,7 +5879,7 @@ class ProxyService:
             session_registered = False
             require_preferred_account = previous_response_id is not None and preferred_account_id is not None
             try:
-                created_session = await self._create_http_bridge_session_compatible(
+                created_session = await self._create_http_bridge_session(
                     key,
                     headers=headers,
                     affinity=affinity,
@@ -6322,7 +6282,7 @@ class ProxyService:
         retry_same_account_once = preferred_account_id is not None
         preferred_candidate_id = preferred_account_id
         while True:
-            selection = await self._select_account_with_budget_compatible(
+            selection = await self._select_account_with_budget(
                 deadline,
                 request_id=request_state.request_log_id or request_state.request_id,
                 kind="http_bridge",
@@ -7094,7 +7054,7 @@ class ProxyService:
         retry_same_account_once = not skip_same_account
         preferred_candidate_id: str | None = None if skip_same_account else session.account.id
         while True:
-            selection = await self._select_account_with_budget_compatible(
+            selection = await self._select_account_with_budget(
                 deadline,
                 request_id=request_state.request_log_id or request_state.request_id,
                 kind="http_bridge",
@@ -9602,7 +9562,7 @@ class ProxyService:
                     yield format_sse_event(_proxy_request_timeout_event(request_id))
                     return
                 try:
-                    selection = await self._select_account_with_budget_compatible(
+                    selection = await self._select_account_with_budget(
                         deadline,
                         request_id=request_id,
                         kind="stream",
@@ -11172,10 +11132,7 @@ class ProxyService:
         force: bool = False,
         timeout_seconds: float | None = None,
     ) -> Account:
-        parameters = inspect.signature(self._ensure_fresh).parameters
-        if "timeout_seconds" in parameters:
-            return await self._ensure_fresh(account, force=force, timeout_seconds=timeout_seconds)
-        return await self._ensure_fresh(account, force=force)
+        return await self._ensure_fresh(account, force=force, timeout_seconds=timeout_seconds)
 
     async def _ensure_fresh_with_budget_or_auth_error(
         self,

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import inspect
 import logging
 import math
 import time
@@ -681,24 +680,11 @@ async def _add_additional_usage_entry(
     reset_at: int | None,
     window_minutes: int | None,
 ) -> None:
-    add_entry = repo.add_entry
-    if "quota_key" in inspect.signature(add_entry).parameters:
-        await add_entry(
-            account_id=account_id,
-            limit_name=limit_name,
-            metered_feature=metered_feature,
-            quota_key=quota_key,
-            window=window,
-            used_percent=used_percent,
-            reset_at=reset_at,
-            window_minutes=window_minutes,
-        )
-        return
-
-    await add_entry(
+    await repo.add_entry(
         account_id=account_id,
         limit_name=limit_name,
         metered_feature=metered_feature,
+        quota_key=quota_key,
         window=window,
         used_percent=used_percent,
         reset_at=reset_at,
@@ -711,10 +697,7 @@ async def _list_additional_usage_quota_keys(
     *,
     account_ids: Collection[str] | None = None,
 ) -> list[str]:
-    list_quota_keys = getattr(repo, "list_quota_keys", None)
-    if callable(list_quota_keys):
-        return await list_quota_keys(account_ids=account_ids)
-    return await repo.list_limit_names(account_ids=account_ids)
+    return await repo.list_quota_keys(account_ids=account_ids)
 
 
 async def _delete_additional_usage_quota_key(
@@ -722,11 +705,7 @@ async def _delete_additional_usage_quota_key(
     account_id: str,
     quota_key: str,
 ) -> None:
-    delete_by_quota_key = getattr(repo, "delete_for_account_and_quota_key", None)
-    if callable(delete_by_quota_key):
-        await delete_by_quota_key(account_id, quota_key)
-        return
-    await repo.delete_for_account_and_limit(account_id, quota_key)
+    await repo.delete_for_account_and_quota_key(account_id, quota_key)
 
 
 async def _delete_additional_usage_quota_key_window(
@@ -735,11 +714,7 @@ async def _delete_additional_usage_quota_key_window(
     quota_key: str,
     window: str,
 ) -> None:
-    delete_by_quota_key_window = getattr(repo, "delete_for_account_quota_key_window", None)
-    if callable(delete_by_quota_key_window):
-        await delete_by_quota_key_window(account_id, quota_key, window)
-        return
-    await repo.delete_for_account_limit_window(account_id, quota_key, window)
+    await repo.delete_for_account_quota_key_window(account_id, quota_key, window)
 
 
 def _latest_usage_is_fresh(

--- a/openspec/changes/fix-ws-terminal-auth-failover/.openspec.yaml
+++ b/openspec/changes/fix-ws-terminal-auth-failover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/fix-ws-terminal-auth-failover/design.md
+++ b/openspec/changes/fix-ws-terminal-auth-failover/design.md
@@ -1,0 +1,25 @@
+# Design: WebSocket terminal auth failover
+
+## Problem model
+
+The WebSocket proxy has two different auth-failure surfaces:
+
+1. Connect-time auth failure: upstream rejects the WebSocket handshake with HTTP 401. This already performs forced refresh and account failover.
+2. Terminal in-band auth failure: upstream accepts the WebSocket, then returns `response.failed` or `error` with `invalid_api_key`/`authentication_error` before `response.created` or any visible output. This currently finalizes the request as a normal terminal error and does not refresh, fail over, or deactivate the selected account.
+
+The second surface is account-local when it occurs before downstream-visible output and the request has a replayable `response.create` body. It is safe to suppress the failed terminal event and replay on a refreshed or alternate account because no response content has been shown to the client.
+
+## Recovery policy
+
+- Detect auth terminal events by normalized `invalid_api_key` or `authentication_error`.
+- Treat messages containing `session has ended`, `log in again`, `session expired`, or `reauth` as explicit re-authentication-required signals.
+- If the auth error is re-authentication-required, mark the account permanent with an internal `account_session_expired` code and replay excluding that account.
+- If the auth error is generic and the request has not yet attempted an auth replay, reconnect to the same account with forced token refresh and replay once.
+- If the same replay fails with terminal auth again, mark the account permanent with `account_auth_invalidated`, exclude it, and replay on another eligible account.
+
+## Safety constraints
+
+- Only replay when `_websocket_precreated_retry_error_code`-style pre-visible guards hold: one pending request, no `response_id`, no response events, `awaiting_response_created`, request text present, and replay count budget available.
+- Do not replay after text deltas or other downstream-visible output.
+- Do not silently switch account for owner-pinned `previous_response_id` continuations; those remain fail-closed unless the request has a safe fresh replay body.
+- Preserve downstream compatibility by continuing to expose OpenAI-shaped auth errors when no safe recovery is possible.

--- a/openspec/changes/fix-ws-terminal-auth-failover/proposal.md
+++ b/openspec/changes/fix-ws-terminal-auth-failover/proposal.md
@@ -1,0 +1,19 @@
+# Fix WebSocket terminal auth failover
+
+## Why
+
+Codex-native WebSocket sessions can receive an upstream terminal `response.failed`/`error` with `invalid_api_key` and messages such as `Your session has ended. Please log in again.` after the upstream WebSocket is already open. The existing failover path handles WebSocket handshake `401` responses, but terminal WebSocket auth failures are not classified as account-local auth failures, so the selected account can remain active and subsequent requests can repeat the same failure.
+
+## What Changes
+
+- Treat pre-visible WebSocket terminal authentication failures as account-local auth failures.
+- When the error explicitly indicates the ChatGPT session ended, mark the selected account re-authentication-required before replaying the request on another eligible account.
+- For generic pre-visible WebSocket `invalid_api_key`/`authentication_error`, retry the same account once after a forced token refresh, then exclude/deactivate the account if the refreshed replay still fails with auth.
+- Preserve no-replay behavior after downstream-visible output or when the request is not safely replayable.
+- Add regression coverage for WebSocket terminal session-ended failover and refreshed auth-failure handling.
+
+## Impact
+
+- **Code**: `app/modules/proxy/service.py`, `app/core/balancer/logic.py`
+- **Tests**: `tests/integration/test_proxy_websocket_responses.py`
+- **Behavior**: Account-local WebSocket auth failures stop repeating on the same account when another eligible account can serve the pre-visible request.

--- a/openspec/changes/fix-ws-terminal-auth-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-ws-terminal-auth-failover/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: WebSocket terminal auth failures recover before visible output
+
+When a Codex or OpenAI-compatible Responses WebSocket request receives an upstream terminal `response.failed` or `error` before downstream-visible output with `error.code = "invalid_api_key"` or `error.type = "authentication_error"`, the proxy MUST treat the failure as account-local auth state instead of immediately surfacing the terminal event. The proxy MUST preserve the existing no-replay rule after downstream-visible output or for non-replayable continuation requests.
+
+#### Scenario: Session-ended WebSocket auth failure uses another account
+
+- **GIVEN** at least two accounts are eligible for a WebSocket `response.create` request
+- **AND** the selected account returns a pre-visible terminal auth failure whose message says the session ended or asks the user to log in again
+- **WHEN** another eligible account can complete the request
+- **THEN** the downstream WebSocket response succeeds from the other account
+- **AND** the selected account is marked re-authentication-required and excluded from that replay
+
+#### Scenario: Generic WebSocket auth failure refreshes once before failover
+
+- **GIVEN** at least two accounts are eligible for a WebSocket `response.create` request
+- **AND** the selected account returns a pre-visible terminal `invalid_api_key` failure
+- **WHEN** the forced-refresh replay on the selected account also returns a pre-visible terminal `invalid_api_key` failure
+- **THEN** the proxy excludes the selected account and tries another eligible account
+- **AND** the downstream WebSocket response succeeds from the other account when it completes
+
+#### Scenario: WebSocket auth failure after visible output is not replayed
+
+- **GIVEN** a WebSocket response has emitted downstream-visible output
+- **WHEN** upstream later returns a terminal `invalid_api_key` or `authentication_error`
+- **THEN** the proxy MUST surface the terminal error without replaying the request on another account

--- a/openspec/changes/fix-ws-terminal-auth-failover/tasks.md
+++ b/openspec/changes/fix-ws-terminal-auth-failover/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+
+- [x] 1.1 Add permanent account status reasons for terminal WebSocket session-ended and post-refresh auth invalidation.
+- [x] 1.2 Detect pre-visible terminal WebSocket auth failures on direct Responses WebSocket handling.
+- [x] 1.3 Retry generic terminal auth failures once with forced refresh on the same account.
+- [x] 1.4 Mark/exclude re-auth-required or post-refresh-invalidated accounts and replay on another eligible account when possible.
+- [x] 1.5 Keep visible-output and non-replayable continuation failures surfaced without replay.
+
+## 2. Tests
+
+- [x] 2.1 Add WebSocket integration coverage for session-ended auth failure failing over to another account.
+- [x] 2.2 Add WebSocket integration coverage for generic auth failure retrying after forced refresh before failover.
+- [x] 2.3 Add or preserve coverage that visible-output auth failures are not replayed.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted WebSocket response tests.
+- [x] 3.2 Run `openspec validate --specs`.
+- [x] 3.3 Review diff and PR readiness.

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -2367,7 +2367,7 @@ async def test_stream_401_retry_success_finalizes_once(async_client, monkeypatch
         event = {"type": "response.completed", "response": {"id": "resp_retry", "usage": usage}}
         yield f"data: {json.dumps(event)}\n\n"
 
-    async def fake_ensure_fresh(self, account, force: bool = False):
+    async def fake_ensure_fresh(self, account, *, force: bool = False, timeout_seconds=None):
         if force:
             account.chatgpt_account_id = "acc_401_retry_refreshed"
         return account

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -1398,6 +1398,7 @@ async def test_v1_responses_http_bridge_codex_session_uses_extended_idle_ttl(asy
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -1408,12 +1409,15 @@ async def test_v1_responses_http_bridge_codex_session_uses_extended_idle_ttl(asy
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -1509,6 +1513,7 @@ async def test_v1_responses_http_bridge_creation_honors_prefer_earlier_reset(asy
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -1519,12 +1524,15 @@ async def test_v1_responses_http_bridge_creation_honors_prefer_earlier_reset(asy
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -1610,6 +1618,7 @@ async def test_v1_responses_http_bridge_codex_session_prewarms_first_request(asy
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -1620,12 +1629,15 @@ async def test_v1_responses_http_bridge_codex_session_prewarms_first_request(asy
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -1687,6 +1699,7 @@ async def test_v1_responses_http_bridge_codex_session_does_not_prewarm_by_defaul
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -1697,12 +1710,15 @@ async def test_v1_responses_http_bridge_codex_session_does_not_prewarm_by_defaul
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -1777,6 +1793,7 @@ async def test_v1_responses_http_bridge_non_owner_instance_falls_back_to_local_s
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -1787,12 +1804,15 @@ async def test_v1_responses_http_bridge_non_owner_instance_falls_back_to_local_s
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -1901,6 +1921,7 @@ async def test_v1_responses_http_bridge_non_owner_prompt_cache_rebinds_locally_w
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -1909,14 +1930,17 @@ async def test_v1_responses_http_bridge_non_owner_prompt_cache_rebinds_locally_w
         routing_strategy,
         model,
         api_key=None,
+        preferred_account_id=None,
         exclude_account_ids=None,
         additional_limit_name=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -2052,6 +2076,7 @@ async def test_v1_responses_http_bridge_replayed_turn_state_alias_preserves_owne
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -2062,12 +2087,15 @@ async def test_v1_responses_http_bridge_replayed_turn_state_alias_preserves_owne
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -2259,6 +2287,7 @@ async def test_v1_responses_http_bridge_generated_turn_state_fails_closed_withou
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -2269,12 +2298,15 @@ async def test_v1_responses_http_bridge_generated_turn_state_fails_closed_withou
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -2330,6 +2362,7 @@ async def test_v1_responses_http_bridge_turn_state_alias_respects_api_key_isolat
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -2340,12 +2373,15 @@ async def test_v1_responses_http_bridge_turn_state_alias_respects_api_key_isolat
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -2516,6 +2552,7 @@ async def test_v1_responses_http_bridge_preserves_prior_turn_state_aliases(
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -2526,12 +2563,15 @@ async def test_v1_responses_http_bridge_preserves_prior_turn_state_aliases(
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -2638,6 +2678,7 @@ async def test_v1_responses_http_bridge_close_waits_for_turn_state_index_lock(
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -2648,12 +2689,15 @@ async def test_v1_responses_http_bridge_close_waits_for_turn_state_index_lock(
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -2741,6 +2785,7 @@ async def test_v1_responses_http_bridge_allows_unstable_request_key_even_on_non_
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -2751,12 +2796,15 @@ async def test_v1_responses_http_bridge_allows_unstable_request_key_even_on_non_
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -2848,6 +2896,7 @@ async def test_v1_responses_http_bridge_reconnect_uses_last_upstream_turn_state(
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -2858,12 +2907,15 @@ async def test_v1_responses_http_bridge_reconnect_uses_last_upstream_turn_state(
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -2970,6 +3022,7 @@ async def test_v1_responses_http_bridge_session_id_reconnect_keeps_upstream_turn
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -2980,12 +3033,15 @@ async def test_v1_responses_http_bridge_session_id_reconnect_keeps_upstream_turn
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -3096,6 +3152,7 @@ async def test_v1_responses_http_bridge_reconnect_uses_refreshed_api_key_assignm
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -3106,12 +3163,15 @@ async def test_v1_responses_http_bridge_reconnect_uses_refreshed_api_key_assignm
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -3229,6 +3289,7 @@ async def test_v1_responses_http_bridge_reconnect_fails_when_reader_cancel_times
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -3239,12 +3300,15 @@ async def test_v1_responses_http_bridge_reconnect_fails_when_reader_cancel_times
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -3368,6 +3432,7 @@ async def test_v1_responses_http_bridge_prefers_evicting_prompt_cache_session_be
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -3378,12 +3443,15 @@ async def test_v1_responses_http_bridge_prefers_evicting_prompt_cache_session_be
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -3581,6 +3649,7 @@ async def test_get_or_create_http_bridge_session_honors_passed_prompt_cache_idle
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -3591,12 +3660,15 @@ async def test_get_or_create_http_bridge_session_honors_passed_prompt_cache_idle
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -3661,6 +3733,7 @@ async def test_v1_responses_http_bridge_reuses_upstream_websocket_and_preserves_
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -3671,12 +3744,15 @@ async def test_v1_responses_http_bridge_reuses_upstream_websocket_and_preserves_
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -3758,6 +3834,7 @@ async def test_backend_responses_http_bridge_reuses_upstream_websocket_and_prese
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -3768,12 +3845,15 @@ async def test_backend_responses_http_bridge_reuses_upstream_websocket_and_prese
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -3857,6 +3937,7 @@ async def test_backend_responses_http_bridge_prefers_codex_session_header_over_p
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -3867,7 +3948,9 @@ async def test_backend_responses_http_bridge_prefers_codex_session_header_over_p
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
@@ -3961,6 +4044,7 @@ async def test_backend_responses_http_emits_turn_state_header_and_reuses_when_re
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -3971,7 +4055,9 @@ async def test_backend_responses_http_emits_turn_state_header_and_reuses_when_re
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
@@ -4062,6 +4148,7 @@ async def test_v1_responses_http_bridge_reuses_session_across_model_change_for_p
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4072,12 +4159,15 @@ async def test_v1_responses_http_bridge_reuses_session_across_model_change_for_p
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -4159,6 +4249,7 @@ async def test_v1_responses_http_bridge_recovers_previous_response_id_across_key
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4169,12 +4260,15 @@ async def test_v1_responses_http_bridge_recovers_previous_response_id_across_key
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -4254,6 +4348,7 @@ async def test_v1_responses_http_emits_turn_state_header_and_reuses_when_replaye
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4264,7 +4359,9 @@ async def test_v1_responses_http_emits_turn_state_header_and_reuses_when_replaye
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
@@ -4344,6 +4441,7 @@ async def test_v1_responses_http_bridge_streaming_path_uses_persistent_upstream_
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4354,12 +4452,15 @@ async def test_v1_responses_http_bridge_streaming_path_uses_persistent_upstream_
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -4545,6 +4646,7 @@ async def test_backend_responses_http_bridge_refresh_failure_returns_proxy_error
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4555,12 +4657,15 @@ async def test_backend_responses_http_bridge_refresh_failure_returns_proxy_error
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -4611,6 +4716,7 @@ async def test_v1_responses_http_bridge_refresh_failure_returns_proxy_error(asyn
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4621,12 +4727,15 @@ async def test_v1_responses_http_bridge_refresh_failure_returns_proxy_error(asyn
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -4676,6 +4785,7 @@ async def test_v1_responses_http_bridge_transient_refresh_failure_returns_upstre
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4686,12 +4796,15 @@ async def test_v1_responses_http_bridge_transient_refresh_failure_returns_upstre
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -4747,6 +4860,7 @@ async def test_v1_responses_http_bridge_does_not_register_turn_state_alias_befor
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4757,12 +4871,15 @@ async def test_v1_responses_http_bridge_does_not_register_turn_state_alias_befor
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -4856,6 +4973,7 @@ async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(as
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4866,12 +4984,15 @@ async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(as
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -4948,6 +5069,7 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -4958,12 +5080,15 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -5046,6 +5171,7 @@ async def test_v1_responses_http_bridge_reuses_derived_prompt_cache_key_when_cli
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -5056,12 +5182,15 @@ async def test_v1_responses_http_bridge_reuses_derived_prompt_cache_key_when_cli
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -5130,6 +5259,7 @@ async def test_v1_responses_http_bridge_prefers_session_header_for_isolation(asy
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -5140,12 +5270,15 @@ async def test_v1_responses_http_bridge_prefers_session_header_for_isolation(asy
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -5210,6 +5343,7 @@ async def test_v1_responses_http_bridge_retries_once_when_upstream_closes_before
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -5220,12 +5354,15 @@ async def test_v1_responses_http_bridge_retries_once_when_upstream_closes_before
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -5338,6 +5475,7 @@ async def test_v1_responses_http_bridge_slims_historical_inline_artifacts_and_su
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -5348,12 +5486,15 @@ async def test_v1_responses_http_bridge_slims_historical_inline_artifacts_and_su
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -5430,6 +5571,7 @@ async def test_v1_responses_http_bridge_does_not_evict_active_session_when_pool_
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -5440,12 +5582,15 @@ async def test_v1_responses_http_bridge_does_not_evict_active_session_when_pool_
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -5591,6 +5736,7 @@ async def test_v1_responses_http_bridge_does_not_evict_queued_session_when_pool_
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -5601,12 +5747,15 @@ async def test_v1_responses_http_bridge_does_not_evict_queued_session_when_pool_
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -5755,6 +5904,7 @@ async def test_v1_responses_http_bridge_enforces_queue_limit_atomically_for_same
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -5765,12 +5915,15 @@ async def test_v1_responses_http_bridge_enforces_queue_limit_atomically_for_same
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -5891,8 +6044,20 @@ async def test_v1_responses_http_bridge_creates_different_session_keys_in_parall
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         create_started.append(key.affinity_key)
         create_started_events[key.affinity_key].set()
         await _wait_for_event(release_create)
@@ -5978,8 +6143,20 @@ async def test_v1_responses_http_bridge_singleflights_same_session_key_during_cr
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         create_started.append(key.affinity_key)
         create_started_event.set()
         await _wait_for_event(release_create)
@@ -6066,8 +6243,20 @@ async def test_v1_responses_http_bridge_waits_for_inflight_capacity_before_rate_
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         create_attempts.append(key.affinity_key)
         if key.affinity_key == "bridge-capacity-a":
             first_create_started.set()
@@ -6151,8 +6340,20 @@ async def test_v1_responses_http_bridge_singleflight_follower_refreshes_session_
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         create_started.set()
         await _wait_for_event(release_create)
         session = _make_dummy_bridge_session(key)
@@ -6249,8 +6450,20 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         create_calls.append(list(api_key.assigned_account_ids if api_key is not None else []))
         if len(create_calls) == 1:
             create_started.set()
@@ -6343,8 +6556,20 @@ async def test_v1_responses_http_bridge_singleflights_stale_session_replacement(
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         create_started.append(key.affinity_key)
         await asyncio.sleep(0.2)
         return _make_dummy_bridge_session(key)
@@ -6421,8 +6646,20 @@ async def test_v1_responses_http_bridge_cleans_up_cancelled_singleflight_creator
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         nonlocal create_attempts
         create_attempts += 1
         if create_attempts == 1:
@@ -6502,8 +6739,20 @@ async def test_v1_responses_http_bridge_cleans_up_cancelled_singleflight_creator
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         nonlocal create_attempts
         create_attempts += 1
         if create_attempts == 1:
@@ -6583,8 +6832,20 @@ async def test_v1_responses_http_bridge_waits_for_inflight_session_before_contin
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         create_started.set()
         await _wait_for_event(release_create)
         return _make_dummy_bridge_session(key)
@@ -6666,8 +6927,20 @@ async def test_v1_responses_http_bridge_prunes_idle_session_before_reuse(app_ins
         api_key,
         request_model,
         idle_ttl_seconds,
+        request_stage="first_turn",
+        preferred_account_id=None,
+        require_preferred_account=False,
     ):
-        del self, headers, affinity, request_model, idle_ttl_seconds
+        del (
+            self,
+            headers,
+            affinity,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         create_started.append(key.affinity_key)
         return _make_dummy_bridge_session(key)
 
@@ -6716,6 +6989,7 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -6726,12 +7000,15 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -6800,6 +7077,7 @@ async def test_v1_responses_http_bridge_surfaces_upstream_error_event_as_http_40
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -6810,12 +7088,15 @@ async def test_v1_responses_http_bridge_surfaces_upstream_error_event_as_http_40
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -6885,6 +7166,7 @@ async def test_v1_responses_http_bridge_preserves_rate_limit_metadata_in_429(asy
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -6895,7 +7177,9 @@ async def test_v1_responses_http_bridge_preserves_rate_limit_metadata_in_429(asy
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         return AccountSelection(account=account, error_message=None, error_code=None)
 
     async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
@@ -6948,6 +7232,7 @@ async def test_v1_responses_http_bridge_cancellation_releases_queued_slot(async_
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -6958,12 +7243,15 @@ async def test_v1_responses_http_bridge_cancellation_releases_queued_slot(async_
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -7068,6 +7356,7 @@ async def test_v1_responses_http_bridge_send_retry_restarts_reader(async_client,
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -7078,12 +7367,15 @@ async def test_v1_responses_http_bridge_send_retry_restarts_reader(async_client,
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -7310,6 +7602,7 @@ async def test_v1_responses_http_bridge_send_failure_returns_upstream_unavailabl
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -7320,12 +7613,15 @@ async def test_v1_responses_http_bridge_send_failure_returns_upstream_unavailabl
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -7416,6 +7712,7 @@ async def test_v1_responses_http_bridge_precreated_disconnect_returns_upstream_u
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -7426,12 +7723,15 @@ async def test_v1_responses_http_bridge_precreated_disconnect_returns_upstream_u
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -7526,6 +7826,7 @@ async def test_v1_responses_http_bridge_rebinds_after_upstream_previous_response
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -7536,12 +7837,15 @@ async def test_v1_responses_http_bridge_rebinds_after_upstream_previous_response
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -7638,6 +7942,7 @@ async def test_v1_responses_http_bridge_rebinds_after_upstream_invalid_request_p
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -7648,12 +7953,15 @@ async def test_v1_responses_http_bridge_rebinds_after_upstream_invalid_request_p
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -7742,6 +8050,7 @@ async def test_v1_responses_http_bridge_masks_anonymous_previous_response_not_fo
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -7752,12 +8061,15 @@ async def test_v1_responses_http_bridge_masks_anonymous_previous_response_not_fo
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -7866,6 +8178,7 @@ async def test_v1_responses_http_bridge_keeps_session_alive_after_foreign_previo
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -7876,12 +8189,15 @@ async def test_v1_responses_http_bridge_keeps_session_alive_after_foreign_previo
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -7980,6 +8296,7 @@ async def test_v1_responses_http_bridge_stream_keeps_session_alive_after_foreign
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -7990,12 +8307,15 @@ async def test_v1_responses_http_bridge_stream_keeps_session_alive_after_foreign
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -8093,6 +8413,7 @@ async def test_v1_responses_http_bridge_stream_keeps_session_alive_after_anonymo
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -8103,12 +8424,15 @@ async def test_v1_responses_http_bridge_stream_keeps_session_alive_after_anonymo
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -8230,6 +8554,7 @@ async def test_v1_responses_http_bridge_stream_matches_previous_response_error_t
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -8240,12 +8565,15 @@ async def test_v1_responses_http_bridge_stream_matches_previous_response_error_t
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -8395,6 +8723,7 @@ async def test_v1_responses_http_bridge_stream_masks_anonymous_previous_response
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -8405,12 +8734,15 @@ async def test_v1_responses_http_bridge_stream_masks_anonymous_previous_response
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -8555,6 +8887,7 @@ async def test_v1_responses_http_bridge_send_retry_keeps_session_open_for_follow
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -8565,12 +8898,15 @@ async def test_v1_responses_http_bridge_send_retry_keeps_session_open_for_follow
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,
@@ -8690,6 +9026,7 @@ async def test_v1_responses_http_bridge_stream_cancel_retires_session(
         *,
         request_id,
         kind,
+        request_stage="first_turn",
         sticky_key,
         sticky_kind,
         reallocate_sticky,
@@ -8700,12 +9037,15 @@ async def test_v1_responses_http_bridge_stream_cancel_retires_session(
         exclude_account_ids=None,
         additional_limit_name=None,
         api_key=None,
+        preferred_account_id=None,
     ):
+        del preferred_account_id
         del (
             self,
             deadline,
             request_id,
             kind,
+            request_stage,
             sticky_key,
             sticky_kind,
             reallocate_sticky,

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -361,7 +361,7 @@ async def test_thread_goal_get_propagates_selection_failures(async_client, monke
             error_code="no_accounts",
         )
 
-    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget_compatible", fake_select)
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select)
 
     response = await async_client.post(
         "/backend-api/codex/thread/goal/get",
@@ -490,7 +490,7 @@ async def test_thread_goal_set_uses_active_account_when_budget_selection_is_empt
         calls.append((operation, dict(payload), access_token, account_id, method, timeout_seconds))
         return {"cleared": True}
 
-    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget_compatible", fake_select)
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select)
     monkeypatch.setattr(proxy_module, "core_thread_goal_request", fake_thread_goal)
     payload = {"threadId": "019debd9-2372-7f23-92b9-9f34002a6355"}
 

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -408,7 +408,7 @@ async def test_proxy_compact_retry_uses_refreshed_account_id(async_client, monke
             )
         return OpenAIResponsePayload.model_validate({"output": []})
 
-    async def fake_ensure_fresh(self, account, force: bool = False):
+    async def fake_ensure_fresh(self, account, *, force: bool = False, timeout_seconds=None):
         if force:
             account.chatgpt_account_id = "acc_compact_retry_new"
         return account
@@ -476,7 +476,7 @@ async def test_proxy_compact_repeated_401_after_refresh_fails_over(async_client,
             )
         return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
 
-    async def fake_ensure_fresh(self, account, force: bool = False):
+    async def fake_ensure_fresh(self, account, *, force: bool = False, timeout_seconds=None):
         return account
 
     monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
@@ -516,7 +516,7 @@ async def test_proxy_compact_repeated_401_settles_reservation_if_error_recording
             ),
         )
 
-    async def fake_ensure_fresh(self, account, force: bool = False):
+    async def fake_ensure_fresh(self, account, *, force: bool = False, timeout_seconds=None):
         return account
 
     async def fake_handle_proxy_error(self, account, exc):

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -787,7 +787,7 @@ async def test_v1_responses_previous_response_followup_without_http_bridge_recov
         del self, kwargs
         return account
 
-    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget_compatible", fake_select_account)
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account)
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
 

--- a/tests/integration/test_proxy_transcriptions.py
+++ b/tests/integration/test_proxy_transcriptions.py
@@ -185,7 +185,7 @@ async def test_backend_transcribe_retry_uses_refreshed_account_id(async_client, 
             )
         return {"text": "retried"}
 
-    async def fake_ensure_fresh(self, account, force: bool = False):
+    async def fake_ensure_fresh(self, account, *, force: bool = False, timeout_seconds=None):
         if force:
             account.chatgpt_account_id = "acc_transcribe_retry_new"
         return account
@@ -272,7 +272,7 @@ async def test_backend_transcribe_initial_refresh_failure_returns_handled_error(
         transcribe_calls += 1
         return {"text": "unexpected"}
 
-    async def fake_ensure_fresh(self, account, force: bool = False):
+    async def fake_ensure_fresh(self, account, *, force: bool = False, timeout_seconds=None):
         if not force:
             raise RefreshError(
                 code="invalid_grant",

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -127,6 +127,284 @@ def _websocket_settings(**overrides):
     return SimpleNamespace(**values)
 
 
+def test_backend_responses_websocket_session_ended_auth_failure_fails_over_before_visible_output(
+    app_instance,
+    monkeypatch,
+):
+    first_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.failed",
+                            "response": {
+                                "id": "resp_ws_session_expired",
+                                "status": "failed",
+                                "error": {
+                                    "type": "authentication_error",
+                                    "code": "invalid_api_key",
+                                    "message": "Your session has ended. Please log in again.",
+                                },
+                            },
+                        },
+                        separators=(",", ":"),
+                    ),
+                )
+            ]
+        ],
+    )
+    recovered_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.created",
+                            "response": {"id": "resp_ws_session_recovered", "status": "in_progress"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_ws_session_recovered", "status": "completed"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+            ]
+        ],
+    )
+    connect_accounts: list[str] = []
+    permanent_failures: list[tuple[str, str]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        excluded = getattr(request_state, "excluded_account_ids", set())
+        if "acct_ws_expired" in excluded:
+            connect_accounts.append("acct_ws_recovered")
+            return SimpleNamespace(id="acct_ws_recovered"), recovered_upstream
+        connect_accounts.append("acct_ws_expired")
+        return SimpleNamespace(id="acct_ws_expired"), first_upstream
+
+    async def fake_mark_permanent_failure(self, account, error_code):
+        del self
+        permanent_failures.append((account.id, error_code))
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.LoadBalancer, "mark_permanent_failure", fake_mark_permanent_failure)
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "input": "hello",
+                        "stream": True,
+                    }
+                )
+            )
+            created = json.loads(websocket.receive_text())
+            completed = json.loads(websocket.receive_text())
+
+    assert created["type"] == "response.created"
+    assert completed["type"] == "response.completed"
+    assert completed["response"]["id"] == "resp_ws_session_recovered"
+    assert connect_accounts == ["acct_ws_expired", "acct_ws_recovered"]
+    assert permanent_failures == [("acct_ws_expired", "account_session_expired")]
+
+
+def test_backend_responses_websocket_generic_auth_failure_refreshes_once_then_fails_over(
+    app_instance,
+    monkeypatch,
+):
+    auth_failure_batch = [
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.failed",
+                    "response": {
+                        "id": "resp_ws_auth_failed",
+                        "status": "failed",
+                        "error": {
+                            "type": "authentication_error",
+                            "code": "invalid_api_key",
+                            "message": "token invalidated",
+                        },
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        )
+    ]
+    first_upstream = _SequencedUpstreamWebSocket([], deferred_message_batches=[auth_failure_batch])
+    refreshed_upstream = _SequencedUpstreamWebSocket([], deferred_message_batches=[auth_failure_batch])
+    recovered_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.created",
+                            "response": {"id": "resp_ws_auth_recovered", "status": "in_progress"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_ws_auth_recovered", "status": "completed"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+            ]
+        ],
+    )
+    connect_accounts: list[str] = []
+    forced_refresh_markers: list[str | None] = []
+    permanent_failures: list[tuple[str, str]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        forced_refresh_markers.append(getattr(request_state, "force_refresh_account_id", None))
+        excluded = getattr(request_state, "excluded_account_ids", set())
+        if "acct_ws_auth" in excluded:
+            connect_accounts.append("acct_ws_auth_recovered")
+            return SimpleNamespace(id="acct_ws_auth_recovered"), recovered_upstream
+        connect_accounts.append("acct_ws_auth")
+        if len(connect_accounts) == 1:
+            return SimpleNamespace(id="acct_ws_auth"), first_upstream
+        return SimpleNamespace(id="acct_ws_auth"), refreshed_upstream
+
+    async def fake_mark_permanent_failure(self, account, error_code):
+        del self
+        permanent_failures.append((account.id, error_code))
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.LoadBalancer, "mark_permanent_failure", fake_mark_permanent_failure)
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "input": "hello",
+                        "stream": True,
+                    }
+                )
+            )
+            created = json.loads(websocket.receive_text())
+            completed = json.loads(websocket.receive_text())
+
+    assert created["type"] == "response.created"
+    assert completed["type"] == "response.completed"
+    assert completed["response"]["id"] == "resp_ws_auth_recovered"
+    assert connect_accounts == ["acct_ws_auth", "acct_ws_auth", "acct_ws_auth_recovered"]
+    assert forced_refresh_markers[1] == "acct_ws_auth"
+    assert permanent_failures == [("acct_ws_auth", "account_auth_invalidated")]
+
+
 def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_instance, monkeypatch):
     upstream_messages = [
         _FakeUpstreamMessage(

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -193,7 +193,7 @@ def test_backend_responses_websocket_session_ended_auth_failure_fails_over_befor
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -329,7 +329,7 @@ def test_backend_responses_websocket_generic_auth_failure_refreshes_once_then_fa
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -445,7 +445,7 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(authorization: str | None):
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
         assert authorization == "Bearer external-token"
         return None
 
@@ -625,7 +625,7 @@ def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -735,7 +735,7 @@ def test_backend_responses_websocket_strips_image_generation_tool_advertisement(
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(authorization: str | None):
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
         assert authorization == "Bearer external-token"
         return None
 
@@ -849,7 +849,7 @@ def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(authorization: str | None):
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
         assert authorization == "Bearer external-token"
         return None
 
@@ -954,7 +954,7 @@ def test_backend_responses_websocket_echoes_existing_turn_state_header(app_insta
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(authorization: str | None):
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
         assert authorization == "Bearer external-token"
         return None
 
@@ -1086,7 +1086,7 @@ def test_v1_responses_websocket_reuses_upstream_for_sequential_requests(app_inst
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -1219,7 +1219,7 @@ def test_v1_responses_websocket_accepts_and_reuses_generated_turn_state(app_inst
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -1318,7 +1318,7 @@ def test_v1_responses_websocket_normalizes_payload_before_forwarding(app_instanc
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -1408,7 +1408,7 @@ def test_v1_responses_websocket_rejects_invalid_payload_before_connect(app_insta
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fail_connect_proxy_websocket(*args, **kwargs):
@@ -1466,7 +1466,7 @@ def test_backend_responses_websocket_forwards_previous_response_id(app_instance,
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -1567,7 +1567,7 @@ def test_backend_responses_websocket_trims_replayed_tool_call_items_with_previou
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -1673,7 +1673,7 @@ def test_v1_responses_websocket_forwards_previous_response_id(app_instance, monk
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -1816,7 +1816,7 @@ def test_v1_responses_websocket_masks_short_previous_response_not_found_without_
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -1960,7 +1960,7 @@ def test_v1_responses_websocket_marks_fresh_turn_as_retry_safe_at_prep_time(
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -2131,7 +2131,7 @@ def test_responses_websocket_replays_client_full_resend_previous_response_miss_w
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -2303,7 +2303,7 @@ def test_v1_responses_websocket_masks_invalid_request_previous_response_not_foun
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -2397,7 +2397,7 @@ def test_backend_responses_websocket_connect_failure_masks_previous_response_not
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_select_websocket_connect_account(
@@ -2418,6 +2418,7 @@ def test_backend_responses_websocket_connect_failure_masks_previous_response_not
         exclude_account_ids,
         preferred_account_id,
         require_preferred_account,
+        defer_no_account_error,
     ):
         del (
             self,
@@ -2435,6 +2436,7 @@ def test_backend_responses_websocket_connect_failure_masks_previous_response_not
             exclude_account_ids,
             preferred_account_id,
             require_preferred_account,
+            defer_no_account_error,
         )
         assert request_state.previous_response_id == "resp_ws_prev_anchor"
         return SimpleNamespace(id="acct_ws_prev_connect_failure")
@@ -2589,7 +2591,7 @@ def test_backend_responses_websocket_masks_short_previous_response_not_found_wit
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -2751,7 +2753,7 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -2889,7 +2891,7 @@ def test_backend_responses_websocket_masks_top_level_previous_response_not_found
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -3057,7 +3059,7 @@ def test_backend_responses_websocket_masks_previous_response_not_found_when_mess
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -3245,7 +3247,7 @@ def test_backend_responses_websocket_keeps_session_alive_after_foreign_previous_
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -3482,7 +3484,7 @@ def test_backend_responses_websocket_keeps_session_alive_after_anonymous_prev_nf
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -3758,7 +3760,7 @@ def test_backend_responses_websocket_matches_previous_response_error_to_anchor_w
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -3987,7 +3989,7 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -4116,7 +4118,7 @@ def test_backend_responses_websocket_rejects_malformed_first_frame_as_invalid_pa
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fail_connect_proxy_websocket(*args, **kwargs):
@@ -4169,7 +4171,7 @@ def test_backend_responses_websocket_emits_timeout_failure_for_stalled_upstream(
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -4297,7 +4299,7 @@ def test_backend_responses_websocket_treats_typeless_upstream_error_as_terminal(
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -4369,7 +4371,7 @@ def test_backend_responses_websocket_emits_terminal_failure_when_upstream_send_b
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -4448,7 +4450,7 @@ def test_backend_responses_websocket_rejects_oversized_response_create_before_up
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fail_connect_proxy_websocket(
@@ -4561,7 +4563,7 @@ def test_backend_responses_websocket_slims_historical_inline_artifacts_and_succe
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -4697,7 +4699,7 @@ def test_backend_responses_websocket_keeps_downstream_open_after_clean_upstream_
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -4807,7 +4809,7 @@ def test_backend_responses_websocket_reclaims_idle_downstream_session_and_upstre
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -4925,7 +4927,7 @@ def test_backend_responses_websocket_does_not_expire_downstream_while_request_pe
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -5057,7 +5059,7 @@ def test_backend_responses_websocket_reconnects_after_account_health_failure(app
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -5217,7 +5219,7 @@ def test_backend_responses_websocket_transparently_retries_precreated_usage_limi
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -5350,7 +5352,7 @@ def test_backend_responses_websocket_transparently_retries_precreated_error_usag
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -5458,7 +5460,7 @@ def test_backend_responses_websocket_previous_response_usage_limit_returns_upstr
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_resolve_previous_response_owner(
@@ -5579,7 +5581,7 @@ def test_backend_responses_websocket_transparent_replay_emits_no_accounts_when_r
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -5669,7 +5671,7 @@ def test_backend_responses_websocket_emits_no_accounts_error(app_instance, monke
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(authorization: str | None):
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
         assert authorization is None
         return None
 
@@ -5786,7 +5788,7 @@ def test_backend_responses_websocket_matches_terminal_events_by_response_id(app_
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(
@@ -5896,7 +5898,7 @@ def test_backend_responses_websocket_emits_response_failed_before_close_on_upstr
     async def allow_firewall(_websocket):
         return None
 
-    async def allow_proxy_api_key(_authorization: str | None):
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
         return None
 
     async def fake_connect_proxy_websocket(

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -2449,8 +2449,9 @@ def test_backend_responses_websocket_connect_failure_masks_previous_response_not
         request_state,
         client_send_lock,
         websocket,
+        force_refresh,
     ):
-        del self, account, headers, deadline, api_key, request_state, client_send_lock, websocket
+        del self, account, headers, deadline, api_key, request_state, client_send_lock, websocket, force_refresh
         payload = proxy_module.openai_error(
             "previous_response_not_found",
             "Previous response with id 'resp_ws_prev_anchor' not found.",

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -405,6 +405,154 @@ def test_backend_responses_websocket_generic_auth_failure_refreshes_once_then_fa
     assert permanent_failures == [("acct_ws_auth", "account_auth_invalidated")]
 
 
+def test_backend_responses_websocket_generic_auth_refresh_budget_is_per_account(
+    app_instance,
+    monkeypatch,
+):
+    auth_failure_batch = [
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.failed",
+                    "response": {
+                        "id": "resp_ws_auth_failed",
+                        "status": "failed",
+                        "error": {
+                            "type": "authentication_error",
+                            "code": "invalid_api_key",
+                            "message": "token invalidated",
+                        },
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        )
+    ]
+    account_a_first = _SequencedUpstreamWebSocket([], deferred_message_batches=[auth_failure_batch])
+    account_a_refreshed = _SequencedUpstreamWebSocket([], deferred_message_batches=[auth_failure_batch])
+    account_b_first = _SequencedUpstreamWebSocket([], deferred_message_batches=[auth_failure_batch])
+    account_b_refreshed = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.created",
+                            "response": {"id": "resp_ws_auth_recovered", "status": "in_progress"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {"id": "resp_ws_auth_recovered", "status": "completed"},
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+            ]
+        ],
+    )
+    connect_accounts: list[str] = []
+    forced_refresh_markers: list[str | None] = []
+    permanent_failures: list[tuple[str, str]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            routing_strategy,
+            model,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        forced_refresh_markers.append(getattr(request_state, "force_refresh_account_id", None))
+        excluded = getattr(request_state, "excluded_account_ids", set())
+        if "acct_ws_auth_a" not in excluded:
+            connect_accounts.append("acct_ws_auth_a")
+            if len([account for account in connect_accounts if account == "acct_ws_auth_a"]) == 1:
+                return SimpleNamespace(id="acct_ws_auth_a"), account_a_first
+            return SimpleNamespace(id="acct_ws_auth_a"), account_a_refreshed
+        connect_accounts.append("acct_ws_auth_b")
+        if getattr(request_state, "force_refresh_account_id", None) == "acct_ws_auth_b":
+            return SimpleNamespace(id="acct_ws_auth_b"), account_b_refreshed
+        return SimpleNamespace(id="acct_ws_auth_b"), account_b_first
+
+    async def fake_mark_permanent_failure(self, account, error_code):
+        del self
+        permanent_failures.append((account.id, error_code))
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.LoadBalancer, "mark_permanent_failure", fake_mark_permanent_failure)
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "input": "hello",
+                        "stream": True,
+                    }
+                )
+            )
+            created = json.loads(websocket.receive_text())
+            completed = json.loads(websocket.receive_text())
+
+    assert created["type"] == "response.created"
+    assert completed["type"] == "response.completed"
+    assert completed["response"]["id"] == "resp_ws_auth_recovered"
+    assert connect_accounts == [
+        "acct_ws_auth_a",
+        "acct_ws_auth_a",
+        "acct_ws_auth_b",
+        "acct_ws_auth_b",
+    ]
+    assert forced_refresh_markers == [None, "acct_ws_auth_a", None, "acct_ws_auth_b"]
+    assert permanent_failures == [("acct_ws_auth_a", "account_auth_invalidated")]
+
+
 def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_instance, monkeypatch):
     upstream_messages = [
         _FakeUpstreamMessage(

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -526,7 +526,7 @@ async def test_lifespan_shutdown_fails_bridge_capacity_waiter_and_cancels_usage_
                 AsyncMock(return_value=("pod-a", ("pod-a",))),
             )
             create_http_bridge_session = AsyncMock()
-            monkeypatch.setattr(service, "_create_http_bridge_session_compatible", create_http_bridge_session)
+            monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
             monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
             monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
 

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -33,7 +33,7 @@ async def test_validate_proxy_websocket_request_returns_firewall_denial(monkeypa
     async def fake_denial(_websocket):
         return denial
 
-    async def fail_auth(_authorization):
+    async def fail_auth(_authorization, *, request: object | None = None):
         raise AssertionError("authorization validation must not run when firewall already denied the websocket")
 
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
@@ -52,7 +52,7 @@ async def test_validate_proxy_websocket_request_maps_auth_error(monkeypatch):
     async def fake_denial(_websocket):
         return None
 
-    async def fail_auth(_authorization):
+    async def fail_auth(_authorization, *, request: object | None = None):
         raise ProxyAuthError("Missing API key in Authorization header")
 
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
@@ -89,7 +89,7 @@ async def test_validate_proxy_websocket_request_returns_validated_api_key(monkey
         last_used_at=None,
     )
 
-    async def pass_auth(authorization: str | None):
+    async def pass_auth(authorization: str | None, *, request: object | None = None):
         assert authorization == "Bearer valid-key"
         return api_key
 

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -141,6 +141,30 @@ async def test_validate_proxy_websocket_request_supports_legacy_auth_override(mo
 
 
 @pytest.mark.asyncio
+async def test_validate_proxy_websocket_request_reraises_unrelated_type_error(monkeypatch):
+    async def fake_denial(_websocket):
+        return None
+
+    calls = 0
+
+    async def broken_auth_override(authorization: str | None, *, request: object | None = None):
+        nonlocal calls
+        del authorization, request
+        calls += 1
+        raise TypeError("unexpected keyword argument 'request_id'")
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", broken_auth_override)
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'request_id'"):
+        await proxy_api_module._validate_proxy_websocket_request(
+            cast(WebSocket, SimpleNamespace(headers={"authorization": "Bearer broken-key"})),
+        )
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
 async def test_validate_proxy_websocket_request_allows_explicit_socket_peer_when_auth_disabled(monkeypatch):
     async def fake_denial(_websocket):
         return None

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -105,6 +105,42 @@ async def test_validate_proxy_websocket_request_returns_validated_api_key(monkey
 
 
 @pytest.mark.asyncio
+async def test_validate_proxy_websocket_request_supports_legacy_auth_override(monkeypatch):
+    async def fake_denial(_websocket):
+        return None
+
+    api_key = ApiKeyData(
+        id="key_legacy",
+        name="Legacy Key",
+        key_prefix="sk-legacy",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=datetime(2026, 3, 10),
+        last_used_at=None,
+    )
+    seen_authorizations: list[str | None] = []
+
+    async def legacy_auth_override(authorization: str | None):
+        seen_authorizations.append(authorization)
+        return api_key
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", legacy_auth_override)
+
+    resolved_api_key, response = await proxy_api_module._validate_proxy_websocket_request(
+        cast(WebSocket, SimpleNamespace(headers={"authorization": "Bearer legacy-key"})),
+    )
+
+    assert response is None
+    assert resolved_api_key == api_key
+    assert seen_authorizations == ["Bearer legacy-key"]
+
+
+@pytest.mark.asyncio
 async def test_validate_proxy_websocket_request_allows_explicit_socket_peer_when_auth_disabled(monkeypatch):
     async def fake_denial(_websocket):
         return None

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -4747,8 +4747,18 @@ async def test_get_or_create_http_bridge_session_preserves_explicit_forwarded_af
         idle_ttl_seconds: float,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
+        require_preferred_account: bool = False,
     ) -> proxy_service._HTTPBridgeSession:
-        del headers, affinity, api_key, request_model, idle_ttl_seconds, request_stage, preferred_account_id
+        del (
+            headers,
+            affinity,
+            api_key,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         captured["key"] = create_key
         return created_session
 
@@ -4820,8 +4830,18 @@ async def test_get_or_create_http_bridge_session_falls_back_to_session_header_wh
         idle_ttl_seconds: float,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
+        require_preferred_account: bool = False,
     ) -> proxy_service._HTTPBridgeSession:
-        del headers, affinity, api_key, request_model, idle_ttl_seconds, request_stage, preferred_account_id
+        del (
+            headers,
+            affinity,
+            api_key,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         captured["key"] = create_key
         return created_session
 
@@ -4893,8 +4913,18 @@ async def test_get_or_create_http_bridge_session_preserves_durable_canonical_pro
         idle_ttl_seconds: float,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
+        require_preferred_account: bool = False,
     ) -> proxy_service._HTTPBridgeSession:
-        del headers, affinity, api_key, request_model, idle_ttl_seconds, request_stage, preferred_account_id
+        del (
+            headers,
+            affinity,
+            api_key,
+            request_model,
+            idle_ttl_seconds,
+            request_stage,
+            preferred_account_id,
+            require_preferred_account,
+        )
         captured["key"] = create_key
         return created_session
 
@@ -5928,7 +5958,7 @@ async def test_close_all_http_bridge_sessions_fails_capacity_waiters_instead_of_
         AsyncMock(return_value=("instance-a", ("instance-a",))),
     )
     create_http_bridge_session = AsyncMock()
-    monkeypatch.setattr(service, "_create_http_bridge_session_compatible", create_http_bridge_session)
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
 
@@ -6002,7 +6032,7 @@ async def test_get_or_create_http_bridge_session_capacity_wait_times_out(
         AsyncMock(return_value=("instance-a", ("instance-a",))),
     )
     create_http_bridge_session = AsyncMock()
-    monkeypatch.setattr(service, "_create_http_bridge_session_compatible", create_http_bridge_session)
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     monkeypatch.setattr(service, "_close_http_bridge_session", AsyncMock())
 
@@ -6079,7 +6109,7 @@ async def test_get_or_create_http_bridge_session_cancel_during_stale_close_clean
         AsyncMock(return_value=("instance-a", ("instance-a",))),
     )
     create_http_bridge_session = AsyncMock()
-    monkeypatch.setattr(service, "_create_http_bridge_session_compatible", create_http_bridge_session)
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
 
     task = asyncio.create_task(
@@ -6126,7 +6156,7 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
         return created
 
     monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
-    monkeypatch.setattr(service, "_create_http_bridge_session_compatible", create_session)
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     close_http_bridge_session = AsyncMock()
     monkeypatch.setattr(service, "_close_http_bridge_session", close_http_bridge_session)
@@ -7997,7 +8027,7 @@ async def test_create_http_bridge_session_fails_closed_when_previous_response_ow
             ),
         ),
     )
-    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_select_account_with_budget", select_account)
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
     monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", open_upstream)
     monkeypatch.setattr(service, "_relay_http_bridge_upstream_messages", fake_relay)

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14430,6 +14430,52 @@ def test_classify_upstream_close_rejected_only_for_clean_close_before_any_respon
 
 
 @pytest.mark.asyncio
+async def test_try_open_websocket_connect_attempt_does_not_refresh_twice_after_forced_refresh(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_forced_refresh_401")
+    handshake_error = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "still invalid"))
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 10.0)
+    ensure_fresh = AsyncMock(return_value=account)
+    open_upstream = AsyncMock(side_effect=handshake_error)
+    retry_after_401 = AsyncMock(side_effect=AssertionError("forced refresh must not refresh same account twice"))
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", open_upstream)
+    monkeypatch.setattr(service, "_retry_websocket_connect_after_401", retry_after_401)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_ws_forced_refresh_401",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=10.0,
+        force_refresh_account_id=account.id,
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._try_open_websocket_connect_attempt(
+            account,
+            {},
+            deadline=20.0,
+            api_key=None,
+            request_state=request_state,
+            client_send_lock=anyio.Lock(),
+            websocket=cast(WebSocket, SimpleNamespace()),
+            force_refresh=True,
+        )
+
+    assert exc_info.value is handshake_error
+    ensure_fresh.assert_awaited_once_with(account, force=True, timeout_seconds=10.0)
+    open_upstream.assert_awaited_once()
+    retry_after_401.assert_not_called()
+    assert request_state.force_refresh_account_id is None
+
+
+@pytest.mark.asyncio
 async def test_reconnect_http_bridge_skips_extra_same_account_retry_after_keepalive_close(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5888,6 +5888,72 @@ async def test_connect_proxy_websocket_scopes_transient_exclusions_to_connect_lo
 
 
 @pytest.mark.asyncio
+async def test_connect_proxy_websocket_clears_stale_forced_refresh_when_fallback_account_selected(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    force_refresh_account = _make_account("acc_ws_stale_force_refresh")
+    fallback_account = _make_account("acc_ws_stale_force_fallback")
+    upstream = SimpleNamespace()
+    ensure_calls: list[tuple[str, bool]] = []
+    seen_account_id_filters: list[set[str] | None] = []
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        account_ids = cast(set[str] | None, kwargs.get("account_ids"))
+        seen_account_id_filters.append(set(account_ids) if account_ids is not None else None)
+        if account_ids == {force_refresh_account.id}:
+            return AccountSelection(account=None, error_message="preferred unavailable", error_code="no_accounts")
+        return AccountSelection(account=fallback_account, error_message=None)
+
+    async def ensure_fresh_with_budget(
+        account: Account,
+        *,
+        force: bool = False,
+        timeout_seconds: float | None = None,
+    ) -> Account:
+        del timeout_seconds
+        ensure_calls.append((account.id, force))
+        return account
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh_with_budget)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", AsyncMock(return_value=upstream))
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_stale_forced_refresh",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        force_refresh_account_id=force_refresh_account.id,
+        preferred_account_id=force_refresh_account.id,
+    )
+    websocket = cast(WebSocket, SimpleNamespace(send_text=AsyncMock()))
+
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=websocket,
+    )
+
+    assert selected_account == fallback_account
+    assert selected_upstream is upstream
+    assert seen_account_id_filters == [{force_refresh_account.id}, None]
+    assert ensure_calls == [(fallback_account.id, False)]
+    assert request_state.force_refresh_account_id is None
+    assert request_state.preferred_account_id is None
+    assert request_logs.calls == []
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_fails_over_after_repeated_401_refresh_retry(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5785,6 +5785,109 @@ async def test_connect_proxy_websocket_fails_over_on_handshake_usage_limit_reach
 
 
 @pytest.mark.asyncio
+async def test_connect_proxy_websocket_scopes_transient_exclusions_to_connect_loop(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_ws_transient_reconnect_a")
+    account_b = _make_account("acc_ws_transient_reconnect_b")
+    upstream_b = SimpleNamespace(name="upstream-b")
+    upstream_a = SimpleNamespace(name="upstream-a")
+    transient_handshake_error = proxy_module.ProxyResponseError(
+        429,
+        openai_error("usage_limit_reached", "usage limit reached"),
+    )
+    seen_excluded_account_ids: list[set[str]] = []
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if len(seen_excluded_account_ids) == 1:
+            return AccountSelection(account=account_a, error_message=None)
+        if len(seen_excluded_account_ids) == 2:
+            return AccountSelection(account=account_b, error_message=None)
+        if len(seen_excluded_account_ids) == 3:
+            return AccountSelection(account=account_a, error_message=None)
+        raise AssertionError("unexpected extra account selection")
+
+    async def ensure_fresh_with_budget(
+        account: Account,
+        *,
+        force: bool = False,
+        timeout_seconds: float | None = None,
+    ) -> Account:
+        del force, timeout_seconds
+        return account
+
+    async def open_upstream_with_budget(
+        account: Account,
+        headers: dict[str, str],
+        *,
+        timeout_seconds: float,
+    ) -> SimpleNamespace:
+        del account, headers, timeout_seconds
+        result = open_results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    open_results: list[SimpleNamespace | BaseException] = [
+        transient_handshake_error,
+        upstream_b,
+        upstream_a,
+    ]
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "mark_rate_limit", AsyncMock())
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh_with_budget)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", open_upstream_with_budget)
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_transient_exclusion_scope",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    websocket = cast(WebSocket, SimpleNamespace(send_text=AsyncMock()))
+
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=websocket,
+    )
+    assert selected_account == account_b
+    assert selected_upstream is upstream_b
+    assert request_state.excluded_account_ids == set()
+
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=websocket,
+    )
+
+    assert selected_account == account_a
+    assert selected_upstream is upstream_a
+    assert seen_excluded_account_ids == [set(), {account_a.id}, set()]
+    assert request_logs.calls == []
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_fails_over_after_repeated_401_refresh_retry(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5916,7 +5916,7 @@ async def test_connect_proxy_websocket_previous_response_owner_usage_limit_fails
         openai_error("usage_limit_reached", "usage limit reached"),
     )
 
-    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_select_account_with_budget", select_account)
     monkeypatch.setattr(service._load_balancer, "mark_rate_limit", mark_rate_limit)
     monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account_owner))
     monkeypatch.setattr(service, "_open_upstream_websocket", AsyncMock(side_effect=[first_handshake_error]))
@@ -6228,7 +6228,7 @@ async def test_select_websocket_connect_account_requires_preferred_account_for_p
 
     monkeypatch.setattr(
         service,
-        "_select_account_with_budget_compatible",
+        "_select_account_with_budget",
         AsyncMock(return_value=AccountSelection(account=selected_account, error_message=None)),
     )
     monkeypatch.setattr(service, "_emit_websocket_connect_failure", emit_connect_failure)
@@ -6285,7 +6285,7 @@ async def test_select_websocket_connect_account_records_fail_closed_for_preferre
     monkeypatch.setattr(proxy_service, "continuity_fail_closed_total", counter, raising=False)
     monkeypatch.setattr(
         service,
-        "_select_account_with_budget_compatible",
+        "_select_account_with_budget",
         AsyncMock(return_value=AccountSelection(account=selected_account, error_message=None)),
     )
     monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
@@ -6350,7 +6350,7 @@ async def test_select_websocket_connect_account_preferred_owner_missing_fails_cl
     monkeypatch.setattr(proxy_service, "continuity_fail_closed_total", counter, raising=False)
     monkeypatch.setattr(
         service,
-        "_select_account_with_budget_compatible",
+        "_select_account_with_budget",
         AsyncMock(
             return_value=AccountSelection(
                 account=None,
@@ -11041,7 +11041,7 @@ async def test_stream_with_retry_releases_api_key_reservation_when_owner_lookup_
     owner_lookup = AsyncMock(side_effect=owner_lookup_error)
     monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", owner_lookup)
     select_account = AsyncMock(side_effect=AssertionError("owner lookup failure must happen before account selection"))
-    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_select_account_with_budget", select_account)
 
     with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
         async for _ in service._stream_with_retry(


### PR DESCRIPTION
## Summary\n- treat pre-visible WebSocket terminal auth failures as account-local auth state\n- mark session-ended accounts reauth-required and replay on another eligible account\n- retry generic terminal auth failures once with forced refresh before failover/deactivation\n- add OpenSpec change and WebSocket regression coverage\n\n## Verification\n- uv run pytest tests/integration/test_proxy_websocket_responses.py -q\n- uv run ruff check app/core/balancer/logic.py app/modules/proxy/service.py tests/integration/test_proxy_websocket_responses.py\n- NODE_OPTIONS='--jitless --max-old-space-size=512' openspec validate --specs\n\nNote: openspec validate --changes still reports unrelated pre-existing failures in fix-enforced-service-tier-default and strip-codex-v1-prefix; this change validated successfully in that run.