### PR TITLE
fix(proxy): fail over pre-visible refresh connect stalls

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2144,19 +2144,38 @@ class ProxyService:
                                 )
                                 raise exc
                             except (aiohttp.ClientError, asyncio.TimeoutError) as timeout_exc:
-                                await self._settle_compact_api_key_usage(
-                                    api_key=api_key,
-                                    api_key_reservation=api_key_reservation,
-                                    response=None,
-                                    request_service_tier=request_service_tier,
-                                )
+                                message = str(timeout_exc) or "Request to upstream timed out"
                                 logger.warning(
                                     "Compact forced refresh/connect failed request_id=%s account_id=%s",
                                     request_id,
                                     account.id,
                                     exc_info=True,
                                 )
-                                _raise_proxy_unavailable(str(timeout_exc) or "Request to upstream timed out")
+                                if not _should_retry_transient_stream_error("upstream_unavailable", message):
+                                    await self._settle_compact_api_key_usage(
+                                        api_key=api_key,
+                                        api_key_reservation=api_key_reservation,
+                                        response=None,
+                                        request_service_tier=request_service_tier,
+                                    )
+                                    _raise_proxy_unavailable(message)
+                                if file_preferred_account_id is not None:
+                                    await self._settle_compact_api_key_usage(
+                                        api_key=api_key,
+                                        api_key_reservation=api_key_reservation,
+                                        response=None,
+                                        request_service_tier=request_service_tier,
+                                    )
+                                    _raise_proxy_unavailable(message)
+                                await self._handle_stream_error(
+                                    account,
+                                    {"message": message},
+                                    "upstream_unavailable",
+                                )
+                                last_exc = ProxyResponseError(502, openai_error("upstream_unavailable", message))
+                                excluded_account_ids.add(account.id)
+                                transient_exhausted = True
+                                break
                             refresh_retry_used = True
                             continue
                         if exc.status_code == 500:
@@ -9763,6 +9782,24 @@ class ProxyService:
                             exc_info=True,
                         )
                         message = str(exc) or "Request to upstream timed out"
+                        if (
+                            not require_preferred_account
+                            and preferred_account_id is None
+                            and _should_retry_transient_stream_error("upstream_unavailable", message)
+                            and attempt + 1 < max_attempts
+                        ):
+                            await self._handle_stream_error(
+                                account,
+                                {"message": message},
+                                "upstream_unavailable",
+                            )
+                            last_retryable_stream_error = _RetryableStreamError(
+                                "upstream_unavailable",
+                                {"message": message},
+                                exclude_account=True,
+                            )
+                            excluded_account_ids.add(account.id)
+                            continue
                         await self._write_stream_preflight_error(
                             account_id=account.id,
                             api_key=api_key,
@@ -10044,6 +10081,24 @@ class ProxyService:
                                 exc_info=True,
                             )
                             message = str(exc) or "Request to upstream timed out"
+                            if (
+                                not require_preferred_account
+                                and preferred_account_id is None
+                                and _should_retry_transient_stream_error("upstream_unavailable", message)
+                                and attempt + 1 < max_attempts
+                            ):
+                                await self._handle_stream_error(
+                                    account,
+                                    {"message": message},
+                                    "upstream_unavailable",
+                                )
+                                last_retryable_stream_error = _RetryableStreamError(
+                                    "upstream_unavailable",
+                                    {"message": message},
+                                    exclude_account=True,
+                                )
+                                excluded_account_ids.add(account.id)
+                                continue
                             await self._write_stream_preflight_error(
                                 account_id=account.id,
                                 api_key=api_key,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2058,6 +2058,8 @@ class ProxyService:
                     )
                     if not _should_retry_transient_stream_error("upstream_unavailable", message):
                         _raise_proxy_unavailable(message)
