### PR TITLE
feat(proxy): add fill-first routing strategy

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -520,12 +520,11 @@ def _select_capacity_weighted(available: list[AccountState]) -> AccountState:
 def _fill_first_sort_key(state: AccountState) -> tuple[float, float, str]:
     primary_used = state.used_percent if state.used_percent is not None else 0.0
     secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else 0.0
-    # Primary usage ascending, then secondary usage *descending* (negate so
-    # higher secondary-used breaks ties first), then account_id ascending as
-    # a final stable fallback. Higher secondary-used means lower remaining
-    # weekly capacity, so we drain the most-saturated account first and
-    # preserve the freshest one for later.
-    return primary_used, -secondary_used, state.account_id
+    # Primary usage descending keeps traffic on the account currently being
+    # filled instead of switching away after the first refreshed usage tick.
+    # Secondary usage also descends to drain the most-saturated weekly pool
+    # first when primary usage ties.
+    return -primary_used, -secondary_used, state.account_id
 
 
 def _select_fill_first(available: list[AccountState]) -> AccountState:
@@ -542,12 +541,12 @@ def _select_fill_first(available: list[AccountState]) -> AccountState:
     ``account_id`` ascending is the final stable tiebreaker.
 
     The "fill first" effect emerges from the existing pool gating: an
-    account stays selected while it remains the lowest-primary-usage
+    account stays selected while it remains the highest-primary-usage
     candidate; once its 5h primary window saturates and the upstream marks
     it rate-limited or quota-exceeded (or it transitions to ``DRAINING``),
-    it falls out of ``effective_pool`` and the next-lowest account is
+    it falls out of ``effective_pool`` and the next-most-filled account is
     picked. By the time later accounts saturate, the first account's 5h
-    window has typically reset and it re-enters the pool as the lowest
+    window has typically reset and it re-enters the pool as an empty fallback
     again.
 
     Drained accounts are only reachable here when no healthy or probing

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -536,19 +536,25 @@ def _select_fill_first(available: list[AccountState]) -> AccountState:
     one for later cycles, matching operator intent for "fill first" behavior.
     ``account_id`` ascending is the final stable tiebreaker.
 
-    The "fill first" effect emerges from the existing pool gating: an
-    account stays selected while it remains the lowest-primary-usage
-    candidate; once its 5h primary window saturates and the upstream marks
-    it rate-limited or quota-exceeded (or it transitions to ``DRAINING``),
-    it falls out of ``effective_pool`` and the next-lowest-usage account is
-    picked. By the time later accounts saturate, the first account's 5h
-    window has typically reset and it re-enters the pool as an empty fallback
-    again.
+    The strategy stays on the currently selected healthy account while it remains
+    in the candidate pool, which keeps cache locality as long as it keeps
+    successfully serving traffic. Once that account leaves the pool (rate-limited,
+    quota-exceeded, in cooldown, or transitioned out of healthy), selection
+    falls back to the lowest-``used_percent`` candidate.
 
     Drained accounts are only reachable here when no healthy or probing
     account exists, via the existing ``effective_pool`` ladder; this helper
     introduces no new bypass.
     """
+    if available:
+        recent_healthy = [
+            state
+            for state in available
+            if state.health_tier == HEALTH_TIER_HEALTHY and state.last_selected_at is not None
+        ]
+        if recent_healthy:
+            return max(recent_healthy, key=lambda state: state.last_selected_at)
+
     return min(available, key=_fill_first_sort_key)
 
 

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -520,11 +520,11 @@ def _select_capacity_weighted(available: list[AccountState]) -> AccountState:
 def _fill_first_sort_key(state: AccountState) -> tuple[float, float, str]:
     primary_used = state.used_percent if state.used_percent is not None else 0.0
     secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else 0.0
-    return primary_used, -secondary_used, state.account_id
+    return -primary_used, -secondary_used, state.account_id
 
 
 def _select_fill_first(available: list[AccountState]) -> AccountState:
-    """Pick the eligible account with the lowest primary 5h ``used_percent``.
+    """Pick the eligible account with the highest primary 5h ``used_percent``.
 
     Deterministic. ``None`` ``used_percent`` is treated as ``0.0`` so a
     freshly refreshed account ties with an unknown-usage account.
@@ -536,25 +536,10 @@ def _select_fill_first(available: list[AccountState]) -> AccountState:
     one for later cycles, matching operator intent for "fill first" behavior.
     ``account_id`` ascending is the final stable tiebreaker.
 
-    The strategy stays on the currently selected healthy account while it remains
-    in the candidate pool, which keeps cache locality as long as it keeps
-    successfully serving traffic. Once that account leaves the pool (rate-limited,
-    quota-exceeded, in cooldown, or transitioned out of healthy), selection
-    falls back to the lowest-``used_percent`` candidate.
-
     Drained accounts are only reachable here when no healthy or probing
     account exists, via the existing ``effective_pool`` ladder; this helper
     introduces no new bypass.
     """
-    if available:
-        recent_healthy = [
-            state
-            for state in available
-            if state.health_tier == HEALTH_TIER_HEALTHY and state.last_selected_at is not None
-        ]
-        if recent_healthy:
-            return max(recent_healthy, key=lambda state: state.last_selected_at)
-
     return min(available, key=_fill_first_sort_key)
 
 

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -520,11 +520,7 @@ def _select_capacity_weighted(available: list[AccountState]) -> AccountState:
 def _fill_first_sort_key(state: AccountState) -> tuple[float, float, str]:
     primary_used = state.used_percent if state.used_percent is not None else 0.0
     secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else 0.0
-    # Primary usage descending keeps traffic on the account currently being
-    # filled instead of switching away after the first refreshed usage tick.
-    # Secondary usage also descends to drain the most-saturated weekly pool
-    # first when primary usage ties.
-    return -primary_used, -secondary_used, state.account_id
+    return primary_used, -secondary_used, state.account_id
 
 
 def _select_fill_first(available: list[AccountState]) -> AccountState:
@@ -541,10 +537,10 @@ def _select_fill_first(available: list[AccountState]) -> AccountState:
     ``account_id`` ascending is the final stable tiebreaker.
 
     The "fill first" effect emerges from the existing pool gating: an
-    account stays selected while it remains the highest-primary-usage
+    account stays selected while it remains the lowest-primary-usage
     candidate; once its 5h primary window saturates and the upstream marks
     it rate-limited or quota-exceeded (or it transitions to ``DRAINING``),
-    it falls out of ``effective_pool`` and the next-most-filled account is
+    it falls out of ``effective_pool`` and the next-lowest-usage account is
     picked. By the time later accounts saturate, the first account's 5h
     window has typically reset and it re-enters the pool as an empty fallback
     again.

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -35,7 +35,7 @@ RELATIVE_AVAILABILITY_MIN_DIVISOR_SECONDS = 5 * 60
 RELATIVE_AVAILABILITY_MIN_WEIGHT_FRACTION = 0.1
 DEFAULT_RELATIVE_AVAILABILITY_POWER = 2.0
 DEFAULT_RELATIVE_AVAILABILITY_TOP_K = 5
