### PR TITLE
fix(proxy-responses): harden concurrent responses routing

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -82,6 +82,9 @@ class AccountState:
     plan_type: str | None = None
     capacity_credits: float | None = None
     health_tier: int = 0
+    inflight_response_creates: int = 0
+    inflight_streams: int = 0
+    leased_tokens: float = 0.0
 
 
 @dataclass

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -267,6 +267,11 @@ class Settings(BaseSettings):
     proxy_response_create_limit: int = Field(default=256, ge=0)
     proxy_compact_response_create_limit: int = Field(default=64, ge=0)
     proxy_admission_wait_timeout_seconds: float = Field(default=10.0, gt=0)
+    proxy_account_response_create_limit: int = Field(default=4, ge=0)
+    proxy_account_stream_limit: int = Field(default=8, ge=0)
+    proxy_account_inflight_penalty_pct: float = Field(default=2.5, ge=0)
+    proxy_account_lease_token_weight: float = Field(default=1.0, ge=0)
+    proxy_account_lease_ttl_seconds: float = Field(default=900.0, gt=0)
     proxy_refresh_failure_cooldown_seconds: float = Field(default=5.0, ge=0.0)
     usage_refresh_auth_failure_cooldown_seconds: float = Field(default=300.0, ge=0.0)
 

--- a/app/core/metrics/prometheus.py
+++ b/app/core/metrics/prometheus.py
@@ -183,6 +183,30 @@ if PROMETHEUS_AVAILABLE:
         ["surface", "reason"],
         registry=REGISTRY,
     )
+    account_lease_acquired_total = Counter(
+        "codex_lb_account_lease_acquired_total",
+        "Total account pressure leases acquired by kind",
+        ["kind"],
+        registry=REGISTRY,
+    )
+    account_lease_released_total = Counter(
+        "codex_lb_account_lease_released_total",
+        "Total account pressure leases released by kind and reason",
+        ["kind", "reason"],
+        registry=REGISTRY,
+    )
+    account_lease_stale_reclaimed_total = Counter(
+        "codex_lb_account_lease_stale_reclaimed_total",
+        "Total stale account pressure leases reclaimed by kind",
+        ["kind"],
+        registry=REGISTRY,
+    )
+    account_cap_rejections_total = Counter(
+        "codex_lb_account_cap_rejections_total",
+        "Total account-local cap rejections by kind",
+        ["kind"],
+        registry=REGISTRY,
+    )
 
     def make_scrape_registry() -> CollectorRegistryLike:
         if MULTIPROCESS_MODE:
@@ -225,6 +249,10 @@ else:
     bridge_public_contract_error_total: CounterLike | None = None
     continuity_owner_resolution_total: CounterLike | None = None
     continuity_fail_closed_total: CounterLike | None = None
+    account_lease_acquired_total: CounterLike | None = None
+    account_lease_released_total: CounterLike | None = None
+    account_lease_stale_reclaimed_total: CounterLike | None = None
+    account_cap_rejections_total: CounterLike | None = None
 
     def make_scrape_registry() -> None:
         return None
