### PR TITLE
fix(api): tolerate null model filters and truncation

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -466,7 +466,9 @@ class ResponsesRequest(BaseModel):
     def _validate_truncation(cls, value: str | None) -> str | None:
         if value is None:
             return value
-        raise ValueError("truncation is not supported")
+        if value not in {"auto", "disabled"}:
+            raise ValueError("truncation must be 'auto' or 'disabled'")
+        return value
 
     @field_validator("store")
     @classmethod
@@ -563,6 +565,7 @@ _UNSUPPORTED_UPSTREAM_FIELDS = {
     "safety_identifier",
     "temperature",
     "top_p",
+    "truncation",
     "user",
 }
 

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -1142,7 +1142,7 @@ def _deserialize_allowed_models(payload: str | None) -> list[str] | None:
     parsed = json.loads(payload)
     if not isinstance(parsed, list):
         return None
-    models = [str(value).strip() for value in parsed if str(value).strip()]
+    models = [value.strip() for value in parsed if isinstance(value, str) and value.strip()]
     return models
 
 

--- a/openspec/changes/fix-api-key-null-models-and-truncation/proposal.md
+++ b/openspec/changes/fix-api-key-null-models-and-truncation/proposal.md
@@ -1,0 +1,20 @@
+# fix-api-key-null-models-and-truncation
+
+## Summary
+
+Fix two compatibility edge cases:
+
+- API key `allowed_models` deserialization must ignore JSON `null` and other non-string entries instead of converting them into model names.
+- Responses requests may include OpenAI's `truncation` control; codex-lb should accept the documented values and omit the field before forwarding to the ChatGPT-backed upstream path.
+
+## Motivation
+
+Users can hit false `model_not_allowed` 403 responses when stored `allowed_models` data contains JSON nulls, because `null` was deserialized as the string `"None"`.
+
+VS Code/Copilot custom endpoint traffic can include `truncation: "auto"`, which codex-lb rejected before account selection even though the field can be safely treated as a compatibility hint for the downstream OpenAI-compatible surface.
+
+## Scope
+
+- Backend request/model normalization only.
+- No database schema changes.
+- No frontend changes.

--- a/openspec/changes/fix-api-key-null-models-and-truncation/specs/api-keys/spec.md
+++ b/openspec/changes/fix-api-key-null-models-and-truncation/specs/api-keys/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Model restriction enforcement
+
+The system SHALL enforce per-key model restrictions in the proxy service layer (not middleware). When `allowed_models` is set (non-null, non-empty) and the requested model is not in the list, the system MUST reject the request. When reading stored `allowed_models`, JSON `null`, blank strings, and non-string array entries MUST be ignored and MUST NOT become model names. The `/v1/models` endpoint MUST filter the model list based on the authenticated key's `allowed_models`.
+
+#### Scenario: Stored null allowed-model entries are ignored
+
+- **GIVEN** an API key row stores `allowed_models` as `[null, "gpt-5.2", 42, ""]`
+- **WHEN** the key policy is loaded
+- **THEN** the effective allowed model list is `["gpt-5.2"]`
+- **AND** `null` is not converted to `"None"`

--- a/openspec/changes/fix-api-key-null-models-and-truncation/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-api-key-null-models-and-truncation/specs/responses-api-compat/spec.md
@@ -1,4 +1,4 @@
-## MODIFIED Requirements
+## ADDED Requirements
 
 ### Requirement: Responses request compatibility controls
 

--- a/openspec/changes/fix-api-key-null-models-and-truncation/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-api-key-null-models-and-truncation/specs/responses-api-compat/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Responses request compatibility controls
+
+The system SHALL accept OpenAI-compatible Responses request controls that clients may send for `/v1/responses` and `/backend-api/codex/responses` when those controls can be safely normalized before the ChatGPT-backed upstream request. Specifically, `truncation` values `"auto"` and `"disabled"` MUST pass request validation and MUST be omitted from the upstream payload because the current ChatGPT-backed path does not consume the field. Unsupported `truncation` values MUST still be rejected with HTTP 400.
+
+#### Scenario: Truncation auto is accepted and stripped
+
+- **WHEN** a client sends a Responses request with `truncation: "auto"`
+- **THEN** codex-lb accepts the request
+- **AND** the upstream payload does not include `truncation`
+
+#### Scenario: Truncation disabled is accepted and stripped
+
+- **WHEN** a client sends a Responses request with `truncation: "disabled"`
+- **THEN** codex-lb accepts the request
+- **AND** the upstream payload does not include `truncation`