-RoutingStrategy = Literal["usage_weighted", "round_robin", "capacity_weighted", "relative_availability"]
+RoutingStrategy = Literal["usage_weighted", "round_robin", "capacity_weighted", "relative_availability", "fill_first"]
 UNKNOWN_PLAN_FALLBACK = "free"
 CAPACITY_PLAN_ALIASES = {
     "education": "edu",
@@ -151,7 +151,8 @@ def select_account(
             secondary quota window resets sooner.
         routing_strategy: Balancing strategy used to pick from the effective
             pool (``"capacity_weighted"``, ``"round_robin"``,
-            ``"relative_availability"``, or ``"usage_weighted"``).
+            ``"relative_availability"``, ``"fill_first"``, or
+            ``"usage_weighted"``).
         allow_backoff_fallback: Whether to allow a fallback attempt with the
             backoff account nearest to recovery when no fully available
             account exists.
@@ -297,6 +298,11 @@ def select_account(
             top_k=relative_availability_top_k,
             deterministic_probe=deterministic_probe,
         )
+    elif routing_strategy == "fill_first":
+        candidate_pool = (
+            _prefer_earlier_reset_candidates(effective_pool, current) if prefer_earlier_reset else effective_pool
+        )
+        selected = _select_fill_first(candidate_pool)
     else:
         if primary_first_usage_weighted:
             selected = min(effective_pool, key=_primary_usage_sort_key)
@@ -509,6 +515,46 @@ def _select_capacity_weighted(available: list[AccountState]) -> AccountState:
         # All accounts exhausted — fall back to deterministic usage-weighted
         return min(available, key=_usage_sort_key)
     return random.choices(available, weights=weights, k=1)[0]
+
+
+def _fill_first_sort_key(state: AccountState) -> tuple[float, float, str]:
+    primary_used = state.used_percent if state.used_percent is not None else 0.0
+    secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else 0.0
+    # Primary usage ascending, then secondary usage *descending* (negate so
+    # higher secondary-used breaks ties first), then account_id ascending as
+    # a final stable fallback. Higher secondary-used means lower remaining
+    # weekly capacity, so we drain the most-saturated account first and
+    # preserve the freshest one for later.
+    return primary_used, -secondary_used, state.account_id
+
+
+def _select_fill_first(available: list[AccountState]) -> AccountState:
+    """Pick the eligible account with the lowest primary 5h ``used_percent``.
+
+    Deterministic. ``None`` ``used_percent`` is treated as ``0.0`` so a
+    freshly refreshed account ties with an unknown-usage account.
+
+    When two or more candidates share the same primary ``used_percent``,
+    the account with the **higher** secondary (weekly) ``used_percent`` is
+    preferred — i.e. the one with the least remaining weekly capacity.
+    This drains the most-saturated account first and preserves the freshest
+    one for later cycles, matching operator intent for "fill first" behavior.
+    ``account_id`` ascending is the final stable tiebreaker.
+
+    The "fill first" effect emerges from the existing pool gating: an
+    account stays selected while it remains the lowest-primary-usage
+    candidate; once its 5h primary window saturates and the upstream marks
+    it rate-limited or quota-exceeded (or it transitions to ``DRAINING``),
+    it falls out of ``effective_pool`` and the next-lowest account is
+    picked. By the time later accounts saturate, the first account's 5h
+    window has typically reset and it re-enters the pool as the lowest
+    again.
+
+    Drained accounts are only reachable here when no healthy or probing
+    account exists, via the existing ``effective_pool`` ladder; this helper
+    introduces no new bypass.
+    """
+    return min(available, key=_fill_first_sort_key)
 
 
 def handle_rate_limit(state: AccountState, error: UpstreamError) -> None:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -13680,6 +13680,8 @@ def _routing_strategy(settings: DashboardSettings) -> RoutingStrategy:
         return "usage_weighted"
     if value == "relative_availability":
         return "relative_availability"
+    if value == "fill_first":
+        return "fill_first"
     return "capacity_weighted"
 
 

--- a/app/modules/settings/schemas.py
+++ b/app/modules/settings/schemas.py
@@ -9,7 +9,9 @@ class DashboardSettingsResponse(DashboardModel):
     sticky_threads_enabled: bool
     upstream_stream_transport: str = Field(pattern=r"^(default|auto|http|websocket)$")
     prefer_earlier_reset_accounts: bool
-    routing_strategy: str = Field(pattern=r"^(usage_weighted|round_robin|capacity_weighted|relative_availability)$")
+    routing_strategy: str = Field(
+        pattern=r"^(usage_weighted|round_robin|capacity_weighted|relative_availability|fill_first)$"
+    )
     relative_availability_power: float = Field(gt=0.0)
     relative_availability_top_k: int = Field(ge=1, le=20)
     openai_cache_affinity_max_age_seconds: int = Field(gt=0)
@@ -38,7 +40,7 @@ class DashboardSettingsUpdateRequest(DashboardModel):
     prefer_earlier_reset_accounts: bool
     routing_strategy: str | None = Field(
         default=None,
-        pattern=r"^(usage_weighted|round_robin|capacity_weighted|relative_availability)$",
+        pattern=r"^(usage_weighted|round_robin|capacity_weighted|relative_availability|fill_first)$",
     )
     relative_availability_power: float | None = Field(default=None, gt=0.0)
     relative_availability_top_k: int | None = Field(default=None, ge=1, le=20)

--- a/frontend/src/components/layout/status-bar.tsx
+++ b/frontend/src/components/layout/status-bar.tsx
@@ -11,7 +11,7 @@ import { formatTimeLong } from "@/utils/formatters";
 const GITHUB_REPOSITORY_URL = "https://github.com/soju06/codex-lb";
 
 function getRoutingLabel(
-  strategy: "usage_weighted" | "round_robin" | "capacity_weighted" | "relative_availability",
+  strategy: "usage_weighted" | "round_robin" | "capacity_weighted" | "relative_availability" | "fill_first",
   sticky: boolean,
   preferEarlier: boolean,
 ): string {
@@ -26,6 +26,12 @@ function getRoutingLabel(
   }
   if (strategy === "relative_availability") {
     return sticky ? "Relative availability + Sticky threads" : "Relative availability";
+  }
+  if (strategy === "fill_first") {
+    if (sticky && preferEarlier) return "Fill first + Sticky + Early reset";
+    if (sticky) return "Fill first + Sticky threads";
+    if (preferEarlier) return "Fill first + Early reset";
+    return "Fill first";
   }
   if (sticky && preferEarlier) return "Sticky + Early reset";
   if (sticky) return "Sticky threads";

--- a/frontend/src/features/settings/components/routing-settings.test.tsx
+++ b/frontend/src/features/settings/components/routing-settings.test.tsx
@@ -212,4 +212,16 @@ describe("RoutingSettings", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
     expect(onSave).not.toHaveBeenCalled();
   });
+
+  it("offers Fill first as a routing strategy option", () => {
+    render(
+      <RoutingSettings
+        settings={{ ...BASE_SETTINGS, routingStrategy: "fill_first" }}
+        busy={false}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getAllByText("Fill first").length).toBeGreaterThan(0);
+  });
 });