@@ -238,6 +266,10 @@ __all__ = [
     "PROMETHEUS_AVAILABLE",
     "REGISTRY",
     "active_connections",
+    "account_cap_rejections_total",
+    "account_lease_acquired_total",
+    "account_lease_released_total",
+    "account_lease_stale_reclaimed_total",
     "accounts_total",
     "bridge_instance_mismatch_total",
     "bridge_forward_latency_seconds",

--- a/app/core/resilience/overload.py
+++ b/app/core/resilience/overload.py
@@ -9,10 +9,21 @@ from app.core.errors import OpenAIErrorEnvelope, openai_error
 
 LOCAL_OVERLOAD_CODE = "proxy_overloaded"
 LOCAL_OVERLOAD_RETRY_AFTER_SECONDS = "5"
+LOCAL_OVERLOAD_CODES = frozenset(
+    {
+        LOCAL_OVERLOAD_CODE,
+        "account_response_create_cap",
+        "account_stream_cap",
+        "bridge_queue_full",
+        "response_create_gate_timeout",
+        "global_admission_timeout",
+        "capacity_exhausted_active_sessions",
+    }
+)
 
 
-def local_overload_error(message: str) -> OpenAIErrorEnvelope:
-    return openai_error(LOCAL_OVERLOAD_CODE, message, error_type="rate_limit_error")
+def local_overload_error(message: str, *, code: str = LOCAL_OVERLOAD_CODE) -> OpenAIErrorEnvelope:
+    return openai_error(code, message, error_type="rate_limit_error")
 
 
 def local_unavailable_error(message: str) -> OpenAIErrorEnvelope:
@@ -20,7 +31,7 @@ def local_unavailable_error(message: str) -> OpenAIErrorEnvelope:
 
 
 def is_local_overload_error_code(code: str | None) -> bool:
-    return code == LOCAL_OVERLOAD_CODE
+    return code in LOCAL_OVERLOAD_CODES
 
 
 def merge_retry_after_headers(

--- a/app/db/alembic/versions/20260601_000000_merge_relative_availability_and_usage_raw_heads.py
+++ b/app/db/alembic/versions/20260601_000000_merge_relative_availability_and_usage_raw_heads.py
@@ -1,0 +1,24 @@
+"""Merge relative availability and raw usage latest index heads.
+
+Revision ID: 20260601_000000_merge_relative_availability_and_usage_raw_heads
+Revises: 20260426_000000_add_dashboard_relative_availability_settings, 20260525_000000_add_usage_raw_window_latest_index
+Create Date: 2026-06-01 03:10:00.000000
+"""
+
+from __future__ import annotations
+
+revision = "20260601_000000_merge_relative_availability_and_usage_raw_heads"
+down_revision = (
+    "20260426_000000_add_dashboard_relative_availability_settings",
+    "20260525_000000_add_usage_raw_window_latest_index",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -294,6 +294,9 @@ def _sticky_key_for_responses_request(
     sticky_threads_enabled: bool,
     api_key: ApiKeyData | None = None,
 ) -> _AffinityPolicy:
+    # This helper only classifies locality keys. Stored-object continuity such
+    # as `previous_response_id` is resolved later by ProxyService and must stay
+    # hard owner-bound even if this returns a prompt-cache affinity policy.
     cache_key, _ = _resolve_prompt_cache_key(
         payload,
         openai_cache_affinity=openai_cache_affinity,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -70,6 +70,7 @@ from app.core.resilience.overload import is_local_overload_error_code, merge_ret
 from app.core.runtime_logging import log_error_response
 from app.core.types import JsonValue
 from app.core.utils.json_guards import is_json_mapping
+from app.core.utils.request_id import get_request_id
 from app.core.utils.sse import (
     CODEX_KEEPALIVE_FRAME,
     SSE_KEEPALIVE_FRAME,
@@ -1952,14 +1953,26 @@ async def _stream_responses(
         ),
         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
     )
+    keepalive_frame = CODEX_KEEPALIVE_FRAME if not enforce_openai_sdk_contract else SSE_KEEPALIVE_FRAME
+    stream = _prepend_initial_sse_heartbeat(
+        stream,
+        keepalive_frame,
+        request_id=get_request_id(),
+        route_family="responses",
+    )
     return StreamingResponse(
         inject_sse_keepalives(
             stream,
             get_settings().sse_keepalive_interval_seconds,
-            keepalive_frame=CODEX_KEEPALIVE_FRAME if not enforce_openai_sdk_contract else SSE_KEEPALIVE_FRAME,
+            keepalive_frame=keepalive_frame,
         ),
         media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", **turn_state_headers, **rate_limit_headers},
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+            **turn_state_headers,
+            **rate_limit_headers,
+        },
     )
 
 
@@ -2247,6 +2260,23 @@ async def _prepend_first_task(first_task: asyncio.Task[str], stream: AsyncIterat
         yield await first_task
     except StopAsyncIteration:
         return
+    async for line in stream:
+        yield line
+
+
+async def _prepend_initial_sse_heartbeat(
+    stream: AsyncIterator[str],
+    keepalive_frame: str,
+    *,
+    request_id: str | None = None,
+    route_family: str = "responses",
+) -> AsyncIterator[str]:
+    logger.info(
+        "responses_stream_heartbeat request_id=%s route_family=%s stage=initial elapsed_seconds=0.000",
+        request_id,
+        route_family,
+    )
+    yield keepalive_frame
     async for line in stream:
         yield line
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1954,12 +1954,13 @@ async def _stream_responses(
         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
     )
     keepalive_frame = CODEX_KEEPALIVE_FRAME if not enforce_openai_sdk_contract else SSE_KEEPALIVE_FRAME
-    stream = _prepend_initial_sse_heartbeat(
-        stream,
-        keepalive_frame,
-        request_id=get_request_id(),
-        route_family="responses",
-    )
+    if not enforce_openai_sdk_contract:
+        stream = _prepend_initial_sse_heartbeat(
+            stream,
+            keepalive_frame,
+            request_id=get_request_id(),
+            route_family="responses",
+        )
     return StreamingResponse(
         inject_sse_keepalives(
             stream,

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -6,7 +6,8 @@ import time
 from collections.abc import Collection
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Literal
+from uuid import uuid4
 
 from app.core import usage as usage_core
 from app.core.balancer import (
@@ -25,6 +26,13 @@ from app.core.balancer import (
 )
 from app.core.balancer.types import UpstreamError
 from app.core.config.settings import get_settings
+from app.core.metrics.prometheus import (
+    PROMETHEUS_AVAILABLE,
+    account_cap_rejections_total,
+    account_lease_acquired_total,
+    account_lease_released_total,
+    account_lease_stale_reclaimed_total,
+)
 from app.core.openai.model_registry import get_model_registry
 from app.core.plan_types import account_plan_matches_allowed, normalize_account_plan_type
 from app.core.resilience.circuit_breaker import are_all_account_circuit_breakers_open
@@ -64,6 +72,8 @@ ADDITIONAL_QUOTA_DATA_UNAVAILABLE = "additional_quota_data_unavailable"
 NO_ADDITIONAL_QUOTA_ELIGIBLE_ACCOUNTS = "no_additional_quota_eligible_accounts"
 _ADDITIONAL_QUOTA_EXEMPT_PLAN_TYPES = frozenset({"free", "plus"})
 
+AccountLeaseKind = Literal["response_create", "stream"]
+
 
 @dataclass
 class RuntimeState:
@@ -77,6 +87,19 @@ class RuntimeState:
     health_tier: int = 0
     drain_entered_at: float | None = None
     probe_success_streak: int = 0
+    inflight_response_creates: int = 0
+    inflight_streams: int = 0
+    leased_tokens: float = 0.0
+    leases: dict[str, "AccountLease"] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AccountLease:
+    lease_id: str
+    account_id: str
+    kind: AccountLeaseKind
+    acquired_at: float
+    estimated_tokens: float = 0.0
 
 
 @dataclass
@@ -84,6 +107,7 @@ class AccountSelection:
     account: Account | None
     error_message: str | None
     error_code: str | None = None
+    lease: AccountLease | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -108,6 +132,115 @@ class LoadBalancer:
         self._account_locks_registry_lock = asyncio.Lock()
         self._selection_inputs_cache = get_account_selection_cache()
 
+    async def release_account_lease(self, lease: AccountLease | None) -> None:
+        if lease is None:
+            return
+        async with self._runtime_lock:
+            self._release_account_lease_locked(lease, reason="explicit")
+
+    async def acquire_account_lease(
+        self,
+        account_id: str,
+        *,
+        kind: AccountLeaseKind,
+        estimated_tokens: float = 0.0,
+    ) -> AccountLease | None:
+        async with self._runtime_lock:
+            self._reclaim_stale_account_leases_locked()
+            runtime = self._runtime.setdefault(account_id, RuntimeState())
+            if kind == "response_create":
+                cap = get_settings().proxy_account_response_create_limit
+                if cap > 0 and runtime.inflight_response_creates >= cap:
+                    _record_account_cap_rejection("response_create")
+                    return None
+            else:
+                cap = get_settings().proxy_account_stream_limit
+                if cap > 0 and runtime.inflight_streams >= cap:
+                    _record_account_cap_rejection("stream")
+                    return None
+            return self._acquire_account_lease_locked(
+                account_id,
+                kind=kind,
+                estimated_tokens=estimated_tokens,
+            )
+
+    async def account_pressure_snapshot(self, account_id: str) -> tuple[int, int, float]:
+        async with self._runtime_lock:
+            runtime = self._runtime.get(account_id)
+            if runtime is None:
+                return 0, 0, 0.0
+            return runtime.inflight_response_creates, runtime.inflight_streams, runtime.leased_tokens
+
+    def _acquire_account_lease_locked(
+        self,
+        account_id: str,
+        *,
+        kind: AccountLeaseKind,
+        estimated_tokens: float,
+    ) -> AccountLease:
+        runtime = self._runtime.setdefault(account_id, RuntimeState())
+        lease = AccountLease(
+            lease_id=uuid4().hex,
+            account_id=account_id,
+            kind=kind,
+            acquired_at=time.monotonic(),
+            estimated_tokens=max(0.0, estimated_tokens),
+        )
+        if runtime.leases is None:
+            runtime.leases = {}
+        runtime.leases[lease.lease_id] = lease
+        if kind == "response_create":
+            runtime.inflight_response_creates += 1
+        else:
+            runtime.inflight_streams += 1
+        runtime.leased_tokens += lease.estimated_tokens
+        runtime.last_selected_at = time.time()
+        runtime.version += 1
+        _record_account_lease_acquired(kind)
+        return lease
+
+    def _account_lease_allowed_locked(self, account_id: str, *, kind: AccountLeaseKind) -> bool:
+        runtime = self._runtime.setdefault(account_id, RuntimeState())
+        if kind == "response_create":
+            cap = get_settings().proxy_account_response_create_limit
+            return cap <= 0 or runtime.inflight_response_creates < cap
+        cap = get_settings().proxy_account_stream_limit
+        return cap <= 0 or runtime.inflight_streams < cap
+
+    def _release_account_lease_locked(self, lease: AccountLease, *, reason: str) -> bool:
+        runtime = self._runtime.get(lease.account_id)
+        if runtime is None or runtime.leases is None:
+            return False
+        current = runtime.leases.pop(lease.lease_id, None)
+        if current is None:
+            return False
+        if current.kind == "response_create":
+            runtime.inflight_response_creates = max(0, runtime.inflight_response_creates - 1)
+        else:
+            runtime.inflight_streams = max(0, runtime.inflight_streams - 1)
+        runtime.leased_tokens = max(0.0, runtime.leased_tokens - current.estimated_tokens)
+        runtime.version += 1
+        _record_account_lease_released(current.kind, reason)
+        if reason == "stale":
+            _record_account_lease_stale_reclaimed(current.kind)
+            logger.warning(
+                "Reclaimed stale account lease account_id=%s kind=%s age_seconds=%.3f",
+                current.account_id,
+                current.kind,
+                time.monotonic() - current.acquired_at,
+            )
+        return True
+
+    def _reclaim_stale_account_leases_locked(self) -> None:
+        ttl_seconds = get_settings().proxy_account_lease_ttl_seconds
+        now = time.monotonic()
+        for runtime in self._runtime.values():
+            if not runtime.leases:
+                continue
+            stale = [lease for lease in runtime.leases.values() if now - lease.acquired_at >= ttl_seconds]
+            for lease in stale:
+                self._release_account_lease_locked(lease, reason="stale")
+
     async def select_account(
         self,
         sticky_key: str | None = None,
@@ -124,6 +257,8 @@ class LoadBalancer:
         account_ids: Collection[str] | None = None,
         exclude_account_ids: Collection[str] | None = None,
         budget_threshold_pct: float = 95.0,
+        lease_kind: AccountLeaseKind | None = None,
+        estimated_lease_tokens: float = 0.0,
     ) -> AccountSelection:
         excluded_ids = set(exclude_account_ids or ())
         scoped_account_ids = None if account_ids is None else set(account_ids)
@@ -165,58 +300,81 @@ class LoadBalancer:
         error_message: str | None = None
         selected_states: list[AccountState] = []
         selected_account_map: dict[str, Account] = {}
+        selected_lease: AccountLease | None = None
+        selection_error_code: str | None = None
         if sticky_key is None:
             attempt = 0
             while True:
                 attempt += 1
-                self._prune_runtime(selection_inputs.runtime_accounts or selection_inputs.accounts)
-                states, account_map = _build_states(
-                    accounts=selection_inputs.accounts,
-                    latest_primary=selection_inputs.latest_primary,
-                    latest_secondary=selection_inputs.latest_secondary,
-                    runtime=self._runtime,
-                )
-
-                result = _select_account_preferring_budget_safe(
-                    states,
-                    prefer_earlier_reset=prefer_earlier_reset_accounts,
-                    routing_strategy=routing_strategy,
-                    relative_availability_power=relative_availability_power,
-                    relative_availability_top_k=relative_availability_top_k,
-                    budget_threshold_pct=budget_threshold_pct,
-                )
-
-                selected_account_map = account_map
-                selected_states = []
-                for state in states:
-                    account = account_map.get(state.account_id)
-                    if account is None:
-                        continue
-                    await self._sync_runtime_state_for_account(
-                        account,
-                        state,
-                        selected=result.account is not None and state.account_id == result.account.account_id,
+                async with self._runtime_lock:
+                    self._reclaim_stale_account_leases_locked()
+                    self._prune_runtime(selection_inputs.runtime_accounts or selection_inputs.accounts)
+                    states, account_map = _build_states(
+                        accounts=selection_inputs.accounts,
+                        latest_primary=selection_inputs.latest_primary,
+                        latest_secondary=selection_inputs.latest_secondary,
+                        runtime=self._runtime,
                     )
-                    selected_states.append(state)
-
-                if result.account is not None:
-                    selected = account_map.get(result.account.account_id)
-                    if selected is None:
+                    selection_states = _filter_states_for_account_caps(states, lease_kind=lease_kind)
+                    if not selection_states and states:
+                        result = SelectionResult(None, "No available accounts")
                         error_message = result.error_message
+                        selection_error_code = _account_cap_error_code(lease_kind)
+                        logger.warning(
+                            "Account cap exhausted during selection lease_kind=%s reason=%s candidates=%s",
+                            lease_kind,
+                            selection_error_code,
+                            len(states),
+                        )
+                        _record_account_cap_rejection(lease_kind)
                     else:
-                        selected_reset_at = selected.reset_at
-                        for state in states:
-                            if state.account_id == result.account.account_id:
-                                state.status = result.account.status
-                                state.deactivation_reason = result.account.deactivation_reason
-                                selected_reset_at = int(state.reset_at) if state.reset_at else None
-                                break
-                        selected_snapshot = _clone_account(selected)
-                        selected_snapshot.status = result.account.status
-                        selected_snapshot.deactivation_reason = result.account.deactivation_reason
-                        selected_snapshot.reset_at = selected_reset_at
-                else:
-                    error_message = result.error_message
+                        selection_error_code = None
+                        result = _select_account_preferring_budget_safe(
+                            selection_states,
+                            prefer_earlier_reset=prefer_earlier_reset_accounts,
+                            routing_strategy=routing_strategy,
+                            relative_availability_power=relative_availability_power,
+                            relative_availability_top_k=relative_availability_top_k,
+                            budget_threshold_pct=budget_threshold_pct,
+                        )
+
+                    selected_account_map = account_map
+                    selected_states = []
+                    for state in states:
+                        account = account_map.get(state.account_id)
+                        if account is None:
+                            continue
+                        self._sync_runtime_state(
+                            account,
+                            state,
+                            selected=result.account is not None and state.account_id == result.account.account_id,
+                        )
+                        selected_states.append(state)
+
+                    if result.account is not None:
+                        selected = account_map.get(result.account.account_id)
+                        if selected is None:
+                            error_message = result.error_message
+                        else:
+                            selected_reset_at = selected.reset_at
+                            for state in states:
+                                if state.account_id == result.account.account_id:
+                                    state.status = result.account.status
+                                    state.deactivation_reason = result.account.deactivation_reason
+                                    selected_reset_at = int(state.reset_at) if state.reset_at else None
+                                    break
+                            if lease_kind is not None:
+                                selected_lease = self._acquire_account_lease_locked(
+                                    selected.id,
+                                    kind=lease_kind,
+                                    estimated_tokens=estimated_lease_tokens,
+                                )
+                            selected_snapshot = _clone_account(selected)
+                            selected_snapshot.status = result.account.status
+                            selected_snapshot.deactivation_reason = result.account.deactivation_reason
+                            selected_snapshot.reset_at = selected_reset_at
+                    else:
+                        error_message = result.error_message
 
                 pre_persist_runtime_state = {
                     aid: (
@@ -229,14 +387,21 @@ class LoadBalancer:
                 }
                 pre_persist_cache_generation = self._selection_inputs_cache.generation
 
-                async with self._repo_factory() as repos:
-                    stale_account_ids = await self._persist_selection_state(
-                        repos.accounts,
-                        selected_account_map,
-                        selected_states,
-                    )
+                try:
+                    async with self._repo_factory() as repos:
+                        stale_account_ids = await self._persist_selection_state(
+                            repos.accounts,
+                            selected_account_map,
+                            selected_states,
+                        )
+                except BaseException:
+                    await self.release_account_lease(selected_lease)
+                    selected_lease = None
+                    raise
                 stale_account_ids = stale_account_ids or set()
                 if selected_snapshot is not None and selected_snapshot.id in stale_account_ids:
+                    await self.release_account_lease(selected_lease)
+                    selected_lease = None
                     if attempt >= _MAX_SELECTION_ATTEMPTS:
                         selected_snapshot = None
                         error_message = None
@@ -259,6 +424,8 @@ class LoadBalancer:
                     and self._selection_inputs_cache.generation != pre_persist_cache_generation
                     and attempt < _MAX_SELECTION_ATTEMPTS
                 ):
+                    await self.release_account_lease(selected_lease)
+                    selected_lease = None
                     selection_inputs = await load_selection_inputs()
                     if selection_inputs.error_code is not None and not selection_inputs.accounts:
                         return AccountSelection(
@@ -301,35 +468,54 @@ class LoadBalancer:
             attempt = 0
             while True:
                 attempt += 1
-                self._prune_runtime(selection_inputs.runtime_accounts or selection_inputs.accounts)
-                states, account_map = _build_states(
-                    accounts=selection_inputs.accounts,
-                    latest_primary=selection_inputs.latest_primary,
-                    latest_secondary=selection_inputs.latest_secondary,
-                    runtime=self._runtime,
-                )
-                async with self._repo_factory() as repos:
-                    result = await self._select_with_stickiness(
-                        states=states,
-                        account_map=account_map,
-                        sticky_key=sticky_key,
-                        sticky_kind=sticky_kind,
-                        reallocate_sticky=reallocate_sticky,
-                        sticky_max_age_seconds=sticky_max_age_seconds,
-                        budget_threshold_pct=budget_threshold_pct,
-                        prefer_earlier_reset_accounts=prefer_earlier_reset_accounts,
-                        routing_strategy=routing_strategy,
-                        relative_availability_power=relative_availability_power,
-                        relative_availability_top_k=relative_availability_top_k,
-                        sticky_repo=repos.sticky_sessions,
+                async with self._runtime_lock:
+                    self._reclaim_stale_account_leases_locked()
+                    self._prune_runtime(selection_inputs.runtime_accounts or selection_inputs.accounts)
+                    states, account_map = _build_states(
+                        accounts=selection_inputs.accounts,
+                        latest_primary=selection_inputs.latest_primary,
+                        latest_secondary=selection_inputs.latest_secondary,
+                        runtime=self._runtime,
                     )
-                    selected_account_map = account_map
-                    selected_states = []
+                hard_sticky = sticky_kind == StickySessionKind.CODEX_SESSION
+                selection_states = (
+                    states if hard_sticky else _filter_states_for_account_caps(states, lease_kind=lease_kind)
+                )
+                if not selection_states and states:
+                    result = SelectionResult(None, "No available accounts")
+                    selection_error_code = _account_cap_error_code(lease_kind)
+                    logger.warning(
+                        "Account cap exhausted during sticky selection lease_kind=%s reason=%s candidates=%s",
+                        lease_kind,
+                        selection_error_code,
+                        len(states),
+                    )
+                    _record_account_cap_rejection(lease_kind)
+                else:
+                    selection_error_code = None
+                    async with self._repo_factory() as repos:
+                        result = await self._select_with_stickiness(
+                            states=selection_states,
+                            account_map=account_map,
+                            sticky_key=sticky_key,
+                            sticky_kind=sticky_kind,
+                            reallocate_sticky=reallocate_sticky,
+                            sticky_max_age_seconds=sticky_max_age_seconds,
+                            budget_threshold_pct=budget_threshold_pct,
+                            prefer_earlier_reset_accounts=prefer_earlier_reset_accounts,
+                            routing_strategy=routing_strategy,
+                            relative_availability_power=relative_availability_power,
+                            relative_availability_top_k=relative_availability_top_k,
+                            sticky_repo=repos.sticky_sessions,
+                        )
+                selected_account_map = account_map
+                selected_states = []
+                async with self._runtime_lock:
                     for state in states:
                         account = account_map.get(state.account_id)
                         if account is None:
                             continue
-                        await self._sync_runtime_state_for_account(
+                        self._sync_runtime_state(
                             account,
                             state,
                             selected=result.account is not None and state.account_id == result.account.account_id,
@@ -351,16 +537,35 @@ class LoadBalancer:
                             selected_snapshot.status = result.account.status
                             selected_snapshot.deactivation_reason = result.account.deactivation_reason
                             selected_snapshot.reset_at = selected_reset_at
+                            if lease_kind is not None:
+                                if not self._account_lease_allowed_locked(selected.id, kind=lease_kind):
+                                    selected_snapshot = None
+                                    error_message = "No available accounts"
+                                    selection_error_code = _account_cap_error_code(lease_kind)
+                                else:
+                                    selected_lease = self._acquire_account_lease_locked(
+                                        selected.id,
+                                        kind=lease_kind,
+                                        estimated_tokens=estimated_lease_tokens,
+                                    )
                     else:
                         error_message = result.error_message
 
-                    stale_account_ids = await self._persist_selection_state(
-                        repos.accounts,
-                        selected_account_map,
-                        selected_states,
-                    )
+                try:
+                    async with self._repo_factory() as repos:
+                        stale_account_ids = await self._persist_selection_state(
+                            repos.accounts,
+                            selected_account_map,
+                            selected_states,
+                        )
+                except BaseException:
+                    await self.release_account_lease(selected_lease)
+                    selected_lease = None
+                    raise
                 stale_account_ids = stale_account_ids or set()
                 if selected_snapshot is not None and selected_snapshot.id in stale_account_ids:
+                    await self.release_account_lease(selected_lease)
+                    selected_lease = None
                     selected_snapshot = None
                     error_message = None
                     selected_states = []
@@ -374,6 +579,24 @@ class LoadBalancer:
                             error_message=selection_inputs.error_message,
                             error_code=selection_inputs.error_code,
                         )
+                    await asyncio.sleep(0)
+                    continue
+                if (
+                    selected_snapshot is None
+                    and selection_error_code is not None
+                    and not hard_sticky
+                    and attempt < _MAX_SELECTION_ATTEMPTS
+                ):
+                    selection_inputs = await load_selection_inputs()
+                    if selection_inputs.error_code is not None and not selection_inputs.accounts:
+                        return AccountSelection(
+                            account=None,
+                            error_message=selection_inputs.error_message,
+                            error_code=selection_inputs.error_code,
+                        )
+                    error_message = None
+                    selected_states = []
+                    selected_account_map = {}
                     await asyncio.sleep(0)
                     continue
                 break
@@ -391,7 +614,7 @@ class LoadBalancer:
             if error_message == "No available accounts":
                 set_degraded("all upstream accounts are unavailable")
                 error_message = _format_degraded_error_message(error_message)
-            return AccountSelection(account=None, error_message=error_message, error_code=None)
+            return AccountSelection(account=None, error_message=error_message, error_code=selection_error_code)
         logger.info(
             "Selected account_id=%s strategy=%s sticky=%s model=%s",
             selected_snapshot.id,
@@ -399,7 +622,7 @@ class LoadBalancer:
             bool(sticky_key),
             model,
         )
-        return AccountSelection(account=selected_snapshot, error_message=None, error_code=None)
+        return AccountSelection(account=selected_snapshot, error_message=None, error_code=None, lease=selected_lease)
 
     async def _load_selection_inputs(
         self,
@@ -680,6 +903,7 @@ class LoadBalancer:
             kind=sticky_kind,
             max_age_seconds=sticky_max_age_seconds,
         )
+        hard_sticky = sticky_kind == StickySessionKind.CODEX_SESSION
 
         # When the pinned account is temporarily unavailable (rate-limited,
         # error backoff) but still in the pool, pick a fallback WITHOUT
@@ -692,6 +916,16 @@ class LoadBalancer:
         if existing:
             pinned = next((state for state in states if state.account_id == existing), None)
             if pinned is not None:
+                if hard_sticky:
+                    pinned_result = select_account(
+                        [pinned],
+                        prefer_earlier_reset=prefer_earlier_reset_accounts,
+                        routing_strategy=routing_strategy,
+                        allow_backoff_fallback=False,
+                    )
+                    if pinned_result.account is not None and sticky_max_age_seconds is not None:
+                        await sticky_repo.upsert(sticky_key, pinned.account_id, kind=sticky_kind)
+                    return pinned_result
                 # Proactively rebind session affinity for any sticky kind
                 # once the pinned account is already above the configured
                 # budget threshold. That preserves continuity below the
@@ -702,7 +936,6 @@ class LoadBalancer:
                     sticky_kind
                     in (
                         StickySessionKind.PROMPT_CACHE,
-                        StickySessionKind.CODEX_SESSION,
                         StickySessionKind.STICKY_THREAD,
                     )
                     and pinned.status != AccountStatus.RATE_LIMITED
@@ -1051,6 +1284,58 @@ def _build_states(
     return states, account_map
 
 
+def _filter_states_for_account_caps(
+    states: Iterable[AccountState],
+    *,
+    lease_kind: AccountLeaseKind | None,
+) -> list[AccountState]:
+    if lease_kind is None:
+        return list(states)
+    settings = get_settings()
+    filtered: list[AccountState] = []
+    for state in states:
+        if lease_kind == "response_create":
+            cap = settings.proxy_account_response_create_limit
+            if cap > 0 and state.inflight_response_creates >= cap:
+                continue
+        else:
+            cap = settings.proxy_account_stream_limit
+            if cap > 0 and state.inflight_streams >= cap:
+                continue
+        filtered.append(state)
+    return filtered
+
+
+def _account_cap_error_code(lease_kind: AccountLeaseKind | None) -> str | None:
+    if lease_kind == "response_create":
+        return "account_response_create_cap"
+    if lease_kind == "stream":
+        return "account_stream_cap"
+    return None
+
+
+def _record_account_lease_acquired(kind: AccountLeaseKind) -> None:
+    if PROMETHEUS_AVAILABLE and account_lease_acquired_total is not None:
+        account_lease_acquired_total.labels(kind=kind).inc()
+
+
+def _record_account_lease_released(kind: AccountLeaseKind, reason: str) -> None:
+    if PROMETHEUS_AVAILABLE and account_lease_released_total is not None:
+        account_lease_released_total.labels(kind=kind, reason=reason).inc()
+
+
+def _record_account_lease_stale_reclaimed(kind: AccountLeaseKind) -> None:
+    if PROMETHEUS_AVAILABLE and account_lease_stale_reclaimed_total is not None:
+        account_lease_stale_reclaimed_total.labels(kind=kind).inc()
+
+
+def _record_account_cap_rejection(kind: AccountLeaseKind | None) -> None:
+    if kind is None:
+        return
+    if PROMETHEUS_AVAILABLE and account_cap_rejections_total is not None:
+        account_cap_rejections_total.labels(kind=kind).inc()
+
+
 def _state_from_account(
     *,
     account: Account,
@@ -1193,22 +1478,38 @@ def _state_from_account(
         runtime.probe_success_streak = 0
         runtime.health_tier = HEALTH_TIER_HEALTHY
 
+    inflight_pressure_pct = (
+        runtime.inflight_response_creates + runtime.inflight_streams
+    ) * settings.proxy_account_inflight_penalty_pct
+    leased_token_pressure_pct = 0.0
+    capacity_credits = usage_core.capacity_for_plan(account.plan_type, "secondary") or 0.0
+    if capacity_credits > 0.0 and runtime.leased_tokens > 0:
+        leased_token_pressure_pct = (
+            runtime.leased_tokens * settings.proxy_account_lease_token_weight / capacity_credits * 100.0
+        )
+    pressure_pct = inflight_pressure_pct + leased_token_pressure_pct
+    effective_used_percent = None if used_percent is None else min(100.0, used_percent + pressure_pct)
+    effective_secondary_used_percent = None if secondary_used is None else min(100.0, secondary_used + pressure_pct)
+
     return AccountState(
         account_id=account.id,
         status=status,
-        used_percent=used_percent,
+        used_percent=effective_used_percent,
         reset_at=reset_at,
         blocked_at=next_blocked_at,
         cooldown_until=runtime.cooldown_until,
-        secondary_used_percent=secondary_used,
+        secondary_used_percent=effective_secondary_used_percent,
         secondary_reset_at=secondary_reset,
         last_error_at=runtime.last_error_at,
         last_selected_at=runtime.last_selected_at,
         error_count=runtime.error_count,
         deactivation_reason=account.deactivation_reason,
         plan_type=account.plan_type,
-        capacity_credits=usage_core.capacity_for_plan(account.plan_type, "secondary"),
+        capacity_credits=capacity_credits,
         health_tier=new_tier,
+        inflight_response_creates=runtime.inflight_response_creates,
+        inflight_streams=runtime.inflight_streams,
+        leased_tokens=runtime.leased_tokens,
     )
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 _MAX_SELECTION_ATTEMPTS = 4
 
 _STICKY_GRACE_PERIOD_SECONDS = 10.0
+_STICKY_EXISTING_UNSET = object()
 _RECOVERABLE_STATUSES = frozenset(
     {
         AccountStatus.ACTIVE,
@@ -232,7 +233,7 @@ class LoadBalancer:
         return True
 
     def _reclaim_stale_account_leases_locked(self) -> None:
-        ttl_seconds = get_settings().proxy_account_lease_ttl_seconds
+        ttl_seconds = getattr(get_settings(), "proxy_account_lease_ttl_seconds", 900.0)
         now = time.monotonic()
         for runtime in self._runtime.values():
             if not runtime.leases:
@@ -465,6 +466,7 @@ class LoadBalancer:
                 break
 
         else:
+            sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET
             attempt = 0
             while True:
                 attempt += 1
@@ -477,7 +479,16 @@ class LoadBalancer:
                         latest_secondary=selection_inputs.latest_secondary,
                         runtime=self._runtime,
                     )
-                hard_sticky = sticky_kind == StickySessionKind.CODEX_SESSION
+                if sticky_key and sticky_kind == StickySessionKind.CODEX_SESSION:
+                    async with self._repo_factory() as repos:
+                        sticky_existing_account_id = await repos.sticky_sessions.get_account_id(
+                            sticky_key,
+                            kind=sticky_kind,
+                            max_age_seconds=sticky_max_age_seconds,
+                        )
+                hard_sticky = sticky_kind == StickySessionKind.CODEX_SESSION and isinstance(
+                    sticky_existing_account_id, str
+                )
                 selection_states = (
                     states if hard_sticky else _filter_states_for_account_caps(states, lease_kind=lease_kind)
                 )
@@ -507,6 +518,7 @@ class LoadBalancer:
                             relative_availability_power=relative_availability_power,
                             relative_availability_top_k=relative_availability_top_k,
                             sticky_repo=repos.sticky_sessions,
+                            sticky_existing_account_id=sticky_existing_account_id,
                         )
                 selected_account_map = account_map
                 selected_states = []
@@ -885,6 +897,7 @@ class LoadBalancer:
         relative_availability_power: float = 2.0,
         relative_availability_top_k: int = 5,
         sticky_repo: StickySessionsRepository | None,
+        sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET,
     ) -> SelectionResult:
         if not sticky_key or not sticky_repo:
             return _select_account_preferring_budget_safe(
@@ -898,13 +911,14 @@ class LoadBalancer:
         if sticky_kind is None:
             raise ValueError("sticky_kind is required when sticky_key is provided")
 
-        existing = await sticky_repo.get_account_id(
-            sticky_key,
-            kind=sticky_kind,
-            max_age_seconds=sticky_max_age_seconds,
-        )
-        hard_sticky = sticky_kind == StickySessionKind.CODEX_SESSION
-
+        if sticky_existing_account_id is _STICKY_EXISTING_UNSET:
+            existing = await sticky_repo.get_account_id(
+                sticky_key,
+                kind=sticky_kind,
+                max_age_seconds=sticky_max_age_seconds,
+            )
+        else:
+            existing = sticky_existing_account_id if isinstance(sticky_existing_account_id, str) else None
         # When the pinned account is temporarily unavailable (rate-limited,
         # error backoff) but still in the pool, pick a fallback WITHOUT
         # overwriting the sticky mapping so the next request returns to the
@@ -916,16 +930,6 @@ class LoadBalancer:
         if existing:
             pinned = next((state for state in states if state.account_id == existing), None)
             if pinned is not None:
-                if hard_sticky:
-                    pinned_result = select_account(
-                        [pinned],
-                        prefer_earlier_reset=prefer_earlier_reset_accounts,
-                        routing_strategy=routing_strategy,
-                        allow_backoff_fallback=False,
-                    )
-                    if pinned_result.account is not None and sticky_max_age_seconds is not None:
-                        await sticky_repo.upsert(sticky_key, pinned.account_id, kind=sticky_kind)
-                    return pinned_result
                 # Proactively rebind session affinity for any sticky kind
                 # once the pinned account is already above the configured
                 # budget threshold. That preserves continuity below the
@@ -937,6 +941,7 @@ class LoadBalancer:
                     in (
                         StickySessionKind.PROMPT_CACHE,
                         StickySessionKind.STICKY_THREAD,
+                        StickySessionKind.CODEX_SESSION,
                     )
                     and pinned.status != AccountStatus.RATE_LIMITED
                     and _state_above_sticky_budget_threshold(pinned, budget_threshold_pct)
@@ -1478,15 +1483,14 @@ def _state_from_account(
         runtime.probe_success_streak = 0
         runtime.health_tier = HEALTH_TIER_HEALTHY
 
-    inflight_pressure_pct = (
-        runtime.inflight_response_creates + runtime.inflight_streams
-    ) * settings.proxy_account_inflight_penalty_pct
+    inflight_pressure_pct = (runtime.inflight_response_creates + runtime.inflight_streams) * getattr(
+        settings, "proxy_account_inflight_penalty_pct", 2.5
+    )
     leased_token_pressure_pct = 0.0
     capacity_credits = usage_core.capacity_for_plan(account.plan_type, "secondary") or 0.0
     if capacity_credits > 0.0 and runtime.leased_tokens > 0:
-        leased_token_pressure_pct = (
-            runtime.leased_tokens * settings.proxy_account_lease_token_weight / capacity_credits * 100.0
-        )
+        lease_token_weight = getattr(settings, "proxy_account_lease_token_weight", 1.0)
+        leased_token_pressure_pct = runtime.leased_tokens * lease_token_weight / capacity_credits * 100.0
     pressure_pct = inflight_pressure_pct + leased_token_pressure_pct
     effective_used_percent = None if used_percent is None else min(100.0, used_percent + pressure_pct)
     effective_secondary_used_percent = None if secondary_used is None else min(100.0, secondary_used + pressure_pct)

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -855,7 +855,11 @@ class LoadBalancer:
 
     def _prune_runtime(self, accounts: Iterable[Account]) -> None:
         account_ids = {account.id for account in accounts}
-        stale_ids = [account_id for account_id in self._runtime if account_id not in account_ids]
+        stale_ids = [
+            account_id
+            for account_id, runtime in self._runtime.items()
+            if account_id not in account_ids and not runtime.leases
+        ]
         for account_id in stale_ids:
             self._runtime.pop(account_id, None)
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -58,6 +58,7 @@ logger = logging.getLogger(__name__)
 
 _MAX_SELECTION_ATTEMPTS = 4
 
+_ACCOUNT_STREAM_LEASE_STALE_GRACE_SECONDS = 60.0
 _STICKY_GRACE_PERIOD_SECONDS = 10.0
 _STICKY_EXISTING_UNSET = object()
 _RECOVERABLE_STATUSES = frozenset(
@@ -233,12 +234,16 @@ class LoadBalancer:
         return True
 
     def _reclaim_stale_account_leases_locked(self) -> None:
-        ttl_seconds = getattr(get_settings(), "proxy_account_lease_ttl_seconds", 900.0)
+        settings = get_settings()
         now = time.monotonic()
         for runtime in self._runtime.values():
             if not runtime.leases:
                 continue
-            stale = [lease for lease in runtime.leases.values() if now - lease.acquired_at >= ttl_seconds]
+            stale = [
+                lease
+                for lease in runtime.leases.values()
+                if now - lease.acquired_at >= _account_lease_stale_ttl_seconds(lease.kind, settings)
+            ]
             for lease in stale:
                 self._release_account_lease_locked(lease, reason="stale")
 
@@ -1287,6 +1292,19 @@ def _build_states(
         states.append(state)
         account_map[account.id] = account
     return states, account_map
+
+
+def _account_lease_stale_ttl_seconds(kind: AccountLeaseKind, settings: object) -> float:
+    ttl_seconds = float(getattr(settings, "proxy_account_lease_ttl_seconds", 900.0))
+    if kind != "stream":
+        return ttl_seconds
+    valid_stream_budget_seconds = max(
+        ttl_seconds,
+        float(getattr(settings, "proxy_request_budget_seconds", ttl_seconds)),
+        float(getattr(settings, "http_responses_stream_request_budget_seconds", ttl_seconds)),
+        float(getattr(settings, "http_responses_session_bridge_request_budget_seconds", ttl_seconds)),
+    )
+    return max(ttl_seconds, valid_stream_budget_seconds + _ACCOUNT_STREAM_LEASE_STALE_GRACE_SECONDS)
 
 
 def _filter_states_for_account_caps(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1348,10 +1348,13 @@ class ProxyService:
                     default_message="Upstream error",
                 )
                 return
-            if _http_bridge_should_attempt_soft_affinity_reroute(
-                exc,
-                key=bridge_session_key,
-                previous_response_id=effective_payload.previous_response_id,
+            if (
+                _http_bridge_should_attempt_soft_affinity_reroute(
+                    exc,
+                    key=bridge_session_key,
+                    previous_response_id=effective_payload.previous_response_id,
+                )
+                and not file_required_preferred_account
             ):
                 _log_http_bridge_event(
                     "internal_soft_affinity_reroute",

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2077,14 +2077,14 @@ class ProxyService:
                         connect_timeout_seconds=remaining_budget,
                         total_timeout_seconds=remaining_budget,
                     )
-                if account_response_create_lease is None:
-                    account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
-                        account_id=target.id,
-                        request_id=request_id,
-                        surface="compact",
-                    )
                 create_lease: AdmissionLease | None = None
                 try:
+                    if account_response_create_lease is None:
+                        account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
+                            account_id=target.id,
+                            request_id=request_id,
+                            surface="compact",
+                        )
                     create_lease = await self._get_work_admission().acquire_response_create(compact=True)
                     return await core_compact_responses(payload, filtered, access_token, account_id)
                 finally:
@@ -4666,6 +4666,8 @@ class ProxyService:
                 error = _parse_openai_error(exc.payload)
                 error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
                 error_message = error.message if error else None
+                await self._load_balancer.release_account_lease(selected_stream_lease)
+                selected_stream_lease = None
                 await self._emit_websocket_connect_failure(
                     websocket,
                     client_send_lock=client_send_lock,
@@ -4677,7 +4679,6 @@ class ProxyService:
                     error_code=error_code or "upstream_error",
                     error_message=error_message or "Upstream error",
                 )
-                await self._load_balancer.release_account_lease(selected_stream_lease)
                 return None, None
             except BaseException:
                 await self._load_balancer.release_account_lease(selected_stream_lease)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6931,6 +6931,8 @@ class ProxyService:
                 await self._acquire_request_state_response_create_admission(
                     warmup_state,
                     response_create_gate=session.response_create_gate,
+                    account_id=session.account.id,
+                    surface="http_bridge_prewarm",
                 )
                 gate_acquired = True
                 async with session.pending_lock:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3985,7 +3985,7 @@ class ProxyService:
                     error_message = error.message if error and error.message else "Upstream error"
                     error_type = error.type if error and error.type else "server_error"
                     if request_state is not None:
-                        self._cancel_request_state_api_key_reservation_heartbeat(request_state)
+                        await self._release_websocket_request_state_reservation(request_state)
                         if request_state_registered:
                             async with pending_lock:
                                 if request_state in pending_requests:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -175,7 +175,7 @@ from app.modules.proxy.http_bridge_forwarding import (
     HTTPBridgeOwnerClient,
     OwnerForwardRelayFailure,
 )
-from app.modules.proxy.load_balancer import AccountSelection, LoadBalancer
+from app.modules.proxy.load_balancer import AccountLease, AccountSelection, LoadBalancer
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.proxy.repo_bundle import ProxyRepoFactory, ProxyRepositories
 from app.modules.proxy.request_policy import (
@@ -258,9 +258,13 @@ def _proxy_admission_wait_timeout_seconds(settings: Any | None = None) -> float:
     return max(0.001, timeout)
 
 
-def _http_bridge_startup_wait_timeout_error(stage: str) -> ProxyResponseError:
+def _http_bridge_startup_wait_timeout_error(
+    stage: str,
+    *,
+    code: str = "global_admission_timeout",
+) -> ProxyResponseError:
     message = f"codex-lb is temporarily overloaded during {stage}"
-    return ProxyResponseError(429, local_overload_error(message))
+    return ProxyResponseError(429, local_overload_error(message, code=code))
 
 
 def _log_http_bridge_startup_wait_timeout(
@@ -1331,6 +1335,65 @@ class ProxyService:
                     default_message="Upstream error",
                 )
                 return
+            if _http_bridge_should_attempt_soft_affinity_reroute(
+                exc,
+                key=bridge_session_key,
+                previous_response_id=effective_payload.previous_response_id,
+            ):
+                _log_http_bridge_event(
+                    "internal_soft_affinity_reroute",
+                    bridge_session_key,
+                    account_id=session.account.id,
+                    model=effective_payload.model,
+                    detail="reason=bridge_local_pressure",
+                    cache_key_family=bridge_session_key.affinity_kind,
+                    model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
+                    owner_check_applied=False,
+                )
+                reroute_key = _HTTPBridgeSessionKey(
+                    "internal_soft_affinity_reroute",
+                    f"{bridge_session_key.affinity_kind}:{uuid4().hex}",
+                    bridge_session_key.api_key_id,
+                    strength="soft",
+                )
+                reroute_session = await self._get_or_create_http_bridge_session(
+                    reroute_key,
+                    headers=dict(headers),
+                    affinity=_AffinityPolicy(),
+                    api_key=api_key,
+                    request_model=effective_payload.model,
+                    idle_ttl_seconds=_effective_http_bridge_idle_ttl_seconds(
+                        affinity=_AffinityPolicy(),
+                        idle_ttl_seconds=idle_ttl_seconds,
+                        codex_idle_ttl_seconds=codex_idle_ttl_seconds,
+                        prompt_cache_idle_ttl_seconds=prompt_cache_idle_ttl_seconds,
+                    ),
+                    max_sessions=max_sessions,
+                    previous_response_id=None,
+                    gateway_safe_mode=runtime_config.gateway_safe_mode,
+                    allow_forward_to_owner=False,
+                    forwarded_request=forwarded_request,
+                    durable_lookup=None,
+                    request_stage=request_state.request_stage,
+                    preferred_account_id=None,
+                )
+                retry_events: AsyncGenerator[str, None] = self._stream_http_bridge_session_events(
+                    reroute_session,
+                    request_state=request_state,
+                    text_data=text_data,
+                    queue_limit=queue_limit,
+                    propagate_http_errors=propagate_http_errors,
+                    downstream_turn_state=downstream_turn_state,
+                )
+                try:
+                    async for event_block in retry_events:
+                        yield event_block
+                finally:
+                    try:
+                        await retry_events.aclose()
+                    except Exception:
+                        pass
+                return
             is_context_overflow = _http_bridge_is_context_overflow_error(exc)
             should_rollover_after_context_overflow = _http_bridge_should_rollover_after_context_overflow(
                 exc,
@@ -1990,7 +2053,10 @@ class ProxyService:
             file_preferred_account_id = await self._resolve_file_account_for_responses(payload, headers)
         try:
 
-            async def _call_compact(target: Account) -> CompactResponsePayload:
+            async def _call_compact(
+                target: Account,
+                account_response_create_lease: AccountLease | None = None,
+            ) -> CompactResponsePayload:
                 access_token = self._encryptor.decrypt(target.access_token_encrypted)
                 account_id = _header_account_id(target.chatgpt_account_id)
                 remaining_budget = _remaining_budget_seconds(deadline)
@@ -2010,11 +2076,20 @@ class ProxyService:
                         connect_timeout_seconds=remaining_budget,
                         total_timeout_seconds=remaining_budget,
                     )
-                create_lease = await self._get_work_admission().acquire_response_create(compact=True)
+                if account_response_create_lease is None:
+                    account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
+                        account_id=target.id,
+                        request_id=request_id,
+                        surface="compact",
+                    )
+                create_lease: AdmissionLease | None = None
                 try:
+                    create_lease = await self._get_work_admission().acquire_response_create(compact=True)
                     return await core_compact_responses(payload, filtered, access_token, account_id)
                 finally:
-                    create_lease.release()
+                    if create_lease is not None:
+                        create_lease.release()
+                    await self._load_balancer.release_account_lease(account_response_create_lease)
                     pop_compact_timeout_overrides(timeout_tokens)
 
             last_exc: ProxyResponseError | None = None
@@ -2034,6 +2109,7 @@ class ProxyService:
                     model=payload.model,
                     exclude_account_ids=excluded_account_ids,
                     preferred_account_id=file_preferred_account_id,
+                    lease_kind="response_create",
                 )
                 account = selection.account
                 if not account:
@@ -2041,18 +2117,27 @@ class ProxyService:
                         break
                     log_error_code = selection.error_code or "no_accounts"
                     log_error_message = selection.error_message or "No active accounts available"
+                    status_code = 429 if log_error_code == "account_response_create_cap" else 503
                     raise ProxyResponseError(
-                        503,
-                        openai_error(log_error_code, log_error_message),
+                        status_code,
+                        openai_error(
+                            log_error_code,
+                            log_error_message,
+                            error_type="rate_limit_error" if status_code == 429 else "server_error",
+                        ),
                     )
                 account_id_value = account.id
+                selected_account_response_create_lease = selection.lease
                 remaining_budget = _remaining_budget_seconds(deadline)
                 if remaining_budget <= 0:
                     logger.warning("Compact request budget exhausted before freshness check request_id=%s", request_id)
+                    await self._load_balancer.release_account_lease(selected_account_response_create_lease)
                     _raise_proxy_budget_exhausted()
                 try:
                     account = await self._ensure_fresh_with_budget(account, timeout_seconds=remaining_budget)
                 except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                    await self._load_balancer.release_account_lease(selected_account_response_create_lease)
+                    selected_account_response_create_lease = None
                     message = str(exc) or "Request to upstream timed out"
                     logger.warning(
                         "Compact refresh/connect failed request_id=%s account_id=%s",
@@ -2070,6 +2155,10 @@ class ProxyService:
                     last_exc = ProxyResponseError(502, openai_error("upstream_unavailable", message))
                     excluded_account_ids.add(account.id)
                     continue
+                except BaseException:
+                    await self._load_balancer.release_account_lease(selected_account_response_create_lease)
+                    selected_account_response_create_lease = None
+                    raise
                 request_service_tier = _service_tier_from_compact_payload(payload)
 
                 safe_retry_budget = _COMPACT_SAME_CONTRACT_RETRY_BUDGET
@@ -2078,7 +2167,9 @@ class ProxyService:
                 transient_exhausted = False
                 while True:
                     try:
-                        response = await _call_compact(account)
+                        account_response_create_lease = selected_account_response_create_lease
+                        selected_account_response_create_lease = None
+                        response = await _call_compact(account, account_response_create_lease)
                         actual_service_tier = _service_tier_from_response(response)
                         await self._load_balancer.record_success(account)
                         await self._settle_compact_api_key_usage(
@@ -2205,6 +2296,11 @@ class ProxyService:
                             error.code if error else None,
                             error.type if error else None,
                         )
+                        if code == "account_response_create_cap":
+                            last_exc = exc
+                            excluded_account_ids.add(account.id)
+                            transient_exhausted = True
+                            break
                         if _is_account_neutral_error_code(code):
                             await self._settle_compact_api_key_usage(
                                 api_key=api_key,
@@ -3389,9 +3485,15 @@ class ProxyService:
             codex_session_affinity=codex_session_affinity,
         )
         account: Account | None = None
+        account_lease: AccountLease | None = None
         upstream_turn_state: str | None = _sticky_key_from_turn_state_header(headers)
         downstream_activity = _DownstreamWebSocketActivity()
         replay_request_state: _WebSocketRequestState | None = None
+
+        async def release_current_account_lease() -> None:
+            nonlocal account_lease
+            await self._load_balancer.release_account_lease(account_lease)
+            account_lease = None
 
         try:
             while True:
@@ -3410,6 +3512,7 @@ class ProxyService:
                         except Exception:
                             logger.debug("Failed to close upstream websocket", exc_info=True)
                     upstream = None
+                    await release_current_account_lease()
                     account = None
 
                 text_data: str | None = None
@@ -3614,6 +3717,7 @@ class ProxyService:
                         except Exception:
                             logger.debug("Failed to close upstream websocket", exc_info=True)
                     upstream = None
+                    await release_current_account_lease()
                     account = None
 
                 if (
@@ -3633,6 +3737,7 @@ class ProxyService:
                         except Exception:
                             logger.debug("Failed to close upstream websocket", exc_info=True)
                     upstream = None
+                    await release_current_account_lease()
                     account = None
 
                 if (
@@ -3812,6 +3917,8 @@ class ProxyService:
                                     pending_requests.remove(request_state)
                             _release_websocket_response_create_gate(request_state, response_create_gate)
                         continue
+                    account_lease = request_state.websocket_stream_lease
+                    request_state.websocket_stream_lease = None
                     upstream_turn_state = _upstream_turn_state_from_socket(upstream) or upstream_turn_state
                     upstream_control = _WebSocketUpstreamControl()
                     upstream_reader = asyncio.create_task(
@@ -3835,10 +3942,49 @@ class ProxyService:
                     )
 
                 try:
+                    if (
+                        text_data is not None
+                        and request_state is not None
+                        and payload is not None
+                        and account is not None
+                        and _is_websocket_response_create(payload)
+                        and request_state.account_response_create_lease is None
+                    ):
+                        request_state.account_response_create_lease = (
+                            await self._acquire_account_response_create_lease_or_overload(
+                                account_id=account.id,
+                                request_id=request_state.request_log_id or request_state.request_id,
+                                surface="websocket",
+                            )
+                        )
+                        request_state.account_response_create_release = self._load_balancer.release_account_lease
                     if text_data is not None:
                         await upstream.send_text(text_data)
                     elif bytes_data is not None:
                         await upstream.send_bytes(bytes_data)
+                except ProxyResponseError as exc:
+                    error = _parse_openai_error(exc.payload)
+                    error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
+                    error_message = error.message if error and error.message else "Upstream error"
+                    error_type = error.type if error and error.type else "server_error"
+                    if request_state is not None:
+                        self._cancel_request_state_api_key_reservation_heartbeat(request_state)
+                        if request_state_registered:
+                            async with pending_lock:
+                                if request_state in pending_requests:
+                                    pending_requests.remove(request_state)
+                            _release_websocket_response_create_gate(request_state, response_create_gate)
+                        await self._emit_websocket_terminal_error(
+                            websocket,
+                            client_send_lock=client_send_lock,
+                            request_state=request_state,
+                            error_code=error_code or "upstream_error",
+                            error_message=error_message,
+                            error_type=error_type,
+                            error_param=error.param if error else None,
+                            downstream_activity=downstream_activity,
+                        )
+                    continue
                 except Exception:
                     replay_candidate = await _pop_replayable_precreated_websocket_request_state(
                         pending_requests,
@@ -3863,6 +4009,7 @@ class ProxyService:
                                     exc_info=True,
                                 )
                         upstream = None
+                        await release_current_account_lease()
                         account = None
                         continue
                     await self._fail_pending_websocket_requests(
@@ -3888,6 +4035,7 @@ class ProxyService:
                         except Exception:
                             logger.debug("Failed to close upstream websocket after send failure", exc_info=True)
                     upstream = None
+                    await release_current_account_lease()
                     account = None
                     continue
         finally:
@@ -3898,6 +4046,7 @@ class ProxyService:
                     await upstream.close()
                 except Exception:
                     logger.debug("Failed to close upstream websocket", exc_info=True)
+            await release_current_account_lease()
             if replay_request_state is not None:
                 await self._release_websocket_request_state_reservation(replay_request_state)
                 replay_request_state.api_key_reservation = None
@@ -4356,12 +4505,22 @@ class ProxyService:
         *,
         response_create_gate: asyncio.Semaphore,
         compact: bool = False,
+        account_id: str | None = None,
+        surface: str = "websocket",
     ) -> None:
         timeout_seconds = _proxy_admission_wait_timeout_seconds()
         request_state.response_create_gate = response_create_gate
+        if account_id is not None:
+            request_state.account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
+                account_id=account_id,
+                request_id=request_state.request_id,
+                surface=surface,
+            )
+            request_state.account_response_create_release = self._load_balancer.release_account_lease
         try:
             await asyncio.wait_for(response_create_gate.acquire(), timeout=timeout_seconds)
         except TimeoutError as exc:
+            await self._release_request_state_account_response_create_lease(request_state)
             request_state.response_create_gate = None
             request_state.response_create_gate_acquired = False
             request_state.awaiting_response_created = False
@@ -4372,7 +4531,16 @@ class ProxyService:
                 request_model=request_state.model,
                 available=getattr(response_create_gate, "_value", None),
             )
-            raise _http_bridge_startup_wait_timeout_error("http_bridge_response_create_gate") from exc
+            raise _http_bridge_startup_wait_timeout_error(
+                "http_bridge_response_create_gate",
+                code="response_create_gate_timeout",
+            ) from exc
+        except BaseException:
+            await self._release_request_state_account_response_create_lease(request_state)
+            request_state.response_create_gate = None
+            request_state.response_create_gate_acquired = False
+            request_state.awaiting_response_created = False
+            raise
         request_state.response_create_gate_acquired = True
         request_state.awaiting_response_created = True
         try:
@@ -4380,8 +4548,18 @@ class ProxyService:
                 compact=compact
             )
         except BaseException:
+            await self._release_request_state_account_response_create_lease(request_state)
             _release_websocket_response_create_gate(request_state, response_create_gate)
             raise
+
+    async def _release_request_state_account_response_create_lease(
+        self,
+        request_state: "_WebSocketRequestState",
+    ) -> None:
+        lease = request_state.account_response_create_lease
+        request_state.account_response_create_lease = None
+        request_state.account_response_create_release = None
+        await self._load_balancer.release_account_lease(lease)
 
     async def _connect_proxy_websocket(
         self,
@@ -4433,7 +4611,10 @@ class ProxyService:
                 )
             except _WebSocketConnectFailureEmitted:
                 return None, None
+            selected_stream_lease = request_state.websocket_stream_lease
+            request_state.websocket_stream_lease = None
             if account is None:
+                await self._load_balancer.release_account_lease(selected_stream_lease)
                 if (
                     last_failover_exc is not None
                     and not require_preferred_account
@@ -4476,6 +4657,7 @@ class ProxyService:
                     deterministic_failover_enabled=getattr(base_settings, "deterministic_failover_enabled", True),
                 )
                 if action == "failover_next":
+                    await self._load_balancer.release_account_lease(selected_stream_lease)
                     last_failover_exc = exc
                     last_failover_account = account
                     excluded_account_ids.add(account.id)
@@ -4494,10 +4676,16 @@ class ProxyService:
                     error_code=error_code or "upstream_error",
                     error_message=error_message or "Upstream error",
                 )
+                await self._load_balancer.release_account_lease(selected_stream_lease)
                 return None, None
+            except BaseException:
+                await self._load_balancer.release_account_lease(selected_stream_lease)
+                raise
 
             if connect_result is None:
+                await self._load_balancer.release_account_lease(selected_stream_lease)
                 return None, None
+            request_state.websocket_stream_lease = selected_stream_lease
             return connect_result
 
         if last_failover_exc is not None and last_failover_account is not None:
@@ -4552,6 +4740,7 @@ class ProxyService:
                 model=model,
                 exclude_account_ids=exclude_account_ids,
                 preferred_account_id=preferred_account_id,
+                lease_kind="stream",
             )
         except ProxyResponseError as exc:
             if _is_proxy_budget_exhausted_error(exc):
@@ -4572,13 +4761,14 @@ class ProxyService:
             and preferred_account_id is not None
             and account.id != preferred_account_id
         ):
+            await self._load_balancer.release_account_lease(selection.lease)
             message = "Previous response owner account is unavailable; retry later."
             _record_continuity_fail_closed(
                 surface="websocket_connect",
                 reason="owner_account_unavailable",
                 previous_response_id=request_state.previous_response_id,
                 session_id=request_state.session_id,
-                upstream_error_code="upstream_unavailable",
+                upstream_error_code="previous_response_owner_unavailable",
             )
             await self._emit_websocket_connect_failure(
                 websocket,
@@ -4588,15 +4778,16 @@ class ProxyService:
                 request_state=request_state,
                 status_code=502,
                 payload=openai_error(
-                    "upstream_unavailable",
+                    "previous_response_owner_unavailable",
                     message,
                     error_type="server_error",
                 ),
-                error_code="upstream_unavailable",
+                error_code="previous_response_owner_unavailable",
                 error_message=message,
             )
             return None
         if account:
+            request_state.websocket_stream_lease = selection.lease
             return account
         if defer_no_account_error:
             return None
@@ -4619,25 +4810,26 @@ class ProxyService:
                 request_state=request_state,
                 status_code=502,
                 payload=openai_error(
-                    "upstream_unavailable",
+                    "previous_response_owner_unavailable",
                     message,
                     error_type="server_error",
                 ),
-                error_code="upstream_unavailable",
+                error_code="previous_response_owner_unavailable",
                 error_message=message,
             )
             return None
+        status_code = 429 if is_local_overload_error_code(error_code) else 503
         await self._emit_websocket_connect_failure(
             websocket,
             client_send_lock=client_send_lock,
             account_id=None,
             api_key=api_key,
             request_state=request_state,
-            status_code=503,
+            status_code=status_code,
             payload=openai_error(
                 error_code,
                 error_message,
-                error_type="server_error",
+                error_type="rate_limit_error" if status_code == 429 else "server_error",
             ),
             error_code=error_code,
             error_message=error_message,
@@ -5765,10 +5957,9 @@ class ProxyService:
                                 )
                                 raise ProxyResponseError(
                                     429,
-                                    openai_error(
-                                        "rate_limit_exceeded",
+                                    local_overload_error(
                                         "HTTP responses session bridge has no idle capacity",
-                                        error_type="rate_limit_error",
+                                        code="capacity_exhausted_active_sessions",
                                     ),
                                 )
                         else:
@@ -5808,7 +5999,10 @@ class ProxyService:
                         continue
                     raise
                 except TimeoutError as exc:
-                    timeout_error = _http_bridge_startup_wait_timeout_error("http_bridge_capacity")
+                    timeout_error = _http_bridge_startup_wait_timeout_error(
+                        "http_bridge_capacity",
+                        code="capacity_exhausted_active_sessions",
+                    )
                     stale_key = await self._evict_http_bridge_inflight_waiter(capacity_wait_future, timeout_error)
                     _log_http_bridge_startup_wait_timeout(
                         stage="capacity",
@@ -5837,7 +6031,10 @@ class ProxyService:
                         continue
                     raise
                 except TimeoutError as exc:
-                    timeout_error = _http_bridge_startup_wait_timeout_error("http_bridge_inflight_session")
+                    timeout_error = _http_bridge_startup_wait_timeout_error(
+                        "http_bridge_inflight_session",
+                        code="capacity_exhausted_active_sessions",
+                    )
                     await self._fail_http_bridge_inflight_session_creation(key, inflight_future, timeout_error)
                     _log_http_bridge_startup_wait_timeout(
                         stage="inflight_session",
@@ -5914,7 +6111,10 @@ class ProxyService:
                         if inflight_future is not None and not inflight_future.done():
                             inflight_future.set_result(created_session)
                 if not session_registered:
-                    raise _http_bridge_startup_wait_timeout_error("http_bridge_session_registration")
+                    raise _http_bridge_startup_wait_timeout_error(
+                        "http_bridge_session_registration",
+                        code="capacity_exhausted_active_sessions",
+                    )
             except BaseException as exc:
                 async with self._http_bridge_lock:
                     current_future = self._http_bridge_inflight_sessions.get(key)
@@ -6063,6 +6263,8 @@ class ProxyService:
                 )
             except Exception:
                 logger.warning("Failed to release durable HTTP bridge session", exc_info=True)
+        await self._load_balancer.release_account_lease(session.account_lease)
+        session.account_lease = None
         _log_http_bridge_event(
             "close",
             session.key,
@@ -6292,6 +6494,7 @@ class ProxyService:
         excluded_account_ids: set[str] = set()
         retry_same_account_once = preferred_account_id is not None
         preferred_candidate_id = preferred_account_id
+        selected_account_lease: AccountLease | None = None
         while True:
             selection = await self._select_account_with_budget(
                 deadline,
@@ -6308,23 +6511,31 @@ class ProxyService:
                 model=request_model,
                 exclude_account_ids=excluded_account_ids,
                 preferred_account_id=preferred_candidate_id,
+                lease_kind="stream",
             )
+            selected_account_lease = selection.lease
             account = selection.account
             if account is None:
+                await self._load_balancer.release_account_lease(selected_account_lease)
+                selected_account_lease = None
                 _record_same_account_takeover(
                     preferred_account_id=preferred_account_id,
                     selected_account_id=None,
                 )
+                status_code = 429 if _is_local_account_cap_code(selection.error_code) else 503
+                error_type = "rate_limit_error" if status_code == 429 else "server_error"
                 raise ProxyResponseError(
-                    503,
+                    status_code,
                     openai_error(
                         selection.error_code or "no_accounts",
                         selection.error_message or "No active accounts available",
-                        error_type="server_error",
+                        error_type=error_type,
                     ),
                 )
             if require_preferred_account and preferred_account_id is not None and account.id != preferred_account_id:
                 message = "Previous response owner account is unavailable; retry later."
+                await self._load_balancer.release_account_lease(selected_account_lease)
+                selected_account_lease = None
                 _record_same_account_takeover(
                     preferred_account_id=preferred_account_id,
                     selected_account_id=account.id,
@@ -6332,7 +6543,7 @@ class ProxyService:
                 raise ProxyResponseError(
                     502,
                     openai_error(
-                        "upstream_unavailable",
+                        "previous_response_owner_unavailable",
                         message,
                         error_type="server_error",
                     ),
@@ -6356,6 +6567,8 @@ class ProxyService:
                 break
             except ProxyResponseError as exc:
                 if exc.status_code != 401 or _remaining_budget_seconds(deadline) <= 0:
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     raise
                 try:
                     account = await self._ensure_fresh_with_budget(
@@ -6376,20 +6589,30 @@ class ProxyService:
                     break
                 except ProxyResponseError as retry_exc:
                     if retry_exc.status_code != 401:
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
                         raise
                     await self._handle_proxy_error(account, retry_exc)
                     if require_preferred_account and selected_is_preferred:
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
                         raise
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     continue
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
                         await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
                     if require_preferred_account and selected_is_preferred:
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
                         raise
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     continue
             except RefreshError as exc:
                 if exc.is_permanent:
@@ -6397,11 +6620,17 @@ class ProxyService:
                 if selected_is_preferred and _remaining_budget_seconds(deadline) > 0:
                     if retry_same_account_once and not exc.is_permanent:
                         retry_same_account_once = False
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
                         continue
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     continue
                 if exc.is_permanent:
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     raise ProxyResponseError(
                         401,
                         openai_error(
@@ -6412,18 +6641,30 @@ class ProxyService:
                     ) from exc
                 if request_stage == "first_turn":
                     _record_bridge_first_turn_timeout()
+                await self._load_balancer.release_account_lease(selected_account_lease)
+                selected_account_lease = None
                 _raise_proxy_unavailable(exc.message or "Temporary upstream refresh failure")
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 if selected_is_preferred and _remaining_budget_seconds(deadline) > 0:
                     if retry_same_account_once:
                         retry_same_account_once = False
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
                         continue
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     continue
                 if request_stage == "first_turn":
                     _record_bridge_first_turn_timeout()
+                await self._load_balancer.release_account_lease(selected_account_lease)
+                selected_account_lease = None
                 _raise_proxy_unavailable(str(exc) or "Request to upstream timed out")
+            except BaseException:
+                await self._load_balancer.release_account_lease(selected_account_lease)
+                selected_account_lease = None
+                raise
         session = _HTTPBridgeSession(
             key=key,
             headers=connect_headers,
@@ -6443,6 +6684,7 @@ class ProxyService:
             prewarm_lock=anyio.Lock(),
             upstream_turn_state=_upstream_turn_state_from_socket(upstream),
             downstream_turn_state=None,
+            account_lease=selected_account_lease,
         )
         session.upstream_reader = asyncio.create_task(self._relay_http_bridge_upstream_messages(session))
         return session
@@ -6522,7 +6764,7 @@ class ProxyService:
         async with session.pending_lock:
             if session.queued_request_count >= queue_limit:
                 _log_http_bridge_event(
-                    "queue_full",
+                    "bridge_queue_full",
                     session.key,
                     account_id=session.account.id,
                     model=session.request_model,
@@ -6533,7 +6775,7 @@ class ProxyService:
                 raise ProxyResponseError(
                     429,
                     openai_error(
-                        "rate_limit_exceeded",
+                        "bridge_queue_full",
                         "HTTP responses session bridge queue is full",
                         error_type="rate_limit_error",
                     ),
@@ -6549,6 +6791,8 @@ class ProxyService:
             await self._acquire_request_state_response_create_admission(
                 request_state,
                 response_create_gate=session.response_create_gate,
+                account_id=session.account.id,
+                surface="http_bridge",
             )
             gate_acquired = True
             async with session.pending_lock:
@@ -7065,6 +7309,7 @@ class ProxyService:
         excluded_account_ids: set[str] = {session.account.id} if skip_same_account else set()
         retry_same_account_once = not skip_same_account
         preferred_candidate_id: str | None = None if skip_same_account else session.account.id
+        selected_account_lease: AccountLease | None = None
         while True:
             selection = await self._select_account_with_budget(
                 deadline,
@@ -7081,19 +7326,24 @@ class ProxyService:
                 model=session.request_model,
                 exclude_account_ids=excluded_account_ids,
                 preferred_account_id=preferred_candidate_id,
+                lease_kind="stream",
             )
+            selected_account_lease = selection.lease
             account = selection.account
             if account is None:
+                await self._load_balancer.release_account_lease(selected_account_lease)
+                selected_account_lease = None
                 _record_same_account_takeover(
                     preferred_account_id=session.account.id,
                     selected_account_id=None,
                 )
+                status_code = 429 if _is_local_account_cap_code(selection.error_code) else 503
                 raise ProxyResponseError(
-                    503,
+                    status_code,
                     openai_error(
                         selection.error_code or "no_accounts",
                         selection.error_message or "No active accounts available",
-                        error_type="server_error",
+                        error_type="rate_limit_error" if status_code == 429 else "server_error",
                     ),
                 )
             selected_is_preferred = account.id == session.account.id
@@ -7118,6 +7368,8 @@ class ProxyService:
                 break
             except ProxyResponseError as exc:
                 if exc.status_code != 401 or _remaining_budget_seconds(deadline) <= 0:
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     raise
                 try:
                     account = await self._ensure_fresh_with_budget(
@@ -7141,16 +7393,22 @@ class ProxyService:
                     break
                 except ProxyResponseError as retry_exc:
                     if retry_exc.status_code != 401:
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
                         raise
                     await self._handle_proxy_error(account, retry_exc)
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     continue
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
                         await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     continue
             except RefreshError as exc:
                 if exc.is_permanent:
@@ -7158,20 +7416,34 @@ class ProxyService:
                 if selected_is_preferred and _remaining_budget_seconds(deadline) > 0:
                     if retry_same_account_once and not exc.is_permanent:
                         retry_same_account_once = False
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
                         continue
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     continue
+                await self._load_balancer.release_account_lease(selected_account_lease)
+                selected_account_lease = None
                 raise
             except (aiohttp.ClientError, asyncio.TimeoutError):
                 if selected_is_preferred and _remaining_budget_seconds(deadline) > 0:
                     if retry_same_account_once:
                         retry_same_account_once = False
+                        await self._load_balancer.release_account_lease(selected_account_lease)
+                        selected_account_lease = None
                         continue
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
+                    await self._load_balancer.release_account_lease(selected_account_lease)
+                    selected_account_lease = None
                     continue
+                await self._load_balancer.release_account_lease(selected_account_lease)
+                selected_account_lease = None
                 raise
+        await self._load_balancer.release_account_lease(session.account_lease)
+        session.account_lease = selected_account_lease
         session.account = account
         session.headers = connect_headers
         session.upstream = upstream
@@ -9546,6 +9818,17 @@ class ProxyService:
         preferred_account_id: str | None = None
         require_preferred_account = False
         last_retryable_stream_error: _RetryableStreamError | None = None
+        account_leases: list[AccountLease] = []
+
+        async def _release_tracked_stream_lease(lease: AccountLease | None) -> None:
+            if lease is None:
+                return
+            try:
+                account_leases.remove(lease)
+            except ValueError:
+                pass
+            await self._load_balancer.release_account_lease(lease)
+
         try:
             if payload.previous_response_id is not None:
                 preferred_account_id = await self._resolve_websocket_previous_response_owner(
@@ -9602,6 +9885,7 @@ class ProxyService:
                         model=payload.model,
                         exclude_account_ids=excluded_account_ids,
                         preferred_account_id=preferred_account_id,
+                        lease_kind="stream",
                     )
                 except ProxyResponseError as exc:
                     error = _parse_openai_error(exc.payload)
@@ -9632,7 +9916,19 @@ class ProxyService:
                     yield format_sse_event(event)
                     return
                 account = selection.account
+                current_account_lease = selection.lease
+                if selection.lease is not None:
+                    account_leases.append(selection.lease)
                 if not account:
+                    if _is_local_account_cap_code(selection.error_code):
+                        raise ProxyResponseError(
+                            429,
+                            openai_error(
+                                selection.error_code or "account_stream_cap",
+                                selection.error_message or "Account stream capacity is exhausted",
+                                error_type="rate_limit_error",
+                            ),
+                        )
                     if require_preferred_account and preferred_account_id is not None:
                         message = "Previous response owner account is unavailable; retry later."
                         _record_continuity_fail_closed(
@@ -9643,7 +9939,7 @@ class ProxyService:
                             upstream_error_code="no_accounts",
                         )
                         event = response_failed_event(
-                            "upstream_unavailable",
+                            "previous_response_owner_unavailable",
                             message,
                             response_id=request_id,
                         )
@@ -9655,7 +9951,7 @@ class ProxyService:
                             model=payload.model,
                             latency_ms=int((time.monotonic() - start) * 1000),
                             status="error",
-                            error_code="upstream_unavailable",
+                            error_code="previous_response_owner_unavailable",
                             error_message=message,
                             reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
                             transport=request_transport,
@@ -9730,7 +10026,7 @@ class ProxyService:
                         upstream_error_code="upstream_unavailable",
                     )
                     event = response_failed_event(
-                        "upstream_unavailable",
+                        "previous_response_owner_unavailable",
                         message,
                         response_id=request_id,
                     )
@@ -9742,7 +10038,7 @@ class ProxyService:
                         model=payload.model,
                         latency_ms=int((time.monotonic() - start) * 1000),
                         status="error",
-                        error_code="upstream_unavailable",
+                        error_code="previous_response_owner_unavailable",
                         error_message=message,
                         reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
                         transport=request_transport,
@@ -9921,6 +10217,12 @@ class ProxyService:
                                     error.code if error else None,
                                     error.type if error else None,
                                 )
+                                if code == "account_response_create_cap":
+                                    last_transient_exc = tex
+                                    await _release_tracked_stream_lease(current_account_lease)
+                                    current_account_lease = None
+                                    excluded_account_ids.add(account.id)
+                                    break
                                 if _is_account_neutral_error_code(code):
                                     raise
                                 classified = await self._handle_stream_error(
@@ -9948,6 +10250,8 @@ class ProxyService:
                                 )
                                 if action == "failover_next":
                                     last_transient_exc = tex
+                                    await _release_tracked_stream_lease(current_account_lease)
+                                    current_account_lease = None
                                     excluded_account_ids.add(account.id)
                                     break
                                 raise
@@ -9992,6 +10296,8 @@ class ProxyService:
                             # Preserve last ProxyResponseError for propagate_http_errors path.
                             if isinstance(tex, ProxyResponseError):
                                 last_transient_exc = tex
+                            await _release_tracked_stream_lease(current_account_lease)
+                            current_account_lease = None
                             excluded_account_ids.add(account.id)
                             break  # outer loop: select different account
                         finally:
@@ -10016,6 +10322,8 @@ class ProxyService:
                     await self._handle_stream_error(account, exc.error, exc.code)
                     last_retryable_stream_error = exc
                     if exc.exclude_account:
+                        await _release_tracked_stream_lease(current_account_lease)
+                        current_account_lease = None
                         excluded_account_ids.add(account.id)
                     continue
                 except _TerminalStreamError as exc:
@@ -10176,6 +10484,12 @@ class ProxyService:
                                 error.code if error else None,
                                 error.type if error else None,
                             )
+                            if error_code == "account_response_create_cap":
+                                last_transient_exc = retry_exc
+                                await _release_tracked_stream_lease(current_account_lease)
+                                current_account_lease = None
+                                excluded_account_ids.add(account.id)
+                                continue
                             if _is_account_neutral_error_code(error_code):
                                 raise
                             classified = await self._handle_stream_error(
@@ -10206,6 +10520,8 @@ class ProxyService:
                             )
                             if action == "failover_next":
                                 last_transient_exc = retry_exc
+                                await _release_tracked_stream_lease(current_account_lease)
+                                current_account_lease = None
                                 excluded_account_ids.add(account.id)
                                 continue
                             if propagate_http_errors:
@@ -10330,6 +10646,8 @@ class ProxyService:
                     requested_service_tier=payload.service_tier,
                 )
         finally:
+            for account_lease in account_leases:
+                await self._load_balancer.release_account_lease(account_lease)
             if not settled and api_key is not None and api_key_reservation is not None:
                 release_coro = self._release_unsettled_stream_api_key_usage(
                     api_key=api_key,
@@ -10386,6 +10704,7 @@ class ProxyService:
             tool_call_dedupe = _WebSocketUpstreamControl()
         suppressed_duplicate_tool_call = False
         response_create_lease = AdmissionLease(None, stage="response_create", request_id=request_id)
+        account_response_create_lease: AccountLease | None = None
         api_key_reservation_touch_state = _ApiKeyReservationTouchState(last_touch_at=start)
         api_key_reservation_heartbeat_stop = asyncio.Event()
         api_key_reservation_heartbeat_task: asyncio.Task[None] | None = None
@@ -10402,6 +10721,11 @@ class ProxyService:
             )
 
         try:
+            account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
+                account_id=account.id,
+                request_id=request_id,
+                surface="stream",
+            )
             response_create_lease = await self._get_work_admission().acquire_response_create()
             if upstream_stream_transport is not None:
                 stream = core_stream_responses(
@@ -10425,6 +10749,8 @@ class ProxyService:
                 first = await iterator.__anext__()
             except StopAsyncIteration:
                 response_create_lease.release()
+                await self._load_balancer.release_account_lease(account_response_create_lease)
+                account_response_create_lease = None
                 status = "error"
                 error_code = "stream_incomplete"
                 error_message = "Upstream websocket closed before response.completed"
@@ -10441,6 +10767,8 @@ class ProxyService:
                 return
             except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
                 response_create_lease.release()
+                await self._load_balancer.release_account_lease(account_response_create_lease)
+                account_response_create_lease = None
                 status = "error"
                 error_code = "upstream_unavailable"
                 error_message = str(exc) or "Request to upstream timed out"
@@ -10458,6 +10786,8 @@ class ProxyService:
                 )
                 return
             response_create_lease.release()
+            await self._load_balancer.release_account_lease(account_response_create_lease)
+            account_response_create_lease = None
             first_payload = parse_sse_data_json(first)
             event = parse_sse_event(first)
             event_type = _event_type_from_payload(event, first_payload)
@@ -10762,6 +11092,7 @@ class ProxyService:
             if api_key_reservation_heartbeat_task is not None:
                 self._cancel_api_key_reservation_heartbeat_task(api_key_reservation_heartbeat_task)
             response_create_lease.release()
+            await self._load_balancer.release_account_lease(account_response_create_lease)
             input_tokens = usage.input_tokens if usage else None
             output_tokens = usage.output_tokens if usage else None
             cached_input_tokens = (
@@ -11201,6 +11532,7 @@ class ProxyService:
         additional_limit_name: str | None = None,
         exclude_account_ids: Collection[str] | None = None,
         preferred_account_id: str | None = None,
+        lease_kind: Literal["response_create", "stream"] | None = None,
     ) -> AccountSelection:
         remaining_budget = _remaining_budget_seconds(deadline)
         if remaining_budget <= 0:
@@ -11235,6 +11567,7 @@ class ProxyService:
                         additional_limit_name=additional_limit_name,
                         account_ids={preferred_account_id},
                         budget_threshold_pct=settings.sticky_reallocation_budget_threshold_pct,
+                        lease_kind=lease_kind,
                     )
                     if preferred_selection.account is not None:
                         logger.info(
@@ -11259,6 +11592,7 @@ class ProxyService:
                     account_ids=scoped_account_ids,
                     exclude_account_ids=excluded_account_ids_set,
                     budget_threshold_pct=settings.sticky_reallocation_budget_threshold_pct,
+                    lease_kind=lease_kind,
                 )
                 if selection.account is not None and selection.account.id in excluded_account_ids_set:
                     return AccountSelection(
@@ -11270,6 +11604,41 @@ class ProxyService:
         except TimeoutError:
             logger.warning("%s account selection exceeded request budget request_id=%s", kind.title(), request_id)
             _raise_proxy_budget_exhausted()
+
+    async def _acquire_account_response_create_lease_or_overload(
+        self,
+        *,
+        account_id: str,
+        request_id: str,
+        surface: str,
+    ) -> AccountLease:
+        lease = await self._load_balancer.acquire_account_lease(
+            account_id,
+            kind="response_create",
+        )
+        if lease is not None:
+            return lease
+        inflight_create, inflight_stream, leased_tokens = await self._load_balancer.account_pressure_snapshot(
+            account_id
+        )
+        logger.warning(
+            "Responses account response-create cap reached request_id=%s surface=%s account_id=%s "
+            "inflight_create=%s inflight_stream=%s leased_tokens=%.3f",
+            request_id,
+            surface,
+            account_id,
+            inflight_create,
+            inflight_stream,
+            leased_tokens,
+        )
+        raise ProxyResponseError(
+            429,
+            openai_error(
+                "account_response_create_cap",
+                "Account response-create capacity is exhausted",
+                error_type="rate_limit_error",
+            ),
+        )
 
     async def _handle_proxy_error(self, account: Account, exc: ProxyResponseError) -> None:
         error = _parse_openai_error(exc.payload)
@@ -11411,7 +11780,11 @@ def _should_retry_transient_stream_error(code: str | None, message: str | None) 
 
 
 def _is_account_neutral_error_code(code: str | None) -> bool:
-    return code in {"proxy_overloaded", "proxy_unavailable"}
+    return is_local_overload_error_code(code) or code == "proxy_unavailable"
+
+
+def _is_local_account_cap_code(code: str | None) -> bool:
+    return code in {"account_response_create_cap", "account_stream_cap"}
 
 
 def _classify_upstream_close(
@@ -11558,6 +11931,9 @@ class _WebSocketRequestState:
     response_create_gate_acquired: bool = False
     response_create_gate: asyncio.Semaphore | None = None
     response_create_admission: AdmissionLease | None = None
+    account_response_create_lease: AccountLease | None = None
+    account_response_create_release: Callable[[AccountLease | None], Coroutine[Any, Any, None]] | None = None
+    websocket_stream_lease: AccountLease | None = None
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
     suppressed_downstream_tool_call: bool = False
     suppressed_duplicate_tool_call: bool = False
@@ -11629,6 +12005,7 @@ class _HTTPBridgeSession:
     upstream_reader: asyncio.Task[None] | None = None
     last_upstream_close_code: int | None = None
     closed: bool = False
+    account_lease: AccountLease | None = None
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
 
 
@@ -13100,9 +13477,15 @@ def _release_websocket_response_create_gate(
     request_state: _WebSocketRequestState,
     response_create_gate: asyncio.Semaphore,
 ) -> None:
+    account_response_create_lease = request_state.account_response_create_lease
+    account_response_create_release = request_state.account_response_create_release
+    request_state.account_response_create_lease = None
+    request_state.account_response_create_release = None
     if request_state.response_create_admission is not None:
         request_state.response_create_admission.release()
         request_state.response_create_admission = None
+    if account_response_create_lease is not None and account_response_create_release is not None:
+        asyncio.create_task(account_response_create_release(account_response_create_lease))
     request_state.awaiting_response_created = False
     request_state.response_create_gate = None
     if not request_state.response_create_gate_acquired:
@@ -14635,9 +15018,37 @@ def _http_bridge_is_previous_response_owner_unavailable(exc: ProxyResponseError)
     if not isinstance(error, dict):
         return False
     return (
-        error.get("code") == "upstream_unavailable"
+        error.get("code")
+        in {
+            "previous_response_owner_unavailable",
+            "upstream_unavailable",
+        }
         and error.get("message") == "Previous response owner account is unavailable; retry later."
     )
+
+
+def _http_bridge_should_attempt_soft_affinity_reroute(
+    exc: ProxyResponseError,
+    *,
+    key: "_HTTPBridgeSessionKey",
+    previous_response_id: str | None,
+) -> bool:
+    if exc.status_code != 429:
+        return False
+    if key.strength == "hard" or previous_response_id is not None:
+        return False
+    payload = exc.payload
+    if not isinstance(payload, dict):
+        return False
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return False
+    return error.get("code") in {
+        "bridge_queue_full",
+        "response_create_gate_timeout",
+        "account_response_create_cap",
+        "account_stream_cap",
+    }
 
 
 def _http_bridge_is_context_overflow_error(exc: ProxyResponseError) -> bool:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -908,16 +908,20 @@ class ProxyService:
                 session_id=request_state.session_id,
                 surface="http_bridge",
             )
+        file_required_preferred_account = False
         if request_state.preferred_account_id is None:
             # ``input_file.file_id`` references must land on the account
             # that registered the upload (chatgpt-account-id-scoped).
             # The helper returns ``None`` when stronger affinity signals
             # are present, so this never overrides existing routing.
-            request_state.preferred_account_id = rewritten_file_account_id
+            if rewritten_file_account_id is not None:
+                request_state.preferred_account_id = rewritten_file_account_id
+                file_required_preferred_account = True
         if request_state.preferred_account_id is None:
-            request_state.preferred_account_id = await self._resolve_file_account_for_responses(
-                effective_payload, headers
-            )
+            resolved_file_account_id = await self._resolve_file_account_for_responses(effective_payload, headers)
+            if resolved_file_account_id is not None:
+                request_state.preferred_account_id = resolved_file_account_id
+                file_required_preferred_account = True
         if proxy_injected_previous_response_id:
             request_state.proxy_injected_previous_response_id = True
             request_state.fresh_upstream_request_text = fresh_upstream_request_text or text_data
@@ -953,6 +957,7 @@ class ProxyService:
                 durable_lookup=durable_lookup,
                 request_stage=request_state.request_stage,
                 preferred_account_id=request_state.preferred_account_id,
+                fallback_on_preferred_account_unavailable=not file_required_preferred_account,
             )
         except ProxyResponseError as exc:
             if not (
@@ -987,9 +992,15 @@ class ProxyService:
                 payload=payload,
                 durable_lookup=None,
             )
-            request_state.preferred_account_id = rewritten_file_account_id
+            file_required_preferred_account = False
+            if rewritten_file_account_id is not None:
+                request_state.preferred_account_id = rewritten_file_account_id
+                file_required_preferred_account = True
             if request_state.preferred_account_id is None:
-                request_state.preferred_account_id = await self._resolve_file_account_for_responses(payload, headers)
+                resolved_file_account_id = await self._resolve_file_account_for_responses(payload, headers)
+                if resolved_file_account_id is not None:
+                    request_state.preferred_account_id = resolved_file_account_id
+                    file_required_preferred_account = True
             effective_payload = payload
             untrimmed_effective_payload = payload
             proxy_injected_previous_response_id = False
@@ -1019,6 +1030,7 @@ class ProxyService:
                 durable_lookup=None,
                 request_stage=request_state.request_stage,
                 preferred_account_id=request_state.preferred_account_id,
+                fallback_on_preferred_account_unavailable=not file_required_preferred_account,
             )
         if isinstance(session_or_forward, _HTTPBridgeOwnerForward):
             forwarded_any = False
@@ -2111,6 +2123,7 @@ class ProxyService:
                     exclude_account_ids=excluded_account_ids,
                     preferred_account_id=file_preferred_account_id,
                     lease_kind="response_create",
+                    fallback_on_preferred_account_unavailable=file_preferred_account_id is None,
                 )
                 account = selection.account
                 if not account:
@@ -5195,6 +5208,7 @@ class ProxyService:
         durable_lookup: DurableBridgeLookup | None = None,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
+        fallback_on_preferred_account_unavailable: bool = True,
     ) -> "_HTTPBridgeSession": ...
 
     @overload
@@ -5219,6 +5233,7 @@ class ProxyService:
         durable_lookup: DurableBridgeLookup | None = None,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
+        fallback_on_preferred_account_unavailable: bool = True,
     ) -> "_HTTPBridgeSession | _HTTPBridgeOwnerForward": ...
 
     async def _get_or_create_http_bridge_session(
@@ -5242,6 +5257,7 @@ class ProxyService:
         durable_lookup: DurableBridgeLookup | None = None,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
+        fallback_on_preferred_account_unavailable: bool = True,
     ) -> "_HTTPBridgeSession | _HTTPBridgeOwnerForward":
         settings = get_settings()
         api_key_id = api_key.id if api_key is not None else None
@@ -5325,6 +5341,7 @@ class ProxyService:
                                 session=alias_session,
                                 previous_response_id=previous_response_id,
                                 preferred_account_id=preferred_account_id,
+                                require_preferred_account=not fallback_on_preferred_account_unavailable,
                             )
                         ):
                             self._http_bridge_turn_state_index.pop(alias_index_key, None)
@@ -5358,6 +5375,7 @@ class ProxyService:
                                     session=previous_session,
                                     previous_response_id=previous_response_id,
                                     preferred_account_id=preferred_account_id,
+                                    require_preferred_account=not fallback_on_preferred_account_unavailable,
                                 )
                             ):
                                 key = previous_session.key
@@ -5402,6 +5420,7 @@ class ProxyService:
                         session=existing,
                         previous_response_id=previous_response_id,
                         preferred_account_id=preferred_account_id,
+                        require_preferred_account=not fallback_on_preferred_account_unavailable,
                     )
                 ):
                     current_instance = settings.http_responses_session_bridge_instance_id
@@ -6065,6 +6084,7 @@ class ProxyService:
                         session=session,
                         previous_response_id=previous_response_id,
                         preferred_account_id=preferred_account_id,
+                        require_preferred_account=not fallback_on_preferred_account_unavailable,
                     )
                 ):
                     current_instance = settings.http_responses_session_bridge_instance_id
@@ -6099,6 +6119,7 @@ class ProxyService:
                     request_stage=request_stage,
                     preferred_account_id=preferred_account_id,
                     require_preferred_account=require_preferred_account,
+                    fallback_on_preferred_account_unavailable=fallback_on_preferred_account_unavailable,
                 )
                 await self._claim_durable_http_bridge_session(
                     created_session,
@@ -6471,20 +6492,20 @@ class ProxyService:
 
     async def _select_account_with_budget_for_stream(self, deadline: float, **kwargs: Any) -> AccountSelection:
         selector = self._select_account_with_budget
-        if "lease_kind" in kwargs:
+        optional_kwargs = ("lease_kind", "fallback_on_preferred_account_unavailable")
+        if any(name in kwargs for name in optional_kwargs):
             try:
                 signature = inspect.signature(selector)
             except (TypeError, ValueError):
                 signature = None
-            if (
-                signature is not None
-                and "lease_kind" not in signature.parameters
-                and not any(
-                    parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()
-                )
-            ):
+            accepts_var_keyword = signature is not None and any(
+                parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()
+            )
+            if signature is not None and not accepts_var_keyword:
                 kwargs = dict(kwargs)
-                kwargs.pop("lease_kind", None)
+                for name in optional_kwargs:
+                    if name not in signature.parameters:
+                        kwargs.pop(name, None)
         return await selector(deadline, **kwargs)
 
     async def _create_http_bridge_session(
@@ -6499,6 +6520,7 @@ class ProxyService:
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         require_preferred_account: bool = False,
+        fallback_on_preferred_account_unavailable: bool = True,
     ) -> "_HTTPBridgeSession":
         request_state = _WebSocketRequestState(
             request_id=f"http_bridge_connect_{uuid4().hex}",
@@ -6531,6 +6553,7 @@ class ProxyService:
                 "exclude_account_ids": excluded_account_ids,
                 "preferred_account_id": preferred_candidate_id,
                 "lease_kind": "stream",
+                "fallback_on_preferred_account_unavailable": fallback_on_preferred_account_unavailable,
             }
             selection = await self._select_account_with_budget_for_stream(deadline, **select_kwargs)
             selected_account_lease = selection.lease
@@ -9860,6 +9883,7 @@ class ProxyService:
                     surface="http_stream",
                 )
                 require_preferred_account = preferred_account_id is not None
+            file_required_preferred_account = False
             if preferred_account_id is None:
                 # ``input_file.file_id`` references must land on the account
                 # that registered the upload; otherwise upstream rejects the
@@ -9867,9 +9891,14 @@ class ProxyService:
                 # priority -- it returns ``None`` when stronger affinity
                 # signals (prompt_cache_key / session header / turn_state
                 # header) are present, so this never overrides them.
-                preferred_account_id = rewritten_file_account_id
+                if rewritten_file_account_id is not None:
+                    preferred_account_id = rewritten_file_account_id
+                    file_required_preferred_account = True
             if preferred_account_id is None:
-                preferred_account_id = await self._resolve_file_account_for_responses(payload, headers)
+                resolved_file_account_id = await self._resolve_file_account_for_responses(payload, headers)
+                if resolved_file_account_id is not None:
+                    preferred_account_id = resolved_file_account_id
+                    file_required_preferred_account = True
             for attempt in range(max_attempts):
                 remaining_budget = _remaining_budget_seconds(deadline)
                 if remaining_budget <= 0:
@@ -9908,6 +9937,7 @@ class ProxyService:
                         exclude_account_ids=excluded_account_ids,
                         preferred_account_id=preferred_account_id,
                         lease_kind="stream",
+                        fallback_on_preferred_account_unavailable=not file_required_preferred_account,
                     )
                 except ProxyResponseError as exc:
                     error = _parse_openai_error(exc.payload)
@@ -11555,6 +11585,7 @@ class ProxyService:
         exclude_account_ids: Collection[str] | None = None,
         preferred_account_id: str | None = None,
         lease_kind: Literal["response_create", "stream"] | None = None,
+        fallback_on_preferred_account_unavailable: bool = True,
     ) -> AccountSelection:
         remaining_budget = _remaining_budget_seconds(deadline)
         if remaining_budget <= 0:
