### PR TITLE
fix(sticky-sessions): chunk delete_entries to avoid sqlite bind overflow

### DIFF
--- a/app/modules/proxy/sticky_repository.py
+++ b/app/modules/proxy/sticky_repository.py
@@ -15,6 +15,15 @@ from app.db.models import Account, StickySession, StickySessionKind
 from app.db.session import sqlite_writer_section
 from app.modules.sticky_sessions.schemas import StickySessionSortBy, StickySessionSortDir
 
+# Each (key, kind) pair in delete_entries contributes 2 bind parameters to
+# the underlying DELETE...OR (key=:k AND kind=:t)... statement. SQLite's
+# default SQLITE_LIMIT_VARIABLE_NUMBER is 999 on builds older than 3.32
+# and 32766 on newer builds, so chunking conservatively at 250 pairs
+# (500 bind parameters) keeps delete-filtered safe on any libsqlite that
+# ships with current Python interpreters. Postgres allows up to 65535
+# bind parameters, which this chunk size also respects.
+_DELETE_ENTRIES_CHUNK_SIZE = 250
+
 
 @dataclass(frozen=True, slots=True)
 class StickySessionListEntryRecord:
@@ -85,13 +94,19 @@ class StickySessionsRepository:
         targets = {(key, kind) for key, kind in entries if key}
         if not targets:
             return []
-        statement = delete(StickySession).where(
-            or_(*(and_(StickySession.key == key, StickySession.kind == kind) for key, kind in targets))
-        )
-        async with sqlite_writer_section():
-            result = await self._session.execute(statement.returning(StickySession.key, StickySession.kind))
-            await self._session.commit()
-        return [(key, kind) for key, kind in result.all()]
+
+        deleted: list[tuple[str, StickySessionKind]] = []
+        targets_list = list(targets)
+        for offset in range(0, len(targets_list), _DELETE_ENTRIES_CHUNK_SIZE):
+            chunk = targets_list[offset : offset + _DELETE_ENTRIES_CHUNK_SIZE]
+            statement = delete(StickySession).where(
+                or_(*(and_(StickySession.key == key, StickySession.kind == kind) for key, kind in chunk))
+            )
+            async with sqlite_writer_section():
+                result = await self._session.execute(statement.returning(StickySession.key, StickySession.kind))
+                await self._session.commit()
+            deleted.extend((key, kind) for key, kind in result.all())
+        return deleted
 
     async def list_entry_identifiers(
         self,

--- a/tests/integration/test_sticky_sessions_api.py
+++ b/tests/integration/test_sticky_sessions_api.py
@@ -644,3 +644,59 @@ async def test_durable_bridge_closed_session_purge_drains_multiple_batches(db_se
     assert deleted == 3
     assert bridge_remaining == {"active-batched-session"}
     assert alias_remaining == {"active-batched-session"}
+
+
+@pytest.mark.asyncio
+async def test_sticky_sessions_api_deletes_filtered_chunks_large_match_set(async_client):
+    """Regression test for the codex-lb #787 (D) bug: POST
+    /api/sticky-sessions/delete-filtered used to issue a single
+    DELETE...OR (key=:k AND kind=:t)... statement whose bind-parameter
+    count grew with the match-set size, and trip SQLite's
+    SQLITE_LIMIT_VARIABLE_NUMBER (999 on older libsqlite, 32766 on
+    newer) with a 500 internal_error.
+
+    Insert significantly more rows than the
+    ``_DELETE_ENTRIES_CHUNK_SIZE`` constant guards against (250 pairs ->
+    500 bind parameters per chunk) and assert the endpoint returns 200
+    with the full delete count, proving the chunk loop ran without
+    overflow.
+    """
+
+    accounts = await _create_accounts()
+    await _set_affinity_ttl(60)
+
+    bulk_count = 600
+    async with SessionLocal() as session:
+        for i in range(bulk_count):
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO sticky_sessions (key, account_id, kind, created_at, updated_at)
+                    VALUES (:key, :account_id, :kind, :timestamp, :timestamp)
+                    """
+                ),
+                {
+                    "key": f"bulk-delete-{i:04d}",
+                    "account_id": accounts[0].id,
+                    "kind": StickySessionKind.STICKY_THREAD.value,
+                    "timestamp": utcnow() - timedelta(seconds=i),
+                },
+            )
+        await session.commit()
+
+    response = await async_client.post(
+        "/api/sticky-sessions/delete-filtered",
+        json={"accountQuery": "sticky-a", "keyQuery": "bulk-delete-"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"deletedCount": bulk_count}
+
+    async with SessionLocal() as session:
+        remaining = (
+            await session.execute(
+                text(
+                    "SELECT COUNT(*) FROM sticky_sessions WHERE key LIKE 'bulk-delete-%'",
+                )
+            )
+        ).scalar_one()
+    assert remaining == 0


### PR DESCRIPTION
## Summary

Addresses #787 (D).

`POST /api/sticky-sessions/delete-filtered` with a non-empty filter that matches a large number of rows previously issued a single `DELETE ... WHERE OR(key=:k AND kind=:t)...` statement whose bind-parameter count grew with the match-set size. On large `sticky_sessions` tables (the reporter saw thousands of rows pinned to a single account email) the statement tripped SQLite's `SQLITE_LIMIT_VARIABLE_NUMBER` (999 on libsqlite < 3.32, 32766 on newer) and the endpoint surfaced a 500 `internal_error`.

The fix chunks the deduplicated target list inside `StickySessionsRepository.delete_entries` at `_DELETE_ENTRIES_CHUNK_SIZE = 250` pairs (500 bind parameters per chunk), which is safe on every libsqlite version that ships with current Python interpreters and well under Postgres's 65535 bind-parameter ceiling.

## Behavior

- `/api/sticky-sessions/delete-filtered` with any filter size now returns 200 with the full delete count.
- `/api/sticky-sessions/delete` already enforces `maxItems=500` at the schema layer, so the explicit-list endpoint never reached this path.
- Chunks commit independently (one `sqlite_writer_section` per chunk) to keep the writer lock window short — matches the pattern already used by `delete` / `upsert` on this repository.

## Tests

`tests/integration/test_sticky_sessions_api.py::test_sticky_sessions_api_deletes_filtered_chunks_large_match_set` (new) inserts 600 sticky_sessions for one account, calls `/delete-filtered`, and pins:

- response `200` with `{"deletedCount": 600}`
- zero `bulk-delete-%` rows remaining in `sticky_sessions`

This forces the chunk loop to execute more than once and would have surfaced the original 500 if the single-statement variant were still in place. Existing `test_sticky_sessions_api_deletes_filtered_rows` and the full `tests/integration/test_sticky_sessions_api.py` / `tests/integration/test_proxy_sticky_sessions.py` suites stay green (32 passed).