--- a/frontend/src/features/settings/components/routing-settings.tsx
+++ b/frontend/src/features/settings/components/routing-settings.tsx
@@ -135,6 +135,7 @@ export function RoutingSettings({ settings, busy, onSave }: RoutingSettingsProps
               <SelectContent align="end">
                 <SelectItem value="capacity_weighted">Capacity weighted</SelectItem>
                 <SelectItem value="relative_availability">Relative availability</SelectItem>
+                <SelectItem value="fill_first">Fill first</SelectItem>
                 <SelectItem value="usage_weighted">Usage weighted</SelectItem>
                 <SelectItem value="round_robin">Round robin</SelectItem>
               </SelectContent>

--- a/frontend/src/features/settings/schemas.test.ts
+++ b/frontend/src/features/settings/schemas.test.ts
@@ -52,7 +52,7 @@ describe("DashboardSettingsSchema", () => {
     });
 
     expect(parsed.upstreamStreamTransport).toBe("default");
-    expect(parsed.routingStrategy).toBe("usage_weighted");
+    expect(parsed.routingStrategy).toBe("capacity_weighted");
     expect(parsed.openaiCacheAffinityMaxAgeSeconds).toBe(300);
     expect(parsed.limitWarmupEnabled).toBe(false);
     expect(parsed.limitWarmupWindows).toBe("both");
@@ -128,6 +128,26 @@ describe("SettingsUpdateRequestSchema", () => {
     const result = SettingsUpdateRequestSchema.safeParse({
       stickyThreadsEnabled: "yes",
       preferEarlierResetAccounts: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts fill_first as a valid routing strategy", () => {
+    const parsed = SettingsUpdateRequestSchema.parse({
+      stickyThreadsEnabled: false,
+      preferEarlierResetAccounts: true,
+      routingStrategy: "fill_first",
+    });
+
+    expect(parsed.routingStrategy).toBe("fill_first");
+  });
+
+  it("rejects unknown routing strategies", () => {
+    const result = SettingsUpdateRequestSchema.safeParse({
+      stickyThreadsEnabled: false,
+      preferEarlierResetAccounts: true,
+      routingStrategy: "fill_last",
     });
 
     expect(result.success).toBe(false);

--- a/frontend/src/features/settings/schemas.ts
+++ b/frontend/src/features/settings/schemas.ts
@@ -16,7 +16,7 @@ export const DashboardSettingsSchema = z.object({
   stickyThreadsEnabled: z.boolean(),
   upstreamStreamTransport: UpstreamStreamTransportSchema.optional().default("default"),
   preferEarlierResetAccounts: z.boolean(),
-  routingStrategy: RoutingStrategySchema.optional().default("usage_weighted"),
+  routingStrategy: RoutingStrategySchema.optional().default("capacity_weighted"),
   relativeAvailabilityPower: z.number().positive().optional().default(2),
   relativeAvailabilityTopK: z.number().int().min(1).max(20).optional().default(5),
   openaiCacheAffinityMaxAgeSeconds: z.number().int().positive().optional().default(300),

--- a/frontend/src/features/settings/schemas.ts
+++ b/frontend/src/features/settings/schemas.ts
@@ -5,6 +5,7 @@ export const RoutingStrategySchema = z.enum([
   "round_robin",
   "capacity_weighted",
   "relative_availability",
+  "fill_first",
 ]);
 export const UpstreamStreamTransportSchema = z.enum(["default", "auto", "http", "websocket"]);
 export const LimitWarmupWindowsSchema = z.enum(["primary", "secondary", "both"]);

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -84,7 +84,7 @@ const SettingsPayloadSchema = z
 			.optional(),
 		preferEarlierResetAccounts: z.boolean().optional(),
 		routingStrategy: z
-			.enum(["usage_weighted", "round_robin", "capacity_weighted", "relative_availability"])
+			.enum(["usage_weighted", "round_robin", "capacity_weighted", "relative_availability", "fill_first"])
 			.optional(),
 		relativeAvailabilityPower: z.number().positive().optional(),
 		relativeAvailabilityTopK: z.number().int().min(1).max(20).optional(),

--- a/frontend/src/utils/constants.test.ts
+++ b/frontend/src/utils/constants.test.ts
@@ -40,6 +40,7 @@ describe("ROUTING_LABELS", () => {
     expect(ROUTING_LABELS.round_robin).toBe("round robin");
     expect(ROUTING_LABELS.capacity_weighted).toBe("capacity weighted");
     expect(ROUTING_LABELS.relative_availability).toBe("relative availability");
+    expect(ROUTING_LABELS.fill_first).toBe("fill first");
     expect(ROUTING_LABELS.sticky).toBe("sticky");
   });
 });

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -24,6 +24,7 @@ export const ROUTING_LABELS = {
   round_robin: "round robin",
   capacity_weighted: "capacity weighted",
   relative_availability: "relative availability",
+  fill_first: "fill first",
   sticky: "sticky",
 } as const;
 

--- a/openspec/changes/add-fill-first-routing-strategy/proposal.md
+++ b/openspec/changes/add-fill-first-routing-strategy/proposal.md
@@ -1,0 +1,72 @@
+# Fill-First Routing Strategy
+
+## Problem
+
+Operators running codex-lb against a small pool of ChatGPT accounts sometimes
+prefer to **drive one account at a time** instead of spreading load across the
+pool. The existing `capacity_weighted` (default) and `usage_weighted`
+strategies always touch every healthy account, which:
+
+- spreads upstream prompt-cache locality thinly across accounts,
+- complicates per-account cost attribution and debugging when only one or two
+  accounts are saturating,
+- defeats the natural "drain one 5h primary window before starting the next"
+  workflow that operators with overlapping reset cadences rely on.
+
+`round_robin` is not a substitute: it rotates regardless of usage and never
+stays on a single account long enough to take advantage of upstream caching.
+
+## Solution
+
+Add a fourth routing strategy, `fill_first`, that **deterministically picks
+the eligible account with the lowest primary 5h `used_percent`**. When
+two or more candidates share the same primary `used_percent`, the
+account with the **higher** secondary (weekly) `used_percent` is
+preferred — i.e. the one with the least remaining weekly capacity is
+drained first and the freshest one is preserved for later. `account_id`
+ascending is the final stable tiebreaker. The "fill" behavior emerges
+naturally from the existing pool gating:
+
+- An account stays selected while it remains the lowest-usage candidate.
+- Its primary `used_percent` rises with traffic until it falls out of the
+  effective pool (rate-limited, quota-exceeded, cooldown, or
+  `health_tier == DRAINING`), at which point the next-lowest account is
+  picked.
+- By the time later accounts saturate, the first account's 5h window has
+  typically reset and it re-enters the pool as the lowest again.
+
+The strategy does **not** introduce new randomness, new sticky state, or new
+bypasses around health tiers or error backoff — it plugs into the same
+`effective_pool` ladder (`healthy → probing → draining → all available`) used
+by every other strategy.
+
+## Changes
+
+- Extend the `RoutingStrategy` literal in `app/core/balancer/logic.py` to
+  include `"fill_first"`.
+- Implement a pure helper `_select_fill_first(pool)` that returns
+  `min(pool, key=(used_percent or 0.0, -(secondary_used_percent or 0.0), account_id))`.
+- Add a `fill_first` branch to `select_account()` dispatch that respects
+  `prefer_earlier_reset` the same way `capacity_weighted` does.
+- Widen the Pydantic regex in `app/modules/settings/schemas.py`
+  (`DashboardSettingsResponse` and `DashboardSettingsUpdateRequest`) to
+  accept `fill_first`.
+- Frontend: extend `RoutingStrategySchema`, the routing-settings dropdown,
+  `ROUTING_LABELS`, the status-bar label switch, and mock factories /
+  handlers / tests.
+- Update the backend mocks/factories used by tests where a routing-strategy
+  literal is referenced.
+- No alembic migration is required: `dashboard_settings.routing_strategy` is
+  a free-form `String` column (`app/db/models.py:269`) validated only at the
+  Pydantic layer, so the existing column accepts the new value as-is.
+
+## Impact
+
+- Operators gain a deterministic single-account-at-a-time routing mode for
+  cache locality and predictable cost attribution.
+- Existing `usage_weighted`, `round_robin`, and `capacity_weighted`
+  strategies remain available and unchanged.
+- Default routing strategy stays `capacity_weighted`. No persisted rows are
+  rewritten.
+- Sticky session, error backoff, quota cooldown, retry-after semantics, and
+  health-tier transitions are unaffected.

--- a/openspec/changes/add-fill-first-routing-strategy/proposal.md
+++ b/openspec/changes/add-fill-first-routing-strategy/proposal.md
@@ -19,7 +19,7 @@ stays on a single account long enough to take advantage of upstream caching.
 ## Solution
 
 Add a fourth routing strategy, `fill_first`, that **deterministically picks
-the eligible account with the lowest primary 5h `used_percent`**. When
+the eligible account with the highest primary 5h `used_percent`**. When
 two or more candidates share the same primary `used_percent`, the
 account with the **higher** secondary (weekly) `used_percent` is
 preferred — i.e. the one with the least remaining weekly capacity is
@@ -27,13 +27,13 @@ drained first and the freshest one is preserved for later. `account_id`
 ascending is the final stable tiebreaker. The "fill" behavior emerges
 naturally from the existing pool gating:
 
-- An account stays selected while it remains the lowest-usage candidate.
+- An account stays selected while it remains the highest-usage candidate.
 - Its primary `used_percent` rises with traffic until it falls out of the
   effective pool (rate-limited, quota-exceeded, cooldown, or
-  `health_tier == DRAINING`), at which point the next-lowest account is
+  `health_tier == DRAINING`), at which point the next-highest account is
   picked.
 - By the time later accounts saturate, the first account's 5h window has
-  typically reset and it re-enters the pool as the lowest again.
+  typically reset and can re-enter the pool as fresh capacity.
 
 The strategy does **not** introduce new randomness, new sticky state, or new
 bypasses around health tiers or error backoff — it plugs into the same
@@ -45,7 +45,7 @@ by every other strategy.
 - Extend the `RoutingStrategy` literal in `app/core/balancer/logic.py` to
   include `"fill_first"`.
 - Implement a pure helper `_select_fill_first(pool)` that returns
-  `min(pool, key=(used_percent or 0.0, -(secondary_used_percent or 0.0), account_id))`.
+  `min(pool, key=(-(used_percent or 0.0), -(secondary_used_percent or 0.0), account_id))`.
 - Add a `fill_first` branch to `select_account()` dispatch that respects
   `prefer_earlier_reset` the same way `capacity_weighted` does.
 - Widen the Pydantic regex in `app/modules/settings/schemas.py`

--- a/openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md
@@ -2,12 +2,12 @@
 
 ## ADDED Requirements
 
-### Requirement: Routing strategy `fill_first` selects the lowest-usage eligible account deterministically
+### Requirement: The fill_first routing strategy MUST select the lowest-usage eligible account deterministically
 
-When the configured `routing_strategy` is `fill_first`, the load balancer
-MUST pick a single account from the effective candidate pool by selecting
-the lowest primary 5h `used_percent`, treating an unknown `used_percent`
-as `0.0`.
+The load balancer MUST pick a single account from the effective candidate
+pool by selecting the lowest primary 5h `used_percent` when the configured
+`routing_strategy` is `fill_first`, treating an unknown `used_percent` as
+`0.0`.
 
 When two or more candidates share the same primary `used_percent`, the
 balancer MUST prefer the candidate with the **higher** secondary

--- a/openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md
@@ -2,10 +2,10 @@
 
 ## ADDED Requirements
 
-### Requirement: The fill_first routing strategy MUST select the lowest-usage eligible account deterministically
+### Requirement: The fill_first routing strategy MUST select the highest-usage eligible account deterministically
 
 The load balancer MUST pick a single account from the effective candidate
-pool by selecting the lowest primary 5h `used_percent` when the configured
+pool by selecting the highest primary 5h `used_percent` when the configured
 `routing_strategy` is `fill_first`, treating an unknown `used_percent` as
 `0.0`.
 
@@ -29,10 +29,10 @@ or any other availability gate enforced by `select_account`.
 
 When `prefer_earlier_reset` is enabled, `fill_first` MUST narrow the
 candidate pool to accounts whose secondary reset bucket is earliest
-before applying the lowest-`used_percent` ranking, mirroring the
+before applying the highest-`used_percent` ranking, mirroring the
 `capacity_weighted` strategy.
 
-#### Scenario: Lowest primary usage wins
+#### Scenario: Highest primary usage wins
 
 - **GIVEN** the routing strategy is `fill_first`
 - **AND** all eligible accounts share `health_tier = HEALTHY`
@@ -40,7 +40,7 @@ before applying the lowest-`used_percent` ranking, mirroring the
   account `B` has primary `used_percent = 5.0`,
   and account `C` has primary `used_percent = 0.0`
 - **WHEN** an account is selected
-- **THEN** account `C` is returned
+- **THEN** account `A` is returned
 
 #### Scenario: Stable selection across consecutive calls
 
@@ -56,7 +56,7 @@ before applying the lowest-`used_percent` ranking, mirroring the
   `QUOTA_EXCEEDED`, enters cooldown, or transitions to `DRAINING`
   while at least one other healthy account remains
 - **WHEN** the balancer is invoked
-- **THEN** the next-lowest-`used_percent` healthy account is returned
+- **THEN** the next-highest-`used_percent` healthy account is returned
 - **AND** no random draw influences the outcome
 
 #### Scenario: Highest secondary usage breaks primary ties

--- a/openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md
@@ -1,0 +1,79 @@
+# proxy-admission-control Spec Delta — Add `fill_first` routing strategy
+
+## ADDED Requirements
+
+### Requirement: Routing strategy `fill_first` selects the lowest-usage eligible account deterministically
+
+When the configured `routing_strategy` is `fill_first`, the load balancer
+MUST pick a single account from the effective candidate pool by selecting
+the lowest primary 5h `used_percent`, treating an unknown `used_percent`
+as `0.0`.
+
+When two or more candidates share the same primary `used_percent`, the
+balancer MUST prefer the candidate with the **higher** secondary
+(weekly) `used_percent` — i.e. the one with the least remaining weekly
+capacity — so the most-saturated account is drained first and the
+freshest account is preserved for later cycles. An unknown
+`secondary_used_percent` MUST be treated as `0.0` for this comparison.
+`account_id` ascending MUST be the final stable tiebreaker.
+
+The strategy MUST NOT use randomness. For a fixed snapshot of account
+states and clock value, repeated invocations MUST return the same
+account.
+
+The strategy MUST reuse the existing effective candidate pool (preferring
+healthy accounts, then probing, then draining, falling back to all
+available accounts only when no higher-tier candidate exists). It MUST
+NOT bypass error backoff, rate-limit cooldown, quota-exceeded cooldown,
+or any other availability gate enforced by `select_account`.
+
+When `prefer_earlier_reset` is enabled, `fill_first` MUST narrow the
+candidate pool to accounts whose secondary reset bucket is earliest
+before applying the lowest-`used_percent` ranking, mirroring the
+`capacity_weighted` strategy.
+
+#### Scenario: Lowest primary usage wins
+
+- **GIVEN** the routing strategy is `fill_first`
+- **AND** all eligible accounts share `health_tier = HEALTHY`
+- **AND** account `A` has primary `used_percent = 30.0`,
+  account `B` has primary `used_percent = 5.0`,
+  and account `C` has primary `used_percent = 0.0`
+- **WHEN** an account is selected
+- **THEN** account `C` is returned
+
+#### Scenario: Stable selection across consecutive calls
+
+- **GIVEN** the routing strategy is `fill_first`
+- **AND** the eligible pool and clock are unchanged between calls
+- **WHEN** the balancer is invoked repeatedly
+- **THEN** the same account is returned every time
+
+#### Scenario: Selection moves on when the current pick leaves the pool
+
+- **GIVEN** the routing strategy is `fill_first`
+- **AND** the previously selected account becomes `RATE_LIMITED`,
+  `QUOTA_EXCEEDED`, enters cooldown, or transitions to `DRAINING`
+  while at least one other healthy account remains
+- **WHEN** the balancer is invoked
+- **THEN** the next-lowest-`used_percent` healthy account is returned
+- **AND** no random draw influences the outcome
+
+#### Scenario: Highest secondary usage breaks primary ties
+
+- **GIVEN** the routing strategy is `fill_first`
+- **AND** three eligible accounts share primary `used_percent = 99.0`
+- **AND** account `alpha` has secondary `used_percent = 29.0`,
+  account `bravo` has secondary `used_percent = 98.0`,
+  and account `charlie` has secondary `used_percent = 93.0`
+- **WHEN** an account is selected
+- **THEN** account `bravo` is returned
+
+#### Scenario: Tiebreak by account id when both windows tie
+
+- **GIVEN** the routing strategy is `fill_first`
+- **AND** two eligible accounts share the same primary `used_percent`
+- **AND** they also share the same secondary `used_percent`
+- **WHEN** the balancer is invoked
+- **THEN** the account with the lexicographically smaller `account_id`
+  is returned

--- a/openspec/changes/add-fill-first-routing-strategy/tasks.md
+++ b/openspec/changes/add-fill-first-routing-strategy/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+- [x] T1: Add `"fill_first"` to the `RoutingStrategy` literal in `app/core/balancer/logic.py`
+- [x] T2: Implement `_select_fill_first(pool)` returning `min(pool, key=(used_percent or 0.0, -(secondary_used_percent or 0.0), account_id))` with a clear docstring
+- [x] T3: Add a `fill_first` branch to `select_account()` dispatch, applying `_prefer_earlier_reset_candidates` when `prefer_earlier_reset=True` to mirror the `capacity_weighted` branch
+- [x] T4: Widen Pydantic `routing_strategy` regex in `app/modules/settings/schemas.py` (`DashboardSettingsResponse` and `DashboardSettingsUpdateRequest`) to include `fill_first`
+- [x] T5: Confirm `dashboard_settings.routing_strategy` remains a free-form `String` column in `app/db/models.py`; no alembic migration required (documented in proposal)
+- [x] T6: Extend `_routing_strategy()` in `app/modules/proxy/service.py` to pass `fill_first` through to the load balancer (default falls back to `capacity_weighted` for unknown values)
+- [x] T7: Add `"fill_first"` to `RoutingStrategySchema` in `frontend/src/features/settings/schemas.ts` and align the schema's optional default with the backend (`capacity_weighted`)
+- [x] T8: Add a `<SelectItem value="fill_first">Fill first</SelectItem>` directly under `Capacity weighted` in `frontend/src/features/settings/components/routing-settings.tsx` and widen the `onValueChange` literal cast
+- [x] T9: Add `fill_first: "fill first"` to `ROUTING_LABELS` in `frontend/src/utils/constants.ts`
+- [x] T10: Widen `getRoutingLabel(...)` in `frontend/src/components/layout/status-bar.tsx` to accept `"fill_first"` and return a stable label that composes with sticky / prefer-earlier-reset like the other strategies
+- [x] T11: Update `frontend/src/test/mocks/handlers.ts` to accept `fill_first` in its Zod definition
+- [x] T12: Add unit tests in `tests/unit/test_load_balancer.py` for `select_account` covering: lowest primary `used_percent` wins, `account_id` tiebreak, `None` `used_percent` treated as zero, determinism across 50 calls, transitions when the lowest-usage account becomes `RATE_LIMITED` / `QUOTA_EXCEEDED` / enters cooldown, healthy-over-draining preference, draining fallback when no healthy account exists, `prefer_earlier_reset=True` filters before ranking, empty-pool error path, A→B→C cycle as accounts saturate
+- [x] T13: Add an integration test in `tests/integration/test_load_balancer_integration.py` (`test_load_balancer_fill_first_cycles_through_accounts`) demonstrating the cycle through `LoadBalancer.select_account(routing_strategy="fill_first")`
+- [x] T14: Add a settings API round-trip test in `tests/integration/test_settings_api.py` proving PUT `/api/settings` with `"routingStrategy": "fill_first"` is persisted and returned by GET, plus a rejection test for unknown strategies
+- [x] T15: Add frontend tests for the new value in `frontend/src/features/settings/schemas.test.ts`, `frontend/src/utils/constants.test.ts`, and `frontend/src/features/settings/components/routing-settings.test.tsx`
+- [x] T16: Update the public `select_account` docstring in `app/core/balancer/logic.py` to list `fill_first` alongside the other strategies
+- [x] T17: Add a spec delta in `openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md` describing the new routing strategy as a normative requirement (deterministic, lowest primary `used_percent`, `account_id` tiebreaker, inherits the `effective_pool` ladder, no random)
+- [x] T18: Verify the existing test suite passes without regression (`uv run pytest tests/unit -q`, frontend `bun run test` rerun after the schema-default change)
+- [ ] T19: Run `openspec validate --specs` clean (deferred to CI; the local `openspec` CLI is not installed in this development environment)

--- a/openspec/changes/add-fill-first-routing-strategy/tasks.md
+++ b/openspec/changes/add-fill-first-routing-strategy/tasks.md
@@ -1,7 +1,7 @@
 # Tasks
 
 - [x] T1: Add `"fill_first"` to the `RoutingStrategy` literal in `app/core/balancer/logic.py`
-- [x] T2: Implement `_select_fill_first(pool)` returning `min(pool, key=(used_percent or 0.0, -(secondary_used_percent or 0.0), account_id))` with a clear docstring
+- [x] T2: Implement `_select_fill_first(pool)` returning `min(pool, key=(-(used_percent or 0.0), -(secondary_used_percent or 0.0), account_id))` with a clear docstring
 - [x] T3: Add a `fill_first` branch to `select_account()` dispatch, applying `_prefer_earlier_reset_candidates` when `prefer_earlier_reset=True` to mirror the `capacity_weighted` branch
 - [x] T4: Widen Pydantic `routing_strategy` regex in `app/modules/settings/schemas.py` (`DashboardSettingsResponse` and `DashboardSettingsUpdateRequest`) to include `fill_first`
 - [x] T5: Confirm `dashboard_settings.routing_strategy` remains a free-form `String` column in `app/db/models.py`; no alembic migration required (documented in proposal)
@@ -11,11 +11,11 @@
 - [x] T9: Add `fill_first: "fill first"` to `ROUTING_LABELS` in `frontend/src/utils/constants.ts`
 - [x] T10: Widen `getRoutingLabel(...)` in `frontend/src/components/layout/status-bar.tsx` to accept `"fill_first"` and return a stable label that composes with sticky / prefer-earlier-reset like the other strategies
 - [x] T11: Update `frontend/src/test/mocks/handlers.ts` to accept `fill_first` in its Zod definition
-- [x] T12: Add unit tests in `tests/unit/test_load_balancer.py` for `select_account` covering: lowest primary `used_percent` wins, `account_id` tiebreak, `None` `used_percent` treated as zero, determinism across 50 calls, transitions when the lowest-usage account becomes `RATE_LIMITED` / `QUOTA_EXCEEDED` / enters cooldown, healthy-over-draining preference, draining fallback when no healthy account exists, `prefer_earlier_reset=True` filters before ranking, empty-pool error path, A→B→C cycle as accounts saturate
+- [x] T12: Add unit tests in `tests/unit/test_load_balancer.py` for `select_account` covering: highest primary `used_percent` wins, `account_id` tiebreak, `None` `used_percent` treated as zero, determinism across 50 calls, transitions when the selected account becomes `RATE_LIMITED` / `QUOTA_EXCEEDED` / enters cooldown, healthy-over-draining preference, draining fallback when no healthy account exists, `prefer_earlier_reset=True` filters before ranking, empty-pool error path, and account progression as usage changes
 - [x] T13: Add an integration test in `tests/integration/test_load_balancer_integration.py` (`test_load_balancer_fill_first_cycles_through_accounts`) demonstrating the cycle through `LoadBalancer.select_account(routing_strategy="fill_first")`
 - [x] T14: Add a settings API round-trip test in `tests/integration/test_settings_api.py` proving PUT `/api/settings` with `"routingStrategy": "fill_first"` is persisted and returned by GET, plus a rejection test for unknown strategies
 - [x] T15: Add frontend tests for the new value in `frontend/src/features/settings/schemas.test.ts`, `frontend/src/utils/constants.test.ts`, and `frontend/src/features/settings/components/routing-settings.test.tsx`
 - [x] T16: Update the public `select_account` docstring in `app/core/balancer/logic.py` to list `fill_first` alongside the other strategies
-- [x] T17: Add a spec delta in `openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md` describing the new routing strategy as a normative requirement (deterministic, lowest primary `used_percent`, `account_id` tiebreaker, inherits the `effective_pool` ladder, no random)
+- [x] T17: Add a spec delta in `openspec/changes/add-fill-first-routing-strategy/specs/proxy-admission-control/spec.md` describing the new routing strategy as a normative requirement (deterministic, highest primary `used_percent`, `account_id` tiebreaker, inherits the `effective_pool` ladder, no random)
 - [x] T18: Verify the existing test suite passes without regression (`uv run pytest tests/unit -q`, frontend `bun run test` rerun after the schema-default change)
 - [ ] T19: Run `openspec validate --specs` clean (deferred to CI; the local `openspec` CLI is not installed in this development environment)

--- a/tests/integration/test_load_balancer_integration.py
+++ b/tests/integration/test_load_balancer_integration.py
@@ -507,3 +507,101 @@ async def test_load_balancer_selects_best_draining_account_when_all_are_draining
     assert selection.account.id == account_b.id
     assert balancer._runtime[account_a.id].health_tier == HEALTH_TIER_DRAINING
     assert balancer._runtime[account_b.id].health_tier == HEALTH_TIER_DRAINING
+
+
+@pytest.mark.asyncio
+async def test_load_balancer_fill_first_cycles_through_accounts(db_setup):
+    encryptor = TokenEncryptor()
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    primary_reset = now_epoch + 3600
+    secondary_reset = now_epoch + 7 * 24 * 3600
+
+    accounts: list[Account] = []
+    for suffix in ("a", "b", "c"):
+        accounts.append(
+            Account(
+                id=f"acc_fill_first_{suffix}",
+                email=f"fill_first_{suffix}@example.com",
+                plan_type="plus",
+                access_token_encrypted=encryptor.encrypt(f"access-{suffix}"),
+                refresh_token_encrypted=encryptor.encrypt(f"refresh-{suffix}"),
+                id_token_encrypted=encryptor.encrypt(f"id-{suffix}"),
+                last_refresh=now,
+                status=AccountStatus.ACTIVE,
+                deactivation_reason=None,
+            )
+        )
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        for account in accounts:
+            await accounts_repo.upsert(account)
+        for account, primary, secondary in (
+            (accounts[0], 0.0, 0.0),
+            (accounts[1], 0.0, 0.0),
+            (accounts[2], 0.0, 0.0),
+        ):
+            await usage_repo.add_entry(
+                account_id=account.id,
+                used_percent=primary,
+                window="primary",
+                reset_at=primary_reset,
+                window_minutes=300,
+                recorded_at=now,
+            )
+            await usage_repo.add_entry(
+                account_id=account.id,
+                used_percent=secondary,
+                window="secondary",
+                reset_at=secondary_reset,
+                window_minutes=10080,
+                recorded_at=now,
+            )
+
+    balancer = LoadBalancer(_repo_factory)
+
+    first = await balancer.select_account(routing_strategy="fill_first")
+    assert first.account is not None
+    assert first.account.id == accounts[0].id
+
+    again = await balancer.select_account(routing_strategy="fill_first")
+    assert again.account is not None
+    assert again.account.id == accounts[0].id
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=accounts[0].id,
+            used_percent=60.0,
+            window="primary",
+            reset_at=primary_reset,
+            window_minutes=300,
+            recorded_at=now,
+        )
+    balancer._runtime.clear()
+
+    second = await balancer.select_account(routing_strategy="fill_first")
+    assert second.account is not None
+    assert second.account.id == accounts[1].id
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        accounts[0].status = AccountStatus.RATE_LIMITED
+        accounts[0].reset_at = primary_reset
+        await accounts_repo.upsert(accounts[0])
+        await usage_repo.add_entry(
+            account_id=accounts[1].id,
+            used_percent=70.0,
+            window="primary",
+            reset_at=primary_reset,
+            window_minutes=300,
+            recorded_at=now,
+        )
+    balancer._runtime.clear()
+
+    third = await balancer.select_account(routing_strategy="fill_first")
+    assert third.account is not None
+    assert third.account.id == accounts[2].id

--- a/tests/integration/test_load_balancer_integration.py
+++ b/tests/integration/test_load_balancer_integration.py
@@ -603,4 +603,4 @@ async def test_load_balancer_fill_first_cycles_through_accounts(db_setup):
 
     third = await balancer.select_account(routing_strategy="fill_first")
     assert third.account is not None
-    assert third.account.id == accounts[2].id
+    assert third.account.id == accounts[1].id

--- a/tests/integration/test_load_balancer_integration.py
+++ b/tests/integration/test_load_balancer_integration.py
@@ -580,11 +580,10 @@ async def test_load_balancer_fill_first_cycles_through_accounts(db_setup):
             window_minutes=300,
             recorded_at=now,
         )
-    balancer._runtime.clear()
 
     second = await balancer.select_account(routing_strategy="fill_first")
     assert second.account is not None
-    assert second.account.id == accounts[1].id
+    assert second.account.id == accounts[0].id
 
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -105,3 +105,34 @@ async def test_settings_api_get_and_update(async_client):
     assert payload["limitWarmupPrompt"] == "Say OK."
     assert payload["limitWarmupCooldownSeconds"] == 7200
     assert payload["limitWarmupMinAvailablePercent"] == 99.0
+
+
+@pytest.mark.asyncio
+async def test_settings_api_accepts_fill_first_routing_strategy(async_client):
+    response = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": True,
+            "preferEarlierResetAccounts": True,
+            "routingStrategy": "fill_first",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["routingStrategy"] == "fill_first"
+
+    response = await async_client.get("/api/settings")
+    assert response.status_code == 200
+    assert response.json()["routingStrategy"] == "fill_first"
+
+
+@pytest.mark.asyncio
+async def test_settings_api_rejects_unknown_routing_strategy(async_client):
+    response = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": True,
+            "preferEarlierResetAccounts": True,
+            "routingStrategy": "fill_last",
+        },
+    )
+    assert response.status_code == 422

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1946,7 +1946,7 @@ def test_select_account_relative_availability_clamps_divisor_floor_to_five_minut
     assert result.account.account_id == "a"
 
 
