### PR TITLE
perf(dashboard): speed up SQLite overview usage reads

### DIFF
--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -10,7 +10,7 @@ from app.db.models import Account, AccountLimitWarmup, AdditionalUsageHistory, R
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.limit_warmup.repository import LimitWarmupRepository
 from app.modules.request_logs.repository import RequestLogsRepository
-from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+from app.modules.usage.repository import AdditionalUsageRepository, UsageHistorySnapshot, UsageRepository
 
 
 class DashboardRepository:
@@ -40,7 +40,7 @@ class DashboardRepository:
         account_ids: list[str],
         window: str,
         since: datetime,
-    ) -> dict[str, list[UsageHistory]]:
+    ) -> dict[str, list[UsageHistorySnapshot]]:
         return await self._usage_repo.bulk_history_since(account_ids, window, since)
 
     async def latest_window_minutes(self, window: str) -> int | None:

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -4,6 +4,7 @@ import sqlite3
 from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime
+from hashlib import sha256
 from threading import RLock
 
 from anyio import to_thread
@@ -52,6 +53,7 @@ class _BulkHistoryFingerprint:
     reset_at_total: float
     window_minutes_sum: int
     max_recorded_at: str
+    content_digest: str
 
 
 _BULK_HISTORY_SQLITE_CACHE: dict[tuple[str, tuple[str, ...], str], _BulkHistoryCacheEntry] = {}
@@ -95,7 +97,8 @@ def _fingerprint_grouped_history(grouped: dict[str, list[UsageHistorySnapshot]])
     reset_at_total = 0.0
     window_minutes_sum = 0
     max_recorded_at = ""
-    for rows in grouped.values():
+    digest = sha256()
+    for account_id, rows in sorted(grouped.items()):
         for row in rows:
             row_count += 1
             max_id = max(max_id, row.id)
@@ -103,7 +106,20 @@ def _fingerprint_grouped_history(grouped: dict[str, list[UsageHistorySnapshot]])
             used_percent_total += row.used_percent
             reset_at_total += row.reset_at or 0.0
             window_minutes_sum += row.window_minutes or 0
-            max_recorded_at = max(max_recorded_at, row.recorded_at.isoformat(sep=" "))
+            recorded_at = row.recorded_at.isoformat(sep=" ")
+            max_recorded_at = max(max_recorded_at, recorded_at)
+            digest.update(
+                repr(
+                    (
+                        account_id,
+                        row.id,
+                        row.used_percent,
+                        recorded_at,
+                        row.reset_at,
+                        row.window_minutes,
+                    )
+                ).encode("utf-8")
+            )
     return _BulkHistoryFingerprint(
         row_count=row_count,
         max_id=max_id,
@@ -112,6 +128,7 @@ def _fingerprint_grouped_history(grouped: dict[str, list[UsageHistorySnapshot]])
         reset_at_total=reset_at_total,
         window_minutes_sum=window_minutes_sum,
         max_recorded_at=max_recorded_at,
+        content_digest=digest.hexdigest(),
     )
 
 
