### PR TITLE
fix(proxy): fail over unary refresh connect errors

### DIFF
--- a/app/core/clients/files.py
+++ b/app/core/clients/files.py
@@ -121,10 +121,11 @@ class FileProxyError(Exception):
     non-JSON.
     """
 
-    def __init__(self, status_code: int, payload: Any) -> None:
+    def __init__(self, status_code: int, payload: Any, *, failure_phase: str | None = None) -> None:
         super().__init__(f"upstream file request failed: status={status_code}")
         self.status_code = status_code
         self.payload = payload
+        self.failure_phase = failure_phase
 
 
 def _build_files_headers(
@@ -195,9 +196,17 @@ async def create_file(
                 headers=upstream_headers,
                 timeout=timeout,
             ) as response:
-                text = await response.text()
+                try:
+                    text = await response.text()
+                except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                    message = str(exc) or "Request to upstream timed out"
+                    raise FileProxyError(
+                        502,
+                        openai_error("upstream_unavailable", message),
+                        failure_phase="body_read",
+                    ) from exc
                 if response.status >= 400:
-                    raise FileProxyError(response.status, _parse_upstream_error_body(text))
+                    raise FileProxyError(response.status, _parse_upstream_error_body(text), failure_phase="status")
                 try:
                     parsed = json.loads(text)
                 except json.JSONDecodeError as exc:
@@ -207,6 +216,7 @@ async def create_file(
                             "upstream_error",
                             f"Upstream /files response was not JSON: {exc}",
                         ),
+                        failure_phase="parse",
                     ) from exc
                 if not isinstance(parsed, dict):
                     raise FileProxyError(
@@ -215,6 +225,7 @@ async def create_file(
                             "upstream_error",
                             "Upstream /files response was not a JSON object",
                         ),
+                        failure_phase="parse",
                     )
                 return parsed
     except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
@@ -222,6 +233,7 @@ async def create_file(
         raise FileProxyError(
             502,
             openai_error("upstream_unavailable", message),
+            failure_phase="connect",
         ) from exc
 
 
@@ -290,9 +302,17 @@ async def finalize_file(
                     headers=upstream_headers,
                     timeout=timeout,
                 ) as response:
-                    text = await response.text()
+                    try:
+                        text = await response.text()
+                    except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                        message = str(exc) or "Request to upstream timed out"
+                        raise FileProxyError(
+                            502,
+                            openai_error("upstream_unavailable", message),
+                            failure_phase="body_read",
+                        ) from exc
                     if response.status >= 400:
-                        raise FileProxyError(response.status, _parse_upstream_error_body(text))
+                        raise FileProxyError(response.status, _parse_upstream_error_body(text), failure_phase="status")
                     try:
                         parsed = json.loads(text)
                     except json.JSONDecodeError as exc:
@@ -302,6 +322,7 @@ async def finalize_file(
                                 "upstream_error",
                                 f"Upstream /files/{file_id}/uploaded response was not JSON: {exc}",
                             ),
+                            failure_phase="parse",
                         ) from exc
                     if not isinstance(parsed, dict):
                         raise FileProxyError(
@@ -310,12 +331,14 @@ async def finalize_file(
                                 "upstream_error",
                                 "Upstream /files/{file_id}/uploaded response was not a JSON object",
                             ),
+                            failure_phase="parse",
                         )
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 message = str(exc) or "Request to upstream timed out"
                 raise FileProxyError(
                     502,
                     openai_error("upstream_unavailable", message),
+                    failure_phase="connect",
                 ) from exc
 
             status = parsed.get("status")

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2703,7 +2703,17 @@ async def thread_goal_request(
         ) as resp:
             status_code = resp.status
             if resp.status >= 400:
-                error_payload = await _error_payload_from_response(resp)
+                try:
+                    error_payload = await _error_payload_from_response(resp)
+                except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                    message = str(exc) or "Request to upstream timed out"
+                    error_code = "upstream_unavailable"
+                    error_message = message
+                    raise ProxyResponseError(
+                        resp.status,
+                        openai_error("upstream_unavailable", message),
+                        failure_phase="status",
+                    ) from exc
                 error_code, error_message = _error_details_from_envelope(error_payload)
                 raise ProxyResponseError(resp.status, error_payload, failure_phase="status")
             try:
@@ -3017,7 +3027,17 @@ async def _transcribe_audio_with_session(
         ) as resp:
             status_code = resp.status
             if resp.status >= 400:
-                error_payload = await _error_payload_from_response(resp)
+                try:
+                    error_payload = await _error_payload_from_response(resp)
+                except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                    message = str(exc) or "Request to upstream timed out"
+                    error_code = "upstream_unavailable"
+                    error_message = message
+                    raise ProxyResponseError(
+                        resp.status,
+                        openai_error("upstream_unavailable", message),
+                        failure_phase="status",
+                    ) from exc
                 error_code, error_message = _error_details_from_envelope(error_payload)
                 raise ProxyResponseError(resp.status, error_payload, failure_phase="status")
             try:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2705,23 +2705,35 @@ async def thread_goal_request(
             if resp.status >= 400:
                 error_payload = await _error_payload_from_response(resp)
                 error_code, error_message = _error_details_from_envelope(error_payload)
-                raise ProxyResponseError(resp.status, error_payload)
+                raise ProxyResponseError(resp.status, error_payload, failure_phase="status")
             try:
                 data = await resp.json(content_type=None)
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 message = str(exc) or "Request to upstream timed out"
                 error_code = "upstream_unavailable"
                 error_message = message
-                raise ProxyResponseError(502, openai_error("upstream_unavailable", message)) from exc
+                raise ProxyResponseError(
+                    502,
+                    openai_error("upstream_unavailable", message),
+                    failure_phase="body_read",
+                ) from exc
             except Exception as exc:
                 error_code = "upstream_error"
                 error_message = "Invalid JSON from upstream"
-                raise ProxyResponseError(502, openai_error("upstream_error", "Invalid JSON from upstream")) from exc
+                raise ProxyResponseError(
+                    502,
+                    openai_error("upstream_error", "Invalid JSON from upstream"),
+                    failure_phase="parse",
+                ) from exc
             if isinstance(data, dict):
                 return cast(dict[str, JsonValue], data)
             error_code = "upstream_error"
             error_message = "Unexpected upstream payload"
-            raise ProxyResponseError(502, openai_error("upstream_error", "Unexpected upstream payload"))
+            raise ProxyResponseError(
+                502,
+                openai_error("upstream_error", "Unexpected upstream payload"),
+                failure_phase="parse",
+            )
     except ProxyResponseError as exc:
         if error_code is None and error_message is None:
             error_code, error_message = _error_details_from_envelope(exc.payload)
@@ -2729,12 +2741,20 @@ async def thread_goal_request(
     except CircuitBreakerOpenError as exc:
         error_code = "upstream_unavailable"
         error_message = "Upstream circuit breaker is open"
-        raise ProxyResponseError(503, openai_error("upstream_unavailable", error_message)) from exc
+        raise ProxyResponseError(
+            503,
+            openai_error("upstream_unavailable", error_message),
+            failure_phase="connect",
+        ) from exc
     except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
         message = str(exc) or "Request to upstream timed out"
         error_code = "upstream_unavailable"
         error_message = message
-        raise ProxyResponseError(502, openai_error("upstream_unavailable", message)) from exc
+        raise ProxyResponseError(
+            502,
+            openai_error("upstream_unavailable", message),
+            failure_phase="connect",
+        ) from exc
     finally:
         try:
             _maybe_log_upstream_request_complete(
@@ -2831,11 +2851,21 @@ async def codex_control_request(
             account_id=account_id,
         ) as resp:
             status_code = resp.status
-            body = await resp.read()
+            try:
+                body = await resp.read()
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                message = str(exc) or "Request to upstream timed out"
+                error_code = "upstream_unavailable"
+                error_message = message
+                raise ProxyResponseError(
+                    502,
+                    openai_error("upstream_unavailable", message),
+                    failure_phase="body_read",
+                ) from exc
             if resp.status >= 400:
                 error_payload = await _error_payload_from_raw_body(resp, body)
                 error_code, error_message = _error_details_from_envelope(error_payload)
-                raise ProxyResponseError(resp.status, error_payload)
+                raise ProxyResponseError(resp.status, error_payload, failure_phase="status")
             return CodexControlResponse(
                 status_code=resp.status,
                 body=body,
@@ -2848,12 +2878,20 @@ async def codex_control_request(
     except CircuitBreakerOpenError as exc:
         error_code = "upstream_unavailable"
         error_message = "Upstream circuit breaker is open"
-        raise ProxyResponseError(503, openai_error("upstream_unavailable", error_message)) from exc
+        raise ProxyResponseError(
+            503,
+            openai_error("upstream_unavailable", error_message),
+            failure_phase="connect",
+        ) from exc
     except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
         message = str(exc) or "Request to upstream timed out"
         error_code = "upstream_unavailable"
         error_message = message
-        raise ProxyResponseError(502, openai_error("upstream_unavailable", message)) from exc
+        raise ProxyResponseError(
+            502,
+            openai_error("upstream_unavailable", message),
+            failure_phase="connect",
+        ) from exc
     finally:
         try:
             _maybe_log_upstream_request_complete(
@@ -2981,7 +3019,7 @@ async def _transcribe_audio_with_session(
             if resp.status >= 400:
                 error_payload = await _error_payload_from_response(resp)
                 error_code, error_message = _error_details_from_envelope(error_payload)
-                raise ProxyResponseError(resp.status, error_payload)
+                raise ProxyResponseError(resp.status, error_payload, failure_phase="status")
             try:
                 data = await resp.json(content_type=None)
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
@@ -2991,6 +3029,7 @@ async def _transcribe_audio_with_session(
                 raise ProxyResponseError(
                     502,
                     openai_error("upstream_unavailable", message),
+                    failure_phase="body_read",
                 ) from exc
             except Exception as exc:
                 error_code = "upstream_error"
@@ -2998,12 +3037,14 @@ async def _transcribe_audio_with_session(
                 raise ProxyResponseError(
                     502,
                     openai_error("upstream_error", "Invalid JSON from upstream"),
+                    failure_phase="parse",
                 ) from exc
             if isinstance(data, dict):
                 return data
             raise ProxyResponseError(
                 502,
                 openai_error("upstream_error", "Unexpected upstream payload"),
+                failure_phase="parse",
             )
     except ProxyResponseError as exc:
         if error_code is None and error_message is None:
@@ -3015,6 +3056,7 @@ async def _transcribe_audio_with_session(
         raise ProxyResponseError(
             503,
             openai_error("upstream_unavailable", error_message),
+            failure_phase="connect",
         ) from exc
     except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
         message = str(exc) or "Request to upstream timed out"
@@ -3023,6 +3065,7 @@ async def _transcribe_audio_with_session(
         raise ProxyResponseError(
             502,
             openai_error("upstream_unavailable", message),
+            failure_phase="connect",
         ) from exc
     finally:
         _maybe_log_upstream_request_complete(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2379,26 +2379,31 @@ class ProxyService:
                     timeout_seconds=remaining_budget,
                 )
 
+            async def _select_goal_failover(excluded_account_ids: set[str]) -> AccountSelection:
+                return await self._select_account_with_budget(
+                    deadline,
+                    request_id=request_id,
+                    kind=request_kind,
+                    api_key=api_key,
+                    sticky_key=affinity.key,
+                    sticky_kind=affinity.kind,
+                    reallocate_sticky=affinity.reallocate_sticky,
+                    sticky_max_age_seconds=affinity.max_age_seconds,
+                    prefer_earlier_reset_accounts=settings.prefer_earlier_reset_accounts,
+                    routing_strategy=routing_strategy,
+                    model=selection_model,
+                    exclude_account_ids=excluded_account_ids,
+                )
+
             try:
-                remaining_budget = _remaining_budget_seconds(deadline)
-                if remaining_budget <= 0:
-                    logger.warning(
-                        "Thread goal request budget exhausted before freshness check request_id=%s operation=%s",
-                        request_id,
-                        operation,
-                    )
-                    _raise_proxy_budget_exhausted()
-                try:
-                    account = await self._ensure_fresh_with_budget(account, timeout_seconds=remaining_budget)
-                except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-                    logger.warning(
-                        "Thread goal refresh/connect failed request_id=%s operation=%s account_id=%s",
-                        request_id,
-                        operation,
-                        account.id,
-                        exc_info=True,
-                    )
-                    _raise_proxy_unavailable(str(exc) or "Request to upstream timed out")
+                account = await self._ensure_previsible_unary_fresh_with_failover(
+                    account,
+                    deadline=deadline,
+                    request_id=request_id,
+                    kind=request_kind,
+                    select_next_account=_select_goal_failover,
+                )
+                account_id_value = account.id
                 response = await _call_goal(account)
                 await self._load_balancer.record_success(account)
                 log_status = "success"
@@ -2427,11 +2432,15 @@ class ProxyService:
                                 account.id,
                             )
                             _raise_proxy_budget_exhausted()
-                        account = await self._ensure_fresh_with_budget(
+                        account = await self._ensure_previsible_unary_fresh_with_failover(
                             account,
+                            deadline=deadline,
+                            request_id=request_id,
+                            kind=request_kind,
+                            select_next_account=_select_goal_failover,
                             force=True,
-                            timeout_seconds=remaining_budget,
                         )
+                        account_id_value = account.id
                         try:
                             response = await _call_goal(account)
                             await self._load_balancer.record_success(account)
@@ -2486,7 +2495,9 @@ class ProxyService:
                 if operation == "get" and _is_missing_thread_goal_protocol_error(exc):
                     log_status = "success"
                     return {"goal": None}
-                await self._handle_proxy_error(account, exc)
+                failed_account = _proxy_response_failed_account(exc, account)
+                account_id_value = failed_account.id
+                await self._handle_proxy_error(failed_account, exc)
                 raise
         except ProxyResponseError as exc:
             error = _parse_openai_error(exc.payload)
@@ -2591,25 +2602,31 @@ class ProxyService:
                     timeout_seconds=remaining_budget,
                 )
 
+            async def _select_control_failover(excluded_account_ids: set[str]) -> AccountSelection:
+                return await self._select_account_with_budget(
+                    deadline,
+                    request_id=request_id,
+                    kind=request_kind,
+                    api_key=api_key,
+                    sticky_key=affinity.key,
+                    sticky_kind=affinity.kind,
+                    reallocate_sticky=affinity.reallocate_sticky,
+                    sticky_max_age_seconds=affinity.max_age_seconds,
+                    prefer_earlier_reset_accounts=settings.prefer_earlier_reset_accounts,
+                    routing_strategy=routing_strategy,
+                    model=selection_model,
+                    exclude_account_ids=excluded_account_ids,
+                )
+
             try:
-                remaining_budget = _remaining_budget_seconds(deadline)
-                if remaining_budget <= 0:
-                    logger.warning(
-                        "Codex control request budget exhausted before freshness check request_id=%s",
-                        request_id,
-                    )
-                    _raise_proxy_budget_exhausted()
-                try:
-                    account = await self._ensure_fresh_with_budget(account, timeout_seconds=remaining_budget)
-                except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-                    logger.warning(
-                        "Codex control refresh/connect failed request_id=%s path=%s account_id=%s",
-                        request_id,
-                        path,
-                        account.id,
-                        exc_info=True,
-                    )
-                    _raise_proxy_unavailable(str(exc) or "Request to upstream timed out")
+                account = await self._ensure_previsible_unary_fresh_with_failover(
+                    account,
+                    deadline=deadline,
+                    request_id=request_id,
+                    kind=request_kind,
+                    select_next_account=_select_control_failover,
+                )
+                account_id_value = account.id
                 response = await _call_control(account)
                 await self._load_balancer.record_success(account)
                 log_status = "success"
@@ -2638,11 +2655,15 @@ class ProxyService:
                                 account.id,
                             )
                             _raise_proxy_budget_exhausted()
-                        account = await self._ensure_fresh_with_budget(
+                        account = await self._ensure_previsible_unary_fresh_with_failover(
                             account,
+                            deadline=deadline,
+                            request_id=request_id,
+                            kind=request_kind,
+                            select_next_account=_select_control_failover,
                             force=True,
-                            timeout_seconds=remaining_budget,
                         )
+                        account_id_value = account.id
                         try:
                             response = await _call_control(account)
                             await self._load_balancer.record_success(account)
@@ -2694,7 +2715,9 @@ class ProxyService:
                             exc_info=True,
                         )
                         _raise_proxy_unavailable(str(timeout_exc) or "Request to upstream timed out")
-                await self._handle_proxy_error(account, exc)
+                failed_account = _proxy_response_failed_account(exc, account)
+                account_id_value = failed_account.id
+                await self._handle_proxy_error(failed_account, exc)
                 raise
         except ProxyResponseError as exc:
             error = _parse_openai_error(exc.payload)
@@ -2789,23 +2812,27 @@ class ProxyService:
                 finally:
                     pop_transcribe_timeout_overrides(timeout_tokens)
 
+            async def _select_transcribe_failover(excluded_account_ids: set[str]) -> AccountSelection:
+                return await self._select_account_with_budget(
+                    deadline,
+                    request_id=request_id,
+                    kind="transcribe",
+                    api_key=api_key,
+                    prefer_earlier_reset_accounts=prefer_earlier_reset,
+                    routing_strategy=routing_strategy,
+                    model=None,
+                    exclude_account_ids=excluded_account_ids,
+                )
+
             try:
-                remaining_budget = _remaining_budget_seconds(deadline)
-                if remaining_budget <= 0:
-                    logger.warning(
-                        "Transcription request budget exhausted before freshness check request_id=%s", request_id
-                    )
-                    _raise_proxy_budget_exhausted()
-                try:
-                    account = await self._ensure_fresh_with_budget(account, timeout_seconds=remaining_budget)
-                except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-                    logger.warning(
-                        "Transcription refresh/connect failed request_id=%s account_id=%s",
-                        request_id,
-                        account.id,
-                        exc_info=True,
-                    )
-                    _raise_proxy_unavailable(str(exc) or "Request to upstream timed out")
+                account = await self._ensure_previsible_unary_fresh_with_failover(
+                    account,
+                    deadline=deadline,
+                    request_id=request_id,
+                    kind="transcribe",
+                    select_next_account=_select_transcribe_failover,
+                )
+                account_id_value = account.id
                 result = await _call_transcribe(account)
                 await self._load_balancer.record_success(account)
                 log_status = "success"
@@ -2823,7 +2850,9 @@ class ProxyService:
                 ) from refresh_exc
             except ProxyResponseError as exc:
                 if exc.status_code != 401:
-                    await self._handle_proxy_error(account, exc)
+                    failed_account = _proxy_response_failed_account(exc, account)
+                    account_id_value = failed_account.id
+                    await self._handle_proxy_error(failed_account, exc)
                     raise
                 try:
                     remaining_budget = _remaining_budget_seconds(deadline)
@@ -2835,9 +2864,15 @@ class ProxyService:
                             account.id,
                         )
                         _raise_proxy_budget_exhausted()
-                    account = await self._ensure_fresh_with_budget(
-                        account, force=True, timeout_seconds=remaining_budget
+                    account = await self._ensure_previsible_unary_fresh_with_failover(
+                        account,
+                        deadline=deadline,
+                        request_id=request_id,
+                        kind="transcribe",
+                        select_next_account=_select_transcribe_failover,
+                        force=True,
                     )
+                    account_id_value = account.id
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
                         await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
@@ -3231,26 +3266,29 @@ class ProxyService:
                 finally:
                     pop_files_timeout_overrides(timeout_tokens)
 
+            async def _select_files_failover(excluded_account_ids: set[str]) -> AccountSelection:
+                return await self._select_account_with_budget(
+                    deadline,
+                    request_id=request_id,
+                    kind=kind,
+                    api_key=api_key,
+                    prefer_earlier_reset_accounts=prefer_earlier_reset,
+                    routing_strategy=routing_strategy,
+                    model=None,
+                    preferred_account_id=preferred_account_id,
+                    exclude_account_ids=excluded_account_ids,
+                )
+
             try:
-                remaining_budget = _remaining_budget_seconds(deadline)
-                if remaining_budget <= 0:
-                    logger.warning(
-                        "%s request budget exhausted before freshness check request_id=%s",
-                        kind,
-                        request_id,
-                    )
-                    _raise_proxy_budget_exhausted()
-                try:
-                    account = await self._ensure_fresh_with_budget(account, timeout_seconds=remaining_budget)
-                except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-                    logger.warning(
-                        "%s refresh/connect failed request_id=%s account_id=%s",
-                        kind,
-                        request_id,
-                        account.id,
-                        exc_info=True,
-                    )
-                    _raise_proxy_unavailable(str(exc) or "Request to upstream timed out")
+                account = await self._ensure_previsible_unary_fresh_with_failover(
+                    account,
+                    deadline=deadline,
+                    request_id=request_id,
+                    kind=kind,
+                    select_next_account=_select_files_failover,
+                    strict_account_id=preferred_account_id,
+                )
+                account_id_value = account.id
                 result = await _call(account)
                 await self._load_balancer.record_success(account)
                 log_status = "success"
@@ -3268,7 +3306,9 @@ class ProxyService:
                 ) from refresh_exc
             except ProxyResponseError as exc:
                 if exc.status_code != 401:
-                    await self._handle_proxy_error(account, exc)
+                    failed_account = _proxy_response_failed_account(exc, account)
+                    account_id_value = failed_account.id
+                    await self._handle_proxy_error(failed_account, exc)
                     raise
                 try:
                     remaining_budget = _remaining_budget_seconds(deadline)
@@ -3280,9 +3320,16 @@ class ProxyService:
                             account.id,
                         )
                         _raise_proxy_budget_exhausted()
-                    account = await self._ensure_fresh_with_budget(
-                        account, force=True, timeout_seconds=remaining_budget
+                    account = await self._ensure_previsible_unary_fresh_with_failover(
+                        account,
+                        deadline=deadline,
+                        request_id=request_id,
+                        kind=kind,
+                        select_next_account=_select_files_failover,
+                        strict_account_id=preferred_account_id,
+                        force=True,
                     )
+                    account_id_value = account.id
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
                         await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
@@ -11138,6 +11185,66 @@ class ProxyService:
     ) -> Account:
         return await self._ensure_fresh(account, force=force, timeout_seconds=timeout_seconds)
 
+    async def _ensure_previsible_unary_fresh_with_failover(
+        self,
+        account: Account,
+        *,
+        deadline: float,
+        request_id: str,
+        kind: str,
+        select_next_account: Callable[[set[str]], Awaitable[AccountSelection]],
+        strict_account_id: str | None = None,
+        force: bool = False,
+        max_account_attempts: int = 2,
+    ) -> Account:
+        current = account
+        excluded_account_ids: set[str] = set()
+        attempt = 0
+        force_current = force
+        while True:
+            attempt += 1
+            remaining_budget = _remaining_budget_seconds(deadline)
+            if remaining_budget <= 0:
+                logger.warning(
+                    "%s request budget exhausted before freshness check request_id=%s account_id=%s",
+                    kind,
+                    request_id,
+                    current.id,
+                )
+                _raise_proxy_budget_exhausted()
+            try:
+                return await self._ensure_fresh_with_budget(
+                    current,
+                    force=force_current,
+                    timeout_seconds=remaining_budget,
+                )
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                message = str(exc) or "Request to upstream timed out"
+                logger.warning(
+                    "%s refresh/connect failed request_id=%s account_id=%s",
+                    kind,
+                    request_id,
+                    current.id,
+                    exc_info=True,
+                )
+                if not _should_retry_transient_stream_error("upstream_unavailable", message):
+                    _raise_proxy_unavailable_for_account(message, current)
+                if (
+                    strict_account_id is not None and current.id == strict_account_id
+                ) or attempt >= max_account_attempts:
+                    _raise_proxy_unavailable_for_account(message, current)
+                excluded_account_ids.add(current.id)
+                selection = await select_next_account(excluded_account_ids)
+                if selection.account is None:
+                    _raise_proxy_unavailable_for_account(message, current)
+                await self._handle_stream_error(
+                    current,
+                    {"message": message},
+                    "upstream_unavailable",
+                )
+                current = selection.account
+                force_current = False
+
     async def _ensure_fresh_with_budget_or_auth_error(
         self,
         account: Account,
@@ -13783,6 +13890,23 @@ def _raise_proxy_unavailable(message: str) -> NoReturn:
         502,
         openai_error("upstream_unavailable", message),
     )
+
+
+_FAILED_ACCOUNT_ATTR = "_codex_lb_failed_account"
+
+
+def _raise_proxy_unavailable_for_account(message: str, account: Account) -> NoReturn:
+    exc = ProxyResponseError(
+        502,
+        openai_error("upstream_unavailable", message),
+    )
+    setattr(exc, _FAILED_ACCOUNT_ATTR, account)
+    raise exc
+
+
+def _proxy_response_failed_account(exc: ProxyResponseError, fallback: Account) -> Account:
+    account = getattr(exc, _FAILED_ACCOUNT_ATTR, None)
+    return account if isinstance(account, Account) else fallback
 
 
 def _is_proxy_budget_exhausted_error(exc: ProxyResponseError) -> bool:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11390,7 +11390,9 @@ class ProxyService:
         try:
             result = await call_next(next_account)
         except ProxyResponseError as failover_exc:
-            await self._handle_proxy_error(_proxy_response_failed_account(failover_exc, next_account), failover_exc)
+            failover_failed_account = _proxy_response_failed_account(failover_exc, next_account)
+            setattr(failover_exc, _FAILED_ACCOUNT_ATTR, failover_failed_account)
+            await self._handle_proxy_error(failover_failed_account, failover_exc)
             raise
         await self._load_balancer.record_success(next_account)
         return next_account, result

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2410,7 +2410,9 @@ class ProxyService:
                 return response
             except RefreshError as refresh_exc:
                 if refresh_exc.is_permanent:
-                    await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                    failed_account = _refresh_error_failed_account(refresh_exc, account)
+                    account_id_value = failed_account.id
+                    await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
                 raise ProxyResponseError(
                     401,
                     openai_error(
@@ -2500,7 +2502,9 @@ class ProxyService:
                             raise
                     except RefreshError as refresh_exc:
                         if refresh_exc.is_permanent:
-                            await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                            failed_account = _refresh_error_failed_account(refresh_exc, account)
+                            account_id_value = failed_account.id
+                            await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
                         raise exc
                     except (aiohttp.ClientError, asyncio.TimeoutError) as timeout_exc:
                         logger.warning(
@@ -2652,7 +2656,9 @@ class ProxyService:
                 return response
             except RefreshError as refresh_exc:
                 if refresh_exc.is_permanent:
-                    await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                    failed_account = _refresh_error_failed_account(refresh_exc, account)
+                    account_id_value = failed_account.id
+                    await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
                 raise ProxyResponseError(
                     401,
                     openai_error(
@@ -2742,7 +2748,9 @@ class ProxyService:
                             raise
                     except RefreshError as refresh_exc:
                         if refresh_exc.is_permanent:
-                            await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                            failed_account = _refresh_error_failed_account(refresh_exc, account)
+                            account_id_value = failed_account.id
+                            await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
                         raise exc
                     except (aiohttp.ClientError, asyncio.TimeoutError) as timeout_exc:
                         logger.warning(
@@ -2877,7 +2885,9 @@ class ProxyService:
                 return result
             except RefreshError as refresh_exc:
                 if refresh_exc.is_permanent:
-                    await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                    failed_account = _refresh_error_failed_account(refresh_exc, account)
+                    account_id_value = failed_account.id
+                    await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
                 raise ProxyResponseError(
                     401,
                     openai_error(
@@ -2931,7 +2941,9 @@ class ProxyService:
                     account_id_value = account.id
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
-                        await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                        failed_account = _refresh_error_failed_account(refresh_exc, account)
+                        account_id_value = failed_account.id
+                        await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
                     raise exc
                 except (aiohttp.ClientError, asyncio.TimeoutError) as timeout_exc:
                     logger.warning(
@@ -3351,7 +3363,9 @@ class ProxyService:
                 return result, account_id_value
             except RefreshError as refresh_exc:
                 if refresh_exc.is_permanent:
-                    await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                    failed_account = _refresh_error_failed_account(refresh_exc, account)
+                    account_id_value = failed_account.id
+                    await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
                 raise ProxyResponseError(
                     401,
                     openai_error(
@@ -3407,7 +3421,9 @@ class ProxyService:
                     account_id_value = account.id
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
-                        await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                        failed_account = _refresh_error_failed_account(refresh_exc, account)
+                        account_id_value = failed_account.id
+                        await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
                     raise exc
                 except (aiohttp.ClientError, asyncio.TimeoutError) as timeout_exc:
                     logger.warning(
@@ -11293,6 +11309,9 @@ class ProxyService:
                     force=force_current,
                     timeout_seconds=remaining_budget,
                 )
+            except RefreshError as exc:
+                setattr(exc, _FAILED_ACCOUNT_ATTR, current)
+                raise
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 message = str(exc) or "Request to upstream timed out"
                 logger.warning(
@@ -11337,10 +11356,10 @@ class ProxyService:
         failed_account = _proxy_response_failed_account(exc, account)
         if strict_account_id is not None and failed_account.id == strict_account_id:
             return None
-        await self._handle_proxy_error(failed_account, exc)
         selection = await select_next_account({failed_account.id})
         if selection.account is None:
             return None
+        await self._handle_proxy_error(failed_account, exc)
         next_account = await self._ensure_fresh_with_budget_or_auth_error(
             selection.account,
             timeout_seconds=_remaining_budget_seconds(deadline),
@@ -11364,7 +11383,8 @@ class ProxyService:
             return await self._ensure_fresh_with_budget(account, timeout_seconds=timeout_seconds)
         except RefreshError as refresh_exc:
             if refresh_exc.is_permanent:
-                await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
+                failed_account = _refresh_error_failed_account(refresh_exc, account)
+                await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
             raise ProxyResponseError(
                 401,
                 openai_error(
@@ -14013,6 +14033,11 @@ def _raise_proxy_unavailable_for_account(message: str, account: Account) -> NoRe
 
 
 def _proxy_response_failed_account(exc: ProxyResponseError, fallback: Account) -> Account:
+    account = getattr(exc, _FAILED_ACCOUNT_ATTR, None)
+    return account if isinstance(account, Account) else fallback
+
+
+def _refresh_error_failed_account(exc: RefreshError, fallback: Account) -> Account:
     account = getattr(exc, _FAILED_ACCOUNT_ATTR, None)
     return account if isinstance(account, Account) else fallback
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2523,6 +2523,9 @@ class ProxyService:
                 await self._handle_proxy_error(failed_account, exc)
                 raise
         except ProxyResponseError as exc:
+            failed_account = getattr(exc, _FAILED_ACCOUNT_ATTR, None)
+            if isinstance(failed_account, Account):
+                account_id_value = failed_account.id
             error = _parse_openai_error(exc.payload)
             log_error_code = log_error_code or _normalize_error_code(
                 error.code if error else None,
@@ -2766,6 +2769,9 @@ class ProxyService:
                 await self._handle_proxy_error(failed_account, exc)
                 raise
         except ProxyResponseError as exc:
+            failed_account = getattr(exc, _FAILED_ACCOUNT_ATTR, None)
+            if isinstance(failed_account, Account):
+                account_id_value = failed_account.id
             error = _parse_openai_error(exc.payload)
             log_error_code = log_error_code or _normalize_error_code(
                 error.code if error else None,
@@ -2988,6 +2994,9 @@ class ProxyService:
                                 raise
                     raise
         except ProxyResponseError as exc:
+            failed_account = getattr(exc, _FAILED_ACCOUNT_ATTR, None)
+            if isinstance(failed_account, Account):
+                account_id_value = failed_account.id
             error = _parse_openai_error(exc.payload)
             log_error_code = log_error_code or _normalize_error_code(
                 error.code if error else None,
@@ -3474,6 +3483,9 @@ class ProxyService:
                                 raise
                     raise
         except ProxyResponseError as exc:
+            failed_account = getattr(exc, _FAILED_ACCOUNT_ATTR, None)
+            if isinstance(failed_account, Account):
+                account_id_value = failed_account.id
             error = _parse_openai_error(exc.payload)
             log_error_code = log_error_code or _normalize_error_code(
                 error.code if error else None,
@@ -11360,10 +11372,17 @@ class ProxyService:
         if selection.account is None:
             return None
         await self._handle_proxy_error(failed_account, exc)
-        next_account = await self._ensure_fresh_with_budget_or_auth_error(
-            selection.account,
-            timeout_seconds=_remaining_budget_seconds(deadline),
-        )
+        try:
+            next_account = await self._ensure_fresh_with_budget_or_auth_error(
+                selection.account,
+                timeout_seconds=_remaining_budget_seconds(deadline),
+            )
+        except ProxyResponseError as failover_exc:
+            failover_failed_account = _proxy_response_failed_account(failover_exc, selection.account)
+            setattr(failover_exc, _FAILED_ACCOUNT_ATTR, failover_failed_account)
+            if failover_exc.status_code != 401:
+                await self._handle_proxy_error(failover_failed_account, failover_exc)
+            raise
         try:
             result = await call_next(next_account)
         except ProxyResponseError as failover_exc:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2420,6 +2420,19 @@ class ProxyService:
                     ),
                 ) from refresh_exc
             except ProxyResponseError as exc:
+                if exc.status_code != 401:
+                    failover = await self._retry_previsible_unary_call_failover(
+                        exc,
+                        account,
+                        deadline=deadline,
+                        select_next_account=_select_goal_failover,
+                        call_next=_call_goal,
+                    )
+                    if failover is not None:
+                        account, response = failover
+                        account_id_value = account.id
+                        log_status = "success"
+                        return response
                 if exc.status_code == 401:
                     try:
                         remaining_budget = _remaining_budget_seconds(deadline)
@@ -2432,14 +2445,20 @@ class ProxyService:
                                 account.id,
                             )
                             _raise_proxy_budget_exhausted()
-                        account = await self._ensure_previsible_unary_fresh_with_failover(
-                            account,
-                            deadline=deadline,
-                            request_id=request_id,
-                            kind=request_kind,
-                            select_next_account=_select_goal_failover,
-                            force=True,
-                        )
+                        try:
+                            account = await self._ensure_previsible_unary_fresh_with_failover(
+                                account,
+                                deadline=deadline,
+                                request_id=request_id,
+                                kind=request_kind,
+                                select_next_account=_select_goal_failover,
+                                force=True,
+                            )
+                        except ProxyResponseError as refresh_failover_exc:
+                            failed_account = _proxy_response_failed_account(refresh_failover_exc, account)
+                            account_id_value = failed_account.id
+                            await self._handle_proxy_error(failed_account, refresh_failover_exc)
+                            raise
                         account_id_value = account.id
                         try:
                             response = await _call_goal(account)
@@ -2643,6 +2662,19 @@ class ProxyService:
                     ),
                 ) from refresh_exc
             except ProxyResponseError as exc:
+                if exc.status_code != 401:
+                    failover = await self._retry_previsible_unary_call_failover(
+                        exc,
+                        account,
+                        deadline=deadline,
+                        select_next_account=_select_control_failover,
+                        call_next=_call_control,
+                    )
+                    if failover is not None:
+                        account, response = failover
+                        account_id_value = account.id
+                        log_status = "success"
+                        return response
                 if exc.status_code == 401:
                     try:
                         remaining_budget = _remaining_budget_seconds(deadline)
@@ -2655,14 +2687,20 @@ class ProxyService:
                                 account.id,
                             )
                             _raise_proxy_budget_exhausted()
-                        account = await self._ensure_previsible_unary_fresh_with_failover(
-                            account,
-                            deadline=deadline,
-                            request_id=request_id,
-                            kind=request_kind,
-                            select_next_account=_select_control_failover,
-                            force=True,
-                        )
+                        try:
+                            account = await self._ensure_previsible_unary_fresh_with_failover(
+                                account,
+                                deadline=deadline,
+                                request_id=request_id,
+                                kind=request_kind,
+                                select_next_account=_select_control_failover,
+                                force=True,
+                            )
+                        except ProxyResponseError as refresh_failover_exc:
+                            failed_account = _proxy_response_failed_account(refresh_failover_exc, account)
+                            account_id_value = failed_account.id
+                            await self._handle_proxy_error(failed_account, refresh_failover_exc)
+                            raise
                         account_id_value = account.id
                         try:
                             response = await _call_control(account)
@@ -2850,6 +2888,18 @@ class ProxyService:
                 ) from refresh_exc
             except ProxyResponseError as exc:
                 if exc.status_code != 401:
+                    failover = await self._retry_previsible_unary_call_failover(
+                        exc,
+                        account,
+                        deadline=deadline,
+                        select_next_account=_select_transcribe_failover,
+                        call_next=_call_transcribe,
+                    )
+                    if failover is not None:
+                        account, result = failover
+                        account_id_value = account.id
+                        log_status = "success"
+                        return result
                     failed_account = _proxy_response_failed_account(exc, account)
                     account_id_value = failed_account.id
                     await self._handle_proxy_error(failed_account, exc)
@@ -2864,14 +2914,20 @@ class ProxyService:
                             account.id,
                         )
                         _raise_proxy_budget_exhausted()
-                    account = await self._ensure_previsible_unary_fresh_with_failover(
-                        account,
-                        deadline=deadline,
-                        request_id=request_id,
-                        kind="transcribe",
-                        select_next_account=_select_transcribe_failover,
-                        force=True,
-                    )
+                    try:
+                        account = await self._ensure_previsible_unary_fresh_with_failover(
+                            account,
+                            deadline=deadline,
+                            request_id=request_id,
+                            kind="transcribe",
+                            select_next_account=_select_transcribe_failover,
+                            force=True,
+                        )
+                    except ProxyResponseError as refresh_failover_exc:
+                        failed_account = _proxy_response_failed_account(refresh_failover_exc, account)
+                        account_id_value = failed_account.id
+                        await self._handle_proxy_error(failed_account, refresh_failover_exc)
+                        raise
                     account_id_value = account.id
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
@@ -3306,6 +3362,19 @@ class ProxyService:
                 ) from refresh_exc
             except ProxyResponseError as exc:
                 if exc.status_code != 401:
+                    failover = await self._retry_previsible_unary_call_failover(
+                        exc,
+                        account,
+                        deadline=deadline,
+                        select_next_account=_select_files_failover,
+                        call_next=_call,
+                        strict_account_id=preferred_account_id,
+                    )
+                    if failover is not None:
+                        account, result = failover
+                        account_id_value = account.id
+                        log_status = "success"
+                        return result, account_id_value
                     failed_account = _proxy_response_failed_account(exc, account)
                     account_id_value = failed_account.id
                     await self._handle_proxy_error(failed_account, exc)
@@ -3320,15 +3389,21 @@ class ProxyService:
                             account.id,
                         )
                         _raise_proxy_budget_exhausted()
-                    account = await self._ensure_previsible_unary_fresh_with_failover(
-                        account,
-                        deadline=deadline,
-                        request_id=request_id,
-                        kind=kind,
-                        select_next_account=_select_files_failover,
-                        strict_account_id=preferred_account_id,
-                        force=True,
-                    )
+                    try:
+                        account = await self._ensure_previsible_unary_fresh_with_failover(
+                            account,
+                            deadline=deadline,
+                            request_id=request_id,
+                            kind=kind,
+                            select_next_account=_select_files_failover,
+                            strict_account_id=preferred_account_id,
+                            force=True,
+                        )
+                    except ProxyResponseError as refresh_failover_exc:
+                        failed_account = _proxy_response_failed_account(refresh_failover_exc, account)
+                        account_id_value = failed_account.id
+                        await self._handle_proxy_error(failed_account, refresh_failover_exc)
+                        raise
                     account_id_value = account.id
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
@@ -11245,6 +11320,39 @@ class ProxyService:
                 current = selection.account
                 force_current = False
 
+    async def _retry_previsible_unary_call_failover(
+        self,
+        exc: ProxyResponseError,
+        account: Account,
+        *,
+        deadline: float,
+        select_next_account: Callable[[set[str]], Awaitable[AccountSelection]],
+        call_next: Callable[[Account], Awaitable[Any]],
+        strict_account_id: str | None = None,
+    ) -> tuple[Account, Any] | None:
+        if hasattr(exc, _FAILED_ACCOUNT_ATTR):
+            return None
+        if not _should_failover_previsible_unary_proxy_error(exc):
+            return None
+        failed_account = _proxy_response_failed_account(exc, account)
+        if strict_account_id is not None and failed_account.id == strict_account_id:
+            return None
+        await self._handle_proxy_error(failed_account, exc)
+        selection = await select_next_account({failed_account.id})
+        if selection.account is None:
+            return None
+        next_account = await self._ensure_fresh_with_budget_or_auth_error(
+            selection.account,
+            timeout_seconds=_remaining_budget_seconds(deadline),
+        )
+        try:
+            result = await call_next(next_account)
+        except ProxyResponseError as failover_exc:
+            await self._handle_proxy_error(_proxy_response_failed_account(failover_exc, next_account), failover_exc)
+            raise
+        await self._load_balancer.record_success(next_account)
+        return next_account, result
+
     async def _ensure_fresh_with_budget_or_auth_error(
         self,
         account: Account,
@@ -13907,6 +14015,16 @@ def _raise_proxy_unavailable_for_account(message: str, account: Account) -> NoRe
 def _proxy_response_failed_account(exc: ProxyResponseError, fallback: Account) -> Account:
     account = getattr(exc, _FAILED_ACCOUNT_ATTR, None)
     return account if isinstance(account, Account) else fallback
+
+
+def _should_failover_previsible_unary_proxy_error(exc: ProxyResponseError) -> bool:
+    error = _parse_openai_error(exc.payload)
+    error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
+    error_message = error.message if error else None
+    return error_code == "upstream_unavailable" and _should_retry_transient_stream_error(
+        "upstream_unavailable",
+        error_message,
+    )
 
 
 def _is_proxy_budget_exhausted_error(exc: ProxyResponseError) -> bool:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11438,8 +11438,13 @@ class ProxyService:
         try:
             return await self._ensure_fresh_with_budget(account, timeout_seconds=timeout_seconds)
         except RefreshError as refresh_exc:
+            failed_account = _refresh_error_failed_account(refresh_exc, account)
+            if refresh_exc.transport_error:
+                _raise_proxy_unavailable_for_account(
+                    refresh_exc.message or str(refresh_exc) or "Request to upstream timed out",
+                    failed_account,
+                )
             if refresh_exc.is_permanent:
-                failed_account = _refresh_error_failed_account(refresh_exc, account)
                 await self._load_balancer.mark_permanent_failure(failed_account, refresh_exc.code)
             raise ProxyResponseError(
                 401,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3339,7 +3339,11 @@ class ProxyService:
                 try:
                     return await invoke(access_token, account_id, filtered)
                 except FileProxyError as files_exc:
-                    raise ProxyResponseError(files_exc.status_code, files_exc.payload) from files_exc
+                    raise ProxyResponseError(
+                        files_exc.status_code,
+                        files_exc.payload,
+                        failure_phase=files_exc.failure_phase,
+                    ) from files_exc
                 finally:
                     pop_files_timeout_overrides(timeout_tokens)
 
@@ -14062,6 +14066,8 @@ def _refresh_error_failed_account(exc: RefreshError, fallback: Account) -> Accou
 
 
 def _should_failover_previsible_unary_proxy_error(exc: ProxyResponseError) -> bool:
+    if exc.failure_phase != "connect":
+        return False
     error = _parse_openai_error(exc.payload)
     error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
     error_message = error.message if error else None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11326,6 +11326,35 @@ class ProxyService:
                     timeout_seconds=remaining_budget,
                 )
             except RefreshError as exc:
+                if exc.transport_error:
+                    message = exc.message or str(exc) or "Request to upstream timed out"
+                    logger.warning(
+                        "%s refresh transport failed request_id=%s account_id=%s",
+                        kind,
+                        request_id,
+                        current.id,
+                        exc_info=True,
+                    )
+                    if not _should_retry_transient_stream_error("upstream_unavailable", message):
+                        _raise_proxy_unavailable_for_account(message, current)
+                    if (
+                        strict_account_id is not None and current.id == strict_account_id
+                    ) or attempt >= max_account_attempts:
+                        _raise_proxy_unavailable_for_account(message, current)
+                    excluded_account_ids.add(current.id)
+                    selection = await select_next_account(excluded_account_ids)
+                    selected_account = selection.account
+                    if selected_account is None:
+                        _raise_proxy_unavailable_for_account(message, current)
+                    assert selected_account is not None
+                    await self._handle_stream_error(
+                        current,
+                        {"message": message},
+                        "upstream_unavailable",
+                    )
+                    current = selected_account
+                    force_current = False
+                    continue
                 setattr(exc, _FAILED_ACCOUNT_ATTR, current)
                 raise
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
@@ -11345,14 +11374,16 @@ class ProxyService:
                     _raise_proxy_unavailable_for_account(message, current)
                 excluded_account_ids.add(current.id)
                 selection = await select_next_account(excluded_account_ids)
-                if selection.account is None:
+                selected_account = selection.account
+                if selected_account is None:
                     _raise_proxy_unavailable_for_account(message, current)
+                assert selected_account is not None
                 await self._handle_stream_error(
                     current,
                     {"message": message},
                     "upstream_unavailable",
                 )
-                current = selection.account
+                current = selected_account
                 force_current = False
 
     async def _retry_previsible_unary_call_failover(

--- a/openspec/changes/fix-unary-refresh-connect-failover/proposal.md
+++ b/openspec/changes/fix-unary-refresh-connect-failover/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Unary proxy surfaces such as Codex thread goals, Codex control calls,
+transcription, and file create/finalize perform account token refresh before
+opening the upstream request. If that refresh/connect step fails with a
+transient transport error, the request previously failed immediately even when
+another eligible account could serve it. Because no downstream-visible response
+body has been emitted yet, these paths can safely exclude the failed account for
+the current request and try another account within the request budget.
+
+File finalization may be pinned to the account that owns the file. That strict
+owner case must not fail over to a different account because the upstream file
+handle is account-local.
+
+## What Changes
+
+- Treat retryable token-refresh/connect transport errors on pre-visible unary
+  proxy surfaces as account-local transient failures.
+- Record the failed account through normal proxy error handling, exclude it for
+  the current request, and try one other eligible account when available.
+- Preserve fail-closed behavior for strict account-owner requests, including
+  pinned file finalization.
+- Keep the existing request-budget checks around refresh/connect and upstream
+  calls.
+
+## Impact
+
+- **Code**: `app/modules/proxy/service.py`
+- **Tests**: `tests/unit/test_proxy_utils.py`
+- **Behavior**: transient refresh/connect failures on one account no longer
+  fail pre-visible unary requests immediately when another eligible account can
+  complete them.

--- a/openspec/changes/fix-unary-refresh-connect-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-unary-refresh-connect-failover/specs/responses-api-compat/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Pre-visible unary refresh/connect failures fail over
+
+For unary proxy requests that have not emitted downstream-visible output, the proxy MUST treat retryable token-refresh or upstream-connect transport failures as account-local transient failures.
+
+This applies to Codex thread-goal requests, Codex control requests,
+transcription requests, and file create/finalize requests. When another
+eligible account is available within the request budget, the proxy MUST record
+the failed account, exclude it from the current request, and retry the unary
+operation on the fallback account. The proxy MUST NOT fail over strict
+account-owner requests whose upstream resource is bound to the selected account.
+
+#### Scenario: Unary refresh transport failure uses another account
+
+- **GIVEN** at least two accounts are eligible for a Codex thread-goal, Codex
+  control, transcription, or file-create request
+- **AND** the selected account fails during token refresh or upstream connect
+  with a retryable transient transport error before downstream-visible output
+- **WHEN** another eligible account can complete the request within the request
+  budget
+- **THEN** the downstream request succeeds from the fallback account
+- **AND** the failed account is recorded and excluded from further attempts for
+  that request
+
+#### Scenario: Strict file-owner refresh failure fails closed
+
+- **GIVEN** a file-finalize request is pinned to the account that owns the file
+- **AND** the pinned account fails during token refresh or upstream connect with
+  a retryable transient transport error before downstream-visible output
+- **WHEN** another account would otherwise be eligible for proxy traffic
+- **THEN** the proxy fails the request with an upstream-unavailable error
+- **AND** the proxy does not send the file-finalize operation through another
+  account

--- a/openspec/changes/fix-unary-refresh-connect-failover/tasks.md
+++ b/openspec/changes/fix-unary-refresh-connect-failover/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Add bounded pre-visible refresh/connect failover for thread-goal, Codex control, transcription, and file create/finalize paths.
+- [x] 1.2 Record the failed account and exclude it from the current unary request before selecting a fallback account.
+- [x] 1.3 Preserve strict account-owner fail-closed behavior for pinned file finalization.
+
+## 2. Tests
+
+- [x] 2.1 Add unit coverage proving thread-goal, Codex control, transcription, and file create retryable refresh/connect failures use another eligible account.
+- [x] 2.2 Add unit coverage proving pinned file finalization does not fail over to another account.
+
+## 3. OpenSpec
+
+- [x] 3.1 Add a `responses-api-compat` delta for pre-visible unary refresh/connect failover.
+- [x] 3.2 Validate the OpenSpec change.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6,7 +6,7 @@ import logging
 import ssl
 import time
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
 from typing import Any, Protocol, Self, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -1466,6 +1466,23 @@ def _make_account(account_id: str) -> Account:
         status=AccountStatus.ACTIVE,
         deactivation_reason=None,
     )
+
+
+def _install_two_account_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    service: proxy_service.ProxyService,
+    account_a: Account,
+    account_b: Account,
+    seen_excluded_account_ids: list[set[str]],
+) -> None:
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if account_a.id in excluded_account_ids:
+            return AccountSelection(account=account_b, error_message=None)
+        return AccountSelection(account=account_a, error_message=None)
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
 
 
 class _JsonCompactResponse:
@@ -14823,6 +14840,286 @@ async def test_transcribe_fallback_refresh_error_surfaces_proxy_error_not_raw_re
     assert exc_info.value.payload["error"].get("code") == "invalid_api_key"
     assert exc_info.value.payload["error"].get("message") == "fallback token invalid"
     assert seen_excluded_account_ids == [set(), {account_a.id}]
+
+
+@pytest.mark.asyncio
+async def test_thread_goal_refresh_connection_reset_fails_over(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_refresh_a")
+    account_b = _make_account("acc_thread_goal_refresh_b")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=[aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer"), account_b]),
+    )
+
+    async def fake_thread_goal_request(
+        operation: str,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        *,
+        method: str,
+        timeout_seconds: float,
+    ) -> dict[str, JsonValue]:
+        del operation, payload, headers, access_token, method, timeout_seconds
+        assert account_id == account_b.chatgpt_account_id
+        return {"goal": {"id": "goal-ok"}}
+
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
+
+    response = await service.thread_goal_request("get", {}, {"session_id": "sid-thread-goal"})
+
+    assert response == {"goal": {"id": "goal-ok"}}
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    record_error.assert_awaited_once_with(account_a)
+    record_success.assert_awaited_once_with(account_b)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_thread_goal_second_refresh_connection_reset_marks_second_account(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_refresh_terminal_a")
+    account_b = _make_account("acc_thread_goal_refresh_terminal_b")
+    handle_stream_error = AsyncMock()
+    handle_proxy_error = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_handle_proxy_error", handle_proxy_error)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(
+            side_effect=[
+                aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer"),
+                aiohttp.ClientConnectionError("Timeout on reading data from socket"),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "core_thread_goal_request",
+        AsyncMock(side_effect=AssertionError("upstream must not be called after refresh/connect failures")),
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.thread_goal_request("get", {}, {"session_id": "sid-thread-goal"})
+
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    handle_stream_error.assert_awaited_once()
+    handle_stream_call = handle_stream_error.await_args
+    assert handle_stream_call is not None
+    assert handle_stream_call.args[0] == account_a
+    handle_proxy_error.assert_awaited_once()
+    handle_proxy_call = handle_proxy_error.await_args
+    assert handle_proxy_call is not None
+    assert handle_proxy_call.args[0] == account_b
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_codex_control_refresh_connection_reset_fails_over(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_control_refresh_a")
+    account_b = _make_account("acc_control_refresh_b")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=[aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer"), account_b]),
+    )
+
+    async def fake_codex_control_request(
+        path: str,
+        *,
+        method: str,
+        payload: bytes | None,
+        query_params: Mapping[str, str] | Sequence[tuple[str, str]],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        timeout_seconds: float,
+    ) -> proxy_module.CodexControlResponse:
+        del path, method, payload, query_params, headers, access_token, timeout_seconds
+        assert account_id == account_b.chatgpt_account_id
+        return proxy_module.CodexControlResponse(status_code=200, body=b"ok", headers={})
+
+    monkeypatch.setattr(proxy_service, "core_codex_control_request", fake_codex_control_request)
+
+    response = await service.codex_control_request(
+        "/backend-api/codex-control/foo",
+        method="POST",
+        payload=b"{}",
+        query_params={},
+        headers={"session_id": "sid-control"},
+    )
+
+    assert response.body == b"ok"
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    record_error.assert_awaited_once_with(account_a)
+    record_success.assert_awaited_once_with(account_b)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_transcribe_refresh_connection_reset_fails_over(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_transcribe_refresh_a")
+    account_b = _make_account("acc_transcribe_refresh_b")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=[aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer"), account_b]),
+    )
+
+    async def fake_transcribe(
+        audio_bytes: bytes,
+        *,
+        filename: str,
+        content_type: str | None,
+        prompt: str | None,
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        base_url=None,
+        session=None,
+    ) -> dict[str, JsonValue]:
+        del audio_bytes, filename, content_type, prompt, headers, access_token, base_url, session
+        assert account_id == account_b.chatgpt_account_id
+        return {"text": "ok"}
+
+    monkeypatch.setattr(proxy_service, "core_transcribe_audio", fake_transcribe)
+
+    response = await service.transcribe(
+        audio_bytes=b"audio",
+        filename="audio.wav",
+        content_type="audio/wav",
+        prompt=None,
+        headers={"session_id": "sid-transcribe"},
+    )
+
+    assert response == {"text": "ok"}
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    record_error.assert_awaited_once_with(account_a)
+    record_success.assert_awaited_once_with(account_b)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_files_create_refresh_connection_reset_fails_over(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_files_create_refresh_a")
+    account_b = _make_account("acc_files_create_refresh_b")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=[aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer"), account_b]),
+    )
+
+    async def fake_create_file(
+        *,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+    ) -> dict[str, JsonValue]:
+        del payload, headers, access_token
+        assert account_id == account_b.chatgpt_account_id
+        return {"file_id": "file_ok"}
+
+    monkeypatch.setattr(proxy_service, "core_create_file", fake_create_file)
+
+    response = await service.create_file({"filename": "a.txt"}, {"session_id": "sid-files-create"})
+
+    assert response == {"file_id": "file_ok"}
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    record_error.assert_awaited_once_with(account_a)
+    record_success.assert_awaited_once_with(account_b)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_files_finalize_pinned_refresh_connection_reset_fails_closed(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_files_finalize_pinned")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        return AccountSelection(account=account, error_message=None)
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(side_effect=aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer")),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "core_finalize_file",
+        AsyncMock(side_effect=AssertionError("strict file owner must not fail over or invoke upstream")),
+    )
+    await service._pin_file_account("file_pinned", account.id)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.finalize_file("file_pinned", {"session_id": "sid-files-finalize"})
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "upstream_unavailable"
+    assert seen_excluded_account_ids == [set()]
+    record_error.assert_awaited_once_with(account)
+    record_success.assert_not_awaited()
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account.id
 
 
 def test_prepare_response_bridge_request_state_dedupes_replayed_previous_response_tool_calls_before_serializing():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14982,6 +14982,78 @@ async def test_thread_goal_second_refresh_connection_reset_marks_second_account(
 
 
 @pytest.mark.asyncio
+async def test_thread_goal_failover_refresh_error_marks_failover_account(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_refresh_original")
+    account_b = _make_account("acc_thread_goal_refresh_permanent")
+    mark_permanent_failure = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service._load_balancer, "mark_permanent_failure", mark_permanent_failure)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(
+            side_effect=[
+                aiohttp.ClientConnectionError("[Errno 104] Connection reset by peer"),
+                proxy_service.RefreshError("refresh_token_expired", "expired", True),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "core_thread_goal_request",
+        AsyncMock(side_effect=AssertionError("upstream must not be called after refresh failures")),
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.thread_goal_request("get", {}, {"session_id": "sid-thread-goal"})
+
+    assert exc_info.value.status_code == 401
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    mark_permanent_failure.assert_awaited_once_with(account_b, "refresh_token_expired")
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_thread_goal_upstream_connection_reset_without_failover_records_once(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_thread_goal_call_no_failover")
+    record_error = AsyncMock()
+    selection_calls: list[set[str]] = []
+
+    async def select_account(**kwargs):
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        selection_calls.append(excluded_account_ids)
+        if account.id in excluded_account_ids:
+            return AccountSelection(account=None, error_message="No available accounts")
+        return AccountSelection(account=account, error_message=None)
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+
+    async def fake_thread_goal_request(*args, **kwargs):
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+        )
+
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
+
+    with pytest.raises(proxy_module.ProxyResponseError):
+        await service.thread_goal_request("get", {}, {"session_id": "sid-thread-goal"})
+
+    assert selection_calls == [set(), {account.id}]
+    record_error.assert_awaited_once_with(account)
+
+
+@pytest.mark.asyncio
 async def test_codex_control_refresh_connection_reset_fails_over(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14936,6 +14936,59 @@ async def test_thread_goal_upstream_connection_reset_fails_over_after_freshness(
 
 
 @pytest.mark.asyncio
+async def test_thread_goal_failover_freshness_connection_reset_marks_failover_account(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_call_failover_a")
+    account_b = _make_account("acc_thread_goal_call_failover_refresh_b")
+    handle_proxy_error = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+    upstream_accounts: list[str | None] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service, "_handle_proxy_error", handle_proxy_error)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(
+            side_effect=[
+                account_a,
+                aiohttp.ClientConnectionError("Timeout on reading data from socket"),
+            ]
+        ),
+    )
+
+    async def fake_thread_goal_request(
+        operation: str,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        *,
+        method: str,
+        timeout_seconds: float,
+    ) -> dict[str, JsonValue]:
+        del operation, payload, headers, access_token, method, timeout_seconds
+        upstream_accounts.append(account_id)
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+        )
+
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.thread_goal_request("get", {}, {"session_id": "sid-thread-goal"})
+
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert upstream_accounts == [account_a.chatgpt_account_id]
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert [call.args[0] for call in handle_proxy_error.await_args_list] == [account_a, account_b]
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
 async def test_thread_goal_second_refresh_connection_reset_marks_second_account(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15070,6 +15070,60 @@ async def test_thread_goal_body_read_connection_reset_does_not_fail_over(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_thread_goal_failover_call_error_records_fallback_account(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_call_error_a")
+    account_b = _make_account("acc_thread_goal_call_error_b")
+    handle_proxy_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+    upstream_accounts: list[str | None] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service, "_handle_proxy_error", handle_proxy_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_a, account_b]))
+
+    async def fake_thread_goal_request(
+        operation: str,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        *,
+        method: str,
+        timeout_seconds: float,
+    ) -> dict[str, JsonValue]:
+        del operation, payload, headers, access_token, method, timeout_seconds
+        upstream_accounts.append(account_id)
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                502,
+                openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+                failure_phase="connect",
+            )
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_unavailable", "fallback body read failed"),
+            failure_phase="body_read",
+        )
+
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.thread_goal_request("post", {}, {"session_id": "sid-thread-goal"})
+
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert upstream_accounts == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert [call.args[0] for call in handle_proxy_error.await_args_list] == [account_a, account_b]
+    record_success.assert_not_awaited()
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
 async def test_thread_goal_failover_freshness_connection_reset_marks_failover_account(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14888,6 +14888,54 @@ async def test_thread_goal_refresh_connection_reset_fails_over(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_thread_goal_upstream_connection_reset_fails_over_after_freshness(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_call_a")
+    account_b = _make_account("acc_thread_goal_call_b")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+    upstream_accounts: list[str | None] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_a, account_b]))
+
+    async def fake_thread_goal_request(
+        operation: str,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        *,
+        method: str,
+        timeout_seconds: float,
+    ) -> dict[str, JsonValue]:
+        del operation, payload, headers, access_token, method, timeout_seconds
+        upstream_accounts.append(account_id)
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                502,
+                openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+            )
+        return {"goal": {"id": "goal-ok-after-call-failover"}}
+
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
+
+    response = await service.thread_goal_request("get", {}, {"session_id": "sid-thread-goal"})
+
+    assert response == {"goal": {"id": "goal-ok-after-call-failover"}}
+    assert upstream_accounts == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    record_error.assert_awaited_once_with(account_a)
+    record_success.assert_awaited_once_with(account_b)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
 async def test_thread_goal_second_refresh_connection_reset_marks_second_account(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1220,9 +1220,16 @@ class _DummyResponse(proxy_module.SSEResponseProtocol):
 
 
 class _TranscribeResponse:
-    def __init__(self, payload: dict[str, object], *, json_error: Exception | None = None) -> None:
-        self.status = 200
-        self.reason = "OK"
+    def __init__(
+        self,
+        payload: dict[str, object],
+        *,
+        json_error: Exception | None = None,
+        status: int = 200,
+        reason: str = "OK",
+    ) -> None:
+        self.status = status
+        self.reason = reason
         self._payload = payload
         self._json_error = json_error
 
@@ -1524,6 +1531,21 @@ class _CompactSession:
         timeout=None,
     ):
         self.calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        return self._response
+
+
+class _ThreadGoalRequestSession:
+    def __init__(self, response: object) -> None:
+        self._response = response
+        self.calls: list[dict[str, object]] = []
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: object,
+    ):
+        self.calls.append({"method": method, "url": url, **kwargs})
         return self._response
 
 
@@ -14285,6 +14307,69 @@ async def test_transcribe_audio_maps_body_read_transport_errors_to_upstream_unav
     assert exc.status_code == 502
     assert _proxy_error_code(exc) == "upstream_unavailable"
     assert _proxy_error_message(exc) == expected_message
+
+
+@pytest.mark.asyncio
+async def test_thread_goal_status_body_read_transport_error_keeps_status_phase(monkeypatch):
+    response = _TranscribeResponse({}, status=429, reason="Too Many Requests")
+    session = _ThreadGoalRequestSession(response)
+
+    async def raise_body_read_error(resp):
+        del resp
+        raise proxy_module.aiohttp.ClientPayloadError("status body read failed")
+
+    monkeypatch.setattr(proxy_module, "_error_payload_from_response", raise_body_read_error)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module.thread_goal_request(
+            "post",
+            {},
+            headers={"X-Request-Id": "req_thread_goal_status_body_read"},
+            access_token="token-1",
+            account_id="acc_thread_goal_1",
+            method="POST",
+            timeout_seconds=10.0,
+            base_url="https://upstream.example",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 429
+    assert exc.failure_phase == "status"
+    assert _proxy_error_code(exc) == "upstream_unavailable"
+    assert _proxy_error_message(exc) == "status body read failed"
+    assert session.calls[0]["method"] == "POST"
+
+
+@pytest.mark.asyncio
+async def test_transcribe_audio_status_body_read_transport_error_keeps_status_phase(monkeypatch):
+    response = _TranscribeResponse({}, status=503, reason="Service Unavailable")
+    session = _TranscribeSession(response)
+
+    async def raise_body_read_error(resp):
+        del resp
+        raise proxy_module.aiohttp.ClientPayloadError("status body read failed")
+
+    monkeypatch.setattr(proxy_module, "_error_payload_from_response", raise_body_read_error)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module.transcribe_audio(
+            b"\x01\x02",
+            filename="sample.wav",
+            content_type="audio/wav",
+            prompt=None,
+            headers={"X-Request-Id": "req_transcribe_status_body_read"},
+            access_token="token-1",
+            account_id="acc_transcribe_1",
+            base_url="https://upstream.example",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 503
+    assert exc.failure_phase == "status"
+    assert _proxy_error_code(exc) == "upstream_unavailable"
+    assert _proxy_error_message(exc) == "status body read failed"
 
 
 class _CBStub:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15233,6 +15233,66 @@ async def test_thread_goal_failover_freshness_connection_reset_marks_failover_ac
 
 
 @pytest.mark.asyncio
+async def test_thread_goal_failover_refresh_transport_error_marks_failover_account(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_call_failover_transport_a")
+    account_b = _make_account("acc_thread_goal_call_failover_transport_b")
+    handle_proxy_error = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+    upstream_accounts: list[str | None] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service, "_handle_proxy_error", handle_proxy_error)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(
+            side_effect=[
+                account_a,
+                proxy_service.RefreshError(
+                    "transport_error",
+                    "Timeout on reading data from socket",
+                    False,
+                    transport_error=True,
+                ),
+            ]
+        ),
+    )
+
+    async def fake_thread_goal_request(
+        operation: str,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        *,
+        method: str,
+        timeout_seconds: float,
+    ) -> dict[str, JsonValue]:
+        del operation, payload, headers, access_token, method, timeout_seconds
+        upstream_accounts.append(account_id)
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+            failure_phase="connect",
+        )
+
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.thread_goal_request("get", {}, {"session_id": "sid-thread-goal"})
+
+    assert exc_info.value.status_code == 502
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert upstream_accounts == [account_a.chatgpt_account_id]
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert [call.args[0] for call in handle_proxy_error.await_args_list] == [account_a, account_b]
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
 async def test_thread_goal_second_refresh_connection_reset_marks_second_account(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14973,6 +14973,61 @@ async def test_thread_goal_refresh_connection_reset_fails_over(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_thread_goal_refresh_transport_error_fails_over(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_refresh_transport_a")
+    account_b = _make_account("acc_thread_goal_refresh_transport_b")
+    record_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service._load_balancer, "record_error", record_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh",
+        AsyncMock(
+            side_effect=[
+                proxy_service.RefreshError(
+                    "transport_error",
+                    "[Errno 104] Connection reset by peer",
+                    False,
+                    transport_error=True,
+                ),
+                account_b,
+            ]
+        ),
+    )
+
+    async def fake_thread_goal_request(
+        operation: str,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        *,
+        method: str,
+        timeout_seconds: float,
+    ) -> dict[str, JsonValue]:
+        del operation, payload, headers, access_token, method, timeout_seconds
+        assert account_id == account_b.chatgpt_account_id
+        return {"goal": {"id": "goal-ok"}}
+
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
+
+    response = await service.thread_goal_request("get", {}, {"session_id": "sid-thread-goal"})
+
+    assert response == {"goal": {"id": "goal-ok"}}
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    record_error.assert_awaited_once_with(account_a)
+    record_success.assert_awaited_once_with(account_b)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
 async def test_thread_goal_upstream_connection_reset_fails_over_after_freshness(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14919,6 +14919,7 @@ async def test_thread_goal_upstream_connection_reset_fails_over_after_freshness(
             raise proxy_module.ProxyResponseError(
                 502,
                 openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+                failure_phase="connect",
             )
         return {"goal": {"id": "goal-ok-after-call-failover"}}
 
@@ -14933,6 +14934,54 @@ async def test_thread_goal_upstream_connection_reset_fails_over_after_freshness(
     record_success.assert_awaited_once_with(account_b)
     assert request_logs.calls[0]["status"] == "success"
     assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_thread_goal_body_read_connection_reset_does_not_fail_over(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_thread_goal_body_read_a")
+    account_b = _make_account("acc_thread_goal_body_read_b")
+    handle_proxy_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+    upstream_accounts: list[str | None] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service, "_handle_proxy_error", handle_proxy_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account_a))
+
+    async def fake_thread_goal_request(
+        operation: str,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+        *,
+        method: str,
+        timeout_seconds: float,
+    ) -> dict[str, JsonValue]:
+        del operation, payload, headers, access_token, method, timeout_seconds
+        upstream_accounts.append(account_id)
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+            failure_phase="body_read",
+        )
+
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.thread_goal_request("post", {}, {"session_id": "sid-thread-goal"})
+
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert upstream_accounts == [account_a.chatgpt_account_id]
+    assert seen_excluded_account_ids == [set()]
+    handle_proxy_error.assert_awaited_once_with(account_a, exc_info.value)
+    record_success.assert_not_awaited()
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account_a.id
 
 
 @pytest.mark.asyncio
@@ -14973,6 +15022,7 @@ async def test_thread_goal_failover_freshness_connection_reset_marks_failover_ac
         raise proxy_module.ProxyResponseError(
             502,
             openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+            failure_phase="connect",
         )
 
     monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
@@ -15095,6 +15145,7 @@ async def test_thread_goal_upstream_connection_reset_without_failover_records_on
         raise proxy_module.ProxyResponseError(
             502,
             openai_error("upstream_unavailable", "[Errno 104] Connection reset by peer"),
+            failure_phase="connect",
         )
 
     monkeypatch.setattr(proxy_service, "core_thread_goal_request", fake_thread_goal_request)
@@ -15251,6 +15302,51 @@ async def test_files_create_refresh_connection_reset_fails_over(monkeypatch):
     record_success.assert_awaited_once_with(account_b)
     assert request_logs.calls[0]["status"] == "success"
     assert request_logs.calls[0]["account_id"] == account_b.id
+
+
+@pytest.mark.asyncio
+async def test_files_create_body_read_connection_reset_does_not_fail_over(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_files_create_body_read_a")
+    account_b = _make_account("acc_files_create_body_read_b")
+    handle_proxy_error = AsyncMock()
+    record_success = AsyncMock()
+    seen_excluded_account_ids: list[set[str]] = []
+    upstream_accounts: list[str | None] = []
+
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+    monkeypatch.setattr(service, "_handle_proxy_error", handle_proxy_error)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account_a))
+
+    async def fake_create_file(
+        *,
+        payload: Mapping[str, JsonValue],
+        headers: Mapping[str, str],
+        access_token: str,
+        account_id: str | None,
+    ) -> dict[str, JsonValue]:
+        del payload, headers, access_token
+        upstream_accounts.append(account_id)
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_unavailable", "Timeout on reading data from socket"),
+            failure_phase="body_read",
+        )
+
+    monkeypatch.setattr(proxy_service, "core_create_file", fake_create_file)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.create_file({"filename": "a.txt"}, {"session_id": "sid-files-create"})
+
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert upstream_accounts == [account_a.chatgpt_account_id]
+    assert seen_excluded_account_ids == [set()]
+    handle_proxy_error.assert_awaited_once_with(account_a, exc_info.value)
+    record_success.assert_not_awaited()
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["account_id"] == account_a.id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a shared pre-visible unary freshness helper that retries another eligible account on transient refresh/connect failures
- apply it to thread-goal, codex-control, transcribe, and file create/finalize flows
- keep strict file-owner operations fail-closed instead of moving pinned file operations across accounts

## Tests
- uv run pytest tests/unit/test_proxy_utils.py::test_thread_goal_refresh_connection_reset_fails_over tests/unit/test_proxy_utils.py::test_codex_control_refresh_connection_reset_fails_over tests/unit/test_proxy_utils.py::test_transcribe_refresh_connection_reset_fails_over tests/unit/test_proxy_utils.py::test_files_create_refresh_connection_reset_fails_over tests/unit/test_proxy_utils.py::test_files_finalize_pinned_refresh_connection_reset_fails_closed -q
- uv run pytest tests/unit/test_proxy_utils.py -q
- uv run ruff check app/modules/proxy/service.py tests/unit/test_proxy_utils.py
- uv run ruff format --check app/modules/proxy/service.py tests/unit/test_proxy_utils.py
- uv run ty check app/modules/proxy/service.py tests/unit/test_proxy_utils.py
- python -m compileall -q app/modules/proxy/service.py tests/unit/test_proxy_utils.py
- git diff --check

No linked issue; addresses the owner-review unary refresh/connect failover gate in this PR.
