### PR TITLE
fix(proxy): retire stale HTTP bridge pending sessions

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6855,6 +6855,7 @@ class ProxyService:
             pending_lock=anyio.Lock(),
             response_create_gate=asyncio.Semaphore(1),
             queued_request_count=0,
+            lifecycle_lock=anyio.Lock(),
             last_used_at=time.monotonic(),
             idle_ttl_seconds=idle_ttl_seconds,
             codex_session=affinity.kind == StickySessionKind.CODEX_SESSION,
@@ -6896,6 +6897,22 @@ class ProxyService:
                 ),
             )
         if session.closed:
+            async with self._http_bridge_lock:
+                current_session = self._http_bridge_sessions.get(session.key)
+            if current_session is not session:
+                _log_http_bridge_event(
+                    "submit_on_closed",
+                    session.key,
+                    account_id=session.account.id,
+                    model=session.request_model,
+                    detail="session_replaced_before_reconnect",
+                    cache_key_family=session.key.affinity_kind,
+                    model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                )
+                raise ProxyResponseError(
+                    502,
+                    openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
+                )
             # Try reconnecting the upstream websocket first.  For requests
             # carrying previous_response_id we only reconnect (send_request=
             # False) because the fresh upstream won't recognise the old
@@ -6973,9 +6990,10 @@ class ProxyService:
                 bridge_session=session,
             )
             gate_acquired = True
-            async with self._http_bridge_lock:
-                current_session = self._http_bridge_sessions.get(session.key)
-                session_replaced = current_session is not None and current_session is not session
+            async with session.lifecycle_lock:
+                async with self._http_bridge_lock:
+                    current_session = self._http_bridge_sessions.get(session.key)
+                session_replaced = current_session is not session
                 if session.closed or session_replaced:
                     _log_http_bridge_event(
                         "submit_on_closed",
@@ -6994,17 +7012,18 @@ class ProxyService:
                         502,
                         openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
                     )
-            async with session.pending_lock:
-                session.pending_requests.append(request_state)
-            request_enqueued = True
-            await session.upstream.send_text(text_data)
-            session.last_used_at = time.monotonic()
+                async with session.pending_lock:
+                    session.pending_requests.append(request_state)
+                request_enqueued = True
+                await session.upstream.send_text(text_data)
+                session.last_used_at = time.monotonic()
         except ProxyResponseError:
             await self._cleanup_http_bridge_submit_interruption(
                 session,
                 request_state=request_state,
                 gate_acquired=gate_acquired,
                 request_enqueued=request_enqueued,
+                counted_in_queue=True,
             )
             raise
         except asyncio.CancelledError:
@@ -7013,6 +7032,7 @@ class ProxyService:
                 request_state=request_state,
                 gate_acquired=gate_acquired,
                 request_enqueued=request_enqueued,
+                counted_in_queue=True,
             )
             raise
         except Exception as exc:
@@ -7037,6 +7057,7 @@ class ProxyService:
                 request_state=request_state,
                 gate_acquired=gate_acquired,
                 request_enqueued=request_enqueued,
+                counted_in_queue=True,
             )
             await self._fail_pending_websocket_requests(
                 account=session.account,
@@ -7116,9 +7137,10 @@ class ProxyService:
                     bridge_session=session,
                 )
                 gate_acquired = True
-                async with self._http_bridge_lock:
-                    current_session = self._http_bridge_sessions.get(session.key)
-                    session_replaced = current_session is not None and current_session is not session
+                async with session.lifecycle_lock:
+                    async with self._http_bridge_lock:
+                        current_session = self._http_bridge_sessions.get(session.key)
+                    session_replaced = current_session is not session
                     if session.closed or session_replaced:
                         _log_http_bridge_event(
                             "submit_on_closed",
@@ -7139,13 +7161,14 @@ class ProxyService:
                             request_state=warmup_state,
                             gate_acquired=gate_acquired,
                             request_enqueued=request_enqueued,
+                            counted_in_queue=False,
                         )
                         gate_acquired = False
                         return
-                async with session.pending_lock:
-                    session.pending_requests.append(warmup_state)
-                request_enqueued = True
-                await session.upstream.send_text(warmup_text)
+                    async with session.pending_lock:
+                        session.pending_requests.append(warmup_state)
+                    request_enqueued = True
+                    await session.upstream.send_text(warmup_text)
                 while True:
                     try:
                         event_block = await asyncio.wait_for(
@@ -7204,6 +7227,7 @@ class ProxyService:
                     request_state=warmup_state,
                     gate_acquired=gate_acquired,
                     request_enqueued=request_enqueued,
+                    counted_in_queue=False,
                 )
                 if is_local_overload_error_code(code):
                     session.prewarmed = False
@@ -7217,6 +7241,7 @@ class ProxyService:
                     request_state=warmup_state,
                     gate_acquired=gate_acquired,
                     request_enqueued=request_enqueued,
+                    counted_in_queue=False,
                 )
                 raise
 
@@ -7227,11 +7252,13 @@ class ProxyService:
         request_state: _WebSocketRequestState,
         gate_acquired: bool,
         request_enqueued: bool,
+        counted_in_queue: bool,
     ) -> None:
         async with session.pending_lock:
             if request_enqueued and request_state in session.pending_requests:
                 session.pending_requests.remove(request_state)
-            session.queued_request_count = max(0, session.queued_request_count - 1)
+            if counted_in_queue:
+                session.queued_request_count = max(0, session.queued_request_count - 1)
         self._cancel_request_state_api_key_reservation_heartbeat(request_state)
         if gate_acquired:
             await _release_websocket_response_create_gate(request_state, session.response_create_gate)
@@ -7302,19 +7329,27 @@ class ProxyService:
                 self._unregister_http_bridge_turn_states_locked(session)
                 self._unregister_http_bridge_previous_response_ids_locked(session)
         if session.durable_session_id is not None and session.durable_owner_epoch is not None:
+            durable_session_id = session.durable_session_id
+            durable_owner_epoch = session.durable_owner_epoch
+            session.durable_session_id = None
+            session.durable_owner_epoch = None
             try:
                 await self._durable_bridge.release_live_session(
-                    session_id=session.durable_session_id,
+                    session_id=durable_session_id,
                     instance_id=get_settings().http_responses_session_bridge_instance_id,
-                    owner_epoch=session.durable_owner_epoch,
+                    owner_epoch=durable_owner_epoch,
                     draining=shutdown_state.is_bridge_drain_active(),
                 )
             except Exception:
+                session.durable_session_id = durable_session_id
+                session.durable_owner_epoch = durable_owner_epoch
                 logger.warning("Failed to release stale pending HTTP bridge session lease", exc_info=True)
-        try:
-            await session.upstream.close()
-        except Exception:
-            logger.debug("Failed to close stale pending HTTP bridge upstream websocket", exc_info=True)
+        if not session.upstream_close_attempted:
+            session.upstream_close_attempted = True
+            try:
+                await session.upstream.close()
+            except Exception:
+                logger.debug("Failed to close stale pending HTTP bridge upstream websocket", exc_info=True)
         _log_http_bridge_event(
             "retire_stale_pending",
             session.key,
@@ -7355,20 +7390,21 @@ class ProxyService:
                     retried = await self._retry_http_bridge_precreated_request(session)
                     if retried:
                         continue
-                    session.closed = True
-                    async with session.pending_lock:
-                        session.queued_request_count = 0
                     try:
-                        await self._fail_pending_websocket_requests(
-                            account=session.account,
-                            account_id_value=session.account.id,
-                            pending_requests=session.pending_requests,
-                            pending_lock=session.pending_lock,
-                            error_code=receive_timeout.error_code,
-                            error_message=receive_timeout.error_message,
-                            api_key=None,
-                            response_create_gate=session.response_create_gate,
-                        )
+                        async with session.lifecycle_lock:
+                            session.closed = True
+                            async with session.pending_lock:
+                                session.queued_request_count = 0
+                            await self._fail_pending_websocket_requests(
+                                account=session.account,
+                                account_id_value=session.account.id,
+                                pending_requests=session.pending_requests,
+                                pending_lock=session.pending_lock,
+                                error_code=receive_timeout.error_code,
+                                error_message=receive_timeout.error_message,
+                                api_key=None,
+                                response_create_gate=session.response_create_gate,
+                            )
                     finally:
                         await self._retire_stale_pending_http_bridge_session(
                             session,
@@ -7387,20 +7423,21 @@ class ProxyService:
                 retried = await self._retry_http_bridge_precreated_request(session)
                 if retried:
                     continue
-                session.closed = True
-                async with session.pending_lock:
-                    session.queued_request_count = 0
                 try:
-                    await self._fail_pending_websocket_requests(
-                        account=session.account,
-                        account_id_value=session.account.id,
-                        pending_requests=session.pending_requests,
-                        pending_lock=session.pending_lock,
-                        error_code="stream_incomplete",
-                        error_message=_upstream_websocket_disconnect_message(message),
-                        api_key=None,
-                        response_create_gate=session.response_create_gate,
-                    )
+                    async with session.lifecycle_lock:
+                        session.closed = True
+                        async with session.pending_lock:
+                            session.queued_request_count = 0
+                        await self._fail_pending_websocket_requests(
+                            account=session.account,
+                            account_id_value=session.account.id,
+                            pending_requests=session.pending_requests,
+                            pending_lock=session.pending_lock,
+                            error_code="stream_incomplete",
+                            error_message=_upstream_websocket_disconnect_message(message),
+                            api_key=None,
+                            response_create_gate=session.response_create_gate,
+                        )
                 finally:
                     await self._retire_stale_pending_http_bridge_session(
                         session,
@@ -7416,18 +7453,26 @@ class ProxyService:
                 session.key.affinity_kind,
                 exc_info=True,
             )
-            async with session.pending_lock:
-                session.queued_request_count = 0
-            await self._fail_pending_websocket_requests(
-                account=session.account,
-                account_id_value=session.account.id,
-                pending_requests=session.pending_requests,
-                pending_lock=session.pending_lock,
-                error_code="stream_incomplete",
-                error_message="HTTP bridge upstream reader crashed before response.completed",
-                api_key=None,
-                response_create_gate=session.response_create_gate,
-            )
+            try:
+                async with session.lifecycle_lock:
+                    session.closed = True
+                    async with session.pending_lock:
+                        session.queued_request_count = 0
+                    await self._fail_pending_websocket_requests(
+                        account=session.account,
+                        account_id_value=session.account.id,
+                        pending_requests=session.pending_requests,
+                        pending_lock=session.pending_lock,
+                        error_code="stream_incomplete",
+                        error_message="HTTP bridge upstream reader crashed before response.completed",
+                        api_key=None,
+                        response_create_gate=session.response_create_gate,
+                    )
+            finally:
+                await self._retire_stale_pending_http_bridge_session(
+                    session,
+                    detail="reader_crash",
+                )
         finally:
             session.closed = True
 
@@ -12421,6 +12466,7 @@ class _HTTPBridgeSession:
     queued_request_count: int
     last_used_at: float
     idle_ttl_seconds: float
+    lifecycle_lock: anyio.Lock = field(default_factory=anyio.Lock)
     api_key: ApiKeyData | None = None
     codex_session: bool = False
     prewarmed: bool = False
@@ -12438,6 +12484,7 @@ class _HTTPBridgeSession:
     last_upstream_close_code: int | None = None
     closed: bool = False
     account_lease: AccountLease | None = None
+    upstream_close_attempted: bool = False
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6897,51 +6897,53 @@ class ProxyService:
                 ),
             )
         if session.closed:
-            async with self._http_bridge_lock:
-                current_session = self._http_bridge_sessions.get(session.key)
-            if current_session is not session:
-                _log_http_bridge_event(
-                    "submit_on_closed",
-                    session.key,
-                    account_id=session.account.id,
-                    model=session.request_model,
-                    detail="session_replaced_before_reconnect",
-                    cache_key_family=session.key.affinity_kind,
-                    model_class=_extract_model_class(session.request_model) if session.request_model else None,
-                )
-                raise ProxyResponseError(
-                    502,
-                    openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
-                )
-            # Try reconnecting the upstream websocket first.  For requests
-            # carrying previous_response_id we only reconnect (send_request=
-            # False) because the fresh upstream won't recognise the old
-            # response id.  If reconnection itself fails, raise 502 so the
-            # client retries with previous_response_id intact rather than
-            # receiving 400 previous_response_not_found (which causes the
-            # CLI to drop previous_response_id and resend the full
-            # conversation history, inflating per-turn context by ~20x).
-            recovered = await self._retry_http_bridge_request_on_fresh_upstream(
-                session,
-                request_state=request_state,
-                text_data=text_data,
-                send_request=False,
-            )
-            if recovered:
-                session.closed = False
-            else:
-                _log_http_bridge_event(
-                    "submit_on_closed",
-                    session.key,
-                    account_id=session.account.id,
-                    model=session.request_model,
-                    cache_key_family=session.key.affinity_kind,
-                    model_class=_extract_model_class(session.request_model) if session.request_model else None,
-                )
-                raise ProxyResponseError(
-                    502,
-                    openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
-                )
+            async with session.lifecycle_lock:
+                if session.closed:
+                    async with self._http_bridge_lock:
+                        current_session = self._http_bridge_sessions.get(session.key)
+                    if current_session is not session:
+                        _log_http_bridge_event(
+                            "submit_on_closed",
+                            session.key,
+                            account_id=session.account.id,
+                            model=session.request_model,
+                            detail="session_replaced_before_reconnect",
+                            cache_key_family=session.key.affinity_kind,
+                            model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                        )
+                        raise ProxyResponseError(
+                            502,
+                            openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
+                        )
+                    # Try reconnecting the upstream websocket first.  For requests
+                    # carrying previous_response_id we only reconnect (send_request=
+                    # False) because the fresh upstream won't recognise the old
+                    # response id.  If reconnection itself fails, raise 502 so the
+                    # client retries with previous_response_id intact rather than
+                    # receiving 400 previous_response_not_found (which causes the
+                    # CLI to drop previous_response_id and resend the full
+                    # conversation history, inflating per-turn context by ~20x).
+                    recovered = await self._retry_http_bridge_request_on_fresh_upstream(
+                        session,
+                        request_state=request_state,
+                        text_data=text_data,
+                        send_request=False,
+                    )
+                    if recovered:
+                        session.closed = False
+                    else:
+                        _log_http_bridge_event(
+                            "submit_on_closed",
+                            session.key,
+                            account_id=session.account.id,
+                            model=session.request_model,
+                            cache_key_family=session.key.affinity_kind,
+                            model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                        )
+                        raise ProxyResponseError(
+                            502,
+                            openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
+                        )
         if session.upstream_control.retire_after_drain:
             await self._retire_http_bridge_after_drain_if_ready(session)
             raise ProxyResponseError(
@@ -7390,8 +7392,8 @@ class ProxyService:
                     retried = await self._retry_http_bridge_precreated_request(session)
                     if retried:
                         continue
-                    try:
-                        async with session.lifecycle_lock:
+                    async with session.lifecycle_lock:
+                        try:
                             session.closed = True
                             async with session.pending_lock:
                                 session.queued_request_count = 0
@@ -7405,11 +7407,11 @@ class ProxyService:
                                 api_key=None,
                                 response_create_gate=session.response_create_gate,
                             )
-                    finally:
-                        await self._retire_stale_pending_http_bridge_session(
-                            session,
-                            detail=receive_timeout.error_code,
-                        )
+                        finally:
+                            await self._retire_stale_pending_http_bridge_session(
+                                session,
+                                detail=receive_timeout.error_code,
+                            )
                     break
 
                 if message.kind == "text" and message.text is not None:
@@ -7423,8 +7425,8 @@ class ProxyService:
                 retried = await self._retry_http_bridge_precreated_request(session)
                 if retried:
                     continue
-                try:
-                    async with session.lifecycle_lock:
+                async with session.lifecycle_lock:
+                    try:
                         session.closed = True
                         async with session.pending_lock:
                             session.queued_request_count = 0
@@ -7438,11 +7440,11 @@ class ProxyService:
                             api_key=None,
                             response_create_gate=session.response_create_gate,
                         )
-                finally:
-                    await self._retire_stale_pending_http_bridge_session(
-                        session,
-                        detail="stream_incomplete",
-                    )
+                    finally:
+                        await self._retire_stale_pending_http_bridge_session(
+                            session,
+                            detail="stream_incomplete",
+                        )
                 break
         except asyncio.CancelledError:
             raise
@@ -7453,8 +7455,8 @@ class ProxyService:
                 session.key.affinity_kind,
                 exc_info=True,
             )
-            try:
-                async with session.lifecycle_lock:
+            async with session.lifecycle_lock:
+                try:
                     session.closed = True
                     async with session.pending_lock:
                         session.queued_request_count = 0
@@ -7468,11 +7470,11 @@ class ProxyService:
                         api_key=None,
                         response_create_gate=session.response_create_gate,
                     )
-            finally:
-                await self._retire_stale_pending_http_bridge_session(
-                    session,
-                    detail="reader_crash",
-                )
+                finally:
+                    await self._retire_stale_pending_http_bridge_session(
+                        session,
+                        detail="reader_crash",
+                    )
         finally:
             session.closed = True
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -280,19 +280,27 @@ def _log_http_bridge_startup_wait_timeout(
     request_model: str | None = None,
     pending_count: int | None = None,
     inflight_count: int | None = None,
+    queued_count: int | None = None,
     available: int | None = None,
+    pending_request_ids: Sequence[str] | None = None,
+    pending_request_ages_seconds: Sequence[float] | None = None,
 ) -> None:
     logger.warning(
         "http_bridge_startup_wait_timeout request_id=%s stage=%s wait_timeout_seconds=%.1f "
-        "affinity_kind=%s model_class=%s pending_count=%s inflight_count=%s available=%s",
+        "affinity_kind=%s bridge_key=%s model_class=%s pending_count=%s queued_count=%s "
+        "inflight_count=%s available=%s pending_request_ids=%s pending_request_ages_seconds=%s",
         request_id or get_request_id() or "unknown",
         stage,
         timeout_seconds,
         key.affinity_kind if key is not None else None,
+        _hash_identifier(key.affinity_key) if key is not None else None,
         _extract_model_class(request_model) if request_model else None,
         pending_count,
+        queued_count,
         inflight_count,
         available,
+        ",".join(pending_request_ids) if pending_request_ids else None,
+        ",".join(f"{age:.1f}" for age in pending_request_ages_seconds) if pending_request_ages_seconds else None,
     )
 
 
@@ -4559,6 +4567,7 @@ class ProxyService:
         request_state: _WebSocketRequestState,
         *,
         response_create_gate: asyncio.Semaphore,
+        bridge_session: "_HTTPBridgeSession | None" = None,
         compact: bool = False,
         account_id: str | None = None,
         surface: str = "websocket",
@@ -4579,12 +4588,29 @@ class ProxyService:
             request_state.response_create_gate = None
             request_state.response_create_gate_acquired = False
             request_state.awaiting_response_created = False
+            pending_count = None
+            queued_count = None
+            pending_request_ids: list[str] | None = None
+            pending_request_ages_seconds: list[float] | None = None
+            if bridge_session is not None:
+                now = time.monotonic()
+                async with bridge_session.pending_lock:
+                    pending_states = list(bridge_session.pending_requests)
+                    pending_count = len(pending_states)
+                    queued_count = bridge_session.queued_request_count
+                pending_request_ids = [state.request_log_id or state.request_id for state in pending_states]
+                pending_request_ages_seconds = [max(0.0, now - state.started_at) for state in pending_states]
             _log_http_bridge_startup_wait_timeout(
                 stage="response_create_gate",
                 timeout_seconds=timeout_seconds,
+                key=bridge_session.key if bridge_session is not None else None,
                 request_id=request_state.request_id,
                 request_model=request_state.model,
+                pending_count=pending_count,
+                queued_count=queued_count,
                 available=getattr(response_create_gate, "_value", None),
+                pending_request_ids=pending_request_ids,
+                pending_request_ages_seconds=pending_request_ages_seconds,
             )
             raise _http_bridge_startup_wait_timeout_error(
                 "http_bridge_response_create_gate",
@@ -4850,6 +4876,17 @@ class ProxyService:
             request_state.websocket_stream_lease = selection.lease
             return account
         if defer_no_account_error:
+            logger.warning(
+                "Websocket account selection deferred no-account error request_id=%s model=%s "
+                "preferred_account_id=%s require_preferred=%s error_code=%s error=%s excluded_count=%s",
+                request_state.request_log_id or request_state.request_id,
+                model,
+                preferred_account_id,
+                require_preferred_account,
+                selection.error_code,
+                selection.error_message,
+                len(exclude_account_ids),
+            )
             return None
         error_code = selection.error_code or "no_accounts"
         error_message = selection.error_message or "No active accounts available"
@@ -4895,6 +4932,18 @@ class ProxyService:
                 error_message=message,
             )
             return None