+                    if file_preferred_account_id is not None:
+                        _raise_proxy_unavailable(message)
                     await self._handle_stream_error(
                         account,
                         {"message": message},

--- a/openspec/changes/fix-previsible-refresh-connect-failover/.openspec.yaml
+++ b/openspec/changes/fix-previsible-refresh-connect-failover/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/fix-previsible-refresh-connect-failover/proposal.md
+++ b/openspec/changes/fix-previsible-refresh-connect-failover/proposal.md
@@ -1,0 +1,31 @@
+# Fix pre-visible refresh/connect failover
+
+## Why
+
+PR #822 tightens the compact retry path after the selected account cannot be
+refreshed or connected before any compact output exists. Ordinary pre-visible
+auth and transport failures can move to another eligible account, but a compact
+request that references `input_file.file_id` can be account-bound by the upload
+pin. Retrying that request on a different account would lose the file-owner
+contract and can turn a real upstream availability problem into an incorrect
+cross-account replay.
+
+## What Changes
+
+- Document that pre-visible refresh/connect failover remains allowed only when
+  the request is replayable on another eligible account.
+- Document that compact requests with live file-id routing pins fail closed on
+  refresh/connect unavailability instead of excluding the pinned account and
+  selecting a different account.
+- Keep the existing repeated auth-401 failover contract for replayable compact,
+  websocket connect, and HTTP bridge handshake paths.
+
+## Issue Trace
+
+- Refs #822
+
+## Impact
+
+- **Spec**: `responses-api-compat`
+- **Behavior**: compact requests with pinned upload files preserve file-owner
+  routing during pre-visible refresh/connect failures.

--- a/openspec/changes/fix-previsible-refresh-connect-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-previsible-refresh-connect-failover/specs/responses-api-compat/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: File-pinned compact refresh/connect failures fail closed
+
+The proxy SHALL preserve file-owner routing during pre-visible refresh and
+upstream-connect failure handling. If the pinned account cannot refresh or open
+the upstream compact connection before any compact response is emitted, the proxy
+MUST surface a stable upstream-unavailable failure for that request instead of
+excluding the pinned account and replaying the compact request on another
+account. This fail-closed rule applies only to file-pinned compact requests;
+replayable compact/connect requests without a live file-id pin continue to use
+the existing pre-visible forced-refresh and eligible-account failover behavior.
+
+#### Scenario: file-pinned compact request fails closed on refresh transport failure
+
+- **GIVEN** `file_pinned` was uploaded through `account_a` and its in-memory pin is live
+- **AND** a compact request references `{"type": "input_file", "file_id": "file_pinned"}`
+- **WHEN** `account_a` fails token refresh with a pre-visible transport or connection error
+- **THEN** the proxy returns an upstream-unavailable error for that compact request
+- **AND** it does not select another account for that request
+
+#### Scenario: replayable compact request without file pins can still fail over
+
+- **GIVEN** at least two accounts are eligible for a compact request
+- **AND** the compact request has no live `input_file.file_id` routing pin
+- **WHEN** the selected account fails before compact output is emitted and the
+  failure is classified by an existing pre-visible failover rule
+- **THEN** the proxy may exclude that account for the current request and try
+  another eligible account

--- a/openspec/changes/fix-previsible-refresh-connect-failover/tasks.md
+++ b/openspec/changes/fix-previsible-refresh-connect-failover/tasks.md
@@ -1,0 +1,13 @@
+## 1. Spec Delta
+
+- [x] 1.1 Add a `responses-api-compat` requirement for file-pinned compact
+  refresh/connect failures.
+- [x] 1.2 Preserve the existing pre-visible failover contract for replayable
+  compact/connect surfaces.
+- [x] 1.3 Include issue trace for PR #822.
+
+## 2. Verification
+
+- [x] 2.1 Validate the OpenSpec change with `uv run openspec validate
+  fix-previsible-refresh-connect-failover --strict`.
+- [x] 2.2 Validate all specs with `uv run openspec validate --specs`.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12676,77 +12676,103 @@ async def test_stream_selection_budget_exhaustion_emits_timeout_event(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_stream_refresh_timeout_emits_upstream_unavailable_and_logs(monkeypatch):
+async def test_stream_refresh_timeout_before_visible_output_fails_over(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
-    account = _make_account("acc_stream_refresh_timeout")
+    account_a = _make_account("acc_stream_refresh_timeout_a")
+    account_b = _make_account("acc_stream_refresh_timeout_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    stream_account_ids: list[str | None] = []
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
-    monkeypatch.setattr(
-        service._load_balancer,
-        "select_account",
-        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
-    )
 
-    async def failing_ensure_fresh(account, *, force: bool = False, timeout_seconds: float | None = None):
-        raise asyncio.TimeoutError
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if not excluded_account_ids:
+            return AccountSelection(account=account_a, error_message=None)
+        return AccountSelection(account=account_b, error_message=None)
 
-    monkeypatch.setattr(service, "_ensure_fresh", failing_ensure_fresh)
+    async def fake_ensure_fresh(account, *, force: bool = False, timeout_seconds: float | None = None):
+        del force, timeout_seconds
+        if account.id == account_a.id:
+            raise asyncio.TimeoutError
+        return account
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, base_url, raise_for_status
+        stream_account_ids.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_refresh_connect_failover"}}\n\n'
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh", fake_ensure_fresh)
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
 
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
 
     chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
 
     event = json.loads(chunks[0].split("data: ", 1)[1])
-    assert event["response"]["error"]["code"] == "upstream_unavailable"
-    assert event["response"]["error"]["message"] == "Request to upstream timed out"
-    assert request_logs.calls[-1]["account_id"] == account.id
-    assert request_logs.calls[-1]["status"] == "error"
-    assert request_logs.calls[-1]["error_code"] == "upstream_unavailable"
-    assert request_logs.calls[-1]["error_message"] == "Request to upstream timed out"
+    assert event["type"] == "response.completed"
+    assert event["response"]["id"] == "resp_refresh_connect_failover"
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert stream_account_ids == [account_b.chatgpt_account_id]
+    assert request_logs.calls[-1]["account_id"] == account_b.id
+    assert request_logs.calls[-1]["status"] == "success"
 
 
 @pytest.mark.asyncio
-async def test_stream_forced_refresh_timeout_emits_upstream_unavailable_and_logs(monkeypatch):
+async def test_stream_forced_refresh_timeout_before_visible_output_fails_over(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
-    account = _make_account("acc_stream_forced_refresh_timeout")
+    account_a = _make_account("acc_stream_forced_refresh_timeout_a")
+    account_b = _make_account("acc_stream_forced_refresh_timeout_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    stream_account_ids: list[str | None] = []
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
-    monkeypatch.setattr(
-        service._load_balancer,
-        "select_account",
-        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
-    )
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if not excluded_account_ids:
+            return AccountSelection(account=account_a, error_message=None)
+        return AccountSelection(account=account_b, error_message=None)
 
     async def fake_ensure_fresh(account, *, force: bool = False, timeout_seconds: float | None = None):
-        if force:
+        del timeout_seconds
+        if account.id == account_a.id and force:
             raise asyncio.TimeoutError
         return account
 
     async def failing_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
-        raise proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "token expired"))
-        if False:
-            yield ""
+        del payload, headers, access_token, base_url, raise_for_status
+        stream_account_ids.append(account_id)
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "token expired"))
+        yield 'data: {"type":"response.completed","response":{"id":"resp_forced_refresh_connect_failover"}}\n\n'
 
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
     monkeypatch.setattr(service, "_ensure_fresh", fake_ensure_fresh)
     monkeypatch.setattr(proxy_service, "core_stream_responses", failing_stream)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
 
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
 
     chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
 
     event = json.loads(chunks[0].split("data: ", 1)[1])
-    assert event["response"]["error"]["code"] == "upstream_unavailable"
-    assert event["response"]["error"]["message"] == "Request to upstream timed out"
-    assert request_logs.calls[-1]["account_id"] == account.id
-    assert request_logs.calls[-1]["status"] == "error"
-    assert request_logs.calls[-1]["error_code"] == "upstream_unavailable"
-    assert request_logs.calls[-1]["error_message"] == "Request to upstream timed out"
+    assert event["type"] == "response.completed"
+    assert event["response"]["id"] == "resp_forced_refresh_connect_failover"
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert stream_account_ids == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
+    assert request_logs.calls[-1]["account_id"] == account_b.id
+    assert request_logs.calls[-1]["status"] == "success"
 
 
 @pytest.mark.asyncio
@@ -13474,6 +13500,117 @@ async def test_compact_responses_refresh_connection_reset_fails_over(monkeypatch
     record_success.assert_awaited_once_with(account_b)
     assert request_logs.calls[0]["status"] == "success"
     assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_forced_refresh_connection_reset_fails_over(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_forced_reset_a")
+    account_b = _make_account("acc_compact_forced_reset_b")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+    compact_account_ids: list[str | None] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = kwargs.get("exclude_account_ids")
+        seen_excluded_account_ids.append(set(cast(set[str], excluded_account_ids)))
+        if not excluded_account_ids:
+            return AccountSelection(account=account_a, error_message=None)
+        return AccountSelection(account=account_b, error_message=None)
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(
+            side_effect=[
+                account_a,
+                aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer"),
+                account_b,
+            ],
+        ),
+    )
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        compact_account_ids.append(account_id)
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "token expired"))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+
+    response = await service.compact_responses(payload, {"session_id": "sid-compact"})
+
+    assert response.model_extra == {"output": []}
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert compact_account_ids == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
+    record_error.assert_awaited_once_with(account_a)
+    record_success.assert_awaited_once_with(account_b)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_forced_refresh_connection_reset_preserves_file_pin(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_forced_reset_pinned")
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None))
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=account.id))
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(
+            side_effect=[
+                account,
+                aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer"),
+            ],
+        ),
+    )
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        raise proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "token expired"))
+
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"type": "input_file", "file_id": "file_pinned"}],
+        }
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(payload, {"session_id": "sid-compact"})
+
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert select_account.await_count == 1
+    handle_stream_error.assert_not_awaited()
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account.id
+    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -13614,6 +13614,49 @@ async def test_compact_responses_forced_refresh_connection_reset_preserves_file_
 
 
 @pytest.mark.asyncio
