### PR TITLE
fix(models): hide unsupported API models

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -707,6 +707,8 @@
         "code"
       ]
     },
+    {
+      "login": "KakatkarAkshay",
       "name": "Akshay Kakatkar",
       "avatar_url": "https://avatars.githubusercontent.com/u/49910222?v=4",
       "profile": "https://github.com/KakatkarAkshay",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -707,8 +707,6 @@
         "code"
       ]
     },
-    {
-      "login": "KakatkarAkshay",
       "name": "Akshay Kakatkar",
       "avatar_url": "https://avatars.githubusercontent.com/u/49910222?v=4",
       "profile": "https://github.com/KakatkarAkshay",

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -312,6 +312,8 @@ def get_model_registry() -> ModelRegistry:
 
 
 def is_public_model(model: UpstreamModel, allowed_models: set[str] | None) -> bool:
+    if not model.supported_in_api:
+        return False
     if allowed_models is None:
         return True
     return model.slug in allowed_models

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -178,7 +178,6 @@ _BOOTSTRAP_STATIC_MODELS: tuple[UpstreamModel, ...] = (
         context_window=128_000,
         input_modalities=("text",),
         default_reasoning_level="high",
-        supported_in_api=False,
         minimal_client_version="0.100.0",
     ),
     _bootstrap_model(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1754,7 +1754,7 @@ async def _build_models_response(api_key: ApiKeyData | None) -> Response:
 
     if not models:
         await _release_reservation(reservation)
-        return JSONResponse(content=ModelListResponse(data=[]).model_dump(mode="json"))
+        return JSONResponse(content=_dump_v1_models_response(ModelListResponse(data=[])))
 
     items: list[ModelListItem] = []
     for slug, model in models.items():
@@ -1762,7 +1762,19 @@ async def _build_models_response(api_key: ApiKeyData | None) -> Response:
             continue
         items.append(_to_model_list_item(slug, model, created=created))
     await _release_reservation(reservation)
-    return JSONResponse(content=ModelListResponse(data=items).model_dump(mode="json"))
+    return JSONResponse(content=_dump_v1_models_response(ModelListResponse(data=items)))
+
+
+def _dump_v1_models_response(response: ModelListResponse) -> dict[str, JsonValue]:
+    payload = response.model_dump(mode="json")
+    for item in payload["data"]:
+        metadata = item.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        for key in ("additional_speed_tiers", "service_tiers", "default_service_tier"):
+            if metadata.get(key) is None:
+                metadata.pop(key, None)
+    return payload
 
 
 def _allowed_models_for_api_key(api_key: ApiKeyData | None) -> set[str] | None:
@@ -1942,17 +1954,17 @@ def _to_model_metadata(model: UpstreamModel) -> ModelMetadata:
     )
 
 
-def _raw_string_list(raw: Mapping[str, JsonValue], key: str) -> list[str]:
+def _raw_string_list(raw: Mapping[str, JsonValue], key: str) -> list[str] | None:
     value = raw.get(key)
     if not isinstance(value, list):
-        return []
+        return None
     return [item for item in value if isinstance(item, str)]
 
 
-def _raw_object_list(raw: Mapping[str, JsonValue], key: str) -> list[dict[str, JsonValue]]:
+def _raw_object_list(raw: Mapping[str, JsonValue], key: str) -> list[dict[str, JsonValue]] | None:
     value = raw.get(key)
     if not isinstance(value, list):
-        return []
+        return None
     return [dict(cast(Mapping[str, JsonValue], item)) for item in value if isinstance(item, Mapping)]
 
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1936,7 +1936,29 @@ def _to_model_metadata(model: UpstreamModel) -> ModelMetadata:
         supported_in_api=model.supported_in_api,
         minimal_client_version=model.minimal_client_version,
         priority=model.priority,
+        additional_speed_tiers=_raw_string_list(model.raw, "additional_speed_tiers"),
+        service_tiers=_raw_object_list(model.raw, "service_tiers"),
+        default_service_tier=_raw_optional_string(model.raw, "default_service_tier"),
     )