+        logger.warning(
+            "Websocket account selection failed request_id=%s model=%s preferred_account_id=%s "
+            "require_preferred=%s error_code=%s error=%s excluded_count=%s api_key_present=%s",
+            request_state.request_log_id or request_state.request_id,
+            model,
+            preferred_account_id,
+            require_preferred_account,
+            error_code,
+            error_message,
+            len(exclude_account_ids),
+            api_key is not None,
+        )
         status_code = 429 if is_local_overload_error_code(error_code) else 503
         await self._emit_websocket_connect_failure(
             websocket,
@@ -6921,6 +6970,7 @@ class ProxyService:
                 response_create_gate=session.response_create_gate,
                 account_id=session.account.id,
                 surface="http_bridge",
+                bridge_session=session,
             )
             gate_acquired = True
             async with session.pending_lock:
@@ -7042,6 +7092,7 @@ class ProxyService:
                     response_create_gate=session.response_create_gate,
                     account_id=session.account.id,
                     surface="http_bridge_prewarm",
+                    bridge_session=session,
                 )
                 gate_acquired = True
                 async with session.pending_lock:
@@ -7191,6 +7242,43 @@ class ProxyService:
             )
         return True
 
+    async def _retire_stale_pending_http_bridge_session(
+        self,
+        session: "_HTTPBridgeSession",
+        *,
+        detail: str,
+    ) -> None:
+        session.closed = True
+        async with self._http_bridge_lock:
+            if self._http_bridge_sessions.get(session.key) is session:
+                self._http_bridge_sessions.pop(session.key, None)
+                self._unregister_http_bridge_turn_states_locked(session)
+                self._unregister_http_bridge_previous_response_ids_locked(session)
+        if session.durable_session_id is not None and session.durable_owner_epoch is not None:
+            try:
+                await self._durable_bridge.release_live_session(
+                    session_id=session.durable_session_id,
+                    instance_id=get_settings().http_responses_session_bridge_instance_id,
+                    owner_epoch=session.durable_owner_epoch,
+                    draining=shutdown_state.is_bridge_drain_active(),
+                )
+            except Exception:
+                logger.warning("Failed to release stale pending HTTP bridge session lease", exc_info=True)
+        try:
+            await session.upstream.close()
+        except Exception:
+            logger.debug("Failed to close stale pending HTTP bridge upstream websocket", exc_info=True)
+        _log_http_bridge_event(
+            "retire_stale_pending",
+            session.key,
+            account_id=session.account.id,
+            model=session.request_model,
+            pending_count=await self._http_bridge_pending_count(session),
+            detail=detail,
+            cache_key_family=session.key.affinity_kind,
+            model_class=_extract_model_class(session.request_model) if session.request_model else None,
+        )
+
     async def _relay_http_bridge_upstream_messages(
         self,
         session: "_HTTPBridgeSession",
@@ -7222,17 +7310,22 @@ class ProxyService:
                         continue
                     async with session.pending_lock:
                         session.queued_request_count = 0
-                    await self._fail_pending_websocket_requests(
-                        account=session.account,
-                        account_id_value=session.account.id,
-                        pending_requests=session.pending_requests,
-                        pending_lock=session.pending_lock,
-                        error_code=receive_timeout.error_code,
-                        error_message=receive_timeout.error_message,
-                        api_key=None,
-                        response_create_gate=session.response_create_gate,
-                    )
-                    session.closed = True
+                    try:
+                        await self._fail_pending_websocket_requests(
+                            account=session.account,
+                            account_id_value=session.account.id,
+                            pending_requests=session.pending_requests,
+                            pending_lock=session.pending_lock,
+                            error_code=receive_timeout.error_code,
+                            error_message=receive_timeout.error_message,
+                            api_key=None,
+                            response_create_gate=session.response_create_gate,
+                        )
+                    finally:
+                        await self._retire_stale_pending_http_bridge_session(
+                            session,
+                            detail=receive_timeout.error_code,
+                        )
                     break
 
                 if message.kind == "text" and message.text is not None:
@@ -7248,17 +7341,22 @@ class ProxyService:
                     continue
                 async with session.pending_lock:
                     session.queued_request_count = 0
-                await self._fail_pending_websocket_requests(
-                    account=session.account,
-                    account_id_value=session.account.id,
-                    pending_requests=session.pending_requests,
-                    pending_lock=session.pending_lock,
-                    error_code="stream_incomplete",
-                    error_message=_upstream_websocket_disconnect_message(message),
-                    api_key=None,
-                    response_create_gate=session.response_create_gate,
-                )
-                session.closed = True
+                try:
+                    await self._fail_pending_websocket_requests(
+                        account=session.account,
+                        account_id_value=session.account.id,
+                        pending_requests=session.pending_requests,
+                        pending_lock=session.pending_lock,
+                        error_code="stream_incomplete",
+                        error_message=_upstream_websocket_disconnect_message(message),
+                        api_key=None,
+                        response_create_gate=session.response_create_gate,
+                    )
+                finally:
+                    await self._retire_stale_pending_http_bridge_session(
+                        session,
+                        detail="stream_incomplete",
+                    )
                 break
         except asyncio.CancelledError:
             raise
@@ -10824,6 +10922,17 @@ class ProxyService:
                     )
                 return
             retries_exhausted_msg = "No available accounts after retries"
+            logger.warning(
+                "Proxy streaming exhausted accounts request_id=%s model=%s transport=%s attempts=%s "
+                "excluded_count=%s preferred_account_id=%s api_key_present=%s",
+                request_id,
+                payload.model,
+                request_transport,
+                attempt,
+                len(excluded_account_ids),
+                preferred_account_id,
+                api_key is not None,
+            )
             event = response_failed_event(
                 "no_accounts",
                 retries_exhausted_msg,
@@ -11748,23 +11857,48 @@ class ProxyService:
             else None
         )
         excluded_account_ids_set = set(exclude_account_ids or ())
+        logger.info(
+            "Proxy account selection start request_id=%s kind=%s request_stage=%s model=%s "
+            "additional_limit=%s sticky=%s sticky_kind=%s reallocate_sticky=%s prefer_earlier_reset=%s "
+            "routing_strategy=%s api_key_present=%s api_key_scope_enabled=%s scoped_count=%s "
+            "excluded_count=%s preferred_account_id=%s remaining_budget=%.2f",
+            request_id,
+            kind,
+            request_stage,
+            model,
+            additional_limit_name,
+            bool(sticky_key),
+            sticky_kind.value if hasattr(sticky_kind, "value") else sticky_kind,
+            reallocate_sticky,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            api_key is not None,
+            bool(api_key is not None and api_key.account_assignment_scope_enabled),
+            None if scoped_account_ids is None else len(scoped_account_ids),
+            len(excluded_account_ids_set),
+            preferred_account_id,
+            remaining_budget,
+        )
         try:
             with anyio.fail_after(remaining_budget):
                 settings = await get_settings_cache().get()
-                preferred_account_selectable = (
+                preferred_eligible = (
                     preferred_account_id is not None
                     and preferred_account_id not in excluded_account_ids_set
                     and (scoped_account_ids is None or preferred_account_id in scoped_account_ids)
                 )
-                if preferred_account_id is not None and not preferred_account_selectable:
-                    if not fallback_on_preferred_account_unavailable:
-                        return AccountSelection(
-                            account=None,
-                            error_message="Preferred account is unavailable",
-                            error_code="no_accounts",
-                        )
-                if preferred_account_selectable:
-                    assert preferred_account_id is not None
+                if preferred_account_id is not None and not preferred_eligible:
+                    logger.warning(
+                        "Proxy preferred account skipped request_id=%s kind=%s request_stage=%s "
+                        "preferred_account_id=%s excluded=%s outside_api_key_scope=%s",
+                        request_id,
+                        kind,
+                        request_stage,
+                        preferred_account_id,
+                        preferred_account_id in excluded_account_ids_set,
+                        scoped_account_ids is not None and preferred_account_id not in scoped_account_ids,
+                    )
+                if preferred_eligible:
                     preferred_selection = await self._load_balancer.select_account(
                         sticky_key=sticky_key,
                         sticky_kind=sticky_kind,
@@ -11791,6 +11925,16 @@ class ProxyService:
                         )
                         return preferred_selection
                     if not fallback_on_preferred_account_unavailable:
+                        logger.warning(
+                            "Proxy preferred account unavailable request_id=%s kind=%s request_stage=%s "
+                            "preferred_account_id=%s error_code=%s error=%s",
+                            request_id,
+                            kind,
+                            request_stage,
+                            preferred_account_id,
+                            preferred_selection.error_code,
+                            preferred_selection.error_message,
+                        )
                         return preferred_selection
                 selection = await self._load_balancer.select_account(
                     sticky_key=sticky_key,
@@ -11810,11 +11954,33 @@ class ProxyService:
                     estimated_lease_tokens=estimated_lease_tokens,
                 )
                 if selection.account is not None and selection.account.id in excluded_account_ids_set:
+                    logger.warning(
+                        "Proxy account selection returned excluded account request_id=%s kind=%s request_stage=%s "
+                        "account_id=%s excluded_count=%s",
+                        request_id,
+                        kind,
+                        request_stage,
+                        selection.account.id,
+                        len(excluded_account_ids_set),
+                    )
                     return AccountSelection(
                         account=None,
                         error_message="No active accounts available",
                         error_code="no_accounts",
                     )
+                logger.info(
+                    "Proxy account selection result request_id=%s kind=%s request_stage=%s model=%s "
+                    "selected_account_id=%s error_code=%s error=%s scoped_count=%s excluded_count=%s",
+                    request_id,
+                    kind,
+                    request_stage,
+                    model,
+                    selection.account.id if selection.account is not None else None,
+                    selection.error_code,
+                    selection.error_message,
+                    None if scoped_account_ids is None else len(scoped_account_ids),
+                    len(excluded_account_ids_set),
+                )
                 return selection
         except TimeoutError:
             logger.warning("%s account selection exceeded request budget request_id=%s", kind.title(), request_id)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6800,6 +6800,17 @@ class ProxyService:
                         await self._load_balancer.release_account_lease(selected_account_lease)
                         selected_account_lease = None
                         continue
+                    if require_preferred_account:
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
+                        raise ProxyResponseError(
+                            503,
+                            openai_error(
+                                "no_accounts",
+                                "Preferred account is unavailable; retry later.",
+                                error_type="server_error",
+                            ),
+                        ) from exc
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
                     await self._load_balancer.release_account_lease(selected_account_lease)
@@ -6828,6 +6839,17 @@ class ProxyService:
                         await self._load_balancer.release_account_lease(selected_account_lease)
                         selected_account_lease = None
                         continue
+                    if require_preferred_account:
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
+                        raise ProxyResponseError(
+                            503,
+                            openai_error(
+                                "no_accounts",
+                                "Preferred account is unavailable; retry later.",
+                                error_type="server_error",
+                            ),
+                        ) from exc
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
                     await self._load_balancer.release_account_lease(selected_account_lease)
@@ -7365,6 +7387,8 @@ class ProxyService:
                 session.durable_session_id = durable_session_id
                 session.durable_owner_epoch = durable_owner_epoch
                 logger.warning("Failed to release stale pending HTTP bridge session lease", exc_info=True)
+        await self._load_balancer.release_account_lease(session.account_lease)
+        session.account_lease = None
         if not session.upstream_close_attempted:
             session.upstream_close_attempted = True
             try:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -12037,6 +12037,12 @@ class ProxyService:
                         preferred_account_id in excluded_account_ids_set,
                         scoped_account_ids is not None and preferred_account_id not in scoped_account_ids,
                     )