+async def test_compact_responses_initial_refresh_connection_reset_preserves_file_pin(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_initial_reset_pinned")
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None))
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=account.id))
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer")),
+    )
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+    core_compact_responses = AsyncMock()
+    monkeypatch.setattr(proxy_service, "core_compact_responses", core_compact_responses)
+
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"type": "input_file", "file_id": "file_pinned"}],
+        }
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(payload, {"session_id": "sid-compact"})
+
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert select_account.await_count == 1
+    handle_stream_error.assert_not_awaited()
+    core_compact_responses.assert_not_awaited()
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account.id
+    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_compact_responses_refresh_non_transient_client_error_does_not_penalize_accounts(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()


### PR DESCRIPTION
## Summary
- fail over compact forced-refresh/connect stalls to another eligible account instead of surfacing before output
- fail over HTTP Responses stream refresh/connect and post-401 forced-refresh/connect stalls before visible output
- keep strict preferred-owner and file-pin paths fail-closed so pinned resources do not silently move accounts

## Tests
- uv run pytest tests/unit/test_proxy_utils.py::test_stream_refresh_timeout_before_visible_output_fails_over tests/unit/test_proxy_utils.py::test_stream_forced_refresh_timeout_before_visible_output_fails_over tests/unit/test_proxy_utils.py::test_compact_responses_forced_refresh_connection_reset_fails_over tests/unit/test_proxy_utils.py::test_compact_responses_refresh_connection_reset_fails_over tests/unit/test_proxy_utils.py::test_compact_responses_refresh_non_transient_client_error_does_not_penalize_accounts -q
- uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py
- uv run ty check app/modules/proxy/service.py tests/unit/test_proxy_utils.py
- git diff --check

## Follow-up
- thread-goal, codex-control, transcribe, and files still have unary refresh/connect no-failover gaps; those should use a shared unary retry helper rather than four copy-paste loops.

No linked issue; addresses the owner-review file-pinned compact failover blocker in this PR.