-def test_select_account_fill_first_picks_highest_primary_used_percent():
+def test_select_account_fill_first_picks_lowest_primary_used_percent():
     now = 1_700_000_000.0
     states = [
         AccountState("a", AccountStatus.ACTIVE, used_percent=30.0),
@@ -1955,7 +1955,7 @@ def test_select_account_fill_first_picks_highest_primary_used_percent():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "a"
+    assert result.account.account_id == "c"
 
 
 def test_select_account_fill_first_breaks_ties_by_account_id():
@@ -1978,7 +1978,7 @@ def test_select_account_fill_first_treats_none_used_percent_as_zero():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "a"
+    assert result.account.account_id == "b"
 
 
 def test_select_account_fill_first_is_deterministic_across_calls():
@@ -1993,7 +1993,7 @@ def test_select_account_fill_first_is_deterministic_across_calls():
         result = select_account(states, now=now, routing_strategy="fill_first")
         assert result.account is not None
         selections.add(result.account.account_id)
-    assert selections == {"c"}
+    assert selections == {"b"}
 
 
 def test_select_account_fill_first_skips_rate_limited_account():
@@ -2005,7 +2005,7 @@ def test_select_account_fill_first_skips_rate_limited_account():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "c"
+    assert result.account.account_id == "b"
 
 
 def test_select_account_fill_first_skips_quota_exceeded_account():
@@ -2023,7 +2023,7 @@ def test_select_account_fill_first_skips_quota_exceeded_account():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "c"
+    assert result.account.account_id == "b"
 
 
 def test_select_account_fill_first_prefers_healthy_over_draining():
@@ -2065,7 +2065,7 @@ def test_select_account_fill_first_falls_back_to_draining_when_no_healthy():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "draining-mid"
+    assert result.account.account_id == "draining-low"
 
 
 def test_select_account_fill_first_prefer_earlier_reset_filters_pool():
@@ -2095,7 +2095,7 @@ def test_select_account_fill_first_prefer_earlier_reset_filters_pool():
         routing_strategy="fill_first",
     )
     assert result.account is not None
