### PR TITLE
perf(usage): avoid SQLite window latest usage lookup

### DIFF
--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -195,20 +195,24 @@ class UsageRepository:
             stmt = select(UsageHistory).where(UsageHistory.id.in_(id_query))
             result = await self._session.execute(stmt)
             return {entry.account_id: entry for entry in result.scalars().all()}
-        subq = (
-            select(
-                UsageHistory.id.label("usage_id"),
-                func.row_number()
-                .over(
-                    partition_by=UsageHistory.account_id,
-                    order_by=(UsageHistory.recorded_at.desc(), UsageHistory.id.desc()),
-                )
-                .label("row_number"),
+
+        acct_stmt = select(Account.id)
+        if account_ids is not None:
+            acct_stmt = acct_stmt.where(Account.id.in_(account_ids))
+        acct_subq = acct_stmt.subquery("accts")
+        latest_id = (
+            select(UsageHistory.id)
+            .where(
+                conditions,
+                UsageHistory.account_id == acct_subq.c.id,
             )
-            .where(conditions)
-            .subquery()
+            .order_by(UsageHistory.recorded_at.desc(), UsageHistory.id.desc())
+            .limit(1)
+            .correlate(acct_subq)
+            .scalar_subquery()
         )
-        stmt = select(UsageHistory).join(subq, UsageHistory.id == subq.c.usage_id).where(subq.c.row_number == 1)
+        id_rows = select(latest_id.label("usage_id")).select_from(acct_subq).subquery("latest_ids")
+        stmt = select(UsageHistory).join(id_rows, UsageHistory.id == id_rows.c.usage_id)
         result = await self._session.execute(stmt)
         return {entry.account_id: entry for entry in result.scalars().all()}
 

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -4,13 +4,13 @@ import json
 from datetime import datetime, timedelta
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
-from app.db.session import SessionLocal
+from app.db.session import SessionLocal, engine
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.usage.repository import UsageRepository
 
@@ -111,6 +111,39 @@ async def test_latest_by_account_uses_recorded_at_with_deterministic_tie_breaker
 
         latest = await repo.latest_by_account(window="primary")
         assert latest["acc1"].used_percent == 30.0
+
+
+@pytest.mark.asyncio
+async def test_latest_by_account_sqlite_avoids_window_function_for_latest_rows(db_setup):
+    now = utcnow()
+    statements: list[str] = []
+
+    def capture_statement(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    async with SessionLocal() as session:
+        if _dialect_name(session) != "sqlite":
+            pytest.skip("SQLite-only SQL shape test")
+
+        accounts_repo = AccountsRepository(session)
+        repo = UsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc1"))
+        await accounts_repo.upsert(_make_account("acc2"))
+        await repo.add_entry("acc1", 10.0, window=None, recorded_at=now - timedelta(hours=2))
+        await repo.add_entry("acc1", 20.0, window="primary", recorded_at=now)
+        await repo.add_entry("acc2", 30.0, window=None, recorded_at=now - timedelta(hours=1))
+        await repo.add_entry("acc2", 40.0, window="primary", recorded_at=now)
+
+        event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+        try:
+            latest = await repo.latest_by_account(window="primary")
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    assert set(latest.keys()) == {"acc1", "acc2"}
+    emitted_sql = "\n".join(statements).lower()
+    assert "row_number" not in emitted_sql
+    assert " over " not in emitted_sql
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Avoid the SQLite `row_number()` window-function plan in `UsageRepository.latest_by_account()`, which is used by dashboard/account usage refresh paths to fetch each account's latest usage sample.

SQLite now performs an indexed latest-row lookup per account, matching the existing PostgreSQL intent while avoiding the large-table window scan called out in #708.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Part of #708

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — performance bug fix that preserves existing behavior
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Replaces the SQLite `latest_by_account()` window-function query with a correlated latest-id lookup over `Account` rows.
- Keeps the existing PostgreSQL lateral-query path unchanged.
- Adds an integration regression test that captures the emitted SQLite SQL and asserts the latest-row lookup no longer contains `row_number()` / `OVER`.

## Test plan

```text
uv run pytest tests/integration/test_usage_repository.py::test_latest_by_account_sqlite_avoids_window_function_for_latest_rows -q
# RED before fix: failed because emitted SQL contained row_number() over (...)
# GREEN after fix: 1 passed

uv run pytest tests/integration/test_usage_repository.py -q
# 8 passed, 1 skipped

uv run ruff check .
# All checks passed!

uv run ruff format --check .
# 500 files already formatted

uv run ty check
# All checks passed!
```

## Screenshots / output (optional)

N/A

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset locally: pytest integration target, ruff check, ruff format --check, ty check.
- [x] If touching specs: not applicable; no spec changes.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
