### PR TITLE
feat(balancer): bypass QUOTA_EXCEEDED filter for gated models with additional quota

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -194,7 +194,6 @@ def select_account(
     bypass_account_ids = None if bypass_quota_exceeded_account_ids is None else set(bypass_quota_exceeded_account_ids)
 
     for state in all_states:
-        quota_bypass_applied = False
         if state.status == AccountStatus.DEACTIVATED:
             continue
         if state.status == AccountStatus.PAUSED:
@@ -217,7 +216,7 @@ def select_account(
                 # Primary-window quota is exhausted but an additional
                 # independent quota (already verified upstream) is
                 # available — keep the account in the pool.
-                quota_bypass_applied = True
+                pass
             else:
                 continue
         if state.cooldown_until and current >= state.cooldown_until:
@@ -225,8 +224,7 @@ def select_account(
             state.last_error_at = None
             state.error_count = 0
         if state.cooldown_until and current < state.cooldown_until:
-            if not quota_bypass_applied:
-                continue
+            continue
         if state.error_count >= 3:
             backoff = min(300, 30 * (2 ** (state.error_count - 3)))
             if state.last_error_at and current - state.last_error_at < backoff:
@@ -354,6 +352,8 @@ def _priority_primary_used(state: AccountState) -> float:
 
 
 def _priority_secondary_used(state: AccountState, primary_used: float | None = None) -> float:
+    if state.limit_scoped_usage and state.priority_secondary_used_percent is None:
+        return primary_used if primary_used is not None else _priority_primary_used(state)
     value = (
         state.priority_secondary_used_percent
         if state.priority_secondary_used_percent is not None

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -192,6 +192,7 @@ def select_account(
     in_error_backoff: list[AccountState] = []
     all_states = list(states)
     bypass_account_ids = None if bypass_quota_exceeded_account_ids is None else set(bypass_quota_exceeded_account_ids)
+    bypassed_quota_account_ids: set[str] = set()
 
     for state in all_states:
         if state.status == AccountStatus.DEACTIVATED:
@@ -216,6 +217,7 @@ def select_account(
                 # Primary-window quota is exhausted but an additional
                 # independent quota (already verified upstream) is
                 # available — keep the account in the pool.
+                bypassed_quota_account_ids.add(state.account_id)
                 pass
             else:
                 continue
@@ -249,6 +251,7 @@ def select_account(
                 AccountStatus.RATE_LIMITED,
                 AccountStatus.QUOTA_EXCEEDED,
             )
+            and not (state.status == AccountStatus.QUOTA_EXCEEDED and state.account_id in bypassed_quota_account_ids)
             for state in all_states
         )
         if allow_backoff_fallback and (len(in_error_backoff) > 1 or (in_error_backoff and hard_blocked_exists)):

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -83,6 +83,11 @@ class AccountState:
     plan_type: str | None = None
     capacity_credits: float | None = None
     health_tier: int = 0
+    priority_used_percent: float | None = None
+    priority_secondary_used_percent: float | None = None
+    priority_reset_at: int | None = None
+    priority_capacity_credits: float | None = None
+    limit_scoped_usage: bool = False
 
 
 @dataclass
@@ -92,23 +97,24 @@ class SelectionResult:
 
 
 def _usage_sort_key(state: AccountState) -> tuple[float, float, float, str]:
-    primary_used = state.used_percent if state.used_percent is not None else 0.0
-    secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else primary_used
+    primary_used = _priority_primary_used(state)
+    secondary_used = _priority_secondary_used(state, primary_used)
     last_selected = state.last_selected_at or 0.0
     return secondary_used, primary_used, last_selected, state.account_id
 
 
 def _primary_usage_sort_key(state: AccountState) -> tuple[float, float, float, str]:
-    primary_used = state.used_percent if state.used_percent is not None else 0.0
-    secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else primary_used
+    primary_used = _priority_primary_used(state)
+    secondary_used = _priority_secondary_used(state, primary_used)
     last_selected = state.last_selected_at or 0.0
     return primary_used, secondary_used, last_selected, state.account_id
 
 
 def _reset_bucket_days(state: AccountState, current: float) -> int:
-    if state.secondary_reset_at is None:
+    reset_at = state.priority_reset_at if state.priority_reset_at is not None else state.secondary_reset_at
+    if reset_at is None:
         return UNKNOWN_RESET_BUCKET_DAYS
-    return max(0, int((state.secondary_reset_at - current) // SECONDS_PER_DAY))
+    return max(0, int((reset_at - current) // SECONDS_PER_DAY))
 
 
 def _prefer_earlier_reset_candidates(available: list[AccountState], current: float) -> list[AccountState]:
@@ -188,6 +194,7 @@ def select_account(
     bypass_account_ids = None if bypass_quota_exceeded_account_ids is None else set(bypass_quota_exceeded_account_ids)
 
     for state in all_states:
+        quota_bypass_applied = False
         if state.status == AccountStatus.DEACTIVATED:
             continue
         if state.status == AccountStatus.PAUSED:
@@ -210,7 +217,7 @@ def select_account(
                 # Primary-window quota is exhausted but an additional
                 # independent quota (already verified upstream) is
                 # available — keep the account in the pool.
-                pass
+                quota_bypass_applied = True
             else:
                 continue
         if state.cooldown_until and current >= state.cooldown_until:
@@ -218,7 +225,8 @@ def select_account(
             state.last_error_at = None
             state.error_count = 0
         if state.cooldown_until and current < state.cooldown_until:
-            continue
+            if not quota_bypass_applied:
+                continue
         if state.error_count >= 3:
             backoff = min(300, 30 * (2 ** (state.error_count - 3)))
             if state.last_error_at and current - state.last_error_at < backoff:
@@ -328,18 +336,32 @@ def select_account(
 
 def _remaining_secondary_credits(state: AccountState) -> float:
     """Return remaining absolute credits for the secondary (7-day) window."""
-    capacity = state.capacity_credits
+    capacity = (
+        state.priority_capacity_credits if state.priority_capacity_credits is not None else state.capacity_credits
+    )
     if capacity is None:
         capacity = _fallback_secondary_capacity_credits(state.plan_type)
     elif capacity <= 0:
         return 0.0
-    if state.secondary_used_percent is not None:
-        used_pct = state.secondary_used_percent
-    elif state.used_percent is not None:
-        used_pct = state.used_percent
-    else:
-        used_pct = 0.0
+    primary_used = _priority_primary_used(state)
+    used_pct = _priority_secondary_used(state, primary_used)
     return max(0.0, capacity * (1.0 - min(used_pct, 100.0) / 100.0))
+
+
+def _priority_primary_used(state: AccountState) -> float:
+    value = state.priority_used_percent if state.priority_used_percent is not None else state.used_percent
+    return value if value is not None else 0.0
+
+
+def _priority_secondary_used(state: AccountState, primary_used: float | None = None) -> float:
+    value = (
+        state.priority_secondary_used_percent
+        if state.priority_secondary_used_percent is not None
+        else state.secondary_used_percent
+    )
+    if value is not None:
+        return value
+    return primary_used if primary_used is not None else _priority_primary_used(state)
 
 
 def _capacity_probe_sort_key(state: AccountState) -> tuple[float, float, float, float, str]:

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import random
 import time
+from collections.abc import Collection
 from dataclasses import dataclass
 from typing import Iterable, Literal
 
@@ -136,6 +137,7 @@ def select_account(
     relative_availability_top_k: int = DEFAULT_RELATIVE_AVAILABILITY_TOP_K,
     primary_first_usage_weighted: bool = False,
     bypass_quota_exceeded: bool = False,
+    bypass_quota_exceeded_account_ids: Collection[str] | None = None,
 ) -> SelectionResult:
     """Select an eligible account by applying availability checks and routing strategy.
 
@@ -170,6 +172,9 @@ def select_account(
             has already been verified as available, so the primary-window
             ``QUOTA_EXCEEDED`` status should not cause the account to be
             excluded.
+        bypass_quota_exceeded_account_ids: Optional narrower account-id scope
+            for the same bypass. This lets callers keep ordinary quota
+            enforcement for accounts whose independent quota was not verified.
 
     Returns:
         A ``SelectionResult`` containing the selected ``AccountState`` and no
@@ -180,6 +185,7 @@ def select_account(
     available: list[AccountState] = []
     in_error_backoff: list[AccountState] = []
     all_states = list(states)
+    bypass_account_ids = None if bypass_quota_exceeded_account_ids is None else set(bypass_quota_exceeded_account_ids)
 
     for state in all_states:
         if state.status == AccountStatus.DEACTIVATED:
@@ -195,16 +201,16 @@ def select_account(
             else:
                 continue
         if state.status == AccountStatus.QUOTA_EXCEEDED:
-            if bypass_quota_exceeded:
-                # Primary-window quota is exhausted but an additional
-                # independent quota (already verified upstream) is
-                # available — keep the account in the pool.
-                pass
-            elif state.reset_at and current >= state.reset_at:
+            if state.reset_at and current >= state.reset_at:
                 state.status = AccountStatus.ACTIVE
                 state.used_percent = 0.0
                 state.secondary_used_percent = 0.0
                 state.reset_at = None
+            elif bypass_quota_exceeded or (bypass_account_ids is not None and state.account_id in bypass_account_ids):
+                # Primary-window quota is exhausted but an additional
+                # independent quota (already verified upstream) is
+                # available — keep the account in the pool.
+                pass
             else:
                 continue
         if state.cooldown_until and current >= state.cooldown_until:

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -370,17 +370,19 @@ def _capacity_probe_sort_key(state: AccountState) -> tuple[float, float, float, 
 
 
 def _relative_availability_divisor_seconds(state: AccountState, current: float) -> float:
-    if state.secondary_reset_at is None:
+    reset_at = state.priority_reset_at if state.priority_reset_at is not None else state.secondary_reset_at
+    if reset_at is None:
         remaining_seconds = float(UNKNOWN_RESET_FALLBACK_SECONDS)
     else:
-        remaining_seconds = max(0.0, float(state.secondary_reset_at) - current)
+        remaining_seconds = max(0.0, float(reset_at) - current)
     return max(remaining_seconds, float(RELATIVE_AVAILABILITY_MIN_DIVISOR_SECONDS))
 
 
 def _relative_availability_remaining_seconds(state: AccountState, current: float) -> float:
-    if state.secondary_reset_at is None:
+    reset_at = state.priority_reset_at if state.priority_reset_at is not None else state.secondary_reset_at
+    if reset_at is None:
         return float(UNKNOWN_RESET_FALLBACK_SECONDS)
-    return max(0.0, float(state.secondary_reset_at) - current)
+    return max(0.0, float(reset_at) - current)
 
 
 def _relative_availability_raw_score(state: AccountState, current: float) -> float:

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -135,6 +135,7 @@ def select_account(
     relative_availability_power: float = DEFAULT_RELATIVE_AVAILABILITY_POWER,
     relative_availability_top_k: int = DEFAULT_RELATIVE_AVAILABILITY_TOP_K,
     primary_first_usage_weighted: bool = False,
+    bypass_quota_exceeded: bool = False,
 ) -> SelectionResult:
     """Select an eligible account by applying availability checks and routing strategy.
 
@@ -163,6 +164,12 @@ def select_account(
             relative-availability candidates retained before weighted draw.
         primary_first_usage_weighted: Whether usage-weighted routing should
             rank by primary-window pressure before secondary-window pressure.
+        bypass_quota_exceeded: When ``True``, accounts with
+            ``QUOTA_EXCEEDED`` status are **not** filtered out.  This is
+            intended for gated models where an additional (independent) quota
+            has already been verified as available, so the primary-window
+            ``QUOTA_EXCEEDED`` status should not cause the account to be
+            excluded.
 
     Returns:
         A ``SelectionResult`` containing the selected ``AccountState`` and no
@@ -188,7 +195,12 @@ def select_account(
             else:
                 continue
         if state.status == AccountStatus.QUOTA_EXCEEDED:
-            if state.reset_at and current >= state.reset_at:
+            if bypass_quota_exceeded:
+                # Primary-window quota is exhausted but an additional
+                # independent quota (already verified upstream) is
+                # available — keep the account in the pool.
+                pass
+            elif state.reset_at and current >= state.reset_at:
                 state.status = AccountStatus.ACTIVE
                 state.used_percent = 0.0
                 state.secondary_used_percent = 0.0

--- a/app/modules/proxy/account_cache.py
+++ b/app/modules/proxy/account_cache.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from app.modules.proxy.load_balancer import SelectionInputs
 
 _AssignedAccountsKey = tuple[str, ...] | None
-_CacheKey = tuple[str | None, str | None, _AssignedAccountsKey]
+_CacheKey = tuple[str | None, str | None, str | None, _AssignedAccountsKey]
 
 
 @dataclass(slots=True)
@@ -36,7 +36,7 @@ class AccountSelectionCache:
     def generation(self) -> int:
         return self._generation
 
-    async def get(self, key: _CacheKey = (None, None, None)) -> SelectionInputs | None:
+    async def get(self, key: _CacheKey = (None, None, None, None)) -> SelectionInputs | None:
         if self._ttl_seconds == 0:
             return None
         entry = self._cache.get(key)
@@ -49,7 +49,7 @@ class AccountSelectionCache:
     async def set(
         self,
         data: SelectionInputs,
-        key: _CacheKey = (None, None, None),
+        key: _CacheKey = (None, None, None, None),
         *,
         generation: int | None = None,
     ) -> None:

--- a/app/modules/proxy/account_cache.py
+++ b/app/modules/proxy/account_cache.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from app.modules.proxy.load_balancer import SelectionInputs
 
 _AssignedAccountsKey = tuple[str, ...] | None
-_CacheKey = tuple[str | None, str | None, str | None, _AssignedAccountsKey]
+_CacheKey = tuple[str | None, str | None, str | None, bool, _AssignedAccountsKey]
 
 
 @dataclass(slots=True)
@@ -36,7 +36,7 @@ class AccountSelectionCache:
     def generation(self) -> int:
         return self._generation
 
-    async def get(self, key: _CacheKey = (None, None, None, None)) -> SelectionInputs | None:
+    async def get(self, key: _CacheKey = (None, None, None, False, None)) -> SelectionInputs | None:
         if self._ttl_seconds == 0:
             return None
         entry = self._cache.get(key)
@@ -49,7 +49,7 @@ class AccountSelectionCache:
     async def set(
         self,
         data: SelectionInputs,
-        key: _CacheKey = (None, None, None, None),
+        key: _CacheKey = (None, None, None, False, None),
         *,
         generation: int | None = None,
     ) -> None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -198,6 +198,7 @@ _UNAVAILABLE_SELECTION_ERROR_CODES = {
     "no_accounts",
     "no_plan_support_for_model",
     "additional_quota_data_unavailable",
+    "quota_exhausted",
     "no_additional_quota_eligible_accounts",
 }
 _STREAM_STARTUP_ERROR_PROBE_SECONDS = 0.05

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -128,6 +128,13 @@ class LoadBalancer:
         excluded_ids = set(exclude_account_ids or ())
         scoped_account_ids = None if account_ids is None else set(account_ids)
 
+        # When an additional (gated) quota is being used, the primary-window
+        # QUOTA_EXCEEDED status may be stale or irrelevant — the additional
+        # quota gate has already determined eligibility.  Signal downstream
+        # selection to keep these accounts in the pool rather than filtering
+        # them out.
+        _effective_bypass_quota_exceeded = additional_limit_name is not None
+
         async def load_selection_inputs() -> _SelectionInputs:
             selection_inputs = await self._load_selection_inputs(
                 model=model,
@@ -184,6 +191,7 @@ class LoadBalancer:
                     relative_availability_power=relative_availability_power,
                     relative_availability_top_k=relative_availability_top_k,
                     budget_threshold_pct=budget_threshold_pct,
+                    bypass_quota_exceeded=_effective_bypass_quota_exceeded,
                 )
 
                 selected_account_map = account_map
@@ -322,6 +330,7 @@ class LoadBalancer:
                         relative_availability_power=relative_availability_power,
                         relative_availability_top_k=relative_availability_top_k,
                         sticky_repo=repos.sticky_sessions,
+                        bypass_quota_exceeded=_effective_bypass_quota_exceeded,
                     )
                     selected_account_map = account_map
                     selected_states = []
@@ -662,6 +671,7 @@ class LoadBalancer:
         relative_availability_power: float = 2.0,
         relative_availability_top_k: int = 5,
         sticky_repo: StickySessionsRepository | None,
+        bypass_quota_exceeded: bool = False,
     ) -> SelectionResult:
         if not sticky_key or not sticky_repo:
             return _select_account_preferring_budget_safe(
@@ -671,6 +681,7 @@ class LoadBalancer:
                 relative_availability_power=relative_availability_power,
                 relative_availability_top_k=relative_availability_top_k,
                 budget_threshold_pct=budget_threshold_pct,
+                bypass_quota_exceeded=bypass_quota_exceeded,
             )
         if sticky_kind is None:
             raise ValueError("sticky_kind is required when sticky_key is provided")
@@ -722,6 +733,7 @@ class LoadBalancer:
                         allow_backoff_fallback=False,
                         relative_availability_power=relative_availability_power,
                         relative_availability_top_k=relative_availability_top_k,
+                        bypass_quota_exceeded=bypass_quota_exceeded,
                     )
                     if pinned_result.account is not None:
                         if sticky_max_age_seconds is not None:
@@ -742,6 +754,7 @@ class LoadBalancer:
                             relative_availability_top_k=relative_availability_top_k,
                             deterministic_probe=True,
                             budget_threshold_pct=budget_threshold_pct,
+                            bypass_quota_exceeded=bypass_quota_exceeded,
                         )
                         pool_exhausted = (
                             _state_above_budget_threshold
@@ -760,6 +773,7 @@ class LoadBalancer:
                                 allow_backoff_fallback=False,
                                 relative_availability_power=relative_availability_power,
                                 relative_availability_top_k=relative_availability_top_k,
+                                bypass_quota_exceeded=bypass_quota_exceeded,
                             )
                             if pinned_result.account is not None:
                                 if sticky_max_age_seconds is not None:
@@ -786,6 +800,7 @@ class LoadBalancer:
                         allow_backoff_fallback=False,
                         relative_availability_power=relative_availability_power,
                         relative_availability_top_k=relative_availability_top_k,
+                        bypass_quota_exceeded=bypass_quota_exceeded,
                     )
                     if grace_result.account is not None:
                         if sticky_max_age_seconds is not None:
@@ -816,6 +831,7 @@ class LoadBalancer:
             relative_availability_power=relative_availability_power,
             relative_availability_top_k=relative_availability_top_k,
             budget_threshold_pct=budget_threshold_pct,
+            bypass_quota_exceeded=bypass_quota_exceeded,
         )
         if persist_fallback and chosen.account is not None and chosen.account.account_id in account_map:
             await sticky_repo.upsert(sticky_key, chosen.account.account_id, kind=sticky_kind)
@@ -1468,6 +1484,7 @@ def _select_account_preferring_budget_safe(
     budget_threshold_pct: float,
     allow_backoff_fallback: bool = True,
     deterministic_probe: bool = False,
+    bypass_quota_exceeded: bool = False,
 ) -> SelectionResult:
     state_list = list(states)
     preferred_states = [state for state in state_list if not _state_above_budget_threshold(state, budget_threshold_pct)]
@@ -1481,6 +1498,7 @@ def _select_account_preferring_budget_safe(
             deterministic_probe=deterministic_probe,
             relative_availability_power=relative_availability_power,
             relative_availability_top_k=relative_availability_top_k,
+            bypass_quota_exceeded=bypass_quota_exceeded,
         )
         if preferred.account is not None:
             return preferred
@@ -1494,6 +1512,7 @@ def _select_account_preferring_budget_safe(
             allow_backoff_fallback=allow_backoff_fallback,
             deterministic_probe=deterministic_probe,
             primary_first_usage_weighted=True,
+            bypass_quota_exceeded=bypass_quota_exceeded,
         )
     return select_account(
         state_list,
@@ -1503,6 +1522,7 @@ def _select_account_preferring_budget_safe(
         deterministic_probe=deterministic_probe,
         relative_availability_power=relative_availability_power,
         relative_availability_top_k=relative_availability_top_k,
+        bypass_quota_exceeded=bypass_quota_exceeded,
     )
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -61,8 +61,16 @@ _RECOVERABLE_STATUSES = frozenset(
 
 NO_PLAN_SUPPORT_FOR_MODEL = "no_plan_support_for_model"
 ADDITIONAL_QUOTA_DATA_UNAVAILABLE = "additional_quota_data_unavailable"
+ADDITIONAL_QUOTA_EXHAUSTED = "quota_exhausted"
 NO_ADDITIONAL_QUOTA_ELIGIBLE_ACCOUNTS = "no_additional_quota_eligible_accounts"
-_ADDITIONAL_QUOTA_EXEMPT_PLAN_TYPES = frozenset({"free", "plus"})
+
+
+@dataclass(frozen=True, slots=True)
+class RequestedLimitState:
+    credential_slot_id: str
+    quota_key: str
+    primary: AdditionalUsageHistory | None = None
+    secondary: AdditionalUsageHistory | None = None
 
 
 @dataclass
@@ -93,6 +101,7 @@ class _SelectionInputs:
     latest_secondary: dict[str, UsageHistory]
     runtime_accounts: list[Account] | None = None
     quota_exceeded_bypass_account_ids: frozenset[str] = frozenset()
+    requested_limit_account_ids: frozenset[str] = frozenset()
     error_message: str | None = None
     error_code: str | None = None
 
@@ -144,6 +153,7 @@ class LoadBalancer:
                     latest_secondary=selection_inputs.latest_secondary,
                     runtime_accounts=selection_inputs.runtime_accounts,
                     quota_exceeded_bypass_account_ids=selection_inputs.quota_exceeded_bypass_account_ids,
+                    requested_limit_account_ids=selection_inputs.requested_limit_account_ids,
                     error_message=selection_inputs.error_message,
                     error_code=selection_inputs.error_code,
                 )
@@ -179,6 +189,7 @@ class LoadBalancer:
                     latest_primary=selection_inputs.latest_primary,
                     latest_secondary=selection_inputs.latest_secondary,
                     runtime=self._runtime,
+                    requested_limit_account_ids=selection_inputs.requested_limit_account_ids,
                 )
 
                 result = _select_account_preferring_budget_safe(
@@ -212,13 +223,15 @@ class LoadBalancer:
                         selected_reset_at = selected.reset_at
                         for state in states:
                             if state.account_id == result.account.account_id:
-                                state.status = result.account.status
-                                state.deactivation_reason = result.account.deactivation_reason
-                                selected_reset_at = int(state.reset_at) if state.reset_at else None
+                                if not state.limit_scoped_usage:
+                                    state.status = result.account.status
+                                    state.deactivation_reason = result.account.deactivation_reason
+                                    selected_reset_at = int(state.reset_at) if state.reset_at else None
                                 break
                         selected_snapshot = _clone_account(selected)
-                        selected_snapshot.status = result.account.status
-                        selected_snapshot.deactivation_reason = result.account.deactivation_reason
+                        if not result.account.limit_scoped_usage:
+                            selected_snapshot.status = result.account.status
+                            selected_snapshot.deactivation_reason = result.account.deactivation_reason
                         selected_snapshot.reset_at = selected_reset_at
                 else:
                     error_message = result.error_message
@@ -312,6 +325,7 @@ class LoadBalancer:
                     latest_primary=selection_inputs.latest_primary,
                     latest_secondary=selection_inputs.latest_secondary,
                     runtime=self._runtime,
+                    requested_limit_account_ids=selection_inputs.requested_limit_account_ids,
                 )
                 async with self._repo_factory() as repos:
                     result = await self._select_with_stickiness(
@@ -349,13 +363,15 @@ class LoadBalancer:
                             selected_reset_at = selected.reset_at
                             for state in selected_states:
                                 if state.account_id == result.account.account_id:
-                                    state.status = result.account.status
-                                    state.deactivation_reason = result.account.deactivation_reason
-                                    selected_reset_at = int(state.reset_at) if state.reset_at else None
+                                    if not state.limit_scoped_usage:
+                                        state.status = result.account.status
+                                        state.deactivation_reason = result.account.deactivation_reason
+                                        selected_reset_at = int(state.reset_at) if state.reset_at else None
                                     break
                             selected_snapshot = _clone_account(selected)
-                            selected_snapshot.status = result.account.status
-                            selected_snapshot.deactivation_reason = result.account.deactivation_reason
+                            if not result.account.limit_scoped_usage:
+                                selected_snapshot.status = result.account.status
+                                selected_snapshot.deactivation_reason = result.account.deactivation_reason
                             selected_snapshot.reset_at = selected_reset_at
                     else:
                         error_message = result.error_message
@@ -414,9 +430,18 @@ class LoadBalancer:
         additional_limit_name: str | None = None,
         account_ids: Collection[str] | None = None,
     ) -> _SelectionInputs:
+        canonical_limit_name = (
+            canonicalize_additional_quota_key(
+                quota_key=additional_limit_name,
+                limit_name=additional_limit_name,
+            )
+            if additional_limit_name is not None
+            else None
+        )
         cache_key = (
             model,
             additional_limit_name,
+            canonical_limit_name,
             None if account_ids is None else tuple(sorted(set(account_ids))),
         )
         cached = await self._selection_inputs_cache.get(cache_key)
@@ -427,7 +452,9 @@ class LoadBalancer:
 
         async with self._repo_factory() as repos:
             all_accounts = await repos.accounts.list_accounts()
-            effective_limit_name = additional_limit_name or _gated_limit_name_for_model(model)
+            effective_limit_name = canonical_limit_name or additional_limit_name or _gated_limit_name_for_model(model)
+            quota_exceeded_bypass_account_ids: frozenset[str] = frozenset()
+            requested_limit_states: dict[str, RequestedLimitState] = {}
             accounts = _selectable_accounts(all_accounts)
             if account_ids is not None:
                 allowed_account_ids = set(account_ids)
@@ -475,6 +502,7 @@ class LoadBalancer:
                 (
                     accounts,
                     quota_exceeded_bypass_account_ids,
+                    requested_limit_states,
                     error_code,
                     error_message,
                 ) = await self._filter_accounts_for_additional_limit(
@@ -513,18 +541,22 @@ class LoadBalancer:
                 repos.usage.latest_by_account(),
                 repos.usage.latest_by_account(window="secondary"),
             )
+            latest_primary = {account_id: _clone_usage_history(entry) for account_id, entry in latest_primary.items()}
+            latest_secondary = {
+                account_id: _clone_usage_history(entry) for account_id, entry in latest_secondary.items()
+            }
+            for credential_slot_id, requested_limit in requested_limit_states.items():
+                if requested_limit.primary is not None:
+                    latest_primary[credential_slot_id] = _additional_usage_to_usage_history(requested_limit.primary)
+                if requested_limit.secondary is not None:
+                    latest_secondary[credential_slot_id] = _additional_usage_to_usage_history(requested_limit.secondary)
             selection_inputs = _SelectionInputs(
                 accounts=[_clone_account(account) for account in accounts],
-                latest_primary={
-                    account_id: _clone_usage_history(entry) for account_id, entry in latest_primary.items()
-                },
-                latest_secondary={
-                    account_id: _clone_usage_history(entry) for account_id, entry in latest_secondary.items()
-                },
+                latest_primary=latest_primary,
+                latest_secondary=latest_secondary,
                 runtime_accounts=[_clone_account(account) for account in all_accounts],
-                quota_exceeded_bypass_account_ids=frozenset(quota_exceeded_bypass_account_ids)
-                if effective_limit_name
-                else frozenset(),
+                quota_exceeded_bypass_account_ids=quota_exceeded_bypass_account_ids,
+                requested_limit_account_ids=frozenset(requested_limit_states),
             )
             await self._selection_inputs_cache.set(
                 _clone_selection_inputs(selection_inputs), key=cache_key, generation=load_generation
@@ -539,9 +571,9 @@ class LoadBalancer:
         limit_name: str,
         explicit_limit: bool = False,
         repos: ProxyRepositories,
-    ) -> tuple[list[Account], frozenset[str], str | None, str | None]:
+    ) -> tuple[list[Account], frozenset[str], dict[str, RequestedLimitState], str | None, str | None]:
         if not accounts:
-            return [], frozenset(), None, None
+            return [], frozenset(), {}, None, None
 
         fresh_since = _additional_usage_fresh_since()
         account_ids = [account.id for account in accounts]
@@ -576,7 +608,9 @@ class LoadBalancer:
 
         eligible_accounts: list[Account] = []
         quota_exceeded_bypass_account_ids: set[str] = set()
+        requested_limit_states: dict[str, RequestedLimitState] = {}
         blocked_by_data = False
+        blocked_by_exhaustion = False
         for account in accounts:
             additional_quota_applies = _additional_quota_applies_to_plan(
                 quota_key=limit_name,
@@ -585,6 +619,8 @@ class LoadBalancer:
             eligibility = _additional_quota_eligibility(
                 account_id=account.id,
                 account_plan_type=account.plan_type,
+                account_status=account.status,
+                account_blocked_at=account.blocked_at,
                 quota_key=limit_name,
                 explicit_limit=explicit_limit,
                 latest_primary=latest_primary,
@@ -592,20 +628,40 @@ class LoadBalancer:
                 fresh_primary=fresh_primary,
                 fresh_secondary=fresh_secondary,
             )
+            if eligibility == "not_applicable":
+                eligible_accounts.append(account)
+                continue
             if eligibility == "eligible":
                 eligible_accounts.append(account)
                 if additional_quota_applies:
                     quota_exceeded_bypass_account_ids.add(account.id)
+                    requested_limit_states[account.id] = RequestedLimitState(
+                        credential_slot_id=account.id,
+                        quota_key=canonicalize_additional_quota_key(quota_key=limit_name) or limit_name,
+                        primary=fresh_primary.get(account.id) or latest_primary.get(account.id),
+                        secondary=fresh_secondary.get(account.id) or latest_secondary.get(account.id),
+                    )
                 continue
             if eligibility == "data_unavailable":
                 blocked_by_data = True
+            elif eligibility == "quota_exhausted":
+                blocked_by_exhaustion = True
 
         if not eligible_accounts:
-            error_code = ADDITIONAL_QUOTA_DATA_UNAVAILABLE if blocked_by_data else NO_ADDITIONAL_QUOTA_ELIGIBLE_ACCOUNTS
+            if blocked_by_data:
+                error_code = ADDITIONAL_QUOTA_DATA_UNAVAILABLE
+            elif blocked_by_exhaustion:
+                error_code = ADDITIONAL_QUOTA_EXHAUSTED
+            else:
+                error_code = NO_ADDITIONAL_QUOTA_ELIGIBLE_ACCOUNTS
             error_message = (
                 f"No fresh additional quota data available for model '{model}'"
                 if blocked_by_data
-                else f"No accounts with available additional quota for model '{model}'"
+                else (
+                    f"Requested additional quota is exhausted for model '{model}'"
+                    if blocked_by_exhaustion
+                    else f"No accounts with available additional quota for model '{model}'"
+                )
             )
             logger.warning(
                 (
@@ -619,7 +675,7 @@ class LoadBalancer:
                 len(accounts),
                 len(fresh_account_ids),
             )
-            return ([], frozenset(), error_code, error_message)
+            return ([], frozenset(), {}, error_code, error_message)
 
         logger.info(
             (
@@ -632,7 +688,7 @@ class LoadBalancer:
             len(fresh_account_ids),
             len(eligible_accounts),
         )
-        return eligible_accounts, frozenset(quota_exceeded_bypass_account_ids), None, None
+        return eligible_accounts, frozenset(quota_exceeded_bypass_account_ids), requested_limit_states, None, None
 
     def _prune_runtime(self, accounts: Iterable[Account]) -> None:
         account_ids = {account.id for account in accounts}
@@ -777,18 +833,18 @@ class LoadBalancer:
                             pool_best.account.account_id == pinned.account_id
                             or pool_exhausted(pool_best.account, budget_threshold_pct)
                         )
-                            if pool_also_exhausted:
-                                pinned_result = select_account(
-                                    [pinned],
-                                    prefer_earlier_reset=prefer_earlier_reset_accounts,
-                                    routing_strategy=routing_strategy,
-                                    allow_backoff_fallback=False,
-                                    relative_availability_power=relative_availability_power,
-                                    relative_availability_top_k=relative_availability_top_k,
-                                    bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
-                                )
-                                if pinned_result.account is not None:
-                                    if sticky_max_age_seconds is not None:
+                        if pool_also_exhausted:
+                            pinned_result = select_account(
+                                [pinned],
+                                prefer_earlier_reset=prefer_earlier_reset_accounts,
+                                routing_strategy=routing_strategy,
+                                allow_backoff_fallback=False,
+                                relative_availability_power=relative_availability_power,
+                                relative_availability_top_k=relative_availability_top_k,
+                                bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
+                            )
+                            if pinned_result.account is not None:
+                                if sticky_max_age_seconds is not None:
                                     await sticky_repo.upsert(
                                         sticky_key,
                                         pinned.account_id,
@@ -947,13 +1003,14 @@ class LoadBalancer:
             return False
 
         dirty = False
-        if runtime.reset_at != state.reset_at:
+        can_sync_account_usage = not state.limit_scoped_usage
+        if can_sync_account_usage and runtime.reset_at != state.reset_at:
             runtime.reset_at = state.reset_at
             dirty = True
         if runtime.cooldown_until != state.cooldown_until:
             runtime.cooldown_until = state.cooldown_until
             dirty = True
-        if runtime.blocked_at != state.blocked_at:
+        if can_sync_account_usage and runtime.blocked_at != state.blocked_at:
             runtime.blocked_at = state.blocked_at
             dirty = True
         if runtime.last_error_at != state.last_error_at:
@@ -962,7 +1019,7 @@ class LoadBalancer:
         if runtime.error_count != state.error_count:
             runtime.error_count = state.error_count
             dirty = True
-        if account.status != state.status:
+        if can_sync_account_usage and account.status != state.status:
             dirty = True
         if account.deactivation_reason != state.deactivation_reason:
             dirty = True
@@ -994,6 +1051,8 @@ class LoadBalancer:
         account: Account,
         state: AccountState,
     ) -> None:
+        if state.limit_scoped_usage:
+            return
         reset_at_int = int(state.reset_at) if state.reset_at else None
         blocked_at_int = int(state.blocked_at) if state.blocked_at else None
         status_changed = account.status != state.status
@@ -1020,6 +1079,8 @@ class LoadBalancer:
         account: Account,
         state: AccountState,
     ) -> bool:
+        if state.limit_scoped_usage:
+            return True
         reset_at_int = int(state.reset_at) if state.reset_at else None
         blocked_at_int = int(state.blocked_at) if state.blocked_at else None
         status_changed = account.status != state.status
@@ -1063,9 +1124,11 @@ def _build_states(
     latest_primary: dict[str, UsageHistory],
     latest_secondary: dict[str, UsageHistory],
     runtime: dict[str, RuntimeState],
+    requested_limit_account_ids: Collection[str] | None = None,
 ) -> tuple[list[AccountState], dict[str, Account]]:
     states: list[AccountState] = []
     account_map: dict[str, Account] = {}
+    requested_limit_ids = set(requested_limit_account_ids or ())
 
     for account in accounts:
         state = _state_from_account(
@@ -1073,6 +1136,7 @@ def _build_states(
             primary_entry=latest_primary.get(account.id),
             secondary_entry=latest_secondary.get(account.id),
             runtime=runtime.setdefault(account.id, RuntimeState()),
+            requested_limit_priority=account.id in requested_limit_ids,
         )
         states.append(state)
         account_map[account.id] = account
@@ -1085,6 +1149,7 @@ def _state_from_account(
     primary_entry: UsageHistory | None,
     secondary_entry: UsageHistory | None,
     runtime: RuntimeState,
+    requested_limit_priority: bool = False,
 ) -> AccountState:
     primary_used = primary_entry.used_percent if primary_entry else None
     primary_reset = primary_entry.reset_at if primary_entry else None
@@ -1117,6 +1182,12 @@ def _state_from_account(
         if secondary_reset is not None and secondary_reset <= now_epoch:
             secondary_used = 0.0
             secondary_reset = None
+
+    priority_used = primary_used if requested_limit_priority else None
+    priority_secondary_used = secondary_used if requested_limit_priority else None
+    priority_reset_at = (
+        (secondary_reset if secondary_reset is not None else primary_reset) if requested_limit_priority else None
+    )
 
     # Use account.reset_at from DB as the authoritative source for runtime reset
     # and to survive process restarts.
@@ -1237,6 +1308,11 @@ def _state_from_account(
         plan_type=account.plan_type,
         capacity_credits=usage_core.capacity_for_plan(account.plan_type, "secondary"),
         health_tier=new_tier,
+        priority_used_percent=priority_used,
+        priority_secondary_used_percent=priority_secondary_used,
+        priority_reset_at=priority_reset_at,
+        priority_capacity_credits=100.0 if requested_limit_priority else None,
+        limit_scoped_usage=requested_limit_priority,
     )
 
 
@@ -1374,6 +1450,23 @@ def _clone_usage_history(entry: UsageHistory) -> UsageHistory:
     return UsageHistory(**data)
 
 
+def _additional_usage_to_usage_history(entry: AdditionalUsageHistory) -> UsageHistory:
+    return UsageHistory(
+        id=entry.id,
+        account_id=entry.account_id,
+        recorded_at=entry.recorded_at,
+        window=entry.window,
+        used_percent=entry.used_percent,
+        input_tokens=None,
+        output_tokens=None,
+        reset_at=entry.reset_at,
+        window_minutes=entry.window_minutes,
+        credits_has=None,
+        credits_unlimited=None,
+        credits_balance=None,
+    )
+
+
 def _clone_selection_inputs(selection_inputs: SelectionInputs) -> SelectionInputs:
     return _SelectionInputs(
         accounts=[_clone_account(account) for account in selection_inputs.accounts],
@@ -1389,6 +1482,7 @@ def _clone_selection_inputs(selection_inputs: SelectionInputs) -> SelectionInput
             else [_clone_account(account) for account in selection_inputs.runtime_accounts]
         ),
         quota_exceeded_bypass_account_ids=selection_inputs.quota_exceeded_bypass_account_ids,
+        requested_limit_account_ids=selection_inputs.requested_limit_account_ids,
         error_message=selection_inputs.error_message,
         error_code=selection_inputs.error_code,
     )
@@ -1428,6 +1522,8 @@ def _additional_quota_eligibility(
     *,
     account_id: str,
     account_plan_type: str | None,
+    account_status: AccountStatus,
+    account_blocked_at: int | None,
     quota_key: str | None,
     explicit_limit: bool = False,
     latest_primary: dict[str, AdditionalUsageHistory],
@@ -1440,8 +1536,8 @@ def _additional_quota_eligibility(
     primary_entry = fresh_primary.get(account_id)
     secondary_entry = fresh_secondary.get(account_id)
 
-    if not explicit_limit and not _additional_quota_applies_to_plan(quota_key=quota_key, plan_type=account_plan_type):
-        return "eligible"
+    if not _additional_quota_applies_to_plan(quota_key=quota_key, plan_type=account_plan_type):
+        return "not_applicable"
 
     if latest_primary_entry is None and latest_secondary_entry is None:
         return "data_unavailable"
@@ -1449,6 +1545,14 @@ def _additional_quota_eligibility(
         return "data_unavailable"
     if latest_secondary_entry is not None and secondary_entry is None:
         return "data_unavailable"
+    if account_status == AccountStatus.QUOTA_EXCEEDED and account_blocked_at is not None:
+        if primary_entry is not None and not _additional_usage_recorded_after_block(primary_entry, account_blocked_at):
+            return "data_unavailable"
+        if secondary_entry is not None and not _additional_usage_recorded_after_block(
+            secondary_entry,
+            account_blocked_at,
+        ):
+            return "data_unavailable"
 
     if primary_entry is not None and _additional_usage_is_exhausted(primary_entry):
         return "quota_exhausted"
@@ -1464,9 +1568,14 @@ def _additional_quota_applies_to_plan(*, quota_key: str | None, plan_type: str |
     normalized_plan = normalize_account_plan_type(plan_type)
     if normalized_plan is None:
         return True
-    if normalized_plan in definition.applies_to_plans:
-        return True
-    return normalized_plan not in _ADDITIONAL_QUOTA_EXEMPT_PLAN_TYPES
+    return normalized_plan in definition.applies_to_plans
+
+
+def _additional_usage_recorded_after_block(entry: AdditionalUsageHistory, blocked_at: int) -> bool:
+    recorded_at = entry.recorded_at
+    if recorded_at.tzinfo is None:
+        recorded_at = recorded_at.replace(tzinfo=timezone.utc)
+    return recorded_at.timestamp() > float(blocked_at)
 
 
 def _additional_usage_is_exhausted(entry: AdditionalUsageHistory) -> bool:
@@ -1478,12 +1587,19 @@ def _additional_usage_is_exhausted(entry: AdditionalUsageHistory) -> bool:
 
 
 def _state_above_budget_threshold(state: AccountState, budget_threshold_pct: float) -> bool:
-    return state.used_percent is not None and state.used_percent > budget_threshold_pct
+    used_percent = state.priority_used_percent if state.priority_used_percent is not None else state.used_percent
+    return used_percent is not None and used_percent > budget_threshold_pct
 
 
 def _state_above_sticky_budget_threshold(state: AccountState, budget_threshold_pct: float) -> bool:
-    return (state.used_percent is not None and state.used_percent > budget_threshold_pct) or (
-        state.secondary_used_percent is not None and state.secondary_used_percent > budget_threshold_pct
+    used_percent = state.priority_used_percent if state.priority_used_percent is not None else state.used_percent
+    secondary_used_percent = (
+        state.priority_secondary_used_percent
+        if state.priority_secondary_used_percent is not None
+        else state.secondary_used_percent
+    )
+    return (used_percent is not None and used_percent > budget_threshold_pct) or (
+        secondary_used_percent is not None and secondary_used_percent > budget_threshold_pct
     )
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -102,6 +102,7 @@ class _SelectionInputs:
     runtime_accounts: list[Account] | None = None
     quota_exceeded_bypass_account_ids: frozenset[str] = frozenset()
     requested_limit_account_ids: frozenset[str] = frozenset()
+    requested_limit_secondary_account_ids: frozenset[str] = frozenset()
     error_message: str | None = None
     error_code: str | None = None
 
@@ -154,6 +155,7 @@ class LoadBalancer:
                     runtime_accounts=selection_inputs.runtime_accounts,
                     quota_exceeded_bypass_account_ids=selection_inputs.quota_exceeded_bypass_account_ids,
                     requested_limit_account_ids=selection_inputs.requested_limit_account_ids,
+                    requested_limit_secondary_account_ids=selection_inputs.requested_limit_secondary_account_ids,
                     error_message=selection_inputs.error_message,
                     error_code=selection_inputs.error_code,
                 )
@@ -190,6 +192,7 @@ class LoadBalancer:
                     latest_secondary=selection_inputs.latest_secondary,
                     runtime=self._runtime,
                     requested_limit_account_ids=selection_inputs.requested_limit_account_ids,
+                    requested_limit_secondary_account_ids=selection_inputs.requested_limit_secondary_account_ids,
                 )
 
                 result = _select_account_preferring_budget_safe(
@@ -326,6 +329,7 @@ class LoadBalancer:
                     latest_secondary=selection_inputs.latest_secondary,
                     runtime=self._runtime,
                     requested_limit_account_ids=selection_inputs.requested_limit_account_ids,
+                    requested_limit_secondary_account_ids=selection_inputs.requested_limit_secondary_account_ids,
                 )
                 async with self._repo_factory() as repos:
                     result = await self._select_with_stickiness(
@@ -557,6 +561,11 @@ class LoadBalancer:
                 runtime_accounts=[_clone_account(account) for account in all_accounts],
                 quota_exceeded_bypass_account_ids=quota_exceeded_bypass_account_ids,
                 requested_limit_account_ids=frozenset(requested_limit_states),
+                requested_limit_secondary_account_ids=frozenset(
+                    account_id
+                    for account_id, requested in requested_limit_states.items()
+                    if requested.secondary is not None
+                ),
             )
             await self._selection_inputs_cache.set(
                 _clone_selection_inputs(selection_inputs), key=cache_key, generation=load_generation
@@ -1125,10 +1134,12 @@ def _build_states(
     latest_secondary: dict[str, UsageHistory],
     runtime: dict[str, RuntimeState],
     requested_limit_account_ids: Collection[str] | None = None,
+    requested_limit_secondary_account_ids: Collection[str] | None = None,
 ) -> tuple[list[AccountState], dict[str, Account]]:
     states: list[AccountState] = []
     account_map: dict[str, Account] = {}
     requested_limit_ids = set(requested_limit_account_ids or ())
+    requested_limit_secondary_ids = set(requested_limit_secondary_account_ids or ())
 
     for account in accounts:
         state = _state_from_account(
@@ -1137,6 +1148,7 @@ def _build_states(
             secondary_entry=latest_secondary.get(account.id),
             runtime=runtime.setdefault(account.id, RuntimeState()),
             requested_limit_priority=account.id in requested_limit_ids,
+            requested_limit_secondary_priority=account.id in requested_limit_secondary_ids,
         )
         states.append(state)
         account_map[account.id] = account
@@ -1150,6 +1162,7 @@ def _state_from_account(
     secondary_entry: UsageHistory | None,
     runtime: RuntimeState,
     requested_limit_priority: bool = False,
+    requested_limit_secondary_priority: bool = False,
 ) -> AccountState:
     primary_used = primary_entry.used_percent if primary_entry else None
     primary_reset = primary_entry.reset_at if primary_entry else None
@@ -1184,7 +1197,7 @@ def _state_from_account(
             secondary_reset = None
 
     priority_used = primary_used if requested_limit_priority else None
-    priority_secondary_used = secondary_used if requested_limit_priority else None
+    priority_secondary_used = secondary_used if requested_limit_secondary_priority else None
     priority_reset_at = (
         (secondary_reset if secondary_reset is not None else primary_reset) if requested_limit_priority else None
     )
@@ -1483,6 +1496,7 @@ def _clone_selection_inputs(selection_inputs: SelectionInputs) -> SelectionInput
         ),
         quota_exceeded_bypass_account_ids=selection_inputs.quota_exceeded_bypass_account_ids,
         requested_limit_account_ids=selection_inputs.requested_limit_account_ids,
+        requested_limit_secondary_account_ids=selection_inputs.requested_limit_secondary_account_ids,
         error_message=selection_inputs.error_message,
         error_code=selection_inputs.error_code,
     )
@@ -1593,11 +1607,14 @@ def _state_above_budget_threshold(state: AccountState, budget_threshold_pct: flo
 
 def _state_above_sticky_budget_threshold(state: AccountState, budget_threshold_pct: float) -> bool:
     used_percent = state.priority_used_percent if state.priority_used_percent is not None else state.used_percent
-    secondary_used_percent = (
-        state.priority_secondary_used_percent
-        if state.priority_secondary_used_percent is not None
-        else state.secondary_used_percent
-    )
+    if state.limit_scoped_usage and state.priority_secondary_used_percent is None:
+        secondary_used_percent = used_percent
+    else:
+        secondary_used_percent = (
+            state.priority_secondary_used_percent
+            if state.priority_secondary_used_percent is not None
+            else state.secondary_used_percent
+        )
     return (used_percent is not None and used_percent > budget_threshold_pct) or (
         secondary_used_percent is not None and secondary_used_percent > budget_threshold_pct
     )

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -92,6 +92,7 @@ class _SelectionInputs:
     latest_primary: dict[str, UsageHistory]
     latest_secondary: dict[str, UsageHistory]
     runtime_accounts: list[Account] | None = None
+    quota_exceeded_bypass_account_ids: frozenset[str] = frozenset()
     error_message: str | None = None
     error_code: str | None = None
 
@@ -128,17 +129,12 @@ class LoadBalancer:
         excluded_ids = set(exclude_account_ids or ())
         scoped_account_ids = None if account_ids is None else set(account_ids)
 
-        # When an additional (gated) quota is being used, the primary-window
-        # QUOTA_EXCEEDED status may be stale or irrelevant — the additional
-        # quota gate has already determined eligibility.  Signal downstream
-        # selection to keep these accounts in the pool rather than filtering
-        # them out.
-        _effective_bypass_quota_exceeded = additional_limit_name is not None
+        effective_limit_name = additional_limit_name or _gated_limit_name_for_model(model)
 
         async def load_selection_inputs() -> _SelectionInputs:
             selection_inputs = await self._load_selection_inputs(
                 model=model,
-                additional_limit_name=additional_limit_name,
+                additional_limit_name=effective_limit_name,
                 account_ids=scoped_account_ids,
             )
             if excluded_ids and selection_inputs.accounts:
@@ -147,6 +143,7 @@ class LoadBalancer:
                     latest_primary=selection_inputs.latest_primary,
                     latest_secondary=selection_inputs.latest_secondary,
                     runtime_accounts=selection_inputs.runtime_accounts,
+                    quota_exceeded_bypass_account_ids=selection_inputs.quota_exceeded_bypass_account_ids,
                     error_message=selection_inputs.error_message,
                     error_code=selection_inputs.error_code,
                 )
@@ -191,7 +188,7 @@ class LoadBalancer:
                     relative_availability_power=relative_availability_power,
                     relative_availability_top_k=relative_availability_top_k,
                     budget_threshold_pct=budget_threshold_pct,
-                    bypass_quota_exceeded=_effective_bypass_quota_exceeded,
+                    bypass_quota_exceeded_account_ids=selection_inputs.quota_exceeded_bypass_account_ids,
                 )
 
                 selected_account_map = account_map
@@ -330,7 +327,7 @@ class LoadBalancer:
                         relative_availability_power=relative_availability_power,
                         relative_availability_top_k=relative_availability_top_k,
                         sticky_repo=repos.sticky_sessions,
-                        bypass_quota_exceeded=_effective_bypass_quota_exceeded,
+                        bypass_quota_exceeded_account_ids=selection_inputs.quota_exceeded_bypass_account_ids,
                     )
                     selected_account_map = account_map
                     selected_states = []
@@ -475,7 +472,12 @@ class LoadBalancer:
                 return selection_inputs
 
             if effective_limit_name:
-                accounts, error_code, error_message = await self._filter_accounts_for_additional_limit(
+                (
+                    accounts,
+                    quota_exceeded_bypass_account_ids,
+                    error_code,
+                    error_message,
+                ) = await self._filter_accounts_for_additional_limit(
                     accounts,
                     model=model,
                     limit_name=effective_limit_name,
@@ -520,6 +522,9 @@ class LoadBalancer:
                     account_id: _clone_usage_history(entry) for account_id, entry in latest_secondary.items()
                 },
                 runtime_accounts=[_clone_account(account) for account in all_accounts],
+                quota_exceeded_bypass_account_ids=frozenset(quota_exceeded_bypass_account_ids)
+                if effective_limit_name
+                else frozenset(),
             )
             await self._selection_inputs_cache.set(
                 _clone_selection_inputs(selection_inputs), key=cache_key, generation=load_generation
@@ -534,9 +539,9 @@ class LoadBalancer:
         limit_name: str,
         explicit_limit: bool = False,
         repos: ProxyRepositories,
-    ) -> tuple[list[Account], str | None, str | None]:
+    ) -> tuple[list[Account], frozenset[str], str | None, str | None]:
         if not accounts:
-            return [], None, None
+            return [], frozenset(), None, None
 
         fresh_since = _additional_usage_fresh_since()
         account_ids = [account.id for account in accounts]
@@ -570,8 +575,13 @@ class LoadBalancer:
         fresh_account_ids = set(fresh_primary) | set(fresh_secondary)
 
         eligible_accounts: list[Account] = []
+        quota_exceeded_bypass_account_ids: set[str] = set()
         blocked_by_data = False
         for account in accounts:
+            additional_quota_applies = _additional_quota_applies_to_plan(
+                quota_key=limit_name,
+                plan_type=account.plan_type,
+            )
             eligibility = _additional_quota_eligibility(
                 account_id=account.id,
                 account_plan_type=account.plan_type,
@@ -584,6 +594,8 @@ class LoadBalancer:
             )
             if eligibility == "eligible":
                 eligible_accounts.append(account)
+                if additional_quota_applies:
+                    quota_exceeded_bypass_account_ids.add(account.id)
                 continue
             if eligibility == "data_unavailable":
                 blocked_by_data = True
@@ -607,7 +619,7 @@ class LoadBalancer:
                 len(accounts),
                 len(fresh_account_ids),
             )
-            return ([], error_code, error_message)
+            return ([], frozenset(), error_code, error_message)
 
         logger.info(
             (
@@ -620,7 +632,7 @@ class LoadBalancer:
             len(fresh_account_ids),
             len(eligible_accounts),
         )
-        return eligible_accounts, None, None
+        return eligible_accounts, frozenset(quota_exceeded_bypass_account_ids), None, None
 
     def _prune_runtime(self, accounts: Iterable[Account]) -> None:
         account_ids = {account.id for account in accounts}
@@ -671,7 +683,7 @@ class LoadBalancer:
         relative_availability_power: float = 2.0,
         relative_availability_top_k: int = 5,
         sticky_repo: StickySessionsRepository | None,
-        bypass_quota_exceeded: bool = False,
+        bypass_quota_exceeded_account_ids: Collection[str] | None = None,
     ) -> SelectionResult:
         if not sticky_key or not sticky_repo:
             return _select_account_preferring_budget_safe(
@@ -681,7 +693,7 @@ class LoadBalancer:
                 relative_availability_power=relative_availability_power,
                 relative_availability_top_k=relative_availability_top_k,
                 budget_threshold_pct=budget_threshold_pct,
-                bypass_quota_exceeded=bypass_quota_exceeded,
+                bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
             )
         if sticky_kind is None:
             raise ValueError("sticky_kind is required when sticky_key is provided")
@@ -733,7 +745,7 @@ class LoadBalancer:
                         allow_backoff_fallback=False,
                         relative_availability_power=relative_availability_power,
                         relative_availability_top_k=relative_availability_top_k,
-                        bypass_quota_exceeded=bypass_quota_exceeded,
+                        bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
                     )
                     if pinned_result.account is not None:
                         if sticky_max_age_seconds is not None:
@@ -754,7 +766,7 @@ class LoadBalancer:
                             relative_availability_top_k=relative_availability_top_k,
                             deterministic_probe=True,
                             budget_threshold_pct=budget_threshold_pct,
-                            bypass_quota_exceeded=bypass_quota_exceeded,
+                            bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
                         )
                         pool_exhausted = (
                             _state_above_budget_threshold
@@ -765,18 +777,18 @@ class LoadBalancer:
                             pool_best.account.account_id == pinned.account_id
                             or pool_exhausted(pool_best.account, budget_threshold_pct)
                         )
-                        if pool_also_exhausted:
-                            pinned_result = select_account(
-                                [pinned],
-                                prefer_earlier_reset=prefer_earlier_reset_accounts,
-                                routing_strategy=routing_strategy,
-                                allow_backoff_fallback=False,
-                                relative_availability_power=relative_availability_power,
-                                relative_availability_top_k=relative_availability_top_k,
-                                bypass_quota_exceeded=bypass_quota_exceeded,
-                            )
-                            if pinned_result.account is not None:
-                                if sticky_max_age_seconds is not None:
+                            if pool_also_exhausted:
+                                pinned_result = select_account(
+                                    [pinned],
+                                    prefer_earlier_reset=prefer_earlier_reset_accounts,
+                                    routing_strategy=routing_strategy,
+                                    allow_backoff_fallback=False,
+                                    relative_availability_power=relative_availability_power,
+                                    relative_availability_top_k=relative_availability_top_k,
+                                    bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
+                                )
+                                if pinned_result.account is not None:
+                                    if sticky_max_age_seconds is not None:
                                     await sticky_repo.upsert(
                                         sticky_key,
                                         pinned.account_id,
@@ -800,7 +812,7 @@ class LoadBalancer:
                         allow_backoff_fallback=False,
                         relative_availability_power=relative_availability_power,
                         relative_availability_top_k=relative_availability_top_k,
-                        bypass_quota_exceeded=bypass_quota_exceeded,
+                        bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
                     )
                     if grace_result.account is not None:
                         if sticky_max_age_seconds is not None:
@@ -831,7 +843,7 @@ class LoadBalancer:
             relative_availability_power=relative_availability_power,
             relative_availability_top_k=relative_availability_top_k,
             budget_threshold_pct=budget_threshold_pct,
-            bypass_quota_exceeded=bypass_quota_exceeded,
+            bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
         )
         if persist_fallback and chosen.account is not None and chosen.account.account_id in account_map:
             await sticky_repo.upsert(sticky_key, chosen.account.account_id, kind=sticky_kind)
@@ -1376,6 +1388,7 @@ def _clone_selection_inputs(selection_inputs: SelectionInputs) -> SelectionInput
             if selection_inputs.runtime_accounts is None
             else [_clone_account(account) for account in selection_inputs.runtime_accounts]
         ),
+        quota_exceeded_bypass_account_ids=selection_inputs.quota_exceeded_bypass_account_ids,
         error_message=selection_inputs.error_message,
         error_code=selection_inputs.error_code,
     )
@@ -1484,7 +1497,7 @@ def _select_account_preferring_budget_safe(
     budget_threshold_pct: float,
     allow_backoff_fallback: bool = True,
     deterministic_probe: bool = False,
-    bypass_quota_exceeded: bool = False,
+    bypass_quota_exceeded_account_ids: Collection[str] | None = None,
 ) -> SelectionResult:
     state_list = list(states)
     preferred_states = [state for state in state_list if not _state_above_budget_threshold(state, budget_threshold_pct)]
@@ -1498,7 +1511,7 @@ def _select_account_preferring_budget_safe(
             deterministic_probe=deterministic_probe,
             relative_availability_power=relative_availability_power,
             relative_availability_top_k=relative_availability_top_k,
-            bypass_quota_exceeded=bypass_quota_exceeded,
+            bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
         )
         if preferred.account is not None:
             return preferred
@@ -1512,7 +1525,7 @@ def _select_account_preferring_budget_safe(
             allow_backoff_fallback=allow_backoff_fallback,
             deterministic_probe=deterministic_probe,
             primary_first_usage_weighted=True,
-            bypass_quota_exceeded=bypass_quota_exceeded,
+            bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
         )
     return select_account(
         state_list,
@@ -1522,7 +1535,7 @@ def _select_account_preferring_budget_safe(
         deterministic_probe=deterministic_probe,
         relative_availability_power=relative_availability_power,
         relative_availability_top_k=relative_availability_top_k,
-        bypass_quota_exceeded=bypass_quota_exceeded,
+        bypass_quota_exceeded_account_ids=bypass_quota_exceeded_account_ids,
     )
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -82,6 +82,7 @@ class RequestedLimitState:
     primary: AdditionalUsageHistory | None = None
     secondary: AdditionalUsageHistory | None = None
 
+
 AccountLeaseKind = Literal["response_create", "stream"]
 
 
@@ -795,8 +796,12 @@ class LoadBalancer:
             for credential_slot_id, requested_limit in requested_limit_states.items():
                 if requested_limit.primary is not None:
                     latest_primary[credential_slot_id] = _additional_usage_to_usage_history(requested_limit.primary)
+                else:
+                    latest_primary.pop(credential_slot_id, None)
                 if requested_limit.secondary is not None:
                     latest_secondary[credential_slot_id] = _additional_usage_to_usage_history(requested_limit.secondary)
+                else:
+                    latest_secondary.pop(credential_slot_id, None)
             selection_inputs = _SelectionInputs(
                 accounts=[_clone_account(account) for account in accounts],
                 latest_primary=latest_primary,

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -145,6 +145,7 @@ class LoadBalancer:
             selection_inputs = await self._load_selection_inputs(
                 model=model,
                 additional_limit_name=effective_limit_name,
+                explicit_additional_limit=additional_limit_name is not None,
                 account_ids=scoped_account_ids,
             )
             if excluded_ids and selection_inputs.accounts:
@@ -432,6 +433,7 @@ class LoadBalancer:
         *,
         model: str | None,
         additional_limit_name: str | None = None,
+        explicit_additional_limit: bool = False,
         account_ids: Collection[str] | None = None,
     ) -> _SelectionInputs:
         canonical_limit_name = (
@@ -446,6 +448,7 @@ class LoadBalancer:
             model,
             additional_limit_name,
             canonical_limit_name,
+            explicit_additional_limit,
             None if account_ids is None else tuple(sorted(set(account_ids))),
         )
         cached = await self._selection_inputs_cache.get(cache_key)
@@ -513,7 +516,7 @@ class LoadBalancer:
                     accounts,
                     model=model,
                     limit_name=effective_limit_name,
-                    explicit_limit=additional_limit_name is not None,
+                    explicit_limit=explicit_additional_limit,
                     repos=repos,
                 )
                 if not accounts:
@@ -1551,6 +1554,8 @@ def _additional_quota_eligibility(
     secondary_entry = fresh_secondary.get(account_id)
 
     if not _additional_quota_applies_to_plan(quota_key=quota_key, plan_type=account_plan_type):
+        if explicit_limit:
+            return "data_unavailable"
         return "not_applicable"
 
     if latest_primary_entry is None and latest_secondary_entry is None:

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -465,7 +465,7 @@ class AdditionalUsageRepository:
         account_ids: Collection[str] | None = None,
         since: datetime | None = None,
     ) -> dict[str, AdditionalUsageHistory]:
-        """Returns the most recent entry per account for a given canonical quota key + window."""
+        """Returns the latest effective entry per account for a canonical quota key + window."""
         scope = _resolve_additional_quota_query_scope(
             quota_key=quota_key,
             limit_name=limit_name,
@@ -486,7 +486,11 @@ class AdditionalUsageRepository:
                 func.row_number()
                 .over(
                     partition_by=AdditionalUsageHistory.account_id,
-                    order_by=(AdditionalUsageHistory.recorded_at.desc(), AdditionalUsageHistory.id.desc()),
+                    order_by=(
+                        AdditionalUsageHistory.recorded_at.desc(),
+                        AdditionalUsageHistory.used_percent.desc(),
+                        AdditionalUsageHistory.id.desc(),
+                    ),
                 )
                 .label("row_number"),
             )

--- a/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/.openspec.yaml
+++ b/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/proposal.md
+++ b/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The proxy now supports routing gated models by a requested or derived additional
+quota, including `QUOTA_EXCEEDED` bypass and requested-limit usage weighting.
+Current routing behavior has to keep two invariants clear:
+
+- requested-limit ranking must never mix additional-quota signals with ordinary
+  account usage windows when those additional windows are missing.
+- `QUOTA_EXCEEDED` cooldown semantics must remain enforced even when
+  additional-quota bypass is used.
+
+## What Changes
+
+- Extend load-balancer state handling so requested-limit secondary quota pressure is
+  applied only when a requested secondary window exists; requested-limit primary
+  pressure remains the priority input.
+- Keep requested-limit selection from bypassing `cooldown_until` in
+  `select_account`, so cooldown backoff stays in effect after quota errors.
+- Preserve behavior for regular non-gated selection paths.
+
+## Impact
+
+- Gated/requested-limit routing follows documented request-window behavior without
+  borrowing ordinary secondary usage pressure.
+- Cooldown protection remains in force for `QUOTA_EXCEEDED` accounts even when
+  requested-quota bypass is active.
+- Existing selection fallback and tests remain aligned with the stronger
+  backoff/selection semantics.

--- a/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/specs/query-caching/spec.md
+++ b/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/specs/query-caching/spec.md
@@ -15,6 +15,12 @@ When a request targets a gated model whose canonical additional quota is known, 
 - **WHEN** selecting an account for the gated model with requested-limit routing
 - **THEN** both requested additional windows may contribute to ranking and budget-safety decisions
 
+#### Scenario: Requested reset window drives relative availability
+- **GIVEN** account A has an ordinary secondary window that resets later than its requested additional quota
+- **AND** account B has an ordinary secondary window that resets sooner than its requested additional quota
+- **WHEN** selecting an account for the gated model with relative-availability routing
+- **THEN** requested-limit scoring uses each account's requested additional-quota reset window instead of the ordinary secondary reset window
+
 ### Requirement: Quota status bypass preserves cooldown backoff
 When requested additional-quota data proves an account can serve a gated model despite persisted `QUOTA_EXCEEDED` account status, account selection MAY bypass the persisted quota status for that requested gated model. This bypass SHALL NOT bypass `cooldown_until`, pause, deactivation, rate-limit, or error-backoff gates.
 

--- a/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/specs/query-caching/spec.md
+++ b/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/specs/query-caching/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Gated model selection keeps requested quota windows isolated
+When a request targets a gated model whose canonical additional quota is known, account selection SHALL rank and budget candidates using persisted usage windows for that requested additional quota only. Missing requested additional-quota windows SHALL NOT fall back to ordinary account usage windows for requested-limit ranking, budget-safety checks, or relative-availability scoring.
+
+#### Scenario: Missing requested secondary window does not borrow ordinary secondary usage
+- **GIVEN** account A has requested additional primary usage but no requested additional secondary usage
+- **AND** account A has ordinary secondary usage near exhaustion
+- **AND** account B has worse requested additional primary usage
+- **WHEN** selecting an account for the gated model with requested-limit routing
+- **THEN** account A is not penalized by its ordinary secondary usage for requested-limit ranking
+
+#### Scenario: Requested secondary window is used when present
+- **GIVEN** an account has requested additional primary and secondary usage windows
+- **WHEN** selecting an account for the gated model with requested-limit routing
+- **THEN** both requested additional windows may contribute to ranking and budget-safety decisions
+
+### Requirement: Quota status bypass preserves cooldown backoff
+When requested additional-quota data proves an account can serve a gated model despite persisted `QUOTA_EXCEEDED` account status, account selection MAY bypass the persisted quota status for that requested gated model. This bypass SHALL NOT bypass `cooldown_until`, pause, deactivation, rate-limit, or error-backoff gates.
+
+#### Scenario: Requested quota bypass does not bypass cooldown
+- **GIVEN** an account is `QUOTA_EXCEEDED`
+- **AND** requested additional-quota data marks the account eligible for the gated model
+- **AND** the account has `cooldown_until` in the future
+- **WHEN** selecting an account for that gated model
+- **THEN** the account is not selected until the cooldown expires
+
+#### Scenario: Requested quota bypass can select a cooled eligible account
+- **GIVEN** an account is `QUOTA_EXCEEDED`
+- **AND** requested additional-quota data marks the account eligible for the gated model
+- **AND** the account has no active cooldown, pause, deactivation, rate-limit, or error backoff
+- **WHEN** selecting an account for that gated model
+- **THEN** the persisted quota status does not by itself exclude the account

--- a/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/tasks.md
+++ b/openspec/changes/fix-gated-model-requested-limit-bypass-semantics/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] 1.1 Thread requested secondary availability as a distinct priority signal set.
+- [x] 1.2 Keep requested-limit selection from treating missing requested secondary
+  usage as ordinary secondary usage.
+- [x] 1.3 Ensure `cooldown_until` is enforced regardless of quota-bypass flags.
+- [x] 1.4 Keep requested-limit status recovery behavior unchanged for existing
+  account status/bypass semantics.
+
+## 2. Verification
+
+- [x] 2.1 Update/add unit tests for `select_account` and requested-limit ranking.
+- [x] 2.2 Update/add unit tests for quota-bypass/cooldown interaction.
+- [x] 2.3 Run focused backend tests for proxy balancer and usage-repository paths.

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -141,7 +141,7 @@ async def test_proxy_compact_strips_tool_fields_before_upstream(async_client, mo
 
 
 @pytest.mark.asyncio
-async def test_proxy_compact_surfaces_no_additional_quota_eligible_accounts(async_client):
+async def test_proxy_compact_surfaces_additional_quota_exhausted(async_client):
     email = "compact-gated@example.com"
     raw_account_id = "acc_compact_gated"
     auth_json = _make_auth_json(raw_account_id, email, plan_type="pro")
@@ -179,7 +179,7 @@ async def test_proxy_compact_surfaces_no_additional_quota_eligible_accounts(asyn
     response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
     assert response.status_code == 503
     error = response.json()["error"]
-    assert error["code"] == "no_additional_quota_eligible_accounts"
+    assert error["code"] == "quota_exhausted"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_additional_usage_repo.py
+++ b/tests/unit/test_additional_usage_repo.py
@@ -273,6 +273,96 @@ async def test_latest_by_account_reads_rows_under_legacy_quota_key_alias(
 
 
 @pytest.mark.asyncio
+async def test_latest_by_account_merges_alias_rows_conservatively(
+    async_session: AsyncSession,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "additional_quota_registry.json"
+    _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
+    monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    clear_additional_quota_registry_cache()
+
+    repo = AdditionalUsageRepository(async_session)
+    now = datetime.now(tz=timezone.utc)
+
+    async_session.add_all(
+        [
+            AdditionalUsageHistory(
+                account_id="acc_alias_merge",
+                quota_key="codex_spark",
+                limit_name="codex_other",
+                metered_feature="codex_bengalfox",
+                window="primary",
+                used_percent=92.0,
+                recorded_at=now,
+            ),
+            AdditionalUsageHistory(
+                account_id="acc_alias_merge",
+                quota_key="spark_enterprise",
+                limit_name="GPT-5.3-Codex-Spark",
+                metered_feature="codex_bengalfox",
+                window="primary",
+                used_percent=40.0,
+                recorded_at=now,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    result = await repo.latest_by_account(quota_key="spark_enterprise", window="primary")
+
+    assert list(result) == ["acc_alias_merge"]
+    assert result["acc_alias_merge"].quota_key == "codex_spark"
+    assert result["acc_alias_merge"].used_percent == 92.0
+
+
+@pytest.mark.asyncio
+async def test_latest_by_account_prefers_newer_alias_row_after_reset(
+    async_session: AsyncSession,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "additional_quota_registry.json"
+    _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
+    monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    clear_additional_quota_registry_cache()
+
+    repo = AdditionalUsageRepository(async_session)
+    now = datetime.now(tz=timezone.utc)
+
+    async_session.add_all(
+        [
+            AdditionalUsageHistory(
+                account_id="acc_alias_reset",
+                quota_key="codex_spark",
+                limit_name="codex_other",
+                metered_feature="codex_bengalfox",
+                window="primary",
+                used_percent=96.0,
+                recorded_at=now - timedelta(seconds=10),
+            ),
+            AdditionalUsageHistory(
+                account_id="acc_alias_reset",
+                quota_key="spark_enterprise",
+                limit_name="GPT-5.3-Codex-Spark",
+                metered_feature="codex_bengalfox",
+                window="primary",
+                used_percent=12.0,
+                recorded_at=now,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    result = await repo.latest_by_account(quota_key="spark_enterprise", window="primary")
+
+    assert list(result) == ["acc_alias_reset"]
+    assert result["acc_alias_reset"].quota_key == "spark_enterprise"
+    assert result["acc_alias_reset"].used_percent == 12.0
+
+
+@pytest.mark.asyncio
 async def test_list_limit_names_returns_distinct_names(async_session: AsyncSession) -> None:
     """Test list_limit_names returns distinct limit names."""
     repo = AdditionalUsageRepository(async_session)

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -557,6 +557,42 @@ def test_bypass_quota_exceeded_keeps_account_in_pool():
     assert result_bypass.account.account_id == "a"
 
 
+def test_bypass_quota_exceeded_still_recovers_expired_quota_state():
+    now = 1_700_000_000.0
+    state = AccountState(
+        "a",
+        AccountStatus.QUOTA_EXCEEDED,
+        used_percent=100.0,
+        secondary_used_percent=100.0,
+        reset_at=int(now) - 1,
+    )
+
+    result = select_account([state], now=now, bypass_quota_exceeded=True)
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent == 0.0
+    assert state.secondary_used_percent == 0.0
+    assert state.reset_at is None
+
+
+def test_bypass_quota_exceeded_can_be_scoped_to_account_ids():
+    now = 1_700_000_000.0
+    blocked = AccountState("blocked", AccountStatus.QUOTA_EXCEEDED, used_percent=100.0, reset_at=int(now) + 3600)
+    allowed = AccountState("allowed", AccountStatus.QUOTA_EXCEEDED, used_percent=100.0, reset_at=int(now) + 3600)
+
+    result = select_account(
+        [blocked, allowed],
+        now=now,
+        routing_strategy="round_robin",
+        bypass_quota_exceeded_account_ids={"allowed"},
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "allowed"
+
+
 def test_bypass_quota_exceeded_does_not_affect_other_statuses():
     """bypass_quota_exceeded should only affect QUOTA_EXCEEDED, not PAUSED/DEACTIVATED."""
     now = 1_700_000_000.0

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -669,6 +669,46 @@ def test_requested_limit_relative_availability_uses_requested_secondary_only_whe
     assert result.account.account_id == "limited-high-second"
 
 
+def test_requested_limit_relative_availability_uses_requested_reset_window():
+    now = int(time.time())
+    states = [
+        AccountState(
+            "ordinary-late-requested-soon",
+            AccountStatus.ACTIVE,
+            used_percent=0.0,
+            secondary_used_percent=90.0,
+            secondary_reset_at=now + 7 * 24 * 3600,
+            priority_used_percent=0.0,
+            priority_secondary_used_percent=0.0,
+            priority_reset_at=now + 3_600,
+            priority_capacity_credits=100.0,
+            limit_scoped_usage=True,
+        ),
+        AccountState(
+            "ordinary-soon-requested-late",
+            AccountStatus.ACTIVE,
+            used_percent=0.0,
+            secondary_used_percent=0.0,
+            secondary_reset_at=now + 3_600,
+            priority_used_percent=0.0,
+            priority_secondary_used_percent=0.0,
+            priority_reset_at=now + 7 * 24 * 3600,
+            priority_capacity_credits=100.0,
+            limit_scoped_usage=True,
+        ),
+    ]
+
+    result = select_account(
+        states,
+        routing_strategy="relative_availability",
+        deterministic_probe=True,
+        now=now,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "ordinary-late-requested-soon"
+
+
 def test_bypass_quota_exceeded_does_not_affect_other_statuses():
     """bypass_quota_exceeded should only affect QUOTA_EXCEEDED, not PAUSED/DEACTIVATED."""
     now = 1_700_000_000.0

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -617,8 +617,7 @@ def test_scoped_quota_bypass_ignores_quota_cooldown_only_for_allowed_account():
         bypass_quota_exceeded_account_ids={"allowed"},
     )
 
-    assert result.account is not None
-    assert result.account.account_id == "allowed"
+    assert result.account is None
     assert allowed.cooldown_until == now + 120.0
 
 
@@ -634,6 +633,40 @@ def test_scoped_quota_bypass_does_not_ignore_active_account_cooldown():
     result = select_account([state], now=now, bypass_quota_exceeded_account_ids={"a"})
 
     assert result.account is None
+
+
+def test_requested_limit_relative_availability_uses_requested_secondary_only_when_available():
+    now = int(time.time())
+    states = [
+        AccountState(
+            "limited-high-second",
+            AccountStatus.ACTIVE,
+            used_percent=1.0,
+            secondary_used_percent=100.0,
+            secondary_reset_at=now + 3_600,
+            priority_used_percent=1.0,
+            priority_capacity_credits=100.0,
+            limit_scoped_usage=True,
+        ),
+        AccountState(
+            "not-limited",
+            AccountStatus.ACTIVE,
+            used_percent=80.0,
+            secondary_used_percent=20.0,
+            secondary_reset_at=now + 3_600,
+            priority_capacity_credits=100.0,
+        ),
+    ]
+
+    result = select_account(
+        states,
+        routing_strategy="relative_availability",
+        deterministic_probe=True,
+        now=now,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "limited-high-second"
 
 
 def test_bypass_quota_exceeded_does_not_affect_other_statuses():

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -538,6 +538,38 @@ def test_quota_exceeded_cooldown_allows_selection_after_expiry():
     assert result.account.account_id == "a"
 
 
+def test_bypass_quota_exceeded_keeps_account_in_pool():
+    """When bypass_quota_exceeded=True, a QUOTA_EXCEEDED account should not be filtered out."""
+    now = 1_700_000_000.0
+    state = AccountState(
+        "a",
+        AccountStatus.QUOTA_EXCEEDED,
+        used_percent=100.0,
+        reset_at=int(now) + 3600,
+    )
+    # Default (bypass=False) → account is excluded.
+    result_default = select_account([state], now=now)
+    assert result_default.account is None
+
+    # With bypass=True → account stays in the pool.
+    result_bypass = select_account([state], now=now, bypass_quota_exceeded=True)
+    assert result_bypass.account is not None
+    assert result_bypass.account.account_id == "a"
+
+
+def test_bypass_quota_exceeded_does_not_affect_other_statuses():
+    """bypass_quota_exceeded should only affect QUOTA_EXCEEDED, not PAUSED/DEACTIVATED."""
+    now = 1_700_000_000.0
+    paused = AccountState("p", AccountStatus.PAUSED, used_percent=5.0)
+    deactivated = AccountState("d", AccountStatus.DEACTIVATED, used_percent=5.0)
+    quota = AccountState("q", AccountStatus.QUOTA_EXCEEDED, used_percent=100.0, reset_at=int(now) + 3600)
+
+    result = select_account([paused, deactivated, quota], now=now, bypass_quota_exceeded=True)
+    # PAUSED and DEACTIVATED still excluded; QUOTA_EXCEEDED is kept.
+    assert result.account is not None
+    assert result.account.account_id == "q"
+
+
 def _make_test_account(
     account_id: str = "a",
     status: AccountStatus = AccountStatus.ACTIVE,

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -593,6 +593,49 @@ def test_bypass_quota_exceeded_can_be_scoped_to_account_ids():
     assert result.account.account_id == "allowed"
 
 
+def test_scoped_quota_bypass_ignores_quota_cooldown_only_for_allowed_account():
+    now = 1_700_000_000.0
+    blocked = AccountState(
+        "blocked",
+        AccountStatus.QUOTA_EXCEEDED,
+        used_percent=100.0,
+        reset_at=int(now) + 3600,
+        cooldown_until=now + 120.0,
+    )
+    allowed = AccountState(
+        "allowed",
+        AccountStatus.QUOTA_EXCEEDED,
+        used_percent=100.0,
+        reset_at=int(now) + 3600,
+        cooldown_until=now + 120.0,
+    )
+
+    result = select_account(
+        [blocked, allowed],
+        now=now,
+        routing_strategy="round_robin",
+        bypass_quota_exceeded_account_ids={"allowed"},
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "allowed"
+    assert allowed.cooldown_until == now + 120.0
+
+
+def test_scoped_quota_bypass_does_not_ignore_active_account_cooldown():
+    now = 1_700_000_000.0
+    state = AccountState(
+        "a",
+        AccountStatus.ACTIVE,
+        used_percent=5.0,
+        cooldown_until=now + 120.0,
+    )
+
+    result = select_account([state], now=now, bypass_quota_exceeded_account_ids={"a"})
+
+    assert result.account is None
+
+
 def test_bypass_quota_exceeded_does_not_affect_other_statuses():
     """bypass_quota_exceeded should only affect QUOTA_EXCEEDED, not PAUSED/DEACTIVATED."""
     now = 1_700_000_000.0
@@ -1498,12 +1541,20 @@ def test_select_account_capacity_weighted_unknown_plan_uses_conservative_fallbac
     assert counts["plus"] > counts["unknown-plan"]
 
 
-@pytest.mark.parametrize("plan_type", ["pro", "prolite", "team", "business", "enterprise", "edu", "unknown", None])
+@pytest.mark.parametrize("plan_type", ["pro", "prolite", "team", "business", "enterprise"])
 def test_additional_quota_applies_to_quota_enforced_and_unmapped_plans(plan_type):
     assert _additional_quota_applies_to_plan(quota_key="codex_spark", plan_type=plan_type) is True
 
 
-@pytest.mark.parametrize("plan_type", ["free", "plus"])
+def test_additional_quota_applies_conservatively_when_plan_is_missing():
+    assert _additional_quota_applies_to_plan(quota_key="codex_spark", plan_type=None) is True
+
+
+def test_additional_quota_applies_conservatively_when_plan_is_unknown():
+    assert _additional_quota_applies_to_plan(quota_key="codex_spark", plan_type="unknown") is True
+
+
+@pytest.mark.parametrize("plan_type", ["free", "plus", "edu"])
 def test_additional_quota_does_not_apply_to_known_non_additional_quota_plans(plan_type):
     assert _additional_quota_applies_to_plan(quota_key="codex_spark", plan_type=plan_type) is False
 
@@ -1763,6 +1814,112 @@ def test_sticky_budget_threshold_still_counts_secondary_pressure():
     )
 
     assert _state_above_sticky_budget_threshold(state, 95.0) is True
+
+
+def test_select_account_uses_requested_limit_usage_before_account_usage():
+    states = [
+        AccountState(
+            "account-high-limit-low",
+            AccountStatus.ACTIVE,
+            used_percent=90.0,
+            secondary_used_percent=90.0,
+            priority_used_percent=10.0,
+            priority_secondary_used_percent=10.0,
+        ),
+        AccountState(
+            "account-low-limit-high",
+            AccountStatus.ACTIVE,
+            used_percent=20.0,
+            secondary_used_percent=20.0,
+            priority_used_percent=80.0,
+            priority_secondary_used_percent=80.0,
+        ),
+    ]
+
+    result = select_account(states, routing_strategy="usage_weighted")
+
+    assert result.account is not None
+    assert result.account.account_id == "account-high-limit-low"
+
+
+def test_select_account_uses_requested_limit_reset_for_burn_first():
+    now = time.time()
+    states = [
+        AccountState(
+            "base-early-limit-late",
+            AccountStatus.ACTIVE,
+            used_percent=10.0,
+            secondary_used_percent=10.0,
+            secondary_reset_at=int(now + 3600),
+            priority_used_percent=10.0,
+            priority_secondary_used_percent=10.0,
+            priority_reset_at=int(now + 5 * 24 * 3600),
+        ),
+        AccountState(
+            "base-late-limit-early",
+            AccountStatus.ACTIVE,
+            used_percent=90.0,
+            secondary_used_percent=90.0,
+            secondary_reset_at=int(now + 5 * 24 * 3600),
+            priority_used_percent=90.0,
+            priority_secondary_used_percent=90.0,
+            priority_reset_at=int(now + 3600),
+        ),
+    ]
+
+    result = select_account(
+        states,
+        now=now,
+        prefer_earlier_reset=True,
+        routing_strategy="usage_weighted",
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "base-late-limit-early"
+
+
+def test_budget_safe_selection_uses_requested_limit_pressure():
+    states = [
+        AccountState(
+            "base-pressured-limit-safe",
+            AccountStatus.ACTIVE,
+            used_percent=99.0,
+            secondary_used_percent=99.0,
+            priority_used_percent=10.0,
+            priority_secondary_used_percent=10.0,
+        ),
+        AccountState(
+            "base-safe-limit-pressured",
+            AccountStatus.ACTIVE,
+            used_percent=10.0,
+            secondary_used_percent=10.0,
+            priority_used_percent=99.0,
+            priority_secondary_used_percent=99.0,
+        ),
+    ]
+
+    result = _select_account_preferring_budget_safe(
+        states,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=95.0,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "base-pressured-limit-safe"
+
+
+def test_sticky_budget_threshold_uses_requested_limit_pressure():
+    state = AccountState(
+        "sticky",
+        AccountStatus.ACTIVE,
+        used_percent=99.0,
+        secondary_used_percent=99.0,
+        priority_used_percent=10.0,
+        priority_secondary_used_percent=10.0,
+    )
+
+    assert _state_above_sticky_budget_threshold(state, 95.0) is False
 
 
 def test_select_account_capacity_weighted_prefers_capacity_within_same_reset_bucket():

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -577,6 +577,27 @@ def test_bypass_quota_exceeded_still_recovers_expired_quota_state():
     assert state.reset_at is None
 
 
+def test_bypass_quota_exceeded_does_not_bypass_error_backoff_fallback():
+    now = 1_700_000_000.0
+    state = AccountState(
+        "a",
+        AccountStatus.QUOTA_EXCEEDED,
+        used_percent=100.0,
+        reset_at=int(now) + 3600,
+        error_count=3,
+        last_error_at=now - 1.0,
+    )
+
+    result = select_account(
+        [state],
+        now=now,
+        allow_backoff_fallback=True,
+        bypass_quota_exceeded=True,
+    )
+
+    assert result.account is None
+
+
 def test_bypass_quota_exceeded_can_be_scoped_to_account_ids():
     now = 1_700_000_000.0
     blocked = AccountState("blocked", AccountStatus.QUOTA_EXCEEDED, used_percent=100.0, reset_at=int(now) + 3600)

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -790,6 +790,8 @@ async def test_select_account_proceeds_without_cached_usage_rows(monkeypatch) ->
 async def test_select_account_prefilters_accounts_by_additional_usage_limit() -> None:
     account_ineligible = _make_account("acc-additional-exhausted", email="full@example.com")
     account_eligible = _make_account("acc-additional-eligible", email="ok@example.com")
+    account_ineligible.plan_type = "pro"
+    account_eligible.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     primary_entry = UsageHistory(
@@ -824,6 +826,7 @@ async def test_select_account_prefilters_accounts_by_additional_usage_limit() ->
                 account_id=account_ineligible.id,
                 window="primary",
                 used_percent=100.0,
+                reset_at=now_epoch + 300,
                 recorded_at=now,
             ),
             account_eligible.id: _additional_entry(
@@ -831,6 +834,7 @@ async def test_select_account_prefilters_accounts_by_additional_usage_limit() ->
                 account_id=account_eligible.id,
                 window="primary",
                 used_percent=35.0,
+                reset_at=now_epoch + 300,
                 recorded_at=now,
             ),
         }
@@ -978,6 +982,7 @@ async def test_select_account_uses_canonical_quota_key_for_upstream_limit_alias(
 @pytest.mark.parametrize("additional_limit_name", ["codex_other", "GPT-5.3-Codex-Spark"])
 async def test_select_account_accepts_legacy_additional_limit_aliases(additional_limit_name: str) -> None:
     account = _make_account(f"acc-additional-{additional_limit_name}")
+    account.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     usage_repo = StubUsageRepository(
@@ -1020,6 +1025,41 @@ async def test_select_account_accepts_legacy_additional_limit_aliases(additional
 
     assert selection.account is not None
     assert selection.account.id == account.id
+
+
+@pytest.mark.asyncio
+async def test_select_account_requires_explicit_additional_limit_to_apply_to_plan() -> None:
+    account = _make_account("acc-explicit-limit-plan-mismatch", "explicit-limit-plan-mismatch@example.com")
+    account.plan_type = "plus"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: UsageHistory(
+                id=61,
+                account_id=account.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=10.0,
+                reset_at=now_epoch + 300,
+                window_minutes=5,
+            )
+        },
+        secondary={},
+    )
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            StubAccountsRepository([account]),
+            usage_repo,
+            StubStickySessionsRepository(),
+            StubAdditionalUsageRepository(primary={}, secondary={}),
+        )
+    )
+
+    selection = await balancer.select_account(additional_limit_name="codex_spark")
+
+    assert selection.account is None
+    assert selection.error_code == "additional_quota_data_unavailable"
 
 
 @pytest.mark.asyncio
@@ -1441,9 +1481,10 @@ async def test_select_account_does_not_open_repo_before_runtime_lock(monkeypatch
         *,
         model: str | None,
         additional_limit_name: str | None = None,
+        explicit_additional_limit: bool = False,
         account_ids: Collection[str] | None = None,
     ):
-        del model, additional_limit_name, account_ids
+        del model, additional_limit_name, explicit_additional_limit, account_ids
         return load_balancer_module._SelectionInputs(
             accounts=[account],
             latest_primary={account.id: primary_entry},
@@ -1693,6 +1734,7 @@ async def test_select_account_reloads_inputs_after_version_conflict(monkeypatch)
         *,
         model: str | None,
         additional_limit_name: str | None = None,
+        explicit_additional_limit: bool = False,
         account_ids: Collection[str] | None = None,
     ):
         nonlocal load_calls
@@ -1700,6 +1742,7 @@ async def test_select_account_reloads_inputs_after_version_conflict(monkeypatch)
         return await original_load_selection_inputs(
             model=model,
             additional_limit_name=additional_limit_name,
+            explicit_additional_limit=explicit_additional_limit,
             account_ids=account_ids,
         )
 
@@ -1833,6 +1876,7 @@ async def test_select_account_sticky_reloads_inputs_after_stale_selected_persist
         *,
         model: str | None,
         additional_limit_name: str | None = None,
+        explicit_additional_limit: bool = False,
         account_ids: Collection[str] | None = None,
     ):
         nonlocal load_calls
@@ -1840,6 +1884,7 @@ async def test_select_account_sticky_reloads_inputs_after_stale_selected_persist
         return await original_load_selection_inputs(
             model=model,
             additional_limit_name=additional_limit_name,
+            explicit_additional_limit=explicit_additional_limit,
             account_ids=account_ids,
         )
 
@@ -1917,6 +1962,7 @@ async def test_select_account_sticky_does_not_return_stale_selection_at_retry_ca
         *,
         model: str | None,
         additional_limit_name: str | None = None,
+        explicit_additional_limit: bool = False,
         account_ids: Collection[str] | None = None,
     ):
         nonlocal load_calls
@@ -1924,6 +1970,7 @@ async def test_select_account_sticky_does_not_return_stale_selection_at_retry_ca
         return await original_load_selection_inputs(
             model=model,
             additional_limit_name=additional_limit_name,
+            explicit_additional_limit=explicit_additional_limit,
             account_ids=account_ids,
         )
 
@@ -2044,6 +2091,7 @@ async def test_load_selection_inputs_excludes_paused_accounts_from_sticky_pool(m
 @pytest.mark.asyncio
 async def test_select_account_skips_registry_plan_filter_for_mapped_model(monkeypatch) -> None:
     account = _make_account("acc-gated-registry-skip", "gated-registry-skip@example.com")
+    account.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     primary_entry = UsageHistory(

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -2089,6 +2089,112 @@ async def test_select_account_skips_registry_plan_filter_for_mapped_model(monkey
     assert selection.account is not None
     assert selection.account.id == account.id
     assert selection.error_code is None
+    cached_selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+    assert cached_selection.account is not None
+    assert cached_selection.account.id == account.id
+    assert cached_selection.error_code is None
+
+
+@pytest.mark.asyncio
+async def test_select_account_bypasses_primary_quota_for_model_derived_gated_limit(monkeypatch) -> None:
+    account = _make_account("acc-gated-quota-bypass", "gated-quota-bypass@example.com")
+    account.plan_type = "pro"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = now_epoch + 3600
+    primary_entry = UsageHistory(
+        id=1,
+        account_id=account.id,
+        recorded_at=now,
+        window="primary",
+        used_percent=20.0,
+        reset_at=now_epoch + 3600,
+        window_minutes=60,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(primary={account.id: primary_entry}, secondary={})
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(
+        primary={
+            account.id: _additional_entry(
+                2,
+                account_id=account.id,
+                window="primary",
+                used_percent=20.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now,
+            )
+        }
+    )
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+
+    assert selection.account is not None
+    assert selection.account.id == account.id
+    assert selection.error_code is None
+
+
+@pytest.mark.asyncio
+async def test_select_account_keeps_exempt_plan_quota_exceeded_for_model_derived_limit(monkeypatch) -> None:
+    account = _make_account("acc-gated-exempt-bypass", "gated-exempt-bypass@example.com")
+    account.plan_type = "plus"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = now_epoch + 3600
+    primary_entry = UsageHistory(
+        id=1,
+        account_id=account.id,
+        recorded_at=now,
+        window="primary",
+        used_percent=20.0,
+        reset_at=now_epoch + 3600,
+        window_minutes=60,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(primary={account.id: primary_entry}, secondary={})
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(primary={}, secondary={})
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+
+    assert selection.account is None
+    assert selection.error_message is not None
+    assert "Rate limit exceeded" in selection.error_message
+    assert selection.error_code is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -2262,6 +2262,65 @@ async def test_select_account_bypasses_primary_quota_for_model_derived_gated_lim
 
 
 @pytest.mark.asyncio
+async def test_select_account_ignores_ordinary_primary_usage_for_secondary_only_gated_limit(monkeypatch) -> None:
+    account = _make_account("acc-gated-secondary-only", "gated-secondary-only@example.com")
+    account.plan_type = "pro"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: UsageHistory(
+                id=1,
+                account_id=account.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=100.0,
+                reset_at=now_epoch + 3600,
+                window_minutes=60,
+            )
+        },
+        secondary={},
+    )
+    accounts_repo = StubAccountsRepository([account])
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(
+        primary={},
+        secondary={
+            account.id: _additional_entry(
+                2,
+                account_id=account.id,
+                window="secondary",
+                used_percent=20.0,
+                reset_at=now_epoch + 3600,
+                recorded_at=now,
+            )
+        },
+    )
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+
+    assert selection.account is not None
+    assert selection.account.id == account.id
+    assert selection.error_code is None
+
+
+@pytest.mark.asyncio
 async def test_select_account_prioritizes_requested_limit_usage_for_gated_model(monkeypatch) -> None:
     base_hot_limit_cool = _make_account("acc-base-hot-limit-cool", "base-hot@example.com")
     base_cool_limit_hot = _make_account("acc-base-cool-limit-hot", "base-cool@example.com")

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -25,9 +25,10 @@ from app.db.models import (
 )
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.proxy.account_cache import AccountSelectionCache
 from app.modules.proxy.load_balancer import (
     ADDITIONAL_QUOTA_DATA_UNAVAILABLE,
-    NO_ADDITIONAL_QUOTA_ELIGIBLE_ACCOUNTS,
+    ADDITIONAL_QUOTA_EXHAUSTED,
     NO_PLAN_SUPPORT_FOR_MODEL,
     LoadBalancer,
     RuntimeState,
@@ -861,6 +862,8 @@ async def test_select_account_requires_fresh_additional_usage_data(monkeypatch) 
 
     account_stale = _make_account("acc-additional-stale", email="stale@example.com")
     account_fresh = _make_account("acc-additional-fresh", email="fresh@example.com")
+    account_stale.plan_type = "pro"
+    account_fresh.plan_type = "pro"
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
     usage_rows = {
@@ -2152,6 +2155,445 @@ async def test_select_account_bypasses_primary_quota_for_model_derived_gated_lim
 
 
 @pytest.mark.asyncio
+async def test_select_account_prioritizes_requested_limit_usage_for_gated_model(monkeypatch) -> None:
+    base_hot_limit_cool = _make_account("acc-base-hot-limit-cool", "base-hot@example.com")
+    base_cool_limit_hot = _make_account("acc-base-cool-limit-hot", "base-cool@example.com")
+    base_hot_limit_cool.plan_type = "pro"
+    base_cool_limit_hot.plan_type = "pro"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    usage_repo = StubUsageRepository(
+        primary={
+            base_hot_limit_cool.id: UsageHistory(
+                id=1,
+                account_id=base_hot_limit_cool.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=95.0,
+                reset_at=now_epoch + 300,
+                window_minutes=5,
+            ),
+            base_cool_limit_hot.id: UsageHistory(
+                id=2,
+                account_id=base_cool_limit_hot.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=5.0,
+                reset_at=now_epoch + 300,
+                window_minutes=5,
+            ),
+        },
+        secondary={},
+    )
+    accounts_repo = StubAccountsRepository([base_hot_limit_cool, base_cool_limit_hot])
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(
+        primary={
+            base_hot_limit_cool.id: _additional_entry(
+                11,
+                account_id=base_hot_limit_cool.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now,
+            ),
+            base_cool_limit_hot.id: _additional_entry(
+                12,
+                account_id=base_cool_limit_hot.id,
+                window="primary",
+                used_percent=85.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now,
+            ),
+        }
+    )
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(
+        model="gpt-5.3-codex-spark",
+        routing_strategy="usage_weighted",
+    )
+
+    assert selection.account is not None
+    assert selection.account.id == base_hot_limit_cool.id
+
+
+@pytest.mark.asyncio
+async def test_select_account_keeps_additional_quota_per_account_slot(monkeypatch) -> None:
+    exhausted_slot = _make_account("acc-same-workspace-exhausted", "same-workspace@example.com")
+    available_slot = _make_account("acc-same-workspace-available", "same-workspace@example.com")
+    exhausted_slot.chatgpt_account_id = "workspace-shared"
+    available_slot.chatgpt_account_id = "workspace-shared"
+    exhausted_slot.plan_type = "pro"
+    available_slot.plan_type = "pro"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    usage_repo = StubUsageRepository(
+        primary={
+            exhausted_slot.id: UsageHistory(
+                id=1,
+                account_id=exhausted_slot.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=5.0,
+                reset_at=now_epoch + 300,
+                window_minutes=5,
+            ),
+            available_slot.id: UsageHistory(
+                id=2,
+                account_id=available_slot.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=5.0,
+                reset_at=now_epoch + 300,
+                window_minutes=5,
+            ),
+        },
+        secondary={},
+    )
+    accounts_repo = StubAccountsRepository([exhausted_slot, available_slot])
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(
+        primary={
+            exhausted_slot.id: _additional_entry(
+                21,
+                account_id=exhausted_slot.id,
+                window="primary",
+                used_percent=100.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now,
+            ),
+            available_slot.id: _additional_entry(
+                22,
+                account_id=available_slot.id,
+                window="primary",
+                used_percent=20.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now,
+            ),
+        }
+    )
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+
+    assert selection.account is not None
+    assert selection.account.id == available_slot.id
+
+
+@pytest.mark.asyncio
+async def test_select_account_keeps_additional_quotas_separate_for_one_slot(monkeypatch) -> None:
+    account = _make_account("acc-multi-quota", "multi-quota@example.com")
+    account.plan_type = "pro"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: UsageHistory(
+                id=1,
+                account_id=account.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=5.0,
+                reset_at=now_epoch + 300,
+                window_minutes=5,
+            )
+        },
+        secondary={},
+    )
+    accounts_repo = StubAccountsRepository([account])
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(
+        primary={
+            account.id: _additional_entry(
+                22,
+                account_id=account.id,
+                window="primary",
+                used_percent=20.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now,
+                limit_name="Other-Gated-Quota",
+                quota_key="other_gated_quota",
+            )
+        },
+        secondary={
+            account.id: _additional_entry(
+                21,
+                account_id=account.id,
+                window="secondary",
+                used_percent=100.0,
+                reset_at=now_epoch + 3600,
+                recorded_at=now,
+                limit_name="GPT-5.3-Codex-Spark",
+                quota_key="codex_spark",
+            )
+        },
+    )
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(additional_limit_name="other_gated_quota")
+
+    assert selection.account is not None
+    assert selection.account.id == account.id
+
+
+@pytest.mark.asyncio
+async def test_selection_cache_keeps_requested_quota_identity_separate(monkeypatch) -> None:
+    account = _make_account("acc-cache-quota", "cache-quota@example.com")
+    account.plan_type = "pro"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: UsageHistory(
+                id=1,
+                account_id=account.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=5.0,
+                reset_at=now_epoch + 300,
+                window_minutes=5,
+            )
+        },
+        secondary={},
+    )
+    accounts_repo = StubAccountsRepository([account])
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(
+        primary={
+            account.id: _additional_entry(
+                31,
+                account_id=account.id,
+                window="primary",
+                used_percent=20.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now,
+                limit_name="Quota-A",
+                quota_key="quota_a",
+            )
+        },
+        secondary={
+            account.id: _additional_entry(
+                32,
+                account_id=account.id,
+                window="secondary",
+                used_percent=100.0,
+                reset_at=now_epoch + 3600,
+                recorded_at=now,
+                limit_name="Quota-B",
+                quota_key="quota_b",
+            )
+        },
+    )
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    balancer._selection_inputs_cache = AccountSelectionCache(ttl_seconds=30)
+
+    available = await balancer.select_account(additional_limit_name="quota_a")
+    exhausted = await balancer.select_account(additional_limit_name="quota_b")
+
+    assert available.account is not None
+    assert available.account.id == account.id
+    assert exhausted.account is None
+    assert exhausted.error_code == ADDITIONAL_QUOTA_EXHAUSTED
+
+
+@pytest.mark.asyncio
+async def test_select_account_does_not_trust_pre_block_additional_usage(monkeypatch) -> None:
+    account = _make_account("acc-pre-block-additional", "pre-block@example.com")
+    account.plan_type = "pro"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = now_epoch + 3600
+    account.blocked_at = now_epoch
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: UsageHistory(
+                id=1,
+                account_id=account.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=20.0,
+                reset_at=now_epoch + 3600,
+                window_minutes=60,
+            )
+        },
+        secondary={},
+    )
+    accounts_repo = StubAccountsRepository([account])
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(
+        primary={
+            account.id: _additional_entry(
+                2,
+                account_id=account.id,
+                window="primary",
+                used_percent=20.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now - timedelta(seconds=1),
+            )
+        }
+    )
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+
+    assert selection.account is None
+    assert selection.error_code == ADDITIONAL_QUOTA_DATA_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_requested_limit_selection_does_not_recover_account_status(monkeypatch) -> None:
+    account = _make_account("acc-limit-scoped-status", "limit-scoped-status@example.com")
+    account.plan_type = "pro"
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = now_epoch - 60
+    account.blocked_at = now_epoch - 600
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: UsageHistory(
+                id=1,
+                account_id=account.id,
+                recorded_at=now,
+                window="primary",
+                used_percent=100.0,
+                reset_at=now_epoch + 300,
+                window_minutes=5,
+            )
+        },
+        secondary={},
+    )
+    accounts_repo = StubAccountsRepository([account])
+    sticky_repo = StubStickySessionsRepository()
+    additional_usage_repo = StubAdditionalUsageRepository(
+        primary={
+            account.id: _additional_entry(
+                2,
+                account_id=account.id,
+                window="primary",
+                used_percent=20.0,
+                reset_at=now_epoch + 300,
+                recorded_at=now,
+            )
+        },
+        secondary={
+            account.id: _additional_entry(
+                3,
+                account_id=account.id,
+                window="secondary",
+                used_percent=20.0,
+                reset_at=now_epoch + 3600,
+                recorded_at=now,
+            )
+        },
+    )
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            get_snapshot=lambda: SimpleNamespace(model_plans={}),
+            plan_types_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(
+        lambda: _repo_factory(
+            accounts_repo,
+            usage_repo,
+            sticky_repo,
+            additional_usage_repo,
+        )
+    )
+    selection = await balancer.select_account(model="gpt-5.3-codex-spark")
+
+    assert selection.account is not None
+    assert selection.account.id == account.id
+    assert selection.account.status == AccountStatus.QUOTA_EXCEEDED
+    assert accounts_repo.status_updates == []
+    assert account.status == AccountStatus.QUOTA_EXCEEDED
+    assert account.reset_at == now_epoch - 60
+    assert account.blocked_at == now_epoch - 600
+
+
+@pytest.mark.asyncio
 async def test_select_account_keeps_exempt_plan_quota_exceeded_for_model_derived_limit(monkeypatch) -> None:
     account = _make_account("acc-gated-exempt-bypass", "gated-exempt-bypass@example.com")
     account.plan_type = "plus"
@@ -2569,7 +3011,7 @@ async def test_select_account_allows_plus_plan_without_additional_quota_rows(mon
 
 
 @pytest.mark.asyncio
-async def test_select_account_fails_closed_for_unmapped_plan_without_additional_quota_rows(monkeypatch) -> None:
+async def test_select_account_allows_mapped_plan_when_additional_quota_does_not_apply(monkeypatch) -> None:
     account = _make_account("acc-unmapped-no-gated-rows", "unmapped-no-gated-rows@example.com")
     account.plan_type = "edu"
     now = utcnow()
@@ -2603,8 +3045,9 @@ async def test_select_account_fails_closed_for_unmapped_plan_without_additional_
     )
     selection = await balancer.select_account(model="gpt-5.3-codex-spark")
 
-    assert selection.account is None
-    assert selection.error_code == ADDITIONAL_QUOTA_DATA_UNAVAILABLE
+    assert selection.account is not None
+    assert selection.account.id == account.id
+    assert selection.error_code is None
 
 
 @pytest.mark.asyncio
@@ -2752,7 +3195,7 @@ async def test_select_account_allows_primary_only_account_when_other_account_has
 
 
 @pytest.mark.asyncio
-async def test_select_account_returns_no_eligible_error_for_mapped_model(monkeypatch) -> None:
+async def test_select_account_returns_quota_exhausted_error_for_mapped_model(monkeypatch) -> None:
     account = _make_account("acc-gated-exhausted", "gated-exhausted@example.com")
     account.plan_type = "pro"
     now = utcnow()
@@ -2808,7 +3251,7 @@ async def test_select_account_returns_no_eligible_error_for_mapped_model(monkeyp
     selection = await balancer.select_account(model="gpt-5.3-codex-spark")
 
     assert selection.account is None
-    assert selection.error_code == NO_ADDITIONAL_QUOTA_ELIGIBLE_ACCOUNTS
+    assert selection.error_code == ADDITIONAL_QUOTA_EXHAUSTED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When a model is routed through an additional (gated) quota (e.g. \`GPT-5.3-Codex-Spark\`), \`select_account()\` unconditionally filters out all accounts with \`QUOTA_EXCEEDED\` status — even when the **additional** (independent) quota is available and the account is otherwise healthy. This causes legitimate gated-model requests to fail with "No available accounts".

The root cause: the \`QUOTA_EXCEEDED\` branch in \`select_account()\` does \`continue\` without checking whether an additional quota gate has already determined the account is eligible.

## Change

Add a \`bypass_quota_exceeded=False\` keyword parameter to \`select_account()\` that, when \`True\`, skips the \`QUOTA_EXCEEDED continue\` branch while **still respecting all other status checks** (PAUSED, DEACTIVATED, RATE_LIMITED, cooldown, error backoff).

At the \`LoadBalancer.select_account()\` entry point, automatically compute:

\`\`\`python
_effective_bypass_quota_exceeded = additional_limit_name is not None
\`\`\`

so bypass is enabled for any gated-model request. The parameter flows through the full call chain:
- \`LoadBalancer.select_account()\` → \`_select_account_preferring_budget_safe()\` → \`select_account()\`
- \`LoadBalancer.select_account()\` → \`_select_with_stickiness()\` → \`select_account()\`

**Impact scope**: Only affects requests routed through an additional quota gate. Standard (non-gated) requests are unaffected (\`additional_limit_name=None\` → bypass stays \`False\`).

## Testing

84/84 pass (82 existing + 2 new):
- \`test_bypass_quota_exceeded_keeps_account_in_pool\`: confirms QUOTA_EXCEEDED account stays in pool when bypass=True
- \`test_bypass_quota_exceeded_does_not_affect_other_statuses\`: confirms PAUSED/DEACTIVATED still filtered when bypass=True

## Files changed (3 files, +65/-1)

| File | Change |
|------|--------|
| \`app/core/balancer/logic.py\` | New \`bypass_quota_exceeded\` param + skip logic |
| \`app/modules/proxy/load_balancer.py\` | Param forwarding + entry-point computation |
| \`tests/unit/test_load_balancer.py\` | 2 regression tests |