+                    if not fallback_on_preferred_account_unavailable:
+                        return AccountSelection(
+                            account=None,
+                            error_message="Preferred account is not available",
+                            error_code="preferred_account_unavailable",
+                        )
                 if preferred_eligible:
                     preferred_selection = await self._load_balancer.select_account(
                         sticky_key=sticky_key,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6899,8 +6899,15 @@ class ProxyService:
         if session.closed:
             async with session.lifecycle_lock:
                 if session.closed:
-                    async with self._http_bridge_lock:
-                        current_session = self._http_bridge_sessions.get(session.key)
+                    current_session = session
+                    http_bridge_sessions = getattr(self, "_http_bridge_sessions", None)
+                    bridge_lock = getattr(self, "_http_bridge_lock", None)
+                    if bridge_lock is not None:
+                        async with bridge_lock:
+                            if http_bridge_sessions is not None:
+                                current_session = http_bridge_sessions.get(session.key, session)
+                    elif http_bridge_sessions is not None:
+                        current_session = http_bridge_sessions.get(session.key, session)
                     if current_session is not session:
                         _log_http_bridge_event(
                             "submit_on_closed",
@@ -6910,10 +6917,6 @@ class ProxyService:
                             detail="session_replaced_before_reconnect",
                             cache_key_family=session.key.affinity_kind,
                             model_class=_extract_model_class(session.request_model) if session.request_model else None,
-                        )
-                        raise ProxyResponseError(
-                            502,
-                            openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
                         )
                     # Try reconnecting the upstream websocket first.  For requests
                     # carrying previous_response_id we only reconnect (send_request=
@@ -6993,8 +6996,15 @@ class ProxyService:
             )
             gate_acquired = True
             async with session.lifecycle_lock:
-                async with self._http_bridge_lock:
-                    current_session = self._http_bridge_sessions.get(session.key)
+                current_session = session
+                http_bridge_sessions = getattr(self, "_http_bridge_sessions", None)
+                bridge_lock = getattr(self, "_http_bridge_lock", None)
+                if bridge_lock is not None:
+                    async with bridge_lock:
+                        if http_bridge_sessions is not None:
+                            current_session = http_bridge_sessions.get(session.key, session)
+                elif http_bridge_sessions is not None:
+                    current_session = http_bridge_sessions.get(session.key, session)
                 session_replaced = current_session is not session
                 if session.closed or session_replaced:
                     _log_http_bridge_event(
@@ -7003,17 +7013,16 @@ class ProxyService:
                         account_id=session.account.id,
                         model=session.request_model,
                         detail=(
-                            "session_retired_after_admission"
-                            if session.closed
-                            else "session_replaced_after_admission"
+                            "session_retired_after_admission" if session.closed else "session_replaced_after_admission"
                         ),
                         cache_key_family=session.key.affinity_kind,
                         model_class=_extract_model_class(session.request_model) if session.request_model else None,
                     )
-                    raise ProxyResponseError(
-                        502,
-                        openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
-                    )
+                    if session.closed:
+                        raise ProxyResponseError(
+                            502,
+                            openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
+                        )
                 async with session.pending_lock:
                     session.pending_requests.append(request_state)
                 request_enqueued = True
@@ -7140,8 +7149,15 @@ class ProxyService:
                 )
                 gate_acquired = True
                 async with session.lifecycle_lock:
-                    async with self._http_bridge_lock:
-                        current_session = self._http_bridge_sessions.get(session.key)
+                    current_session = session
+                    http_bridge_sessions = getattr(self, "_http_bridge_sessions", None)
+                    bridge_lock = getattr(self, "_http_bridge_lock", None)
+                    if bridge_lock is not None:
+                        async with bridge_lock:
+                            if http_bridge_sessions is not None:
+                                current_session = http_bridge_sessions.get(session.key, session)
+                    elif http_bridge_sessions is not None:
+                        current_session = http_bridge_sessions.get(session.key, session)
                     session_replaced = current_session is not session
                     if session.closed or session_replaced:
                         _log_http_bridge_event(
@@ -7157,15 +7173,20 @@ class ProxyService:
                             cache_key_family=session.key.affinity_kind,
                             model_class=_extract_model_class(session.request_model) if session.request_model else None,
                         )
+                        if not session_replaced or session.closed:
+                            session.prewarmed = False
+                            await self._cleanup_http_bridge_submit_interruption(
+                                session,
+                                request_state=warmup_state,
+                                gate_acquired=gate_acquired,
+                                request_enqueued=request_enqueued,
+                                counted_in_queue=False,
+                            )
+                            gate_acquired = False
+                            return
                         session.prewarmed = False
-                        await self._cleanup_http_bridge_submit_interruption(
-                            session,
-                            request_state=warmup_state,
-                            gate_acquired=gate_acquired,
-                            request_enqueued=request_enqueued,
-                            counted_in_queue=False,
-                        )
-                        gate_acquired = False
+                        # Session was replaced during admission; warmup can be
+                        # retried on demand with the current request path.
                         return
                     async with session.pending_lock:
                         session.pending_requests.append(warmup_state)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6973,6 +6973,27 @@ class ProxyService:
                 bridge_session=session,
             )
             gate_acquired = True
+            async with self._http_bridge_lock:
+                current_session = self._http_bridge_sessions.get(session.key)
+                session_replaced = current_session is not None and current_session is not session
+                if session.closed or session_replaced:
+                    _log_http_bridge_event(
+                        "submit_on_closed",
+                        session.key,
+                        account_id=session.account.id,
+                        model=session.request_model,
+                        detail=(
+                            "session_retired_after_admission"
+                            if session.closed
+                            else "session_replaced_after_admission"
+                        ),
+                        cache_key_family=session.key.affinity_kind,
+                        model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                    )
+                    raise ProxyResponseError(
+                        502,
+                        openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
+                    )
             async with session.pending_lock:
                 session.pending_requests.append(request_state)
             request_enqueued = True
@@ -7095,6 +7116,32 @@ class ProxyService:
                     bridge_session=session,
                 )
                 gate_acquired = True
+                async with self._http_bridge_lock:
+                    current_session = self._http_bridge_sessions.get(session.key)
+                    session_replaced = current_session is not None and current_session is not session
+                    if session.closed or session_replaced:
+                        _log_http_bridge_event(
+                            "submit_on_closed",
+                            session.key,
+                            account_id=session.account.id,
+                            model=session.request_model,
+                            detail=(
+                                "prewarm_session_retired_after_admission"
+                                if session.closed
+                                else "prewarm_session_replaced_after_admission"
+                            ),
+                            cache_key_family=session.key.affinity_kind,
+                            model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                        )
+                        session.prewarmed = False
+                        await self._cleanup_http_bridge_submit_interruption(
+                            session,
+                            request_state=warmup_state,
+                            gate_acquired=gate_acquired,
+                            request_enqueued=request_enqueued,
+                        )
+                        gate_acquired = False
+                        return
                 async with session.pending_lock:
                     session.pending_requests.append(warmup_state)
                 request_enqueued = True
@@ -7308,6 +7355,7 @@ class ProxyService:
                     retried = await self._retry_http_bridge_precreated_request(session)
                     if retried:
                         continue
+                    session.closed = True
                     async with session.pending_lock:
                         session.queued_request_count = 0
                     try:
@@ -7339,6 +7387,7 @@ class ProxyService:
                 retried = await self._retry_http_bridge_precreated_request(session)
                 if retried:
                     continue
+                session.closed = True
                 async with session.pending_lock:
                     session.queued_request_count = 0
                 try:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6905,9 +6905,9 @@ class ProxyService:
                     if bridge_lock is not None:
                         async with bridge_lock:
                             if http_bridge_sessions is not None:
-                                current_session = http_bridge_sessions.get(session.key, session)
+                                current_session = http_bridge_sessions.get(session.key)
                     elif http_bridge_sessions is not None:
-                        current_session = http_bridge_sessions.get(session.key, session)
+                        current_session = http_bridge_sessions.get(session.key)
                     if current_session is not session:
                         _log_http_bridge_event(
                             "submit_on_closed",
@@ -6917,6 +6917,10 @@ class ProxyService:
                             detail="session_replaced_before_reconnect",
                             cache_key_family=session.key.affinity_kind,
                             model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                        )
+                        raise ProxyResponseError(
+                            502,
+                            openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
                         )
                     # Try reconnecting the upstream websocket first.  For requests
                     # carrying previous_response_id we only reconnect (send_request=
@@ -7002,9 +7006,9 @@ class ProxyService:
                 if bridge_lock is not None:
                     async with bridge_lock:
                         if http_bridge_sessions is not None:
-                            current_session = http_bridge_sessions.get(session.key, session)
+                            current_session = http_bridge_sessions.get(session.key)
                 elif http_bridge_sessions is not None:
-                    current_session = http_bridge_sessions.get(session.key, session)
+                    current_session = http_bridge_sessions.get(session.key)
                 session_replaced = current_session is not session
                 if session.closed or session_replaced:
                     _log_http_bridge_event(
@@ -7018,11 +7022,10 @@ class ProxyService:
                         cache_key_family=session.key.affinity_kind,
                         model_class=_extract_model_class(session.request_model) if session.request_model else None,
                     )