@@ -11571,11 +11602,20 @@ class ProxyService:
         try:
             with anyio.fail_after(remaining_budget):
                 settings = await get_settings_cache().get()
-                if (
+                preferred_account_selectable = (
                     preferred_account_id is not None
                     and preferred_account_id not in excluded_account_ids_set
                     and (scoped_account_ids is None or preferred_account_id in scoped_account_ids)
-                ):
+                )
+                if preferred_account_id is not None and not preferred_account_selectable:
+                    if not fallback_on_preferred_account_unavailable:
+                        return AccountSelection(
+                            account=None,
+                            error_message="Preferred account is unavailable",
+                            error_code="no_accounts",
+                        )
+                if preferred_account_selectable:
+                    assert preferred_account_id is not None
                     preferred_selection = await self._load_balancer.select_account(
                         sticky_key=sticky_key,
                         sticky_kind=sticky_kind,
@@ -11599,6 +11639,8 @@ class ProxyService:
                             request_stage,
                             preferred_account_id,
                         )
+                        return preferred_selection
+                    if not fallback_on_preferred_account_unavailable:
                         return preferred_selection
                 selection = await self._load_balancer.select_account(
                     sticky_key=sticky_key,
@@ -14625,8 +14667,11 @@ def _http_bridge_session_matches_preferred_account(
     session: "_HTTPBridgeSession",
     previous_response_id: str | None,
     preferred_account_id: str | None,
+    require_preferred_account: bool = False,
 ) -> bool:
-    if previous_response_id is None or preferred_account_id is None:
+    if preferred_account_id is None:
+        return True
+    if previous_response_id is None and not require_preferred_account:
         return True
     return session.account.id == preferred_account_id
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7355,7 +7355,21 @@ class ProxyService:
         retry_same_account_once = not skip_same_account
         preferred_candidate_id: str | None = None if skip_same_account else session.account.id
         selected_account_lease: AccountLease | None = None
+
+        async def release_selected_account_lease() -> None:
+            nonlocal selected_account_lease
+            lease = selected_account_lease
+            selected_account_lease = None
+            if lease is None:
+                return
+            if lease is session.account_lease:
+                session.account_lease = None
+            await self._load_balancer.release_account_lease(lease)
+
         while True:
+            reuse_current_account_lease = (
+                preferred_candidate_id == session.account.id and session.account_lease is not None
+            )
             selection = await self._select_account_with_budget_for_stream(
                 deadline,
                 request_id=request_state.request_log_id or request_state.request_id,
@@ -7371,13 +7385,15 @@ class ProxyService:
                 model=session.request_model,
                 exclude_account_ids=excluded_account_ids,
                 preferred_account_id=preferred_candidate_id,
-                lease_kind="stream",
+                lease_kind=None if reuse_current_account_lease else "stream",
+                fallback_on_preferred_account_unavailable=not reuse_current_account_lease,
             )
-            selected_account_lease = selection.lease
             account = selection.account
             if account is None:
-                await self._load_balancer.release_account_lease(selected_account_lease)
-                selected_account_lease = None
+                await release_selected_account_lease()
+                if reuse_current_account_lease and _remaining_budget_seconds(deadline) > 0:
+                    preferred_candidate_id = None
+                    continue
                 _record_same_account_takeover(
                     preferred_account_id=session.account.id,
                     selected_account_id=None,
@@ -7391,6 +7407,11 @@ class ProxyService:
                         error_type="rate_limit_error" if status_code == 429 else "server_error",
                     ),
                 )
