### PR TITLE
fix(accounts): avoid SQLite window plan for usage trends

### DIFF
--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -277,74 +277,153 @@ class UsageRepository:
             conditions.append(UsageHistory.account_id == account_id)
 
         window_expr = _normalized_window_expr()
-        base_rows = (
-            select(
-                bucket_col,
-                UsageHistory.id.label("usage_id"),
-                UsageHistory.account_id.label("account_id"),
-                window_expr.label("window"),
-                UsageHistory.used_percent.label("used_percent"),
-                UsageHistory.reset_at.label("reset_at"),
-                UsageHistory.window_minutes.label("window_minutes"),
-                UsageHistory.recorded_at.label("recorded_at"),
+        if dialect == "sqlite":
+            base_rows = (
+                select(
+                    bucket_col,
+                    UsageHistory.id.label("usage_id"),
+                    UsageHistory.account_id.label("account_id"),
+                    window_expr.label("window"),
+                    UsageHistory.used_percent.label("used_percent"),
+                    UsageHistory.recorded_at.label("recorded_at"),
+                )
+                .where(*conditions)
+                .subquery()
             )
-            .where(*conditions)
-            .subquery()
-        )
 
-        aggregate_rows = (
-            select(
+            aggregate_rows = (
+                select(
+                    base_rows.c.bucket_epoch,
+                    base_rows.c.account_id,
+                    base_rows.c.window,
+                    func.avg(base_rows.c.used_percent).label("avg_used_percent"),
+                    func.count(base_rows.c.usage_id).label("samples"),
+                    func.max(base_rows.c.recorded_at).label("max_recorded_at"),
+                )
+                .group_by(
+                    base_rows.c.bucket_epoch,
+                    base_rows.c.account_id,
+                    base_rows.c.window,
+                )
+                .subquery()
+            )
+
+            latest_ids = (
+                select(
+                    aggregate_rows.c.bucket_epoch,
+                    aggregate_rows.c.account_id,
+                    aggregate_rows.c.window,
+                    func.max(base_rows.c.usage_id).label("usage_id"),
+                )
+                .join(
+                    base_rows,
+                    and_(
+                        base_rows.c.bucket_epoch == aggregate_rows.c.bucket_epoch,
+                        base_rows.c.account_id == aggregate_rows.c.account_id,
+                        base_rows.c.window == aggregate_rows.c.window,
+                        base_rows.c.recorded_at == aggregate_rows.c.max_recorded_at,
+                    ),
+                )
+                .group_by(
+                    aggregate_rows.c.bucket_epoch,
+                    aggregate_rows.c.account_id,
+                    aggregate_rows.c.window,
+                )
+                .subquery()
+            )
+
+            stmt = (
+                select(
+                    aggregate_rows.c.bucket_epoch,
+                    aggregate_rows.c.account_id,
+                    aggregate_rows.c.window,
+                    aggregate_rows.c.avg_used_percent,
+                    aggregate_rows.c.samples,
+                    UsageHistory.reset_at,
+                    UsageHistory.window_minutes,
+                    UsageHistory.recorded_at,
+                )
+                .join(
+                    latest_ids,
+                    and_(
+                        latest_ids.c.bucket_epoch == aggregate_rows.c.bucket_epoch,
+                        latest_ids.c.account_id == aggregate_rows.c.account_id,
+                        latest_ids.c.window == aggregate_rows.c.window,
+                    ),
+                )
+                .join(UsageHistory, UsageHistory.id == latest_ids.c.usage_id)
+                .order_by(aggregate_rows.c.bucket_epoch)
+            )
+        else:
+            base_rows = (
+                select(
+                    bucket_col,
+                    UsageHistory.id.label("usage_id"),
+                    UsageHistory.account_id.label("account_id"),
+                    window_expr.label("window"),
+                    UsageHistory.used_percent.label("used_percent"),
+                    UsageHistory.reset_at.label("reset_at"),
+                    UsageHistory.window_minutes.label("window_minutes"),
+                    UsageHistory.recorded_at.label("recorded_at"),
+                )
+                .where(*conditions)
+                .subquery()
+            )
+
+            aggregate_rows = (
+                select(
+                    base_rows.c.bucket_epoch,
+                    base_rows.c.account_id,
+                    base_rows.c.window,
+                    func.avg(base_rows.c.used_percent).label("avg_used_percent"),
+                    func.count(base_rows.c.usage_id).label("samples"),
+                )
+                .group_by(
+                    base_rows.c.bucket_epoch,
+                    base_rows.c.account_id,
+                    base_rows.c.window,
+                )
+                .subquery()
+            )
+
+            latest_rows = select(
                 base_rows.c.bucket_epoch,
                 base_rows.c.account_id,
                 base_rows.c.window,
-                func.avg(base_rows.c.used_percent).label("avg_used_percent"),
-                func.count(base_rows.c.usage_id).label("samples"),
-            )
-            .group_by(
-                base_rows.c.bucket_epoch,
-                base_rows.c.account_id,
-                base_rows.c.window,
-            )
-            .subquery()
-        )
+                base_rows.c.reset_at,
+                base_rows.c.window_minutes,
+                base_rows.c.recorded_at,
+                func.row_number()
+                .over(
+                    partition_by=(base_rows.c.bucket_epoch, base_rows.c.account_id, base_rows.c.window),
+                    order_by=(base_rows.c.recorded_at.desc(), base_rows.c.usage_id.desc()),
+                )
+                .label("row_number"),
+            ).subquery()
 
-        latest_rows = select(
-            base_rows.c.bucket_epoch,
-            base_rows.c.account_id,
-            base_rows.c.window,
-            base_rows.c.reset_at,
-            base_rows.c.window_minutes,
-            base_rows.c.recorded_at,
-            func.row_number()
-            .over(
-                partition_by=(base_rows.c.bucket_epoch, base_rows.c.account_id, base_rows.c.window),
-                order_by=(base_rows.c.recorded_at.desc(), base_rows.c.usage_id.desc()),
+            stmt = (
+                select(
+                    aggregate_rows.c.bucket_epoch,
+                    aggregate_rows.c.account_id,
+                    aggregate_rows.c.window,
+                    aggregate_rows.c.avg_used_percent,
+                    aggregate_rows.c.samples,
+                    latest_rows.c.reset_at,
+                    latest_rows.c.window_minutes,
+                    latest_rows.c.recorded_at,
+                )
+                .join(
+                    latest_rows,
+                    and_(
+                        latest_rows.c.bucket_epoch == aggregate_rows.c.bucket_epoch,
+                        latest_rows.c.account_id == aggregate_rows.c.account_id,
+                        latest_rows.c.window == aggregate_rows.c.window,
+                        latest_rows.c.row_number == 1,
+                    ),
+                )
+                .order_by(aggregate_rows.c.bucket_epoch)
             )
-            .label("row_number"),
-        ).subquery()
 
-        stmt = (
-            select(
-                aggregate_rows.c.bucket_epoch,
-                aggregate_rows.c.account_id,
-                aggregate_rows.c.window,
-                aggregate_rows.c.avg_used_percent,
-                aggregate_rows.c.samples,
-                latest_rows.c.reset_at,
-                latest_rows.c.window_minutes,
-                latest_rows.c.recorded_at,
-            )
-            .join(
-                latest_rows,
-                and_(
-                    latest_rows.c.bucket_epoch == aggregate_rows.c.bucket_epoch,
-                    latest_rows.c.account_id == aggregate_rows.c.account_id,
-                    latest_rows.c.window == aggregate_rows.c.window,
-                    latest_rows.c.row_number == 1,
-                ),
-            )
-            .order_by(aggregate_rows.c.bucket_epoch)
-        )
         result = await self._session.execute(stmt)
         return [
             UsageTrendBucket(

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, timedelta
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.crypto import TokenEncryptor
@@ -273,3 +273,62 @@ async def test_trends_by_bucket_uses_latest_sample_window_metadata(db_setup):
     assert trends[0].reset_at == 1111
     assert trends[0].window_minutes == 300
     assert trends[0].recorded_at == recorded_at + timedelta(minutes=5)
+
+
+@pytest.mark.asyncio
+async def test_trends_by_bucket_sqlite_avoids_window_function_for_latest_metadata(db_setup):
+    recorded_at = datetime(2026, 1, 1, 12, 0, 0)
+    statements: list[str] = []
+
+    async with SessionLocal() as session:
+        if _dialect_name(session) != "sqlite":
+            pytest.skip("SQLite-only SQL shape test")
+
+        bind = session.get_bind()
+        assert bind is not None
+
+        def _capture_sql(_conn, _cursor, statement, _parameters, _context, _executemany):
+            statements.append(statement)
+
+        event.listen(bind, "before_cursor_execute", _capture_sql)
+        try:
+            accounts_repo = AccountsRepository(session)
+            repo = UsageRepository(session)
+            await accounts_repo.upsert(_make_account("acc1"))
+
+            await repo.add_entry(
+                "acc1",
+                10.0,
+                window="secondary",
+                reset_at=9999,
+                window_minutes=10080,
+                recorded_at=recorded_at,
+            )
+            await repo.add_entry(
+                "acc1",
+                30.0,
+                window="secondary",
+                reset_at=1111,
+                window_minutes=300,
+                recorded_at=recorded_at + timedelta(minutes=5),
+            )
+
+            trends = await repo.trends_by_bucket(
+                since=recorded_at - timedelta(minutes=1),
+                bucket_seconds=86400,
+                window="secondary",
+                account_id="acc1",
+            )
+        finally:
+            event.remove(bind, "before_cursor_execute", _capture_sql)
+
+    assert len(trends) == 1
+    assert trends[0].samples == 2
+    assert trends[0].reset_at == 1111
+    assert trends[0].window_minutes == 300
+
+    trend_queries = [
+        statement for statement in statements if "usage_history" in statement and "bucket_epoch" in statement
+    ]
+    assert len(trend_queries) == 1
+    assert "row_number()" not in trend_queries[0].lower()


### PR DESCRIPTION
## Summary

Optimize `UsageRepository.trends_by_bucket()` on SQLite so the account trends endpoint no longer uses a `row_number()` window-function plan to fetch latest per-bucket metadata.

The first scalar-subquery attempt was tested against a live SQLite database and regressed. This revision uses a two-stage aggregate instead:

1. aggregate each `(bucket, account, window)` once, including `max(recorded_at)`
2. resolve the deterministic latest row with `max(id)` among rows at that max timestamp
3. join that latest id back to `usage_history` for metadata

This preserves the existing latest-metadata semantics, including the recorded-at/id tie-breaker, while avoiding SQLite's expensive window-function plan.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Fixes #859

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Adds a SQLite-specific trends query path that aggregates buckets once, then resolves latest per-bucket metadata via `max(recorded_at)` + deterministic `max(id)` tie-break instead of a `row_number()` window query.
- Leaves the existing PostgreSQL query path unchanged.
- Adds an integration regression test that captures the emitted SQLite trends SQL and asserts the latest-metadata path does not use `row_number()` while preserving latest metadata values.

## Live SQLite benchmark

Benchmarked against a live SQLite `usage_history` table with 184,654 rows, using a read-only transaction snapshot and 5 runs per query shape.

All results matched the baseline rows/metadata.

```text
-- ALL ACCOUNTS --
baseline old row_number window:       median 1252.71 ms
rejected scalar-subquery attempt:     median 4533.12 ms
after this fix, max-time/max-id path: median  665.90 ms

-- HEAVIEST SINGLE ACCOUNT --
baseline old row_number window:       median 240.67 ms
rejected scalar-subquery attempt:     median 850.67 ms
after this fix, max-time/max-id path: median 137.43 ms

Confirmation rerun for fixed path:
all accounts: median 663.22 ms
one account:  median 132.58 ms
```

## Test plan

```text
uv run pytest tests/integration/test_usage_repository.py::test_trends_by_bucket_sqlite_avoids_window_function_for_latest_metadata -q
# 1 passed

uv run pytest tests/integration/test_usage_repository.py -q
# 8 passed, 1 skipped

uv run ruff check app/modules/usage/repository.py tests/integration/test_usage_repository.py
# All checks passed!

uv run ruff format --check app/modules/usage/repository.py tests/integration/test_usage_repository.py
# 2 files already formatted
```
