### PR TITLE
feat(config): flexible location of DATA_DIR by env-variable

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -425,11 +425,15 @@ class Settings(BaseSettings):
     def _apply_data_dir_defaults(self) -> "Settings":
         if self.data_dir == DEFAULT_HOME_DIR:
             return self
-        if self.database_url == DEFAULT_DATABASE_URL:
+        explicitly_set = self.model_fields_set
+        if "database_url" not in explicitly_set and self.database_url == DEFAULT_DATABASE_URL:
             self.database_url = f"sqlite+aiosqlite:///{self.data_dir / 'store.db'}"
-        if self.encryption_key_file == DEFAULT_ENCRYPTION_KEY_FILE:
+        if "encryption_key_file" not in explicitly_set and self.encryption_key_file == DEFAULT_ENCRYPTION_KEY_FILE:
             self.encryption_key_file = self.data_dir / "encryption.key"
-        if self.conversation_archive_dir == DEFAULT_CONVERSATION_ARCHIVE_DIR:
+        if (
+            "conversation_archive_dir" not in explicitly_set
+            and self.conversation_archive_dir == DEFAULT_CONVERSATION_ARCHIVE_DIR
+        ):
             self.conversation_archive_dir = self.data_dir / "conversation-archive"
         return self
 

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -27,8 +27,8 @@ def _in_container() -> bool:
 
 def _default_home_dir() -> Path:
     env_dir = os.getenv("CODEX_LB_DATA_DIR")
-    if env_dir:
-        return Path(env_dir)
+    if env_dir and env_dir.strip():
+        return Path(env_dir.strip())
     home_dir = Path.home() / ".codex-lb"
     if home_dir.exists():
         return home_dir

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -26,9 +26,15 @@ def _in_container() -> bool:
 
 
 def _default_home_dir() -> Path:
+    env_dir = os.getenv("CODEX_LB_DATA_DIR")
+    if env_dir:
+        return Path(env_dir)
+    home_dir = Path.home() / ".codex-lb"
+    if home_dir.exists():
+        return home_dir
     if _in_container():
         return DOCKER_DATA_DIR
-    return Path.home() / ".codex-lb"
+    return home_dir
 
 
 def _default_oauth_callback_host() -> str:
@@ -45,6 +51,8 @@ def _default_http_bridge_instance_id() -> str:
 DEFAULT_HOME_DIR = _default_home_dir()
 DEFAULT_DB_PATH = DEFAULT_HOME_DIR / "store.db"
 DEFAULT_ENCRYPTION_KEY_FILE = DEFAULT_HOME_DIR / "encryption.key"
+DEFAULT_CONVERSATION_ARCHIVE_DIR = DEFAULT_HOME_DIR / "conversation-archive"
+DEFAULT_DATABASE_URL = f"sqlite+aiosqlite:///{DEFAULT_DB_PATH}"
 type StringListInput = str | list[str] | None
 type OptionalStringInput = str | None
 type ModelContextWindowOverridesInput = str | dict[str, int] | None
@@ -117,7 +125,8 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    database_url: str = f"sqlite+aiosqlite:///{DEFAULT_DB_PATH}"
+    data_dir: Path = Field(default_factory=_default_home_dir)
+    database_url: str = DEFAULT_DATABASE_URL
     database_pool_size: int = Field(default=15, gt=0)
     database_max_overflow: int = Field(default=10, ge=0)
     database_background_pool_size: int | None = Field(default=None, gt=0)
@@ -185,7 +194,7 @@ class Settings(BaseSettings):
     log_upstream_request_summary: bool = False
     log_upstream_request_payload: bool = False
     conversation_archive_enabled: bool = False
-    conversation_archive_dir: Path = DEFAULT_HOME_DIR / "conversation-archive"
+    conversation_archive_dir: Path = DEFAULT_CONVERSATION_ARCHIVE_DIR
     conversation_archive_queue_max_bytes: int = Field(default=256 * 1024 * 1024, gt=0)
     max_decompressed_body_bytes: int = Field(default=32 * 1024 * 1024, gt=0)
     max_decompressed_responses_body_bytes: int = Field(default=128 * 1024 * 1024, gt=0)
@@ -275,6 +284,18 @@ class Settings(BaseSettings):
     http_connector_limit: int = 100
     http_connector_limit_per_host: int = 50
 