+            selected_account_lease = (
+                session.account_lease
+                if reuse_current_account_lease and account.id == session.account.id
+                else selection.lease
+            )
             selected_is_preferred = account.id == session.account.id
             try:
                 account = await self._ensure_fresh_with_budget(
@@ -7413,8 +7434,7 @@ class ProxyService:
                 break
             except ProxyResponseError as exc:
                 if exc.status_code != 401 or _remaining_budget_seconds(deadline) <= 0:
-                    await self._load_balancer.release_account_lease(selected_account_lease)
-                    selected_account_lease = None
+                    await release_selected_account_lease()
                     raise
                 try:
                     account = await self._ensure_fresh_with_budget(
@@ -7438,22 +7458,19 @@ class ProxyService:
                     break
                 except ProxyResponseError as retry_exc:
                     if retry_exc.status_code != 401:
-                        await self._load_balancer.release_account_lease(selected_account_lease)
-                        selected_account_lease = None
+                        await release_selected_account_lease()
                         raise
                     await self._handle_proxy_error(account, retry_exc)
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
-                    await self._load_balancer.release_account_lease(selected_account_lease)
-                    selected_account_lease = None
+                    await release_selected_account_lease()
                     continue
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
                         await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
-                    await self._load_balancer.release_account_lease(selected_account_lease)
-                    selected_account_lease = None
+                    await release_selected_account_lease()
                     continue
             except RefreshError as exc:
                 if exc.is_permanent:
@@ -7461,33 +7478,28 @@ class ProxyService:
                 if selected_is_preferred and _remaining_budget_seconds(deadline) > 0:
                     if retry_same_account_once and not exc.is_permanent:
                         retry_same_account_once = False
-                        await self._load_balancer.release_account_lease(selected_account_lease)
-                        selected_account_lease = None
+                        await release_selected_account_lease()
                         continue
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
-                    await self._load_balancer.release_account_lease(selected_account_lease)
-                    selected_account_lease = None
+                    await release_selected_account_lease()
                     continue
-                await self._load_balancer.release_account_lease(selected_account_lease)
-                selected_account_lease = None
+                await release_selected_account_lease()
                 raise
             except (aiohttp.ClientError, asyncio.TimeoutError):
                 if selected_is_preferred and _remaining_budget_seconds(deadline) > 0:
                     if retry_same_account_once:
                         retry_same_account_once = False
-                        await self._load_balancer.release_account_lease(selected_account_lease)
-                        selected_account_lease = None
+                        await release_selected_account_lease()
                         continue
                     excluded_account_ids.add(account.id)
                     preferred_candidate_id = None
-                    await self._load_balancer.release_account_lease(selected_account_lease)
-                    selected_account_lease = None
+                    await release_selected_account_lease()
                     continue
-                await self._load_balancer.release_account_lease(selected_account_lease)
-                selected_account_lease = None
+                await release_selected_account_lease()
                 raise
-        await self._load_balancer.release_account_lease(session.account_lease)
+        if selected_account_lease is not session.account_lease:
+            await self._load_balancer.release_account_lease(session.account_lease)
         session.account_lease = selected_account_lease
         session.account = account
         session.headers = connect_headers

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3590,7 +3590,7 @@ class ProxyService:
                             error_type="server_error",
                             downstream_activity=downstream_activity,
                         )
-                        _release_websocket_response_create_gate(request_state, response_create_gate)
+                        await _release_websocket_response_create_gate(request_state, response_create_gate)
                         continue
                     payload = _parse_websocket_payload(text_data)
                     if payload is None:
@@ -3604,7 +3604,7 @@ class ProxyService:
                             error_type="server_error",
                             downstream_activity=downstream_activity,
                         )
-                        _release_websocket_response_create_gate(request_state, response_create_gate)
+                        await _release_websocket_response_create_gate(request_state, response_create_gate)
                         continue
                     async with pending_lock:
                         pending_requests.append(request_state)
@@ -3903,7 +3903,7 @@ class ProxyService:
                             error_param=error_param,
                             downstream_activity=downstream_activity,
                         )
-                        _release_websocket_response_create_gate(request_state, response_create_gate)
+                        await _release_websocket_response_create_gate(request_state, response_create_gate)
                         continue
                     except asyncio.CancelledError:
                         await self._release_websocket_request_state_reservation(request_state)
@@ -3911,7 +3911,7 @@ class ProxyService:
                             async with pending_lock:
                                 if request_state in pending_requests:
                                     pending_requests.remove(request_state)
-                        _release_websocket_response_create_gate(request_state, response_create_gate)
+                        await _release_websocket_response_create_gate(request_state, response_create_gate)
                         raise
                     except Exception:
                         await self._release_websocket_request_state_reservation(request_state)
@@ -3919,7 +3919,7 @@ class ProxyService:
                             async with pending_lock:
                                 if request_state in pending_requests:
                                     pending_requests.remove(request_state)
-                        _release_websocket_response_create_gate(request_state, response_create_gate)
+                        await _release_websocket_response_create_gate(request_state, response_create_gate)
                         raise
 
                 if upstream is None:
@@ -3967,7 +3967,7 @@ class ProxyService:
                             async with pending_lock:
                                 if request_state in pending_requests:
                                     pending_requests.remove(request_state)
-                            _release_websocket_response_create_gate(request_state, response_create_gate)
+                            await _release_websocket_response_create_gate(request_state, response_create_gate)
                         continue
                     account_lease = request_state.websocket_stream_lease
                     request_state.websocket_stream_lease = None
@@ -4025,7 +4025,7 @@ class ProxyService:
                             async with pending_lock:
                                 if request_state in pending_requests:
                                     pending_requests.remove(request_state)
-                            _release_websocket_response_create_gate(request_state, response_create_gate)
+                            await _release_websocket_response_create_gate(request_state, response_create_gate)
                         await self._emit_websocket_terminal_error(
                             websocket,
                             client_send_lock=client_send_lock,
@@ -4102,7 +4102,7 @@ class ProxyService:
             if replay_request_state is not None:
                 await self._release_websocket_request_state_reservation(replay_request_state)
                 replay_request_state.api_key_reservation = None
-                _release_websocket_response_create_gate(replay_request_state, response_create_gate)
+                await _release_websocket_response_create_gate(replay_request_state, response_create_gate)
             client_disconnected = downstream_activity.disconnected
             await self._fail_pending_websocket_requests(
                 account=None if client_disconnected else account,
@@ -4604,7 +4604,7 @@ class ProxyService:
             )
         except BaseException:
             await self._release_request_state_account_response_create_lease(request_state)
-            _release_websocket_response_create_gate(request_state, response_create_gate)
+            await _release_websocket_response_create_gate(request_state, response_create_gate)
             raise
 
     async def _release_request_state_account_response_create_lease(
@@ -7079,7 +7079,10 @@ class ProxyService:
                                     session.pending_requests.remove(warmup_state)
                             self._cancel_request_state_api_key_reservation_heartbeat(warmup_state)
                             if gate_acquired:
-                                _release_websocket_response_create_gate(warmup_state, session.response_create_gate)
+                                await _release_websocket_response_create_gate(
+                                    warmup_state,
+                                    session.response_create_gate,
+                                )
                         return
                     if event_block is None:
                         break
@@ -7133,7 +7136,7 @@ class ProxyService:
             session.queued_request_count = max(0, session.queued_request_count - 1)
         self._cancel_request_state_api_key_reservation_heartbeat(request_state)
         if gate_acquired:
-            _release_websocket_response_create_gate(request_state, session.response_create_gate)
+            await _release_websocket_response_create_gate(request_state, session.response_create_gate)
 
     async def _detach_http_bridge_request(
         self,
@@ -7156,7 +7159,7 @@ class ProxyService:
         # _stream_http_bridge_session_events, the terminal event has
         # already been delivered via _pop_terminal_websocket_request_state.
         # A late-arriving event on a nulled queue is a no-op.
-        _release_websocket_response_create_gate(request_state, session.response_create_gate)
+        await _release_websocket_response_create_gate(request_state, session.response_create_gate)
         if not detached:
             return False
         self._cancel_request_state_api_key_reservation_heartbeat(request_state)
@@ -8005,7 +8008,7 @@ class ProxyService:
             )
 
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
-            _release_websocket_response_create_gate(created_request_state, session.response_create_gate)
+            await _release_websocket_response_create_gate(created_request_state, session.response_create_gate)
 
         if response_id is not None and matched_request_state is not None and event_type == "response.completed":
             await self._register_http_bridge_previous_response_id(
@@ -8720,7 +8723,7 @@ class ProxyService:
                 request_state = None
 
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
-            _release_websocket_response_create_gate(created_request_state, response_create_gate)
+            await _release_websocket_response_create_gate(created_request_state, response_create_gate)
 
         if len(grouped_previous_response_request_states) > 1:
             upstream_control.reconnect_requested = True
@@ -9077,7 +9080,7 @@ class ProxyService:
         response_service_tier = request_state.service_tier
 
         if request_state.draining_until_terminal:
-            _release_websocket_response_create_gate(request_state, response_create_gate)
+            await _release_websocket_response_create_gate(request_state, response_create_gate)
             await self._release_websocket_reservation(request_state.api_key_reservation)
             request_state.api_key_reservation = None
             return
@@ -9141,7 +9144,7 @@ class ProxyService:
         ):
             settlement.account_health_error = False
         self._cancel_request_state_api_key_reservation_heartbeat(request_state)
-        _release_websocket_response_create_gate(request_state, response_create_gate)
+        await _release_websocket_response_create_gate(request_state, response_create_gate)
         await self._settle_stream_api_key_usage(
             api_key,
             request_state.api_key_reservation,
@@ -9256,7 +9259,7 @@ class ProxyService:
         )
         response_create_gate = request_state.response_create_gate
         if response_create_gate is not None:
-            _release_websocket_response_create_gate(request_state, response_create_gate)
+            await _release_websocket_response_create_gate(request_state, response_create_gate)
         async with client_send_lock:
             await websocket.send_text(
                 _serialize_websocket_error_event(_wrapped_websocket_error_event(status_code, payload))
@@ -9362,7 +9365,7 @@ class ProxyService:
                     error_message=request_error_message,
                 )
             if response_create_gate is not None:
-                _release_websocket_response_create_gate(request_state, response_create_gate)
+                await _release_websocket_response_create_gate(request_state, response_create_gate)
             if request_state.event_queue is not None:
                 await request_state.event_queue.put(
                     format_sse_event(
@@ -9437,7 +9440,7 @@ class ProxyService:
         )
         response_create_gate = request_state.response_create_gate
         if response_create_gate is not None:
-            _release_websocket_response_create_gate(request_state, response_create_gate)
+            await _release_websocket_response_create_gate(request_state, response_create_gate)
         try:
             await self._send_downstream_websocket_text(
                 websocket,
@@ -13683,7 +13686,7 @@ def _build_stream_incomplete_terminal_event_for_request(
     return downstream_text, event_block, event, payload, event_type
 
 
-def _release_websocket_response_create_gate(
+async def _release_websocket_response_create_gate(
     request_state: _WebSocketRequestState,
     response_create_gate: asyncio.Semaphore,
 ) -> None:
@@ -13695,7 +13698,7 @@ def _release_websocket_response_create_gate(
         request_state.response_create_admission.release()
         request_state.response_create_admission = None
     if account_response_create_lease is not None and account_response_create_release is not None:
-        asyncio.create_task(account_response_create_release(account_response_create_lease))
+        await account_response_create_release(account_response_create_lease)
     request_state.awaiting_response_created = False
     request_state.response_create_gate = None
     if not request_state.response_create_gate_acquired:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -131,6 +131,9 @@ from app.db.models import (
 from app.db.session import SessionLocal
 from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManager
 from app.modules.api_keys.service import (
+    API_KEY_USAGE_RESERVATION_DEFAULT_INPUT_TOKENS,
+    API_KEY_USAGE_RESERVATION_DEFAULT_OUTPUT_TOKENS,
+    API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET,
     ApiKeyData,
     ApiKeyInvalidError,
     ApiKeyRateLimitExceededError,
@@ -492,6 +495,26 @@ def _response_create_text_with_size_guard(
             )
             return None
     return text_data
+
+
+def _estimated_lease_tokens_from_request_usage_budget(budget: ApiKeyRequestUsageBudget | None) -> float:
+    if budget is None:
+        return 0.0
+    input_tokens = _bounded_lease_token_estimate(
+        budget.input_tokens,
+        default=API_KEY_USAGE_RESERVATION_DEFAULT_INPUT_TOKENS,
+    )
+    output_tokens = _bounded_lease_token_estimate(
+        budget.output_tokens,
+        default=API_KEY_USAGE_RESERVATION_DEFAULT_OUTPUT_TOKENS,
+    )
+    return float(input_tokens + output_tokens)
+
+
+def _bounded_lease_token_estimate(value: int | None, *, default: int) -> int:
+    if value is None:
+        return default
+    return max(0, min(value, API_KEY_USAGE_RESERVATION_MAX_TOKEN_BUDGET))
 
 
 class ProxyService:
@@ -958,6 +981,7 @@ class ProxyService:
                 request_stage=request_state.request_stage,
                 preferred_account_id=request_state.preferred_account_id,
                 fallback_on_preferred_account_unavailable=not file_required_preferred_account,
+                request_usage_budget=request_state.request_usage_budget,
             )
         except ProxyResponseError as exc:
             if not (
@@ -1031,6 +1055,7 @@ class ProxyService:
                 request_stage=request_state.request_stage,
                 preferred_account_id=request_state.preferred_account_id,
                 fallback_on_preferred_account_unavailable=not file_required_preferred_account,
+                request_usage_budget=request_state.request_usage_budget,
             )
         if isinstance(session_or_forward, _HTTPBridgeOwnerForward):
             forwarded_any = False
@@ -1115,6 +1140,7 @@ class ProxyService:
                     durable_lookup=durable_lookup,
                     request_stage="reattach",
                     preferred_account_id=request_state.preferred_account_id,
+                    request_usage_budget=request_state.request_usage_budget,
                 )
                 _record_bridge_reattach(
                     path="owner_forward_fail"
@@ -1392,6 +1418,7 @@ class ProxyService:
                     durable_lookup=None,
                     request_stage=request_state.request_stage,
                     preferred_account_id=None,
+                    request_usage_budget=request_state.request_usage_budget,
                 )
                 retry_events: AsyncGenerator[str, None] = self._stream_http_bridge_session_events(
                     reroute_session,
@@ -1532,6 +1559,7 @@ class ProxyService:
                 fallback_on_preferred_account_unavailable=not (
                     file_required_preferred_account and retry_preferred_account_id is not None
                 ),
+                request_usage_budget=estimate_api_key_request_usage(retry_payload),
             )
             _record_bridge_reattach(path=recovery_path, outcome="success")
 
@@ -2113,7 +2141,9 @@ class ProxyService:
 
             last_exc: ProxyResponseError | None = None
             excluded_account_ids: set[str] = set()
-            estimated_lease_tokens = float(estimate_api_key_request_usage(payload).input_tokens or 0)
+            estimated_lease_tokens = _estimated_lease_tokens_from_request_usage_budget(
+                estimate_api_key_request_usage(payload)
+            )
             for _account_attempt in range(_COMPACT_MAX_ACCOUNT_ATTEMPTS):
                 selection = await self._select_account_with_budget(
                     deadline,
@@ -4413,6 +4443,7 @@ class ProxyService:
             event_queue=asyncio.Queue() if attach_event_queue else None,
             transport=transport,
             api_key=api_key,
+            request_usage_budget=estimate_api_key_request_usage(payload),
             previous_response_id=payload.previous_response_id,
             session_id=_normalize_session_id(session_id),
             input_item_count=input_item_count,
@@ -4766,7 +4797,9 @@ class ProxyService:
                 exclude_account_ids=exclude_account_ids,
                 preferred_account_id=preferred_account_id,
                 lease_kind="stream",
-                estimated_lease_tokens=float(len((request_state.request_text or "").encode("utf-8"))),
+                estimated_lease_tokens=_estimated_lease_tokens_from_request_usage_budget(
+                    request_state.request_usage_budget
+                ),
                 fallback_on_preferred_account_unavailable=not require_preferred_account,
             )
         except ProxyResponseError as exc:
@@ -5238,6 +5271,7 @@ class ProxyService:
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         fallback_on_preferred_account_unavailable: bool = True,
+        request_usage_budget: ApiKeyRequestUsageBudget | None = None,
     ) -> "_HTTPBridgeSession": ...
 
     @overload
@@ -5263,6 +5297,7 @@ class ProxyService:
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         fallback_on_preferred_account_unavailable: bool = True,
+        request_usage_budget: ApiKeyRequestUsageBudget | None = None,
     ) -> "_HTTPBridgeSession | _HTTPBridgeOwnerForward": ...
 
     async def _get_or_create_http_bridge_session(
@@ -5287,6 +5322,7 @@ class ProxyService:
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         fallback_on_preferred_account_unavailable: bool = True,
+        request_usage_budget: ApiKeyRequestUsageBudget | None = None,
     ) -> "_HTTPBridgeSession | _HTTPBridgeOwnerForward":
         settings = get_settings()
         api_key_id = api_key.id if api_key is not None else None
@@ -6140,18 +6176,34 @@ class ProxyService:
                 preferred_account_id is not None and not fallback_on_preferred_account_unavailable
             )
             try:
-                created_session = await self._create_http_bridge_session(
-                    key,
-                    headers=headers,
-                    affinity=affinity,
-                    api_key=api_key,
-                    request_model=request_model,
-                    idle_ttl_seconds=effective_idle_ttl_seconds,
-                    request_stage=request_stage,
-                    preferred_account_id=preferred_account_id,
-                    require_preferred_account=require_preferred_account,
-                    fallback_on_preferred_account_unavailable=fallback_on_preferred_account_unavailable,
+                create_session = self._create_http_bridge_session
+                create_kwargs: dict[str, Any] = {
+                    "headers": headers,
+                    "affinity": affinity,
+                    "api_key": api_key,
+                    "request_model": request_model,
+                    "idle_ttl_seconds": effective_idle_ttl_seconds,
+                    "request_stage": request_stage,
+                    "preferred_account_id": preferred_account_id,
+                    "require_preferred_account": require_preferred_account,
+                    "fallback_on_preferred_account_unavailable": fallback_on_preferred_account_unavailable,
+                    "request_usage_budget": request_usage_budget,
+                }
+                try:
+                    create_signature = inspect.signature(create_session)
+                except (TypeError, ValueError):
+                    create_signature = None
+                create_accepts_var_keyword = create_signature is not None and any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in create_signature.parameters.values()
                 )
+                if (
+                    create_signature is not None
+                    and not create_accepts_var_keyword
+                    and "request_usage_budget" not in create_signature.parameters
+                ):
+                    create_kwargs.pop("request_usage_budget", None)
+                created_session = await create_session(key, **create_kwargs)
                 await self._claim_durable_http_bridge_session(
                     created_session,
                     allow_takeover=force_durable_takeover or _http_bridge_allow_durable_takeover(durable_lookup),
@@ -6552,6 +6604,7 @@ class ProxyService:
         preferred_account_id: str | None = None,
         require_preferred_account: bool = False,
         fallback_on_preferred_account_unavailable: bool = True,
+        request_usage_budget: ApiKeyRequestUsageBudget | None = None,
     ) -> "_HTTPBridgeSession":
         request_state = _WebSocketRequestState(
             request_id=f"http_bridge_connect_{uuid4().hex}",
@@ -6584,7 +6637,7 @@ class ProxyService:
                 "exclude_account_ids": excluded_account_ids,
                 "preferred_account_id": preferred_candidate_id,
                 "lease_kind": "stream",
-                "estimated_lease_tokens": 0.0,
+                "estimated_lease_tokens": _estimated_lease_tokens_from_request_usage_budget(request_usage_budget),
                 "fallback_on_preferred_account_unavailable": fallback_on_preferred_account_unavailable,
             }
             selection = await self._select_account_with_budget_for_stream(deadline, **select_kwargs)
@@ -7418,6 +7471,9 @@ class ProxyService:
                 exclude_account_ids=excluded_account_ids,
                 preferred_account_id=preferred_candidate_id,
                 lease_kind=None if reuse_current_account_lease else "stream",
+                estimated_lease_tokens=_estimated_lease_tokens_from_request_usage_budget(
+                    request_state.request_usage_budget
+                ),
                 fallback_on_preferred_account_unavailable=not reuse_current_account_lease,
             )
             account = selection.account
@@ -9898,7 +9954,6 @@ class ProxyService:
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)
-        estimated_lease_tokens = float(estimate_api_key_request_usage(payload).input_tokens or 0)
         max_attempts = _STREAM_MAX_ACCOUNT_ATTEMPTS
         settled = False
         any_attempt_logged = False
@@ -9909,6 +9964,9 @@ class ProxyService:
         require_preferred_account = False
         last_retryable_stream_error: _RetryableStreamError | None = None
         account_leases: list[AccountLease] = []
+        estimated_lease_tokens = _estimated_lease_tokens_from_request_usage_budget(
+            estimate_api_key_request_usage(payload)
+        )
 
         async def _release_tracked_stream_lease(lease: AccountLease | None) -> None:
             if lease is None:
@@ -12047,6 +12105,7 @@ class _WebSocketRequestState:
     event_queue: asyncio.Queue[str | None] | None = None
     transport: str = _REQUEST_TRANSPORT_WEBSOCKET
     api_key: ApiKeyData | None = None
+    request_usage_budget: ApiKeyRequestUsageBudget | None = None
     request_text: str | None = None
     replay_count: int = 0
     auth_replay_count: int = 0

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2113,6 +2113,7 @@ class ProxyService:
 
             last_exc: ProxyResponseError | None = None
             excluded_account_ids: set[str] = set()
+            estimated_lease_tokens = float(estimate_api_key_request_usage(payload).input_tokens or 0)
             for _account_attempt in range(_COMPACT_MAX_ACCOUNT_ATTEMPTS):
                 selection = await self._select_account_with_budget(
                     deadline,
@@ -2129,6 +2130,7 @@ class ProxyService:
                     exclude_account_ids=excluded_account_ids,
                     preferred_account_id=file_preferred_account_id,
                     lease_kind="response_create",
+                    estimated_lease_tokens=estimated_lease_tokens,
                     fallback_on_preferred_account_unavailable=file_preferred_account_id is None,
                 )
                 account = selection.account
@@ -4764,6 +4766,7 @@ class ProxyService:
                 exclude_account_ids=exclude_account_ids,
                 preferred_account_id=preferred_account_id,
                 lease_kind="stream",
+                estimated_lease_tokens=float(len((request_state.request_text or "").encode("utf-8"))),
                 fallback_on_preferred_account_unavailable=not require_preferred_account,
             )
         except ProxyResponseError as exc:
@@ -6520,7 +6523,7 @@ class ProxyService:
 
     async def _select_account_with_budget_for_stream(self, deadline: float, **kwargs: Any) -> AccountSelection:
         selector = self._select_account_with_budget
-        optional_kwargs = ("lease_kind", "fallback_on_preferred_account_unavailable")
+        optional_kwargs = ("lease_kind", "estimated_lease_tokens", "fallback_on_preferred_account_unavailable")
         if any(name in kwargs for name in optional_kwargs):
             try:
                 signature = inspect.signature(selector)
@@ -6581,6 +6584,7 @@ class ProxyService:
                 "exclude_account_ids": excluded_account_ids,
                 "preferred_account_id": preferred_candidate_id,
                 "lease_kind": "stream",
+                "estimated_lease_tokens": 0.0,
                 "fallback_on_preferred_account_unavailable": fallback_on_preferred_account_unavailable,
             }
             selection = await self._select_account_with_budget_for_stream(deadline, **select_kwargs)
