### PR TITLE
feat(auth): support x-api-key for proxy API key auth

### DIFF
--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -7,6 +7,7 @@ from typing import cast
 
 from fastapi import Request, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from starlette.datastructures import Headers
 from starlette.requests import HTTPConnection
 
 from app.core.auth.api_key_cache import get_api_key_cache
@@ -47,12 +48,17 @@ async def validate_proxy_api_key(
     credentials: HTTPAuthorizationCredentials | None = Security(_bearer),
 ) -> ApiKeyData | None:
     authorization = None if credentials is None else f"Bearer {credentials.credentials}"
-    return await validate_proxy_api_key_authorization(authorization, request=request)
+    return await validate_proxy_api_key_headers(
+        authorization,
+        x_api_key=request.headers.get("x-api-key"),
+        request=request,
+    )
 
 
-async def validate_proxy_api_key_authorization(
+async def validate_proxy_api_key_headers(
     authorization: str | None,
     *,
+    x_api_key: str | None = None,
     request: HTTPConnection | None = None,
 ) -> ApiKeyData | None:
     settings = await get_settings_cache().get()
@@ -62,11 +68,20 @@ async def validate_proxy_api_key_authorization(
                 raise ProxyAuthError("Proxy authentication must be configured before remote access is allowed")
         return None
 
-    token = _extract_bearer_token(authorization)
-    if not token:
-        raise ProxyAuthError("Missing API key in Authorization header")
+    return await _validate_proxy_api_key_value(authorization, x_api_key=x_api_key)
 
-    return await _validate_api_key_token(token)
+
+async def validate_proxy_api_key_authorization(
+    authorization: str | None,
+    *,
+    request: HTTPConnection | None = None,
+) -> ApiKeyData | None:
+    headers = request.headers if request is not None else Headers()
+    return await validate_proxy_api_key_headers(
+        authorization,
+        x_api_key=headers.get("x-api-key"),
+        request=request,
+    )
 
 
 async def _validate_api_key_token(token: str) -> ApiKeyData:
@@ -102,14 +117,11 @@ async def validate_usage_api_key(
     """Validate API key for self-service usage endpoint.
 
     Unlike ``validate_proxy_api_key``, this dependency always requires a valid
-    Bearer API key, regardless of the global ``api_key_auth_enabled`` setting.
+    API key regardless of the global ``api_key_auth_enabled`` setting.
     Raises ProxyAuthError when the key is missing or invalid.
     """
-    token = _extract_bearer_token(None if credentials is None else f"Bearer {credentials.credentials}")
-    if not token:
-        raise ProxyAuthError("Missing API key in Authorization header")
-
-    return await _validate_api_key_token(token)
+    authorization = None if credentials is None else f"Bearer {credentials.credentials}"
+    return await _validate_proxy_api_key_value(authorization, x_api_key=request.headers.get("x-api-key"))
 
 
 # --- Dashboard session auth ---
@@ -203,6 +215,28 @@ async def validate_codex_usage_identity(request: Request) -> ApiKeyData | None:
     return None
 
 
+async def _validate_proxy_api_key_value(
+    authorization: str | None,
+    *,
+    x_api_key: str | None = None,
+) -> ApiKeyData:
+    token = _extract_bearer_token(authorization)
+    if token:
+        try:
+            return await _validate_api_key_token(token)
+        except ProxyAuthError as exc:
+            fallback_token = _extract_x_api_key_token(x_api_key)
+            if fallback_token is None:
+                raise exc
+            return await _validate_api_key_token(fallback_token)
+
+    fallback_token = _extract_x_api_key_token(x_api_key)
+    if fallback_token:
+        return await _validate_api_key_token(fallback_token)
+
+    raise ProxyAuthError("Missing API key in Authorization header or x-api-key header")
+
+
 def _extract_bearer_token(authorization: str | None) -> str | None:
     if authorization is None:
         return None
@@ -211,6 +245,15 @@ def _extract_bearer_token(authorization: str | None) -> str | None:
     if not value.lower().startswith(prefix):
         return None
     token = value[len(prefix) :].strip()
+    if not token:
+        return None
+    return token
+
+
+def _extract_x_api_key_token(value: str | None) -> str | None:
+    if value is None:
+        return None
+    token = value.strip()
     if not token:
         return None
     return token

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -67,6 +67,7 @@ from app.core.utils.sse import format_sse_event
 
 IGNORE_INBOUND_HEADERS = {
     "authorization",
+    "x-api-key",
     "chatgpt-account-id",
     "content-length",
     "host",

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -598,6 +598,7 @@ class ProxyService:
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream_http", payload, headers)
         proxy_api_authorization = _header_value_case_insensitive(headers, "authorization")
+        proxy_api_x_api_key = _header_value_case_insensitive(headers, "x-api-key")
         filtered = filter_inbound_headers(headers)
         return self._stream_http_bridge_or_retry(
             payload,
@@ -611,6 +612,7 @@ class ProxyService:
             downstream_turn_state=downstream_turn_state,
             forwarded_request=forwarded_request,
             proxy_api_authorization=proxy_api_authorization,
+            proxy_api_x_api_key=proxy_api_x_api_key,
             forwarded_affinity_kind=forwarded_affinity_kind,
             forwarded_affinity_key=forwarded_affinity_key,
         )
@@ -629,6 +631,7 @@ class ProxyService:
         downstream_turn_state: str | None = None,
         forwarded_request: bool = False,
         proxy_api_authorization: str | None = None,
+        proxy_api_x_api_key: str | None = None,
         forwarded_affinity_kind: str | None = None,
         forwarded_affinity_key: str | None = None,
     ) -> AsyncIterator[str]:
@@ -682,6 +685,7 @@ class ProxyService:
             downstream_turn_state=downstream_turn_state,
             forwarded_request=forwarded_request,
             proxy_api_authorization=proxy_api_authorization,
+            proxy_api_x_api_key=proxy_api_x_api_key,
             forwarded_affinity_kind=forwarded_affinity_kind,
             forwarded_affinity_key=forwarded_affinity_key,
             rewritten_file_account_id=rewritten_file_account_id,
@@ -707,6 +711,7 @@ class ProxyService:
         downstream_turn_state: str | None = None,
         forwarded_request: bool = False,
         proxy_api_authorization: str | None = None,
+        proxy_api_x_api_key: str | None = None,
         forwarded_affinity_kind: str | None = None,
         forwarded_affinity_key: str | None = None,
         rewritten_file_account_id: str | None = None,
@@ -1023,6 +1028,7 @@ class ProxyService:
                     downstream_turn_state=downstream_turn_state,
                     request_started_at=request_state.started_at,
                     proxy_api_authorization=proxy_api_authorization,
+                    proxy_api_x_api_key=proxy_api_x_api_key,
                 ):
                     forwarded_any = True
                     yield line
@@ -1778,6 +1784,7 @@ class ProxyService:
         downstream_turn_state: str | None,
         request_started_at: float,
         proxy_api_authorization: str | None,
+        proxy_api_x_api_key: str | None = None,
     ) -> AsyncIterator[str]:
         current_instance, _ = _normalized_http_bridge_instance_ring(get_settings())
         forwarded_turn_state = _header_value_case_insensitive(headers, "x-codex-turn-state") or downstream_turn_state
@@ -1791,6 +1798,8 @@ class ProxyService:
             original_affinity_key=owner_forward.key.affinity_key,
         )
         forward_headers = _headers_with_authorization(headers, proxy_api_authorization)
