### PR TITLE
Route expired dashboard sessions back to login

### DIFF
--- a/frontend/src/features/auth/hooks/use-auth-unauthorized.test.ts
+++ b/frontend/src/features/auth/hooks/use-auth-unauthorized.test.ts
@@ -42,4 +42,26 @@ describe("useAuthStore unauthorized handler", () => {
     expect(next.bootstrapRequired).toBe(true);
     expect(next.bootstrapTokenConfigured).toBe(true);
   });
+
+  it("clears stale pending totp state on 401 handling", async () => {
+    const { useAuthStore } = await import("@/features/auth/hooks/use-auth");
+
+    useAuthStore.setState({
+      authenticated: true,
+      initialized: true,
+      passwordRequired: true,
+      totpRequiredOnLogin: true,
+      passwordSessionActive: true,
+    });
+
+    expect(registeredUnauthorizedHandler).not.toBeNull();
+    registeredUnauthorizedHandler?.();
+
+    const next = useAuthStore.getState();
+    expect(next.authenticated).toBe(false);
+    expect(next.totpRequiredOnLogin).toBe(false);
+    expect(next.passwordSessionActive).toBe(false);
+    expect(next.passwordRequired).toBe(true);
+    expect(next.initialized).toBe(true);
+  });
 });

--- a/frontend/src/features/auth/hooks/use-auth.ts
+++ b/frontend/src/features/auth/hooks/use-auth.ts
@@ -124,10 +124,11 @@ export const useAuthStore = create<AuthState>((set) => ({
 }));
 
 setUnauthorizedHandler(() => {
-  useAuthStore.setState((state) => ({
-    ...state,
+  useAuthStore.setState({
     authenticated: false,
+    totpRequiredOnLogin: false,
+    passwordSessionActive: false,
     initialized: true,
     error: null,
-  }));
+  });
 });

--- a/openspec/changes/fix-expired-dashboard-session-login-redirect/proposal.md
+++ b/openspec/changes/fix-expired-dashboard-session-login-redirect/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+Dashboard API calls can return 401 after the browser still has a stale frontend
+state from a password login that was waiting for TOTP. The current 401 handler
+marks the user unauthenticated but leaves `totpRequiredOnLogin` set, so the
+auth gate renders the TOTP dialog even though the password-authenticated
+session is gone. Operators should be sent back to the password login form.
+
+## What Changes
+
+- Clear stale pending-TOTP state when the shared API client handles a 401.
+- Clear the frontend `passwordSessionActive` flag at the same boundary.
+- Preserve existing first-run bootstrap, trusted-header, and password-required
+  state so other auth modes keep their current screen selection.
+
+## Impact
+
+- No backend API or session-cookie behavior changes.
+- First-run bootstrap behavior is unchanged.
+- Standard password auth falls back to login after an expired dashboard session.

--- a/openspec/changes/fix-expired-dashboard-session-login-redirect/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-expired-dashboard-session-login-redirect/specs/frontend-architecture/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Expired dashboard session returns to login
+
+When the dashboard API client receives a 401 while standard password
+authentication is required, the SPA SHALL clear any stale pending-TOTP state
+from the auth store before selecting the auth screen. The auth gate SHALL show
+the password login form rather than the TOTP verification dialog unless the
+current session response or a fresh password-login response explicitly reports
+`totpRequiredOnLogin: true`.
+
+#### Scenario: 401 clears stale pending-TOTP state
+
+- **GIVEN** the SPA auth store still has `totpRequiredOnLogin: true` from an earlier password-login step
+- **WHEN** a dashboard API request returns 401 because the password-authenticated session is no longer active
+- **THEN** the auth store sets `authenticated: false`
+- **AND** the auth store sets `totpRequiredOnLogin: false`
+- **AND** the auth store sets `passwordSessionActive: false`
+- **AND** the auth gate shows the password login form for standard password auth
+
+#### Scenario: Bootstrap state is preserved
+
+- **GIVEN** the SPA auth store indicates first-run bootstrap is required
+- **WHEN** a dashboard API request returns 401
+- **THEN** the auth store preserves the bootstrap-required state
+- **AND** the bootstrap setup screen remains eligible to render

--- a/openspec/changes/fix-expired-dashboard-session-login-redirect/tasks.md
+++ b/openspec/changes/fix-expired-dashboard-session-login-redirect/tasks.md
@@ -1,0 +1,3 @@
+- [x] Update the frontend 401 handler to clear stale pending-TOTP and password-session state.
+- [x] Add regression coverage for stale pending-TOTP state after a 401.
+- [ ] Validate OpenSpec specs and targeted frontend auth tests. Blocked locally: `openspec` and `bun` are not on PATH.


### PR DESCRIPTION
## Summary

This PR fixes the dashboard auth flow after an expired password-authenticated session.

When a dashboard API call returns `401`, the frontend now clears stale pending-TOTP state from the auth store. That sends the user back to the password login form instead of showing the two-factor verification dialog for a session that no longer exists.

It also adds an OpenSpec change and a small regression test for the 401 handler.

## 한국어 설명

대시보드 인증 세션이 만료된 뒤에도 프론트 상태에 예전 `totpRequiredOnLogin` 값이 남아 있으면, 실제로는 비밀번호 세션이 끊겼는데도 화면이 2FA 입력창으로 넘어가는 문제가 있었습니다.

이번 변경은 API 요청에서 `401`을 받았을 때 그 오래된 2FA 대기 상태를 같이 정리해서, 세션이 끊긴 사용자가 자연스럽게 로그인 화면으로 돌아가도록 합니다. 첫 설정용 bootstrap 상태는 그대로 보존해서 초기 설정 화면 동작은 바꾸지 않았습니다.

## Root Cause

The shared API client's 401 handler only cleared `authenticated`. It did not clear stale `totpRequiredOnLogin` or `passwordSessionActive`, so `AuthGate` could still choose the TOTP screen after the underlying password session had expired.

## Validation

- `git diff --check`
- Not run locally: `openspec validate --specs` because `openspec` is not on `PATH`
- Not run locally: targeted frontend `bun test ...` because `bun` is not on `PATH`