+
+
+def _raw_string_list(raw: Mapping[str, JsonValue], key: str) -> list[str]:
+    value = raw.get(key)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _raw_object_list(raw: Mapping[str, JsonValue], key: str) -> list[dict[str, JsonValue]]:
+    value = raw.get(key)
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, Mapping)]
+
+
+def _raw_optional_string(raw: Mapping[str, JsonValue], key: str) -> str | None:
+    value = raw.get(key)
+    return value if isinstance(value, str) else None
 
 
 @v1_router.post(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1953,7 +1953,7 @@ def _raw_object_list(raw: Mapping[str, JsonValue], key: str) -> list[dict[str, J
     value = raw.get(key)
     if not isinstance(value, list):
         return []
-    return [dict(item) for item in value if isinstance(item, Mapping)]
+    return [dict(cast(Mapping[str, JsonValue], item)) for item in value if isinstance(item, Mapping)]
 
 
 def _raw_optional_string(raw: Mapping[str, JsonValue], key: str) -> str | None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1716,7 +1716,6 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
 
     entries: list[CodexModelEntry] = []
     data: list[ModelListItem] = []
-    created = int(time.time())
     for slug, model in models.items():
         if not model.supported_in_api:
             continue
@@ -1726,7 +1725,7 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
             entry = _to_codex_model_entry(model)
             entries.append(entry)
             if entry.visibility == "list":
-                data.append(_to_model_list_item(slug, model, created=created))
+                data.append(_to_model_list_item(slug, model, created=_model_list_created_at(model)))
             continue
         entry = _to_codex_model_entry(
             model,
@@ -1734,7 +1733,7 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
         )
         entries.append(entry)
         if entry.visibility == "list":
-            data.append(_to_model_list_item(slug, model, created=created))
+            data.append(_to_model_list_item(slug, model, created=_model_list_created_at(model)))
     await _release_reservation(reservation)
     return JSONResponse(content=CodexModelsResponse(models=entries, data=data).model_dump(mode="json"))
 
@@ -1814,6 +1813,16 @@ def _to_model_list_item(slug: str, model: UpstreamModel, *, created: int) -> Mod
             "supportsVision": _v1_supports_vision(model),
         }
     )
+
+
+def _model_list_created_at(model: UpstreamModel) -> int:
+    for key in ("created", "created_at", "createdAt"):
+        raw_value = model.raw.get(key)
+        if isinstance(raw_value, int):
+            return raw_value
+        if isinstance(raw_value, float):
+            return int(raw_value)
+    return 0
 
 
 def _codex_model_visibility_allowed_models(api_key: ApiKeyData | None) -> set[str] | None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1712,25 +1712,31 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
 
     if not models:
         await _release_reservation(reservation)
-        return JSONResponse(content=CodexModelsResponse(models=[]).model_dump(mode="json"))
+        return JSONResponse(content=CodexModelsResponse(models=[], data=[]).model_dump(mode="json"))
 
     entries: list[CodexModelEntry] = []
+    data: list[ModelListItem] = []
+    created = int(time.time())
     for slug, model in models.items():
         if not model.supported_in_api:
             continue
         if visibility_allowed_models is None:
             if not is_public_model(model, allowed_models):
                 continue
-            entries.append(_to_codex_model_entry(model))
+            entry = _to_codex_model_entry(model)
+            entries.append(entry)
+            if entry.visibility == "list":
+                data.append(_to_model_list_item(slug, model, created=created))
             continue
-        entries.append(
-            _to_codex_model_entry(
-                model,
-                visibility="list" if slug in visibility_allowed_models else "hide",
-            )
+        entry = _to_codex_model_entry(
+            model,
+            visibility="list" if slug in visibility_allowed_models else "hide",
         )
+        entries.append(entry)
+        if entry.visibility == "list":
+            data.append(_to_model_list_item(slug, model, created=created))
     await _release_reservation(reservation)
-    return JSONResponse(content=CodexModelsResponse(models=entries).model_dump(mode="json"))
+    return JSONResponse(content=CodexModelsResponse(models=entries, data=data).model_dump(mode="json"))
 
 
 async def _build_models_response(api_key: ApiKeyData | None) -> Response:
@@ -1754,28 +1760,7 @@ async def _build_models_response(api_key: ApiKeyData | None) -> Response:
     for slug, model in models.items():
         if not is_public_model(model, allowed_models):
             continue
-        items.append(
-            ModelListItem.model_validate(
-                {
-                    "id": slug,
-                    "created": created,
-                    "owned_by": "codex-lb",
-                    "metadata": _to_model_metadata(model),
-                    "api_types": ["chat_completions"],
-                    "capabilities": _v1_model_capabilities(model),
-                    "context_length": _v1_input_context_window(model),
-                    "contextLength": _v1_input_context_window(model),
-                    "max_output_tokens": _v1_max_output_tokens(model),
-                    "maxOutputTokens": _v1_max_output_tokens(model),
-                    "supports_reasoning": _v1_supports_reasoning(model),
-                    "supportsReasoning": _v1_supports_reasoning(model),
-                    "supports_images": _v1_supports_vision(model),
-                    "supportsImages": _v1_supports_vision(model),
-                    "supports_vision": _v1_supports_vision(model),
-                    "supportsVision": _v1_supports_vision(model),
-                }
-            )
-        )
+        items.append(_to_model_list_item(slug, model, created=created))
     await _release_reservation(reservation)
     return JSONResponse(content=ModelListResponse(data=items).model_dump(mode="json"))
 
@@ -1794,6 +1779,29 @@ def _canonical_model_set(models: Iterable[str]) -> set[str]:
 
 def _canonical_model_slug(model: str) -> str:
     return resolve_model_alias(model) or model
+
+
+def _to_model_list_item(slug: str, model: UpstreamModel, *, created: int) -> ModelListItem:
+    return ModelListItem.model_validate(
+        {
+            "id": slug,
+            "created": created,
+            "owned_by": "codex-lb",
+            "metadata": _to_model_metadata(model),
+            "api_types": ["chat_completions"],
+            "capabilities": _v1_model_capabilities(model),
+            "context_length": _v1_input_context_window(model),
+            "contextLength": _v1_input_context_window(model),
+            "max_output_tokens": _v1_max_output_tokens(model),
+            "maxOutputTokens": _v1_max_output_tokens(model),
+            "supports_reasoning": _v1_supports_reasoning(model),
+            "supportsReasoning": _v1_supports_reasoning(model),
+            "supports_images": _v1_supports_vision(model),
+            "supportsImages": _v1_supports_vision(model),
+            "supports_vision": _v1_supports_vision(model),
+            "supportsVision": _v1_supports_vision(model),
+        }
+    )
 
 
 def _codex_model_visibility_allowed_models(api_key: ApiKeyData | None) -> set[str] | None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1716,6 +1716,8 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
 
     entries: list[CodexModelEntry] = []
     for slug, model in models.items():
+        if not model.supported_in_api:
+            continue
         if visibility_allowed_models is None:
             if not is_public_model(model, allowed_models):
                 continue

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -176,6 +176,9 @@ class ModelMetadata(BaseModel):
     supported_in_api: bool = True
     minimal_client_version: str | None = None
     priority: int = 0
+    additional_speed_tiers: list[str] = []
+    service_tiers: list[dict[str, JsonValue]] = []
+    default_service_tier: str | None = None
 
 
 class ModelListItem(BaseModel):

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -176,8 +176,8 @@ class ModelMetadata(BaseModel):
     supported_in_api: bool = True
     minimal_client_version: str | None = None
     priority: int = 0
-    additional_speed_tiers: list[str] = []
-    service_tiers: list[dict[str, JsonValue]] = []
+    additional_speed_tiers: list[str] | None = None
+    service_tiers: list[dict[str, JsonValue]] | None = None
     default_service_tier: str | None = None
 
 

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -157,10 +157,6 @@ class CodexModelEntry(BaseModel):
     visibility: str = "list"
 
 
-class CodexModelsResponse(BaseModel):
-    models: list[CodexModelEntry]
-
-
 class ModelMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -201,6 +197,12 @@ class ModelListResponse(BaseModel):
 
     object: str = "list"
     data: list[ModelListItem]
+
+
+class CodexModelsResponse(BaseModel):
+    models: list[CodexModelEntry]
+    object: str = "list"
+    data: list[ModelListItem] = []
 
 
 class V1UsageLimitResponse(BaseModel):

--- a/openspec/changes/add-codex-models-data-alias/proposal.md
+++ b/openspec/changes/add-codex-models-data-alias/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Some OpenAI-compatible clients, including JetBrains IDE provider setup, probe the configured base URL by requesting `GET /backend-api/codex/models` and deserializing an OpenAI-style model list with a top-level `data` field. codex-lb's Codex-native endpoint only returned `models`, so those clients rejected the otherwise valid response before they could use the provider.
+
+## What Changes
+
+- Preserve the Codex-native `models` payload for `/backend-api/codex/models`.
+- Add an OpenAI-compatible top-level `object: "list"` and `data` model list alias to the same response.
+- Keep `data` limited to entries whose Codex visibility is `list`, so hidden Codex catalog entries remain hidden from generic OpenAI-style clients.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `model-catalog-compat`: `/backend-api/codex/models` remains Codex-native while also exposing an OpenAI-style `data` alias for generic client probes.
+
+## Impact
+
+- Code: `app/modules/proxy/api.py`, `app/modules/proxy/schemas.py`
+- Tests: `tests/integration/test_v1_models.py`
+- Compatibility: JetBrains/OpenAI-style model-list deserializers can read `/backend-api/codex/models` without losing Codex-native clients.

--- a/openspec/changes/add-codex-models-data-alias/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/add-codex-models-data-alias/specs/model-catalog-compat/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Native Codex model catalog stays backend-faithful
+
+When serving `GET /backend-api/codex/models`, the system MUST keep Codex-native model catalog semantics unchanged: the top-level `context_window` field remains the backend compact/input budget unless an explicit operator override applies, and upstream raw fields such as `max_context_window` remain available when upstream provides them. The `/v1/models` compatibility metadata MUST NOT mutate the native Codex endpoint.
+
+#### Scenario: Codex model catalog also exposes OpenAI data alias
+
+- **WHEN** a client requests `GET /backend-api/codex/models`
+- **THEN** the response keeps the Codex-native `models` list
+- **AND** the response includes `object: "list"` and an OpenAI-compatible `data` list
+- **AND** `data` contains model entries whose Codex visibility is `list`
+- **AND** `data` excludes entries whose Codex visibility is `hide`

--- a/openspec/changes/add-codex-models-data-alias/tasks.md
+++ b/openspec/changes/add-codex-models-data-alias/tasks.md
@@ -1,0 +1,16 @@
+## 1. Spec And Regression Coverage
+
+- [x] 1.1 Add an OpenSpec delta for the `/backend-api/codex/models` `data` alias.
+- [x] 1.2 Add integration coverage proving the Codex-native `models` payload remains present.
+- [x] 1.3 Add integration coverage proving `data` is OpenAI-style and excludes Codex-hidden entries.
+
+## 2. Implementation
+
+- [x] 2.1 Add `data` to the Codex models response schema.
+- [x] 2.2 Reuse the `/v1/models` model-list item mapping for the compatibility alias.
+- [x] 2.3 Preserve existing Codex-native `models` behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted model endpoint tests.
+- [x] 3.2 Run OpenSpec validation for this change.

--- a/openspec/changes/expose-v1-model-speed-tiers/proposal.md
+++ b/openspec/changes/expose-v1-model-speed-tiers/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+OpenAI-compatible model discovery clients need to know when Codex models expose upstream speed tiers, such as GPT-5.5 Fast. The Codex-native `/backend-api/codex/models` endpoint already preserves these upstream fields, but `/v1/models` drops them from `metadata`.
+
+## What Changes
+
+- Preserve upstream speed-tier metadata on `/v1/models` metadata entries.
+- Include `additional_speed_tiers`, `service_tiers`, and `default_service_tier` when upstream provides them.
+- Keep existing model IDs and pricing/request behavior unchanged.
+
+## Impact
+
+- OpenAI-compatible clients can synthesize fast-mode model aliases from `/v1/models` metadata.
+- No database migration or dashboard UI change.

--- a/openspec/changes/expose-v1-model-speed-tiers/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/expose-v1-model-speed-tiers/specs/model-catalog-compat/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: OpenAI-compatible model metadata preserves speed tiers
+
+When serving `GET /v1/models`, the system SHALL preserve upstream speed-tier metadata in each model's `metadata` object when upstream provides it. This includes `additional_speed_tiers`, `service_tiers`, and `default_service_tier`. The system MUST NOT invent speed tiers for models whose upstream catalog entry does not advertise them.
+
+#### Scenario: /v1/models exposes upstream fast tier metadata
+
+- **WHEN** the upstream model catalog contains `gpt-5.5` with `additional_speed_tiers=["fast"]`
+- **AND** the upstream model catalog includes a `service_tiers` entry with `id="priority"` and `name="Fast"`
+- **WHEN** a client calls `GET /v1/models`
+- **THEN** the `gpt-5.5` entry's metadata includes `additional_speed_tiers=["fast"]`
+- **AND** the metadata includes the upstream `service_tiers` entry
+- **AND** the metadata includes the upstream `default_service_tier` when present

--- a/openspec/changes/expose-v1-model-speed-tiers/tasks.md
+++ b/openspec/changes/expose-v1-model-speed-tiers/tasks.md
@@ -1,0 +1,5 @@
+## Tasks
+
+- [x] Add `/v1/models` metadata fields for upstream speed tiers.
+- [x] Map fields from the refreshed model registry raw upstream payload.
+- [x] Add integration coverage for speed-tier metadata on `/v1/models`.

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -447,6 +447,13 @@ This predicate SHALL be applied consistently across `/api/models`, `/v1/models`,
 - **WHEN** a model is in the `allowed_models` set but has `supported_in_api=false`
 - **THEN** that model is not exposed in any model list endpoint
 
+#### Scenario: gpt-5.3-codex aliases share availability gate consistently
+
+- **WHEN** `gpt-5.3-codex` has `supported_in_api=false`
+- **AND** `gpt-5.3-codex-spark` has `supported_in_api=true`
+- **THEN** `/api/models`, `/v1/models`, and `/backend-api/codex/models`
+      expose `gpt-5.3-codex-spark` but do not expose `gpt-5.3-codex`
+
 #### Scenario: Consistent model set across endpoints
 
 - **GIVEN** any model registry state

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -2356,7 +2356,7 @@ async def test_release_stale_usage_reservations_uses_sqlite_writer_section(async
 
 
 @pytest.mark.asyncio
-async def test_allowed_but_unsupported_model_is_exposed(async_client):
+async def test_allowed_but_unsupported_model_is_not_exposed(async_client):
     registry = get_model_registry()
     models = [
         _make_upstream_model(_TEST_MODELS[0], supported_in_api=True),
@@ -2389,7 +2389,7 @@ async def test_allowed_but_unsupported_model_is_exposed(async_client):
     assert listed.status_code == 200
     ids = {item["id"] for item in listed.json()["data"]}
     assert _TEST_MODELS[0] in ids
-    assert _HIDDEN_MODEL in ids
+    assert _HIDDEN_MODEL not in ids
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_path_rewrite_alias.py
+++ b/tests/integration/test_path_rewrite_alias.py
@@ -20,6 +20,24 @@ async def test_backend_api_codex_v1_models_aliases_canonical(async_client) -> No
 
 
 @pytest.mark.asyncio
+async def test_backend_api_codex_v1_models_alias_is_stable_across_second_boundary(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    times = iter([1_700_000_000.0, 1_700_000_001.0])
+    monkeypatch.setattr(
+        "app.modules.proxy.api.time.time",
+        lambda: next(times, 1_700_000_001.0),
+    )
+
+    canonical = await async_client.get("/backend-api/codex/models")
+    aliased = await async_client.get("/backend-api/codex/v1/models")
+
+    assert canonical.status_code == aliased.status_code == 200
+    assert canonical.json() == aliased.json()
+
+
+@pytest.mark.asyncio
 async def test_top_level_v1_models_is_unaffected(async_client) -> None:
     """/v1/models is the canonical OpenAI-style namespace; the alias
     middleware must not interfere with it.

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -734,6 +734,43 @@ async def test_v1_models_reports_backend_context_window(async_client):
 
 
 @pytest.mark.asyncio
+async def test_v1_models_exposes_speed_tier_metadata(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model(
+            "gpt-5.5",
+            raw={
+                "additional_speed_tiers": ["fast"],
+                "default_service_tier": "priority",
+                "service_tiers": [
+                    {
+                        "id": "priority",
+                        "name": "Fast",
+                        "description": "1.5x speed, increased usage",
+                    }
+                ],
+            },
+        )
+    ]
+    await registry.update({"pro": models})
+
+    resp = await async_client.get("/v1/models")
+    assert resp.status_code == 200
+    entry = next(item for item in resp.json()["data"] if item["id"] == "gpt-5.5")
+    metadata = entry["metadata"]
+
+    assert metadata["additional_speed_tiers"] == ["fast"]
+    assert metadata["default_service_tier"] == "priority"
+    assert metadata["service_tiers"] == [
+        {
+            "id": "priority",
+            "name": "Fast",
+            "description": "1.5x speed, increased usage",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_v1_models_does_not_promote_raw_max_context_window(async_client):
     registry = get_model_registry()
     models = [_make_upstream_model("gpt-custom", raw=_raw_with_max_context_window(900_000))]

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -771,6 +771,22 @@ async def test_v1_models_exposes_speed_tier_metadata(async_client):
 
 
 @pytest.mark.asyncio
+async def test_v1_models_omits_speed_tier_metadata_when_upstream_omits_it(async_client):
+    registry = get_model_registry()
+    models = [_make_upstream_model("gpt-5.5")]
+    await registry.update({"pro": models})
+
+    resp = await async_client.get("/v1/models")
+    assert resp.status_code == 200
+    entry = next(item for item in resp.json()["data"] if item["id"] == "gpt-5.5")
+    metadata = entry["metadata"]
+
+    assert "additional_speed_tiers" not in metadata
+    assert "default_service_tier" not in metadata
+    assert "service_tiers" not in metadata
+
+
+@pytest.mark.asyncio
 async def test_v1_models_does_not_promote_raw_max_context_window(async_client):
     registry = get_model_registry()
     models = [_make_upstream_model("gpt-custom", raw=_raw_with_max_context_window(900_000))]

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -340,6 +340,14 @@ async def test_backend_codex_models_rewrites_visibility_when_opted_in(async_clie
                 "visibility": "list",
             },
         ),
+        _make_upstream_model(
+            "gpt-hidden",
+            supported_in_api=False,
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "list",
+            },
+        ),
     ]
     await registry.update({"plus": models, "pro": models})
 
@@ -358,7 +366,7 @@ async def test_backend_codex_models_rewrites_visibility_when_opted_in(async_clie
         "/api/api-keys/",
         json={
             "name": "codex-visibility",
-            "allowedModels": ["gpt-5.2"],
+            "allowedModels": ["gpt-5.2", "gpt-hidden"],
             "applyToCodexModel": True,
         },
     )

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -12,7 +12,6 @@ BOOTSTRAP_MODEL_SLUGS = {
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.3-codex",
-    "gpt-5.3-codex-spark",
     "gpt-5.2",
     "codex-auto-review",
 }
@@ -39,7 +38,6 @@ EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
     "gpt-5.3-codex": "0.98.0",
-    "gpt-5.3-codex-spark": "0.100.0",
     "gpt-5.2": "0.0.1",
     "codex-auto-review": "0.98.0",
 }
@@ -156,12 +154,7 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
     assert mini["minimal_client_version"] == "0.98.0"
     assert {level["effort"] for level in mini["supported_reasoning_levels"]} == {"low", "medium", "high", "xhigh"}
 
-    spark = entries["gpt-5.3-codex-spark"]
-    assert spark["context_window"] == 128_000
-    assert spark["input_modalities"] == ["text"]
-    assert spark["default_reasoning_level"] == "high"
-    assert spark["supported_in_api"] is False
-    assert spark["minimal_client_version"] == "0.100.0"
+    assert "gpt-5.3-codex-spark" not in entries
 
     auto_review = entries["codex-auto-review"]
     assert auto_review["visibility"] == "hide"
@@ -173,7 +166,7 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
 
 
 @pytest.mark.asyncio
-async def test_v1_models_includes_supported_in_api_false_models(async_client):
+async def test_v1_models_excludes_supported_in_api_false_models(async_client):
     registry = get_model_registry()
     models = [
         _make_upstream_model("gpt-5.2"),
@@ -185,7 +178,25 @@ async def test_v1_models_includes_supported_in_api_false_models(async_client):
     resp = await async_client.get("/v1/models")
     assert resp.status_code == 200
     ids = {item["id"] for item in resp.json()["data"]}
-    assert {"gpt-5.2", "gpt-5.3-codex", "gpt-hidden"}.issubset(ids)
+    assert "gpt-5.2" in ids
+    assert "gpt-5.3-codex" in ids
+    assert "gpt-hidden" not in ids
+
+
+@pytest.mark.asyncio
+async def test_v1_models_includes_supported_model_and_excludes_unsupported_spark_alias(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model("gpt-5.3-codex", supported_in_api=False),
+        _make_upstream_model("gpt-5.3-codex-spark", supported_in_api=True),
+    ]
+    await registry.update({"plus": models, "pro": models})
+
+    resp = await async_client.get("/v1/models")
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json()["data"]}
+    assert "gpt-5.3-codex" not in ids
+    assert "gpt-5.3-codex-spark" in ids
 
 
 @pytest.mark.asyncio
@@ -524,7 +535,7 @@ async def test_backend_codex_models_preserves_original_flow_without_allowlist(as
 
 
 @pytest.mark.asyncio
-async def test_backend_codex_models_includes_supported_in_api_false_models(async_client):
+async def test_backend_codex_models_excludes_supported_in_api_false_models(async_client):
     registry = get_model_registry()
     models = [
         _make_upstream_model("gpt-5.2"),
@@ -536,7 +547,9 @@ async def test_backend_codex_models_includes_supported_in_api_false_models(async
     resp = await async_client.get("/backend-api/codex/models")
     assert resp.status_code == 200
     slugs = {m["slug"] for m in resp.json()["models"]}
-    assert {"gpt-5.2", "gpt-5.3-codex", "gpt-hidden"}.issubset(slugs)
+    assert "gpt-5.2" in slugs
+    assert "gpt-5.3-codex" in slugs
+    assert "gpt-hidden" not in slugs
 
 
 @pytest.mark.asyncio
@@ -573,6 +586,9 @@ async def test_model_sets_are_consistent_across_api_endpoints(async_client):
     dashboard_ids = {item["id"] for item in dashboard.json()["models"]}
     v1_ids = {item["id"] for item in v1.json()["data"]}
     codex_slugs = {item["slug"] for item in codex.json()["models"]}
+    assert "gpt-hidden" not in dashboard_ids
+    assert "gpt-hidden" not in v1_ids
+    assert "gpt-hidden" not in codex_slugs
     assert dashboard_ids == v1_ids == codex_slugs
 
 

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -12,6 +12,7 @@ BOOTSTRAP_MODEL_SLUGS = {
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
     "gpt-5.2",
     "codex-auto-review",
 }
@@ -38,6 +39,7 @@ EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
     "gpt-5.3-codex": "0.98.0",
+    "gpt-5.3-codex-spark": "0.100.0",
     "gpt-5.2": "0.0.1",
     "codex-auto-review": "0.98.0",
 }
@@ -154,7 +156,10 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
     assert mini["minimal_client_version"] == "0.98.0"
     assert {level["effort"] for level in mini["supported_reasoning_levels"]} == {"low", "medium", "high", "xhigh"}
 
-    assert "gpt-5.3-codex-spark" not in entries
+    spark = entries["gpt-5.3-codex-spark"]
+    assert spark["context_window"] == 128_000
+    assert spark["minimal_client_version"] == "0.100.0"
+    assert spark["supported_in_api"] is True
 
     auto_review = entries["codex-auto-review"]
     assert auto_review["visibility"] == "hide"

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -229,6 +229,39 @@ async def test_backend_codex_models_returns_format1(async_client):
     assert isinstance(payload["models"], list)
     slugs = {m["slug"] for m in payload["models"]}
     assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(slugs)
+    assert payload["object"] == "list"
+    data_ids = {m["id"] for m in payload["data"]}
+    assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(data_ids)
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_models_data_keeps_only_list_visible_models(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model(
+            "gpt-visible",
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "list",
+            },
+        ),
+        _make_upstream_model(
+            "gpt-hidden",
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "hide",
+            },
+        ),
+    ]
+    await registry.update({"plus": models, "pro": models})
+
+    resp = await async_client.get("/backend-api/codex/models")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert {m["slug"] for m in payload["models"]} == {"gpt-visible", "gpt-hidden"}
+    assert {m["id"] for m in payload["data"]} == {"gpt-visible"}
+    assert payload["data"][0]["object"] == "model"
+    assert payload["data"][0]["owned_by"] == "codex-lb"
 
 
 @pytest.mark.asyncio
@@ -569,6 +602,9 @@ async def test_backend_codex_models_uses_bootstrap_models_when_registry_not_popu
     payload = resp.json()
     slugs = {item["slug"] for item in payload["models"]}
     assert slugs == BOOTSTRAP_MODEL_SLUGS
+    data_ids = {item["id"] for item in payload["data"]}
+    assert data_ids.issubset(BOOTSTRAP_MODEL_SLUGS)
+    assert data_ids
     assert "gpt-5.5-pro" not in slugs
     assert all(not slug.startswith("gpt-image-") for slug in slugs)
 

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -59,6 +59,10 @@ def _model(slug: str) -> UpstreamModel:
     )
 
 
+def _model_with_support(slug: str, *, supported_in_api: bool) -> UpstreamModel:
+    return replace(_model(slug), supported_in_api=supported_in_api)
+
+
 @pytest.mark.asyncio
 async def test_initial_snapshot_is_none():
     registry = ModelRegistry(ttl_seconds=60.0)
@@ -255,6 +259,17 @@ def test_ttl_must_be_positive():
         ModelRegistry(ttl_seconds=0)
     with pytest.raises(ValueError, match="positive"):
         ModelRegistry(ttl_seconds=-1.0)
+
+
+def test_is_public_model_requires_supported_in_api_true():
+    from app.core.openai.model_registry import is_public_model
+
+    public = _model_with_support("model-public", supported_in_api=True)
+    hidden = _model_with_support("model-hidden", supported_in_api=False)
+
+    assert is_public_model(public, None)
+    assert not is_public_model(hidden, None)
+    assert not is_public_model(hidden, {"model-hidden", "model-public"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -159,7 +159,7 @@ def test_bootstrap_models_include_representative_upstream_metadata():
     assert spark.context_window == 128_000
     assert spark.input_modalities == ("text",)
     assert spark.default_reasoning_level == "high"
-    assert spark.supported_in_api is False
+    assert spark.supported_in_api is True
     assert spark.minimal_client_version == "0.100.0"
 
     auto_review = models["codex-auto-review"]


### PR DESCRIPTION
## Summary

Unifies the model catalog compatibility fixes into one PR:

- hide models marked `supported_in_api=false` from `/api/models`, `/v1/models`, and `/backend-api/codex/models`
- preserve API-key allowlist filtering without exposing unsupported models
- add OpenAI-compatible `object: "list"` and `data` fields to `/backend-api/codex/models`
- expose upstream speed-tier metadata on `/v1/models` when upstream provides it

This absorbs #889 and #880. The #880 commits keep @KakatkarAkshay's authorship and contributor credit.

Fixes #876.
Fixes #608.
Fixes #834.

## Folded PRs

- Surviving PR: #887
- Folded into this branch: #889, #880
- Current head: `ff55b5b5cd0765eceabdd604428a44c9fabb833f`
- GitHub CI: pending on current head after follow-up force-push.

## OpenSpec

- Existing `api-keys` public model filtering requirement
- `openspec/changes/add-codex-models-data-alias/`
- `openspec/changes/expose-v1-model-speed-tiers/`

## Changes

- Centralize public model filtering in `is_public_model(...)`.
- Keep unsupported models hidden even when an API-key allowlist includes them.
- Return `/backend-api/codex/models` in a shape compatible with clients expecting OpenAI-style list/data fields.
- Preserve codex-faithful model visibility semantics while adding the compatibility alias.
- Include `additional_speed_tiers`, `service_tiers`, and `default_service_tier` on `/v1/models` entries only when those fields are present upstream.
- Add/update regression coverage for hidden Codex models, backend Codex model list shape, and speed-tier metadata.

## Validation

```bash
uv run pytest tests/unit/test_model_registry.py tests/integration/test_v1_models.py tests/integration/test_api_keys_api.py -k 'model or public_model or supported_in_api or backend_codex_models or speed_tier or allowed_but_unsupported' -q
uv run ruff check app/core/openai/model_registry.py app/modules/proxy/api.py app/modules/proxy/schemas.py tests/unit/test_model_registry.py tests/integration/test_v1_models.py tests/integration/test_api_keys_api.py
uv run ty check app/core/openai/model_registry.py app/modules/proxy/api.py app/modules/proxy/schemas.py
uv run openspec validate add-codex-models-data-alias --strict
uv run openspec validate expose-v1-model-speed-tiers --strict
uv run openspec validate --specs model-catalog-compat
uv run pytest tests/integration/test_path_rewrite_alias.py tests/integration/test_v1_models.py::test_backend_codex_models_returns_format1 tests/integration/test_v1_models.py::test_backend_codex_models_data_keeps_only_list_visible_models tests/integration/test_v1_models.py::test_backend_codex_models_excludes_supported_in_api_false_models -q
uv run ruff check app/modules/proxy/api.py tests/integration/test_path_rewrite_alias.py tests/integration/test_v1_models.py
uv run ty check app/modules/proxy/api.py tests/integration/test_path_rewrite_alias.py
```

Local result: 51 focused pytest cases passed; the deterministic backend Codex
alias regression pack passed; ruff, ty, and OpenSpec passed.