-                    if session.closed:
-                        raise ProxyResponseError(
-                            502,
-                            openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
-                        )
+                    raise ProxyResponseError(
+                        502,
+                        openai_error("upstream_unavailable", "HTTP responses session bridge is closed"),
+                    )
                 async with session.pending_lock:
                     session.pending_requests.append(request_state)
                 request_enqueued = True
@@ -7155,9 +7158,9 @@ class ProxyService:
                     if bridge_lock is not None:
                         async with bridge_lock:
                             if http_bridge_sessions is not None:
-                                current_session = http_bridge_sessions.get(session.key, session)
+                                current_session = http_bridge_sessions.get(session.key)
                     elif http_bridge_sessions is not None:
-                        current_session = http_bridge_sessions.get(session.key, session)
+                        current_session = http_bridge_sessions.get(session.key)
                     session_replaced = current_session is not session
                     if session.closed or session_replaced:
                         _log_http_bridge_event(
@@ -7173,20 +7176,15 @@ class ProxyService:
                             cache_key_family=session.key.affinity_kind,
                             model_class=_extract_model_class(session.request_model) if session.request_model else None,
                         )
-                        if not session_replaced or session.closed:
-                            session.prewarmed = False
-                            await self._cleanup_http_bridge_submit_interruption(
-                                session,
-                                request_state=warmup_state,
-                                gate_acquired=gate_acquired,
-                                request_enqueued=request_enqueued,
-                                counted_in_queue=False,
-                            )
-                            gate_acquired = False
-                            return
                         session.prewarmed = False
-                        # Session was replaced during admission; warmup can be
-                        # retried on demand with the current request path.
+                        await self._cleanup_http_bridge_submit_interruption(
+                            session,
+                            request_state=warmup_state,
+                            gate_acquired=gate_acquired,
+                            request_enqueued=request_enqueued,
+                            counted_in_queue=False,
+                        )
+                        gate_acquired = False
                         return
                     async with session.pending_lock:
                         session.pending_requests.append(warmup_state)

--- a/openspec/changes/bound-http-bridge-startup-waits/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/specs/proxy-runtime-observability/spec.md
@@ -9,3 +9,19 @@ When an HTTP bridge startup wait times out locally, the service MUST log the req
 - **WHEN** a HTTP bridge startup wait exceeds the configured proxy admission wait timeout
 - **THEN** the console log includes the timeout stage and request id
 - **AND** the log includes only low-cardinality affinity metadata, not raw affinity key values
+
+#### Scenario: Response-create gate timeout identifies stale pending work
+
+- **WHEN** a HTTP bridge request times out waiting for the per-session response-create gate
+- **THEN** the console log includes the hashed bridge key, pending count, queued count, gate availability, and pending request ids with ages
+- **AND** the log does not include raw affinity key values or request payload content
+
+### Requirement: Stale pending HTTP bridge retirement is logged
+
+When the service retires an HTTP bridge session because pending precreated replay cannot make progress after upstream close or timeout, the service MUST emit a `retire_stale_pending` bridge event with low-cardinality bridge metadata and the terminal detail code.
+
+#### Scenario: Failed precreated replay emits retirement event
+
+- **WHEN** precreated HTTP bridge replay fails after upstream close or timeout
+- **THEN** the console log includes a HTTP bridge event with `event=retire_stale_pending`
+- **AND** the event includes only hashed bridge identity and low-cardinality metadata

--- a/openspec/changes/bound-http-bridge-startup-waits/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/specs/responses-api-compat/spec.md
@@ -32,3 +32,10 @@ When an HTTP bridge request is still pending before upstream `response.completed
 - **AND** request-log writing fails
 - **THEN** the service still removes the stale bridge session from local reuse
 - **AND** the service releases any durable bridge ownership for that stale session
+
+#### Scenario: Concurrent waiter cannot submit on retired stale bridge
+
+- **WHEN** an HTTP bridge request is waiting on a session response-create gate
+- **AND** the upstream reader retires that same bridge session after a failed precreated replay
+- **THEN** the waiting request or prewarm is rejected before it is appended to pending requests or sent upstream
+- **AND** the retired bridge session remains closed and removed from local reuse

--- a/openspec/changes/bound-http-bridge-startup-waits/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/specs/responses-api-compat/spec.md
@@ -39,3 +39,32 @@ When an HTTP bridge request is still pending before upstream `response.completed
 - **AND** the upstream reader retires that same bridge session after a failed precreated replay
 - **THEN** the waiting request or prewarm is rejected before it is appended to pending requests or sent upstream
 - **AND** the retired bridge session remains closed and removed from local reuse
+- **AND** the post-admission ownership check, pending enqueue, and upstream send are mutually exclusive with stale-session retirement
+
+#### Scenario: Unregistered stale bridge reference cannot submit after admission
+
+- **WHEN** an HTTP bridge request or prewarm holds a stale bridge session reference
+- **AND** that bridge session is no longer the registered local owner for its session key
+- **THEN** the request is rejected after response-create gate admission and before it is appended or sent upstream
+- **AND** response-create gate and admission state acquired by the rejected request is released
+
+#### Scenario: Unregistered closed bridge reference cannot reconnect
+
+- **WHEN** an HTTP bridge request holds a closed stale bridge session reference
+- **AND** that bridge session is no longer the registered local owner for its session key
+- **THEN** the request is rejected before attempting to reconnect the stale bridge upstream
+
+#### Scenario: Reader crash closes bridge before releasing pending gate
+
+- **WHEN** an HTTP bridge upstream reader crashes while a pending request owns the response-create gate
+- **AND** another request or prewarm is waiting on that same gate
+- **THEN** the crashed bridge session is marked closed before the pending request gate is released
+- **AND** the waiting request or prewarm cannot submit on the crashed bridge
+- **AND** the crashed bridge session is removed from local reuse and its upstream resources are closed
+
+#### Scenario: Prewarm cleanup does not consume visible queue slots
+
+- **WHEN** a prewarm request is rejected or interrupted after response-create gate admission
+- **AND** a visible HTTP bridge request is still counted in the session queue
+- **THEN** prewarm cleanup releases its response-create gate and admission state
+- **AND** the visible request queue count is preserved

--- a/openspec/changes/bound-http-bridge-startup-waits/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/specs/responses-api-compat/spec.md
@@ -11,3 +11,24 @@ When the HTTP responses bridge cannot start upstream work because its local brid
 - **AND** the wait exceeds the configured proxy admission wait timeout
 - **THEN** the request fails with a terminal error
 - **AND** the error payload identifies local proxy overload with `error.code = "proxy_overloaded"`
+
+### Requirement: Failed precreated HTTP bridge replay retires stale sessions
+
+When an HTTP bridge request is still pending before upstream `response.completed` and the upstream websocket closes or times out before the pending request can be completed, the service MUST fail the pending request terminally and retire the affected bridge session if precreated replay does not reconnect and resend successfully.
+
+#### Scenario: Precreated replay fails after upstream disconnect
+
+- **WHEN** an HTTP bridge request is pending before `response.completed`
+- **AND** the upstream websocket closes before the request completes
+- **AND** precreated replay fails to reconnect and resend the request
+- **THEN** the pending request is removed from the bridge queue
+- **AND** the per-session response-create gate is released
+- **AND** the bridge session is closed and removed from local reuse
+- **AND** the terminal error preserves the original failure code such as `stream_incomplete` or `upstream_request_timeout`
+
+#### Scenario: Terminal logging failure does not preserve stale bridge ownership
+
+- **WHEN** a failed pending HTTP bridge request is being logged as terminal
+- **AND** request-log writing fails
+- **THEN** the service still removes the stale bridge session from local reuse
+- **AND** the service releases any durable bridge ownership for that stale session

--- a/openspec/changes/bound-http-bridge-startup-waits/tasks.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/tasks.md
@@ -8,5 +8,6 @@
 - [x] Log timeout diagnostics without raw affinity keys.
 - [x] Retire HTTP bridge sessions whose precreated replay cannot make progress after upstream disconnect.
 - [x] Clear stale pending bridge state even when terminal request-log writing fails.
+- [x] Reject concurrent response-create gate and prewarm waiters before they can submit on a retired stale session.
 - [x] Add regression tests for timeout behavior.
 - [x] Validate OpenSpec and run targeted unit tests.

--- a/openspec/changes/bound-http-bridge-startup-waits/tasks.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/tasks.md
@@ -6,5 +6,7 @@
 - [x] Clean up in-flight markers when creation owners are cancelled during stale session close.
 - [x] Evict stalled in-flight markers on startup wait timeout.
 - [x] Log timeout diagnostics without raw affinity keys.
+- [x] Retire HTTP bridge sessions whose precreated replay cannot make progress after upstream disconnect.
+- [x] Clear stale pending bridge state even when terminal request-log writing fails.
 - [x] Add regression tests for timeout behavior.
 - [x] Validate OpenSpec and run targeted unit tests.

--- a/openspec/changes/bound-http-bridge-startup-waits/tasks.md
+++ b/openspec/changes/bound-http-bridge-startup-waits/tasks.md
@@ -9,5 +9,12 @@
 - [x] Retire HTTP bridge sessions whose precreated replay cannot make progress after upstream disconnect.
 - [x] Clear stale pending bridge state even when terminal request-log writing fails.
 - [x] Reject concurrent response-create gate and prewarm waiters before they can submit on a retired stale session.