+    @field_validator("data_dir", mode="before")
+    @classmethod
+    def _expand_data_dir(cls, value: str | Path) -> Path:
+        if isinstance(value, Path):
+            return value.expanduser()
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return _default_home_dir()
+            return Path(stripped).expanduser()
+        raise TypeError("data_dir must be a path")
+
     @field_validator("database_url")
     @classmethod
     def _expand_database_url(cls, value: str) -> str:
@@ -293,6 +314,15 @@ class Settings(BaseSettings):
         if isinstance(value, str):
             return Path(value).expanduser()
         raise TypeError("encryption_key_file must be a path")
+
+    @field_validator("conversation_archive_dir", mode="before")
+    @classmethod
+    def _expand_conversation_archive_dir(cls, value: str | Path) -> Path:
+        if isinstance(value, Path):
+            return value.expanduser()
+        if isinstance(value, str):
+            return Path(value).expanduser()
+        raise TypeError("conversation_archive_dir must be a path")
 
     @field_validator("image_inline_allowed_hosts", mode="before")
     @classmethod
@@ -390,6 +420,18 @@ class Settings(BaseSettings):
         if value <= 0:
             raise ValueError("upstream_compact_timeout_seconds must be greater than zero")
         return value
+
+    @model_validator(mode="after")
+    def _apply_data_dir_defaults(self) -> "Settings":
+        if self.data_dir == DEFAULT_HOME_DIR:
+            return self
+        if self.database_url == DEFAULT_DATABASE_URL:
+            self.database_url = f"sqlite+aiosqlite:///{self.data_dir / 'store.db'}"
+        if self.encryption_key_file == DEFAULT_ENCRYPTION_KEY_FILE:
+            self.encryption_key_file = self.data_dir / "encryption.key"
+        if self.conversation_archive_dir == DEFAULT_CONVERSATION_ARCHIVE_DIR:
+            self.conversation_archive_dir = self.data_dir / "conversation-archive"
+        return self
 
     @model_validator(mode="after")
     def _validate_http_bridge_instance_configuration(self) -> "Settings":

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -222,9 +222,12 @@ _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE = (
     "[codex-lb omitted historical tool output ({bytes} bytes) to fit upstream websocket budget]"
 )
 _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline image to fit upstream websocket budget]"
+_OVERSIZED_RESPONSE_CREATE_DUMP_DIR: Path | None = None
 
 
 def _oversized_response_create_dump_dir() -> Path:
+    if _OVERSIZED_RESPONSE_CREATE_DUMP_DIR is not None:
+        return _OVERSIZED_RESPONSE_CREATE_DUMP_DIR
     data_dir = getattr(get_settings(), "data_dir", DEFAULT_HOME_DIR)
     return data_dir / "debug" / "response-create-dumps"
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -67,7 +67,7 @@ from app.core.clients.proxy_websocket import (
     connect_responses_websocket,
     filter_inbound_websocket_headers,
 )
-from app.core.config.settings import Settings, get_settings
+from app.core.config.settings import DEFAULT_HOME_DIR, Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
@@ -225,7 +225,9 @@ _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline im
 
 
 def _oversized_response_create_dump_dir() -> Path:
-    return get_settings().data_dir / "debug" / "response-create-dumps"
+    data_dir = getattr(get_settings(), "data_dir", DEFAULT_HOME_DIR)
+    return data_dir / "debug" / "response-create-dumps"
+
 
 _TASK_CANCEL_TIMEOUT_SECONDS = 1.0
 _TaskResultT = TypeVar("_TaskResultT")

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from hashlib import sha256
 from ipaddress import ip_address
+from pathlib import Path
 from typing import Any, AsyncIterator, Literal, Mapping, NoReturn, TypeVar, cast, overload
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -66,7 +67,7 @@ from app.core.clients.proxy_websocket import (
     connect_responses_websocket,
     filter_inbound_websocket_headers,
 )
