### PR TITLE
feat(acc-del): cascade delete request log option 

### DIFF
--- a/app/modules/accounts/api.py
+++ b/app/modules/accounts/api.py
@@ -146,14 +146,15 @@ async def update_account_limit_warmup(
 async def delete_account(
     request: Request,
     account_id: str,
+    delete_history: bool = False,
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountDeleteResponse:
-    success = await context.service.delete_account(account_id)
+    success = await context.service.delete_account(account_id, delete_history=delete_history)
     if not success:
         raise DashboardNotFoundError("Account not found", code="account_not_found")
     AuditService.log_async(
         "account_deleted",
         actor_ip=request.client.host if request.client else None,
-        details={"account_id": account_id},
+        details={"account_id": account_id, "delete_history": delete_history},
     )
     return AccountDeleteResponse(status="deleted")

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -224,11 +224,16 @@ class AccountsRepository:
         await self._session.commit()
         return result.scalar_one_or_none() is not None
 
-    async def delete(self, account_id: str) -> bool:
+    async def delete(self, account_id: str, *, delete_history: bool = False) -> bool:
         await self._session.execute(delete(UsageHistory).where(UsageHistory.account_id == account_id))
-        await self._session.execute(
-            update(RequestLog).where(RequestLog.account_id == account_id).values(account_id=None, deleted_at=utcnow())
-        )
+        if delete_history:
+            await self._session.execute(delete(RequestLog).where(RequestLog.account_id == account_id))
+        else:
+            await self._session.execute(
+                update(RequestLog)
+                .where(RequestLog.account_id == account_id)
+                .values(account_id=None, deleted_at=utcnow()),
+            )
         await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
         result = await self._session.execute(delete(Account).where(Account.id == account_id).returning(Account.id))
         await self._session.commit()

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -204,8 +204,8 @@ class AccountsService:
     async def set_limit_warmup_enabled(self, account_id: str, enabled: bool) -> bool:
         return await self._repo.update_limit_warmup_enabled(account_id, enabled)
 
-    async def delete_account(self, account_id: str) -> bool:
-        result = await self._repo.delete(account_id)
+    async def delete_account(self, account_id: str, *, delete_history: bool = False) -> bool:
+        result = await self._repo.delete(account_id, delete_history=delete_history)
         if result:
             get_account_selection_cache().invalidate()
             get_api_key_cache().clear()

--- a/frontend/src/components/confirm-dialog.tsx
+++ b/frontend/src/components/confirm-dialog.tsx
@@ -17,6 +17,7 @@ export type ConfirmDialogProps = {
   cancelLabel?: string;
   onConfirm: () => void;
   onOpenChange: (open: boolean) => void;
+  children?: React.ReactNode;
 };
 
 export function ConfirmDialog({
@@ -27,6 +28,7 @@ export function ConfirmDialog({
   cancelLabel = "Cancel",
   onConfirm,
   onOpenChange,
+  children,
 }: ConfirmDialogProps) {
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -35,6 +37,7 @@ export function ConfirmDialog({
           <AlertDialogTitle>{title}</AlertDialogTitle>
           {description ? <AlertDialogDescription>{description}</AlertDialogDescription> : null}
         </AlertDialogHeader>
+        {children}
         <AlertDialogFooter>
           <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
           <AlertDialogAction onClick={onConfirm}>{confirmLabel}</AlertDialogAction>

--- a/frontend/src/features/accounts/api.ts
+++ b/frontend/src/features/accounts/api.ts
@@ -74,9 +74,10 @@ export function getAccountTrends(accountId: string) {
   );
 }
 
-export function deleteAccount(accountId: string) {
+export function deleteAccount(accountId: string, deleteHistory = false) {
+  const qs = deleteHistory ? "?delete_history=true" : "";
   return del(
-    `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}`,
+    `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}${qs}`,
     AccountActionResponseSchema,
   );
 }

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -1,9 +1,10 @@
-import { Suspense, lazy, useCallback, useMemo } from "react";
+import { Suspense, lazy, useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { AlertMessage } from "@/components/alert-message";
 import { LoadingOverlay } from "@/components/layout/loading-overlay";
+import { Checkbox } from "@/components/ui/checkbox";
 import { useDialogState } from "@/hooks/use-dialog-state";
 import { AccountDetail } from "@/features/accounts/components/account-detail";
 import { AccountList } from "@/features/accounts/components/account-list";
@@ -37,6 +38,7 @@ export function AccountsPage() {
   const importDialog = useDialogState();
   const oauthDialog = useDialogState();
   const deleteDialog = useDialogState<string>();
+  const [deleteHistory, setDeleteHistory] = useState(false);
 
   const accounts = useMemo(() => accountsQuery.data ?? [], [accountsQuery.data]);
   const quotaDisplay = useAccountQuotaDisplayStore((s) => s.quotaDisplay);
@@ -164,16 +166,33 @@ export function AccountsPage() {
         description="This action removes the account from the load balancer configuration."
         confirmLabel="Delete"
         cancelLabel="Cancel"
-        onOpenChange={deleteDialog.onOpenChange}
+        onOpenChange={(open) => {
+          deleteDialog.onOpenChange(open);
+          if (!open) setDeleteHistory(false);
+        }}
         onConfirm={() => {
           if (!deleteDialog.data) {
             return;
           }
-          void deleteMutation.mutateAsync(deleteDialog.data).finally(() => {
-            deleteDialog.hide();
-          });
+          void deleteMutation
+            .mutateAsync({ accountId: deleteDialog.data, deleteHistory })
+            .finally(() => {
+              deleteDialog.hide();
+              setDeleteHistory(false);
+            });
         }}
-      />
+      >
+        <div className="flex items-center gap-2 px-6">
+          <Checkbox
+            id="delete-history"
+            checked={deleteHistory}
+            onCheckedChange={(checked) => setDeleteHistory(checked === true)}
+          />
+          <label htmlFor="delete-history" className="text-sm text-muted-foreground cursor-pointer">
+            Delete all history for this account
+          </label>
+        </div>
+      </ConfirmDialog>
 
       <LoadingOverlay visible={!!accountsQuery.data && mutationBusy} label="Updating accounts..." />
     </div>

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -18,7 +18,9 @@ import { buildDuplicateAccountIdSet } from "@/utils/account-identifiers";
 import { getErrorMessageOrNull } from "@/utils/errors";
 
 const OauthDialog = lazy(() =>
-  import("@/features/accounts/components/oauth-dialog").then((m) => ({ default: m.OauthDialog })),
+  import("@/features/accounts/components/oauth-dialog").then((m) => ({
+    default: m.OauthDialog,
+  })),
 );
 
 export function AccountsPage() {
@@ -40,23 +42,38 @@ export function AccountsPage() {
   const deleteDialog = useDialogState<string>();
   const [deleteHistory, setDeleteHistory] = useState(false);
 
-  const accounts = useMemo(() => accountsQuery.data ?? [], [accountsQuery.data]);
+  const accounts = useMemo(
+    () => accountsQuery.data ?? [],
+    [accountsQuery.data],
+  );
   const quotaDisplay = useAccountQuotaDisplayStore((s) => s.quotaDisplay);
-  const sortedAccounts = useMemo(() => sortAccountsForDisplay(accounts, quotaDisplay), [accounts, quotaDisplay]);
-  const duplicateAccountIds = useMemo(() => buildDuplicateAccountIdSet(accounts), [accounts]);
+  const sortedAccounts = useMemo(
+    () => sortAccountsForDisplay(accounts, quotaDisplay),
+    [accounts, quotaDisplay],
+  );
+  const duplicateAccountIds = useMemo(
+    () => buildDuplicateAccountIdSet(accounts),
+    [accounts],
+  );
   const selectedAccountId = searchParams.get("selected");
 
-  const handleSelectAccount = useCallback((accountId: string) => {
-    const nextSearchParams = new URLSearchParams(searchParams);
-    nextSearchParams.set("selected", accountId);
-    setSearchParams(nextSearchParams);
-  }, [searchParams, setSearchParams]);
+  const handleSelectAccount = useCallback(
+    (accountId: string) => {
+      const nextSearchParams = new URLSearchParams(searchParams);
+      nextSearchParams.set("selected", accountId);
+      setSearchParams(nextSearchParams);
+    },
+    [searchParams, setSearchParams],
+  );
 
   const resolvedSelectedAccountId = useMemo(() => {
     if (accounts.length === 0) {
       return null;
     }
-    if (selectedAccountId && accounts.some((account) => account.accountId === selectedAccountId)) {
+    if (
+      selectedAccountId &&
+      accounts.some((account) => account.accountId === selectedAccountId)
+    ) {
       return selectedAccountId;
     }
     return sortedAccounts[0]?.accountId ?? null;
@@ -65,7 +82,9 @@ export function AccountsPage() {
   const selectedAccount = useMemo(
     () =>
       resolvedSelectedAccountId
-        ? accounts.find((account) => account.accountId === resolvedSelectedAccountId) ?? null
+        ? (accounts.find(
+            (account) => account.accountId === resolvedSelectedAccountId,
+          ) ?? null)
         : null,
     [accounts, resolvedSelectedAccountId],
   );
@@ -98,7 +117,9 @@ export function AccountsPage() {
         </p>
       </div>
 
-      {mutationError ? <AlertMessage variant="error">{mutationError}</AlertMessage> : null}
+      {mutationError ? (
+        <AlertMessage variant="error">{mutationError}</AlertMessage>
+      ) : null}
 
       {!accountsQuery.data ? (
         <AccountsSkeleton />
@@ -116,11 +137,17 @@ export function AccountsPage() {
 
           <AccountDetail
             account={selectedAccount}
-            showAccountId={selectedAccount ? duplicateAccountIds.has(selectedAccount.accountId) : false}
+            showAccountId={
+              selectedAccount
+                ? duplicateAccountIds.has(selectedAccount.accountId)
+                : false
+            }
             busy={mutationBusy}
             onPause={(accountId) => void pauseMutation.mutateAsync(accountId)}
             onResume={(accountId) => void resumeMutation.mutateAsync(accountId)}
-            onSetAlias={(accountId, alias) => setAliasMutation.mutateAsync({ accountId, alias })}
+            onSetAlias={(accountId, alias) =>
+              setAliasMutation.mutateAsync({ accountId, alias })
+            }
             onDelete={(accountId) => deleteDialog.show(accountId)}
             onReauth={() => oauthDialog.show()}
             onExport={(accountId) => void exportMutation.mutateAsync(accountId)}
@@ -182,19 +209,25 @@ export function AccountsPage() {
             });
         }}
       >
-        <div className="flex items-center gap-2 px-6">
+        <div className="flex items-center gap-2">
           <Checkbox
             id="delete-history"
             checked={deleteHistory}
             onCheckedChange={(checked) => setDeleteHistory(checked === true)}
           />
-          <label htmlFor="delete-history" className="text-sm text-muted-foreground cursor-pointer">
+          <label
+            htmlFor="delete-history"
+            className="text-sm text-muted-foreground cursor-pointer"
+          >
             Delete all history for this account
           </label>
         </div>
       </ConfirmDialog>
 
-      <LoadingOverlay visible={!!accountsQuery.data && mutationBusy} label="Updating accounts..." />
+      <LoadingOverlay
+        visible={!!accountsQuery.data && mutationBusy}
+        label="Updating accounts..."
+      />
     </div>
   );
 }

--- a/frontend/src/features/accounts/hooks/use-accounts.test.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.test.ts
@@ -40,7 +40,7 @@ describe("useAccounts", () => {
     const imported = await result.current.importMutation.mutateAsync(
       new File(["{}"], "auth.json", { type: "application/json" }),
     );
-    await result.current.deleteMutation.mutateAsync(imported.accountId);
+    await result.current.deleteMutation.mutateAsync({ accountId: imported.accountId, deleteHistory: false });
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "list"] });

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -72,7 +72,8 @@ export function useAccountMutations() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: deleteAccount,
+    mutationFn: ({ accountId, deleteHistory }: { accountId: string; deleteHistory: boolean }) =>
+      deleteAccount(accountId, deleteHistory),
     onSuccess: () => {
       toast.success("Account deleted");
       invalidateAccountRelatedQueries(queryClient);

--- a/openspec/changes/add-delete-history-checkbox/proposal.md
+++ b/openspec/changes/add-delete-history-checkbox/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+When an operator deletes an account, request logs are currently soft-deleted (account_id=NULL, deleted_at=now()). There is no way to permanently remove the associated request logs and other history. Operators who want to clean up all traces of a removed account need an explicit opt-in to hard-delete all associated data.
+
+## What Changes
+
+- Add a "Delete all history for this account" checkbox to the existing delete confirmation dialog (`ConfirmDialog`). The dialog already has a dimmed backdrop (`AlertDialogOverlay` with `bg-black/50`), satisfying the UX requirement.
+- Extend `ConfirmDialog` with an optional `children` prop that renders between description and footer, so the checkbox can be composed in without forking the dialog component.
+- Pass a `delete_history` query parameter on the `DELETE /api/accounts/{account_id}` request when the checkbox is checked.
+- Backend: when `delete_history=true`, hard-delete `request_logs` (instead of the current `UPDATE ... SET account_id=NULL, deleted_at=NOW()`) in addition to the existing hard-deletes of `usage_history` and `sticky_sessions`. When false/absent, behavior is unchanged.
+
+## Impact
+
+- The existing delete flow is unchanged when the checkbox is not checked.
+- `ConfirmDialog` gains a `children` prop; existing call sites need no changes.
+- No database migration required — the delete query behavior changes but the schema does not.

--- a/openspec/changes/add-delete-history-checkbox/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-delete-history-checkbox/specs/frontend-architecture/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Delete account with history purge
+
+The account delete confirmation dialog SHALL include a checkbox labeled "Delete all history for this account". When checked and the delete action is confirmed, all associated data (request_logs, usage_history, sticky_sessions) SHALL be hard-deleted from the database instead of soft-deleted. When unchecked, the existing soft-delete behavior SHALL apply.
+
+#### Scenario: Delete with history checkbox checked
+
+- **WHEN** an operator opens the delete confirmation dialog for an account and checks "Delete all history for this account"
+- **AND** clicks the confirm/Delete button
+- **THEN** the `DELETE /api/accounts/{account_id}` request includes `?delete_history=true`
+- **AND** all `request_logs` rows for the account are hard-deleted from the database
+- **AND** `usage_history` rows for the account are hard-deleted (existing behavior)
+- **AND** the account itself is deleted
+- **AND** the UI shows a success toast and refreshes the account list
+
+#### Scenario: Delete with history checkbox unchecked
+
+- **WHEN** an operator opens the delete confirmation dialog and does NOT check "Delete all history for this account"
+- **AND** clicks the confirm/Delete button
+- **THEN** the `DELETE /api/accounts/{account_id}` request omits the `delete_history` parameter
+- **AND** `request_logs` rows are soft-deleted (account_id=NULL, deleted_at set)
+- **AND** all other behavior is identical to current account deletion
+
+#### Scenario: Cancel the delete dialog
+
+- **WHEN** an operator opens the delete confirmation dialog
+- **AND** clicks the Cancel button
+- **THEN** the dialog closes and no API request is made
+- **AND** the account remains in the list unchanged

--- a/openspec/changes/add-delete-history-checkbox/tasks.md
+++ b/openspec/changes/add-delete-history-checkbox/tasks.md
@@ -1,0 +1,8 @@
+- [x] Add optional `children` prop to `ConfirmDialog`, rendered between the description and footer in `frontend/src/components/confirm-dialog.tsx`.
+- [x] Add `delete_history: boolean` query parameter support to `DELETE /api/accounts/{account_id}` in `app/modules/accounts/api.py` and `AccountDeleteResponse` schema.
+- [x] Add `delete_history` parameter to `AccountsService.delete_account` and conditionally hard-delete `request_logs` in `AccountsRepository.delete` when true.
+- [x] Add `deleteAccount(accountId, deleteHistory)` signature to `frontend/src/features/accounts/api.ts` passing `?delete_history=true` query param.
+- [x] Update `useAccounts` delete mutation to accept `deleteHistory` parameter in `frontend/src/features/accounts/hooks/use-accounts.ts`.
+- [x] Wire a checked/unchecked state with a `Checkbox` inside `ConfirmDialog` children in `accounts-page.tsx`, passing the boolean to the delete mutation on confirm.
+- [x] Add/update integration tests for delete with `delete_history=true` verifying `request_logs` rows are hard-deleted instead of soft-deleted.
+- [x] Validate with lint, typecheck, and test suite.

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -356,9 +356,7 @@ async def test_delete_account_with_delete_history_hard_deletes_request_logs(asyn
     assert delete.json()["status"] == "deleted"
 
     async with SessionLocal() as session:
-        result = await session.execute(
-            select(RequestLog).where(RequestLog.request_id == "req_hard_delete_1")
-        )
+        result = await session.execute(select(RequestLog).where(RequestLog.request_id == "req_hard_delete_1"))
         assert result.scalar_one_or_none() is None
 
     request_logs = await async_client.get("/api/request-logs?limit=10")

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -334,6 +334,39 @@ async def test_delete_account_soft_deletes_request_logs(async_client, db_setup):
 
 
 @pytest.mark.asyncio
+async def test_delete_account_with_delete_history_hard_deletes_request_logs(async_client, db_setup):
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_hard_delete", "hard-delete@example.com"))
+        await logs_repo.add_log(
+            account_id="acc_hard_delete",
+            request_id="req_hard_delete_1",
+            model="gpt-5.1",
+            input_tokens=10,
+            output_tokens=5,
+            latency_ms=25,
+            status="success",
+            error_code=None,
+            requested_at=utcnow(),
+        )
+
+    delete = await async_client.delete("/api/accounts/acc_hard_delete?delete_history=true")
+    assert delete.status_code == 200
+    assert delete.json()["status"] == "deleted"
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(RequestLog).where(RequestLog.request_id == "req_hard_delete_1")
+        )
+        assert result.scalar_one_or_none() is None
+
+    request_logs = await async_client.get("/api/request-logs?limit=10")
+    assert request_logs.status_code == 200
+    assert request_logs.json()["total"] == 0
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_includes_per_account_reset_times(async_client, db_setup):
     primary_a = 1735689600
     primary_b = 1735693200


### PR DESCRIPTION
## Summary

Adds a "Delete all history for this account" checkbox to the account delete dialog. When checked, request_logs are hard-deleted instead of soft-deleted, allowing operators to permanently remove all traces of a deleted account.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: #746 

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/add-delete-history-checkbox/`

## Changes

- Backend: add `delete_history` query param to `DELETE /api/accounts/{account_id}`; when `true`, hard-deletes `request_logs` rows instead of soft-deleting (`repository.py:227`)
- Backend: pass `delete_history` through service layer (`service.py:207`)
- Backend: log `delete_history` in audit record (`api.py:157`)
- Frontend: add optional `children` prop to `ConfirmDialog` for inline composition (`confirm-dialog.tsx:20`)
- Frontend: add checkbox UX in `accounts-page.tsx` with `deleteHistory` state, reset on dialog close
- Frontend: `deleteAccount()` accepts optional `deleteHistory` boolean, appends `?delete_history=true` query param
- Frontend: `useAccounts.deleteMutation` wraps mutationFn to pass `{ accountId, deleteHistory }` object
- Tests: add integration test `test_delete_account_with_delete_history_hard_deletes_request_logs`

## Test plan

```
uv run ruff check --quiet                    # clean
uv run pytest tests/integration/test_accounts_api_extended.py -q  # 19 passed
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

<img width="513" height="189" alt="螢幕截圖 2026-05-27 01 23 44" src="https://github.com/user-attachments/assets/a229730a-dbc0-48e9-ab81-36f7187a43c4" />
