### PR TITLE
test(api-keys): add ApiKeyTable component tests

### DIFF
--- a/frontend/src/features/api-keys/components/api-key-table.test.tsx
+++ b/frontend/src/features/api-keys/components/api-key-table.test.tsx
@@ -1,0 +1,119 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ApiKeyTable } from "@/features/api-keys/components/api-key-table";
+import { createApiKey, createDefaultApiKeys } from "@/test/mocks/factories";
+import { renderWithProviders } from "@/test/utils";
+
+describe("ApiKeyTable", () => {
+  it("renders the empty state when no keys are provided", () => {
+    renderWithProviders(
+      <ApiKeyTable
+        keys={[]}
+        busy={false}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onRegenerate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No API keys created yet")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders one row per key with prefix, status, and limit/usage summaries", () => {
+    const keys = createDefaultApiKeys();
+    renderWithProviders(
+      <ApiKeyTable
+        keys={keys}
+        busy={false}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onRegenerate={vi.fn()}
+      />,
+    );
+
+    const rows = screen.getAllByRole("row");
+    expect(rows).toHaveLength(keys.length + 1);
+
+    const firstRow = rows[1];
+    expect(within(firstRow).getByText(keys[0].name)).toBeInTheDocument();
+    expect(within(firstRow).getByText(keys[0].keyPrefix)).toBeInTheDocument();
+    expect(within(firstRow).getByText("Active")).toBeInTheDocument();
+
+    const secondRow = rows[2];
+    expect(within(secondRow).getByText("Disabled")).toBeInTheDocument();
+    expect(within(secondRow).getByText("No Limit")).toBeInTheDocument();
+  });
+
+  it("renders 'All' when allowedModels is missing and the configured list otherwise", () => {
+    const restricted = createApiKey({
+      id: "key_restricted",
+      allowedModels: ["gpt-5.1", "gpt-4o-mini"],
+    });
+    const unrestricted = createApiKey({
+      id: "key_unrestricted",
+      name: "Unrestricted key",
+      keyPrefix: "sk-open",
+      allowedModels: null,
+    });
+
+    renderWithProviders(
+      <ApiKeyTable
+        keys={[restricted, unrestricted]}
+        busy={false}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onRegenerate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("gpt-5.1, gpt-4o-mini")).toBeInTheDocument();
+    expect(screen.getByText("All")).toBeInTheDocument();
+  });
+
+  it("invokes onEdit / onRegenerate / onDelete with the selected key from the row menu", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const onRegenerate = vi.fn();
+    const onDelete = vi.fn();
+    const target = createApiKey({ id: "key_target", name: "Target key" });
+
+    renderWithProviders(
+      <ApiKeyTable
+        keys={[target]}
+        busy={false}
+        onEdit={onEdit}
+        onDelete={onDelete}
+        onRegenerate={onRegenerate}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Actions" }));
+    await user.click(screen.getByRole("menuitem", { name: /edit/i }));
+    expect(onEdit).toHaveBeenCalledWith(target);
+
+    await user.click(screen.getByRole("button", { name: "Actions" }));
+    await user.click(screen.getByRole("menuitem", { name: /regenerate/i }));
+    expect(onRegenerate).toHaveBeenCalledWith(target);
+
+    await user.click(screen.getByRole("button", { name: "Actions" }));
+    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+    expect(onDelete).toHaveBeenCalledWith(target);
+  });
+
+  it("disables the row action trigger when busy is true", () => {
+    renderWithProviders(
+      <ApiKeyTable
+        keys={[createApiKey()]}
+        busy={true}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onRegenerate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Actions" })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
Closes #622.

## Summary
Adds direct component tests for `ApiKeyTable`, covering the acceptance criteria spelled out in the issue.

## Coverage
- Empty state renders the \"No API keys created yet\" copy and no table.
- One row per key with name, prefix, and active/disabled status.
- Allowed-models column shows the joined list when restricted and \"All\" when `allowedModels` is null.
- \"No Limit\" copy appears for keys with no limit rules.
- Dropdown actions (Edit / Regenerate / Delete) invoke their respective callbacks with the row's key.
- Action trigger is disabled when `busy` is true.

Uses the existing `createApiKey` / `createDefaultApiKeys` factories so future schema fields stay consistent with the rest of the suite.

## Test plan
- [x] \`bun run test -- src/features/api-keys/components/api-key-table.test.tsx\` — 5/5 pass
- [x] \`bun run test\` — 436/436 pass across 74 files
- [x] \`bun run typecheck\`
- [x] No production behavior changes