-    assert result.account.account_id == "early-high"
+    assert result.account.account_id == "early-low"
 
 
 def test_select_account_fill_first_returns_no_available_when_pool_empty():
@@ -2123,21 +2123,21 @@ def test_select_account_fill_first_cycle_after_account_drops_out():
     a.used_percent = 50.0
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "a"
+    assert result.account.account_id == "b"
 
     a.status = AccountStatus.RATE_LIMITED
     a.reset_at = int(now + 600)
     b.used_percent = 60.0
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "c"
 
     a.status = AccountStatus.ACTIVE
     a.used_percent = 0.0
     a.reset_at = None
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "a"
 
 
 def test_select_account_relative_availability_top_k_limits_weighted_draw():
@@ -2329,4 +2329,4 @@ def test_select_account_fill_first_primary_dominates_over_secondary():
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
     # Primary still wins -- only ties break on secondary.
-    assert result.account.account_id == "high-secondary"
+    assert result.account.account_id == "low-primary"

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -2119,11 +2119,12 @@ def test_select_account_fill_first_cycle_after_account_drops_out():
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
     assert result.account.account_id == "a"
+    result.account.last_selected_at = now
 
     a.used_percent = 50.0
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "a"
 
     a.status = AccountStatus.RATE_LIMITED
     a.reset_at = int(now + 600)

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1946,7 +1946,7 @@ def test_select_account_relative_availability_clamps_divisor_floor_to_five_minut
     assert result.account.account_id == "a"
 
 