+- [x] Reject unregistered stale session references after response-create admission.
+- [x] Make post-admission validation, enqueue, and send mutually exclusive with stale-session retirement.
+- [x] Reject unregistered closed stale session references before reconnect attempts.
+- [x] Mark reader-crashed bridge sessions closed before releasing pending response-create gates.
+- [x] Retire reader-crashed bridge sessions from local reuse and release resources.
+- [x] Preserve visible queue counts when prewarm cleanup runs.
+- [x] Move admission/retirement serialization off the global bridge registry lock.
 - [x] Add regression tests for timeout behavior.
 - [x] Validate OpenSpec and run targeted unit tests.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -9014,6 +9014,223 @@ async def test_http_bridge_reader_failed_precreated_replay_retires_registered_se
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_reader_retirement_rejects_concurrent_gate_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    old_event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    old_request_state = proxy_service._WebSocketRequestState(
+        request_id="req-old-retired-while-new-waits",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=old_event_queue,
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"old"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    new_request_state = proxy_service._WebSocketRequestState(
+        request_id="req-new-waits-on-retired-session",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    old_request_state.response_create_gate = gate
+    old_request_state.response_create_gate_acquired = True
+    send_text = AsyncMock()
+    upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=UpstreamWebSocketMessage(kind="close", close_code=1011)),
+            send_text=send_text,
+            close=AsyncMock(),
+        ),
+    )
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key-concurrent-retire", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key-concurrent-retire"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([old_request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    service._http_bridge_sessions[key] = session
+
+    async def fail_replay(target_session: proxy_service._HTTPBridgeSession) -> bool:
+        assert target_session is session
+        old_request_state.error_code_override = "stream_incomplete"
+        old_request_state.error_message_override = "Upstream closed before response.completed"
+        return False
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", fail_replay)
+
+    submit_task = asyncio.create_task(
+        service._submit_http_bridge_request(
+            session,
+            request_state=new_request_state,
+            text_data=new_request_state.request_text or "{}",
+            queue_limit=8,
+        )
+    )
+    try:
+        with anyio.fail_after(1.0):
+            while session.queued_request_count < 2:
+                await asyncio.sleep(0)
+
+        await service._relay_http_bridge_upstream_messages(session)
+
+        with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+            await submit_task
+
+        assert exc_info.value.status_code == 502
+        assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
+        assert send_text.await_count == 0
+        assert list(session.pending_requests) == []
+        assert session.queued_request_count == 0
+        assert session.closed is True
+        assert key not in service._http_bridge_sessions
+        assert new_request_state.response_create_gate is None
+        assert new_request_state.response_create_gate_acquired is False
+        assert gate.locked() is False
+    finally:
+        if not submit_task.done():
+            submit_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await submit_task
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_retirement_skips_concurrent_prewarm_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    old_event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    old_request_state = proxy_service._WebSocketRequestState(
+        request_id="req-old-retired-while-prewarm-waits",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=old_event_queue,
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"old"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    visible_request_state = proxy_service._WebSocketRequestState(
+        request_id="req-visible-prewarm-waits-on-retired-session",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    old_request_state.response_create_gate = gate
+    old_request_state.response_create_gate_acquired = True
+    send_text = AsyncMock()
+    upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=UpstreamWebSocketMessage(kind="close", close_code=1011)),
+            send_text=send_text,
+            close=AsyncMock(),
+        ),
+    )
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "bridge-key-prewarm-retire", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"x-codex-session-id": "bridge-key-prewarm-retire"},
+        affinity=proxy_service._AffinityPolicy(
+            key="bridge-key-prewarm-retire",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([old_request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+        prewarm_lock=anyio.Lock(),
+    )
+    service._http_bridge_sessions[key] = session
+
+    async def fail_replay(target_session: proxy_service._HTTPBridgeSession) -> bool:
+        assert target_session is session
+        old_request_state.error_code_override = "stream_incomplete"
+        old_request_state.error_message_override = "Upstream closed before response.completed"
+        return False
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_codex_prewarm_enabled=True),
+    )
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", fail_replay)
+
+    prewarm_task = asyncio.create_task(
+        service._maybe_prewarm_http_bridge_session(
+            session,
+            request_state=visible_request_state,
+            text_data=visible_request_state.request_text or "{}",
+        )
+    )
+    try:
+        with anyio.fail_after(1.0):
+            while not session.prewarmed:
+                await asyncio.sleep(0)
+
+        await service._relay_http_bridge_upstream_messages(session)
+        await asyncio.wait_for(prewarm_task, timeout=1.0)
+
+        assert send_text.await_count == 0
+        assert list(session.pending_requests) == []
+        assert session.queued_request_count == 0
+        assert session.closed is True
+        assert session.prewarmed is False
+        assert key not in service._http_bridge_sessions
+        assert gate.locked() is False
+    finally:
+        if not prewarm_task.done():
+            prewarm_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await prewarm_task
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_reader_failed_precreated_replay_retires_when_request_log_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -9156,7 +9156,16 @@ async def test_retire_stale_pending_http_bridge_session_unregisters_aliases_and_
     session.previous_response_ids.add("resp_stale")
     session.durable_session_id = "durable-stale"
     session.durable_owner_epoch = 7
+    lease = proxy_service.AccountLease(
+        lease_id="lease-stale-cleanup",
+        account_id=session.account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    session.account_lease = lease
     close = cast(Any, session.upstream).close
+    release_account_lease = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
     service._http_bridge_sessions[session.key] = session
     service._http_bridge_turn_state_index[
         proxy_service._http_bridge_turn_state_alias_key("http_turn_stale", session.key.api_key_id)
@@ -9184,6 +9193,8 @@ async def test_retire_stale_pending_http_bridge_session_unregisters_aliases_and_
         owner_epoch=7,
         draining=False,
     )
+    release_account_lease.assert_awaited_once_with(lease)
+    assert session.account_lease is None
     close.assert_awaited_once()
 
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1170,6 +1170,42 @@ async def test_select_account_with_budget_required_file_pin_does_not_fallback_on
 
 
 @pytest.mark.asyncio
+async def test_select_account_with_budget_required_preferred_does_not_fallback_when_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    select_account = AsyncMock(
+        return_value=proxy_service.AccountSelection(
+            account=cast(Any, SimpleNamespace(id="acc-other")),
+            error_message=None,
+            error_code=None,
+        )
+    )
+    service._load_balancer = cast(Any, SimpleNamespace(select_account=select_account))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(return_value=SimpleNamespace(sticky_reallocation_budget_threshold_pct=95.0))
+        ),
+    )
+
+    selection = await service._select_account_with_budget(
+        time.monotonic() + 60.0,
+        request_id="req-file-pin-excluded",
+        kind="stream",
+        request_stage="retry",
+        preferred_account_id="acc-file-owner",
+        exclude_account_ids={"acc-file-owner"},
+        fallback_on_preferred_account_unavailable=False,
+    )
+
+    assert selection.account is None
+    assert selection.error_code == "preferred_account_unavailable"
+    select_account.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_select_account_with_budget_soft_preference_can_fallback_after_account_cap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -10070,7 +10070,7 @@ async def test_http_bridge_reader_crash_marks_session_closed_before_releasing_pe
 
     async def fail_pending_requests(**_kwargs: object) -> None:
         assert session.closed is True
-        proxy_service._release_websocket_response_create_gate(request_state, gate)
+        await proxy_service._release_websocket_response_create_gate(request_state, gate)
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(service, "_process_http_bridge_upstream_text", AsyncMock(side_effect=RuntimeError("boom")))

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7730,6 +7730,79 @@ async def test_submit_http_bridge_request_rejects_unregistered_closed_session_wi
 
 
 @pytest.mark.asyncio
