### PR TITLE
ci(release): close superseded beta release PRs

### DIFF
--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -151,3 +151,17 @@ jobs:
           else
             gh pr create --base main --head "${BRANCH}" --title "chore: release ${TAG}" --body-file "${body_file}"
           fi
+
+      - name: Close superseded beta release PRs
+        if: steps.release_pr.outputs.found == 'true'
+        shell: bash
+        env:
+          BRANCH: ${{ steps.prepare.outputs.branch }}
+          TAG: ${{ steps.prepare.outputs.tag }}
+          RELEASE_PR: ${{ steps.release_pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          python -m scripts.cleanup_superseded_beta_prs \
+            --current-branch "${BRANCH}" \
+            --current-tag "${TAG}" \
+            --release-pr "${RELEASE_PR}"

--- a/openspec/changes/cleanup-superseded-beta-release-prs/proposal.md
+++ b/openspec/changes/cleanup-superseded-beta-release-prs/proposal.md
@@ -1,0 +1,18 @@
+# Change: Clean up superseded beta release PRs
+
+## Why
+
+The beta release sync workflow upserts only the beta PR for the currently discovered release-please train. When the release-please train moves before the beta PR is merged, older automation-created beta PRs stay open and remain mergeable even though they no longer represent the current train.
+
+## What changes
+
+- Identify open automation-managed `release/beta-*` PRs that are not the current beta branch.
+- Close superseded beta PRs with an explanatory comment.
+- Delete their repository-owned release branches after closing.
+- Preserve manually-created, protected, or current beta release PRs.
+
+## Impact
+
+- Reduces stale release PR clutter.
+- Prevents accidental publishing of obsolete beta trains.
+- Keeps cleanup scoped to PRs created by the beta release automation sentinel text.

--- a/openspec/changes/cleanup-superseded-beta-release-prs/specs/release-automation/spec.md
+++ b/openspec/changes/cleanup-superseded-beta-release-prs/specs/release-automation/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Superseded beta release PR cleanup
+
+The beta release sync workflow SHALL close open automation-managed beta release PRs that no longer match the current beta release branch.
+
+#### Scenario: Current train supersedes an older beta PR
+
+- **GIVEN** the sync workflow prepares beta branch `release/beta-1.20.0-beta.1`
+- **AND** an open PR from `release/beta-1.19.1-beta.1` contains the beta automation sentinel text
+- **WHEN** the current beta PR is opened or updated
+- **THEN** the workflow closes the older beta PR with a superseded explanation
+- **AND** deletes the older repository-owned beta branch
+
+#### Scenario: Current beta PR is preserved
+
+- **GIVEN** the sync workflow prepares beta branch `release/beta-1.20.0-beta.1`
+- **AND** an open PR from `release/beta-1.20.0-beta.1` exists
+- **WHEN** cleanup evaluates open beta PRs
+- **THEN** the workflow does not close or delete the current beta PR
+
+#### Scenario: Manual and protected beta PRs are preserved
+
+- **GIVEN** an open PR uses a `release/beta-*` head branch
+- **AND** the PR lacks the beta automation sentinel text or carries a protected operator label
+- **WHEN** cleanup evaluates open beta PRs
+- **THEN** the workflow does not close or delete that PR

--- a/openspec/changes/cleanup-superseded-beta-release-prs/tasks.md
+++ b/openspec/changes/cleanup-superseded-beta-release-prs/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+- [x] 1.1 Add tested beta PR cleanup selection logic.
+- [x] 1.2 Wire cleanup into the Sync Beta Release PR workflow after the current beta PR is opened/updated.
+- [x] 1.3 Keep cleanup safe for current branch, manually-created PRs, and protected labels.
+
+## 2. Validation
+
+- [x] 2.1 Run targeted release automation tests.
+- [x] 2.2 Run workflow/script lint or syntax validation.
+- [x] 2.3 Run OpenSpec validation.

--- a/scripts/cleanup_superseded_beta_prs.py
+++ b/scripts/cleanup_superseded_beta_prs.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Close beta release PRs superseded by the current release train.
+
+The Sync Beta Release PR workflow creates release PRs from branches named
+``release/beta-X.Y.Z-beta.N``. When release-please retargets the stable train,
+older automation-created beta PRs can remain open. This script intentionally
+cleans up only PRs carrying the automation sentinel in their body so manually
+created beta branches are not touched by accident.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+_AUTOMATION_SENTINEL_RE = re.compile(r"Synced automatically from release-please PR #\d+")
+_BETA_RELEASE_TITLE_RE = re.compile(r"^chore: release v\d+\.\d+\.\d+-beta\.\d+$")
+_PROTECTED_LABELS = frozenset({"pinned", "security", "in-progress"})
+
+
+@dataclass(frozen=True)
+class CleanupAction:
+    pr_number: int
+    head_ref: str
+    comment: str
+    delete_ref_api_path: str
+
+
+def _label_names(labels: object) -> set[str]:
+    names: set[str] = set()
+    if not isinstance(labels, list):
+        return names
+    for label in labels:
+        if isinstance(label, str):
+            names.add(label)
+        elif isinstance(label, dict):
+            name = cast("dict[str, object]", label).get("name")
+            if isinstance(name, str):
+                names.add(name)
+    return names
+
+
+def _head_owner(pr: Mapping[str, Any]) -> str:
+    owner = pr.get("headRepositoryOwner")
+    if isinstance(owner, Mapping) and isinstance(owner.get("login"), str):
+        return owner["login"]
+    return ""
+
+
+def is_cleanup_candidate(pr: Mapping[str, Any], *, current_branch: str, repo_owner: str) -> bool:
+    """Return whether an open PR is an automation-managed superseded beta PR."""
+
+    head_ref = pr.get("headRefName")
+    if not isinstance(head_ref, str):
+        return False
+    if head_ref == current_branch or not head_ref.startswith("release/beta-"):
+        return False
+
+    if _head_owner(pr) != repo_owner:
+        return False
+
+    title = pr.get("title")
+    if not isinstance(title, str) or not _BETA_RELEASE_TITLE_RE.fullmatch(title):
+        return False
+
+    body = pr.get("body")
+    if not isinstance(body, str) or not _AUTOMATION_SENTINEL_RE.search(body):
+        return False
+
+    if _label_names(pr.get("labels")) & _PROTECTED_LABELS:
+        return False
+
+    return True
+
+
+def cleanup_plan(
+    prs: Iterable[Mapping[str, Any]],
+    *,
+    current_branch: str,
+    current_tag: str,
+    repo: str,
+    repo_owner: str,
+    release_pr: str,
+) -> list[CleanupAction]:
+    """Build the actions needed to close superseded beta release PRs."""
+
+    actions: list[CleanupAction] = []
+    for pr in prs:
+        if not is_cleanup_candidate(pr, current_branch=current_branch, repo_owner=repo_owner):
+            continue
+        pr_number = pr.get("number")
+        head_ref = pr.get("headRefName")
+        if not isinstance(pr_number, int) or not isinstance(head_ref, str):
+            continue
+        comment = (
+            f"Superseded by the current beta release train `{current_tag}` "
+            f"from release-please PR #{release_pr}. Closing this automation-managed "
+            "beta PR to avoid publishing an obsolete train."
+        )
+        actions.append(
+            CleanupAction(
+                pr_number=pr_number,
+                head_ref=head_ref,
+                comment=comment,
+                delete_ref_api_path=f"repos/{repo}/git/refs/heads/{head_ref}",
+            )
+        )
+    return actions
+
+
+def _run_gh(args: Sequence[str]) -> str:
+    proc = subprocess.run(
+        ["gh", *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return proc.stdout
+
+
+def fetch_open_prs(repo: str) -> list[Mapping[str, Any]]:
+    output = _run_gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--base",
+            "main",
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,headRefName,headRepositoryOwner,labels,body",
+        ]
+    )
+    parsed = json.loads(output or "[]")
+    if not isinstance(parsed, list):
+        raise ValueError("gh pr list did not return a JSON array")
+    return [item for item in parsed if isinstance(item, Mapping)]
+
+
+def execute_cleanup(actions: Iterable[CleanupAction], *, repo: str, dry_run: bool) -> None:
+    for action in actions:
+        if dry_run:
+            print(f"Would close PR #{action.pr_number} ({action.head_ref}) and delete branch")
+            continue
+        _run_gh(["pr", "comment", str(action.pr_number), "--repo", repo, "--body", action.comment])
+        _run_gh(["pr", "close", str(action.pr_number), "--repo", repo])
+        _run_gh(["api", "-X", "DELETE", action.delete_ref_api_path])
+        print(f"Closed superseded beta PR #{action.pr_number} and deleted {action.head_ref}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--repo-owner", default=os.environ.get("GITHUB_REPOSITORY_OWNER", ""))
+    parser.add_argument("--current-branch", required=True)
+    parser.add_argument("--current-tag", required=True)
+    parser.add_argument("--release-pr", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    if not args.repo:
+        raise SystemExit("--repo is required when GITHUB_REPOSITORY is not set")
+    repo_owner = args.repo_owner or args.repo.split("/", 1)[0]
+
+    prs = fetch_open_prs(args.repo)
+    actions = cleanup_plan(
+        prs,
+        current_branch=args.current_branch,
+        current_tag=args.current_tag,
+        repo=args.repo,
+        repo_owner=repo_owner,
+        release_pr=args.release_pr,
+    )
+    if not actions:
+        print("No superseded beta release PRs to close.")
+        return 0
+    execute_cleanup(actions, repo=args.repo, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_cleanup_superseded_beta_prs.py
+++ b/tests/unit/test_cleanup_superseded_beta_prs.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_cleanup_plan_closes_only_superseded_managed_beta_prs() -> None:
+    from scripts.cleanup_superseded_beta_prs import cleanup_plan
+
+    prs = [
+        {
+            "number": 807,
+            "title": "chore: release v1.19.1-beta.1",
+            "headRefName": "release/beta-1.19.1-beta.1",
+            "headRepositoryOwner": {"login": "Soju06"},
+            "labels": [],
+            "body": "Synced automatically from release-please PR #806; no manual beta workflow dispatch is required.",
+        },
+        {
+            "number": 827,
+            "title": "chore: release v1.20.0-beta.1",
+            "headRefName": "release/beta-1.20.0-beta.1",
+            "headRepositoryOwner": {"login": "Soju06"},
+            "labels": [],
+            "body": "Synced automatically from release-please PR #806; no manual beta workflow dispatch is required.",
+        },
+        {
+            "number": 900,
+            "title": "chore: release v1.18.0-beta.1",
+            "headRefName": "release/beta-1.18.0-beta.1",
+            "headRepositoryOwner": {"login": "Soju06"},
+            "labels": [{"name": "pinned"}],
+            "body": "Synced automatically from release-please PR #806; no manual beta workflow dispatch is required.",
+        },
+        {
+            "number": 901,
+            "title": "manual beta experiment",
+            "headRefName": "release/beta-manual-test",
+            "headRepositoryOwner": {"login": "Soju06"},
+            "labels": [],
+            "body": "Manual release testing branch.",
+        },
+        {
+            "number": 902,
+            "title": "chore: release v1.17.0-beta.1",
+            "headRefName": "release/beta-1.17.0-beta.1",
+            "headRepositoryOwner": {"login": "external"},
+            "labels": [],
+            "body": "Synced automatically from release-please PR #806; no manual beta workflow dispatch is required.",
+        },
+    ]
+
+    plan = cleanup_plan(
+        prs,
+        current_branch="release/beta-1.20.0-beta.1",
+        current_tag="v1.20.0-beta.1",
+        repo="Soju06/codex-lb",
+        repo_owner="Soju06",
+        release_pr="806",
+    )
+
+    assert [action.pr_number for action in plan] == [807]
+    assert plan[0].head_ref == "release/beta-1.19.1-beta.1"
+    assert plan[0].delete_ref_api_path == "repos/Soju06/codex-lb/git/refs/heads/release/beta-1.19.1-beta.1"
+    assert "v1.20.0-beta.1" in plan[0].comment
+    assert "release-please PR #806" in plan[0].comment
+
+
+def test_execute_cleanup_comments_closes_and_deletes_branch(monkeypatch: pytest.MonkeyPatch) -> None:
+    from scripts import cleanup_superseded_beta_prs as cleanup
+
+    calls: list[list[str]] = []
+
+    def fake_run_gh(args: list[str]) -> str:
+        calls.append(args)
+        return ""
+
+    monkeypatch.setattr(cleanup, "_run_gh", fake_run_gh)
+
+    cleanup.execute_cleanup(
+        [
+            cleanup.CleanupAction(
+                pr_number=807,
+                head_ref="release/beta-1.19.1-beta.1",
+                comment="Superseded by v1.20.0-beta.1",
+                delete_ref_api_path="repos/Soju06/codex-lb/git/refs/heads/release/beta-1.19.1-beta.1",
+            )
+        ],
+        repo="Soju06/codex-lb",
+        dry_run=False,
+    )
+
+    assert calls == [
+        [
+            "pr",
+            "comment",
+            "807",
+            "--repo",
+            "Soju06/codex-lb",
+            "--body",
+            "Superseded by v1.20.0-beta.1",
+        ],
+        ["pr", "close", "807", "--repo", "Soju06/codex-lb"],
+        [
+            "api",
+            "-X",
+            "DELETE",
+            "repos/Soju06/codex-lb/git/refs/heads/release/beta-1.19.1-beta.1",
+        ],
+    ]
+
+
+def test_cleanup_script_dry_run_lists_superseded_pr(tmp_path: Path) -> None:
+    prs = [
+        {
+            "number": 807,
+            "title": "chore: release v1.19.1-beta.1",
+            "headRefName": "release/beta-1.19.1-beta.1",
+            "headRepositoryOwner": {"login": "Soju06"},
+            "labels": [],
+            "body": "Synced automatically from release-please PR #806; no manual beta workflow dispatch is required.",
+        }
+    ]
+    gh = tmp_path / "gh"
+    calls = tmp_path / "calls.jsonl"
+    gh.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, pathlib, sys\n"
+        f"pathlib.Path({str(calls)!r}).write_text(json.dumps(sys.argv[1:]) + '\\n')\n"
+        f"print({json.dumps(prs)!r})\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.cleanup_superseded_beta_prs",
+            "--repo",
+            "Soju06/codex-lb",
+            "--repo-owner",
+            "Soju06",
+            "--current-branch",
+            "release/beta-1.20.0-beta.1",
+            "--current-tag",
+            "v1.20.0-beta.1",
+            "--release-pr",
+            "806",
+            "--dry-run",
+        ],
+        cwd=Path(__file__).parents[2],
+        env={"PATH": f"{tmp_path}:{Path('/usr/bin')}", "PYTHONPATH": str(Path(__file__).parents[2])},
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+    assert "Would close PR #807" in result.stdout
+    assert "release/beta-1.19.1-beta.1" in result.stdout
+    assert json.loads(calls.read_text(encoding="utf-8"))[0:4] == [
+        "pr",
+        "list",
+        "--repo",
+        "Soju06/codex-lb",
+    ]


### PR DESCRIPTION
## Summary
- Add a tested cleanup helper for automation-managed beta release PRs that are superseded by the current release train.
- Wire `Sync Beta Release PR` to close superseded beta PRs after opening/updating the current beta PR.
- Add OpenSpec coverage for preserving the current beta PR, manual PRs, and protected operator-labeled PRs.

## Safety
- Cleanup only targets same-repo `release/beta-*` PRs with the beta automation sentinel in the PR body.
- Skips the current beta branch and PRs labeled `pinned`, `security`, or `in-progress`.
- Posts a superseded explanation before closing and deletes only the matching repo-owned beta branch.

## Validation
- `uv run ruff check scripts/cleanup_superseded_beta_prs.py tests/unit/test_cleanup_superseded_beta_prs.py`
- `uv run ty check scripts/cleanup_superseded_beta_prs.py tests/unit/test_cleanup_superseded_beta_prs.py`
- `uv run pytest tests/unit/test_cleanup_superseded_beta_prs.py tests/unit/test_release_versions.py -q`
- `uv run pytest tests/unit -q` → 2147 passed, 3 skipped, 2 warnings
- `openspec validate cleanup-superseded-beta-release-prs --strict`
- `openspec validate --specs`
- Dry-run against current repo state: would close only `#807` (`release/beta-1.19.1-beta.1`) and preserve current `#827`.
