### PR TITLE
refactor(frontend): split PasswordSettings into focused dialog subcomponents

### DIFF
--- a/frontend/src/features/settings/components/password-change-dialog.tsx
+++ b/frontend/src/features/settings/components/password-change-dialog.tsx
@@ -1,0 +1,109 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { AlertMessage } from "@/components/alert-message";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { changePassword } from "@/features/auth/api";
+import { useAuthStore } from "@/features/auth/hooks/use-auth";
+import { PasswordChangeRequestSchema } from "@/features/auth/schemas";
+import { getErrorMessage } from "@/utils/errors";
+
+export type PasswordChangeDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  disabled?: boolean;
+};
+
+export function PasswordChangeDialog({ open, onOpenChange, disabled = false }: PasswordChangeDialogProps) {
+  const passwordManagementEnabled = useAuthStore((s) => s.passwordManagementEnabled);
+
+  const form = useForm({
+    resolver: zodResolver(PasswordChangeRequestSchema),
+    defaultValues: { currentPassword: "", newPassword: "" },
+  });
+
+  const busy = form.formState.isSubmitting;
+  const lock = busy || disabled || !passwordManagementEnabled;
+
+  useEffect(() => {
+    if (!open) {
+      form.reset();
+      form.clearErrors();
+    }
+  }, [open, form]);
+
+  const handleSubmit = async (values: { currentPassword: string; newPassword: string }) => {
+    form.clearErrors("root");
+    try {
+      await changePassword(values);
+      toast.success("Password changed");
+      onOpenChange(false);
+    } catch (caught) {
+      form.setError("root", { message: getErrorMessage(caught) });
+    }
+  };
+
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Change password</DialogTitle>
+          <DialogDescription>Enter your current password and a new one.</DialogDescription>
+        </DialogHeader>
+        {rootError ? <AlertMessage variant="error">{rootError}</AlertMessage> : null}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="currentPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Current password</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="password" autoComplete="current-password" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="newPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>New password</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="password" autoComplete="new-password" placeholder="Min. 8 characters" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={lock}>
+                Change password
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/settings/components/password-remove-dialog.tsx
+++ b/frontend/src/features/settings/components/password-remove-dialog.tsx
@@ -1,0 +1,98 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { AlertMessage } from "@/components/alert-message";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { removePassword } from "@/features/auth/api";
+import { useAuthStore } from "@/features/auth/hooks/use-auth";
+import { PasswordRemoveRequestSchema } from "@/features/auth/schemas";
+import { getErrorMessage } from "@/utils/errors";
+
+export type PasswordRemoveDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  disabled?: boolean;
+};
+
+export function PasswordRemoveDialog({ open, onOpenChange, disabled = false }: PasswordRemoveDialogProps) {
+  const passwordManagementEnabled = useAuthStore((s) => s.passwordManagementEnabled);
+  const refreshSession = useAuthStore((s) => s.refreshSession);
+
+  const form = useForm({
+    resolver: zodResolver(PasswordRemoveRequestSchema),
+    defaultValues: { password: "" },
+  });
+
+  const busy = form.formState.isSubmitting;
+  const lock = busy || disabled || !passwordManagementEnabled;
+
+  useEffect(() => {
+    if (!open) {
+      form.reset();
+      form.clearErrors();
+    }
+  }, [open, form]);
+
+  const handleSubmit = async (values: { password: string }) => {
+    form.clearErrors("root");
+    try {
+      await removePassword(values);
+      await refreshSession();
+      toast.success("Password removed");
+      onOpenChange(false);
+    } catch (caught) {
+      form.setError("root", { message: getErrorMessage(caught) });
+    }
+  };
+
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Remove password</DialogTitle>
+          <DialogDescription>Confirm your current password to remove it.</DialogDescription>
+        </DialogHeader>
+        {rootError ? <AlertMessage variant="error">{rootError}</AlertMessage> : null}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Current password</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="password" autoComplete="current-password" placeholder="Enter current password" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+                Cancel
+              </Button>
+              <Button type="submit" variant="destructive" disabled={lock}>
+                Remove password
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/settings/components/password-settings.tsx
+++ b/frontend/src/features/settings/components/password-settings.tsx
@@ -1,30 +1,12 @@
-import { zodResolver } from "@hookform/resolvers/zod";
 import { KeyRound } from "lucide-react";
 import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
 
-import { AlertMessage } from "@/components/alert-message";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { changePassword, loginPassword, removePassword, setupPassword, verifyTotp } from "@/features/auth/api";
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
-import {
-  PasswordChangeRequestSchema,
-  PasswordRemoveRequestSchema,
-  PasswordSetupRequestSchema,
-  TotpVerifyRequestSchema,
-} from "@/features/auth/schemas";
-import { getErrorMessage } from "@/utils/errors";
+import { PasswordChangeDialog } from "@/features/settings/components/password-change-dialog";
+import { PasswordRemoveDialog } from "@/features/settings/components/password-remove-dialog";
+import { PasswordSetupDialog } from "@/features/settings/components/password-setup-dialog";
+import { PasswordVerifyDialog } from "@/features/settings/components/password-verify-dialog";
 
 type PasswordDialog = "setup" | "change" | "remove" | "verify" | null;
 
@@ -34,125 +16,17 @@ export type PasswordSettingsProps = {
 
 export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
   const passwordRequired = useAuthStore((s) => s.passwordRequired);
-  const bootstrapRequired = useAuthStore((s) => s.bootstrapRequired);
-  const bootstrapTokenConfigured = useAuthStore((s) => s.bootstrapTokenConfigured);
   const authMode = useAuthStore((s) => s.authMode);
   const passwordManagementEnabled = useAuthStore((s) => s.passwordManagementEnabled);
   const passwordSessionActive = useAuthStore((s) => s.passwordSessionActive);
-  const refreshSession = useAuthStore((s) => s.refreshSession);
-
   const authenticated = useAuthStore((s) => s.authenticated);
+
   const [activeDialog, setActiveDialog] = useState<PasswordDialog>(null);
-  const [verifyStep, setVerifyStep] = useState<"password" | "totp">("password");
-  const [error, setError] = useState<string | null>(null);
 
-  const setupForm = useForm({
-    resolver: zodResolver(PasswordSetupRequestSchema),
-    defaultValues: { password: "", bootstrapToken: "" },
-  });
-
-  const changeForm = useForm({
-    resolver: zodResolver(PasswordChangeRequestSchema),
-    defaultValues: { currentPassword: "", newPassword: "" },
-  });
-
-  const removeForm = useForm({
-    resolver: zodResolver(PasswordRemoveRequestSchema),
-    defaultValues: { password: "" },
-  });
-
-  const verifyForm = useForm({
-    resolver: zodResolver(PasswordRemoveRequestSchema),
-    defaultValues: { password: "" },
-  });
-
-  const verifyTotpForm = useForm({
-    resolver: zodResolver(TotpVerifyRequestSchema),
-    defaultValues: { code: "" },
-  });
-
-  const busy =
-    setupForm.formState.isSubmitting ||
-    changeForm.formState.isSubmitting ||
-    removeForm.formState.isSubmitting ||
-    verifyForm.formState.isSubmitting ||
-    verifyTotpForm.formState.isSubmitting;
-  const lock = busy || disabled || !passwordManagementEnabled;
-
-  const closeDialog = () => {
-    setActiveDialog(null);
-    setError(null);
-    setupForm.reset();
-    changeForm.reset();
-    removeForm.reset();
-    verifyForm.reset();
-    verifyTotpForm.reset();
-    setVerifyStep("password");
-  };
-
-  const handleSetup = async (values: { password: string; bootstrapToken?: string }) => {
-    setError(null);
-    try {
-      await setupPassword({
-        password: values.password,
-        bootstrapToken: values.bootstrapToken?.trim() ? values.bootstrapToken.trim() : undefined,
-      });
-      await refreshSession();
-      toast.success("Password configured");
-      closeDialog();
-    } catch (caught) {
-      setError(getErrorMessage(caught));
-    }
-  };
-
-  const handleChange = async (values: { currentPassword: string; newPassword: string }) => {
-    setError(null);
-    try {
-      await changePassword(values);
-      toast.success("Password changed");
-      closeDialog();
-    } catch (caught) {
-      setError(getErrorMessage(caught));
-    }
-  };
-
-  const handleRemove = async (values: { password: string }) => {
-    setError(null);
-    try {
-      await removePassword(values);
-      await refreshSession();
-      toast.success("Password removed");
-      closeDialog();
-    } catch (caught) {
-      setError(getErrorMessage(caught));
-    }
-  };
-
-  const handleVerify = async (values: { password: string }) => {
-    setError(null);
-    try {
-      const session = await loginPassword(values);
-      if (session.totpRequiredOnLogin && !session.passwordSessionActive) {
-        setVerifyStep("totp");
-        return;
-      }
-      await refreshSession();
-      toast.success("Password session established");
-      closeDialog();
-    } catch (caught) {
-      setError(getErrorMessage(caught));
-    }
-  };
-
-  const handleVerifyTotp = async (values: { code: string }) => {
-    setError(null);
-    try {
-      await verifyTotp(values);
-      await refreshSession();
-      toast.success("Password session established");
-      closeDialog();
-    } catch (caught) {
-      setError(getErrorMessage(caught));
+  const lock = disabled || !passwordManagementEnabled;
+  const closeIfMatches = (dialog: PasswordDialog) => (open: boolean) => {
+    if (!open && activeDialog === dialog) {
+      setActiveDialog(null);
     }
   };
 
@@ -160,286 +34,96 @@ export function PasswordSettings({ disabled = false }: PasswordSettingsProps) {
     <section className="rounded-xl border bg-card p-5">
       <div className="space-y-3">
         <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2.5">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
-            <KeyRound className="h-4 w-4 text-primary" aria-hidden="true" />
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+              <KeyRound className="h-4 w-4 text-primary" aria-hidden="true" />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold">Password</h3>
+              <p className="text-xs text-muted-foreground">
+                {!passwordManagementEnabled
+                  ? "Password login is disabled by the current dashboard auth mode."
+                  : authMode === "trusted_header"
+                    ? passwordRequired
+                      ? "Password is configured as an optional fallback."
+                      : "No fallback password set."
+                    : passwordRequired
+                      ? "Password is configured."
+                      : "No password set."}
+              </p>
+            </div>
           </div>
-          <div>
-            <h3 className="text-sm font-semibold">Password</h3>
-            <p className="text-xs text-muted-foreground">
-              {!passwordManagementEnabled
-                ? "Password login is disabled by the current dashboard auth mode."
-                : authMode === "trusted_header"
-                  ? passwordRequired
-                    ? "Password is configured as an optional fallback."
-                    : "No fallback password set."
-                  : passwordRequired
-                    ? "Password is configured."
-                    : "No password set."}
-            </p>
-          </div>
-        </div>
 
-        <div className="flex items-center gap-2">
-          {!passwordManagementEnabled ? null : passwordRequired && passwordSessionActive ? (
-            <>
+          <div className="flex items-center gap-2">
+            {!passwordManagementEnabled ? null : passwordRequired && passwordSessionActive ? (
+              <>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-8 text-xs"
+                  disabled={lock}
+                  onClick={() => setActiveDialog("change")}
+                >
+                  Change
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-8 text-xs text-destructive hover:text-destructive"
+                  disabled={lock}
+                  onClick={() => setActiveDialog("remove")}
+                >
+                  Remove
+                </Button>
+              </>
+            ) : passwordRequired && authenticated && !passwordSessionActive ? (
               <Button
                 type="button"
                 size="sm"
                 variant="outline"
                 className="h-8 text-xs"
-                disabled={lock}
-                onClick={() => setActiveDialog("change")}
+                disabled={disabled}
+                onClick={() => setActiveDialog("verify")}
               >
-                Change
+                Login to manage
               </Button>
+            ) : !passwordRequired ? (
               <Button
                 type="button"
                 size="sm"
-                variant="outline"
-                className="h-8 text-xs text-destructive hover:text-destructive"
+                className="h-8 text-xs"
                 disabled={lock}
-                onClick={() => setActiveDialog("remove")}
+                onClick={() => setActiveDialog("setup")}
               >
-                Remove
+                Set password
               </Button>
-            </>
-          ) : passwordRequired && authenticated && !passwordSessionActive ? (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="h-8 text-xs"
-              disabled={disabled}
-              onClick={() => setActiveDialog("verify")}
-            >
-              Login to manage
-            </Button>
-          ) : !passwordRequired ? (
-            <Button
-              type="button"
-              size="sm"
-              className="h-8 text-xs"
-              disabled={lock}
-              onClick={() => setActiveDialog("setup")}
-            >
-              Set password
-            </Button>
-          ) : null}
-        </div>
+            ) : null}
+          </div>
         </div>
       </div>
 
-      {/* Setup dialog */}
-      <Dialog open={activeDialog === "setup"} onOpenChange={(open) => !open && closeDialog()}>
-        <DialogContent className="sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>Set password</DialogTitle>
-              <DialogDescription>Set a password for dashboard login.</DialogDescription>
-            </DialogHeader>
-            {bootstrapRequired ? (
-              <AlertMessage variant="error">
-                {bootstrapTokenConfigured
-                  ? "Remote setup requires the configured bootstrap token (from server logs or CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN)."
-                  : "Remote setup is blocked. Set CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN on the server or restart to auto-generate a token."}
-              </AlertMessage>
-            ) : null}
-            {error ? <AlertMessage variant="error">{error}</AlertMessage> : null}
-            <Form {...setupForm}>
-              <form onSubmit={setupForm.handleSubmit(handleSetup)} className="space-y-4">
-              <FormField
-                control={setupForm.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Password</FormLabel>
-                    <FormControl>
-                      <Input {...field} type="password" autoComplete="new-password" placeholder="Min. 8 characters" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-                />
-                {bootstrapRequired ? (
-                  <FormField
-                    control={setupForm.control}
-                    name="bootstrapToken"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Bootstrap token</FormLabel>
-                        <FormControl>
-                          <Input {...field} type="password" autoComplete="one-time-code" placeholder="Enter bootstrap token" />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                ) : null}
-                <DialogFooter>
-                <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={lock}>
-                  Set password
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-
-      {/* Change dialog */}
-      <Dialog open={activeDialog === "change"} onOpenChange={(open) => !open && closeDialog()}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Change password</DialogTitle>
-            <DialogDescription>Enter your current password and a new one.</DialogDescription>
-          </DialogHeader>
-          {error ? <AlertMessage variant="error">{error}</AlertMessage> : null}
-          <Form {...changeForm}>
-            <form onSubmit={changeForm.handleSubmit(handleChange)} className="space-y-4">
-              <FormField
-                control={changeForm.control}
-                name="currentPassword"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Current password</FormLabel>
-                    <FormControl>
-                      <Input {...field} type="password" autoComplete="current-password" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={changeForm.control}
-                name="newPassword"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>New password</FormLabel>
-                    <FormControl>
-                      <Input {...field} type="password" autoComplete="new-password" placeholder="Min. 8 characters" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <DialogFooter>
-                <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={lock}>
-                  Change password
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-
-      {/* Remove dialog */}
-      <Dialog open={activeDialog === "remove"} onOpenChange={(open) => !open && closeDialog()}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Remove password</DialogTitle>
-            <DialogDescription>Confirm your current password to remove it.</DialogDescription>
-          </DialogHeader>
-          {error ? <AlertMessage variant="error">{error}</AlertMessage> : null}
-          <Form {...removeForm}>
-            <form onSubmit={removeForm.handleSubmit(handleRemove)} className="space-y-4">
-              <FormField
-                control={removeForm.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Current password</FormLabel>
-                    <FormControl>
-                      <Input {...field} type="password" autoComplete="current-password" placeholder="Enter current password" />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <DialogFooter>
-                <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
-                  Cancel
-                </Button>
-                <Button type="submit" variant="destructive" disabled={lock}>
-                  Remove password
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-
-      {/* Verify dialog (re-establish password session for proxy-authenticated users) */}
-      <Dialog open={activeDialog === "verify"} onOpenChange={(open) => !open && closeDialog()}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{verifyStep === "password" ? "Verify password" : "TOTP verification"}</DialogTitle>
-            <DialogDescription>
-              {verifyStep === "password"
-                ? "Enter your password to unlock password and TOTP management."
-                : "Enter your TOTP code to complete verification."}
-            </DialogDescription>
-          </DialogHeader>
-          {error ? <AlertMessage variant="error">{error}</AlertMessage> : null}
-          {verifyStep === "password" ? (
-            <Form {...verifyForm}>
-              <form onSubmit={verifyForm.handleSubmit(handleVerify)} className="space-y-4">
-                <FormField
-                  control={verifyForm.control}
-                  name="password"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Password</FormLabel>
-                      <FormControl>
-                        <Input {...field} type="password" autoComplete="current-password" placeholder="Enter current password" />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <DialogFooter>
-                  <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={busy}>
-                    Verify
-                  </Button>
-                </DialogFooter>
-              </form>
-            </Form>
-          ) : (
-            <Form {...verifyTotpForm}>
-              <form onSubmit={verifyTotpForm.handleSubmit(handleVerifyTotp)} className="space-y-4">
-                <FormField
-                  control={verifyTotpForm.control}
-                  name="code"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>TOTP code</FormLabel>
-                      <FormControl>
-                        <Input {...field} type="text" inputMode="numeric" autoComplete="one-time-code" placeholder="6-digit code" />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <DialogFooter>
-                  <Button type="button" variant="outline" onClick={closeDialog} disabled={busy}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={busy}>
-                    Verify
-                  </Button>
-                </DialogFooter>
-              </form>
-            </Form>
-          )}
-        </DialogContent>
-      </Dialog>
+      <PasswordSetupDialog
+        open={activeDialog === "setup"}
+        onOpenChange={closeIfMatches("setup")}
+        disabled={disabled}
+      />
+      <PasswordChangeDialog
+        open={activeDialog === "change"}
+        onOpenChange={closeIfMatches("change")}
+        disabled={disabled}
+      />
+      <PasswordRemoveDialog
+        open={activeDialog === "remove"}
+        onOpenChange={closeIfMatches("remove")}
+        disabled={disabled}
+      />
+      <PasswordVerifyDialog
+        open={activeDialog === "verify"}
+        onOpenChange={closeIfMatches("verify")}
+        disabled={disabled}
+      />
     </section>
   );
 }

--- a/frontend/src/features/settings/components/password-setup-dialog.tsx
+++ b/frontend/src/features/settings/components/password-setup-dialog.tsx
@@ -1,0 +1,125 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { AlertMessage } from "@/components/alert-message";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { setupPassword } from "@/features/auth/api";
+import { useAuthStore } from "@/features/auth/hooks/use-auth";
+import { PasswordSetupRequestSchema } from "@/features/auth/schemas";
+import { getErrorMessage } from "@/utils/errors";
+
+export type PasswordSetupDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  disabled?: boolean;
+};
+
+export function PasswordSetupDialog({ open, onOpenChange, disabled = false }: PasswordSetupDialogProps) {
+  const bootstrapRequired = useAuthStore((s) => s.bootstrapRequired);
+  const bootstrapTokenConfigured = useAuthStore((s) => s.bootstrapTokenConfigured);
+  const passwordManagementEnabled = useAuthStore((s) => s.passwordManagementEnabled);
+  const refreshSession = useAuthStore((s) => s.refreshSession);
+
+  const form = useForm({
+    resolver: zodResolver(PasswordSetupRequestSchema),
+    defaultValues: { password: "", bootstrapToken: "" },
+  });
+
+  const busy = form.formState.isSubmitting;
+  const lock = busy || disabled || !passwordManagementEnabled;
+
+  useEffect(() => {
+    if (!open) {
+      form.reset();
+      form.clearErrors();
+    }
+  }, [open, form]);
+
+  const handleSubmit = async (values: { password: string; bootstrapToken?: string }) => {
+    form.clearErrors("root");
+    try {
+      await setupPassword({
+        password: values.password,
+        bootstrapToken: values.bootstrapToken?.trim() ? values.bootstrapToken.trim() : undefined,
+      });
+      await refreshSession();
+      toast.success("Password configured");
+      onOpenChange(false);
+    } catch (caught) {
+      form.setError("root", { message: getErrorMessage(caught) });
+    }
+  };
+
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Set password</DialogTitle>
+          <DialogDescription>Set a password for dashboard login.</DialogDescription>
+        </DialogHeader>
+        {bootstrapRequired ? (
+          <AlertMessage variant="error">
+            {bootstrapTokenConfigured
+              ? "Remote setup requires the configured bootstrap token (from server logs or CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN)."
+              : "Remote setup is blocked. Set CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN on the server or restart to auto-generate a token."}
+          </AlertMessage>
+        ) : null}
+        {rootError ? <AlertMessage variant="error">{rootError}</AlertMessage> : null}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="password" autoComplete="new-password" placeholder="Min. 8 characters" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {bootstrapRequired ? (
+              <FormField
+                control={form.control}
+                name="bootstrapToken"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Bootstrap token</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="password" autoComplete="one-time-code" placeholder="Enter bootstrap token" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : null}
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={lock}>
+                Set password
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/settings/components/password-verify-dialog.tsx
+++ b/frontend/src/features/settings/components/password-verify-dialog.tsx
@@ -80,7 +80,7 @@ export function PasswordVerifyDialog({ open, onOpenChange, disabled = false }: P
       }
       await refreshSession();
       toast.success("Password session established");
-      onOpenChange(false);
+      handleOpenChange(false);
     } catch (caught) {
       setError(getErrorMessage(caught));
     }
@@ -92,7 +92,7 @@ export function PasswordVerifyDialog({ open, onOpenChange, disabled = false }: P
       await verifyTotp(values);
       await refreshSession();
       toast.success("Password session established");
-      onOpenChange(false);
+      handleOpenChange(false);
     } catch (caught) {
       setError(getErrorMessage(caught));
     }

--- a/frontend/src/features/settings/components/password-verify-dialog.tsx
+++ b/frontend/src/features/settings/components/password-verify-dialog.tsx
@@ -1,0 +1,169 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { AlertMessage } from "@/components/alert-message";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { loginPassword, verifyTotp } from "@/features/auth/api";
+import { useAuthStore } from "@/features/auth/hooks/use-auth";
+import { PasswordRemoveRequestSchema, TotpVerifyRequestSchema } from "@/features/auth/schemas";
+import { getErrorMessage } from "@/utils/errors";
+
+type VerifyStep = "password" | "totp";
+
+export type PasswordVerifyDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  disabled?: boolean;
+};
+
+export function PasswordVerifyDialog({ open, onOpenChange, disabled = false }: PasswordVerifyDialogProps) {
+  const refreshSession = useAuthStore((s) => s.refreshSession);
+
+  const [step, setStep] = useState<VerifyStep>("password");
+  const [error, setError] = useState<string | null>(null);
+
+  const passwordForm = useForm({
+    resolver: zodResolver(PasswordRemoveRequestSchema),
+    defaultValues: { password: "" },
+  });
+
+  const totpForm = useForm({
+    resolver: zodResolver(TotpVerifyRequestSchema),
+    defaultValues: { code: "" },
+  });
+
+  const busy = passwordForm.formState.isSubmitting || totpForm.formState.isSubmitting;
+
+  const resetAll = useCallback(() => {
+    passwordForm.reset();
+    totpForm.reset();
+    setStep("password");
+    setError(null);
+  }, [passwordForm, totpForm]);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) {
+        resetAll();
+      }
+      onOpenChange(next);
+    },
+    [onOpenChange, resetAll],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      passwordForm.reset();
+      totpForm.reset();
+    }
+  }, [open, passwordForm, totpForm]);
+
+  const handlePassword = async (values: { password: string }) => {
+    setError(null);
+    try {
+      const session = await loginPassword(values);
+      if (session.totpRequiredOnLogin && !session.passwordSessionActive) {
+        setStep("totp");
+        return;
+      }
+      await refreshSession();
+      toast.success("Password session established");
+      onOpenChange(false);
+    } catch (caught) {
+      setError(getErrorMessage(caught));
+    }
+  };
+
+  const handleTotp = async (values: { code: string }) => {
+    setError(null);
+    try {
+      await verifyTotp(values);
+      await refreshSession();
+      toast.success("Password session established");
+      onOpenChange(false);
+    } catch (caught) {
+      setError(getErrorMessage(caught));
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{step === "password" ? "Verify password" : "TOTP verification"}</DialogTitle>
+          <DialogDescription>
+            {step === "password"
+              ? "Enter your password to unlock password and TOTP management."
+              : "Enter your TOTP code to complete verification."}
+          </DialogDescription>
+        </DialogHeader>
+        {error ? <AlertMessage variant="error">{error}</AlertMessage> : null}
+        {step === "password" ? (
+          <Form {...passwordForm}>
+            <form onSubmit={passwordForm.handleSubmit(handlePassword)} className="space-y-4">
+              <FormField
+                control={passwordForm.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="password" autoComplete="current-password" placeholder="Enter current password" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={() => handleOpenChange(false)} disabled={busy}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={busy || disabled}>
+                  Verify
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        ) : (
+          <Form {...totpForm}>
+            <form onSubmit={totpForm.handleSubmit(handleTotp)} className="space-y-4">
+              <FormField
+                control={totpForm.control}
+                name="code"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>TOTP code</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="text" inputMode="numeric" autoComplete="one-time-code" placeholder="6-digit code" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button type="button" variant="outline" onClick={() => handleOpenChange(false)} disabled={busy}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={busy || disabled}>
+                  Verify
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Why

`frontend/src/features/settings/components/password-settings.tsx` had grown to 445 lines holding five react-hook-form instances, four submit handlers, and four dialogs (`setup` / `change` / `remove` / `verify`) inside a single component. Touching any one auth flow (bootstrap-token setup, change, remove, proxy-auth re-verify with optional TOTP step) meant scrolling past all the others and risked cross-form state coupling via the shared `activeDialog` / `verifyStep` / `error` trio.

## What

Extract one self-contained subcomponent per dialog and let each own its form + error + (where relevant) sub-step state:

- `password-setup-dialog.tsx` — setup form, bootstrap-token field gated on `bootstrapRequired`, bootstrap warning AlertMessage.
- `password-change-dialog.tsx` — current/new password form.
- `password-remove-dialog.tsx` — confirm-current-password remove form with destructive submit button.
- `password-verify-dialog.tsx` — two-step password → TOTP flow, owns its own `verifyStep` so the parent no longer needs to track it.

`password-settings.tsx` is now layout-only: reads enough auth-store flags to pick which action button to show, drives an `activeDialog` discriminant, and mounts all four subcomponents.

No DOM, copy, route, or store-write change.

## Test plan

- `bunx tsc -b` clean
- `bunx vitest run` 431/431 (baseline before refactor was also 431/431) — `password-settings.test.tsx` 10/10 unchanged
- `bunx eslint src/features/settings/components` clean

Closes #617