### PR TITLE
fix(copy): add legacy handling when clipboard API could not be used due to non-secure context

### DIFF
--- a/frontend/src/components/copy-button.test.tsx
+++ b/frontend/src/components/copy-button.test.tsx
@@ -28,6 +28,10 @@ describe("CopyButton", () => {
 
   it("writes to clipboard and shows success feedback", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
@@ -51,6 +55,10 @@ describe("CopyButton", () => {
 
   it("shows error toast when clipboard write fails", async () => {
     const writeText = vi.fn().mockRejectedValue(new Error("clipboard blocked"));
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
@@ -67,6 +75,10 @@ describe("CopyButton", () => {
 
   it("supports icon-only copy buttons with accessible labeling", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
@@ -80,5 +92,74 @@ describe("CopyButton", () => {
 
     expect(writeText).toHaveBeenCalledWith("secret-value");
     expect(screen.getByRole("button", { name: "Copy Request ID Copied" })).toBeInTheDocument();
+  });
+
+  it("keeps keyboard focus on the trigger after copying", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<CopyButton value="secret-value" />);
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+
+    copyButton.focus();
+    expect(copyButton).toHaveFocus();
+
+    await act(async () => {
+      fireEvent.click(copyButton);
+      await Promise.resolve();
+    });
+
+    expect(copyButton).toHaveFocus();
+  });
+
+  it("restores trigger focus after fallback copy inside a dialog", async () => {
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+
+    let fallbackActiveTag: string | undefined;
+    let fallbackParent: Element | null = null;
+    const execCommand = vi.fn(() => {
+      const active = document.activeElement as HTMLTextAreaElement | null;
+      fallbackActiveTag = active?.tagName;
+      fallbackParent = active?.parentElement ?? null;
+      return true;
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(<CopyButton value="secret-value" />, { container: dialog });
+
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    copyButton.focus();
+
+    await act(async () => {
+      fireEvent.click(copyButton);
+      await Promise.resolve();
+    });
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(fallbackActiveTag).toBe("TEXTAREA");
+    expect(fallbackParent).toBe(dialog);
+    expect(copyButton).toHaveFocus();
+    dialog.remove();
   });
 });

--- a/frontend/src/components/copy-button.tsx
+++ b/frontend/src/components/copy-button.tsx
@@ -1,8 +1,9 @@
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { useState, type MouseEvent } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/utils/clipboard";
 
 export type CopyButtonProps = {
   value: string;
@@ -13,12 +14,22 @@ export type CopyButtonProps = {
 export function CopyButton({ value, label = "Copy", iconOnly = false }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = async () => {
+  const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+    const trigger = event.currentTarget;
+    const dialogContainer = trigger.closest("[role='dialog']");
+
     try {
-      await navigator.clipboard.writeText(value);
-      setCopied(true);
-      toast.success("Copied to clipboard");
-      setTimeout(() => setCopied(false), 1200);
+      const copiedToClipboard = await copyToClipboard(value, {
+        container: dialogContainer instanceof HTMLElement ? dialogContainer : undefined,
+      });
+      if (copiedToClipboard) {
+        setCopied(true);
+        toast.success("Copied to clipboard");
+        setTimeout(() => setCopied(false), 1200);
+        return;
+      }
+
+      toast.error("Failed to copy");
     } catch {
       toast.error("Failed to copy");
     }
@@ -29,7 +40,8 @@ export function CopyButton({ value, label = "Copy", iconOnly = false }: CopyButt
       type="button"
       variant="outline"
       size={iconOnly ? "icon-sm" : "sm"}
-      onClick={handleCopy}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={(event) => void handleCopy(event)}
       aria-label={copied ? `${label} Copied` : label}
       title={copied ? "Copied" : label}
     >

--- a/frontend/src/features/accounts/components/oauth-dialog.test.tsx
+++ b/frontend/src/features/accounts/components/oauth-dialog.test.tsx
@@ -1,8 +1,22 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { OauthDialog } from "@/features/accounts/components/oauth-dialog";
+
+const { toastError } = vi.hoisted(() => ({
+  toastError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastError,
+  },
+}));
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalIsSecureContext = Object.getOwnPropertyDescriptor(window, "isSecureContext");
+const originalExecCommand = Object.getOwnPropertyDescriptor(document, "execCommand");
 
 const idleState = {
   status: "idle" as const,
@@ -60,6 +74,172 @@ const errorState = {
 };
 
 describe("OauthDialog", () => {
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    }
+    if (originalIsSecureContext) {
+      Object.defineProperty(window, "isSecureContext", originalIsSecureContext);
+    }
+    if (originalExecCommand) {
+      Object.defineProperty(document, "execCommand", originalExecCommand);
+    }
+    toastError.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the browser-stage copy button focused after keyboard activation", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <OauthDialog
+        open
+        state={browserPendingState}
+        onOpenChange={vi.fn()}
+        onStart={vi.fn().mockResolvedValue(undefined)}
+        onComplete={vi.fn().mockResolvedValue(undefined)}
+        onManualCallback={vi.fn().mockResolvedValue(undefined)}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    copyButton.focus();
+    expect(copyButton).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(copyButton).toHaveFocus();
+    });
+  });
+
+  it("blurs the browser-stage copy button after pointer activation", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(
+      <OauthDialog
+        open
+        state={browserPendingState}
+        onOpenChange={vi.fn()}
+        onStart={vi.fn().mockResolvedValue(undefined)}
+        onComplete={vi.fn().mockResolvedValue(undefined)}
+        onManualCallback={vi.fn().mockResolvedValue(undefined)}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    copyButton.focus();
+    expect(copyButton).toHaveFocus();
+
+    await user.click(copyButton);
+
+    await waitFor(() => {
+      expect(copyButton).not.toHaveFocus();
+    });
+  });
+
+  it("restores keyboard focus after fallback copy inside dialog", async () => {
+    const user = userEvent.setup();
+    const execCommand = vi.fn(() => {
+      expect(document.activeElement?.tagName).toBe("TEXTAREA");
+      return true;
+    });
+
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(
+      <OauthDialog
+        open
+        state={browserPendingState}
+        onOpenChange={vi.fn()}
+        onStart={vi.fn().mockResolvedValue(undefined)}
+        onComplete={vi.fn().mockResolvedValue(undefined)}
+        onManualCallback={vi.fn().mockResolvedValue(undefined)}
+        onReset={vi.fn()}
+      />,
+    );
+
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    copyButton.focus();
+    expect(copyButton).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith("copy");
+      expect(copyButton).toHaveFocus();
+    });
+  });
+
+  it("shows an error toast when browser-stage copy fails", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard blocked"));
+    const execCommand = vi.fn(() => false);
+
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    render(
+      <OauthDialog
+        open
+        state={browserPendingState}
+        onOpenChange={vi.fn()}
+        onStart={vi.fn().mockResolvedValue(undefined)}
+        onComplete={vi.fn().mockResolvedValue(undefined)}
+        onManualCallback={vi.fn().mockResolvedValue(undefined)}
+        onReset={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => {
+      expect(execCommand).toHaveBeenCalledWith("copy");
+      expect(toastError).toHaveBeenCalledWith("Failed to copy");
+    });
+  });
+
   it("renders intro stage with method selection and starts flow", async () => {
     const user = userEvent.setup();
     const onStart = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/features/accounts/components/oauth-dialog.tsx
+++ b/frontend/src/features/accounts/components/oauth-dialog.tsx
@@ -1,5 +1,6 @@
 import { Check, CircleAlert, Copy, ExternalLink, Loader2, RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { OAuthState } from "@/features/accounts/schemas";
 import { formatCountdown } from "@/utils/formatters";
+import { copyToClipboard } from "@/utils/clipboard";
 
 type Stage = "intro" | "browser" | "device" | "success" | "error";
 
@@ -27,10 +29,29 @@ function getStage(state: OAuthState): Stage {
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
 
-  const handleCopy = useCallback(async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = useCallback(async (event: MouseEvent<HTMLButtonElement>) => {
+    const trigger = event.currentTarget;
+    const dialogContainer = trigger.closest("[role='dialog']");
+    const blurAfterCopy = event.detail > 0;
+
+    try {
+      const copiedToClipboard = await copyToClipboard(text, {
+        container: dialogContainer instanceof HTMLElement ? dialogContainer : undefined,
+      });
+      if (!copiedToClipboard) {
+        toast.error("Failed to copy");
+        return;
+      }
+
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Failed to copy");
+    } finally {
+      if (blurAfterCopy) {
+        trigger.blur();
+      }
+    }
   }, [text]);
 
   return (
@@ -39,7 +60,8 @@ function CopyButton({ text }: { text: string }) {
       size="sm"
       variant="ghost"
       className="h-7 cursor-pointer gap-1 px-2 text-xs disabled:cursor-not-allowed"
-      onClick={() => void handleCopy()}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={(event) => void handleCopy(event)}
     >
       {copied ? (
         <>

--- a/frontend/src/features/accounts/components/opencode-auth-export-dialog.test.tsx
+++ b/frontend/src/features/accounts/components/opencode-auth-export-dialog.test.tsx
@@ -45,6 +45,10 @@ describe("OpenCodeAuthExportDialog", () => {
   it("copies only the official OpenCode auth.json payload", async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
@@ -91,6 +95,10 @@ describe("OpenCodeAuthExportDialog", () => {
   it("shows truncated token previews but copies the full access token", async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },

--- a/frontend/src/features/api-keys/components/api-key-created-dialog.test.tsx
+++ b/frontend/src/features/api-keys/components/api-key-created-dialog.test.tsx
@@ -27,6 +27,10 @@ describe("ApiKeyCreatedDialog", () => {
   it("copies the created API key with the shared copy button", async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RecentRequestsTable } from "@/features/dashboard/components/recent-requests-table";
 
@@ -9,6 +9,8 @@ const { toastSuccess, toastError } = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
 }));
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalIsSecureContext = Object.getOwnPropertyDescriptor(window, "isSecureContext");
 
 vi.mock("sonner", () => ({
   toast: {
@@ -43,10 +45,24 @@ describe("RecentRequestsTable", () => {
     toastError.mockReset();
   });
 
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    }
+
+    if (originalIsSecureContext) {
+      Object.defineProperty(window, "isSecureContext", originalIsSecureContext);
+    }
+  });
+
   it("renders rows with status badges and supports request details and copy actions", async () => {
     const longError = "Rate limit reached while processing this request ".repeat(3);
     const writeText = vi.fn().mockResolvedValue(undefined);
 
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },

--- a/frontend/src/utils/clipboard.test.ts
+++ b/frontend/src/utils/clipboard.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { copyToClipboard } from "@/utils/clipboard";
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalIsSecureContext = Object.getOwnPropertyDescriptor(window, "isSecureContext");
+const originalExecCommand = Object.getOwnPropertyDescriptor(document, "execCommand");
+
+describe("copyToClipboard", () => {
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    }
+
+    if (originalIsSecureContext) {
+      Object.defineProperty(window, "isSecureContext", originalIsSecureContext);
+    }
+
+    if (originalExecCommand) {
+      Object.defineProperty(document, "execCommand", originalExecCommand);
+    }
+
+    vi.restoreAllMocks();
+  });
+
+  it("uses navigator clipboard in secure contexts", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("keeps the execCommand fallback synchronous when clipboard write is blocked", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("clipboard blocked"));
+    const execCommand = vi.fn(() => {
+      expect(document.activeElement?.tagName).toBe("TEXTAREA");
+      return true;
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("falls back to execCommand when Clipboard API is unavailable", async () => {
+    const focusTarget = document.createElement("button");
+    document.body.appendChild(focusTarget);
+    focusTarget.focus();
+
+    const execCommand = vi.fn(() => {
+      expect(document.activeElement?.tagName).toBe("TEXTAREA");
+      return true;
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(focusTarget).toHaveFocus();
+    expect(document.querySelectorAll("textarea")).toHaveLength(0);
+
+    focusTarget.remove();
+  });
+
+  it("returns false when execCommand throws", async () => {
+    const execCommand = vi.fn(() => {
+      throw new Error("copy failed");
+    });
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+  });
+
+  it("uses provided container as fallback target", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const focusTarget = document.createElement("button");
+    container.appendChild(focusTarget);
+    focusTarget.focus();
+
+    const execCommand = vi.fn(() => {
+      const active = document.activeElement as HTMLTextAreaElement | null;
+      expect(active?.tagName).toBe("TEXTAREA");
+      expect(active?.parentElement).toBe(container);
+      return true;
+    });
+
+    Object.defineProperty(window, "isSecureContext", {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await expect(copyToClipboard("hello", { container })).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(focusTarget).toHaveFocus();
+
+    container.remove();
+  });
+});

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,64 @@
+type CopyToClipboardOptions = {
+  container?: HTMLElement | null;
+};
+
+function fallbackCopyToClipboard(
+  text: string,
+  options: CopyToClipboardOptions,
+): boolean {
+  if (typeof document.execCommand !== "function") {
+    return false;
+  }
+
+  const container = options.container ?? document.body;
+  if (!container) {
+    return false;
+  }
+
+  const previousActiveElement =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.setAttribute("aria-hidden", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "-9999px";
+  textarea.style.opacity = "0";
+
+  container.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    if (textarea.parentNode === container) {
+      container.removeChild(textarea);
+    }
+    if (previousActiveElement?.isConnected) {
+      previousActiveElement.focus();
+    }
+  }
+}
+
+export async function copyToClipboard(
+  text: string,
+  options: CopyToClipboardOptions = {},
+): Promise<boolean> {
+  const clipboardWritePromise =
+    window.isSecureContext && typeof navigator.clipboard?.writeText === "function"
+      ? navigator.clipboard.writeText(text).then(() => true).catch(() => false)
+      : null;
+
+  if (fallbackCopyToClipboard(text, options)) {
+    if (clipboardWritePromise) {
+      void clipboardWritePromise;
+    }
+    return true;
+  }
+
+  return clipboardWritePromise ?? false;
+}

--- a/openspec/changes/add-clipboard-fallback/design.md
+++ b/openspec/changes/add-clipboard-fallback/design.md
@@ -1,0 +1,52 @@
+## Context
+
+Clipboard interactions are used from multiple UI flows, including OAuth authorization URL copy and API key post-create copy. Existing copy behavior relied on `navigator.clipboard.writeText`, which can fail in non-secure contexts and within dialog focus management. The current implementation work introduces a shared utility plus dialog-aware fallback handling and associated component wiring.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make copy actions reliable in both secure and non-secure browser contexts.
+- Ensure fallback copy works inside dialog focus scopes used by the UI library.
+- Keep copy behavior centralized in a shared utility to avoid duplicated browser-compat logic.
+- Add regression tests that cover secure, fallback, and dialog-scoped fallback paths.
+
+**Non-Goals:**
+- Redesign dialog visual behavior or keyboard-focus policy beyond copy-trigger handling.
+- Replace `document.execCommand("copy")` with a new polyfill package.
+- Change backend APIs or OAuth/API-key payload contracts.
+
+## Decisions
+
+- **Decision: Introduce a shared clipboard utility with optional container.**
+  - **Why:** A shared utility keeps browser branching in one place and avoids fragmented fallback logic.
+  - **Alternative considered:** Per-component inline fallback logic. Rejected due to duplication and inconsistent behavior risk.
+
+- **Decision: Accept a caller-provided fallback container.**
+  - **Why:** Dialogs use focus scopes; mounting fallback textarea under `document.body` can fail to focus in those scopes.
+  - **Alternative considered:** Utility auto-discovery via hardcoded selectors. Rejected as brittle and framework-coupled.
+
+- **Decision: Pass dialog container from copy-trigger context.**
+  - **Why:** The triggering button already has stable locality (`closest("[role='dialog']")`), enabling explicit and testable behavior.
+  - **Alternative considered:** Global activeElement heuristics inside utility. Rejected due to implicit coupling and reduced clarity.
+
+- **Decision: Add pointer-focus safeguards on copy buttons.**
+  - **Why:** Prevent sticky focus states on copy triggers after pointer interactions in dialog-heavy flows.
+  - **Alternative considered:** Blur-only after async copy completion. Rejected as insufficient in some focus-managed contexts.
+
+## Risks / Trade-offs
+
+- **[Risk] Container detection at call sites can drift across components** -> **Mitigation:** Keep shared `CopyButton` responsible for dialog container forwarding and cover with tests.
+- **[Risk] `execCommand("copy")` remains legacy behavior** -> **Mitigation:** Keep it as the compatibility path while still invoking modern Clipboard API when available.
+- **[Risk] Pointer-specific focus handling could affect accessibility expectations** -> **Mitigation:** Limit behavior to pointer event path and keep keyboard-triggered copy semantics intact.
+
+## Migration Plan
+
+1. Add `copyToClipboard` utility with secure-path and fallback-path support plus optional container parameter.
+2. Update shared `CopyButton` and OAuth dialog copy action to pass dialog container context.
+3. Add/expand tests for utility fallback and dialog container behavior.
+4. Run targeted frontend tests and typecheck.
+5. No data migration or backend rollout steps required.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/add-clipboard-fallback/proposal.md
+++ b/openspec/changes/add-clipboard-fallback/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Clipboard copy currently depends on `navigator.clipboard.writeText`, which can fail in non-secure contexts and inside focus-trapped dialogs. This causes copy actions to fail in real flows even when the UI shows copy controls.
+
+## What Changes
+
+- Add a shared clipboard utility fallback that uses `document.execCommand("copy")` when the Clipboard API is unavailable.
+- Allow callers to provide a container element so fallback copy works inside dialog focus scopes.
+- Update shared and OAuth copy buttons to pass dialog container context when present.
+- Ensure pointer clicks on copy buttons do not leave the copy trigger focused after copy attempts.
+- Add regression tests for secure copy, fallback copy, dialog-scoped fallback, and copy-button dialog behavior.
+
+## Capabilities
+
+### New Capabilities
+- `clipboard-copy-fallback`: Shared frontend clipboard behavior for secure and non-secure contexts, including dialog-scoped fallback copy.
+
+### Modified Capabilities
+- `frontend-architecture`: OAuth dialog copy action requirements now include resilient clipboard fallback behavior.
+- `api-keys`: API key created dialog copy button requirements now include resilient clipboard fallback behavior.
+
+## Impact
+
+- Affected code: `frontend/src/utils/clipboard.ts`, shared copy button components, OAuth dialog copy button wiring.
+- Affected tests: clipboard utility tests and copy-button dialog interaction tests.
+- No backend API or schema changes.

--- a/openspec/changes/add-clipboard-fallback/specs/api-keys/spec.md
+++ b/openspec/changes/add-clipboard-fallback/specs/api-keys/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Frontend API Key management
+
+The SPA settings page SHALL include an API Key management section with: a toggle for `apiKeyAuthEnabled`, a key list table showing prefix/name/models/limit/usage/expiry/status, a create dialog (name, model selection, assigned-account selection, weekly limit, expiry date), and key actions (edit, delete, regenerate). On key creation, the SPA MUST display the plain key in a copy-able dialog with a warning that it will not be shown again, and the copy action MUST remain functional in secure and non-secure contexts.
+
+#### Scenario: Create key with optional account scoping
+
+- **WHEN** an admin opens the create API key dialog
+- **THEN** the dialog shows the Assigned accounts picker
+- **AND** leaving the picker at `All accounts` creates an unscoped key
+- **AND** selecting one or more accounts creates a scoped key for only those accounts
+
+#### Scenario: Create key and show plain key
+
+- **WHEN** admin creates a key via the UI
+- **THEN** a dialog shows the full plain key with a copy button and a warning message
+
+#### Scenario: API key dialog copy fallback
+
+- **WHEN** a user clicks Copy for the created API key inside the dialog
+- **THEN** the copy operation succeeds using secure Clipboard API when available
+- **AND** falls back to dialog-scoped `execCommand("copy")` when secure Clipboard API is unavailable

--- a/openspec/changes/add-clipboard-fallback/specs/clipboard-copy-fallback/spec.md
+++ b/openspec/changes/add-clipboard-fallback/specs/clipboard-copy-fallback/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Clipboard copy utility supports secure and fallback paths
+The frontend clipboard utility SHALL use `navigator.clipboard.writeText` when available in secure contexts and SHALL fall back to `document.execCommand("copy")` when the Clipboard API is unavailable or blocked.
+
+#### Scenario: Secure context uses Clipboard API
+- **WHEN** copy is requested in a secure context with `navigator.clipboard.writeText` available
+- **THEN** the utility writes text using `navigator.clipboard.writeText`
+
+#### Scenario: Blocked secure-context copy keeps a synchronous fallback path
+- **WHEN** copy is requested in a secure context and `navigator.clipboard.writeText` later rejects
+- **THEN** the utility still attempts `document.execCommand("copy")` within the same user interaction
+
+#### Scenario: Non-secure context uses execCommand fallback
+- **WHEN** copy is requested and `navigator.clipboard.writeText` is unavailable or rejected
+- **THEN** the utility uses a hidden textarea and `document.execCommand("copy")`
+
+### Requirement: Fallback copy supports explicit container scoping
+The fallback clipboard path SHALL accept an optional DOM container and SHALL mount the temporary textarea under that container so copy remains functional inside focus-managed regions such as dialogs.
+
+#### Scenario: Dialog-scoped fallback mounts textarea inside dialog
+- **WHEN** copy is requested with a dialog container
+- **THEN** the fallback textarea is appended inside that dialog container before `execCommand("copy")` runs
+
+#### Scenario: Fallback container cleanup always runs
+- **WHEN** fallback copy completes or throws
+- **THEN** the temporary textarea is removed from the provided container

--- a/openspec/changes/add-clipboard-fallback/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-clipboard-fallback/specs/frontend-architecture/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Accounts page
+
+The Accounts page SHALL display a two-column layout: left panel with searchable account list, import button, and add account button; right panel with selected account details including usage, token info, and actions (pause/resume/delete/re-authenticate). The browser OAuth stage SHALL show an authorization URL with a copy action that remains functional in secure and non-secure contexts.
+
+#### Scenario: Account selection
+
+- **WHEN** a user clicks an account in the list
+- **THEN** the right panel shows the selected account's details
+
+#### Scenario: Account import
+
+- **WHEN** a user clicks the import button and uploads an auth.json file
+- **THEN** the app calls `POST /api/accounts/import` and refreshes the account list on success
+
+#### Scenario: OAuth add account
+
+- **WHEN** a user clicks the add account button
+- **THEN** an OAuth dialog opens with browser and device code flow options
+
+#### Scenario: OAuth browser authorization URL copy fallback
+
+- **WHEN** a user clicks Copy for the browser authorization URL inside the OAuth dialog
+- **THEN** the copy operation succeeds using secure Clipboard API when available
+- **AND** falls back to dialog-scoped `execCommand("copy")` when secure Clipboard API is unavailable or blocked
+
+#### Scenario: OAuth browser authorization URL copy failure feedback
+
+- **WHEN** both clipboard copy paths fail for the browser authorization URL inside the OAuth dialog
+- **THEN** the dialog surfaces a visible copy failure message
+
+#### Scenario: Device OAuth start begins polling
+
+- **WHEN** the app starts Device Code OAuth with `POST /api/oauth/start`
+- **AND** the response includes a `deviceAuthId` and `userCode`
+- **THEN** the backend starts polling for the device token without requiring a separate `/api/oauth/complete` call
+- **AND** a later `/api/oauth/complete` call remains safe and does not start a duplicate polling task
+
+#### Scenario: Account actions
+
+- **WHEN** a user clicks pause/resume/delete on an account
+- **THEN** the corresponding API is called and the account list is refreshed

--- a/openspec/changes/add-clipboard-fallback/tasks.md
+++ b/openspec/changes/add-clipboard-fallback/tasks.md
@@ -1,0 +1,16 @@
+## 1. Clipboard utility fallback behavior
+
+- [x] 1.1 Add a shared `copyToClipboard` utility that prefers secure Clipboard API and falls back to `execCommand("copy")`.
+- [x] 1.2 Add optional container support for fallback textarea mounting and guaranteed cleanup.
+
+## 2. Dialog-aware copy integration
+
+- [x] 2.1 Update shared `CopyButton` to pass dialog container context into `copyToClipboard` when used inside dialogs.
+- [x] 2.2 Update OAuth dialog authorization URL copy button to pass dialog container context into `copyToClipboard`.
+- [x] 2.3 Ensure pointer-triggered copy interactions do not leave copy buttons focused.
+
+## 3. Regression coverage and verification
+
+- [x] 3.1 Add clipboard utility tests for secure copy, fallback copy, and container-scoped fallback behavior.
+- [x] 3.2 Add component tests that assert fallback copy works in dialog-hosted copy buttons, including API key created dialog and OAuth dialog paths.
+- [x] 3.3 Run targeted clipboard/copy frontend tests and TypeScript typecheck.


### PR DESCRIPTION
## Summary

Clipboard copy now works reliably in non-secure browser contexts and inside dialog focus scopes. Adds a shared `copyToClipboard` utility that falls back to `document.execCommand("copy")` when the Clipboard API is unavailable or blocked, and integrates dialog-aware fallback into copy buttons across OAuth authorization URL and API key dialogs.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Fixes #842.

Note: HTTPS offloading remains the preferred long-term deployment fix for non-localhost LAN access; this fallback keeps copy actions usable when the Clipboard API is unavailable or blocked.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/add-clipboard-fallback/`

## Changes

- Add `frontend/src/utils/clipboard.ts` — shared `copyToClipboard` utility with secure Clipboard API path and `execCommand("copy")` fallback with optional container scoping.
- Add `frontend/src/utils/clipboard.test.ts` — unit tests for secure copy, fallback copy, blocked-context fallback, container-scoped fallback, and cleanup.
- Update `frontend/src/components/copy-button.tsx` — wire `copyToClipboard`, forward dialog container context, add `onMouseDown` focus management for pointer-triggered copy.
- Update `frontend/src/features/accounts/components/oauth-dialog.tsx` — wire `copyToClipboard` with dialog container, add pointer/keyboard focus handling, add error toast on copy failure.
- Update `frontend/src/components/copy-button.test.tsx` — add tests for focus retention after keyboard copy, fallback copy inside dialogs.
- Update `oauth-dialog.test.tsx` — add tests for keyboard focus retention, pointer blur, fallback copy inside dialog, error toast on copy failure.
- Update `opencode-auth-export-dialog.test.tsx` and `api-key-created-dialog.test.tsx` — set `isSecureContext: true` to match new utility behavior.
- Add OpenSpec change artifacts: `proposal.md`, `design.md`, `tasks.md`, and delta specs.

## Test plan

```
uv run npx vitest run frontend/src/utils/clipboard.test.ts
uv run npx vitest run frontend/src/components/copy-button.test.tsx
uv run npx vitest run frontend/src/features/accounts/components/oauth-dialog.test.tsx
uv run npx tsc --noEmit -p frontend/tsconfig.json
```

## Afterwords

This is just a workaround for the non-secure context (e.g. http://192.168.1.100, which is not https, not localhost). HTTPs installation is always preferred to make the Clipboard API working as intended, even in a LAN installation.

The `commandExec` is in fact deprecated for several years, which may subject removal. This quick patch should not act as a long-term solution, HTTPs via reverse proxy *is* the permanent solution and you should not rely it as a long-term solution. or just leave everything local.