### PR TITLE
refactor(frontend): dedup API-key CRUD client across apis/api-keys modules

### DIFF
--- a/frontend/src/features/api-keys/api.ts
+++ b/frontend/src/features/api-keys/api.ts
@@ -9,7 +9,7 @@ import {
   ModelsResponseSchema,
 } from "@/features/api-keys/schemas";
 
-const API_KEYS_BASE_PATH = "/api/api-keys";
+export const API_KEYS_BASE_PATH = "/api/api-keys";
 const MODELS_PATH = "/api/models";
 
 export function listApiKeys() {

--- a/frontend/src/features/apis/api.ts
+++ b/frontend/src/features/apis/api.ts
@@ -1,44 +1,7 @@
-import { del, get, patch, post } from "@/lib/api-client";
+import { get } from "@/lib/api-client";
 
-import {
-  ApiKeyCreateRequestSchema,
-  ApiKeyCreateResponseSchema,
-  ApiKeyListSchema,
-  ApiKeySchema,
-  ApiKeyUpdateRequestSchema,
-} from "@/features/api-keys/schemas";
+import { API_KEYS_BASE_PATH } from "@/features/api-keys/api";
 import { ApiKeyTrendsResponseSchema, ApiKeyUsage7DayResponseSchema } from "@/features/apis/schemas";
-
-const API_KEYS_BASE_PATH = "/api/api-keys";
-
-export function listApiKeys() {
-  return get(`${API_KEYS_BASE_PATH}/`, ApiKeyListSchema);
-}
-
-export function createApiKey(payload: unknown) {
-  const validated = ApiKeyCreateRequestSchema.parse(payload);
-  return post(`${API_KEYS_BASE_PATH}/`, ApiKeyCreateResponseSchema, {
-    body: validated,
-  });
-}
-
-export function updateApiKey(keyId: string, payload: unknown) {
-  const validated = ApiKeyUpdateRequestSchema.parse(payload);
-  return patch(`${API_KEYS_BASE_PATH}/${encodeURIComponent(keyId)}`, ApiKeySchema, {
-    body: validated,
-  });
-}
-
-export function deleteApiKey(keyId: string) {
-  return del(`${API_KEYS_BASE_PATH}/${encodeURIComponent(keyId)}`);
-}
-
-export function regenerateApiKey(keyId: string) {
-  return post(
-    `${API_KEYS_BASE_PATH}/${encodeURIComponent(keyId)}/regenerate`,
-    ApiKeyCreateResponseSchema,
-  );
-}
 
 export function getApiKeyTrends(keyId: string) {
   return get(

--- a/frontend/src/features/apis/hooks/use-apis.test.ts
+++ b/frontend/src/features/apis/hooks/use-apis.test.ts
@@ -10,22 +10,38 @@ import {
 	createApiKeyUsage7Day,
 } from "@/test/mocks/factories";
 
-const apiMocks = vi.hoisted(() => ({
+const apiKeysApiMocks = vi.hoisted(() => ({
 	listApiKeys: vi.fn(),
 	createApiKey: vi.fn(),
 	updateApiKey: vi.fn(),
 	deleteApiKey: vi.fn(),
 	regenerateApiKey: vi.fn(),
+	listModels: vi.fn(),
+	API_KEYS_BASE_PATH: "/api/api-keys",
+}));
+
+const apisApiMocks = vi.hoisted(() => ({
 	getApiKeyTrends: vi.fn(),
 	getApiKeyUsage7Day: vi.fn(),
 }));
+
+const apiMocks = {
+	listApiKeys: apiKeysApiMocks.listApiKeys,
+	createApiKey: apiKeysApiMocks.createApiKey,
+	updateApiKey: apiKeysApiMocks.updateApiKey,
+	deleteApiKey: apiKeysApiMocks.deleteApiKey,
+	regenerateApiKey: apiKeysApiMocks.regenerateApiKey,
+	getApiKeyTrends: apisApiMocks.getApiKeyTrends,
+	getApiKeyUsage7Day: apisApiMocks.getApiKeyUsage7Day,
+};
 
 const toastMocks = vi.hoisted(() => ({
 	success: vi.fn(),
 	error: vi.fn(),
 }));
 
-vi.mock("@/features/apis/api", () => apiMocks);
+vi.mock("@/features/api-keys/api", () => apiKeysApiMocks);
+vi.mock("@/features/apis/api", () => apisApiMocks);
 vi.mock("sonner", () => ({ toast: toastMocks }));
 
 function createTestQueryClient(): QueryClient {

--- a/frontend/src/features/apis/hooks/use-apis.ts
+++ b/frontend/src/features/apis/hooks/use-apis.ts
@@ -4,16 +4,15 @@ import { toast } from "sonner";
 import {
   createApiKey,
   deleteApiKey,
-  getApiKeyTrends,
-  getApiKeyUsage7Day,
   listApiKeys,
   regenerateApiKey,
   updateApiKey,
-} from "@/features/apis/api";
+} from "@/features/api-keys/api";
 import type {
   ApiKeyCreateRequest,
   ApiKeyUpdateRequest,
 } from "@/features/api-keys/schemas";
+import { getApiKeyTrends, getApiKeyUsage7Day } from "@/features/apis/api";
 
 function invalidateApiKeys(queryClient: ReturnType<typeof useQueryClient>) {
   void queryClient.invalidateQueries({ queryKey: ["api-keys", "list"] });


### PR DESCRIPTION
## Why

`frontend/src/features/apis/api.ts` redeclared the same CRUD surface (`listApiKeys`, `createApiKey`, `updateApiKey`, `deleteApiKey`, `regenerateApiKey`) and the same `/api/api-keys` base path that already exist in `frontend/src/features/api-keys/api.ts`. Two backend-contract sources of truth meant a path or schema change had to land in both files, risking dashboard surface drift between the api-keys page and the apis page.

## What

- `features/api-keys/api.ts` becomes canonical: exports `API_KEYS_BASE_PATH` so analytics helpers can reuse it.
- `features/apis/api.ts` shrinks to only the two analytics endpoints (`getApiKeyTrends`, `getApiKeyUsage7Day`) and imports the path constant from `api-keys/api`.
- `features/apis/hooks/use-apis.ts` splits its imports — CRUD from `api-keys/api`, analytics from `apis/api`. The hook itself keeps its existing refetch cadence (30s list, 5min trends, 2min usage) and dual-key invalidation (`["api-keys", "list"]` + `["api-keys", "trends"]`), so consumers (`features/apis/components/apis-page.tsx`) see no behavior change.
- `features/apis/hooks/use-apis.test.ts` updated to mock the new module boundary.

No behavior change.

## Test plan

- `bunx tsc -b` clean
- `bunx vitest run` 431/431 (baseline before refactor was also 431/431)
- `bunx eslint src/features/apis src/features/api-keys` clean

Closes #616