-from app.core.config.settings import DEFAULT_HOME_DIR, Settings, get_settings
+from app.core.config.settings import Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.errors import (
@@ -213,12 +214,6 @@ logger = logging.getLogger(__name__)
 
 _UPSTREAM_RESPONSE_CREATE_MAX_BYTES = get_settings().upstream_response_create_max_bytes
 _UPSTREAM_RESPONSE_CREATE_WARN_BYTES = int(_UPSTREAM_RESPONSE_CREATE_MAX_BYTES * 0.8)
-# Use the deploy's resolved data directory so non-container installs
-# (notably macOS ``uv tool`` / LaunchAgent layouts that don't have
-# ``/var/lib/codex-lb`` writable) still get oversized-payload dumps.
-# The container image keeps writing to ``/var/lib/codex-lb`` because
-# ``DEFAULT_HOME_DIR`` resolves to that path inside the image.
-_OVERSIZED_RESPONSE_CREATE_DUMP_DIR = DEFAULT_HOME_DIR / "debug" / "response-create-dumps"
 _OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS = 10
 _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE = (
     "[codex-lb omitted {count} historical input items to fit upstream websocket budget]"
@@ -227,6 +222,10 @@ _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE = (
     "[codex-lb omitted historical tool output ({bytes} bytes) to fit upstream websocket budget]"
 )
 _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline image to fit upstream websocket budget]"
+
+
+def _oversized_response_create_dump_dir() -> Path:
+    return get_settings().data_dir / "debug" / "response-create-dumps"
 
 _TASK_CANCEL_TIMEOUT_SECONDS = 1.0
 _TaskResultT = TypeVar("_TaskResultT")
@@ -13395,7 +13394,7 @@ def _write_response_create_dump(
             ),
         )
     )
-    dump_dir = _OVERSIZED_RESPONSE_CREATE_DUMP_DIR
+    dump_dir = _oversized_response_create_dump_dir()
     dump_path = dump_dir / f"{dump_id}.response-create.json.gz"
     meta_path = dump_dir / f"{dump_id}.meta.json"
 

--- a/openspec/changes/data-dir-env-var-home-exists/context.md
+++ b/openspec/changes/data-dir-env-var-home-exists/context.md
@@ -1,0 +1,41 @@
+# Rationale: Flexible Data Directory Resolution
+
+## Decision
+
+Change `_default_home_dir()` so that:
+1. `CODEX_LB_DATA_DIR` overrides everything.
+2. An existing `$HOME/.codex-lb` is preferred even when `/.containerenv` or `/.dockerenv` is present.
+3. Only if neither applies, fall back to `/var/lib/codex-lb` inside containers.
+
+## Why this order?
+
+### Environment variable first (operator intent)
+
+An explicit environment variable expresses deliberate operator intent. It must win over all heuristics so that bind-mounts, volume plugins, or custom images work without guessing path conventions.
+
+### Existing home directory before container default (developer workflow)
+
+Interactive containers (Podman rootless, devcontainers, `docker run -it`) often mount the user's home directory but do not run as root. In those environments `/var/lib/codex-lb` is either read-only or owned by root, causing a permission error on startup. If the user already ran codex-lb natively and has `~/.codex-lb/store.db`, re-using that directory inside the container is the least surprising behavior.
+
+Only production-oriented images that run as root inside a dedicated volume should rely on `/var/lib/codex-lb`.
+
+## Constraints & failure modes
+
+- **Home directory not mounted into container**: If `~/.codex-lb` does not exist, the old behavior (`/var/lib/codex-lb`) is preserved, so existing Docker deployments are unaffected.
+- **Env var points to missing directory**: The caller (Settings) will attempt to create files there and fail fast with a clear `PermissionError` or `OSError`, which is desirable — fail fast rather than silently falling back.
+
+## Concrete example
+
+A developer runs:
+
+```bash
+# 1. Native run
+uv run codex-lb
+# → creates ~/.codex-lb/store.db
+
+# 2. Later, inside a rootless Podman container
+podman run -v "$HOME:$HOME" -e HOME="$HOME" ghcr.io/Soju06/codex-lb:latest
+```
+
+Before this change: container detection triggers → `/var/lib/codex-lb` → permission denied.
+After this change: `~/.codex-lb` exists → reused → no error, data preserved.

--- a/openspec/changes/data-dir-env-var-home-exists/proposal.md
+++ b/openspec/changes/data-dir-env-var-home-exists/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+Interactive and rootless containers (e.g. `podman run …`, devcontainers, `docker run -it`) set `/.containerenv` or `/.dockerenv`, which triggers `_in_container()` and forces the data directory to `/var/lib/codex-lb`. That path is typically not writable for a non-root user, causing a permission error on startup.
+
+Additionally, there is no environment variable to override the default data directory, making it impossible to redirect codex-lb to a writable path without restructuring the container image.
+
+## What Changes
+
+- Introduce `CODEX_LB_DATA_DIR` as the highest-priority override for the default data directory, enabling operators to point codex-lb at any writable path.
+- When no override is set, prefer an existing `$HOME/.codex-lb` directory even inside a container, preserving backward compatibility and avoiding permission errors when the home directory is already mounted.
+- Only fall back to `/var/lib/codex-lb` when running in a container **and** `$HOME/.codex-lb` does not already exist.
+
+## Impact
+
+- Interactive container workflows no longer fail with permission errors when `/var/lib/codex-lb` is read-only or unwritable.
+- Operators can redirect the data directory via an environment variable without bind-mounting `~/.codex-lb` into the exact same path inside the container.

