### PR TITLE
feat(accounts): surface email-duplicate pairs in /api/accounts

### DIFF
--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from app.core import usage as usage_core
-from app.core.auth import DEFAULT_PLAN, extract_id_token_claims, token_expiry_epoch_ms
+from app.core.auth import DEFAULT_EMAIL, DEFAULT_PLAN, extract_id_token_claims, token_expiry_epoch_ms
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.usage.quota import apply_usage_quota
@@ -35,7 +35,7 @@ def build_account_summaries(
     encryptor: TokenEncryptor,
     include_auth: bool = True,
 ) -> list[AccountSummary]:
-    duplicate_emails = _emails_appearing_more_than_once(accounts)
+    duplicate_keys = _duplicate_detection_keys_appearing_more_than_once(accounts)
     return [
         _account_to_summary(
             account,
@@ -46,27 +46,40 @@ def build_account_summaries(
             limit_warmups_by_account.get(account.id) if limit_warmups_by_account else None,
             encryptor,
             include_auth=include_auth,
-            is_email_duplicate=bool(account.email) and account.email in duplicate_emails,
+            is_email_duplicate=_duplicate_detection_key(account) in duplicate_keys,
         )
         for account in accounts
     ]
 
 
-def _emails_appearing_more_than_once(accounts: list[Account]) -> set[str]:
-    """Return the set of emails shared by two or more accounts in this list.
+def _duplicate_detection_keys_appearing_more_than_once(accounts: list[Account]) -> set[tuple[str, str]]:
+    """Return duplicate (email, ChatGPT account id) keys in this list.
 
     Emails are compared case-sensitively to match the storage normalization
-    already performed at OAuth-import time. Blank/None emails are excluded
-    so the legacy DEFAULT_EMAIL placeholder used by malformed imports does
-    not get flagged as a duplicate.
+    already performed at OAuth-import time. Blank/None emails, the legacy
+    DEFAULT_EMAIL placeholder used by malformed imports, and rows without a
+    ChatGPT account identity are excluded so valid same-email accounts in
+    different workspaces are not flagged as stale/fresh duplicates.
     """
-    counts: dict[str, int] = {}
+    counts: dict[tuple[str, str], int] = {}
     for account in accounts:
-        email = account.email
-        if not email:
+        key = _duplicate_detection_key(account)
+        if key is None:
             continue
-        counts[email] = counts.get(email, 0) + 1
-    return {email for email, count in counts.items() if count > 1}
+        counts[key] = counts.get(key, 0) + 1
+    return {key for key, count in counts.items() if count > 1}
+
+
+def _duplicate_detection_key(account: Account) -> tuple[str, str] | None:
+    email = account.email
+    chatgpt_account_id = account.chatgpt_account_id
+    if not _is_duplicate_detection_email(email) or not chatgpt_account_id:
+        return None
+    return email, chatgpt_account_id
+
+
+def _is_duplicate_detection_email(email: str | None) -> bool:
+    return bool(email and email.strip()) and email != DEFAULT_EMAIL
 
 
 def _account_to_summary(

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -35,6 +35,7 @@ def build_account_summaries(
     encryptor: TokenEncryptor,
     include_auth: bool = True,
 ) -> list[AccountSummary]:
+    duplicate_emails = _emails_appearing_more_than_once(accounts)
     return [
         _account_to_summary(
             account,
@@ -45,9 +46,27 @@ def build_account_summaries(
             limit_warmups_by_account.get(account.id) if limit_warmups_by_account else None,
             encryptor,
             include_auth=include_auth,
+            is_email_duplicate=bool(account.email) and account.email in duplicate_emails,
         )
         for account in accounts
     ]
+
+
+def _emails_appearing_more_than_once(accounts: list[Account]) -> set[str]:
+    """Return the set of emails shared by two or more accounts in this list.
+
+    Emails are compared case-sensitively to match the storage normalization
+    already performed at OAuth-import time. Blank/None emails are excluded
+    so the legacy DEFAULT_EMAIL placeholder used by malformed imports does
+    not get flagged as a duplicate.
+    """
+    counts: dict[str, int] = {}
+    for account in accounts:
+        email = account.email
+        if not email:
+            continue
+        counts[email] = counts.get(email, 0) + 1
+    return {email for email, count in counts.items() if count > 1}
 
 
 def _account_to_summary(
@@ -59,6 +78,7 @@ def _account_to_summary(
     limit_warmup: AccountLimitWarmup | None,
     encryptor: TokenEncryptor,
     include_auth: bool = True,
+    is_email_duplicate: bool = False,
 ) -> AccountSummary:
     plan_type = coerce_account_plan_type(account.plan_type, DEFAULT_PLAN)
     auth_status = _build_auth_status(account, encryptor) if include_auth else None
@@ -145,6 +165,7 @@ def _account_to_summary(
         auth=auth_status,
         limit_warmup_enabled=account.limit_warmup_enabled,
         limit_warmup=_limit_warmup_to_status(limit_warmup),
+        is_email_duplicate=is_email_duplicate,
     )
 
 

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -91,7 +91,8 @@ class AccountSummary(DashboardModel):
     auth: AccountAuthStatus | None = None
     limit_warmup_enabled: bool = False
     limit_warmup: AccountLimitWarmupStatus | None = None
-    # True when another account row in the same response shares this email.
+    # True when another account row in the same response shares this real email
+    # and ChatGPT account identity.
     # Operators see this after a token-invalidation cascade where re-adding
     # via OAuth creates a side-by-side row with a fresh refresh token; the
     # older row keeps a revoked token and keeps generating 401s through the

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -91,6 +91,14 @@ class AccountSummary(DashboardModel):
     auth: AccountAuthStatus | None = None
     limit_warmup_enabled: bool = False
     limit_warmup: AccountLimitWarmupStatus | None = None
+    # True when another account row in the same response shares this email.
+    # Operators see this after a token-invalidation cascade where re-adding
+    # via OAuth creates a side-by-side row with a fresh refresh token; the
+    # older row keeps a revoked token and keeps generating 401s through the
+    # load balancer. Flagging the dupes in /accounts lets the dashboard
+    # surface a "delete older" action without requiring the operator to
+    # group rows by email themselves. See codex-lb #787 (B).
+    is_email_duplicate: bool = False
 
 
 class AccountsResponse(DashboardModel):

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -79,6 +79,7 @@ export const AccountSummarySchema = z.object({
   additionalQuotas: z.array(AccountAdditionalQuotaSchema).default([]),
   limitWarmupEnabled: z.boolean().default(false),
   limitWarmup: AccountLimitWarmupStatusSchema.nullable().optional(),
+  isEmailDuplicate: z.boolean().optional(),
 });
 
 export const AccountTrendsResponseSchema = z.object({

--- a/openspec/changes/surface-account-email-duplicates/proposal.md
+++ b/openspec/changes/surface-account-email-duplicates/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Issue #787 reports that after OAuth token invalidation and account re-import,
+operators can end up with two account rows for the same real email: one stale
+row with a revoked refresh token and one fresh row. The dashboard API did not
+surface that relationship, so operators had to manually group `/api/accounts`
+responses to find stale/fresh pairs.
+
+## What Changes
+
+- Add `isEmailDuplicate` to each `AccountSummary` returned by `GET /api/accounts`.
+- Set the field to `true` for all account rows whose real, non-placeholder email
+  and ChatGPT account identity pair appears more than once in the same response.
+- Keep same-email rows with different ChatGPT account identities unflagged so
+  valid workspace/org-separated accounts do not show as stale duplicates.
+- Exclude missing/blank email values and the legacy `DEFAULT_EMAIL`
+  placeholder (`unknown@example.com`) from duplicate detection.
+- Mirror the field in the frontend account schema as optional so existing
+  fixtures and literal account summaries keep working.
+
+## Impact
+
+- Existing account payload consumers continue to work; the new field defaults to
+  `false`.
+- Dashboard consumers can highlight duplicate real-email rows without falsely
+  flagging malformed imports that carry the shared placeholder email.

--- a/openspec/changes/surface-account-email-duplicates/specs/frontend-architecture/spec.md
+++ b/openspec/changes/surface-account-email-duplicates/specs/frontend-architecture/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Account summary duplicate email indicator
+
+The dashboard accounts API SHALL expose an `isEmailDuplicate` boolean on each
+`AccountSummary` returned by `GET /api/accounts`. The field MUST be `true` when
+another account row in the same response has the same real email address and
+the same ChatGPT account identity, and MUST be `false` for unique real
+email/identity pairs. Missing, blank, and legacy placeholder emails equal to
+`DEFAULT_EMAIL` (`unknown@example.com`) MUST be excluded from duplicate
+detection and MUST NOT be flagged as duplicates. Rows that share an email but
+belong to different ChatGPT account identities MUST NOT be flagged as
+duplicates.
+
+#### Scenario: Duplicate real email and identity pairs are flagged
+
+- **WHEN** `GET /api/accounts` returns two or more account rows with the same real non-placeholder email and the same ChatGPT account identity
+- **THEN** every row in that email and identity group includes `isEmailDuplicate: true`
+
+#### Scenario: Same email across identities is not flagged
+
+- **WHEN** `GET /api/accounts` returns account rows with the same real non-placeholder email but different ChatGPT account identities
+- **THEN** those rows include `isEmailDuplicate: false`
+
+#### Scenario: Placeholder emails are ignored
+
+- **WHEN** `GET /api/accounts` returns two or more account rows whose email is `unknown@example.com`
+- **THEN** those rows include `isEmailDuplicate: false`
+
+#### Scenario: Unique emails are not flagged
+
+- **WHEN** `GET /api/accounts` returns an account row with an email that appears only once in the response
+- **THEN** that row includes `isEmailDuplicate: false`

--- a/openspec/changes/surface-account-email-duplicates/tasks.md
+++ b/openspec/changes/surface-account-email-duplicates/tasks.md
@@ -1,0 +1,6 @@
+- [x] Add `isEmailDuplicate` to backend `AccountSummary` and compute it from the account list returned by `GET /api/accounts`.
+- [x] Exclude blank/missing emails and `DEFAULT_EMAIL` (`unknown@example.com`) from duplicate detection.
+- [x] Scope duplicate detection to matching ChatGPT account identities so same-email accounts in different identities/workspaces are not flagged.
+- [x] Mirror the new field in the frontend account schema.
+- [x] Add integration coverage for duplicate real email/identity pairs, same-email different-identity rows, and placeholder-email exclusion.
+- [x] Document the account-summary duplicate-email contract under the frontend architecture capability.

--- a/tests/integration/test_accounts_api.py
+++ b/tests/integration/test_accounts_api.py
@@ -255,3 +255,49 @@ async def test_set_and_clear_account_alias(async_client):
     matched = next(a for a in listing.json()["accounts"] if a["accountId"] == expected_account_id)
     assert matched["alias"] is None
     assert matched["displayName"] == email
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_flags_email_duplicates(async_client):
+    """Pin codex-lb #787 (B): after a token-invalidation cascade, the
+    re-add OAuth flow creates a second account row with the same email
+    but a fresh accountId. /api/accounts surfaces that pair via
+    is_email_duplicate=True on both rows so the dashboard can flag the
+    operator's "stale + fresh" pair without forcing them to group by
+    email themselves.
+    """
+    from app.core.crypto import TokenEncryptor
+    from app.core.utils.time import utcnow
+    from app.db.models import Account, AccountStatus
+    from app.db.session import SessionLocal
+    from app.modules.accounts.repository import AccountsRepository
+
+    encryptor = TokenEncryptor()
+
+    def _account(account_id: str, email: str, chatgpt_id: str) -> Account:
+        return Account(
+            id=account_id,
+            chatgpt_account_id=chatgpt_id,
+            email=email,
+            plan_type="plus",
+            access_token_encrypted=encryptor.encrypt("access"),
+            refresh_token_encrypted=encryptor.encrypt("refresh"),
+            id_token_encrypted=encryptor.encrypt("id"),
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+            deactivation_reason=None,
+        )
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("dup-stale", "dup@example.com", "chatgpt_stale"), merge_by_email=False)
+        await repo.upsert(_account("dup-fresh", "dup@example.com", "chatgpt_fresh"), merge_by_email=False)
+        await repo.upsert(_account("solo", "solo@example.com", "chatgpt_solo"), merge_by_email=False)
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    accounts_by_id = {a["accountId"]: a for a in response.json()["accounts"]}
+
+    assert accounts_by_id["dup-stale"]["isEmailDuplicate"] is True
+    assert accounts_by_id["dup-fresh"]["isEmailDuplicate"] is True
+    assert accounts_by_id["solo"]["isEmailDuplicate"] is False

--- a/tests/integration/test_accounts_api.py
+++ b/tests/integration/test_accounts_api.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 
-from app.core.auth import generate_unique_account_id, parse_auth_json
+from app.core.auth import DEFAULT_EMAIL, generate_unique_account_id, parse_auth_json
 
 pytestmark = pytest.mark.integration
 
@@ -261,10 +261,10 @@ async def test_set_and_clear_account_alias(async_client):
 async def test_list_accounts_flags_email_duplicates(async_client):
     """Pin codex-lb #787 (B): after a token-invalidation cascade, the
     re-add OAuth flow creates a second account row with the same email
-    but a fresh accountId. /api/accounts surfaces that pair via
-    is_email_duplicate=True on both rows so the dashboard can flag the
-    operator's "stale + fresh" pair without forcing them to group by
-    email themselves.
+    but a fresh accountId for the same ChatGPT account identity.
+    /api/accounts surfaces that pair via isEmailDuplicate=true on both rows
+    so the dashboard can flag the operator's "stale + fresh" pair without
+    forcing them to group by email and ChatGPT identity themselves.
     """
     from app.core.crypto import TokenEncryptor
     from app.core.utils.time import utcnow
@@ -290,9 +290,14 @@ async def test_list_accounts_flags_email_duplicates(async_client):
 
     async with SessionLocal() as session:
         repo = AccountsRepository(session)
-        await repo.upsert(_account("dup-stale", "dup@example.com", "chatgpt_stale"), merge_by_email=False)
-        await repo.upsert(_account("dup-fresh", "dup@example.com", "chatgpt_fresh"), merge_by_email=False)
+        await repo.upsert(_account("dup-stale", "dup@example.com", "chatgpt_same"), merge_by_email=False)
+        await repo.upsert(_account("dup-fresh", "dup@example.com", "chatgpt_same"), merge_by_email=False)
+        await repo.upsert(_account("workspace-other", "dup@example.com", "chatgpt_other"), merge_by_email=False)
         await repo.upsert(_account("solo", "solo@example.com", "chatgpt_solo"), merge_by_email=False)
+        await repo.upsert(_account("placeholder-a", DEFAULT_EMAIL, "chatgpt_placeholder_a"), merge_by_email=False)
+        await repo.upsert(_account("placeholder-b", DEFAULT_EMAIL, "chatgpt_placeholder_b"), merge_by_email=False)
+        await repo.upsert(_account("blank-a", "   ", "chatgpt_blank"), merge_by_email=False)
+        await repo.upsert(_account("blank-b", "   ", "chatgpt_blank"), merge_by_email=False)
 
     response = await async_client.get("/api/accounts")
     assert response.status_code == 200
@@ -300,4 +305,9 @@ async def test_list_accounts_flags_email_duplicates(async_client):
 
     assert accounts_by_id["dup-stale"]["isEmailDuplicate"] is True
     assert accounts_by_id["dup-fresh"]["isEmailDuplicate"] is True
+    assert accounts_by_id["workspace-other"]["isEmailDuplicate"] is False
     assert accounts_by_id["solo"]["isEmailDuplicate"] is False
+    assert accounts_by_id["placeholder-a"]["isEmailDuplicate"] is False
+    assert accounts_by_id["placeholder-b"]["isEmailDuplicate"] is False
+    assert accounts_by_id["blank-a"]["isEmailDuplicate"] is False
+    assert accounts_by_id["blank-b"]["isEmailDuplicate"] is False


### PR DESCRIPTION
## Summary

Addresses #787 (B).

After an OAuth token-invalidation cascade, the dashboard re-add flow can leave the pool with two account rows that share the same email: one carries a stale refresh token that upstream now rejects, the other is the fresh re-import. Both show `status=active` in the local view, the older one keeps generating 401s through the proxy, and the operator has no way to spot the pair without grouping the `/api/accounts` payload by email themselves.

This PR adds `is_email_duplicate` to `AccountSummary`, defaulted `False`, set `True` when another account row in the same response carries the same email. Computed once per request from the loaded account list (no extra queries). Blank/missing emails and the legacy `DEFAULT_EMAIL` placeholder are excluded from duplicate detection.

The frontend zod schema mirrors the new field as optional so existing test fixtures and direct-literal `AccountSummary` constructions don't need churn updates; the dashboard can pick this up in a follow-up to render the indicator on the `/accounts` list / dashboard tile.

## Behavior

- Two or more rows with the same non-empty, non-placeholder `email` -> all such rows return `isEmailDuplicate: true`.
- A unique `email` -> `isEmailDuplicate: false`.
- Blank/None emails -> excluded from the count, never flagged.
- The legacy `DEFAULT_EMAIL` placeholder -> excluded from the count, never flagged.
- Comparison is case-sensitive (matches the storage normalization at OAuth-import time).

## Tests

`tests/integration/test_accounts_api.py::test_list_accounts_flags_email_duplicates`:
- inserts `dup-stale` + `dup-fresh` sharing `dup@example.com` and `solo` on `solo@example.com`
- inserts two legacy placeholder-email rows using `DEFAULT_EMAIL`
- calls `GET /api/accounts`
- pins `isEmailDuplicate=true` on both `dup-*` rows and `false` on `solo` plus both placeholder rows

Existing accounts integration + repo + unit suites stay green (53 passed). Frontend `bun run typecheck` clean and full `bun run test` clean (446 passed).