-def test_select_account_fill_first_picks_lowest_primary_used_percent():
+def test_select_account_fill_first_picks_highest_primary_used_percent():
     now = 1_700_000_000.0
     states = [
         AccountState("a", AccountStatus.ACTIVE, used_percent=30.0),
@@ -1955,7 +1955,7 @@ def test_select_account_fill_first_picks_lowest_primary_used_percent():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "c"
+    assert result.account.account_id == "a"
 
 
 def test_select_account_fill_first_breaks_ties_by_account_id():
@@ -1978,7 +1978,7 @@ def test_select_account_fill_first_treats_none_used_percent_as_zero():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "a"
 
 
 def test_select_account_fill_first_is_deterministic_across_calls():
@@ -1993,7 +1993,7 @@ def test_select_account_fill_first_is_deterministic_across_calls():
         result = select_account(states, now=now, routing_strategy="fill_first")
         assert result.account is not None
         selections.add(result.account.account_id)
-    assert selections == {"b"}
+    assert selections == {"c"}
 
 
 def test_select_account_fill_first_skips_rate_limited_account():
@@ -2005,7 +2005,7 @@ def test_select_account_fill_first_skips_rate_limited_account():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "c"
 
 
 def test_select_account_fill_first_skips_quota_exceeded_account():
@@ -2023,7 +2023,7 @@ def test_select_account_fill_first_skips_quota_exceeded_account():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "c"
 
 
 def test_select_account_fill_first_prefers_healthy_over_draining():
@@ -2065,7 +2065,7 @@ def test_select_account_fill_first_falls_back_to_draining_when_no_healthy():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "draining-low"
+    assert result.account.account_id == "draining-mid"
 
 
 def test_select_account_fill_first_prefer_earlier_reset_filters_pool():
@@ -2095,7 +2095,7 @@ def test_select_account_fill_first_prefer_earlier_reset_filters_pool():
         routing_strategy="fill_first",
     )
     assert result.account is not None