--- a/openspec/changes/data-dir-env-var-home-exists/specs/deployment-installation/spec.md
+++ b/openspec/changes/data-dir-env-var-home-exists/specs/deployment-installation/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Application data directory resolution is configurable and container-aware
+
+The application MUST resolve its default data directory from operator intent before container heuristics. A non-empty `CODEX_LB_DATA_DIR` value MUST be the highest-priority data directory override. When no override is configured, an existing `$HOME/.codex-lb` directory MUST remain preferred even if the process detects that it is running inside a container. The container data directory (`/var/lib/codex-lb`) MUST be used only when no override is configured, the home data directory does not already exist, and container detection is true.
+
+#### Scenario: Explicit data directory override wins
+
+- **GIVEN** `CODEX_LB_DATA_DIR` is configured to a non-empty path
+- **WHEN** application settings are loaded
+- **THEN** the configured path is used as the data directory
+- **AND** the container detection result does not override it
+
+#### Scenario: Existing home data is reused inside an interactive container
+
+- **GIVEN** `CODEX_LB_DATA_DIR` is not configured
+- **AND** `$HOME/.codex-lb` already exists
+- **AND** container detection is true
+- **WHEN** application settings are loaded
+- **THEN** `$HOME/.codex-lb` is used as the data directory
+- **AND** `/var/lib/codex-lb` is not selected
+
+#### Scenario: Container default is preserved when no home data exists
+
+- **GIVEN** `CODEX_LB_DATA_DIR` is not configured
+- **AND** `$HOME/.codex-lb` does not exist
+- **AND** container detection is true
+- **WHEN** application settings are loaded
+- **THEN** `/var/lib/codex-lb` is used as the data directory
+
+#### Scenario: Related default paths follow the resolved data directory
+
+- **GIVEN** the resolved data directory differs from the module-import default
+- **AND** the database URL, encryption key file, conversation archive directory, and response-create dump directory are not explicitly configured
+- **WHEN** application settings and proxy dump helpers are used
+- **THEN** the default SQLite database URL points at `<data-dir>/store.db`
+- **AND** the default encryption key file points at `<data-dir>/encryption.key`
+- **AND** the default conversation archive directory points at `<data-dir>/conversation-archive`
+- **AND** oversized response-create dumps are written under `<data-dir>/debug/response-create-dumps`
+
+#### Scenario: Explicit related path overrides are preserved
+
+- **GIVEN** `CODEX_LB_DATA_DIR` is configured
+- **AND** one or more related paths such as `CODEX_LB_DATABASE_URL`, `CODEX_LB_ENCRYPTION_KEY_FILE`, or `CODEX_LB_CONVERSATION_ARCHIVE_DIR` are explicitly configured
+- **WHEN** application settings are loaded
+- **THEN** each explicitly configured related path keeps its configured value
+- **AND** only omitted related paths derive from the resolved data directory

--- a/openspec/changes/data-dir-env-var-home-exists/tasks.md
+++ b/openspec/changes/data-dir-env-var-home-exists/tasks.md
@@ -10,11 +10,16 @@
 - [x] 2.2 Return the home path when it already exists, regardless of container
   detection.
 
-## 3. Verification
+## 3. OpenSpec
 
-- [x] 3.1 Add unit tests covering all precedence combinations:
+- [x] 3.1 Add a parsed OpenSpec requirement delta for data directory precedence,
+  related default paths, and explicit related-path overrides.
+
+## 4. Verification
+
+- [x] 4.1 Add unit tests covering all precedence combinations:
   - `CODEX_LB_DATA_DIR` set → used.
   - `CODEX_LB_DATA_DIR` unset, `~/.codex-lb` exists → used.
   - Neither set, in container → `/var/lib/codex-lb`.
   - Neither set, not in container → `~/.codex-lb` (even if absent).