+        if proxy_api_x_api_key is not None and _header_value_case_insensitive(forward_headers, "x-api-key") is None:
+            forward_headers["x-api-key"] = proxy_api_x_api_key
         start = time.monotonic()
         _log_http_bridge_event(
             "owner_forward_start",

--- a/openspec/changes/support-x-api-key-auth/proposal.md
+++ b/openspec/changes/support-x-api-key-auth/proposal.md
@@ -1,0 +1,18 @@
+# Support x-api-key Authentication
+
+## Why
+
+Some OpenAI-compatible clients and reverse proxies send API keys through `x-api-key` instead of `Authorization: Bearer ...`. `codex-lb` currently accepts only Bearer tokens for its API-key-authenticated proxy surfaces, which forces those clients to be reconfigured even though the same key material is available in a standard header.
+
+## What Changes
+
+- Accept `x-api-key: sk-clb-...` anywhere codex-lb currently accepts its own Bearer API key.
+- Keep existing Bearer behavior unchanged.
+- When both `Authorization` and `x-api-key` are present, prefer `Authorization` first and fall back to `x-api-key` only if the Authorization value is missing, malformed, or invalid.
+- Keep ChatGPT caller-identity flows Bearer-only; `x-api-key` applies only to codex-lb API key authentication.
+
+## Impact
+
+- **Code**: `app/core/auth/dependencies.py`, proxy auth call sites, and focused auth tests.
+- **Behavior**: proxy/API-key clients may authenticate with either `Authorization: Bearer ...` or `x-api-key: ...`.
+- **Non-goals**: no dashboard auth changes, no custom support for `api-key`/`openai-api-key`, and no change to upstream ChatGPT token validation semantics.

--- a/openspec/changes/support-x-api-key-auth/specs/api-keys/spec.md
+++ b/openspec/changes/support-x-api-key-auth/specs/api-keys/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: API Key authentication global switch
+The system SHALL provide an `api_key_auth_enabled` boolean in `DashboardSettings`. When false (default), local requests to protected proxy routes MAY proceed without an API key. Operators MAY additionally opt specific non-local proxy clients into unauthenticated access by configuring `proxy_unauthenticated_client_cidrs`. Requests that are neither local nor explicitly allowlisted MUST be rejected until proxy authentication is configured. When true, protected proxy routes require a valid codex-lb API key in either the `Authorization` header using the Bearer authentication scheme or the `x-api-key` header.
+
+#### Scenario: Enable API key auth
+
+- **WHEN** admin submits `PUT /api/settings` with `{ "apiKeyAuthEnabled": true }`
+- **THEN** subsequent proxy requests without a valid Bearer token or `x-api-key` are rejected with 401
+
+### Requirement: API Key Bearer authentication guard
+The system SHALL validate API keys on protected proxy routes (`/v1/*`, `/backend-api/codex/*`, `/backend-api/transcribe`) when `api_key_auth_enabled` is true. Validation MUST be implemented as a router-level `Security` dependency, not ASGI middleware. The dependency MUST compute `sha256` of the supplied codex-lb API key and look up the hash in the `api_keys` table.
+
+The dependency SHALL accept a valid codex-lb API key from either `Authorization: Bearer <key>` or `x-api-key: <key>`. When both are present, the dependency SHALL try the Authorization value first and SHALL fall back to `x-api-key` only when the Authorization value is missing, malformed, or invalid. This fallback applies only to codex-lb API key authentication; ChatGPT caller-identity validation remains Bearer-only.
+
+The dependency SHALL return a typed `ApiKeyData` value directly to the route handler. Route handlers MUST NOT access API key data via `request.state`.
+
+`/api/codex/usage` SHALL NOT be covered by the API key auth guard scope.
+
+The dependency SHALL raise a domain exception on validation failure. The exception handler SHALL format the response using the OpenAI error envelope.
+
+#### Scenario: Valid x-api-key is injected into handler
+
+- **WHEN** `api_key_auth_enabled` is true and a valid `x-api-key` header is provided
+- **THEN** the route handler receives a typed `ApiKeyData` parameter
+
+#### Scenario: Invalid Authorization falls back to valid x-api-key
+
+- **WHEN** `api_key_auth_enabled` is true
+- **AND** `Authorization` is missing, malformed, or contains an invalid API key
+- **AND** `x-api-key` contains a valid codex-lb API key
+- **THEN** the dependency authenticates the request with `x-api-key`
+
+### Requirement: Self-service API key usage lookup accepts x-api-key
+The system SHALL expose `GET /v1/usage` for self-service usage lookup by API-key clients. The route MUST require a valid API key in either `Authorization: Bearer sk-clb-...` or `x-api-key: sk-clb-...` even when `api_key_auth_enabled` is false globally.
+
+#### Scenario: Self-service usage lookup accepts x-api-key
+
+- **WHEN** `api_key_auth_enabled` is false and a client calls `GET /v1/usage` with a valid `x-api-key`
+- **THEN** the route returns usage for that authenticated key

--- a/openspec/changes/support-x-api-key-auth/tasks.md
+++ b/openspec/changes/support-x-api-key-auth/tasks.md
@@ -1,0 +1,15 @@
+## 1. Spec
+
+- [x] 1.1 Update the API-key auth spec to allow `x-api-key` alongside Bearer for codex-lb API key authentication.
+- [x] 1.2 Preserve Bearer-only semantics for ChatGPT caller-identity validation paths.
+
+## 2. Implementation
+
+- [x] 2.1 Add a lean shared extractor for Bearer-or-`x-api-key` proxy API key resolution.
+- [x] 2.2 Apply it to HTTP proxy auth, websocket proxy auth, and self-service API-key usage lookup.
+- [x] 2.3 Keep Authorization-first behavior with `x-api-key` fallback only when Authorization is absent, malformed, or invalid.
+
+## 3. Verification
+
+- [x] 3.1 Add focused regression coverage for `x-api-key` success and precedence/fallback behavior.
+- [x] 3.2 Run focused pytest coverage for auth and usage endpoints.

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -483,6 +483,15 @@ async def test_api_key_branch_disabled_then_enabled(async_client):
     valid = await async_client.get("/v1/models", headers={"Authorization": f"Bearer {created.key}"})
     assert valid.status_code == 200
 
+    valid_x_api_key = await async_client.get("/v1/models", headers={"x-api-key": created.key})
+    assert valid_x_api_key.status_code == 200
+
+    fallback_x_api_key = await async_client.get(
+        "/v1/models",
+        headers={"Authorization": "Bearer invalid-key", "x-api-key": created.key},
+    )
+    assert fallback_x_api_key.status_code == 200
+
     async with SessionLocal() as session:
         repo = ApiKeysRepository(session)
         row = await repo.get_by_id(created.id)
@@ -518,6 +527,14 @@ async def test_api_key_branch_disabled_then_enabled(async_client):
     over_limit = await async_client.get("/v1/models", headers={"Authorization": f"Bearer {created.key}"})
     assert over_limit.status_code == 429
     assert over_limit.json()["error"]["code"] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_x_api_key_does_not_replace_bearer_only_codex_usage_identity(async_client):
+    blocked = await async_client.get("/api/codex/usage", headers={"x-api-key": "sk-clb-test"})
+
+    assert blocked.status_code == 401
+    assert blocked.json()["error"]["code"] == "invalid_api_key"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_v1_usage.py
+++ b/tests/integration/test_v1_usage.py
@@ -263,7 +263,7 @@ async def _seed_upstream_usage_with_statuses(*, now) -> None:
 @pytest.mark.parametrize(
     ("headers", "expected_message"),
     [
-        ({}, "Missing API key in Authorization header"),
+        ({}, "Missing API key in Authorization header or x-api-key header"),
         ({"Authorization": "Bearer invalid-key"}, "Invalid API key"),
     ],
 )
@@ -281,6 +281,23 @@ async def test_v1_usage_returns_zero_usage_for_key_without_logs(async_client):
     _, plain_key = await _create_api_key(name="zero-usage")
 
     response = await async_client.get("/v1/usage", headers={"Authorization": f"Bearer {plain_key}"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "request_count": 0,
+        "total_tokens": 0,
+        "cached_input_tokens": 0,
+        "total_cost_usd": 0.0,
+        "limits": [],
+        "upstream_limits": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_v1_usage_accepts_x_api_key(async_client):
+    _, plain_key = await _create_api_key(name="x-api-key-usage")
+
+    response = await async_client.get("/v1/usage", headers={"x-api-key": plain_key})
 
     assert response.status_code == 200
     assert response.json() == {

--- a/tests/unit/test_hot_path_caches.py
+++ b/tests/unit/test_hot_path_caches.py
@@ -79,6 +79,10 @@ async def test_api_key_validation_uses_cache_for_repeated_key(monkeypatch: pytes
         resolved = await auth_dependencies.validate_proxy_api_key_authorization(f"Bearer {token}")
         assert resolved == api_key_data
 
+    for _ in range(10):
+        resolved = await auth_dependencies.validate_proxy_api_key_headers(None, x_api_key=token)
+        assert resolved == api_key_data
+
     assert calls == 1
     cache = get_api_key_cache()
     assert expected_hash in cache._cache

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -319,6 +319,63 @@ async def test_validate_internal_bridge_api_key_preserves_local_request_exemptio
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("headers", "expected_authorization"),
+    [
+        ([(b"x-api-key", b"valid-owner-forward-key")], None),
+        (
+            [(b"authorization", b"Bearer invalid-key"), (b"x-api-key", b"valid-owner-forward-key")],
+            "Bearer invalid-key",
+        ),
+    ],
+)
+async def test_validate_internal_bridge_api_key_allows_owner_forward_x_api_key(
+    monkeypatch,
+    headers: list[tuple[bytes, bytes]],
+    expected_authorization: str | None,
+) -> None:
+    async def fake_settings():
+        return SimpleNamespace(api_key_auth_enabled=True)
+
+    api_key = ApiKeyData(
+        id="key_owner_forward",
+        name="Owner Forward",
+        key_prefix="sk-owner",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=datetime(2026, 3, 10),
+        last_used_at=None,
+    )
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/internal/bridge/responses",
+            "headers": headers,
+            "client": ("10.0.0.12", 12345),
+        }
+    )
+
+    async def pass_auth(authorization: str | None, *, request: Request | None = None):
+        assert authorization == expected_authorization
+        assert request is not None
+        assert request.headers["x-api-key"] == "valid-owner-forward-key"
+        return api_key
+
+    monkeypatch.setattr(proxy_api_module, "get_settings_cache", lambda: SimpleNamespace(get=fake_settings))
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", pass_auth)
+
+    resolved_api_key, response = await proxy_api_module._validate_internal_bridge_api_key(request)
+
+    assert response is None
+    assert resolved_api_key == api_key
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_prefers_forwarded_downstream_turn_state(monkeypatch):
     request = Request(
         {

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -53,7 +53,7 @@ async def test_validate_proxy_websocket_request_maps_auth_error(monkeypatch):
         return None
 
     async def fail_auth(_authorization, *, request: object | None = None):
-        raise ProxyAuthError("Missing API key in Authorization header")
+        raise ProxyAuthError("Missing API key in Authorization header or x-api-key header")
 
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
     monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", fail_auth)
@@ -67,7 +67,7 @@ async def test_validate_proxy_websocket_request_maps_auth_error(monkeypatch):
     assert response.status_code == 401
     payload = json.loads(cast(bytes, response.body).decode("utf-8"))
     assert payload["error"]["code"] == "invalid_api_key"
-    assert payload["error"]["message"] == "Missing API key in Authorization header"
+    assert payload["error"]["message"] == "Missing API key in Authorization header or x-api-key header"
 
 
 @pytest.mark.asyncio
@@ -91,6 +91,7 @@ async def test_validate_proxy_websocket_request_returns_validated_api_key(monkey
 
     async def pass_auth(authorization: str | None, *, request: object | None = None):
         assert authorization == "Bearer valid-key"
+        assert request is not None
         return api_key
 
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
@@ -98,6 +99,41 @@ async def test_validate_proxy_websocket_request_returns_validated_api_key(monkey
 
     resolved_api_key, response = await proxy_api_module._validate_proxy_websocket_request(
         cast(WebSocket, SimpleNamespace(headers={"authorization": "Bearer valid-key"})),
+    )
+
+    assert response is None
+    assert resolved_api_key == api_key
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_websocket_request_accepts_x_api_key(monkeypatch):
+    async def fake_denial(_websocket):
+        return None
+
+    api_key = ApiKeyData(
+        id="key_x_header",
+        name="Header Key",
+        key_prefix="sk-header",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=datetime(2026, 3, 10),
+        last_used_at=None,
+    )
+
+    async def pass_auth(authorization: str | None, *, request: object | None = None):
+        assert authorization is None
+        assert request is not None
+        return api_key
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", pass_auth)
+
+    resolved_api_key, response = await proxy_api_module._validate_proxy_websocket_request(
+        cast(WebSocket, SimpleNamespace(headers={"x-api-key": "valid-key"})),
     )
 
     assert response is None

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -3186,6 +3186,98 @@ async def test_forward_http_bridge_request_to_owner_preserves_session_header_key
 
 
 @pytest.mark.asyncio
+async def test_forward_http_bridge_request_to_owner_preserves_x_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_forward = proxy_service._HTTPBridgeOwnerForward(
+        owner_instance="instance-b",
+        owner_endpoint="http://instance-b",
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    captured: dict[str, object] = {}
+
+    async def fake_stream_responses(**kwargs: object):
+        captured.update(kwargs)
+        if False:
+            yield ""
+        return
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        service,
+        "_http_bridge_owner_client",
+        cast(Any, SimpleNamespace(stream_responses=fake_stream_responses)),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._forward_http_bridge_request_to_owner(
+            owner_forward=owner_forward,
+            payload=payload,
+            headers={"x-codex-session-id": "sid-123"},
+            api_key_reservation=None,
+            codex_session_affinity=True,
+            downstream_turn_state="http_turn_generated",
+            request_started_at=10.0,
+            proxy_api_authorization=None,
+            proxy_api_x_api_key="valid-owner-forward-key",
+        )
+    ]
+
+    assert chunks == []
+    assert cast(dict[str, str], captured["headers"])["x-api-key"] == "valid-owner-forward-key"
+
+
+@pytest.mark.asyncio
+async def test_forward_http_bridge_request_to_owner_forwards_x_api_key_with_invalid_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_forward = proxy_service._HTTPBridgeOwnerForward(
+        owner_instance="instance-b",
+        owner_endpoint="http://instance-b",
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-123", None),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": "hi"})
+    captured: dict[str, object] = {}
+
+    async def fake_stream_responses(**kwargs: object):
+        captured.update(kwargs)
+        if False:
+            yield ""
+        return
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        service,
+        "_http_bridge_owner_client",
+        cast(Any, SimpleNamespace(stream_responses=fake_stream_responses)),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._forward_http_bridge_request_to_owner(
+            owner_forward=owner_forward,
+            payload=payload,
+            headers={"x-codex-session-id": "sid-123"},
+            api_key_reservation=None,
+            codex_session_affinity=True,
+            downstream_turn_state="http_turn_generated",
+            request_started_at=10.0,
+            proxy_api_authorization="Bearer wrong",
+            proxy_api_x_api_key="owner-forward-key",
+        )
+    ]
+
+    assert chunks == []
+    headers = cast(dict[str, str], captured["headers"])
+    assert headers["x-api-key"] == "owner-forward-key"
+    assert headers["Authorization"] == "Bearer wrong"
+
+
+@pytest.mark.asyncio
 async def test_forward_http_bridge_request_to_owner_raises_proxy_error_on_relay_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -168,6 +168,7 @@ def test_trim_websocket_previous_response_input_items_keeps_non_replay_prefix() 
 def test_filter_inbound_headers_strips_auth_and_account():
     headers = {
         "Authorization": "Bearer x",
+        "x-api-key": "sk-clb-test",
         "chatgpt-account-id": "acc_1",
         "Content-Encoding": "gzip",
         "Content-Type": "application/json",
@@ -175,6 +176,7 @@ def test_filter_inbound_headers_strips_auth_and_account():
     }
     filtered = filter_inbound_headers(headers)
     assert "Authorization" not in filtered
+    assert "x-api-key" not in filtered
     assert "chatgpt-account-id" not in filtered
     assert filtered["Content-Encoding"] == "gzip"
     assert filtered["Content-Type"] == "application/json"


### PR DESCRIPTION
## Summary

Supports `x-api-key` alongside Bearer tokens for proxy-facing API key authentication so compatible clients and reverse proxies can authenticate without header rewrites. Authorization remains the preferred source when both are present, with `x-api-key` used as a fallback only when needed.

## Type of change

- [x] `feat:` — new user-facing feature or capability
- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: 

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/support-x-api-key-auth/`

## Changes

- Accepts `x-api-key` for proxy API key validation and self-service usage lookup.
- Preserves Bearer-first precedence, with fallback to `x-api-key` when Authorization is absent, malformed, or invalid.
- Keeps ChatGPT caller-identity flows Bearer-only and strips inbound `x-api-key` from proxied requests.
- Adds regression coverage for auth precedence, websocket auth, usage lookup, and header filtering.

## Test plan

```
# uv run pytest tests/unit/test_hot_path_caches.py -q
# uv run pytest tests/unit/test_proxy_api_websocket_auth.py -q
# uv run pytest tests/unit/test_proxy_utils.py -q
# uv run pytest tests/integration/test_auth_middleware.py -q
# uv run pytest tests/integration/test_v1_usage.py -q
```

## Screenshots / output (optional)

Example behavior:
- `Authorization: Bearer ` + `x-api-key: ` now authenticates successfully
- `GET /v1/usage` accepts a valid `x-api-key`
- `x-api-key` is ignored for Bearer-only caller identity paths

## Checklist

- [x] Title is in Conventional Commits format (`()?: `).
- [ ] Linked the related issue / discussion above — Pi custom provider (`openai-codex-responses`) needs `x-api-key` support to use codex-lb without header rewrites.
- [x] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make ` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [ ] CHANGELOG is **not** edited by hand (release-please handles it).