@@ -9894,6 +9898,7 @@ class ProxyService:
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)
+        estimated_lease_tokens = float(estimate_api_key_request_usage(payload).input_tokens or 0)
         max_attempts = _STREAM_MAX_ACCOUNT_ATTEMPTS
         settled = False
         any_attempt_logged = False
@@ -10014,6 +10019,7 @@ class ProxyService:
                         exclude_account_ids=excluded_account_ids,
                         preferred_account_id=preferred_account_id,
                         lease_kind="stream",
+                        estimated_lease_tokens=estimated_lease_tokens,
                         fallback_on_preferred_account_unavailable=not file_required_preferred_account,
                     )
                 except ProxyResponseError as exc:
@@ -11662,6 +11668,7 @@ class ProxyService:
         exclude_account_ids: Collection[str] | None = None,
         preferred_account_id: str | None = None,
         lease_kind: Literal["response_create", "stream"] | None = None,
+        estimated_lease_tokens: float = 0.0,
         fallback_on_preferred_account_unavailable: bool = True,
     ) -> AccountSelection:
         remaining_budget = _remaining_budget_seconds(deadline)
@@ -11707,6 +11714,7 @@ class ProxyService:
                         account_ids={preferred_account_id},
                         budget_threshold_pct=settings.sticky_reallocation_budget_threshold_pct,
                         lease_kind=lease_kind,
+                        estimated_lease_tokens=estimated_lease_tokens,
                     )
                     if preferred_selection.account is not None:
                         logger.info(
@@ -11734,6 +11742,7 @@ class ProxyService:
                     exclude_account_ids=excluded_account_ids_set,
                     budget_threshold_pct=settings.sticky_reallocation_budget_threshold_pct,
                     lease_kind=lease_kind,
+                    estimated_lease_tokens=estimated_lease_tokens,
                 )
                 if selection.account is not None and selection.account.id in excluded_account_ids_set:
                     return AccountSelection(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9990,6 +9990,10 @@ class ProxyService:
                     surface="http_stream",
                 )
                 require_preferred_account = preferred_account_id is not None
+                # `previous_response_id` is a stored-object continuation, so it
+                # remains hard owner-bound even when the request also carries a
+                # soft prompt-cache affinity key. A different account may have a
+                # warmer cache, but it cannot safely resolve the stored response.
                 if preferred_account_id is None:
                     selection_inputs = await self._load_balancer._load_selection_inputs(
                         model=payload.model,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9925,35 +9925,41 @@ class ProxyService:
                 )
                 require_preferred_account = preferred_account_id is not None
                 if preferred_account_id is None:
-                    message = "Previous response owner account is unavailable; retry later."
-                    _record_continuity_fail_closed(
-                        surface="http_stream",
-                        reason="owner_account_unavailable",
-                        previous_response_id=payload.previous_response_id,
-                        session_id=previous_response_lookup_session_id,
-                        upstream_error_code="owner_lookup_miss",
-                    )
-                    event = response_failed_event(
-                        "previous_response_owner_unavailable",
-                        message,
-                        response_id=request_id,
-                    )
-                    yield format_sse_event(event)
-                    await self._write_request_log(
-                        account_id=None,
-                        api_key=api_key,
-                        request_id=request_id,
+                    selection_inputs = await self._load_balancer._load_selection_inputs(
                         model=payload.model,
-                        latency_ms=int((time.monotonic() - start) * 1000),
-                        status="error",
-                        error_code="previous_response_owner_unavailable",
-                        error_message=message,
-                        reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
-                        transport=request_transport,
-                        service_tier=payload.service_tier,
-                        requested_service_tier=payload.service_tier,
+                        additional_limit_name=None,
+                        account_ids=None,
                     )
-                    return
+                    if len(selection_inputs.accounts) != 1:
+                        message = "Previous response owner account is unavailable; retry later."
+                        _record_continuity_fail_closed(
+                            surface="http_stream",
+                            reason="owner_account_unavailable",
+                            previous_response_id=payload.previous_response_id,
+                            session_id=previous_response_lookup_session_id,
+                            upstream_error_code="owner_lookup_miss",
+                        )
+                        event = response_failed_event(
+                            "previous_response_owner_unavailable",
+                            message,
+                            response_id=request_id,
+                        )
+                        yield format_sse_event(event)
+                        await self._write_request_log(
+                            account_id=None,
+                            api_key=api_key,
+                            request_id=request_id,
+                            model=payload.model,
+                            latency_ms=int((time.monotonic() - start) * 1000),
+                            status="error",
+                            error_code="previous_response_owner_unavailable",
+                            error_message=message,
+                            reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
+                            transport=request_transport,
+                            service_tier=payload.service_tier,
+                            requested_service_tier=payload.service_tier,
+                        )
+                        return
             file_required_preferred_account = False
             if preferred_account_id is None:
                 # ``input_file.file_id`` references must land on the account

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -9916,13 +9916,44 @@ class ProxyService:
 
         try:
             if payload.previous_response_id is not None:
+                previous_response_lookup_session_id = _owner_lookup_session_id_from_headers(headers)
                 preferred_account_id = await self._resolve_websocket_previous_response_owner(
                     previous_response_id=payload.previous_response_id,
                     api_key=api_key,
-                    session_id=_owner_lookup_session_id_from_headers(headers),
+                    session_id=previous_response_lookup_session_id,
                     surface="http_stream",
                 )
                 require_preferred_account = preferred_account_id is not None
+                if preferred_account_id is None:
+                    message = "Previous response owner account is unavailable; retry later."
+                    _record_continuity_fail_closed(
+                        surface="http_stream",
+                        reason="owner_account_unavailable",
+                        previous_response_id=payload.previous_response_id,
+                        session_id=previous_response_lookup_session_id,
+                        upstream_error_code="owner_lookup_miss",
+                    )
+                    event = response_failed_event(
+                        "previous_response_owner_unavailable",
+                        message,
+                        response_id=request_id,
+                    )
+                    yield format_sse_event(event)
+                    await self._write_request_log(
+                        account_id=None,
+                        api_key=api_key,
+                        request_id=request_id,
+                        model=payload.model,
+                        latency_ms=int((time.monotonic() - start) * 1000),
+                        status="error",
+                        error_code="previous_response_owner_unavailable",
+                        error_message=message,
+                        reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
+                        transport=request_transport,
+                        service_tier=payload.service_tier,
+                        requested_service_tier=payload.service_tier,
+                    )
+                    return
             file_required_preferred_account = False
             if preferred_account_id is None:
                 # ``input_file.file_id`` references must land on the account

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1526,6 +1526,9 @@ class ProxyService:
                 durable_lookup=durable_lookup,
                 request_stage=retry_request_stage,
                 preferred_account_id=retry_preferred_account_id,
+                fallback_on_preferred_account_unavailable=not (
+                    file_required_preferred_account and retry_preferred_account_id is not None
+                ),
             )
             _record_bridge_reattach(path=recovery_path, outcome="success")
 
@@ -4294,10 +4297,12 @@ class ProxyService:
         # never overrides existing routing.
         if request_state.preferred_account_id is None:
             request_state.preferred_account_id = rewritten_file_account_id
+            request_state.file_required_preferred_account = request_state.preferred_account_id is not None
         if request_state.preferred_account_id is None:
             request_state.preferred_account_id = await self._resolve_file_account_for_responses(
                 responses_payload, headers
             )
+            request_state.file_required_preferred_account = request_state.preferred_account_id is not None
 
         # Direct WebSocket retry-safety classification.
         #
@@ -4603,7 +4608,7 @@ class ProxyService:
             preferred_account_id = forced_refresh_account_id or request_state.preferred_account_id
             require_preferred_account = (
                 request_state.previous_response_id is not None and request_state.preferred_account_id is not None
-            )
+            ) or request_state.file_required_preferred_account
             try:
                 account = await self._select_websocket_connect_account(
                     deadline,
@@ -4756,6 +4761,7 @@ class ProxyService:
                 exclude_account_ids=exclude_account_ids,
                 preferred_account_id=preferred_account_id,
                 lease_kind="stream",
+                fallback_on_preferred_account_unavailable=not require_preferred_account,
             )
         except ProxyResponseError as exc:
             if _is_proxy_budget_exhausted_error(exc):
@@ -4809,6 +4815,23 @@ class ProxyService:
         error_code = selection.error_code or "no_accounts"
         error_message = selection.error_message or "No active accounts available"
         if require_preferred_account and preferred_account_id is not None:
