### PR TITLE
test(settings): add ImportSettings component tests

### DIFF
--- a/frontend/src/features/settings/components/import-settings.test.tsx
+++ b/frontend/src/features/settings/components/import-settings.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ImportSettings } from "@/features/settings/components/import-settings";
+import { createDashboardSettings } from "@/test/mocks/factories";
+
+describe("ImportSettings", () => {
+  it("renders the import-without-overwrite control with descriptive copy", () => {
+    render(
+      <ImportSettings
+        settings={createDashboardSettings()}
+        busy={false}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByText("Import")).toBeInTheDocument();
+    expect(screen.getByText("Allow import without overwrite")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Keep duplicate imports as separate accounts instead of replacing existing ones.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("reflects settings.importWithoutOverwrite in the switch checked state", () => {
+    const { rerender } = render(
+      <ImportSettings
+        settings={createDashboardSettings({ importWithoutOverwrite: false })}
+        busy={false}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole("switch")).not.toBeChecked();
+
+    rerender(
+      <ImportSettings
+        settings={createDashboardSettings({ importWithoutOverwrite: true })}
+        busy={false}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole("switch")).toBeChecked();
+  });
+
+  it("toggling the switch calls onSave with a payload where only importWithoutOverwrite changes", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const settings = createDashboardSettings({ importWithoutOverwrite: false });
+
+    render(<ImportSettings settings={settings} busy={false} onSave={onSave} />);
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const payload = onSave.mock.calls[0][0];
+
+    expect(payload.importWithoutOverwrite).toBe(true);
+
+    const { importWithoutOverwrite: _new, ...payloadRest } = payload;
+    const { importWithoutOverwrite: _orig, totpConfigured: _ignored, ...settingsRest } = settings;
+    expect(payloadRest).toStrictEqual(settingsRest);
+  });
+
+  it("disables the switch when busy is true", () => {
+    render(
+      <ImportSettings
+        settings={createDashboardSettings()}
+        busy={true}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole("switch")).toBeDisabled();
+  });
+});

--- a/frontend/src/features/settings/components/import-settings.test.tsx
+++ b/frontend/src/features/settings/components/import-settings.test.tsx
@@ -60,9 +60,23 @@ describe("ImportSettings", () => {
 
     expect(payload.importWithoutOverwrite).toBe(true);
 
-    const { importWithoutOverwrite: _new, ...payloadRest } = payload;
-    const { importWithoutOverwrite: _orig, totpConfigured: _ignored, ...settingsRest } = settings;
-    expect(payloadRest).toStrictEqual(settingsRest);
+    expect(payload).toStrictEqual({
+      stickyThreadsEnabled: settings.stickyThreadsEnabled,
+      upstreamStreamTransport: settings.upstreamStreamTransport,
+      preferEarlierResetAccounts: settings.preferEarlierResetAccounts,
+      routingStrategy: settings.routingStrategy,
+      openaiCacheAffinityMaxAgeSeconds: settings.openaiCacheAffinityMaxAgeSeconds,
+      dashboardSessionTtlSeconds: settings.dashboardSessionTtlSeconds,
+      importWithoutOverwrite: true,
+      totpRequiredOnLogin: settings.totpRequiredOnLogin,
+      apiKeyAuthEnabled: settings.apiKeyAuthEnabled,
+      limitWarmupEnabled: settings.limitWarmupEnabled,
+      limitWarmupWindows: settings.limitWarmupWindows,
+      limitWarmupModel: settings.limitWarmupModel,
+      limitWarmupPrompt: settings.limitWarmupPrompt,
+      limitWarmupCooldownSeconds: settings.limitWarmupCooldownSeconds,
+      limitWarmupMinAvailablePercent: settings.limitWarmupMinAvailablePercent,
+    });
   });
 
   it("disables the switch when busy is true", () => {


### PR DESCRIPTION
Closes #621.

## Summary
Adds direct component tests for `ImportSettings`, covering the acceptance criteria spelled out in the issue.

## Coverage
- Renders the "Allow import without overwrite" control with its descriptive copy.
- Switch checked state reflects `settings.importWithoutOverwrite` (false / true).
- Toggling the switch calls `onSave` once with a full settings payload where only `importWithoutOverwrite` flips.
- Switch is disabled when `busy` is true.

Uses the existing `createDashboardSettings` factory so future settings fields stay consistent with the rest of the suite.

## Test plan
- [x] `bun run test -- src/features/settings/components/import-settings.test.tsx` — 4/4 pass
- [x] `bun run typecheck`
- [x] No production behavior changes