+async def test_submit_http_bridge_request_waits_for_closed_session_retirement_before_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    retry_started = asyncio.Event()
+
+    async def retry_fresh(*_args: object, **_kwargs: object) -> bool:
+        retry_started.set()
+        return True
+
+    monkeypatch.setattr(service, "_retry_http_bridge_request_on_fresh_upstream", retry_fresh)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-closed-retiring-submit",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.5","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_closed_retiring", None),
+        headers={"x-codex-turn-state": "http_turn_closed_retiring"},
+        affinity=proxy_service._AffinityPolicy(
+            key="http_turn_closed_retiring",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.5",
+        account=cast(Any, SimpleNamespace(id="acc-retiring", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+        closed=True,
+    )
+    service._http_bridge_sessions[session.key] = session
+
+    async with session.lifecycle_lock:
+        submit_task = asyncio.create_task(
+            service._submit_http_bridge_request(
+                session,
+                request_state=request_state,
+                text_data=request_state.request_text or "{}",
+                queue_limit=8,
+            )
+        )
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(retry_started.wait(), timeout=0.01)
+            service._http_bridge_sessions.pop(session.key, None)
+        finally:
+            if submit_task.done():
+                await submit_task
+
+    with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+        await submit_task
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
+    assert retry_started.is_set() is False
+    send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_submit_http_bridge_request_does_not_send_after_retirement_between_validation_and_send() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     request_state = proxy_service._WebSocketRequestState(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -18,7 +18,7 @@ import pytest
 from fastapi import WebSocket
 
 from app.core.clients.proxy import ProxyResponseError
-from app.core.clients.proxy_websocket import UpstreamResponsesWebSocket
+from app.core.clients.proxy_websocket import UpstreamResponsesWebSocket, UpstreamWebSocketMessage
 from app.core.config.settings import Settings
 from app.db.models import AccountStatus, HttpBridgeSessionState
 from app.modules.proxy import service as proxy_service
@@ -7493,11 +7493,15 @@ async def test_submit_http_bridge_request_starts_api_key_reservation_heartbeat(
         state: proxy_service._WebSocketRequestState,
         *,
         response_create_gate: asyncio.Semaphore,
+        bridge_session: proxy_service._HTTPBridgeSession | None = None,
         compact: bool = False,
         account_id: str | None = None,
         surface: str = "websocket",
     ) -> None:
-        del compact, account_id, surface
+        del bridge_session
+        del compact
+        del account_id
+        del surface
         nonlocal admission_saw_heartbeat
         admission_saw_heartbeat = state.api_key_reservation_heartbeat_task is not None
         state.response_create_gate = response_create_gate
@@ -8827,6 +8831,285 @@ async def test_http_bridge_reader_marks_session_closed_before_reconnect_close(
 
     assert session.closed is True
     close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_response_create_gate_timeout_logs_pending_bridge_context(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    held_request = proxy_service._WebSocketRequestState(
+        request_id="req-held-gate",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic() - 5.0,
+        awaiting_response_created=True,
+        transport="http",
+    )
+    new_request = proxy_service._WebSocketRequestState(
+        request_id="req-timeout-gate",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+    )
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    session = _make_bridge_session(
+        key_value="bridge-held-gate",
+        pending_requests=deque([held_request]),
+        queued_request_count=1,
+    )
+    session.response_create_gate = gate
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(proxy_admission_wait_timeout_seconds=0.001),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ProxyResponseError):
+            await service._acquire_request_state_response_create_admission(
+                new_request,
+                response_create_gate=gate,
+                bridge_session=session,
+            )
+
+    assert "http_bridge_startup_wait_timeout" in caplog.text
+    assert "bridge_key=" in caplog.text
+    assert "queued_count=1" in caplog.text
+    assert "pending_request_ids=req-held-gate" in caplog.text
+    assert "pending_request_ages_seconds=" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_retire_stale_pending_http_bridge_session_unregisters_aliases_and_releases_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    release_live_session = AsyncMock()
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(release_live_session=release_live_session),
+    )
+    session = _make_bridge_session(key_value="bridge-stale-cleanup")
+    session.downstream_turn_state_aliases.add("http_turn_stale")
+    session.previous_response_ids.add("resp_stale")
+    session.durable_session_id = "durable-stale"
+    session.durable_owner_epoch = 7
+    close = cast(Any, session.upstream).close
+    service._http_bridge_sessions[session.key] = session
+    service._http_bridge_turn_state_index[
+        proxy_service._http_bridge_turn_state_alias_key("http_turn_stale", session.key.api_key_id)
+    ] = session.key
+    service._http_bridge_previous_response_index[
+        proxy_service._http_bridge_previous_response_alias_key("resp_stale", session.key.api_key_id)
+    ] = session.key
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-cleanup"),
+    )
+
+    await service._retire_stale_pending_http_bridge_session(session, detail="stream_incomplete")
+
+    assert session.closed is True
+    assert session.key not in service._http_bridge_sessions
+    assert service._http_bridge_turn_state_index == {}
+    assert service._http_bridge_previous_response_index == {}
+    assert session.downstream_turn_state_aliases == set()
+    assert session.previous_response_ids == set()
+    release_live_session.assert_awaited_once_with(
+        session_id="durable-stale",
+        instance_id="instance-cleanup",
+        owner_epoch=7,
+        draining=False,
+    )
+    close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_failed_precreated_replay_retires_registered_session(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-precreated-close",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=event_queue,
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"hello"}',
+        transport="http",
+    )
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    request_state.response_create_gate = gate
+    request_state.response_create_gate_acquired = True
+    upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=UpstreamWebSocketMessage(kind="close", close_code=1011)),
+            close=AsyncMock(),
+        ),
+    )
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    service._http_bridge_sessions[key] = session
+
+    async def fail_replay(target_session: proxy_service._HTTPBridgeSession) -> bool:
+        assert target_session is session
+        request_state.error_code_override = "stream_incomplete"
+        request_state.error_message_override = "Upstream closed before response.completed"
+        return False
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", fail_replay)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    write_request_log = AsyncMock()
+    monkeypatch.setattr(service, "_write_request_log", write_request_log)
+
+    with caplog.at_level(logging.INFO):
+        await service._relay_http_bridge_upstream_messages(session)
+
+    failed_event = await asyncio.wait_for(event_queue.get(), timeout=0.1)
+    assert failed_event is not None
+    assert '"code":"stream_incomplete"' in failed_event
+    assert await asyncio.wait_for(event_queue.get(), timeout=0.1) is None
+    assert list(session.pending_requests) == []
+    assert session.queued_request_count == 0
+    assert gate.locked() is False
+    assert request_state.response_create_gate is None
+    assert request_state.response_create_gate_acquired is False
+    assert request_state.awaiting_response_created is False
+    assert session.closed is True
+    assert key not in service._http_bridge_sessions
+    write_request_log.assert_awaited_once()
+    assert write_request_log.await_args.kwargs["error_code"] == "stream_incomplete"
+    assert "http_bridge_event event=retire_stale_pending" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_failed_precreated_replay_retires_when_request_log_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    release_live_session = AsyncMock()
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(release_live_session=release_live_session),
+    )
+    event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-precreated-log-fails",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=event_queue,
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"hello"}',
+        transport="http",
+    )
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    request_state.response_create_gate = gate
+    request_state.response_create_gate_acquired = True
+    upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=UpstreamWebSocketMessage(kind="close", close_code=1011)),
+            close=AsyncMock(),
+        ),
+    )
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key-log-fails", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key-log-fails"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+        durable_session_id="durable-log-fails",
+        durable_owner_epoch=3,
+    )
+    session.downstream_turn_state_aliases.add("http_turn_log_fails")
+    session.previous_response_ids.add("resp_log_fails")
+    service._http_bridge_sessions[key] = session
+    service._http_bridge_turn_state_index[
+        proxy_service._http_bridge_turn_state_alias_key("http_turn_log_fails", key.api_key_id)
+    ] = key
+    service._http_bridge_previous_response_index[
+        proxy_service._http_bridge_previous_response_alias_key("resp_log_fails", key.api_key_id)
+    ] = key
+
+    async def fail_replay(target_session: proxy_service._HTTPBridgeSession) -> bool:
+        assert target_session is session
+        request_state.error_code_override = "stream_incomplete"
+        request_state.error_message_override = "Upstream closed before response.completed"
+        return False
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-log-fails"),
+    )
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", fail_replay)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_write_request_log", AsyncMock(side_effect=RuntimeError("request log failed")))
+
+    await service._relay_http_bridge_upstream_messages(session)
+
+    failed_event = await asyncio.wait_for(event_queue.get(), timeout=0.1)
+    assert failed_event is not None
+    assert '"code":"stream_incomplete"' in failed_event
+    assert await asyncio.wait_for(event_queue.get(), timeout=0.1) is None
+    assert list(session.pending_requests) == []
+    assert session.queued_request_count == 0
+    assert gate.locked() is False
+    assert session.closed is True
+    assert key not in service._http_bridge_sessions
+    assert service._http_bridge_turn_state_index == {}
+    assert service._http_bridge_previous_response_index == {}
+    release_live_session.assert_awaited_once_with(
+        session_id="durable-log-fails",
+        instance_id="instance-log-fails",
+        owner_epoch=3,
+        draining=False,
+    )
+    cast(Any, upstream).close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7478,6 +7478,7 @@ async def test_submit_http_bridge_request_starts_api_key_reservation_heartbeat(
         last_used_at=1.0,
         idle_ttl_seconds=120.0,
     )
+    service._http_bridge_sessions[session.key] = session
     started = asyncio.Event()
     seen: dict[str, object] = {}
 
@@ -7617,6 +7618,186 @@ async def test_submit_http_bridge_request_rejects_retiring_session() -> None:
     assert session.closed is False
     send_text.assert_not_awaited()
     close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_http_bridge_request_rejects_unregistered_session_after_admission() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-unregistered-submit",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.5","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_unregistered", None),