-- [x] 3.2 Run focused tests and lint.
+- [x] 4.2 Run focused tests and lint.

--- a/openspec/changes/data-dir-env-var-home-exists/tasks.md
+++ b/openspec/changes/data-dir-env-var-home-exists/tasks.md
@@ -1,0 +1,20 @@
+## 1. Environment variable override
+
+- [ ] 1.1 Read `CODEX_LB_DATA_DIR` inside `_default_home_dir()`.
+- [ ] 1.2 Return `Path(env_dir)` when the variable is non-empty.
+
+## 2. Existing home-directory detection
+
+- [ ] 2.1 Check whether `Path.home() / ".codex-lb"` exists before deciding on the
+  container path.
+- [ ] 2.2 Return the home path when it already exists, regardless of container
+  detection.
+
+## 3. Verification
+
+- [ ] 3.1 Add unit tests covering all precedence combinations:
+  - `CODEX_LB_DATA_DIR` set → used.
+  - `CODEX_LB_DATA_DIR` unset, `~/.codex-lb` exists → used.
+  - Neither set, in container → `/var/lib/codex-lb`.
+  - Neither set, not in container → `~/.codex-lb` (even if absent).
+- [ ] 3.2 Run focused tests and lint.

--- a/openspec/changes/data-dir-env-var-home-exists/tasks.md
+++ b/openspec/changes/data-dir-env-var-home-exists/tasks.md
@@ -1,20 +1,20 @@
 ## 1. Environment variable override
 
-- [ ] 1.1 Read `CODEX_LB_DATA_DIR` inside `_default_home_dir()`.
-- [ ] 1.2 Return `Path(env_dir)` when the variable is non-empty.
+- [x] 1.1 Read `CODEX_LB_DATA_DIR` inside `_default_home_dir()`.
+- [x] 1.2 Return `Path(env_dir)` when the variable is non-empty.
 
 ## 2. Existing home-directory detection
 
-- [ ] 2.1 Check whether `Path.home() / ".codex-lb"` exists before deciding on the
+- [x] 2.1 Check whether `Path.home() / ".codex-lb"` exists before deciding on the
   container path.
-- [ ] 2.2 Return the home path when it already exists, regardless of container
+- [x] 2.2 Return the home path when it already exists, regardless of container
   detection.
 
 ## 3. Verification
 
-- [ ] 3.1 Add unit tests covering all precedence combinations:
+- [x] 3.1 Add unit tests covering all precedence combinations:
   - `CODEX_LB_DATA_DIR` set → used.
   - `CODEX_LB_DATA_DIR` unset, `~/.codex-lb` exists → used.
   - Neither set, in container → `/var/lib/codex-lb`.
   - Neither set, not in container → `~/.codex-lb` (even if absent).
-- [ ] 3.2 Run focused tests and lint.
+- [x] 3.2 Run focused tests and lint.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -16332,6 +16332,33 @@ async def test_inline_http_bridge_image_urls_rechecks_expanded_payload_size(monk
     assert "data:image/png;base64," in request_state.request_text
 
 
+def test_response_create_dump_uses_configured_data_dir(monkeypatch, tmp_path):
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_dump_data_dir",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","input":"too large"}',
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: SimpleNamespace(data_dir=tmp_path))
+
+    assert proxy_service._write_response_create_dump(
+        request_state,
+        account_id_value="acc-data-dir",
+        error_code="payload_too_large",
+        error_message="too large",
+        log_prefix="unit",
+    )
+
+    dump_dir = tmp_path / "debug" / "response-create-dumps"
+    assert list(dump_dir.glob("*.response-create.json.gz"))
+    assert list(dump_dir.glob("*.meta.json"))
+
+
 @pytest.mark.asyncio
 async def test_submit_http_bridge_request_reinlines_final_text(monkeypatch):
     service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)