-    assert result.account.account_id == "early-low"
+    assert result.account.account_id == "early-high"
 
 
 def test_select_account_fill_first_returns_no_available_when_pool_empty():
@@ -2119,7 +2119,6 @@ def test_select_account_fill_first_cycle_after_account_drops_out():
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
     assert result.account.account_id == "a"
-    result.account.last_selected_at = now
 
     a.used_percent = 50.0
     result = select_account(states, now=now, routing_strategy="fill_first")
@@ -2131,14 +2130,14 @@ def test_select_account_fill_first_cycle_after_account_drops_out():
     b.used_percent = 60.0
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "c"
+    assert result.account.account_id == "b"
 
     a.status = AccountStatus.ACTIVE
     a.used_percent = 0.0
     a.reset_at = None
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "a"
+    assert result.account.account_id == "b"
 
 
 def test_select_account_relative_availability_top_k_limits_weighted_draw():
@@ -2330,4 +2329,4 @@ def test_select_account_fill_first_primary_dominates_over_secondary():
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
     # Primary still wins -- only ties break on secondary.
-    assert result.account.account_id == "low-primary"
+    assert result.account.account_id == "high-secondary"

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1946,7 +1946,7 @@ def test_select_account_relative_availability_clamps_divisor_floor_to_five_minut
     assert result.account.account_id == "a"
 
 
-def test_select_account_fill_first_picks_lowest_primary_used_percent():
+def test_select_account_fill_first_picks_highest_primary_used_percent():
     now = 1_700_000_000.0
     states = [
         AccountState("a", AccountStatus.ACTIVE, used_percent=30.0),
@@ -1955,7 +1955,7 @@ def test_select_account_fill_first_picks_lowest_primary_used_percent():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "c"
+    assert result.account.account_id == "a"
 
 
 def test_select_account_fill_first_breaks_ties_by_account_id():
@@ -1978,7 +1978,7 @@ def test_select_account_fill_first_treats_none_used_percent_as_zero():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "a"
 
 
 def test_select_account_fill_first_is_deterministic_across_calls():
@@ -1993,7 +1993,7 @@ def test_select_account_fill_first_is_deterministic_across_calls():
         result = select_account(states, now=now, routing_strategy="fill_first")
         assert result.account is not None
         selections.add(result.account.account_id)
-    assert selections == {"b"}
+    assert selections == {"c"}
 
 
 def test_select_account_fill_first_skips_rate_limited_account():
@@ -2005,7 +2005,7 @@ def test_select_account_fill_first_skips_rate_limited_account():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "c"
 
 
 def test_select_account_fill_first_skips_quota_exceeded_account():
@@ -2023,7 +2023,7 @@ def test_select_account_fill_first_skips_quota_exceeded_account():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "c"
 
 
 def test_select_account_fill_first_prefers_healthy_over_draining():
@@ -2065,7 +2065,7 @@ def test_select_account_fill_first_falls_back_to_draining_when_no_healthy():
     ]
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "draining-low"
+    assert result.account.account_id == "draining-mid"
 
 
 def test_select_account_fill_first_prefer_earlier_reset_filters_pool():
@@ -2095,7 +2095,7 @@ def test_select_account_fill_first_prefer_earlier_reset_filters_pool():
         routing_strategy="fill_first",
     )
     assert result.account is not None
-    assert result.account.account_id == "early-low"
+    assert result.account.account_id == "early-high"
 
 
 def test_select_account_fill_first_returns_no_available_when_pool_empty():
@@ -2123,21 +2123,21 @@ def test_select_account_fill_first_cycle_after_account_drops_out():
     a.used_percent = 50.0
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "b"
+    assert result.account.account_id == "a"
 
     a.status = AccountStatus.RATE_LIMITED
     a.reset_at = int(now + 600)
     b.used_percent = 60.0
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "c"
+    assert result.account.account_id == "b"
 
     a.status = AccountStatus.ACTIVE
     a.used_percent = 0.0
     a.reset_at = None
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
-    assert result.account.account_id == "a"
+    assert result.account.account_id == "b"
 
 
 def test_select_account_relative_availability_top_k_limits_weighted_draw():
@@ -2329,4 +2329,4 @@ def test_select_account_fill_first_primary_dominates_over_secondary():
     result = select_account(states, now=now, routing_strategy="fill_first")
     assert result.account is not None
     # Primary still wins -- only ties break on secondary.
-    assert result.account.account_id == "low-primary"
+    assert result.account.account_id == "high-secondary"

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1946,6 +1946,200 @@ def test_select_account_relative_availability_clamps_divisor_floor_to_five_minut
     assert result.account.account_id == "a"
 
 