+            if request_state.file_required_preferred_account and _is_local_account_cap_code(error_code):
+                await self._emit_websocket_connect_failure(
+                    websocket,
+                    client_send_lock=client_send_lock,
+                    account_id=preferred_account_id,
+                    api_key=api_key,
+                    request_state=request_state,
+                    status_code=429,
+                    payload=openai_error(
+                        error_code,
+                        error_message,
+                        error_type="rate_limit_error",
+                    ),
+                    error_code=error_code,
+                    error_message=error_message,
+                )
+                return None
             message = "Previous response owner account is unavailable; retry later."
             _record_continuity_fail_closed(
                 surface="websocket_connect",
@@ -6107,7 +6130,9 @@ class ProxyService:
 
             created_session: _HTTPBridgeSession | None = None
             session_registered = False
-            require_preferred_account = previous_response_id is not None and preferred_account_id is not None
+            require_preferred_account = (previous_response_id is not None and preferred_account_id is not None) or (
+                preferred_account_id is not None and not fallback_on_preferred_account_unavailable
+            )
             try:
                 created_session = await self._create_http_bridge_session(
                     key,
@@ -11997,6 +12022,7 @@ class _WebSocketRequestState:
     fresh_upstream_request_is_retry_safe: bool = False
     request_stage: str = "first_turn"
     preferred_account_id: str | None = None
+    file_required_preferred_account: bool = False
     error_code_override: str | None = None
     error_message_override: str | None = None
     error_type_override: str | None = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import gzip
+import inspect
 import json
 import logging
 import math
@@ -6263,7 +6264,7 @@ class ProxyService:
                 )
             except Exception:
                 logger.warning("Failed to release durable HTTP bridge session", exc_info=True)
-        await self._load_balancer.release_account_lease(session.account_lease)
+        await self._load_balancer.release_account_lease(getattr(session, "account_lease", None))
         session.account_lease = None
         _log_http_bridge_event(
             "close",
@@ -6467,6 +6468,24 @@ class ProxyService:
         except Exception:
             logger.warning("Failed to renew durable HTTP bridge session lease", exc_info=True)
 
+    async def _select_account_with_budget_for_stream(self, deadline: float, **kwargs: Any) -> AccountSelection:
+        selector = self._select_account_with_budget
+        if "lease_kind" in kwargs:
+            try:
+                signature = inspect.signature(selector)
+            except (TypeError, ValueError):
+                signature = None
+            if (
+                signature is not None
+                and "lease_kind" not in signature.parameters
+                and not any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in signature.parameters.values()
+                )
+            ):
+                kwargs = dict(kwargs)
+                kwargs.pop("lease_kind", None)
+        return await selector(deadline, **kwargs)
+
     async def _create_http_bridge_session(
         self,
         key: "_HTTPBridgeSessionKey",
@@ -6496,23 +6515,23 @@ class ProxyService:
         preferred_candidate_id = preferred_account_id
         selected_account_lease: AccountLease | None = None
         while True:
-            selection = await self._select_account_with_budget(
-                deadline,
-                request_id=request_state.request_log_id or request_state.request_id,
-                kind="http_bridge",
-                request_stage=request_stage,
-                api_key=api_key,
-                sticky_key=affinity.key,
-                sticky_kind=affinity.kind,
-                reallocate_sticky=affinity.reallocate_sticky,
-                sticky_max_age_seconds=affinity.max_age_seconds,
-                prefer_earlier_reset_accounts=settings.prefer_earlier_reset_accounts,
-                routing_strategy=_routing_strategy(settings),
-                model=request_model,
-                exclude_account_ids=excluded_account_ids,
-                preferred_account_id=preferred_candidate_id,
-                lease_kind="stream",
-            )
+            select_kwargs = {
+                "request_id": request_state.request_log_id or request_state.request_id,
+                "kind": "http_bridge",
+                "request_stage": request_stage,
+                "api_key": api_key,
+                "sticky_key": affinity.key,
+                "sticky_kind": affinity.kind,
+                "reallocate_sticky": affinity.reallocate_sticky,
+                "sticky_max_age_seconds": affinity.max_age_seconds,
+                "prefer_earlier_reset_accounts": settings.prefer_earlier_reset_accounts,
+                "routing_strategy": _routing_strategy(settings),
+                "model": request_model,
+                "exclude_account_ids": excluded_account_ids,
+                "preferred_account_id": preferred_candidate_id,
+                "lease_kind": "stream",
+            }
+            selection = await self._select_account_with_budget_for_stream(deadline, **select_kwargs)
             selected_account_lease = selection.lease
             account = selection.account
             if account is None:
@@ -7311,7 +7330,7 @@ class ProxyService:
         preferred_candidate_id: str | None = None if skip_same_account else session.account.id
         selected_account_lease: AccountLease | None = None
         while True:
-            selection = await self._select_account_with_budget(
+            selection = await self._select_account_with_budget_for_stream(
                 deadline,
                 request_id=request_state.request_log_id or request_state.request_id,
                 kind="http_bridge",
@@ -13157,7 +13176,7 @@ def _rewrite_previous_response_stream_error(
             upstream_error_code=normalized_code,
         )
         return (
-            "upstream_unavailable",
+            "previous_response_owner_unavailable",
             "Previous response owner account is unavailable; retry later.",
             normalized_code,
         )

--- a/app/modules/proxy/work_admission.py
+++ b/app/modules/proxy/work_admission.py
@@ -94,7 +94,7 @@ class WorkAdmissionController:
                 gate.wait_timeout_seconds,
                 message,
             )
-            raise ProxyResponseError(429, local_overload_error(message))
+            raise ProxyResponseError(429, local_overload_error(message, code="global_admission_timeout"))
         return AdmissionLease(gate.semaphore, stage=stage, request_id=get_request_id())
 
 

--- a/frontend/src/features/settings/components/import-settings.test.tsx
+++ b/frontend/src/features/settings/components/import-settings.test.tsx
@@ -65,6 +65,8 @@ describe("ImportSettings", () => {
       upstreamStreamTransport: settings.upstreamStreamTransport,
       preferEarlierResetAccounts: settings.preferEarlierResetAccounts,
       routingStrategy: settings.routingStrategy,
+      relativeAvailabilityPower: settings.relativeAvailabilityPower,
+      relativeAvailabilityTopK: settings.relativeAvailabilityTopK,
       openaiCacheAffinityMaxAgeSeconds: settings.openaiCacheAffinityMaxAgeSeconds,
       dashboardSessionTtlSeconds: settings.dashboardSessionTtlSeconds,
       importWithoutOverwrite: true,

--- a/openspec/changes/stabilize-responses-concurrency-streaming/notes.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/notes.md
@@ -1,0 +1,9 @@
+# Baseline Evidence
+
+- `/v1/responses` route wiring lives in `app/modules/proxy/api.py` and prefers the HTTP responses bridge for eligible Responses traffic.
+- HTTP responses bridge session/capacity/queue behavior lives in `app/modules/proxy/service.py`, including local queue-full and capacity-exhausted rejection paths.
+- Process-wide admission is controlled by `app/core/resilience/bulkhead.py` and `app/modules/proxy/work_admission.py`.
+- Account selection and runtime health live in `app/modules/proxy/load_balancer.py`; pre-change routing uses persisted usage/runtime health but lacks an in-flight lease that is atomically acquired with selection.
+- Upstream HTTP error classification starts in `app/core/clients/proxy.py` and helper/balancer classification paths.
+- SSE keepalive helpers live in `app/core/utils/sse.py`, with streaming response header/event handling in `app/modules/proxy/api.py`.
+- Phase 1 topology guarantee is per proxy instance and service-wide only for single replica or multi-replica deployments with sticky ingress/deterministic owner routing.

--- a/openspec/changes/stabilize-responses-concurrency-streaming/proposal.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/proposal.md
@@ -1,0 +1,19 @@
+# Change: Stabilize Responses Concurrency and Streaming
+
+## Why
+
+Sustained `/v1/responses` workloads with several long-running Codex agents can produce local 429s, occasional upstream 429s, and HTTP streaming origin timeouts. Current routing primarily uses persisted usage snapshots and local bridge/session admission state. During concurrent bursts, many requests can observe the same stale usage snapshot before upstream usage or local request pressure is reflected, causing one account or bridge session to receive disproportionate work. When bridge queues or response-create gates saturate, the service can reject locally or delay first useful bytes long enough for front-door proxies to terminate long-lived streams.
+
+## What Changes
+
+- Add account-level in-flight pressure accounting, leases, and per-account create/stream caps that affect account selection immediately.
+- Keep account selection and lease acquisition atomic while forbidding database, network, sleep, or blocking I/O under the balancer runtime lock.
+- Release leases on all streaming and non-streaming terminal paths, including failover, local errors, cancellation, timeout, downstream disconnect, and stale watchdog recovery.
+- Make soft prompt-cache/sticky-thread bridge saturation reroutable to another eligible account/session, while hard continuity remains bounded and explicit.
+- Normalize local 429/overload reason taxonomy and preserve upstream 429 mapping separately.
+- Harden `/v1/responses` HTTP/SSE streaming for front-door proxies with anti-buffering headers, early/periodic heartbeat behavior, and low-cardinality timeout observability.
+- Add regression tests and a sustained workload reproduction harness for concurrency fairness and streaming timeout behavior.
+
+## Impact
+
+High-concurrency Responses traffic should distribute across eligible accounts based on persisted usage plus immediate in-flight pressure. Local overload responses become easier to diagnose, soft bridge queue saturation should avoid unnecessary 429s when alternatives exist, and streaming clients/proxies should receive timely flushable bytes and explicit timeout diagnostics. Phase 1 guarantees are per proxy instance and service-wide only for single replica or multi-replica deployments with sticky ingress/deterministic owner routing; universal multi-replica fairness without affinity requires a later shared-pressure design.

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/proxy-admission-control/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Account-local Responses work is capped before upstream creation
+
+For `/v1/responses`, `/backend-api/codex/responses`, and compact Responses traffic, the proxy MUST enforce account-local response-create and streaming concurrency limits in addition to process-wide admission limits. The default account response-create cap MUST be 4 and the default account stream cap MUST be 8 unless operators configure a different value. When an account is at either cap, new soft-affinity work MUST prefer another eligible account before returning local overload. Hard-continuity work MAY fail closed when the required owner account is saturated.
+
+#### Scenario: Soft work avoids saturated account
+
+- **GIVEN** account A is at its account response-create cap
+- **AND** account B is eligible and below cap
+- **WHEN** a soft-affinity `/v1/responses` request is routed
+- **THEN** the proxy selects account B instead of queueing on account A
+
+#### Scenario: Hard continuity owner saturation fails closed
+
+- **GIVEN** a follow-up request requires a specific previous-response owner account
+- **AND** that account is at its account stream or response-create cap
+- **WHEN** no safe continuity-preserving alternative exists
+- **THEN** the proxy returns a bounded local overload/continuity failure
+- **AND** the failure reason is stable and low-cardinality
+
+### Requirement: Local overload reasons are stable and distinguishable
+
+Local Responses overload failures MUST expose stable low-cardinality reason fields in logs and metrics so operators can distinguish `bridge_queue_full`, `response_create_gate_timeout`, `hard_affinity_saturated`, `previous_response_owner_unavailable`, `global_admission_timeout`, `capacity_exhausted_active_sessions`, `account_response_create_cap`, and `account_stream_cap`. These local reasons MUST NOT be reported as upstream rate limits.
+
+#### Scenario: Bridge queue saturation is not ambiguous
+
+- **WHEN** a local HTTP bridge queue rejects a request
+- **THEN** logs and metrics use the stable reason `bridge_queue_full`
+- **AND** they do not use the ambiguous alias `queue_full`
+
+#### Scenario: Account cap rejection is local overload
+
+- **WHEN** every eligible account is unavailable because of account-local caps
+- **THEN** the HTTP response is a local overload response with `Retry-After`
+- **AND** logs and metrics identify `account_response_create_cap` or `account_stream_cap`

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Responses concurrency pressure is observable
+
+The service MUST expose low-cardinality logs and metrics for account-local in-flight create count, active stream count, leased token/cost pressure, cap rejections, lease stale reclaims, soft-affinity reroutes, and local-vs-upstream 429 classification. Observability MUST avoid raw prompt text, raw affinity keys, API keys, and request payload content.
+
+#### Scenario: Local and upstream 429s are separated
+
+- **WHEN** local admission rejects a request and upstream later returns a rate limit for another request
+- **THEN** logs and metrics distinguish local overload reasons from normalized upstream `upstream_rate_limit`
+- **AND** preserved upstream wire payloads may retain upstream codes such as `rate_limit_exceeded`, `usage_limit_reached`, or `insufficient_quota`
+
+### Requirement: Streaming timeout diagnostics are emitted
+
+For `/v1/responses` HTTP/SSE streams, the service MUST log low-cardinality diagnostics for early heartbeat emission, keepalive emission, startup wait timeout, downstream disconnect, and stream idle timeout. The diagnostics MUST include request id, route family, account id when known, timeout stage, and elapsed seconds where available, without exposing payload content or raw affinity keys.
+
+#### Scenario: Keepalive path is diagnosable
+
+- **WHEN** a streaming Responses request waits for upstream events long enough to emit keepalive data
+- **THEN** the service records heartbeat or keepalive diagnostics
+- **AND** the diagnostic does not include raw prompt-cache keys or request payloads

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/responses-api-compat/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/responses-api-compat/spec.md
@@ -11,6 +11,14 @@ For Responses API requests, usage-based routing MUST include immediate in-proces
 - **THEN** selected accounts are distributed according to immediate in-flight pressure and caps
 - **AND** one account does not receive all requests solely because persisted usage was stale
 
+#### Scenario: File-pinned bridge request does not reroute under local pressure
+
+- **GIVEN** an HTTP bridge `/v1/responses` request references an `input_file.file_id` pinned to an upstream account
+- **AND** that owner account or bridge session rejects admission with local pressure before output starts
+- **WHEN** the proxy handles the admission failure
+- **THEN** it returns the owner account overload instead of soft-rerouting the payload to another account
+- **AND** the file-scoped request is not replayed to an account that does not own the file
+
 #### Scenario: Runtime lock excludes blocking I/O
 
 - **WHEN** account selection holds the balancer runtime lock

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/responses-api-compat/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/responses-api-compat/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Responses account selection accounts for in-flight pressure
+
+For Responses API requests, usage-based routing MUST include immediate in-process account pressure in addition to persisted usage. Account selection MUST account for in-flight response-create work, active streams, leased token/cost estimates, recent selection pressure, account health, and configured account-local caps. Selection and lease acquisition MUST be atomic with respect to other in-process selections, and the critical section MUST NOT perform database calls, network calls, sleeps, or other blocking I/O.
+
+#### Scenario: Concurrent burst spreads before upstream usage refreshes
+
+- **GIVEN** multiple eligible accounts have similar persisted usage
+- **WHEN** many `/v1/responses` requests arrive concurrently before upstream usage refreshes
+- **THEN** selected accounts are distributed according to immediate in-flight pressure and caps
+- **AND** one account does not receive all requests solely because persisted usage was stale
+
+#### Scenario: Runtime lock excludes blocking I/O
+
+- **WHEN** account selection holds the balancer runtime lock
+- **THEN** the implementation performs only in-memory scoring and lease mutation
+- **AND** database, network, sleep, or bridge queue waits happen outside that lock
+
+### Requirement: Account leases release on all terminal paths
+
+Every account-local lease acquired for a Responses request MUST be idempotently released or settled on success, upstream error, local startup error, bridge submit failure, startup probe conversion, non-streaming collect completion, failover, downstream disconnect, cancellation, timeout, and retry. A bounded stale-lease watchdog MUST reclaim leases that survive unexpected task cancellation or exceptions, and stale reclamation MUST emit warning/metric evidence. Leases MUST NOT be persisted to the database.
+
+#### Scenario: Lease releases after downstream disconnect
+
+- **WHEN** a streaming `/v1/responses` client disconnects before a terminal upstream event
+- **THEN** the account stream lease is released exactly once
+- **AND** later routing pressure no longer includes that stream
+
+#### Scenario: Stale watchdog recovers orphaned lease
+
+- **WHEN** a request task exits unexpectedly after acquiring an account lease
+- **AND** the lease exceeds the configured TTL
+- **THEN** the watchdog releases the stale lease
+- **AND** emits a low-cardinality warning/metric
+
+### Requirement: Public Responses streaming is proxy-timeout friendly
+
+Streaming `/v1/responses` responses MUST include anti-buffering/cache headers suitable for SSE through common front-door proxies and MUST emit an early flushable SSE comment or event before long upstream startup waits can appear idle. Periodic SSE keepalive behavior MUST continue while waiting for upstream events. These heartbeat comments MUST NOT violate the public Responses event contract: OpenAI-contract events still begin with `response.created` when event parsing ignores comments.
+
+#### Scenario: Streaming response includes anti-buffering headers
+
+- **WHEN** a client starts streaming `POST /v1/responses`
+- **THEN** the response headers include SSE content type and anti-buffering/cache directives
+- **AND** the headers are present before upstream response completion
+
+#### Scenario: Early heartbeat precedes long upstream silence
+
+- **WHEN** upstream startup takes longer than the heartbeat interval
+- **THEN** the client receives a flushable SSE heartbeat before a front-door origin idle timeout would trigger
+- **AND** the first OpenAI-contract event remains `response.created` when upstream accepts the request

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/responses-api-compat/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/responses-api-compat/spec.md
@@ -27,6 +27,14 @@ Every account-local lease acquired for a Responses request MUST be idempotently 
 - **THEN** the account stream lease is released exactly once
 - **AND** later routing pressure no longer includes that stream
 
+#### Scenario: WebSocket local account cap releases API-key reservation
+
+- **GIVEN** a WebSocket `response.create` has reserved API-key usage
+- **AND** account-local response-create lease acquisition fails with `account_response_create_cap`
+- **WHEN** the proxy emits the local terminal failure
+- **THEN** the API-key usage reservation is released
+- **AND** the pending request is removed from websocket local state
+
 #### Scenario: Stale watchdog recovers orphaned lease
 
 - **WHEN** a request task exits unexpectedly after acquiring an account lease

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/responses-api-compat/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/responses-api-compat/spec.md
@@ -34,6 +34,14 @@ Every account-local lease acquired for a Responses request MUST be idempotently 
 - **THEN** the watchdog releases the stale lease
 - **AND** emits a low-cardinality warning/metric
 
+#### Scenario: Active stream lease is not reclaimed before valid stream budget
+
+- **GIVEN** a stream lease is older than the base lease TTL
+- **AND** the configured Responses stream or HTTP bridge request budget has not elapsed
+- **WHEN** account lease stale reclamation runs
+- **THEN** the stream lease still counts against account-local stream pressure
+- **AND** the proxy does not admit extra streams over the account stream cap by age alone
+
 ### Requirement: Public Responses streaming is proxy-timeout friendly
 
 Streaming `/v1/responses` responses MUST include anti-buffering/cache headers suitable for SSE through common front-door proxies and MUST emit an early flushable SSE comment or event before long upstream startup waits can appear idle. Periodic SSE keepalive behavior MUST continue while waiting for upstream events. These heartbeat comments MUST NOT violate the public Responses event contract: OpenAI-contract events still begin with `response.created` when event parsing ignores comments.

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/sticky-session-operations/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Soft bridge affinity can reroute under local pressure
+
+Prompt-cache and sticky-thread bridge affinity that does not carry a hard continuity dependency MUST be treated as soft. When the preferred soft bridge session is saturated by queue depth, response-create gate pressure, bridge capacity, or account-local caps, the service MUST evaluate other eligible accounts/sessions before returning a local overload response. The service MUST emit internal diagnostics such as `internal_soft_affinity_reroute` for successful reroutes without adding those diagnostic names to the stable failure taxonomy.
+
+#### Scenario: Prompt-cache bridge queue reroutes to an eligible account
+
+- **GIVEN** a prompt-cache request's preferred bridge session queue is full
+- **AND** another eligible account/session is below cap
+- **WHEN** the request has no hard previous-response or turn-state continuity dependency
+- **THEN** the proxy routes to the alternate account/session
+- **AND** records an internal soft-affinity reroute diagnostic
+
+### Requirement: Hard continuity remains owner-bound and bounded
+
+Requests that depend on `previous_response_id`, hard turn-state, or another required owner continuity source MUST NOT silently reroute to an account that cannot preserve continuity. If the owner account/session is unavailable or saturated, the service MUST fail closed with an explicit retryable continuity/local overload reason instead of flooding the owner queue indefinitely.
+
+#### Scenario: Previous-response owner queue is saturated
+
+- **WHEN** a `/v1/responses` follow-up requires a previous-response owner
+- **AND** the owner session queue or account cap is saturated
+- **THEN** the service fails closed with `hard_affinity_saturated` or `previous_response_owner_unavailable`
+- **AND** it does not route to an unrelated account that lacks continuity state

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/sticky-session-operations/spec.md
@@ -14,7 +14,7 @@ Prompt-cache and sticky-thread bridge affinity that does not carry a hard contin
 
 ### Requirement: Hard continuity remains owner-bound and bounded
 
-Requests that depend on `previous_response_id`, hard turn-state, or another required owner continuity source MUST NOT silently reroute to an account that cannot preserve continuity. If the owner account/session is unavailable or saturated, the service MUST fail closed with an explicit retryable continuity/local overload reason instead of flooding the owner queue indefinitely.
+Requests that depend on `previous_response_id`, hard turn-state, account-scoped `input_file.file_id` pins, or another required owner continuity source MUST NOT silently reroute to an account that cannot preserve continuity. If the owner account/session is unavailable or saturated, the service MUST fail closed with an explicit retryable continuity/local overload reason instead of flooding the owner queue indefinitely.
 
 #### Scenario: Previous-response owner queue is saturated
 
@@ -22,3 +22,10 @@ Requests that depend on `previous_response_id`, hard turn-state, or another requ
 - **AND** the owner session queue or account cap is saturated
 - **THEN** the service fails closed with `hard_affinity_saturated` or `previous_response_owner_unavailable`
 - **AND** it does not route to an unrelated account that lacks continuity state
+
+#### Scenario: File-pinned request owner is capped
+
+- **WHEN** a `/v1/responses` request references an `input_file.file_id` pinned to an owner account
+- **AND** the owner account is at its account stream or response-create cap
+- **THEN** the service returns a local account-cap overload for the owner
+- **AND** it does not route the file reference to another account

--- a/openspec/changes/stabilize-responses-concurrency-streaming/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/specs/sticky-session-operations/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Soft bridge affinity can reroute under local pressure
 
-Prompt-cache and sticky-thread bridge affinity that does not carry a hard continuity dependency MUST be treated as soft. When the preferred soft bridge session is saturated by queue depth, response-create gate pressure, bridge capacity, or account-local caps, the service MUST evaluate other eligible accounts/sessions before returning a local overload response. The service MUST emit internal diagnostics such as `internal_soft_affinity_reroute` for successful reroutes without adding those diagnostic names to the stable failure taxonomy.
+Prompt-cache and sticky-thread bridge affinity that does not carry a hard continuity dependency MUST be treated as soft. A client-supplied or proxy-derived `prompt_cache_key` is a cache-locality hint, not a correctness dependency; the proxy MAY reroute it under local pressure and accept lower cache-hit rates. When the preferred soft bridge session is saturated by queue depth, response-create gate pressure, bridge capacity, or account-local caps, the service MUST evaluate other eligible accounts/sessions before returning a local overload response. The service MUST emit internal diagnostics such as `internal_soft_affinity_reroute` for successful reroutes without adding those diagnostic names to the stable failure taxonomy.
 
 #### Scenario: Prompt-cache bridge queue reroutes to an eligible account
 
@@ -12,9 +12,17 @@ Prompt-cache and sticky-thread bridge affinity that does not carry a hard contin
 - **THEN** the proxy routes to the alternate account/session
 - **AND** records an internal soft-affinity reroute diagnostic
 
+#### Scenario: Prompt cache key does not override hard previous-response continuity
+
+- **GIVEN** a `/v1/responses` request carries both `previous_response_id` and `prompt_cache_key`
+- **AND** the previous response owner is known
+- **WHEN** the prompt-cache preferred account differs from the previous-response owner
+- **THEN** the proxy treats the request as hard owner-bound to the previous-response owner
+- **AND** it does not route to the prompt-cache account when that account cannot preserve the stored response continuation
+
 ### Requirement: Hard continuity remains owner-bound and bounded
 
-Requests that depend on `previous_response_id`, hard turn-state, account-scoped `input_file.file_id` pins, or another required owner continuity source MUST NOT silently reroute to an account that cannot preserve continuity. If the owner account/session is unavailable or saturated, the service MUST fail closed with an explicit retryable continuity/local overload reason instead of flooding the owner queue indefinitely.
+Requests that depend on `previous_response_id`, hard turn-state, account-scoped `input_file.file_id` pins, or another required owner continuity source MUST NOT silently reroute to an account that cannot preserve continuity. A `previous_response_id` is a stored-object continuation reference and remains owner-bound even when the same request also carries `prompt_cache_key` or another soft locality key. If the owner account/session is unavailable or saturated, the service MUST fail closed with an explicit retryable continuity/local overload reason instead of flooding the owner queue indefinitely.
 
 #### Scenario: Previous-response owner queue is saturated
 

--- a/openspec/changes/stabilize-responses-concurrency-streaming/tasks.md
+++ b/openspec/changes/stabilize-responses-concurrency-streaming/tasks.md
@@ -1,0 +1,15 @@
+## Tasks
+
+- [x] Capture baseline code evidence for current `/v1/responses` concurrency, bridge, admission, and streaming timeout touchpoints.
+- [x] Add OpenSpec delta requirements for account leases/caps, bridge soft-affinity reroute, stable overload taxonomy, and streaming timeout hardening.
+- [x] Add account pressure configuration with safe defaults and environment aliases.
+- [x] Implement account-local runtime lease state, pressure scoring, atomic select+lease, and stale lease reclamation without blocking under the balancer runtime lock.
+- [x] Integrate lease acquisition/release with streaming and non-streaming `/v1/responses` paths, including failover/error/cancel/timeout/downstream disconnect paths.
+- [x] Add per-account response-create and stream caps to candidate eligibility and local overload diagnostics.
+- [x] Implement soft-affinity bridge reroute before queue/gate saturation where no hard continuity anchor exists.
+- [x] Preserve hard continuity behavior with explicit bounded local failure reasons.
+- [x] Add anti-buffering SSE headers, early heartbeat/flush behavior, and timeout/heartbeat observability for `/v1/responses` streams.
+- [x] Add targeted unit/integration tests for fairness distribution, caps, lease cleanup, taxonomy, bridge reroute, hard continuity, streaming headers, and heartbeat behavior.
+- [x] Add or update a sustained workload reproduction harness for 5-6 agent/hour style load without requiring production credentials in the repo.
+- [x] Run OpenSpec validation, targeted pytest, and lint/format checks.
+- [x] Run final cleanup and independent review gate before final Ultragoal completion.

--- a/scripts/reproduce_responses_stream_load.py
+++ b/scripts/reproduce_responses_stream_load.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Sustained /v1/responses streaming load reproducer.
+
+This script intentionally keeps credentials out of the repository. Provide the
+base URL and API key via environment variables when running it against a local
+or staging codex-lb deployment:
+
+  CODEX_LB_BASE_URL=https://example.test \
+  CODEX_LB_API_KEY=... \
+  uv run python scripts/reproduce_responses_stream_load.py --agents 6 --duration-seconds 3600
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Final
+
+import aiohttp
+
+DEFAULT_MODEL: Final[str] = "gpt-5.3-codex"
+
+
+@dataclass(slots=True)
+class WorkerStats:
+    requests: int = 0
+    completed: int = 0
+    failed: int = 0
+    heartbeats: int = 0
+    first_byte_timeouts: int = 0
+    status_429: int = 0
+    other_status: int = 0
+
+
+async def _run_worker(
+    worker_id: int,
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    deadline: float,
+    first_byte_timeout_seconds: float,
+) -> WorkerStats:
+    stats = WorkerStats()
+    url = f"{base_url.rstrip('/')}/v1/responses"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    }
+    timeout = aiohttp.ClientTimeout(total=None, sock_connect=30)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        while time.monotonic() < deadline:
+            stats.requests += 1
+            payload = {
+                "model": model,
+                "stream": True,
+                "prompt_cache_key": f"load-worker-{worker_id}",
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "Reply with one short sentence, then stop.",
+                            }
+                        ],
+                    }
+                ],
+            }
+            try:
+                async with session.post(url, headers=headers, data=json.dumps(payload)) as response:
+                    if response.status == 429:
+                        stats.status_429 += 1
+                    elif response.status >= 400:
+                        stats.other_status += 1
+                    first_byte_deadline = time.monotonic() + first_byte_timeout_seconds
+                    saw_terminal = False
+                    async for raw_line in response.content:
+                        line = raw_line.decode("utf-8", errors="replace")
+                        if line.startswith(":") or "codex.keepalive" in line:
+                            stats.heartbeats += 1
+                        if time.monotonic() <= first_byte_deadline:
+                            first_byte_deadline = 0
+                        if "response.completed" in line or "response.failed" in line or "response.incomplete" in line:
+                            saw_terminal = True
+                            break
+                    if first_byte_deadline and time.monotonic() > first_byte_deadline:
+                        stats.first_byte_timeouts += 1
+                    if saw_terminal and response.status < 400:
+                        stats.completed += 1
+                    else:
+                        stats.failed += 1
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                stats.failed += 1
+    return stats
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agents", type=int, default=6)
+    parser.add_argument("--duration-seconds", type=float, default=3600.0)
+    parser.add_argument("--first-byte-timeout-seconds", type=float, default=30.0)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    args = parser.parse_args()
+
+    base_url = os.environ["CODEX_LB_BASE_URL"]
+    api_key = os.environ["CODEX_LB_API_KEY"]
+    deadline = time.monotonic() + args.duration_seconds
+    results = await asyncio.gather(
+        *(
+            _run_worker(
+                worker_id,
+                base_url=base_url,
+                api_key=api_key,
+                model=args.model,
+                deadline=deadline,
+                first_byte_timeout_seconds=args.first_byte_timeout_seconds,
+            )
+            for worker_id in range(args.agents)
+        )
+    )
+    total = WorkerStats()
+    for result in results:
+        total.requests += result.requests
+        total.completed += result.completed
+        total.failed += result.failed
+        total.heartbeats += result.heartbeats
+        total.first_byte_timeouts += result.first_byte_timeouts
+        total.status_429 += result.status_429
+        total.other_status += result.other_status
+    print(json.dumps(total.__dict__, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/tests/integration/test_codex_client_compat.py
+++ b/tests/integration/test_codex_client_compat.py
@@ -37,8 +37,12 @@ async def test_codex_style_responses_payload_is_accepted(async_client):
         lines = [line async for line in resp.aiter_lines() if line]
 
     # Public /v1/responses stream MUST start with `response.created` per the
-    # OpenAI Responses SSE contract; the proxy synthesizes one when the
-    # upstream stream skips it (e.g. when no accounts are available and
+    # OpenAI Responses SSE contract; do not inject a leading comment heartbeat
+    # before the first data event because OpenAI SDK stream parsers use the
+    # first event to establish the response object.
+    assert not lines[0].startswith(":"), lines[:3]
+    # The proxy synthesizes response.created when the upstream stream skips it
+    # (e.g. when no accounts are available and upstream emits only
     # upstream emits only `response.failed`). The original intent of this
     # test is to verify the Codex-style payload (input_text, tool_choice,
     # parallel_tool_calls, include) is accepted and a stream begins —

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -6057,6 +6057,7 @@ async def test_v1_responses_http_bridge_creates_different_session_keys_in_parall
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6067,6 +6068,7 @@ async def test_v1_responses_http_bridge_creates_different_session_keys_in_parall
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         create_started.append(key.affinity_key)
         create_started_events[key.affinity_key].set()
@@ -6156,6 +6158,7 @@ async def test_v1_responses_http_bridge_singleflights_same_session_key_during_cr
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6166,6 +6169,7 @@ async def test_v1_responses_http_bridge_singleflights_same_session_key_during_cr
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         create_started.append(key.affinity_key)
         create_started_event.set()
@@ -6256,6 +6260,7 @@ async def test_v1_responses_http_bridge_waits_for_inflight_capacity_before_rate_
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6266,6 +6271,7 @@ async def test_v1_responses_http_bridge_waits_for_inflight_capacity_before_rate_
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         create_attempts.append(key.affinity_key)
         if key.affinity_key == "bridge-capacity-a":
@@ -6353,6 +6359,7 @@ async def test_v1_responses_http_bridge_singleflight_follower_refreshes_session_
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6363,6 +6370,7 @@ async def test_v1_responses_http_bridge_singleflight_follower_refreshes_session_
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         create_started.set()
         await _wait_for_event(release_create)
@@ -6463,6 +6471,7 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6473,6 +6482,7 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         create_calls.append(list(api_key.assigned_account_ids if api_key is not None else []))
         if len(create_calls) == 1:
@@ -6569,6 +6579,7 @@ async def test_v1_responses_http_bridge_singleflights_stale_session_replacement(
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6579,6 +6590,7 @@ async def test_v1_responses_http_bridge_singleflights_stale_session_replacement(
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         create_started.append(key.affinity_key)
         await asyncio.sleep(0.2)
@@ -6659,6 +6671,7 @@ async def test_v1_responses_http_bridge_cleans_up_cancelled_singleflight_creator
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6669,6 +6682,7 @@ async def test_v1_responses_http_bridge_cleans_up_cancelled_singleflight_creator
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         nonlocal create_attempts
         create_attempts += 1
@@ -6752,6 +6766,7 @@ async def test_v1_responses_http_bridge_cleans_up_cancelled_singleflight_creator
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6762,6 +6777,7 @@ async def test_v1_responses_http_bridge_cleans_up_cancelled_singleflight_creator
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         nonlocal create_attempts
         create_attempts += 1
@@ -6845,6 +6861,7 @@ async def test_v1_responses_http_bridge_waits_for_inflight_session_before_contin
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6855,6 +6872,7 @@ async def test_v1_responses_http_bridge_waits_for_inflight_session_before_contin
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         create_started.set()
         await _wait_for_event(release_create)
@@ -6940,6 +6958,7 @@ async def test_v1_responses_http_bridge_prunes_idle_session_before_reuse(app_ins
         request_stage="first_turn",
         preferred_account_id=None,
         require_preferred_account=False,
+        fallback_on_preferred_account_unavailable=True,
     ):
         del (
             self,
@@ -6950,6 +6969,7 @@ async def test_v1_responses_http_bridge_prunes_idle_session_before_reuse(app_ins
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         create_started.append(key.affinity_key)
         return _make_dummy_bridge_session(key)

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -80,7 +80,12 @@ async def _collect_sse_events(
     async with async_client.stream("POST", path, json=json_body, headers=headers) as response:
         assert response.status_code == 200
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
-    return [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
+    return [
+        event
+        for line in lines
+        if line[6:] != "[DONE]"
+        if (event := json.loads(line[6:])).get("type") != "codex.keepalive"
+    ]
 
 
 async def _collect_sse_events_with_headers(
@@ -94,7 +99,12 @@ async def _collect_sse_events_with_headers(
         assert response.status_code == 200
         response_headers = dict(response.headers)
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
-    return [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"], response_headers
+    return [
+        event
+        for line in lines
+        if line[6:] != "[DONE]"
+        if (event := json.loads(line[6:])).get("type") != "codex.keepalive"
+    ], response_headers
 
 
 def _assert_created_text_delta_completed(events: list[dict]) -> None:

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -70,6 +70,8 @@ def _extract_first_event(lines: list[str]) -> dict:
         if not line.startswith("data: ") or line.startswith("data: [DONE]"):
             continue
         event = json.loads(line[6:])
+        if event.get("type") == "codex.keepalive":
+            continue
         if event.get("type") == "response.created":
             response = event.get("response")
             if isinstance(response, dict) and response.get("status") == "in_progress" and response.get("output") == []:

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -74,7 +74,10 @@ def _extract_first_raw_event(lines: list[str]) -> dict:
 def _iter_sse_events(lines: list[str]):
     for line in lines:
         if line.startswith("data: ") and not line.startswith("data: [DONE]"):
-            yield json.loads(line[6:])
+            event = json.loads(line[6:])
+            if event.get("type") == "codex.keepalive":
+                continue
+            yield event
 
 
 class _FakeUpstreamWebSocket:

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 import pytest
 
 from app.core.crypto import TokenEncryptor
-from app.db.models import Account, AccountStatus, UsageHistory
+from app.db.models import Account, AccountStatus, StickySessionKind, UsageHistory
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.proxy.load_balancer import LoadBalancer
 from app.modules.proxy.repo_bundle import ProxyRepositories
@@ -70,16 +70,26 @@ class _StubUsageRepository:
 
 
 class _StubStickySessionsRepository:
+    def __init__(self) -> None:
+        self.account_id: str | None = None
+        self.deleted: list[tuple[str, StickySessionKind | None]] = []
+        self.upserts: list[tuple[str, str, StickySessionKind | None]] = []
+
     async def get_account_id(self, *args: Any, **kwargs: Any) -> str | None:
         del args, kwargs
-        return None
+        return self.account_id
 
     async def upsert(self, *args: Any, **kwargs: Any) -> Any:
-        del args, kwargs
+        sticky_key = cast(str, args[0])
+        account_id = cast(str, args[1])
+        self.account_id = account_id
+        self.upserts.append((sticky_key, account_id, kwargs.get("kind")))
         return None
 
     async def delete(self, *args: Any, **kwargs: Any) -> bool:
-        del args, kwargs
+        sticky_key = cast(str, args[0])
+        self.deleted.append((sticky_key, kwargs.get("kind")))
+        self.account_id = None
         return True
 
 
@@ -87,12 +97,14 @@ class _StubStickySessionsRepository:
 async def _repo_factory(
     accounts_repo: _StubAccountsRepository,
     usage_repo: _StubUsageRepository,
+    sticky_repo: _StubStickySessionsRepository | None = None,
 ) -> AsyncIterator[ProxyRepositories]:
+    sticky_repo = sticky_repo or _StubStickySessionsRepository()
     yield ProxyRepositories(
         accounts=cast(Any, accounts_repo),
         usage=cast(Any, usage_repo),
         request_logs=cast(RequestLogsRepository, object()),
-        sticky_sessions=cast(Any, _StubStickySessionsRepository()),
+        sticky_sessions=cast(Any, sticky_repo),
         api_keys=cast(ApiKeysRepository, object()),
         additional_usage=cast(AdditionalUsageRepository, object()),
     )
@@ -108,6 +120,18 @@ def _usage_row(entry_id: int, account_id: str, *, window: str, reset_at: int) ->
         reset_at=reset_at,
         window_minutes=5 if window == "primary" else 60,
     )
+
+
+def _usage_row_with_percent(
+    entry_id: int,
+    account_id: str,
+    *,
+    used_percent: float,
+    reset_at: int,
+) -> UsageHistory:
+    row = _usage_row(entry_id, account_id, window="primary", reset_at=reset_at)
+    row.used_percent = used_percent
+    return row
 
 
 @pytest.mark.asyncio
@@ -164,3 +188,155 @@ async def test_record_error_updates_are_atomic_with_per_account_lock() -> None:
     runtime = balancer._runtime[account.id]
     assert runtime.error_count == 50
     assert runtime.last_error_at is not None
+
+
+@pytest.mark.asyncio
+async def test_account_stream_leases_spread_concurrent_burst_until_cap() -> None:
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    account_a = _make_account("acc-lease-a")
+    account_b = _make_account("acc-lease-b")
+    accounts_repo = _StubAccountsRepository([account_a, account_b])
+    usage_repo = _StubUsageRepository(
+        primary={
+            account_a.id: _usage_row(10, account_a.id, window="primary", reset_at=now_epoch + 300),
+            account_b.id: _usage_row(11, account_b.id, window="primary", reset_at=now_epoch + 300),
+        },
+        secondary={
+            account_a.id: _usage_row(12, account_a.id, window="secondary", reset_at=now_epoch + 3600),
+            account_b.id: _usage_row(13, account_b.id, window="secondary", reset_at=now_epoch + 3600),
+        },
+    )
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo))
+
+    results = await asyncio.gather(
+        *(
+            balancer.select_account(
+                routing_strategy="usage_weighted",
+                lease_kind="stream",
+            )
+            for _ in range(16)
+        )
+    )
+
+    selected_ids = [result.account.id for result in results if result.account is not None]
+    assert selected_ids.count(account_a.id) == 8
+    assert selected_ids.count(account_b.id) == 8
+    assert all(result.lease is not None for result in results)
+
+    for result in results:
+        await balancer.release_account_lease(result.lease)
+
+    assert await balancer.account_pressure_snapshot(account_a.id) == (0, 0, 0.0)
+    assert await balancer.account_pressure_snapshot(account_b.id) == (0, 0, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_account_stream_cap_returns_stable_local_reason_until_released() -> None:
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    account = _make_account("acc-stream-cap")
+    accounts_repo = _StubAccountsRepository([account])
+    usage_repo = _StubUsageRepository(
+        primary={account.id: _usage_row(20, account.id, window="primary", reset_at=now_epoch + 300)},
+        secondary={account.id: _usage_row(21, account.id, window="secondary", reset_at=now_epoch + 3600)},
+    )
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo))
+
+    leases = [
+        (
+            await balancer.select_account(
+                routing_strategy="usage_weighted",
+                lease_kind="stream",
+            )
+        ).lease
+        for _ in range(8)
+    ]
+    capped = await balancer.select_account(
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+    )
+
+    assert capped.account is None
+    assert capped.error_code == "account_stream_cap"
+
+    await balancer.release_account_lease(leases[0])
+    recovered = await balancer.select_account(
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+    )
+
+    assert recovered.account is not None
+    assert recovered.account.id == account.id
+    assert recovered.lease is not None
+
+
+@pytest.mark.asyncio
+async def test_account_response_create_cap_prefers_unsaturated_account() -> None:
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    account_a = _make_account("acc-response-create-cap-a")
+    account_b = _make_account("acc-response-create-cap-b")
+    accounts_repo = _StubAccountsRepository([account_a, account_b])
+    usage_repo = _StubUsageRepository(
+        primary={
+            account_a.id: _usage_row(30, account_a.id, window="primary", reset_at=now_epoch + 300),
+            account_b.id: _usage_row(31, account_b.id, window="primary", reset_at=now_epoch + 300),
+        },
+        secondary={
+            account_a.id: _usage_row(32, account_a.id, window="secondary", reset_at=now_epoch + 3600),
+            account_b.id: _usage_row(33, account_b.id, window="secondary", reset_at=now_epoch + 3600),
+        },
+    )
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo))
+
+    saturated_leases = [await balancer.acquire_account_lease(account_a.id, kind="response_create") for _ in range(4)]
+    selected = await balancer.select_account(
+        routing_strategy="usage_weighted",
+        lease_kind="response_create",
+    )
+
+    assert selected.account is not None
+    assert selected.account.id == account_b.id
+    assert selected.lease is not None
+
+    for lease in [*saturated_leases, selected.lease]:
+        await balancer.release_account_lease(lease)
+
+
+@pytest.mark.asyncio
+async def test_codex_session_sticky_does_not_reallocate_under_budget_pressure() -> None:
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    account_a = _make_account("acc-hard-sticky-a")
+    account_b = _make_account("acc-hard-sticky-b")
+    accounts_repo = _StubAccountsRepository([account_a, account_b])
+    usage_repo = _StubUsageRepository(
+        primary={
+            account_a.id: _usage_row_with_percent(
+                40,
+                account_a.id,
+                used_percent=99.0,
+                reset_at=now_epoch + 300,
+            ),
+            account_b.id: _usage_row_with_percent(
+                41,
+                account_b.id,
+                used_percent=10.0,
+                reset_at=now_epoch + 300,
+            ),
+        },
+        secondary={},
+    )
+    sticky_repo = _StubStickySessionsRepository()
+    sticky_repo.account_id = account_a.id
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+
+    result = await balancer.select_account(
+        sticky_key="hard-session",
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+    )
+
+    assert result.account is not None
+    assert result.account.id == account_a.id
+    assert sticky_repo.deleted == []
+    assert sticky_repo.account_id == account_a.id
+    await balancer.release_account_lease(result.lease)

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -302,7 +302,80 @@ async def test_account_response_create_cap_prefers_unsaturated_account() -> None
 
 
 @pytest.mark.asyncio
-async def test_codex_session_sticky_does_not_reallocate_under_budget_pressure() -> None:
+async def test_unbound_codex_session_sticky_filters_saturated_accounts() -> None:
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    account_a = _make_account("acc-hard-sticky-unbound-capped-a")
+    account_b = _make_account("acc-hard-sticky-unbound-capped-b")
+    accounts_repo = _StubAccountsRepository([account_a, account_b])
+    usage_repo = _StubUsageRepository(
+        primary={
+            account_a.id: _usage_row(34, account_a.id, window="primary", reset_at=now_epoch + 300),
+            account_b.id: _usage_row(35, account_b.id, window="primary", reset_at=now_epoch + 300),
+        },
+        secondary={
+            account_a.id: _usage_row(36, account_a.id, window="secondary", reset_at=now_epoch + 3600),
+            account_b.id: _usage_row(37, account_b.id, window="secondary", reset_at=now_epoch + 3600),
+        },
+    )
+    sticky_repo = _StubStickySessionsRepository()
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    saturated_leases = [await balancer.acquire_account_lease(account_a.id, kind="stream") for _ in range(8)]
+
+    selected = await balancer.select_account(
+        sticky_key="new-hard-session",
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+    )
+
+    assert selected.account is not None
+    assert selected.account.id == account_b.id
+    assert selected.error_code is None
+    assert selected.lease is not None
+    assert sticky_repo.account_id == account_b.id
+
+    for lease in [*saturated_leases, selected.lease]:
+        await balancer.release_account_lease(lease)
+
+
+@pytest.mark.asyncio
+async def test_bound_codex_session_sticky_fails_closed_when_pinned_account_is_saturated() -> None:
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    account_a = _make_account("acc-hard-sticky-bound-capped-a")
+    account_b = _make_account("acc-hard-sticky-bound-capped-b")
+    accounts_repo = _StubAccountsRepository([account_a, account_b])
+    usage_repo = _StubUsageRepository(
+        primary={
+            account_a.id: _usage_row(38, account_a.id, window="primary", reset_at=now_epoch + 300),
+            account_b.id: _usage_row(39, account_b.id, window="primary", reset_at=now_epoch + 300),
+        },
+        secondary={
+            account_a.id: _usage_row(42, account_a.id, window="secondary", reset_at=now_epoch + 3600),
+            account_b.id: _usage_row(43, account_b.id, window="secondary", reset_at=now_epoch + 3600),
+        },
+    )
+    sticky_repo = _StubStickySessionsRepository()
+    sticky_repo.account_id = account_a.id
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    saturated_leases = [await balancer.acquire_account_lease(account_a.id, kind="stream") for _ in range(8)]
+
+    selected = await balancer.select_account(
+        sticky_key="existing-hard-session",
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+    )
+
+    assert selected.account is None
+    assert selected.error_code == "account_stream_cap"
+    assert sticky_repo.account_id == account_a.id
+
+    for lease in saturated_leases:
+        await balancer.release_account_lease(lease)
+
+
+@pytest.mark.asyncio
+async def test_codex_session_sticky_reallocates_under_budget_pressure() -> None:
     now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
     account_a = _make_account("acc-hard-sticky-a")
     account_b = _make_account("acc-hard-sticky-b")
@@ -336,7 +409,7 @@ async def test_codex_session_sticky_does_not_reallocate_under_budget_pressure() 
     )
 
     assert result.account is not None
-    assert result.account.id == account_a.id
-    assert sticky_repo.deleted == []
-    assert sticky_repo.account_id == account_a.id
+    assert result.account.id == account_b.id
+    assert sticky_repo.deleted == [("hard-session", StickySessionKind.CODEX_SESSION)]
+    assert sticky_repo.account_id == account_b.id
     await balancer.release_account_lease(result.lease)

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -5,10 +5,12 @@ import time
 from collections.abc import AsyncIterator, Collection
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
+import app.modules.proxy.load_balancer as load_balancer_module
 from app.core.crypto import TokenEncryptor
 from app.db.models import Account, AccountStatus, StickySessionKind, UsageHistory
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -188,6 +190,58 @@ async def test_record_error_updates_are_atomic_with_per_account_lock() -> None:
     runtime = balancer._runtime[account.id]
     assert runtime.error_count == 50
     assert runtime.last_error_at is not None
+
+
+@pytest.mark.asyncio
+async def test_stale_reclaim_keeps_active_stream_lease_within_stream_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SimpleNamespace(
+        proxy_account_lease_ttl_seconds=1.0,
+        proxy_request_budget_seconds=10.0,
+        http_responses_stream_request_budget_seconds=7200.0,
+        http_responses_session_bridge_request_budget_seconds=7200.0,
+        proxy_account_stream_limit=2,
+        proxy_account_response_create_limit=2,
+    )
+    monkeypatch.setattr(load_balancer_module, "get_settings", lambda: settings)
+    account = _make_account("acc-stale-stream-budget")
+    balancer = LoadBalancer(lambda: _repo_factory(_StubAccountsRepository([account]), _StubUsageRepository({}, {})))
+
+    stream_lease = await balancer.acquire_account_lease(account.id, kind="stream")
+    assert stream_lease is not None
+    object.__setattr__(stream_lease, "acquired_at", time.monotonic() - 2.0)
+
+    second_stream_lease = await balancer.acquire_account_lease(account.id, kind="stream")
+
+    assert second_stream_lease is not None
+    assert await balancer.account_pressure_snapshot(account.id) == (0, 2, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_stale_reclaim_still_recovers_old_response_create_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = SimpleNamespace(
+        proxy_account_lease_ttl_seconds=1.0,
+        proxy_request_budget_seconds=10.0,
+        http_responses_stream_request_budget_seconds=7200.0,
+        http_responses_session_bridge_request_budget_seconds=7200.0,
+        proxy_account_stream_limit=2,
+        proxy_account_response_create_limit=2,
+    )
+    monkeypatch.setattr(load_balancer_module, "get_settings", lambda: settings)
+    account = _make_account("acc-stale-response-create")
+    balancer = LoadBalancer(lambda: _repo_factory(_StubAccountsRepository([account]), _StubUsageRepository({}, {})))
+
+    response_lease = await balancer.acquire_account_lease(account.id, kind="response_create")
+    assert response_lease is not None
+    object.__setattr__(response_lease, "acquired_at", time.monotonic() - 2.0)
+
+    replacement_lease = await balancer.acquire_account_lease(account.id, kind="response_create")
+
+    assert replacement_lease is not None
+    assert await balancer.account_pressure_snapshot(account.id) == (1, 0, 0.0)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -969,6 +969,89 @@ async def test_stream_via_http_bridge_soft_prompt_cache_queue_full_reroutes(
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_file_pin_queue_full_does_not_reroute(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [{"type": "input_file", "file_id": "file_doc"}],
+        }
+    )
+    saturated_session = _make_bridge_session(key_value="file-pin-queue-full", queued_request_count=8)
+    get_or_create = AsyncMock(return_value=saturated_session)
+
+    async def fake_stream_events(
+        session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+        propagate_http_errors: bool,
+        downstream_turn_state: str | None,
+    ):
+        del session, request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        raise ProxyResponseError(
+            429,
+            proxy_service.openai_error(
+                "bridge_queue_full",
+                "HTTP responses session bridge queue is full",
+                error_type="rate_limit_error",
+            ),
+        )
+        yield ""
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    with pytest.raises(ProxyResponseError) as info:
+        async for _ in service._stream_via_http_bridge(
+            payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            rewritten_file_account_id="acc-file",
+        ):
+            pass
+
+    assert info.value.status_code == 429
+    assert get_or_create.await_count == 1
+    create_call = get_or_create.await_args
+    assert create_call is not None
+    assert create_call.kwargs["preferred_account_id"] == "acc-file"
+    assert create_call.kwargs["fallback_on_preferred_account_unavailable"] is False
+
+
+@pytest.mark.asyncio
 async def test_select_account_with_budget_prefers_durable_account_id_when_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -878,6 +878,97 @@ def test_http_bridge_owner_check_required_enables_sticky_thread_in_gateway_safe_
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_soft_prompt_cache_queue_full_reroutes(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": "hello",
+            "prompt_cache_key": "soft-queue-full",
+        }
+    )
+    saturated_session = _make_bridge_session(key_value="soft-queue-full", queued_request_count=8)
+    saturated_session.key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "soft-queue-full", None)
+    reroute_session = _make_bridge_session(key_value="soft-reroute")
+    get_or_create = AsyncMock(side_effect=[saturated_session, reroute_session])
+
+    async def fake_stream_events(
+        session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+        propagate_http_errors: bool,
+        downstream_turn_state: str | None,
+    ):
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        if session is saturated_session:
+            raise ProxyResponseError(
+                429,
+                proxy_service.openai_error(
+                    "bridge_queue_full",
+                    "HTTP responses session bridge queue is full",
+                    error_type="rate_limit_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    caplog.set_level(logging.INFO, logger="app.modules.proxy.service")
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert get_or_create.await_count == 2
+    reroute_key = get_or_create.await_args_list[1].args[0]
+    assert reroute_key.affinity_kind == "internal_soft_affinity_reroute"
+    assert reroute_key.strength == "soft"
+    assert get_or_create.await_args_list[1].kwargs["previous_response_id"] is None
+    assert "internal_soft_affinity_reroute" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_select_account_with_budget_prefers_durable_account_id_when_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5892,12 +5983,12 @@ async def test_get_or_create_http_bridge_session_inflight_wait_times_out(
         )
 
     assert exc_info.value.status_code == 429
-    assert exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
     assert key not in service._http_bridge_inflight_sessions
     with pytest.raises(ProxyResponseError) as future_exc_info:
         await inflight_future
     assert future_exc_info.value.status_code == 429
-    assert future_exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert future_exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
 
 
 @pytest.mark.asyncio
@@ -6054,13 +6145,122 @@ async def test_get_or_create_http_bridge_session_capacity_wait_times_out(
         )
 
     assert exc_info.value.status_code == 429
-    assert exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
     assert inflight_key not in service._http_bridge_inflight_sessions
     with pytest.raises(ProxyResponseError) as future_exc_info:
         await inflight_future
     assert future_exc_info.value.status_code == 429
-    assert future_exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert future_exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
     create_http_bridge_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_immediate_capacity_exhaustion_is_local_overload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    existing_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-full", None)
+    existing = _make_bridge_session(key_value="sid-capacity-full", queued_request_count=1)
+    service._http_bridge_sessions[existing_key] = existing
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_http_bridge_pending_count", AsyncMock(return_value=1))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._get_or_create_http_bridge_session(
+            proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-new", None),
+            headers={"x-codex-session-id": "sid-capacity-new"},
+            affinity=proxy_service._AffinityPolicy(
+                key="sid-capacity-new",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=1,
+        )
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+
+
+@pytest.mark.asyncio
+async def test_create_http_bridge_session_cancellation_before_connect_handoff_releases_stream_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    account = cast(
+        Any,
+        SimpleNamespace(
+            id="acc-bridge-cancel-handoff",
+            chatgpt_account_id="acc-bridge-cancel-handoff",
+            status=AccountStatus.ACTIVE,
+            access_token_encrypted="encrypted",
+        ),
+    )
+    selected_lease = await service._load_balancer.acquire_account_lease(account.id, kind="stream")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_ensure_fresh(*_: object, **__: object) -> Any:
+        started.set()
+        await release.wait()
+        return account
+
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget",
+        AsyncMock(return_value=proxy_service.AccountSelection(account, None, lease=selected_lease)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", blocking_ensure_fresh)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        prefer_earlier_reset_accounts=False,
+                        routing_strategy="usage_weighted",
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+
+    task = asyncio.create_task(
+        service._create_http_bridge_session(
+            proxy_service._HTTPBridgeSessionKey("session_header", "sid-bridge-cancel", None),
+            headers={"x-codex-session-id": "sid-bridge-cancel"},
+            affinity=proxy_service._AffinityPolicy(
+                key="sid-bridge-cancel",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+        )
+    )
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 1, 0.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        release.set()
+
+    assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
 
 @pytest.mark.asyncio
@@ -6191,7 +6391,7 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
         await asyncio.wait_for(get_session(), timeout=1.0)
 
     assert waiter_exc_info.value.status_code == 429
-    assert waiter_exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert waiter_exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
     assert key not in service._http_bridge_inflight_sessions
 
     finish_create.set()
@@ -6199,7 +6399,7 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
         await asyncio.wait_for(owner_task, timeout=1.0)
 
     assert owner_exc_info.value.status_code == 429
-    assert owner_exc_info.value.payload["error"]["code"] == "proxy_overloaded"
+    assert owner_exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
     assert key not in service._http_bridge_sessions
     close_http_bridge_session.assert_awaited_once_with(created)
 
@@ -7114,8 +7314,10 @@ async def test_submit_http_bridge_request_starts_api_key_reservation_heartbeat(
         *,
         response_create_gate: asyncio.Semaphore,
         compact: bool = False,
+        account_id: str | None = None,
+        surface: str = "websocket",
     ) -> None:
-        del compact
+        del compact, account_id, surface
         nonlocal admission_saw_heartbeat
         admission_saw_heartbeat = state.api_key_reservation_heartbeat_task is not None
         state.response_create_gate = response_create_gate
@@ -8055,7 +8257,7 @@ async def test_create_http_bridge_session_fails_closed_when_previous_response_ow
         )
 
     assert exc_info.value.status_code == 502
-    assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
+    assert exc_info.value.payload["error"]["code"] == "previous_response_owner_unavailable"
     open_upstream.assert_not_awaited()
 
 
@@ -8097,7 +8299,7 @@ async def test_stream_via_http_bridge_replays_durable_full_resend_when_owner_is_
     owner_unavailable = ProxyResponseError(
         502,
         proxy_service.openai_error(
-            "upstream_unavailable",
+            "previous_response_owner_unavailable",
             "Previous response owner account is unavailable; retry later.",
             error_type="server_error",
         ),

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1041,6 +1041,97 @@ async def test_select_account_with_budget_skips_preferred_account_outside_assign
     assert first_call.kwargs["account_ids"] == {"acc-allowed"}
 
 
+@pytest.mark.asyncio
+async def test_select_account_with_budget_required_file_pin_does_not_fallback_on_account_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    select_account = AsyncMock(
+        side_effect=[
+            proxy_service.AccountSelection(
+                account=None,
+                error_message="Account stream capacity is exhausted",
+                error_code="account_stream_cap",
+            ),
+            proxy_service.AccountSelection(
+                account=cast(Any, SimpleNamespace(id="acc-other")),
+                error_message=None,
+                error_code=None,
+            ),
+        ]
+    )
+    service._load_balancer = cast(Any, SimpleNamespace(select_account=select_account))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(return_value=SimpleNamespace(sticky_reallocation_budget_threshold_pct=95.0))
+        ),
+    )
+
+    selection = await service._select_account_with_budget(
+        time.monotonic() + 60.0,
+        request_id="req-file-pin",
+        kind="stream",
+        request_stage="first_turn",
+        preferred_account_id="acc-file-owner",
+        lease_kind="stream",
+        fallback_on_preferred_account_unavailable=False,
+    )
+
+    assert selection.account is None
+    assert selection.error_code == "account_stream_cap"
+    assert select_account.await_count == 1
+    first_call = select_account.await_args_list[0]
+    assert first_call.kwargs["account_ids"] == {"acc-file-owner"}
+
+
+@pytest.mark.asyncio
+async def test_select_account_with_budget_soft_preference_can_fallback_after_account_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    select_account = AsyncMock(
+        side_effect=[
+            proxy_service.AccountSelection(
+                account=None,
+                error_message="Account stream capacity is exhausted",
+                error_code="account_stream_cap",
+            ),
+            proxy_service.AccountSelection(
+                account=cast(Any, SimpleNamespace(id="acc-other")),
+                error_message=None,
+                error_code=None,
+            ),
+        ]
+    )
+    service._load_balancer = cast(Any, SimpleNamespace(select_account=select_account))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(return_value=SimpleNamespace(sticky_reallocation_budget_threshold_pct=95.0))
+        ),
+    )
+
+    selection = await service._select_account_with_budget(
+        time.monotonic() + 60.0,
+        request_id="req-soft-preferred",
+        kind="stream",
+        request_stage="first_turn",
+        preferred_account_id="acc-soft",
+        lease_kind="stream",
+    )
+
+    assert selection.account is not None
+    assert selection.account.id == "acc-other"
+    assert select_account.await_count == 2
+    first_call = select_account.await_args_list[0]
+    second_call = select_account.await_args_list[1]
+    assert first_call.kwargs["account_ids"] == {"acc-soft"}
+    assert second_call.kwargs["account_ids"] is None
+
+
 def test_headers_with_authorization_restores_missing_proxy_api_header() -> None:
     headers = proxy_service._headers_with_authorization({"x-request-id": "req-1"}, "Bearer proxy-key")
 
@@ -4839,6 +4930,7 @@ async def test_get_or_create_http_bridge_session_preserves_explicit_forwarded_af
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         require_preferred_account: bool = False,
+        fallback_on_preferred_account_unavailable: bool = True,
     ) -> proxy_service._HTTPBridgeSession:
         del (
             headers,
@@ -4849,6 +4941,7 @@ async def test_get_or_create_http_bridge_session_preserves_explicit_forwarded_af
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         captured["key"] = create_key
         return created_session
@@ -4922,6 +5015,7 @@ async def test_get_or_create_http_bridge_session_falls_back_to_session_header_wh
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         require_preferred_account: bool = False,
+        fallback_on_preferred_account_unavailable: bool = True,
     ) -> proxy_service._HTTPBridgeSession:
         del (
             headers,
@@ -4932,6 +5026,7 @@ async def test_get_or_create_http_bridge_session_falls_back_to_session_header_wh
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         captured["key"] = create_key
         return created_session
@@ -5005,6 +5100,7 @@ async def test_get_or_create_http_bridge_session_preserves_durable_canonical_pro
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         require_preferred_account: bool = False,
+        fallback_on_preferred_account_unavailable: bool = True,
     ) -> proxy_service._HTTPBridgeSession:
         del (
             headers,
@@ -5015,6 +5111,7 @@ async def test_get_or_create_http_bridge_session_preserves_durable_canonical_pro
             request_stage,
             preferred_account_id,
             require_preferred_account,
+            fallback_on_preferred_account_unavailable,
         )
         captured["key"] = create_key
         return created_session

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -29,6 +29,7 @@ from app.modules.proxy.load_balancer import (
     ADDITIONAL_QUOTA_DATA_UNAVAILABLE,
     NO_ADDITIONAL_QUOTA_ELIGIBLE_ACCOUNTS,
     NO_PLAN_SUPPORT_FOR_MODEL,
+    AccountLease,
     LoadBalancer,
     RuntimeState,
 )
@@ -1060,6 +1061,64 @@ async def test_select_account_prunes_stale_runtime_for_removed_accounts() -> Non
     selection = await balancer.select_account()
     assert selection.account is not None
     assert selection.account.id == account_id
+
+
+@pytest.mark.asyncio
+async def test_select_account_preserves_leased_runtime_for_removed_accounts() -> None:
+    active = _make_account("acc-active", "active@example.com")
+    removed = _make_account("acc-removed", "removed@example.com")
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    primary = {
+        active.id: UsageHistory(
+            id=1,
+            account_id=active.id,
+            recorded_at=now,
+            window="primary",
+            used_percent=10.0,
+            reset_at=now_epoch + 300,
+            window_minutes=5,
+        ),
+    }
+    secondary = {
+        active.id: UsageHistory(
+            id=2,
+            account_id=active.id,
+            recorded_at=now,
+            window="secondary",
+            used_percent=10.0,
+            reset_at=now_epoch + 3600,
+            window_minutes=60,
+        ),
+    }
+
+    accounts_repo = StubAccountsRepository([active])
+    usage_repo = StubUsageRepository(primary=primary, secondary=secondary)
+    sticky_repo = StubStickySessionsRepository()
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    lease = AccountLease(
+        lease_id="lease-removed",
+        account_id=removed.id,
+        kind="stream",
+        acquired_at=time.monotonic(),
+        estimated_tokens=42.0,
+    )
+    balancer._runtime[removed.id] = RuntimeState(
+        inflight_streams=1,
+        leased_tokens=42.0,
+        leases={lease.lease_id: lease},
+    )
+
+    selection = await balancer.select_account()
+
+    assert selection.account is not None
+    assert selection.account.id == active.id
+    assert removed.id in balancer._runtime
+    retained_runtime = balancer._runtime[removed.id]
+    assert retained_runtime.inflight_streams == 1
+    assert retained_runtime.leased_tokens == 42.0
+    assert retained_runtime.leases == {lease.lease_id: lease}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6151,10 +6151,10 @@ async def test_connect_proxy_websocket_previous_response_owner_usage_limit_fails
     assert await_args is not None
     sent_payload = json.loads(await_args.args[0])
     assert sent_payload["status"] == 502
-    assert sent_payload["error"]["code"] == "upstream_unavailable"
+    assert sent_payload["error"]["code"] == "previous_response_owner_unavailable"
     assert sent_payload["error"]["message"] == "Previous response owner account is unavailable; retry later."
     assert request_logs.calls[0]["request_id"] == "ws_req_prev_owner_handshake_429"
-    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
+    assert request_logs.calls[0]["error_code"] == "previous_response_owner_unavailable"
     assert request_logs.calls[0]["account_id"] == account_owner.id
 
 
@@ -6397,9 +6397,9 @@ async def test_connect_proxy_websocket_surfaces_connect_timeout_when_no_failover
     assert await_args is not None
     sent_payload = json.loads(await_args.args[0])
     assert sent_payload["status"] == 502
-    assert sent_payload["error"]["code"] == "upstream_unavailable"
+    assert sent_payload["error"]["code"] == "previous_response_owner_unavailable"
     assert request_logs.calls[0]["account_id"] == first_account.id
-    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
+    assert request_logs.calls[0]["error_code"] == "previous_response_owner_unavailable"
 
 
 @pytest.mark.asyncio
@@ -6447,7 +6447,7 @@ async def test_select_websocket_connect_account_requires_preferred_account_for_p
     call = emit_connect_failure.await_args
     assert call is not None
     assert call.kwargs["status_code"] == 502
-    assert call.kwargs["error_code"] == "upstream_unavailable"
+    assert call.kwargs["error_code"] == "previous_response_owner_unavailable"
     assert call.kwargs["account_id"] == "acc_owner"
 
 
@@ -6506,7 +6506,7 @@ async def test_select_websocket_connect_account_records_fail_closed_for_preferre
     assert await_args is not None
     sent_payload = json.loads(await_args.args[0])
     assert sent_payload["status"] == 502
-    assert sent_payload["error"]["code"] == "upstream_unavailable"
+    assert sent_payload["error"]["code"] == "previous_response_owner_unavailable"
     assert "continuity_fail_closed surface=websocket_connect reason=owner_account_unavailable" in caplog.text
     assert "resp_prev_owner" not in caplog.text
     assert counter.samples == [
@@ -6577,10 +6577,10 @@ async def test_select_websocket_connect_account_preferred_owner_missing_fails_cl
     assert await_args is not None
     sent_payload = json.loads(await_args.args[0])
     assert sent_payload["status"] == 502
-    assert sent_payload["error"]["code"] == "upstream_unavailable"
+    assert sent_payload["error"]["code"] == "previous_response_owner_unavailable"
     assert sent_payload["error"]["message"] == "Previous response owner account is unavailable; retry later."
     assert request_logs.calls[0]["account_id"] == "acc_owner"
-    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
+    assert request_logs.calls[0]["error_code"] == "previous_response_owner_unavailable"
     assert "continuity_fail_closed surface=websocket_connect reason=owner_account_unavailable" in caplog.text
     assert "resp_prev_owner" not in caplog.text
     assert counter.samples == [
@@ -6589,6 +6589,57 @@ async def test_select_websocket_connect_account_preferred_owner_missing_fails_cl
             "value": 1.0,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_select_websocket_connect_account_stream_cap_is_local_overload(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_stream_cap",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    select_account = AsyncMock(
+        return_value=AccountSelection(
+            account=None,
+            error_message="All eligible accounts are at the stream cap",
+            error_code="account_stream_cap",
+        )
+    )
+    websocket_send = AsyncMock()
+
+    monkeypatch.setattr(service, "_select_account_with_budget", select_account)
+
+    result = await service._select_websocket_connect_account(
+        10_000.0,
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=cast(WebSocket, SimpleNamespace(send_text=websocket_send)),
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+        exclude_account_ids=set(),
+        preferred_account_id=None,
+        require_preferred_account=False,
+    )
+
+    assert result is None
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["lease_kind"] == "stream"
+    await_args = websocket_send.await_args
+    assert await_args is not None
+    sent_payload = json.loads(await_args.args[0])
+    assert sent_payload["status"] == 429
+    assert sent_payload["error"]["code"] == "account_stream_cap"
+    assert sent_payload["error"]["type"] == "rate_limit_error"
 
 
 @pytest.mark.asyncio
@@ -6654,6 +6705,63 @@ async def test_connect_proxy_websocket_fails_over_after_forced_refresh_transport
     record_error.assert_awaited_once_with(first_account)
     websocket_send.assert_not_awaited()
     release_reservation.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_proxy_websocket_cancellation_before_handoff_releases_stream_lease(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_cancel_handoff")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_cancel_handoff",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    selected_lease = await service._load_balancer.acquire_account_lease(account.id, kind="stream")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_select_websocket_connect_account(*args: object, **kwargs: object) -> Account:
+        del args, kwargs
+        request_state.websocket_stream_lease = selected_lease
+        return account
+
+    async def blocking_connect_attempt(*args: object, **kwargs: object) -> tuple[Account, object]:
+        del args, kwargs
+        started.set()
+        await release.wait()
+        return account, object()
+
+    monkeypatch.setattr(service, "_select_websocket_connect_account", fake_select_websocket_connect_account)
+    monkeypatch.setattr(service, "_try_open_websocket_connect_attempt", blocking_connect_attempt)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_proxy_settings(log_proxy_service_tier_trace=False))
+
+    task = asyncio.create_task(
+        service._connect_proxy_websocket(
+            {},
+            sticky_key=None,
+            sticky_kind=None,
+            prefer_earlier_reset=False,
+            routing_strategy="usage_weighted",
+            model="gpt-5.1",
+            request_state=request_state,
+            api_key=None,
+            client_send_lock=anyio.Lock(),
+            websocket=cast(WebSocket, SimpleNamespace()),
+        )
+    )
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 1, 0.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        release.set()
+
+    assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
 
 @pytest.mark.asyncio
@@ -13868,10 +13976,130 @@ async def test_compact_responses_surfaces_local_create_overload_without_penalizi
 
     exc = _assert_proxy_response_error(exc_info.value)
     assert exc.status_code == 429
-    assert _proxy_error_code(exc) == "proxy_overloaded"
+    assert _proxy_error_code(exc) == "global_admission_timeout"
     failing_upstream.assert_not_awaited()
     record_error.assert_not_awaited()
-    assert request_logs.calls[0]["error_code"] == "proxy_overloaded"
+    assert request_logs.calls[0]["error_code"] == "global_admission_timeout"
+    select_account = cast(AsyncMock, service._load_balancer.select_account)
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["lease_kind"] == "response_create"
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_releases_account_create_lease_when_global_admission_times_out(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_compact_response_create_limit = 1
+    settings.proxy_admission_wait_timeout_seconds = 0.05
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_lease_release")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    selected_lease = await service._load_balancer.acquire_account_lease(account.id, kind="response_create")
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None, lease=selected_lease)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    upstream = AsyncMock()
+    monkeypatch.setattr(proxy_service, "core_compact_responses", upstream)
+
+    global_lease = await service._get_work_admission().acquire_response_create(compact=True)
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    try:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            await service.compact_responses(payload, {"session_id": "sid-compact"})
+    finally:
+        global_lease.release()
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 429
+    assert _proxy_error_code(exc) == "global_admission_timeout"
+    assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
+    upstream.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_cancellation_before_freshness_handoff_releases_account_lease(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_cancel_handoff")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    selected_lease = await service._load_balancer.acquire_account_lease(account.id, kind="response_create")
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None, lease=selected_lease)),
+    )
+
+    async def blocking_ensure_fresh(*args: object, **kwargs: object) -> Account:
+        del args, kwargs
+        started.set()
+        await release.wait()
+        return account
+
+    monkeypatch.setattr(service, "_ensure_fresh", blocking_ensure_fresh)
+    monkeypatch.setattr(proxy_service, "core_compact_responses", AsyncMock())
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    task = asyncio.create_task(service.compact_responses(payload, {"session_id": "sid-compact"}))
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        assert await service._load_balancer.account_pressure_snapshot(account.id) == (1, 0, 0.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        release.set()
+
+    assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_account_create_cap_is_local_overload(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(
+            return_value=AccountSelection(
+                account=None,
+                error_code="account_response_create_cap",
+                error_message="All eligible accounts are at the response-create cap",
+            )
+        ),
+    )
+    ensure_fresh = AsyncMock()
+    monkeypatch.setattr(service, "_ensure_fresh", ensure_fresh)
+    upstream = AsyncMock()
+    monkeypatch.setattr(proxy_service, "core_compact_responses", upstream)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(payload, {"session_id": "sid-compact"})
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 429
+    assert _proxy_error_code(exc) == "account_response_create_cap"
+    select_account = cast(AsyncMock, service._load_balancer.select_account)
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["lease_kind"] == "response_create"
+    ensure_fresh.assert_not_awaited()
+    upstream.assert_not_awaited()
+    assert request_logs.calls[0]["error_code"] == "account_response_create_cap"
 
 
 @pytest.mark.asyncio
@@ -14010,7 +14238,7 @@ async def test_response_create_admission_failure_releases_session_gate(monkeypat
 
     exc = _assert_proxy_response_error(exc_info.value)
     assert exc.status_code == 429
-    assert _proxy_error_code(exc) == "proxy_overloaded"
+    assert _proxy_error_code(exc) == "global_admission_timeout"
     assert response_create_gate.locked() is False
     assert request_state.awaiting_response_created is False
     assert request_state.response_create_gate_acquired is False
@@ -14018,7 +14246,50 @@ async def test_response_create_admission_failure_releases_session_gate(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_response_create_admission_session_gate_timeout_returns_proxy_overloaded(monkeypatch):
+async def test_response_create_admission_cancellation_releases_account_lease(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_admission_wait_timeout_seconds = 5.0
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_gate_cancel",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    task = asyncio.create_task(
+        service._acquire_request_state_response_create_admission(
+            request_state,
+            response_create_gate=response_create_gate,
+            account_id="acc-gate-cancel",
+            surface="http_bridge",
+        )
+    )
+    try:
+        for _ in range(50):
+            if await service._load_balancer.account_pressure_snapshot("acc-gate-cancel") == (1, 0, 0.0):
+                break
+            await asyncio.sleep(0.01)
+        assert await service._load_balancer.account_pressure_snapshot("acc-gate-cancel") == (1, 0, 0.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        response_create_gate.release()
+
+    assert await service._load_balancer.account_pressure_snapshot("acc-gate-cancel") == (0, 0, 0.0)
+    assert request_state.account_response_create_lease is None
+    assert request_state.response_create_gate is None
+
+
+@pytest.mark.asyncio
+async def test_response_create_admission_session_gate_timeout_returns_stable_reason(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.proxy_response_create_limit = 64
     settings.proxy_admission_wait_timeout_seconds = 0.01
@@ -14047,7 +14318,7 @@ async def test_response_create_admission_session_gate_timeout_returns_proxy_over
 
     exc = _assert_proxy_response_error(exc_info.value)
     assert exc.status_code == 429
-    assert _proxy_error_code(exc) == "proxy_overloaded"
+    assert _proxy_error_code(exc) == "response_create_gate_timeout"
     assert request_state.response_create_gate is None
     assert request_state.awaiting_response_created is False
     assert request_state.response_create_gate_acquired is False

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -16076,6 +16076,31 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_PREWARM_RESPONSE_TIMEOUT_SECONDS", 0.05)
     reconnect_observations: list[dict[str, object]] = []
+    admission_observations: list[dict[str, object]] = []
+    original_acquire_admission = service._acquire_request_state_response_create_admission
+
+    async def capture_acquire_admission(
+        state: proxy_service._WebSocketRequestState,
+        *,
+        response_create_gate: asyncio.Semaphore,
+        compact: bool = False,
+        account_id: str | None = None,
+        surface: str = "websocket",
+    ) -> None:
+        admission_observations.append(
+            {
+                "request_id": state.request_id,
+                "account_id": account_id,
+                "surface": surface,
+            }
+        )
+        await original_acquire_admission(
+            state,
+            response_create_gate=response_create_gate,
+            compact=compact,
+            account_id=account_id,
+            surface=surface,
+        )
 
     async def fake_reconnect_http_bridge_session(
         reconnect_session: proxy_service._HTTPBridgeSession,
@@ -16094,6 +16119,7 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
         reconnect_session.closed = False
 
     monkeypatch.setattr(service, "_reconnect_http_bridge_session", fake_reconnect_http_bridge_session)
+    monkeypatch.setattr(service, "_acquire_request_state_response_create_admission", capture_acquire_admission)
 
     await asyncio.wait_for(
         service._maybe_prewarm_http_bridge_session(
@@ -16109,6 +16135,16 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
     # warmup events cannot be matched to the next visible request.
     assert session.prewarmed is False
     assert len(reconnect_observations) == 1
+    assert len(admission_observations) == 1
+    prewarm_admission = admission_observations[0]
+    assert admission_observations == [
+        {
+            "request_id": prewarm_admission["request_id"],
+            "account_id": "acc_prewarm_timeout",
+            "surface": "http_bridge_prewarm",
+        }
+    ]
+    assert cast(str, prewarm_admission["request_id"]).startswith("http_prewarm_")
     observation = reconnect_observations[0]
     assert observation["request_id"] == "req_prewarm_timeout"
     assert observation["restart_reader"] is True

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6765,6 +6765,56 @@ async def test_connect_proxy_websocket_cancellation_before_handoff_releases_stre
 
 
 @pytest.mark.asyncio
+async def test_connect_proxy_websocket_releases_stream_lease_when_failure_emit_raises(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_emit_failure_release")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_emit_failure_release",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    selected_lease = await service._load_balancer.acquire_account_lease(account.id, kind="stream")
+
+    async def fake_select_websocket_connect_account(*args: object, **kwargs: object) -> Account:
+        del args, kwargs
+        request_state.websocket_stream_lease = selected_lease
+        return account
+
+    async def failing_connect_attempt(*args: object, **kwargs: object) -> tuple[Account, object]:
+        del args, kwargs
+        raise proxy_module.ProxyResponseError(502, openai_error("upstream_unavailable", "connect failed"))
+
+    async def failing_emit(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise RuntimeError("downstream closed during connect failure emit")
+
+    monkeypatch.setattr(service, "_select_websocket_connect_account", fake_select_websocket_connect_account)
+    monkeypatch.setattr(service, "_try_open_websocket_connect_attempt", failing_connect_attempt)
+    monkeypatch.setattr(service, "_decide_websocket_failover_action", AsyncMock(return_value="emit"))
+    monkeypatch.setattr(service, "_emit_websocket_connect_failure", failing_emit)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_proxy_settings(log_proxy_service_tier_trace=False))
+
+    with pytest.raises(RuntimeError, match="downstream closed"):
+        await service._connect_proxy_websocket(
+            {},
+            sticky_key=None,
+            sticky_kind=None,
+            prefer_earlier_reset=False,
+            routing_strategy="usage_weighted",
+            model="gpt-5.1",
+            request_state=request_state,
+            api_key=None,
+            client_send_lock=anyio.Lock(),
+            websocket=cast(WebSocket, SimpleNamespace()),
+        )
+
+    assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_maps_handshake_budget_exhaustion_to_timeout_error(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -14100,6 +14150,44 @@ async def test_compact_responses_account_create_cap_is_local_overload(monkeypatc
     ensure_fresh.assert_not_awaited()
     upstream.assert_not_awaited()
     assert request_logs.calls[0]["error_code"] == "account_response_create_cap"
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_pops_timeout_overrides_when_account_create_cap_raises(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.proxy_account_response_create_limit = 1
+    settings.upstream_compact_timeout_seconds = None
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_timeout_pop_on_cap")
+    timeout_tokens = object()
+    popped_tokens: list[object] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", AsyncMock())
+    monkeypatch.setattr(proxy_service, "push_compact_timeout_overrides", lambda **kwargs: timeout_tokens)
+    monkeypatch.setattr(proxy_service, "pop_compact_timeout_overrides", lambda token: popped_tokens.append(token))
+
+    held_lease = await service._load_balancer.acquire_account_lease(account.id, kind="response_create")
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    try:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            await service.compact_responses(payload, {"session_id": "sid-compact"})
+    finally:
+        await service._load_balancer.release_account_lease(held_lease)
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 429
+    assert _proxy_error_code(exc) == "account_response_create_cap"
+    assert popped_tokens == [timeout_tokens]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11527,6 +11527,116 @@ async def test_proxy_responses_websocket_masks_prepare_previous_response_not_fou
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_websocket_releases_reservation_on_local_account_create_cap(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.stream_idle_timeout_seconds = 300.0
+    settings.proxy_downstream_websocket_idle_timeout_seconds = 120.0
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    class _FakeDownstreamWebSocket:
+        def __init__(self, request_text: str) -> None:
+            self._request_text = request_text
+            self._request_sent = False
+            self._done = asyncio.Event()
+            self.sent_text: list[str] = []
+
+        async def receive(self) -> dict[str, object]:
+            if not self._request_sent:
+                self._request_sent = True
+                return {"type": "websocket.receive", "text": self._request_text}
+            await self._done.wait()
+            return {"type": "websocket.disconnect"}
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+            self._done.set()
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+        async def close(self, code: int = 1000, reason: str | None = None) -> None:
+            del code, reason
+            self._done.set()
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "stream": True,
+    }
+    request_text = json.dumps(request_payload, separators=(",", ":"))
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_ws_account_cap",
+        key_id="key_ws_account_cap",
+        model="gpt-5.1",
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_ws_account_cap",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=reservation,
+        started_at=10.0,
+        request_text=request_text,
+        awaiting_response_created=True,
+    )
+    prepared_request = proxy_service._PreparedWebSocketRequest(
+        text_data=request_text,
+        request_state=request_state,
+        affinity_policy=proxy_service._AffinityPolicy(),
+    )
+    release_reservation = AsyncMock()
+    start_heartbeat = MagicMock()
+    upstream = SimpleNamespace(send_text=AsyncMock(), send_bytes=AsyncMock(), close=AsyncMock())
+    account = _make_account("acc_ws_account_cap")
+
+    async def fake_connect_proxy_websocket(*args, **kwargs):
+        del args, kwargs
+        return account, upstream
+
+    async def fail_account_response_create_lease(*args, **kwargs):
+        del args, kwargs
+        raise proxy_module.ProxyResponseError(
+            429,
+            proxy_module.openai_error(
+                "account_response_create_cap",
+                "Account response-create concurrency limit reached",
+                error_type="server_error",
+            ),
+        )
+
+    monkeypatch.setattr(service, "_prepare_websocket_response_create_request", AsyncMock(return_value=prepared_request))
+    monkeypatch.setattr(service, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(service, "_relay_upstream_websocket_messages", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        service, "_acquire_account_response_create_lease_or_overload", fail_account_response_create_lease
+    )
+    monkeypatch.setattr(service, "_release_websocket_reservation", release_reservation)
+    monkeypatch.setattr(service, "_start_request_state_api_key_reservation_heartbeat", start_heartbeat)
+
+    downstream = _FakeDownstreamWebSocket(request_text)
+
+    await service.proxy_responses_websocket(
+        cast(WebSocket, downstream),
+        {},
+        codex_session_affinity=False,
+        openai_cache_affinity=False,
+        api_key=None,
+    )
+
+    release_reservation.assert_awaited_once_with(reservation)
+    start_heartbeat.assert_called_once()
+    upstream.send_text.assert_not_awaited()
+    assert len(downstream.sent_text) == 1
+    payload = json.loads(downstream.sent_text[0])
+    assert payload["type"] == "response.failed"
+    assert payload["response"]["error"]["code"] == "account_response_create_cap"
+
+
+@pytest.mark.asyncio
 async def test_stream_with_retry_releases_api_key_reservation_when_owner_lookup_fails(monkeypatch):
     request_logs = _RequestLogsRecorder()
     get_usage_reservation_mock = AsyncMock(return_value=SimpleNamespace(status="reserved", items=[]))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15298,6 +15298,74 @@ async def test_reconnect_http_bridge_skips_extra_same_account_retry_after_keepal
 
 
 @pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_reuses_same_account_stream_lease(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_bridge_reconnect_reuse_lease")
+    old_upstream = AsyncMock()
+    new_upstream = SimpleNamespace(response_header=lambda _name: None)
+    old_lease = proxy_service.AccountLease(
+        lease_id="lease_existing_stream",
+        account_id=account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    seen_lease_kinds: list[object] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 10.0)
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        seen_lease_kinds.append(kwargs.get("lease_kind"))
+        return AccountSelection(account=account, error_message=None)
+
+    release_account_lease = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(
+        service,
+        "_open_upstream_websocket_with_budget",
+        AsyncMock(return_value=new_upstream),
+    )
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_reuse_lease",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=10.0,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-key"),
+        request_model="gpt-5.5",
+        account=account,
+        upstream=old_upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+        account_lease=old_lease,
+    )
+
+    await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert seen_lease_kinds == [None]
+    assert session.account_lease is old_lease
+    assert session.account == account
+    assert session.upstream is new_upstream
+    release_account_lease.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_reconnect_http_bridge_session_fails_over_after_repeated_401_refresh_retry(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6643,6 +6643,59 @@ async def test_select_websocket_connect_account_stream_cap_is_local_overload(mon
 
 
 @pytest.mark.asyncio
+async def test_select_websocket_file_pin_stream_cap_does_not_fall_back(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_file_pin_stream_cap",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        preferred_account_id="acc_file_owner",
+        file_required_preferred_account=True,
+    )
+    select_account = AsyncMock(
+        return_value=AccountSelection(
+            account=None,
+            error_message="All eligible accounts are at the stream cap",
+            error_code="account_stream_cap",
+        )
+    )
+    websocket_send = AsyncMock()
+
+    monkeypatch.setattr(service, "_select_account_with_budget", select_account)
+
+    result = await service._select_websocket_connect_account(
+        10_000.0,
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=cast(WebSocket, SimpleNamespace(send_text=websocket_send)),
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+        exclude_account_ids=set(),
+        preferred_account_id="acc_file_owner",
+        require_preferred_account=True,
+    )
+
+    assert result is None
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["fallback_on_preferred_account_unavailable"] is False
+    await_args = websocket_send.await_args
+    assert await_args is not None
+    sent_payload = json.loads(await_args.args[0])
+    assert sent_payload["status"] == 429
+    assert sent_payload["error"]["code"] == "account_stream_cap"
+    assert sent_payload["error"]["type"] == "rate_limit_error"
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_fails_over_after_forced_refresh_transport_error(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -13965,6 +13965,11 @@ async def test_stream_previous_response_owner_miss_fails_closed_before_unpinned_
     monkeypatch.setattr(proxy_service, "PROMETHEUS_AVAILABLE", True)
     monkeypatch.setattr(proxy_service, "continuity_fail_closed_total", counter, raising=False)
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "_load_selection_inputs",
+        AsyncMock(return_value=SimpleNamespace(accounts=[account_other, _make_account("acc_second_stream")])),
+    )
     monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account_other))
     monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
     monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14742,6 +14742,32 @@ async def test_select_account_with_budget_times_out_during_settings_fetch(monkey
 
 
 @pytest.mark.asyncio
+async def test_select_account_with_budget_forwards_estimated_lease_tokens(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_estimated_lease")
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None))
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+
+    selection = await service._select_account_with_budget(
+        deadline=123.0,
+        request_id="req-estimated-lease",
+        kind="stream",
+        lease_kind="stream",
+        estimated_lease_tokens=1234.0,
+        model="gpt-5.1",
+    )
+
+    assert selection.account == account
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["estimated_lease_tokens"] == 1234.0
+
+
+@pytest.mark.asyncio
 async def test_transcribe_budget_exhaustion_blocks_401_retry_with_timeout(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -42,7 +42,7 @@ from app.modules.proxy import affinity as proxy_affinity
 from app.modules.proxy import api as proxy_api
 from app.modules.proxy import request_policy as proxy_request_policy
 from app.modules.proxy import service as proxy_service
-from app.modules.proxy.load_balancer import AccountSelection
+from app.modules.proxy.load_balancer import AccountLease, AccountSelection
 from app.modules.proxy.repo_bundle import ProxyRepositories
 from app.modules.proxy.sticky_repository import StickySessionsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -14682,12 +14682,61 @@ async def test_response_create_admission_waits_on_session_gate_before_shared_cap
     shared_lease = await service._get_work_admission().acquire_response_create()
     shared_lease.release()
 
-    proxy_service._release_websocket_response_create_gate(first_request, response_create_gate)
+    await proxy_service._release_websocket_response_create_gate(first_request, response_create_gate)
     await second_task
-    proxy_service._release_websocket_response_create_gate(second_request, response_create_gate)
+    await proxy_service._release_websocket_response_create_gate(second_request, response_create_gate)
 
     assert second_request.response_create_gate_acquired is False
     assert second_request.response_create_admission is None
+
+
+@pytest.mark.asyncio
+async def test_response_create_gate_release_waits_for_account_lease_release():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_gate_order",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+    )
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+    request_state.response_create_gate_acquired = True
+    request_state.response_create_gate = response_create_gate
+    lease = AccountLease(
+        lease_id="lease_gate_order",
+        account_id="acc_gate_order",
+        kind="response_create",
+        acquired_at=0.0,
+    )
+    request_state.account_response_create_lease = lease
+    release_started = asyncio.Event()
+    release_allowed = asyncio.Event()
+
+    async def release_account_lease(received_lease: AccountLease | None) -> None:
+        assert received_lease == lease
+        release_started.set()
+        await release_allowed.wait()
+
+    request_state.account_response_create_release = release_account_lease
+
+    release_task = asyncio.create_task(
+        proxy_service._release_websocket_response_create_gate(request_state, response_create_gate)
+    )
+    await release_started.wait()
+    await asyncio.sleep(0)
+
+    assert response_create_gate.locked() is True
+    assert request_state.response_create_gate_acquired is True
+
+    release_allowed.set()
+    await release_task
+
+    assert response_create_gate.locked() is False
+    assert request_state.response_create_gate_acquired is False
+    assert request_state.account_response_create_lease is None
+    assert request_state.account_response_create_release is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -13694,6 +13694,7 @@ async def test_stream_previous_response_not_found_proxy_error_is_masked_to_strea
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     account = _make_account("acc_prev_missing_stream")
+    request_logs.response_owner_by_id[("resp_prev_anchor", None, "sid-stream")] = account.id
     record_error = AsyncMock()
     record_success = AsyncMock()
     counter = _ObservedCounter()
@@ -13764,6 +13765,7 @@ async def test_stream_missing_tool_output_proxy_error_is_masked_to_stream_incomp
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     account = _make_account("acc_missing_tool_output_stream")
+    request_logs.response_owner_by_id[("resp_prev_anchor", None, "sid-stream")] = account.id
     record_error = AsyncMock()
     record_success = AsyncMock()
     counter = _ObservedCounter()
@@ -13935,6 +13937,59 @@ async def test_stream_selection_fail_closed_records_owner_unavailable_metric(mon
     assert request_logs.calls[0]["account_id"] == "acc_prev_owner_stream"
     assert "continuity_fail_closed surface=http_stream reason=owner_account_unavailable" in caplog.text
     assert "resp_prev_anchor" not in caplog.text
+    assert counter.samples == [
+        {
+            "labels": {"surface": "http_stream", "reason": "owner_account_unavailable"},
+            "value": 1.0,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_previous_response_owner_miss_fails_closed_before_unpinned_selection(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_other = _make_account("acc_other_stream")
+    select_account = AsyncMock(return_value=AccountSelection(account=account_other, error_message=None))
+    stream_calls: list[str | None] = []
+    counter = _ObservedCounter()
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, base_url, raise_for_status, kwargs
+        stream_calls.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_wrong_account"}}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(proxy_service, "continuity_fail_closed_total", counter, raising=False)
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account_other))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_missing_owner",
+        }
+    )
+
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+
+    event = json.loads(chunks[0].split("data: ", 1)[1])
+    assert event["type"] == "response.failed"
+    assert event["response"]["error"]["code"] == "previous_response_owner_unavailable"
+    assert event["response"]["error"]["message"] == "Previous response owner account is unavailable; retry later."
+    assert request_logs.lookup_calls == [("resp_missing_owner", None, "sid-stream")]
+    assert request_logs.calls[0]["error_code"] == "previous_response_owner_unavailable"
+    assert request_logs.calls[0]["account_id"] is None
+    select_account.assert_not_awaited()
+    assert stream_calls == []
     assert counter.samples == [
         {
             "labels": {"surface": "http_stream", "reason": "owner_account_unavailable"},

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6217,8 +6217,8 @@ async def test_connect_proxy_websocket_surfaces_local_connect_overload_without_p
     assert websocket_send.await_args is not None
     sent_payload = json.loads(websocket_send.await_args.args[0])
     assert sent_payload["status"] == 429
-    assert sent_payload["error"]["code"] == "proxy_overloaded"
-    assert request_logs.calls[0]["error_code"] == "proxy_overloaded"
+    assert sent_payload["error"]["code"] == "global_admission_timeout"
+    assert request_logs.calls[0]["error_code"] == "global_admission_timeout"
 
 
 @pytest.mark.asyncio
@@ -6397,9 +6397,9 @@ async def test_connect_proxy_websocket_surfaces_connect_timeout_when_no_failover
     assert await_args is not None
     sent_payload = json.loads(await_args.args[0])
     assert sent_payload["status"] == 502
-    assert sent_payload["error"]["code"] == "previous_response_owner_unavailable"
+    assert sent_payload["error"]["code"] == "upstream_unavailable"
     assert request_logs.calls[0]["account_id"] == first_account.id
-    assert request_logs.calls[0]["error_code"] == "previous_response_owner_unavailable"
+    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
 
 
 @pytest.mark.asyncio
@@ -13669,10 +13669,10 @@ async def test_stream_previous_response_owner_usage_limit_fails_closed(monkeypat
 
     event = json.loads(chunks[0].split("data: ", 1)[1])
     assert event["type"] == "response.failed"
-    assert event["response"]["error"]["code"] == "upstream_unavailable"
+    assert event["response"]["error"]["code"] == "previous_response_owner_unavailable"
     assert event["response"]["error"]["message"] == "Previous response owner account is unavailable; retry later."
     assert request_logs.lookup_calls == [("resp_prev_anchor", None, "sid-stream")]
-    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
+    assert request_logs.calls[0]["error_code"] == "previous_response_owner_unavailable"
     assert request_logs.calls[0]["account_id"] == account_owner.id
     assert len(select_account_calls) == 1
     assert select_account_calls[0]["account_ids"] == {account_owner.id}
@@ -13717,7 +13717,7 @@ async def test_stream_selection_fail_closed_records_owner_unavailable_metric(mon
 
     event = json.loads(chunks[0].split("data: ", 1)[1])
     assert event["type"] == "response.failed"
-    assert event["response"]["error"]["code"] == "upstream_unavailable"
+    assert event["response"]["error"]["code"] == "previous_response_owner_unavailable"
     assert event["response"]["error"]["message"] == "Previous response owner account is unavailable; retry later."
     assert request_logs.calls[0]["account_id"] == "acc_prev_owner_stream"
     assert "continuity_fail_closed surface=http_stream reason=owner_account_unavailable" in caplog.text

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -13900,6 +13900,53 @@ async def test_stream_previous_response_owner_usage_limit_fails_closed(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_stream_prompt_cache_key_does_not_soften_previous_response_owner(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_owner = _make_account("acc_prev_owner_stream")
+    account_cache = _make_account("acc_prompt_cache_stream")
+    request_logs.response_owner_by_id[("resp_prev_anchor", None, "sid-stream")] = account_owner.id
+    select_account = AsyncMock(return_value=AccountSelection(account=account_cache, error_message=None))
+    stream_calls: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, base_url, raise_for_status, kwargs
+        stream_calls.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_wrong_cache_account"}}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account_cache))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_prev_anchor",
+            "prompt_cache_key": "cache-soft-affinity",
+        }
+    )
+
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+
+    event = json.loads(chunks[0].split("data: ", 1)[1])
+    assert event["type"] == "response.failed"
+    assert event["response"]["error"]["code"] == "previous_response_owner_unavailable"
+    assert event["response"]["error"]["message"] == "Previous response owner account is unavailable; retry later."
+    assert request_logs.lookup_calls == [("resp_prev_anchor", None, "sid-stream")]
+    assert request_logs.calls[0]["error_code"] == "previous_response_owner_unavailable"
+    assert request_logs.calls[0]["account_id"] == account_owner.id
+    select_account.assert_awaited_once()
+    assert stream_calls == []
+
+
+@pytest.mark.asyncio
 async def test_stream_selection_fail_closed_records_owner_unavailable_metric(monkeypatch, caplog):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()

--- a/tests/unit/test_responses_streaming_timeout_hardening.py
+++ b/tests/unit/test_responses_streaming_timeout_hardening.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from app.core.utils.sse import SSE_KEEPALIVE_FRAME
+from app.modules.proxy import api as proxy_api
+
+pytestmark = pytest.mark.unit
+
+
+async def _one_event_stream() -> AsyncIterator[str]:
+    yield 'event: response.created\ndata: {"type":"response.created"}\n\n'
+
+
+@pytest.mark.asyncio
+async def test_initial_sse_heartbeat_precedes_openai_contract_event() -> None:
+    stream = proxy_api._prepend_initial_sse_heartbeat(
+        _one_event_stream(),
+        SSE_KEEPALIVE_FRAME,
+        request_id="req_test",
+        route_family="responses",
+    )
+
+    first = await anext(stream)
+    second = await anext(stream)
+
+    assert first == SSE_KEEPALIVE_FRAME
+    assert "response.created" in second


### PR DESCRIPTION
## Summary

Hardens `/v1/responses` under high concurrent streaming load so usage-based routing does not concentrate work on one account, and local overloads are reported with stable diagnostics instead of ambiguous upstream-style 429s.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: N/A — operator-reported production load issue, no GitHub issue number.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/stabilize-responses-concurrency-streaming/`

## Changes

- Add per-account response-create and stream leases/caps, stale lease reclamation, and in-flight pressure scoring for account selection.
- Route soft prompt-cache/sticky-thread overloads to alternate eligible accounts while keeping hard `CODEX_SESSION` / previous-response continuity fail-closed.
- Normalize local overload taxonomy for account caps, bridge queue saturation, global admission timeout, response-create gate timeout, and active-session capacity.
- Harden `/v1/responses` streaming with early SSE heartbeat behavior and anti-buffering headers.
- Add Prometheus metrics for account lease acquire/release/stale-reclaim and cap rejections.
- Add a sustained streaming load reproducer that uses env-provided credentials only.
- Add OpenSpec deltas and targeted unit coverage for fairness, caps, lease cleanup, bridge reroute, hard continuity, taxonomy, and streaming timeout behavior.

## Test plan

```bash
uv run pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_load_balancer_concurrency.py tests/unit/test_responses_streaming_timeout_hardening.py tests/unit/test_proxy_utils.py::test_compact_responses_surfaces_local_create_overload_without_penalizing_account tests/unit/test_proxy_utils.py::test_compact_responses_releases_account_create_lease_when_global_admission_times_out tests/unit/test_proxy_utils.py::test_compact_responses_cancellation_before_freshness_handoff_releases_account_lease tests/unit/test_proxy_utils.py::test_compact_responses_account_create_cap_is_local_overload tests/unit/test_proxy_utils.py::test_response_create_admission_failure_releases_session_gate tests/unit/test_proxy_utils.py::test_response_create_admission_cancellation_releases_account_lease tests/unit/test_proxy_utils.py::test_response_create_admission_session_gate_timeout_returns_stable_reason tests/unit/test_proxy_utils.py::test_select_websocket_connect_account_requires_preferred_account_for_previous_response tests/unit/test_proxy_utils.py::test_select_websocket_connect_account_records_fail_closed_for_preferred_account_mismatch tests/unit/test_proxy_utils.py::test_select_websocket_connect_account_preferred_owner_missing_fails_closed tests/unit/test_proxy_utils.py::test_select_websocket_connect_account_stream_cap_is_local_overload tests/unit/test_proxy_utils.py::test_connect_proxy_websocket_cancellation_before_handoff_releases_stream_lease tests/unit/test_proxy_utils.py::test_stream_responses_first_event_connection_reset_fails_over tests/unit/test_proxy_utils.py::test_stream_responses_first_event_upstream_unavailable_fails_over tests/unit/test_proxy_utils.py::test_stream_previous_response_owner_usage_limit_fails_closed -q
# 154 passed

openspec validate --specs
# 21 passed, 0 failed

uv run ruff check app/core/balancer/logic.py app/core/config/settings.py app/core/metrics/prometheus.py app/core/resilience/overload.py app/modules/proxy/load_balancer.py app/modules/proxy/service.py app/modules/proxy/api.py app/modules/proxy/work_admission.py scripts/reproduce_responses_stream_load.py tests/unit/test_load_balancer_concurrency.py tests/unit/test_responses_streaming_timeout_hardening.py tests/unit/test_proxy_http_bridge.py tests/unit/test_proxy_utils.py
# All checks passed

uv run ty check app/modules/proxy/load_balancer.py app/modules/proxy/service.py app/modules/proxy/api.py app/core/resilience/overload.py app/core/metrics/prometheus.py app/modules/proxy/work_admission.py tests/unit/test_load_balancer_concurrency.py tests/unit/test_proxy_http_bridge.py tests/unit/test_proxy_utils.py
# All checks passed

git diff --check
# passed

# post-rebase/format smoke before commit
uv run pytest tests/unit/test_load_balancer_concurrency.py tests/unit/test_proxy_http_bridge.py tests/unit/test_responses_streaming_timeout_hardening.py -q
# 139 passed
```

## Screenshots / output (optional)

N/A — backend/proxy behavior only.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above — N/A, no GitHub issue exists for this operator report.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