--- a/tests/unit/test_settings_home_dir.py
+++ b/tests/unit/test_settings_home_dir.py
@@ -79,6 +79,18 @@ def test_blank_data_dir_from_env_file_uses_default_home_dir(
     assert settings.conversation_archive_dir == expected_data_dir / "conversation-archive"
 
 
+def test_blank_data_dir_from_process_env_uses_default_home_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODEX_LB_DATA_DIR", "   ")
+
+    expected_data_dir = Path("/home/user") / ".codex-lb"
+    with (
+        patch("app.core.config.settings.Path.home", return_value=Path("/home/user")),
+        patch("app.core.config.settings._in_container", return_value=False),
+        patch.object(Path, "exists", return_value=False),
+    ):
+        assert _default_home_dir() == expected_data_dir
+
+
 def test_data_dir_keeps_explicit_related_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CODEX_LB_DATA_DIR", raising=False)
     monkeypatch.delenv("CODEX_LB_DATABASE_URL", raising=False)

--- a/tests/unit/test_settings_home_dir.py
+++ b/tests/unit/test_settings_home_dir.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from app.core.config.settings import DOCKER_DATA_DIR, Settings, _default_home_dir
+
+
+def _settings_from_env_file(env_file: Path) -> Settings:
+    kwargs: dict[str, Any] = {"_env_file": env_file}
+    return Settings(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("env_dir", "home_exists", "in_container", "expected"),
+    [
+        ("/tmp/custom", False, False, Path("/tmp/custom")),
+        (None, True, False, Path("/home/user") / ".codex-lb"),
+        (None, True, True, Path("/home/user") / ".codex-lb"),
+        (None, False, True, DOCKER_DATA_DIR),
+        (None, False, False, Path("/home/user") / ".codex-lb"),
+    ],
+)
+def test_default_home_dir_precedence(
+    env_dir: str | None,
+    home_exists: bool,
+    in_container: bool,
+    expected: Path,
+) -> None:
+    with (
+        patch("app.core.config.settings.os.getenv", return_value=env_dir),
+        patch("app.core.config.settings.Path.home", return_value=Path("/home/user")),
+        patch("app.core.config.settings._in_container", return_value=in_container),
+        patch.object(Path, "exists", return_value=home_exists),
+    ):
+        assert _default_home_dir() == expected
+
+
+def test_data_dir_from_env_file_updates_related_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEX_LB_DATA_DIR", raising=False)
+    monkeypatch.delenv("CODEX_LB_DATABASE_URL", raising=False)
+    monkeypatch.delenv("CODEX_LB_ENCRYPTION_KEY_FILE", raising=False)
+    monkeypatch.delenv("CODEX_LB_CONVERSATION_ARCHIVE_DIR", raising=False)
+    data_dir = tmp_path / "configured"
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"CODEX_LB_DATA_DIR={data_dir}\n", encoding="utf-8")
+
+    settings = _settings_from_env_file(env_file)
+
+    assert settings.data_dir == data_dir
+    assert settings.database_url == f"sqlite+aiosqlite:///{data_dir / 'store.db'}"
+    assert settings.encryption_key_file == data_dir / "encryption.key"
+    assert settings.conversation_archive_dir == data_dir / "conversation-archive"
+
+
+def test_blank_data_dir_from_env_file_uses_default_home_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CODEX_LB_DATA_DIR", raising=False)
+    monkeypatch.delenv("CODEX_LB_DATABASE_URL", raising=False)
+    monkeypatch.delenv("CODEX_LB_ENCRYPTION_KEY_FILE", raising=False)
+    monkeypatch.delenv("CODEX_LB_CONVERSATION_ARCHIVE_DIR", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("CODEX_LB_DATA_DIR=   \n", encoding="utf-8")
+
+    expected_data_dir = Path("/home/user") / ".codex-lb"
+    with (
+        patch("app.core.config.settings.Path.home", return_value=Path("/home/user")),
+        patch("app.core.config.settings._in_container", return_value=False),
+        patch.object(Path, "exists", return_value=False),
+    ):
+        settings = _settings_from_env_file(env_file)
+
+    assert settings.data_dir == expected_data_dir
+    assert settings.database_url == f"sqlite+aiosqlite:///{expected_data_dir / 'store.db'}"
+    assert settings.encryption_key_file == expected_data_dir / "encryption.key"
+    assert settings.conversation_archive_dir == expected_data_dir / "conversation-archive"
+
+
+def test_data_dir_keeps_explicit_related_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CODEX_LB_DATA_DIR", raising=False)
+    monkeypatch.delenv("CODEX_LB_DATABASE_URL", raising=False)
+    monkeypatch.delenv("CODEX_LB_ENCRYPTION_KEY_FILE", raising=False)
+    monkeypatch.delenv("CODEX_LB_CONVERSATION_ARCHIVE_DIR", raising=False)
+    data_dir = tmp_path / "configured"
+    archive_dir = tmp_path / "archive"
+    key_file = tmp_path / "key"
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                f"CODEX_LB_DATA_DIR={data_dir}",
+                "CODEX_LB_DATABASE_URL=sqlite+aiosqlite:///explicit.db",
+                f"CODEX_LB_ENCRYPTION_KEY_FILE={key_file}",
+                f"CODEX_LB_CONVERSATION_ARCHIVE_DIR={archive_dir}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    settings = _settings_from_env_file(env_file)
+
+    assert settings.data_dir == data_dir
+    assert settings.database_url == "sqlite+aiosqlite:///explicit.db"
+    assert settings.encryption_key_file == key_file
+    assert settings.conversation_archive_dir == archive_dir

--- a/tests/unit/test_settings_home_dir.py
+++ b/tests/unit/test_settings_home_dir.py
@@ -4,7 +4,14 @@ from unittest.mock import patch
 
 import pytest
 
-from app.core.config.settings import DOCKER_DATA_DIR, Settings, _default_home_dir
+from app.core.config.settings import (
+    DEFAULT_CONVERSATION_ARCHIVE_DIR,
+    DEFAULT_DATABASE_URL,
+    DEFAULT_ENCRYPTION_KEY_FILE,
+    DOCKER_DATA_DIR,
+    Settings,
+    _default_home_dir,
+)
 
 
 def _settings_from_env_file(env_file: Path) -> Settings:
@@ -118,3 +125,33 @@ def test_data_dir_keeps_explicit_related_overrides(tmp_path: Path, monkeypatch: 
     assert settings.database_url == "sqlite+aiosqlite:///explicit.db"
     assert settings.encryption_key_file == key_file
     assert settings.conversation_archive_dir == archive_dir
+
+
+def test_data_dir_keeps_explicit_related_overrides_that_equal_old_defaults(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CODEX_LB_DATA_DIR", raising=False)
+    monkeypatch.delenv("CODEX_LB_DATABASE_URL", raising=False)
+    monkeypatch.delenv("CODEX_LB_ENCRYPTION_KEY_FILE", raising=False)
+    monkeypatch.delenv("CODEX_LB_CONVERSATION_ARCHIVE_DIR", raising=False)
+    data_dir = tmp_path / "configured"
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                f"CODEX_LB_DATA_DIR={data_dir}",
+                f"CODEX_LB_DATABASE_URL={DEFAULT_DATABASE_URL}",
+                f"CODEX_LB_ENCRYPTION_KEY_FILE={DEFAULT_ENCRYPTION_KEY_FILE}",
+                f"CODEX_LB_CONVERSATION_ARCHIVE_DIR={DEFAULT_CONVERSATION_ARCHIVE_DIR}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    settings = _settings_from_env_file(env_file)
+
+    assert settings.data_dir == data_dir
+    assert settings.database_url == DEFAULT_DATABASE_URL
+    assert settings.encryption_key_file == DEFAULT_ENCRYPTION_KEY_FILE
+    assert settings.conversation_archive_dir == DEFAULT_CONVERSATION_ARCHIVE_DIR


### PR DESCRIPTION
## Summary

Running codex-lb inside an interactive container (e.g. `podman run …`) sets `/.containerenv`, which triggers `_in_container()` and forces the data directory to `/var/lib/codex-lb`. That path is typically not writable for a non-root user, causing a permission error on startup. Additionally, there is no environment variable to override the default data directory.

Fixes #836

## Type of change

- [x] `feat:` new feature (data directory precedence and env override)

## Root cause

`_default_home_dir()` returns `DOCKER_DATA_DIR` as soon as `_in_container()` is true, without checking whether `$HOME/.codex-lb` already exists. This orphans existing local data and breaks interactive containers where `/var/lib/codex-lb` is read-only or unwritable.

## Fix

1. Check `CODEX_LB_DATA_DIR` first - highest priority override.
2. Check whether `Path.home() / ".codex-lb"` exists. If yes, use it even inside a container.
3. Fall back to `/var/lib/codex-lb` only when running in a container **and** the home dir does not already exist.

## Test plan

```text
$ uv run pytest tests/unit/test_settings_home_dir.py -v
5 passed
```

Each regression case fails on `origin/main` (wrong precedence) and passes with the patch.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` locally.

## Additional hint

This doesn't break containers since they normally shouldn't have `~/.codex-lb`.