@@ -149,28 +166,45 @@ def _bulk_history_fingerprint_sqlite(
         window_clause = "window = ?"
         params = [*account_ids, window, since_param]
     sql = f"""
-        select
-            count(*),
-            coalesce(max(id), 0),
-            coalesce(sum(id), 0),
-            coalesce(total(used_percent), 0.0),
-            coalesce(total(coalesce(reset_at, 0)), 0.0),
-            coalesce(sum(coalesce(window_minutes, 0)), 0),
-            coalesce(max(recorded_at), '')
+        select id, account_id, used_percent, recorded_at, reset_at, window_minutes
         from usage_history
         where account_id in ({placeholders})
           and {window_clause}
           and recorded_at >= ?
+        order by account_id, recorded_at asc, id asc
     """
-    row = conn.execute(sql, params).fetchone()
+    row_count = 0
+    max_id = 0
+    id_sum = 0
+    used_percent_total = 0.0
+    reset_at_total = 0.0
+    window_minutes_sum = 0
+    max_recorded_at = ""
+    digest = sha256()
+    for row in conn.execute(sql, params):
+        row_id = int(row[0])
+        account_id = str(row[1])
+        used_percent = float(row[2])
+        recorded_at = str(row[3])
+        reset_at = float(row[4]) if row[4] is not None else None
+        window_minutes = int(row[5]) if row[5] is not None else None
+        row_count += 1
+        max_id = max(max_id, row_id)
+        id_sum += row_id
+        used_percent_total += used_percent
+        reset_at_total += reset_at or 0.0
+        window_minutes_sum += window_minutes or 0
+        max_recorded_at = max(max_recorded_at, recorded_at)
+        digest.update(repr((account_id, row_id, used_percent, recorded_at, reset_at, window_minutes)).encode("utf-8"))
     return _BulkHistoryFingerprint(
-        row_count=int(row[0]),
-        max_id=int(row[1]),
-        id_sum=int(row[2]),
-        used_percent_total=float(row[3]),
-        reset_at_total=float(row[4]),
-        window_minutes_sum=int(row[5]),
-        max_recorded_at=str(row[6]),
+        row_count=row_count,
+        max_id=max_id,
+        id_sum=id_sum,
+        used_percent_total=used_percent_total,
+        reset_at_total=reset_at_total,
+        window_minutes_sum=window_minutes_sum,
+        max_recorded_at=max_recorded_at,
+        content_digest=digest.hexdigest(),
     )
 
 

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Collection
+from dataclasses import dataclass
 from datetime import datetime
 
+from anyio import to_thread
 from sqlalchemy import Integer, and_, cast, delete, func, literal_column, or_, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config.settings import get_settings
 from app.core.usage.types import UsageAggregateRow, UsageTrendBucket
 from app.core.utils.time import utcnow
 from app.db.models import Account, AdditionalUsageHistory, UsageHistory
 from app.db.session import sqlite_writer_section
+from app.db.sqlite_utils import sqlite_db_path_from_url
 from app.modules.usage.additional_quota_keys import (
     AdditionalQuotaQueryScope,
     canonicalize_additional_quota_key,
@@ -17,6 +22,16 @@ from app.modules.usage.additional_quota_keys import (
 )
 
 _PRIMARY_WINDOW_LITERAL = literal_column("'primary'")
+
+
+@dataclass(frozen=True, slots=True)
+class UsageHistorySnapshot:
+    id: int
+    account_id: str
+    used_percent: float
+    recorded_at: datetime
+    reset_at: float | None
+    window_minutes: int | None
 
 
 def _normalized_window_expr():
@@ -27,6 +42,114 @@ def _window_clause(window: str | None):
     if not window or window == "primary":
         return _normalized_window_expr() == "primary"
     return UsageHistory.window == window
+
+
+def _parse_sqlite_datetime(value) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(str(value))
+
+
+def _usage_history_from_sqlite_row(row) -> UsageHistory:
+    return UsageHistory(
+        id=int(row[0]),
+        account_id=str(row[1]),
+        recorded_at=_parse_sqlite_datetime(row[2]),
+        window=row[3],
+        used_percent=float(row[4]),
+        input_tokens=int(row[5]) if row[5] is not None else None,
+        output_tokens=int(row[6]) if row[6] is not None else None,
+        reset_at=int(row[7]) if row[7] is not None else None,
+        window_minutes=int(row[8]) if row[8] is not None else None,
+        credits_has=bool(row[9]) if row[9] is not None else None,
+        credits_unlimited=bool(row[10]) if row[10] is not None else None,
+        credits_balance=float(row[11]) if row[11] is not None else None,
+    )
+
+
+def _latest_by_account_sqlite(
+    db_path: str,
+    window: str | None,
+    account_ids: list[str] | None,
+) -> dict[str, UsageHistory]:
+    if account_ids is None:
+        account_sql = "select id from accounts"
+        account_params: list[object] = []
+    elif not account_ids:
+        return {}
+    else:
+        placeholders = ",".join("?" for _ in account_ids)
+        account_sql = f"select id from accounts where id in ({placeholders})"
+        account_params = list(account_ids)
+
+    if not window or window == "primary":
+        window_clause = "coalesce(window, 'primary') = 'primary'"
+        window_params: list[object] = []
+    else:
+        window_clause = "window = ?"
+        window_params = [window]
+    latest_sql = f"""
+        select id, account_id, recorded_at, window, used_percent,
+               input_tokens, output_tokens, reset_at, window_minutes,
+               credits_has, credits_unlimited, credits_balance
+        from usage_history
+        where account_id = ?
+          and {window_clause}
+        order by recorded_at desc, id desc
+        limit 1
+    """
+
+    latest: dict[str, UsageHistory] = {}
+    with sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as conn:
+        conn.execute("PRAGMA query_only=ON")
+        conn.execute("PRAGMA busy_timeout=30000")
+        accounts = [str(row[0]) for row in conn.execute(account_sql, account_params)]
+        for account_id in accounts:
+            row = conn.execute(latest_sql, [account_id, *window_params]).fetchone()
+            if row is not None:
+                entry = _usage_history_from_sqlite_row(row)
+                latest[entry.account_id] = entry
+    return latest
+
+
+def _bulk_history_since_sqlite(
+    db_path: str,
+    account_ids: list[str],
+    window: str,
+    since: datetime,
+) -> dict[str, list[UsageHistorySnapshot]]:
+    placeholders = ",".join("?" for _ in account_ids)
+    since_param = since.isoformat(sep=" ")
+    if window == "primary":
+        window_clause = "coalesce(window, 'primary') = 'primary'"
+        params: list[object] = [*account_ids, since_param]
+    else:
+        window_clause = "window = ?"
+        params = [*account_ids, window, since_param]
+    sql = f"""
+        select id, account_id, used_percent, recorded_at, reset_at, window_minutes
+        from usage_history
+        where account_id in ({placeholders})
+          and {window_clause}
+          and recorded_at >= ?
+        order by account_id, recorded_at asc
+    """
+    grouped: dict[str, list[UsageHistorySnapshot]] = {}
+    with sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as conn:
+        conn.execute("PRAGMA query_only=ON")
+        conn.execute("PRAGMA busy_timeout=30000")
+        rows = conn.execute(sql, params)
+        for row in rows:
+            snapshot = UsageHistorySnapshot(
+                id=int(row[0]),
+                account_id=str(row[1]),
+                used_percent=float(row[2]),
+                recorded_at=_parse_sqlite_datetime(row[3]),
+                reset_at=float(row[4]) if row[4] is not None else None,
+                window_minutes=int(row[5]) if row[5] is not None else None,
+            )
+            grouped.setdefault(snapshot.account_id, []).append(snapshot)
+    return grouped
 
 
 def _resolve_additional_quota_key(
@@ -173,6 +296,14 @@ class UsageRepository:
             conditions = and_(conditions, UsageHistory.account_id.in_(account_ids))
         bind = self._session.get_bind()
         dialect = bind.dialect.name if bind else "sqlite"
+        sqlite_path = sqlite_db_path_from_url(get_settings().database_url) if dialect == "sqlite" else None
+        if sqlite_path is not None:
+            return await to_thread.run_sync(
+                _latest_by_account_sqlite,
+                str(sqlite_path),
+                window,
+                list(account_ids) if account_ids is not None else None,
+            )
         if dialect == "postgresql":
             acct_stmt = select(Account.id)
             if account_ids is not None:
@@ -235,12 +366,31 @@ class UsageRepository:
         account_ids: list[str],
         window: str,
         since: datetime,
-    ) -> dict[str, list[UsageHistory]]:
-        """Fetch usage history for multiple accounts in a single query."""
+    ) -> dict[str, list[UsageHistorySnapshot]]:
+        """Fetch minimal usage history fields for multiple accounts in a single query."""
         if not account_ids:
             return {}
+        bind = self._session.get_bind()
+        dialect = bind.dialect.name if bind else "sqlite"
+        sqlite_path = sqlite_db_path_from_url(get_settings().database_url) if dialect == "sqlite" else None
+        if sqlite_path is not None:
+            return await to_thread.run_sync(
+                _bulk_history_since_sqlite,
+                str(sqlite_path),
+                list(account_ids),
+                window,
+                since,
+            )
+
         stmt = (
-            select(UsageHistory)
+            select(
+                UsageHistory.id,
+                UsageHistory.account_id,
+                UsageHistory.used_percent,
+                UsageHistory.recorded_at,
+                UsageHistory.reset_at,
+                UsageHistory.window_minutes,
+            )
             .where(
                 UsageHistory.account_id.in_(account_ids),
                 _window_clause(window),
@@ -249,9 +399,17 @@ class UsageRepository:
             .order_by(UsageHistory.account_id, UsageHistory.recorded_at.asc())
         )
         result = await self._session.execute(stmt)
-        grouped: dict[str, list[UsageHistory]] = {}
-        for row in result.scalars().all():
-            grouped.setdefault(row.account_id, []).append(row)
+        grouped: dict[str, list[UsageHistorySnapshot]] = {}
+        for row in result.all():
+            snapshot = UsageHistorySnapshot(
+                id=int(row.id),
+                account_id=row.account_id,
+                used_percent=float(row.used_percent),
+                recorded_at=row.recorded_at,
+                reset_at=float(row.reset_at) if row.reset_at is not None else None,
+                window_minutes=int(row.window_minutes) if row.window_minutes is not None else None,
+            )
+            grouped.setdefault(snapshot.account_id, []).append(snapshot)
         return grouped
 
     async def trends_by_bucket(

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -96,9 +96,10 @@ def _query_bulk_history_since_sqlite(
     placeholders = ",".join("?" for _ in account_ids)
     since_param = since.isoformat(sep=" ")
     id_clause = ""
+    params: list[object]
     if window == "primary":
         window_clause = "coalesce(window, 'primary') = 'primary'"
-        params: list[object] = [*account_ids, since_param]
+        params = [*account_ids, since_param]
     else:
         window_clause = "window = ?"
         params = [*account_ids, window, since_param]

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -39,7 +39,19 @@ class UsageHistorySnapshot:
 class _BulkHistoryCacheEntry:
     since: datetime
     max_id: int
+    fingerprint: _BulkHistoryFingerprint
     rows_by_account: dict[str, list[UsageHistorySnapshot]]
+
+
+@dataclass(frozen=True, slots=True)
+class _BulkHistoryFingerprint:
+    row_count: int
+    max_id: int
+    id_sum: int
+    used_percent_total: float
+    reset_at_total: float
+    window_minutes_sum: int
+    max_recorded_at: str
 
 
 _BULK_HISTORY_SQLITE_CACHE: dict[tuple[str, tuple[str, ...], str], _BulkHistoryCacheEntry] = {}
@@ -75,6 +87,34 @@ def _max_snapshot_id(grouped: dict[str, list[UsageHistorySnapshot]]) -> int:
     return max((row.id for rows in grouped.values() for row in rows), default=0)
 
 
+def _fingerprint_grouped_history(grouped: dict[str, list[UsageHistorySnapshot]]) -> _BulkHistoryFingerprint:
+    row_count = 0
+    max_id = 0
+    id_sum = 0
+    used_percent_total = 0.0
+    reset_at_total = 0.0
+    window_minutes_sum = 0
+    max_recorded_at = ""
+    for rows in grouped.values():
+        for row in rows:
+            row_count += 1
+            max_id = max(max_id, row.id)
+            id_sum += row.id
+            used_percent_total += row.used_percent
+            reset_at_total += row.reset_at or 0.0
+            window_minutes_sum += row.window_minutes or 0
+            max_recorded_at = max(max_recorded_at, row.recorded_at.isoformat(sep=" "))
+    return _BulkHistoryFingerprint(
+        row_count=row_count,
+        max_id=max_id,
+        id_sum=id_sum,
+        used_percent_total=used_percent_total,
+        reset_at_total=reset_at_total,
+        window_minutes_sum=window_minutes_sum,
+        max_recorded_at=max_recorded_at,
+    )
+
+
 def _append_grouped_history(
     target: dict[str, list[UsageHistorySnapshot]],
     source: dict[str, list[UsageHistorySnapshot]],
@@ -83,6 +123,55 @@ def _append_grouped_history(
         bucket = target.setdefault(account_id, [])
         bucket.extend(rows)
         bucket.sort(key=lambda row: (row.recorded_at, row.id))
+
+
+def _merged_grouped_history(
+    target: dict[str, list[UsageHistorySnapshot]],
+    source: dict[str, list[UsageHistorySnapshot]],
+) -> dict[str, list[UsageHistorySnapshot]]:
+    merged = {account_id: list(rows) for account_id, rows in target.items()}
+    _append_grouped_history(merged, source)
+    return merged
+
+
+def _bulk_history_fingerprint_sqlite(
+    conn: sqlite3.Connection,
+    account_ids: list[str],
+    window: str,
+    since: datetime,
+) -> _BulkHistoryFingerprint:
+    placeholders = ",".join("?" for _ in account_ids)
+    since_param = since.isoformat(sep=" ")
+    if window == "primary":
+        window_clause = "coalesce(window, 'primary') = 'primary'"
+        params = [*account_ids, since_param]
+    else:
+        window_clause = "window = ?"
+        params = [*account_ids, window, since_param]
+    sql = f"""
+        select
+            count(*),
+            coalesce(max(id), 0),
+            coalesce(sum(id), 0),
+            coalesce(total(used_percent), 0.0),
+            coalesce(total(coalesce(reset_at, 0)), 0.0),
+            coalesce(sum(coalesce(window_minutes, 0)), 0),
+            coalesce(max(recorded_at), '')
+        from usage_history
+        where account_id in ({placeholders})
+          and {window_clause}
+          and recorded_at >= ?
+    """
+    row = conn.execute(sql, params).fetchone()
+    return _BulkHistoryFingerprint(
+        row_count=int(row[0]),
+        max_id=int(row[1]),
+        id_sum=int(row[2]),
+        used_percent_total=float(row[3]),
+        reset_at_total=float(row[4]),
+        window_minutes_sum=int(row[5]),
+        max_recorded_at=str(row[6]),
+    )
 
 
 def _query_bulk_history_since_sqlite(
@@ -221,6 +310,7 @@ def _bulk_history_since_sqlite(
         with _BULK_HISTORY_SQLITE_CACHE_LOCK:
             cached = _BULK_HISTORY_SQLITE_CACHE.get(cache_key)
             if cached is not None and cached.since <= since:
+                current_fingerprint = _bulk_history_fingerprint_sqlite(conn, account_ids, window, cached.since)
                 new_rows = _query_bulk_history_since_sqlite(
                     conn,
                     account_ids,
@@ -228,15 +318,25 @@ def _bulk_history_since_sqlite(
                     cached.since,
                     after_id=cached.max_id,
                 )
+                candidate_rows = _merged_grouped_history(cached.rows_by_account, new_rows)
+                candidate_fingerprint = _fingerprint_grouped_history(candidate_rows)
+                if current_fingerprint != candidate_fingerprint:
+                    grouped = _query_bulk_history_since_sqlite(conn, account_ids, window, cached.since)
+                    cached.max_id = _max_snapshot_id(grouped)
+                    cached.fingerprint = _fingerprint_grouped_history(grouped)
+                    cached.rows_by_account = grouped
+                    return _clone_filtered_history(grouped, since)
                 if new_rows:
                     _append_grouped_history(cached.rows_by_account, new_rows)
                     cached.max_id = max(cached.max_id, _max_snapshot_id(new_rows))
+                    cached.fingerprint = current_fingerprint
                 return _clone_filtered_history(cached.rows_by_account, since)
 
             grouped = _query_bulk_history_since_sqlite(conn, account_ids, window, since)
             _BULK_HISTORY_SQLITE_CACHE[cache_key] = _BulkHistoryCacheEntry(
                 since=since,
                 max_id=_max_snapshot_id(grouped),
+                fingerprint=_fingerprint_grouped_history(grouped),
                 rows_by_account=grouped,
             )
             return _clone_filtered_history(grouped, since)

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -4,6 +4,7 @@ import sqlite3
 from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime
+from threading import RLock
 
 from anyio import to_thread
 from sqlalchemy import Integer, and_, cast, delete, func, literal_column, or_, select, true
@@ -32,6 +33,100 @@ class UsageHistorySnapshot:
     recorded_at: datetime
     reset_at: float | None
     window_minutes: int | None
+
+
+@dataclass(slots=True)
+class _BulkHistoryCacheEntry:
+    since: datetime
+    max_id: int
+    rows_by_account: dict[str, list[UsageHistorySnapshot]]
+
+
+_BULK_HISTORY_SQLITE_CACHE: dict[tuple[str, tuple[str, ...], str], _BulkHistoryCacheEntry] = {}
+_BULK_HISTORY_SQLITE_CACHE_LOCK = RLock()
+
+
+def _clear_bulk_history_since_sqlite_cache() -> None:
+    with _BULK_HISTORY_SQLITE_CACHE_LOCK:
+        _BULK_HISTORY_SQLITE_CACHE.clear()
+
+
+def _bulk_history_cache_key(
+    db_path: str,
+    account_ids: list[str],
+    window: str,
+) -> tuple[str, tuple[str, ...], str]:
+    return (db_path, tuple(sorted(account_ids)), window)
+
+
+def _clone_filtered_history(
+    grouped: dict[str, list[UsageHistorySnapshot]],
+    since: datetime,
+) -> dict[str, list[UsageHistorySnapshot]]:
+    filtered_grouped: dict[str, list[UsageHistorySnapshot]] = {}
+    for account_id, rows in grouped.items():
+        filtered = [row for row in rows if row.recorded_at >= since]
+        if filtered:
+            filtered_grouped[account_id] = filtered
+    return filtered_grouped
+
+
+def _max_snapshot_id(grouped: dict[str, list[UsageHistorySnapshot]]) -> int:
+    return max((row.id for rows in grouped.values() for row in rows), default=0)
+
+
+def _append_grouped_history(
+    target: dict[str, list[UsageHistorySnapshot]],
+    source: dict[str, list[UsageHistorySnapshot]],
+) -> None:
+    for account_id, rows in source.items():
+        bucket = target.setdefault(account_id, [])
+        bucket.extend(rows)
+        bucket.sort(key=lambda row: (row.recorded_at, row.id))
+
+
+def _query_bulk_history_since_sqlite(
+    conn: sqlite3.Connection,
+    account_ids: list[str],
+    window: str,
+    since: datetime,
+    *,
+    after_id: int | None = None,
+) -> dict[str, list[UsageHistorySnapshot]]:
+    placeholders = ",".join("?" for _ in account_ids)
+    since_param = since.isoformat(sep=" ")
+    id_clause = ""
+    if window == "primary":
+        window_clause = "coalesce(window, 'primary') = 'primary'"
+        params: list[object] = [*account_ids, since_param]
+    else:
+        window_clause = "window = ?"
+        params = [*account_ids, window, since_param]
+    if after_id is not None:
+        id_clause = "and id > ?"
+        params.append(after_id)
+    sql = f"""
+        select id, account_id, used_percent, recorded_at, reset_at, window_minutes
+        from usage_history
+        where account_id in ({placeholders})
+          and {window_clause}
+          and recorded_at >= ?
+          {id_clause}
+        order by account_id, recorded_at asc
+    """
+    grouped: dict[str, list[UsageHistorySnapshot]] = {}
+    rows = conn.execute(sql, params)
+    for row in rows:
+        snapshot = UsageHistorySnapshot(
+            id=int(row[0]),
+            account_id=str(row[1]),
+            used_percent=float(row[2]),
+            recorded_at=_parse_sqlite_datetime(row[3]),
+            reset_at=float(row[4]) if row[4] is not None else None,
+            window_minutes=int(row[5]) if row[5] is not None else None,
+        )
+        grouped.setdefault(snapshot.account_id, []).append(snapshot)
+    return grouped
 
 
 def _normalized_window_expr():
@@ -118,38 +213,32 @@ def _bulk_history_since_sqlite(
     window: str,
     since: datetime,
 ) -> dict[str, list[UsageHistorySnapshot]]:
-    placeholders = ",".join("?" for _ in account_ids)
-    since_param = since.isoformat(sep=" ")
-    if window == "primary":
-        window_clause = "coalesce(window, 'primary') = 'primary'"
-        params: list[object] = [*account_ids, since_param]
-    else:
-        window_clause = "window = ?"
-        params = [*account_ids, window, since_param]
-    sql = f"""
-        select id, account_id, used_percent, recorded_at, reset_at, window_minutes
-        from usage_history
-        where account_id in ({placeholders})
-          and {window_clause}
-          and recorded_at >= ?
-        order by account_id, recorded_at asc
-    """
-    grouped: dict[str, list[UsageHistorySnapshot]] = {}
+    cache_key = _bulk_history_cache_key(db_path, account_ids, window)
     with sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as conn:
         conn.execute("PRAGMA query_only=ON")
         conn.execute("PRAGMA busy_timeout=30000")
-        rows = conn.execute(sql, params)
-        for row in rows:
-            snapshot = UsageHistorySnapshot(
-                id=int(row[0]),
-                account_id=str(row[1]),
-                used_percent=float(row[2]),
-                recorded_at=_parse_sqlite_datetime(row[3]),
-                reset_at=float(row[4]) if row[4] is not None else None,
-                window_minutes=int(row[5]) if row[5] is not None else None,
+        with _BULK_HISTORY_SQLITE_CACHE_LOCK:
+            cached = _BULK_HISTORY_SQLITE_CACHE.get(cache_key)
+            if cached is not None and cached.since <= since:
+                new_rows = _query_bulk_history_since_sqlite(
+                    conn,
+                    account_ids,
+                    window,
+                    cached.since,
+                    after_id=cached.max_id,
+                )
+                if new_rows:
+                    _append_grouped_history(cached.rows_by_account, new_rows)
+                    cached.max_id = max(cached.max_id, _max_snapshot_id(new_rows))
+                return _clone_filtered_history(cached.rows_by_account, since)
+
+            grouped = _query_bulk_history_since_sqlite(conn, account_ids, window, since)
+            _BULK_HISTORY_SQLITE_CACHE[cache_key] = _BulkHistoryCacheEntry(
+                since=since,
+                max_id=_max_snapshot_id(grouped),
+                rows_by_account=grouped,
             )
-            grouped.setdefault(snapshot.account_id, []).append(snapshot)
-    return grouped
+            return _clone_filtered_history(grouped, since)
 
 
 def _resolve_additional_quota_key(

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -185,7 +185,7 @@ def _bulk_history_fingerprint_sqlite(
         row_id = int(row[0])
         account_id = str(row[1])
         used_percent = float(row[2])
-        recorded_at = str(row[3])
+        recorded_at = _parse_sqlite_datetime(row[3]).isoformat(sep=" ")
         reset_at = float(row[4]) if row[4] is not None else None
         window_minutes = int(row[5]) if row[5] is not None else None
         row_count += 1

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import datetime, timedelta
 
 import pytest
@@ -12,7 +13,11 @@ from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
-from app.modules.usage.repository import UsageRepository
+from app.modules.usage.repository import (
+    UsageRepository,
+    _bulk_history_since_sqlite,
+    _clear_bulk_history_since_sqlite_cache,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -234,6 +239,68 @@ async def test_latest_by_account_primary_query_plan_uses_normalized_window_index
     plan_json = json.dumps(plan)
     assert "idx_usage_window_account_latest" in plan_json or "idx_usage_window_account_time" in plan_json
     assert "Seq Scan" not in plan_json
+
+
+def test_bulk_history_since_sqlite_cache_reuses_superset_and_picks_up_appends(tmp_path):
+    db_path = tmp_path / "usage.db"
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.executemany(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, "acc1", 10.0, "2026-01-01 00:00:00", 1000.0, 10080, "secondary"),
+                (2, "acc1", 20.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
+                (3, "acc2", 30.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
+            ],
+        )
+        conn.commit()
+
+    first = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1", "acc2"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+    assert [row.id for row in first["acc1"]] == [1, 2]
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (4, "acc1", 40.0, "2026-01-01 00:02:00", 1000.0, 10080, "secondary"),
+        )
+        conn.commit()
+
+    second = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1", "acc2"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 1, 0),
+    )
+    assert [row.id for row in second["acc1"]] == [2, 4]
+    assert [row.id for row in second["acc2"]] == [3]
+
+    _clear_bulk_history_since_sqlite_cache()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -303,6 +303,69 @@ def test_bulk_history_since_sqlite_cache_reuses_superset_and_picks_up_appends(tm
     _clear_bulk_history_since_sqlite_cache()
 
 
+def test_bulk_history_since_sqlite_cache_rebuilds_after_delete_and_id_reuse(tmp_path):
+    db_path = tmp_path / "usage.db"
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.executemany(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, "acc1", 10.0, "2026-01-01 00:00:00", 1000.0, 10080, "secondary"),
+                (2, "acc1", 20.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
+            ],
+        )
+        conn.commit()
+
+    first = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+    assert [row.used_percent for row in first["acc1"]] == [10.0, 20.0]
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("delete from usage_history")
+        conn.execute(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (1, "acc1", 75.0, "2026-01-01 00:02:00", 2000.0, 10080, "secondary"),
+        )
+        conn.commit()
+
+    second = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+    assert [row.id for row in second["acc1"]] == [1]
+    assert [row.used_percent for row in second["acc1"]] == [75.0]
+
+    _clear_bulk_history_since_sqlite_cache()
+
+
 @pytest.mark.asyncio
 async def test_trends_by_bucket_uses_latest_sample_window_metadata(db_setup):
     recorded_at = datetime(2026, 1, 1, 12, 0, 0)

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -14,9 +14,12 @@ from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.usage.repository import (
+    UsageHistorySnapshot,
     UsageRepository,
+    _bulk_history_fingerprint_sqlite,
     _bulk_history_since_sqlite,
     _clear_bulk_history_since_sqlite_cache,
+    _fingerprint_grouped_history,
 )
 
 pytestmark = pytest.mark.integration
@@ -419,6 +422,56 @@ def test_bulk_history_since_sqlite_cache_rebuilds_after_offsetting_row_correctio
     assert [row.used_percent for row in second["acc1"]] == [15.0, 15.0]
 
     _clear_bulk_history_since_sqlite_cache()
+
+
+def test_bulk_history_sqlite_fingerprint_normalizes_recorded_at_text(tmp_path):
+    db_path = tmp_path / "usage.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.execute(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (1, "acc1", 10.0, "2026-01-01 00:00:00.000000", 1000.0, 10080, "secondary"),
+        )
+        conn.commit()
+
+    grouped = {
+        "acc1": [
+            UsageHistorySnapshot(
+                id=1,
+                account_id="acc1",
+                used_percent=10.0,
+                recorded_at=datetime(2026, 1, 1, 0, 0, 0),
+                reset_at=1000.0,
+                window_minutes=10080,
+            )
+        ]
+    }
+
+    with sqlite3.connect(db_path) as conn:
+        sqlite_fingerprint = _bulk_history_fingerprint_sqlite(
+            conn,
+            ["acc1"],
+            "secondary",
+            datetime(2026, 1, 1, 0, 0, 0),
+        )
+
+    assert sqlite_fingerprint == _fingerprint_grouped_history(grouped)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -366,6 +366,61 @@ def test_bulk_history_since_sqlite_cache_rebuilds_after_delete_and_id_reuse(tmp_
     _clear_bulk_history_since_sqlite_cache()
 
 
+def test_bulk_history_since_sqlite_cache_rebuilds_after_offsetting_row_corrections(tmp_path):
+    db_path = tmp_path / "usage.db"
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.executemany(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, "acc1", 10.0, "2026-01-01 00:00:00", 1000.0, 10080, "secondary"),
+                (2, "acc1", 20.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
+            ],
+        )
+        conn.commit()
+
+    first = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+    assert [row.used_percent for row in first["acc1"]] == [10.0, 20.0]
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("update usage_history set used_percent = 15.0 where id = 1")
+        conn.execute("update usage_history set used_percent = 15.0 where id = 2")
+        conn.commit()
+
+    second = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+    assert [row.used_percent for row in second["acc1"]] == [15.0, 15.0]
+
+    _clear_bulk_history_since_sqlite_cache()
+
+
 @pytest.mark.asyncio
 async def test_trends_by_bucket_uses_latest_sample_window_metadata(db_setup):
     recorded_at = datetime(2026, 1, 1, 12, 0, 0)


### PR DESCRIPTION
## Summary

Optimize the SQLite dashboard overview history path so `/api/dashboard/overview` no longer repeatedly hydrates and reparses the same usage-history rows on every refresh.

The first change keeps the existing behavior but reads only the fields needed by the dashboard's depletion and weekly-pace calculations through a SQLite-specific direct read path. The follow-up adds an in-process SQLite cache for `bulk_history_since()` that reuses a cached superset of parsed history snapshots, incrementally picks up appended rows, and filters by the current `since` window before returning results.

On my live SQLite database, the overview service-layer warm median improved from about 1185 ms to about 455 ms. The first cold request after restart still fills the cache and remains around 1.6 s.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [x] `perf:` — performance optimization with no API behavior change
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Part of #708

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — performance-only change that preserves the existing dashboard API behavior
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Add a lightweight `UsageHistorySnapshot` for dashboard history calculations so SQLite does not hydrate full ORM `UsageHistory` objects for the overview path.
- Add a SQLite-specific `bulk_history_since()` read path that selects only the fields needed by depletion and weekly-pace calculations.
- Add an in-process SQLite cache for parsed history snapshots keyed by database path, account set, and window.
- Reuse cached supersets when the requested `since` is narrower, query only rows appended after the cached max id, then filter by the requested `since` before returning.
- Add regression coverage for cache reuse, `since` filtering, and picking up appended rows.

## Test plan

```text
$ uv run pytest tests/integration/test_dashboard_overview.py tests/integration/test_usage_repository.py -q
....................s..                                                  [100%]
=========================== short test summary info ============================
SKIPPED [1] tests/integration/test_usage_repository.py:212: PostgreSQL-only query plan test
22 passed, 1 skipped in 42.78s
```

Earlier local verification on the same branch also passed:

```text
$ uv run ty check app/modules/usage/repository.py tests/integration/test_usage_repository.py
All checks passed!

$ uv run ruff check app/modules/usage/repository.py tests/integration/test_usage_repository.py
All checks passed!

$ uv run ruff format --check app/modules/usage/repository.py tests/integration/test_usage_repository.py
2 files already formatted
```

## Benchmark / output

Live SQLite service-layer benchmark before the cache follow-up:

```text
RUN 1: total=1618.40 ms
RUN 2: total=1284.41 ms
RUN 3: total=1183.09 ms
RUN 4: total=1181.48 ms
RUN 5: total=1185.08 ms
median_total_ms ~= 1185.08
```

Live SQLite service-layer benchmark after the cache follow-up:

```text
RUN 1: total=1619.36 ms  # cold cache fill
RUN 2: total=459.92 ms
RUN 3: total=454.90 ms
RUN 4: total=446.51 ms
RUN 5: total=446.38 ms
median_total_ms ~= 454.90
```

Correctness check with a fixed `now` compared cold and warm dashboard overview responses and matched exactly:

```text
cold overview response == warm cached overview response: True
```

## Notes / caveats

The cache assumes the dashboard usage-history path is append-mostly. Normal `UsageRepository.add_entry()` writes are picked up incrementally by id. If an external maintenance script updates or deletes existing `usage_history` rows in a running process, the cache may stay warm with stale parsed rows until process restart or explicit cache clear.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: not applicable; no OpenSpec/spec changes.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