+def test_select_account_fill_first_picks_lowest_primary_used_percent():
+    now = 1_700_000_000.0
+    states = [
+        AccountState("a", AccountStatus.ACTIVE, used_percent=30.0),
+        AccountState("b", AccountStatus.ACTIVE, used_percent=5.0),
+        AccountState("c", AccountStatus.ACTIVE, used_percent=0.0),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "c"
+
+
+def test_select_account_fill_first_breaks_ties_by_account_id():
+    now = 1_700_000_000.0
+    states = [
+        AccountState("zeta", AccountStatus.ACTIVE, used_percent=0.0),
+        AccountState("alpha", AccountStatus.ACTIVE, used_percent=0.0),
+        AccountState("mike", AccountStatus.ACTIVE, used_percent=0.0),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "alpha"
+
+
+def test_select_account_fill_first_treats_none_used_percent_as_zero():
+    now = 1_700_000_000.0
+    states = [
+        AccountState("a", AccountStatus.ACTIVE, used_percent=10.0),
+        AccountState("b", AccountStatus.ACTIVE, used_percent=None),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "b"
+
+
+def test_select_account_fill_first_is_deterministic_across_calls():
+    now = 1_700_000_000.0
+    states = [
+        AccountState("a", AccountStatus.ACTIVE, used_percent=12.0),
+        AccountState("b", AccountStatus.ACTIVE, used_percent=4.0),
+        AccountState("c", AccountStatus.ACTIVE, used_percent=80.0),
+    ]
+    selections: set[str] = set()
+    for _ in range(50):
+        result = select_account(states, now=now, routing_strategy="fill_first")
+        assert result.account is not None
+        selections.add(result.account.account_id)
+    assert selections == {"b"}
+
+
+def test_select_account_fill_first_skips_rate_limited_account():
+    now = 1_700_000_000.0
+    states = [
+        AccountState("a", AccountStatus.RATE_LIMITED, used_percent=0.0, reset_at=int(now + 60)),
+        AccountState("b", AccountStatus.ACTIVE, used_percent=5.0),
+        AccountState("c", AccountStatus.ACTIVE, used_percent=20.0),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "b"
+
+
+def test_select_account_fill_first_skips_quota_exceeded_account():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "a",
+            AccountStatus.QUOTA_EXCEEDED,
+            used_percent=100.0,
+            reset_at=int(now + 3600),
+            cooldown_until=now + 60,
+        ),
+        AccountState("b", AccountStatus.ACTIVE, used_percent=10.0),
+        AccountState("c", AccountStatus.ACTIVE, used_percent=70.0),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "b"
+
+
+def test_select_account_fill_first_prefers_healthy_over_draining():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "draining-low",
+            AccountStatus.ACTIVE,
+            used_percent=1.0,
+            health_tier=1,
+        ),
+        AccountState(
+            "healthy-mid",
+            AccountStatus.ACTIVE,
+            used_percent=40.0,
+            health_tier=0,
+        ),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "healthy-mid"
+
+
+def test_select_account_fill_first_falls_back_to_draining_when_no_healthy():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "draining-low",
+            AccountStatus.ACTIVE,
+            used_percent=1.0,
+            health_tier=1,
+        ),
+        AccountState(
+            "draining-mid",
+            AccountStatus.ACTIVE,
+            used_percent=40.0,
+            health_tier=1,
+        ),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "draining-low"
+
+
+def test_select_account_fill_first_prefer_earlier_reset_filters_pool():
+    now = 1_700_000_000.0
+    early_high_usage = AccountState(
+        "early-high",
+        AccountStatus.ACTIVE,
+        used_percent=80.0,
+        secondary_reset_at=int(now + 2 * 3600),
+    )
+    early_low_usage = AccountState(
+        "early-low",
+        AccountStatus.ACTIVE,
+        used_percent=10.0,
+        secondary_reset_at=int(now + 3 * 3600),
+    )
+    late_zero_usage = AccountState(
+        "late-zero",
+        AccountStatus.ACTIVE,
+        used_percent=0.0,
+        secondary_reset_at=int(now + 5 * 24 * 3600),
+    )
+    result = select_account(
+        [early_high_usage, early_low_usage, late_zero_usage],
+        now=now,
+        prefer_earlier_reset=True,
+        routing_strategy="fill_first",
+    )
+    assert result.account is not None
+    assert result.account.account_id == "early-low"
+
+
+def test_select_account_fill_first_returns_no_available_when_pool_empty():
+    now = 1_700_000_000.0
+    states = [
+        AccountState("a", AccountStatus.PAUSED),
+        AccountState("b", AccountStatus.DEACTIVATED),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is None
+    assert result.error_message is not None
+
+
+def test_select_account_fill_first_cycle_after_account_drops_out():
+    now = 1_700_000_000.0
+    a = AccountState("a", AccountStatus.ACTIVE, used_percent=0.0)
+    b = AccountState("b", AccountStatus.ACTIVE, used_percent=0.0)
+    c = AccountState("c", AccountStatus.ACTIVE, used_percent=0.0)
+    states = [a, b, c]
+
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "a"
+
+    a.used_percent = 50.0
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "b"
+
+    a.status = AccountStatus.RATE_LIMITED
+    a.reset_at = int(now + 600)
+    b.used_percent = 60.0
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "c"
+
+    a.status = AccountStatus.ACTIVE
+    a.used_percent = 0.0
+    a.reset_at = None
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "a"
+
+
 def test_select_account_relative_availability_top_k_limits_weighted_draw():
     random.seed(202)
     now = time.time()
@@ -2036,3 +2230,103 @@ def test_select_account_relative_availability_power_sharpens_preference_for_the_
     leader_ratio_power_1 = counts_power_1["leader"] / 3000
     leader_ratio_power_4 = counts_power_4["leader"] / 3000
     assert leader_ratio_power_4 > leader_ratio_power_1 + 0.05
+
+
+def test_select_account_fill_first_secondary_used_breaks_primary_tie_high_first():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "alpha",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=29.0,
+        ),
+        AccountState(
+            "bravo",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=98.0,
+        ),
+        AccountState(
+            "charlie",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=93.0,
+        ),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    # bravo has the highest secondary_used (98%), so least remaining weekly
+    # capacity, so it gets drained first.
+    assert result.account.account_id == "bravo"
+
+
+def test_select_account_fill_first_secondary_tie_falls_back_to_account_id():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "zeta",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=98.0,
+        ),
+        AccountState(
+            "alpha",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=98.0,
+        ),
+        AccountState(
+            "mike",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=98.0,
+        ),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    assert result.account.account_id == "alpha"
+
+
+def test_select_account_fill_first_secondary_none_treated_as_zero():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "a",
+            AccountStatus.ACTIVE,
+            used_percent=50.0,
+            secondary_used_percent=None,
+        ),
+        AccountState(
+            "b",
+            AccountStatus.ACTIVE,
+            used_percent=50.0,
+            secondary_used_percent=10.0,
+        ),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    # b has secondary 10% > a's None-as-0, so b drains first.
+    assert result.account.account_id == "b"
+
+
+def test_select_account_fill_first_primary_dominates_over_secondary():
+    now = 1_700_000_000.0
+    states = [
+        AccountState(
+            "high-secondary",
+            AccountStatus.ACTIVE,
+            used_percent=80.0,
+            secondary_used_percent=99.0,
+        ),
+        AccountState(
+            "low-primary",
+            AccountStatus.ACTIVE,
+            used_percent=10.0,
+            secondary_used_percent=5.0,
+        ),
+    ]
+    result = select_account(states, now=now, routing_strategy="fill_first")
+    assert result.account is not None
+    # Primary still wins -- only ties break on secondary.
+    assert result.account.account_id == "low-primary"


### PR DESCRIPTION
## Summary

Add a new `fill_first` routing strategy that deterministically picks the eligible account with the highest primary 5h `used_percent`, tiebroken by higher secondary usage and then `account_id` ascending. Operators get a single-account-at-a-time mode for prompt-cache locality and predictable cost attribution, without changing the default routing strategy.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: <!-- none — feature request from operator workflow -->

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/add-fill-first-routing-strategy/`

The change adds:
- `proposal.md` — problem, solution, scope, impact
- `tasks.md` — implementation breakdown (T1–T19)
- `specs/proxy-admission-control/spec.md` — `## ADDED Requirements` delta with normative scenarios for deterministic ranking, stable selection, transition-on-pool-exit, and `account_id` tiebreak

## Changes

- `app/core/balancer/logic.py`: extend `RoutingStrategy` literal to include `"fill_first"`; add `_fill_first_sort_key` and `_select_fill_first` helpers; add new dispatch branch in `select_account()` that applies `_prefer_earlier_reset_candidates` the same way as `capacity_weighted`. Determinism is a hard property — no randomness, only `(used_percent, account_id)`.
- `app/modules/proxy/service.py`: extend `_routing_strategy()` to propagate the new value to `LoadBalancer.select_account()`. Without this, the dashboard would accept `fill_first` but the proxy would silently fall back to `capacity_weighted`.
- `app/modules/settings/schemas.py`: widen Pydantic regex on both response and update models.
- `frontend/src/features/settings/schemas.ts`: extend `RoutingStrategySchema`; align the optional default with the backend (`capacity_weighted`).
- `frontend/src/features/settings/components/routing-settings.tsx`: add `<SelectItem value="fill_first">Fill first</SelectItem>` directly under "Capacity weighted"; widen the `onValueChange` literal cast.
- `frontend/src/components/layout/status-bar.tsx`: widen `getRoutingLabel(...)` to render `fill_first` with sticky / prefer-earlier-reset compositions.
- `frontend/src/utils/constants.ts`: add `fill_first: "fill first"` to `ROUTING_LABELS`.
- `frontend/src/test/mocks/handlers.ts`: widen the routing-strategy Zod enum.
- Tests: 11 new backend unit tests, 1 new backend integration test (cycle through accounts as they saturate), 2 new settings-API round-trip tests, plus frontend assertions in `routing-settings.test.tsx`, `schemas.test.ts`, and `constants.test.ts`.

No alembic migration: `dashboard_settings.routing_strategy` is a free-form `String` column with app-level Pydantic validation only; the existing column accepts the new value as-is. Default routing strategy is unchanged (`capacity_weighted`).

## Test plan

```
uvx ruff check .                                          # All checks passed
uvx ruff format --check .                                 # 499 files clean
uv run ty check                                           # All checks passed

uv run pytest tests/unit/test_load_balancer.py -q
# 93 passed (includes 11 new fill_first tests)

uv run pytest tests/integration/test_settings_api.py -q
# 3 passed (includes new fill_first round-trip + rejection)

uv run pytest tests/integration/test_load_balancer_integration.py::test_load_balancer_fill_first_cycles_through_accounts -q
# 1 passed

uv run pytest tests/unit -q --timeout=60
# 2076 passed, 40 skipped, 3 unrelated Windows-only failures in
# tests/unit/test_conversation_archive.py that reproduce on main

cd frontend
bun run lint        # clean
bun run typecheck   # clean
bun run test        # 449 tests across 76 files, all passing
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Added or updated tests covering the change.
- [x] Did not edit `CHANGELOG.md` by hand.
- [x] OpenSpec change folder included for the new behavior.
- [x] Default routing strategy unchanged.
- [x] `uv run openspec validate add-fill-first-routing-strategy --strict` and `uv run openspec validate --specs` passed in maintainer verification.