+        headers={"x-codex-turn-state": "http_turn_unregistered"},
+        affinity=proxy_service._AffinityPolicy(
+            key="http_turn_unregistered",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.5",
+        account=cast(Any, SimpleNamespace(id="acc-unregistered", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+        await service._submit_http_bridge_request(
+            session,
+            request_state=request_state,
+            text_data=request_state.request_text or "{}",
+            queue_limit=8,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
+    assert session.pending_requests == deque()
+    assert session.queued_request_count == 0
+    assert request_state.response_create_gate is None
+    assert request_state.response_create_gate_acquired is False
+    assert session.response_create_gate.locked() is False
+    send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_http_bridge_request_rejects_unregistered_closed_session_without_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    retry_fresh = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_retry_http_bridge_request_on_fresh_upstream", retry_fresh)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-unregistered-closed-submit",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.5","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_unregistered_closed", None),
+        headers={"x-codex-turn-state": "http_turn_unregistered_closed"},
+        affinity=proxy_service._AffinityPolicy(
+            key="http_turn_unregistered_closed",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.5",
+        account=cast(Any, SimpleNamespace(id="acc-unregistered", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+        closed=True,
+    )
+
+    with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+        await service._submit_http_bridge_request(
+            session,
+            request_state=request_state,
+            text_data=request_state.request_text or "{}",
+            queue_limit=8,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
+    retry_fresh.assert_not_awaited()
+    send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_submit_http_bridge_request_does_not_send_after_retirement_between_validation_and_send() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-retired-after-submit-validation",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.5","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_retire_gap", None),
+        headers={"x-codex-turn-state": "http_turn_retire_gap"},
+        affinity=proxy_service._AffinityPolicy(
+            key="http_turn_retire_gap",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.5",
+        account=cast(Any, SimpleNamespace(id="acc-retire-gap", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=AsyncMock(), close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    service._http_bridge_sessions[session.key] = session
+    stale_send_seen = False
+
+    async def send_text(_text: str) -> None:
+        nonlocal stale_send_seen
+        stale_send_seen = service._http_bridge_sessions.get(session.key) is not session or session.closed
+
+    cast(Any, session.upstream).send_text.side_effect = send_text
+
+    class RetireAfterValidationLock:
+        async def __aenter__(self) -> None:
+            return None
+
+        async def __aexit__(self, *_exc: object) -> None:
+            if request_state.response_create_gate_acquired and request_state not in session.pending_requests:
+                session.closed = True
+                service._http_bridge_sessions.pop(session.key, None)
+            return None
+
+    service._http_bridge_lock = cast(Any, RetireAfterValidationLock())
+
+    try:
+        await service._submit_http_bridge_request(
+            session,
+            request_state=request_state,
+            text_data=request_state.request_text or "{}",
+            queue_limit=8,
+        )
+    except proxy_service.ProxyResponseError:
+        pass
+    finally:
+        if request_state.response_create_gate_acquired:
+            proxy_service._release_websocket_response_create_gate(request_state, session.response_create_gate)
+
+    assert stale_send_seen is False
 
 
 @pytest.mark.asyncio
@@ -9231,6 +9412,156 @@ async def test_http_bridge_reader_retirement_skips_concurrent_prewarm_waiter(
 
 
 @pytest.mark.asyncio
+async def test_maybe_prewarm_http_bridge_session_skips_unregistered_session_after_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    send_text = AsyncMock()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-visible-unregistered-prewarm",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "bridge-key-unregistered-prewarm", None),
+        headers={"x-codex-session-id": "bridge-key-unregistered-prewarm"},
+        affinity=proxy_service._AffinityPolicy(
+            key="bridge-key-unregistered-prewarm",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=send_text, close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+        prewarm_lock=anyio.Lock(),
+    )
+
+    async def complete_warmup(_text: str) -> None:
+        assert session.pending_requests
+        warmup_queue = session.pending_requests[-1].event_queue
+        assert warmup_queue is not None
+        await warmup_queue.put(None)
+
+    send_text.side_effect = complete_warmup
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_codex_prewarm_enabled=True),
+    )
+
+    await service._maybe_prewarm_http_bridge_session(
+        session,
+        request_state=request_state,
+        text_data=request_state.request_text or "{}",
+    )
+
+    assert send_text.await_count == 0
+    assert session.pending_requests == deque()
+    assert session.queued_request_count == 0
+    assert session.prewarmed is False
+    assert session.response_create_gate.locked() is False
+
+
+@pytest.mark.asyncio
+async def test_maybe_prewarm_replaced_session_cleanup_preserves_visible_queue_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    held_request = proxy_service._WebSocketRequestState(
+        request_id="req-visible-held-during-prewarm-replace",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"held"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-visible-prewarm-replaced",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "bridge-key-prewarm-count", None),
+        headers={"x-codex-session-id": "bridge-key-prewarm-count"},
+        affinity=proxy_service._AffinityPolicy(
+            key="bridge-key-prewarm-count",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=AsyncMock(), close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([held_request]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+        prewarm_lock=anyio.Lock(),
+    )
+    replacement = proxy_service._HTTPBridgeSession(
+        key=session.key,
+        headers=session.headers,
+        affinity=session.affinity,
+        request_model=session.request_model,
+        account=session.account,
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(send_text=AsyncMock(), close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    service._http_bridge_sessions[session.key] = replacement
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_codex_prewarm_enabled=True),
+    )
+
+    await service._maybe_prewarm_http_bridge_session(
+        session,
+        request_state=request_state,
+        text_data=request_state.request_text or "{}",
+    )
+
+    assert session.queued_request_count == 1
+    assert session.pending_requests == deque([held_request])
+    cast(Any, session.upstream).send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_reader_failed_precreated_replay_retires_when_request_log_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -9334,6 +9665,11 @@ async def test_http_bridge_reader_unexpected_processing_error_fails_pending_requ
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    release_live_session = AsyncMock()
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(release_live_session=release_live_session),
+    )
     request_state = proxy_service._WebSocketRequestState(
         request_id="req-http-reader-crash",
         model="gpt-5.4",
@@ -9372,9 +9708,16 @@ async def test_http_bridge_reader_unexpected_processing_error_fails_pending_requ
         queued_request_count=1,
         last_used_at=time.monotonic(),
         idle_ttl_seconds=120.0,
+        durable_session_id="durable-reader-crash",
+        durable_owner_epoch=9,
     )
+    service._http_bridge_sessions[session.key] = session
 
-    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-reader-crash"),
+    )
     monkeypatch.setattr(service, "_process_http_bridge_upstream_text", AsyncMock(side_effect=RuntimeError("boom")))
     write_request_log = AsyncMock()
     monkeypatch.setattr(service, "_write_request_log", write_request_log)
@@ -9388,7 +9731,281 @@ async def test_http_bridge_reader_unexpected_processing_error_fails_pending_requ
     assert await asyncio.wait_for(event_queue.get(), timeout=0.1) is None
     assert session.closed is True
     assert list(session.pending_requests) == []
+    assert session.key not in service._http_bridge_sessions
+    release_live_session.assert_awaited_once_with(
+        session_id="durable-reader-crash",
+        instance_id="instance-reader-crash",
+        owner_epoch=9,
+        draining=False,
+    )
+    cast(Any, upstream).close.assert_awaited_once()
     write_request_log.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_crash_rejects_concurrent_gate_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    old_event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    old_request_state = proxy_service._WebSocketRequestState(
+        request_id="req-old-reader-crash",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=old_event_queue,
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"old"}',
+        transport="http",
+    )
+    new_request_state = proxy_service._WebSocketRequestState(
+        request_id="req-new-reader-crash-waiter",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    old_request_state.response_create_gate = gate
+    old_request_state.response_create_gate_acquired = True
+    send_text = AsyncMock()
+    upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=SimpleNamespace(kind="text", text='{"type":"response.created"}')),
+            send_text=send_text,
+            close=AsyncMock(),
+        ),
+    )
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key-reader-crash", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key-reader-crash"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([old_request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    service._http_bridge_sessions[key] = session
+
+    async def write_request_log(**_kwargs: object) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", AsyncMock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr(service, "_write_request_log", write_request_log)
+
+    submit_task = asyncio.create_task(
+        service._submit_http_bridge_request(
+            session,
+            request_state=new_request_state,
+            text_data=new_request_state.request_text or "{}",
+            queue_limit=8,
+        )
+    )
+    try:
+        with anyio.fail_after(1.0):
+            while session.queued_request_count < 2:
+                await asyncio.sleep(0)
+
+        await service._relay_http_bridge_upstream_messages(session)
+
+        with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+            await submit_task
+
+        assert exc_info.value.status_code == 502
+        assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
+        assert send_text.await_count == 0
+        assert list(session.pending_requests) == []
+        assert session.queued_request_count == 0
+        assert session.closed is True
+        assert new_request_state.response_create_gate is None
+        assert new_request_state.response_create_gate_acquired is False
+        assert gate.locked() is False
+    finally:
+        if not submit_task.done():
+            submit_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await submit_task
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_crash_rejects_concurrent_prewarm_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    old_event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    old_request_state = proxy_service._WebSocketRequestState(
+        request_id="req-old-reader-crash-prewarm",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=old_event_queue,
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"old"}',
+        transport="http",
+    )
+    visible_request_state = proxy_service._WebSocketRequestState(
+        request_id="req-visible-reader-crash-prewarm",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    old_request_state.response_create_gate = gate
+    old_request_state.response_create_gate_acquired = True
+    send_text = AsyncMock()
+    upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=SimpleNamespace(kind="text", text='{"type":"response.created"}')),
+            send_text=send_text,
+            close=AsyncMock(),
+        ),
+    )
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "bridge-key-reader-crash-prewarm", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"x-codex-session-id": "bridge-key-reader-crash-prewarm"},
+        affinity=proxy_service._AffinityPolicy(
+            key="bridge-key-reader-crash-prewarm",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([old_request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+        prewarm_lock=anyio.Lock(),
+    )
+    service._http_bridge_sessions[key] = session
+
+    async def write_request_log(**_kwargs: object) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_codex_prewarm_enabled=True),
+    )
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", AsyncMock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr(service, "_write_request_log", write_request_log)
+
+    prewarm_task = asyncio.create_task(
+        service._maybe_prewarm_http_bridge_session(
+            session,
+            request_state=visible_request_state,
+            text_data=visible_request_state.request_text or "{}",
+        )
+    )
+    try:
+        with anyio.fail_after(1.0):
+            while not session.prewarmed:
+                await asyncio.sleep(0)
+
+        await service._relay_http_bridge_upstream_messages(session)
+        await asyncio.wait_for(prewarm_task, timeout=1.0)
+
+        assert send_text.await_count == 0
+        assert list(session.pending_requests) == []
+        assert session.queued_request_count == 0
+        assert session.closed is True
+        assert session.prewarmed is False
+        assert visible_request_state.response_create_gate is None
+        assert visible_request_state.response_create_gate_acquired is False
+        assert gate.locked() is False
+    finally:
+        if not prewarm_task.done():
+            prewarm_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await prewarm_task
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_crash_marks_session_closed_before_releasing_pending_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-http-reader-crash-order",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    request_state.response_create_gate = gate
+    request_state.response_create_gate_acquired = True
+    upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=SimpleNamespace(kind="text", text='{"type":"response.created"}')),
+            close=AsyncMock(),
+        ),
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key-reader-crash-order", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key-reader-crash-order"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+
+    async def fail_pending_requests(**_kwargs: object) -> None:
+        assert session.closed is True
+        proxy_service._release_websocket_response_create_gate(request_state, gate)
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", AsyncMock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", fail_pending_requests)
+
+    await service._relay_http_bridge_upstream_messages(session)
+
+    assert gate.locked() is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15777,6 +15777,55 @@ async def test_reconnect_http_bridge_session_fails_over_after_repeated_401_refre
 
 
 @pytest.mark.asyncio
+async def test_create_http_bridge_session_required_preferred_does_not_fall_back_after_retry(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_bridge_required_preferred_a")
+    account_b = _make_account("acc_bridge_required_preferred_b")
+    seen_excluded_account_ids: list[set[str]] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 10.0)
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        if account_a.id in excluded_account_ids:
+            return AccountSelection(account=account_b, error_message=None)
+        return AccountSelection(account=account_a, error_message=None)
+
+    release_account_lease = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account_a))
+    monkeypatch.setattr(
+        service,
+        "_open_upstream_websocket_with_budget",
+        AsyncMock(side_effect=[asyncio.TimeoutError(), asyncio.TimeoutError()]),
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._create_http_bridge_session(
+            proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key-required-preferred", None),
+            headers={},
+            affinity=proxy_service._AffinityPolicy(key="bridge-key-required-preferred"),
+            api_key=None,
+            request_model="gpt-5.5",
+            idle_ttl_seconds=30.0,
+            preferred_account_id=account_a.id,
+            require_preferred_account=True,
+            fallback_on_preferred_account_unavailable=False,
+        )
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload["error"]["code"] == "no_accounts"
+    assert seen_excluded_account_ids == [set(), set()]
+    assert release_account_lease.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_transcribe_fallback_refresh_error_surfaces_proxy_error_not_raw_refresh_error(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
@@ -16573,6 +16622,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
         prewarmed=False,
         prewarm_lock=anyio.Lock(),
     )
+    service._http_bridge_sessions[session.key] = session
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_PREWARM_RESPONSE_TIMEOUT_SECONDS", 0.05)
@@ -16587,6 +16637,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
         compact: bool = False,
         account_id: str | None = None,
         surface: str = "websocket",
+        bridge_session: proxy_service._HTTPBridgeSession | None = None,
     ) -> None:
         admission_observations.append(
             {
@@ -16601,6 +16652,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
             compact=compact,
             account_id=account_id,
             surface=surface,
+            bridge_session=bridge_session,
         )
 
     async def fake_reconnect_http_bridge_session(


### PR DESCRIPTION
## Summary

Fixes HTTP bridge sessions that can get stuck with stale pending work after an upstream websocket closes before `response.completed`. Failed precreated replay now terminally fails pending requests, releases the response-create gate, retires the stale bridge session, and removes local/durable ownership so later same-session requests can recover on a fresh bridge instead of looping on `proxy_overloaded`.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Not linked

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/bound-http-bridge-startup-waits/`

## Changes

- Retire stale HTTP bridge sessions when precreated replay fails after upstream close or timeout.
- Clear pending request state, release `response_create_gate`, release durable bridge ownership, and close the stale upstream websocket.
- Add response-create gate timeout diagnostics for bridge key hash, pending/queued counts, gate availability, pending request ids, and ages.
- Add regression coverage for failed replay, stale cleanup, request-log failure during terminal cleanup, and timeout diagnostics.

## Test plan

```powershell
.\.venv\Scripts\python.exe -m pytest tests\unit\test_proxy_utils.py tests\unit\test_http_bridge_cancel_drain.py tests\unit\test_proxy_http_bridge.py -q
# 502 passed

.\.venv\Scripts\python.exe -m ruff check app\modules\proxy\service.py tests\unit\test_proxy_http_bridge.py
# All checks passed!

```

## Linked issue:
Fixes #857 

## Screenshots / output (optional)

Local `codex exec review --uncommitted --full-auto --ephemeral` completed and reported no actionable findings.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).