--- a/openspec/changes/fix-api-key-null-models-and-truncation/tasks.md
+++ b/openspec/changes/fix-api-key-null-models-and-truncation/tasks.md
@@ -1,0 +1,4 @@
+- [x] Ignore JSON null and non-string entries when reading stored API key `allowed_models`.
+- [x] Accept `truncation: "auto"` and `truncation: "disabled"` on Responses requests.
+- [x] Strip `truncation` before forwarding upstream.
+- [x] Add regression coverage for both issues.

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -337,10 +337,11 @@ async def test_v1_responses_coerces_store_true_to_false(async_client):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("truncation", ["auto", "disabled"])
-async def test_v1_responses_rejects_truncation(async_client, truncation):
+async def test_v1_responses_accepts_truncation(async_client, truncation):
     payload = {"model": "gpt-5.2", "input": "hi", "truncation": truncation}
     resp = await async_client.post("/v1/responses", json=payload)
-    assert resp.status_code == 400
+    # 503 means it passed validation (no 400) but there are no upstream accounts in test
+    assert resp.status_code != 400
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1577,7 +1577,7 @@ def test_v1_responses_websocket_rejects_invalid_payload_before_connect(app_insta
                         "type": "response.create",
                         "model": "gpt-5.4",
                         "input": "hi",
-                        "truncation": "auto",
+                        "truncation": "middle",
                     }
                 )
             )

--- a/tests/unit/test_api_keys_service.py
+++ b/tests/unit/test_api_keys_service.py
@@ -548,6 +548,27 @@ async def test_create_key_stores_hash_and_prefix() -> None:
 
 
 @pytest.mark.asyncio
+async def test_api_key_read_skips_null_allowed_models() -> None:
+    repo = _FakeApiKeysRepository()
+    service = ApiKeysService(repo)
+
+    created = await service.create_key(
+        ApiKeyCreateData(
+            name="nullable-models",
+            allowed_models=["gpt-5.2"],
+            expires_at=None,
+        )
+    )
+    row = await repo.get_by_id(created.id)
+    assert row is not None
+    row.allowed_models = '[null, " gpt-5.2 ", 42, "", "gpt-5.5"]'
+
+    reloaded = await service.get_key_by_id(created.id)
+
+    assert reloaded.allowed_models == ["gpt-5.2", "gpt-5.5"]
+
+
+@pytest.mark.asyncio
 async def test_create_key_normalizes_timezone_aware_expiry_to_utc_naive() -> None:
     repo = _FakeApiKeysRepository()
     service = ApiKeysService(repo)

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -81,6 +81,7 @@ def test_known_unsupported_upstream_fields_are_stripped():
         "safety_identifier": "safe_123",
         "temperature": 0.2,
         "top_p": 0.9,
+        "truncation": "auto",
         "user": "cursor-user",
         "custom_field": "kept",
     }
@@ -93,6 +94,7 @@ def test_known_unsupported_upstream_fields_are_stripped():
     assert "safety_identifier" not in dumped
     assert "temperature" not in dumped
     assert "top_p" not in dumped
+    assert "truncation" not in dumped
     assert "user" not in dumped
     assert dumped["custom_field"] == "kept"
 


### PR DESCRIPTION
## Summary

Normalize API-key allowed-model JSON arrays so `null` and other non-string entries do not become literal model names, and accept OpenAI-compatible Responses `truncation` values without forwarding that local compatibility field upstream.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Fixes #885, Fixes #856

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-api-key-null-models-and-truncation/`

## Changes

- Ignore non-string and blank entries when deserializing API-key `allowed_models` JSON.
- Accept Responses API `truncation` values `auto` and `disabled`, while stripping `truncation` before forwarding to ChatGPT upstream.
- Add OpenSpec deltas and unit/integration coverage for both compatibility fixes.

## Test plan

```bash
uv run pytest tests/unit/test_api_keys_service.py::test_api_key_read_skips_null_allowed_models tests/unit/test_openai_requests.py::test_known_unsupported_upstream_fields_are_stripped tests/integration/test_openai_compat_features.py::test_v1_responses_accepts_truncation -q
# 4 passed in 0.29s

uv run pytest tests/unit/test_api_keys_service.py tests/unit/test_openai_requests.py tests/integration/test_openai_compat_features.py -q
# 181 passed in 4.84s

uv run ruff check app/core/openai/requests.py app/modules/api_keys/service.py tests/unit/test_api_keys_service.py tests/unit/test_openai_requests.py tests/integration/test_openai_compat_features.py
# All checks passed!

openspec validate --specs
# 29 passed, 0 failed

git diff --check
# no output

make typecheck
# All checks passed!
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset locally.
- [x] If touching specs: `openspec validate --specs` passes.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
