### PR TITLE
fix(accounts): ignore free monthly primary resets

### DIFF
--- a/app/core/usage/__init__.py
+++ b/app/core/usage/__init__.py
@@ -178,6 +178,15 @@ def is_weekly_window_minutes(window_minutes: int | None) -> bool:
     return window_minutes == secondary_default
 
 
+def is_primary_window_minutes(window_minutes: int | None) -> bool:
+    if window_minutes is None:
+        return False
+    primary_default = default_window_minutes("primary")
+    if primary_default is None:
+        return False
+    return window_minutes == primary_default
+
+
 def should_use_weekly_primary(
     primary_row: UsageWindowRow,
     secondary_row: UsageWindowRow | None,

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -136,7 +136,8 @@ def _account_to_summary(
                 effective_primary_usage.window_minutes if effective_primary_usage is not None else None
             )
         )
-        if not keep_primary_status_signal and weekly_quota_available:
+        can_hide_zero_capacity_primary = account.status != AccountStatus.RATE_LIMITED or weekly_quota_available
+        if not keep_primary_status_signal and can_hide_zero_capacity_primary:
             status_primary_usage = None
             status_primary_used_percent = None
             if account.status == AccountStatus.RATE_LIMITED:

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -122,6 +122,7 @@ def _account_to_summary(
     status_primary_used_percent = primary_used_percent
     status_runtime_reset = float(account.reset_at) if account.reset_at else None
     status_seed = account.status
+    allow_missing_runtime_reset_recovery = False
     weekly_quota_available = (
         effective_secondary_usage is not None
         and _usage_entry_is_recent_enough(effective_secondary_usage.recorded_at)
@@ -141,6 +142,7 @@ def _account_to_summary(
             status_runtime_reset = None
             if account.status == AccountStatus.RATE_LIMITED:
                 status_seed = AccountStatus.ACTIVE
+                allow_missing_runtime_reset_recovery = True
         effective_primary_usage = None
         primary_used_percent = None
         primary_remaining_percent = None
@@ -173,6 +175,7 @@ def _account_to_summary(
         secondary_usage=effective_secondary_usage,
         secondary_used_percent=secondary_used_percent,
         runtime_reset=status_runtime_reset,
+        allow_missing_runtime_reset_recovery=allow_missing_runtime_reset_recovery,
     )
     return AccountSummary(
         account_id=account.id,
@@ -231,6 +234,7 @@ def _effective_status_from_usage(
     secondary_usage: UsageHistory | None,
     secondary_used_percent: float | None,
     runtime_reset: float | None,
+    allow_missing_runtime_reset_recovery: bool = False,
 ) -> AccountStatus:
     status, _, _ = apply_usage_quota(
         status=status_seed,
@@ -245,7 +249,7 @@ def _effective_status_from_usage(
         credits_balance=_first_not_none(primary_usage, secondary_usage, "credits_balance"),
     )
     if account.status == AccountStatus.RATE_LIMITED and status == AccountStatus.ACTIVE:
-        if runtime_reset is None:
+        if runtime_reset is None and allow_missing_runtime_reset_recovery:
             return status
         if (
             account.blocked_at is None

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from app.core import usage as usage_core
 from app.core.auth import DEFAULT_EMAIL, DEFAULT_PLAN, extract_id_token_claims, token_expiry_epoch_ms
+from app.core.config import settings as config_settings
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.usage.quota import apply_usage_quota
@@ -22,6 +23,8 @@ from app.modules.accounts.schemas import (
     UsageTrendPoint,
 )
 from app.modules.usage.mappers import usage_history_to_window_row
+
+_DEFAULT_USAGE_REFRESH_INTERVAL_SECONDS = 60
 
 
 def build_account_summaries(
@@ -119,6 +122,12 @@ def _account_to_summary(
     status_primary_used_percent = primary_used_percent
     status_runtime_reset = float(account.reset_at) if account.reset_at else None
     status_seed = account.status
+    weekly_quota_available = (
+        effective_secondary_usage is not None
+        and _usage_entry_is_recent_enough(effective_secondary_usage.recorded_at)
+        and effective_secondary_usage.used_percent is not None
+        and float(effective_secondary_usage.used_percent) < 100.0
+    )
     if usage_core.capacity_for_plan(plan_type, "primary") == 0.0:
         keep_primary_status_signal = (
             account.status == AccountStatus.RATE_LIMITED
@@ -126,7 +135,7 @@ def _account_to_summary(
                 effective_primary_usage.window_minutes if effective_primary_usage is not None else None
             )
         )
-        if not keep_primary_status_signal:
+        if not keep_primary_status_signal and weekly_quota_available:
             status_primary_usage = None
             status_primary_used_percent = None
             status_runtime_reset = None
@@ -256,6 +265,20 @@ def _first_not_none(primary_usage: UsageHistory | None, secondary_usage: UsageHi
     if secondary_usage is not None:
         return getattr(secondary_usage, field)
     return None
+
+
+def _usage_entry_is_recent_enough(recorded_at: datetime | None) -> bool:
+    if recorded_at is None:
+        return False
+    current_time = datetime.now(timezone.utc)
+    interval_seconds = max(_usage_refresh_interval_seconds() * 2, 180)
+    recorded_time = recorded_at if recorded_at.tzinfo is not None else recorded_at.replace(tzinfo=timezone.utc)
+    return recorded_time >= current_time - timedelta(seconds=interval_seconds)
+
+
+def _usage_refresh_interval_seconds() -> int:
+    settings = config_settings.get_settings()
+    return int(getattr(settings, "usage_refresh_interval_seconds", _DEFAULT_USAGE_REFRESH_INTERVAL_SECONDS))
 
 
 def _effective_usage_windows(

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -130,7 +130,13 @@ def _account_to_summary(
         and float(effective_secondary_usage.used_percent) < 100.0
     )
     if usage_core.capacity_for_plan(plan_type, "primary") == 0.0:
-        primary_window_minutes = effective_primary_usage.window_minutes if effective_primary_usage is not None else None
+        primary_window_minutes = (
+            effective_primary_usage.window_minutes
+            if effective_primary_usage is not None
+            else primary_usage.window_minutes
+            if weekly_only_usage and primary_usage is not None
+            else None
+        )
         zero_capacity_primary_known_non_primary = (
             primary_window_minutes is not None and not usage_core.is_primary_window_minutes(primary_window_minutes)
         )

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -139,8 +139,8 @@ def _account_to_summary(
         if not keep_primary_status_signal and weekly_quota_available:
             status_primary_usage = None
             status_primary_used_percent = None
-            status_runtime_reset = None
             if account.status == AccountStatus.RATE_LIMITED:
+                status_runtime_reset = None
                 status_seed = AccountStatus.ACTIVE
                 allow_missing_runtime_reset_recovery = True
         effective_primary_usage = None

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -117,10 +117,21 @@ def _account_to_summary(
 
     status_primary_usage = effective_primary_usage
     status_primary_used_percent = primary_used_percent
+    status_runtime_reset = float(account.reset_at) if account.reset_at else None
+    status_seed = account.status
     if usage_core.capacity_for_plan(plan_type, "primary") == 0.0:
-        if account.status != AccountStatus.RATE_LIMITED:
+        keep_primary_status_signal = (
+            account.status == AccountStatus.RATE_LIMITED
+            and usage_core.is_primary_window_minutes(
+                effective_primary_usage.window_minutes if effective_primary_usage is not None else None
+            )
+        )
+        if not keep_primary_status_signal:
             status_primary_usage = None
             status_primary_used_percent = None
+            status_runtime_reset = None
+            if account.status == AccountStatus.RATE_LIMITED:
+                status_seed = AccountStatus.ACTIVE
         effective_primary_usage = None
         primary_used_percent = None
         primary_remaining_percent = None
@@ -147,10 +158,12 @@ def _account_to_summary(
     )
     effective_status = _effective_status_from_usage(
         account,
-        status_primary_usage,
-        status_primary_used_percent,
-        effective_secondary_usage,
-        secondary_used_percent,
+        status_seed=status_seed,
+        primary_usage=status_primary_usage,
+        primary_used_percent=status_primary_used_percent,
+        secondary_usage=effective_secondary_usage,
+        secondary_used_percent=secondary_used_percent,
+        runtime_reset=status_runtime_reset,
     )
     return AccountSummary(
         account_id=account.id,
@@ -202,17 +215,20 @@ def _limit_warmup_to_status(entry: AccountLimitWarmup | None) -> AccountLimitWar
 
 def _effective_status_from_usage(
     account: Account,
+    *,
+    status_seed: AccountStatus,
     primary_usage: UsageHistory | None,
     primary_used_percent: float | None,
     secondary_usage: UsageHistory | None,
     secondary_used_percent: float | None,
+    runtime_reset: float | None,
 ) -> AccountStatus:
     status, _, _ = apply_usage_quota(
-        status=account.status,
+        status=status_seed,
         primary_used=primary_used_percent,
         primary_reset=primary_usage.reset_at if primary_usage is not None else None,
         primary_window_minutes=primary_usage.window_minutes if primary_usage is not None else None,
-        runtime_reset=float(account.reset_at) if account.reset_at else None,
+        runtime_reset=runtime_reset,
         secondary_used=secondary_used_percent,
         secondary_reset=secondary_usage.reset_at if secondary_usage is not None else None,
         credits_has=_first_not_none(primary_usage, secondary_usage, "credits_has"),
@@ -220,6 +236,8 @@ def _effective_status_from_usage(
         credits_balance=_first_not_none(primary_usage, secondary_usage, "credits_balance"),
     )
     if account.status == AccountStatus.RATE_LIMITED and status == AccountStatus.ACTIVE:
+        if runtime_reset is None:
+            return status
         if (
             account.blocked_at is None
             and account.reset_at is not None

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -130,13 +130,17 @@ def _account_to_summary(
         and float(effective_secondary_usage.used_percent) < 100.0
     )
     if usage_core.capacity_for_plan(plan_type, "primary") == 0.0:
+        primary_window_minutes = effective_primary_usage.window_minutes if effective_primary_usage is not None else None
+        zero_capacity_primary_known_non_primary = (
+            primary_window_minutes is not None and not usage_core.is_primary_window_minutes(primary_window_minutes)
+        )
         keep_primary_status_signal = (
             account.status == AccountStatus.RATE_LIMITED
-            and usage_core.is_primary_window_minutes(
-                effective_primary_usage.window_minutes if effective_primary_usage is not None else None
-            )
+            and usage_core.is_primary_window_minutes(primary_window_minutes)
         )
-        can_hide_zero_capacity_primary = account.status != AccountStatus.RATE_LIMITED or weekly_quota_available
+        can_hide_zero_capacity_primary = account.status != AccountStatus.RATE_LIMITED or (
+            zero_capacity_primary_known_non_primary and weekly_quota_available
+        )
         if not keep_primary_status_signal and can_hide_zero_capacity_primary:
             status_primary_usage = None
             status_primary_used_percent = None

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -25,6 +25,7 @@ from app.core.balancer import (
     select_account,
 )
 from app.core.balancer.types import UpstreamError
+from app.core.config import settings as config_settings
 from app.core.config.settings import get_settings
 from app.core.metrics.prometheus import (
     PROMETHEUS_AVAILABLE,
@@ -68,6 +69,8 @@ _RECOVERABLE_STATUSES = frozenset(
         AccountStatus.QUOTA_EXCEEDED,
     }
 )
+
+_DEFAULT_USAGE_REFRESH_INTERVAL_SECONDS = 60
 
 NO_PLAN_SUPPORT_FOR_MODEL = "no_plan_support_for_model"
 ADDITIONAL_QUOTA_DATA_UNAVAILABLE = "additional_quota_data_unavailable"
@@ -1646,9 +1649,14 @@ def _usage_entry_is_recent_enough(recorded_at: datetime | None) -> bool:
     current_time = utcnow()
     if current_time.tzinfo is None:
         current_time = current_time.replace(tzinfo=timezone.utc)
-    interval_seconds = max(get_settings().usage_refresh_interval_seconds * 2, 180)
+    interval_seconds = max(_usage_refresh_interval_seconds() * 2, 180)
     recorded_time = recorded_at if recorded_at.tzinfo is not None else recorded_at.replace(tzinfo=timezone.utc)
     return recorded_time >= current_time - timedelta(seconds=interval_seconds)
+
+
+def _usage_refresh_interval_seconds() -> int:
+    settings = config_settings.get_settings()
+    return int(getattr(settings, "usage_refresh_interval_seconds", _DEFAULT_USAGE_REFRESH_INTERVAL_SECONDS))
 
 
 def _filter_accounts_for_model(accounts: list[Account], model: str) -> list[Account]:
@@ -1738,10 +1746,8 @@ async def _latest_additional_by_key(
 
 
 def _additional_usage_fresh_since(now: datetime | None = None) -> datetime:
-    from app.core.config.settings import get_settings  # noqa: PLC0415
-
     current_time = now or utcnow()
-    interval_seconds = max(get_settings().usage_refresh_interval_seconds * 2, 180)
+    interval_seconds = max(_usage_refresh_interval_seconds() * 2, 180)
     return current_time - timedelta(seconds=interval_seconds)
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1413,11 +1413,13 @@ def _state_from_account(
         and effective_secondary_entry.used_percent is not None
         and float(effective_secondary_entry.used_percent) < 100.0
     )
-    if (
-        usage_core.capacity_for_plan(account.plan_type, "primary") == 0.0
-        and primary_window_minutes is not None
-        and not usage_core.is_primary_window_minutes(primary_window_minutes)
-        and weekly_quota_available
+    if usage_core.capacity_for_plan(account.plan_type, "primary") == 0.0 and (
+        account.status != AccountStatus.RATE_LIMITED
+        or (
+            primary_window_minutes is not None
+            and not usage_core.is_primary_window_minutes(primary_window_minutes)
+            and weekly_quota_available
+        )
     ):
         primary_used = None
         primary_reset = None

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1404,8 +1404,17 @@ def _state_from_account(
 
     ignore_zero_capacity_primary_runtime_reset = False
     status_seed = account.status
-    if usage_core.capacity_for_plan(account.plan_type, "primary") == 0.0 and not usage_core.is_primary_window_minutes(
-        primary_window_minutes
+    weekly_quota_available = (
+        effective_secondary_entry is not None
+        and _usage_entry_is_recent_enough(effective_secondary_entry.recorded_at)
+        and effective_secondary_entry.used_percent is not None
+        and float(effective_secondary_entry.used_percent) < 100.0
+    )
+    if (
+        usage_core.capacity_for_plan(account.plan_type, "primary") == 0.0
+        and primary_window_minutes is not None
+        and not usage_core.is_primary_window_minutes(primary_window_minutes)
+        and weekly_quota_available
     ):
         primary_used = None
         primary_reset = None

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1402,9 +1402,23 @@ def _state_from_account(
             secondary_used = 0.0
             secondary_reset = None
 
+    ignore_zero_capacity_primary_runtime_reset = False
+    status_seed = account.status
+    if usage_core.capacity_for_plan(account.plan_type, "primary") == 0.0 and not usage_core.is_primary_window_minutes(
+        primary_window_minutes
+    ):
+        primary_used = None
+        primary_reset = None
+        primary_window_minutes = None
+        ignore_zero_capacity_primary_runtime_reset = account.status == AccountStatus.RATE_LIMITED
+        if account.status == AccountStatus.RATE_LIMITED:
+            status_seed = AccountStatus.ACTIVE
+
     # Use account.reset_at from DB as the authoritative source for runtime reset
     # and to survive process restarts.
-    db_reset_at = float(account.reset_at) if account.reset_at else None
+    db_reset_at = (
+        None if ignore_zero_capacity_primary_runtime_reset else (float(account.reset_at) if account.reset_at else None)
+    )
     effective_runtime_reset = db_reset_at or runtime.reset_at
     effective_blocked_at = float(account.blocked_at) if account.blocked_at is not None else runtime.blocked_at
 
@@ -1451,7 +1465,7 @@ def _state_from_account(
                 effective_runtime_reset = None
 
     status, used_percent, reset_at = apply_usage_quota(
-        status=account.status,
+        status=status_seed,
         primary_used=primary_used,
         primary_reset=primary_reset,
         primary_window_minutes=primary_window_minutes,

--- a/openspec/changes/ignore-free-monthly-primary-reset/proposal.md
+++ b/openspec/changes/ignore-free-monthly-primary-reset/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Issue #883 reports a new upstream monthly usage window leaking into free-account quota state. codex-lb already hides zero-capacity free-plan primary rows from the UI, but one recovery path still treated any persisted primary window as a real 5h limiter when the account was already marked `rate_limited`.
+
+That let a free account keep a fake primary reset deadline derived from the new monthly snapshot. The dashboard/account list then surfaced the account as blocked and could render `Reset now` even though the only real quota window left was the weekly free-plan quota.
+
+## What Changes
+
+- Treat zero-capacity primary usage as a status-recovery signal only when it is the canonical 5h primary window.
+- Ignore non-5h zero-capacity primary windows (including the new monthly shape) when deriving persisted account status for account summaries and proxy runtime state.
+- Add regressions for the `free + monthly primary + weekly secondary` shape so free accounts stay `active` and only expose their weekly quota.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: zero-capacity free-plan primary windows only affect rate-limit recovery when the window is the canonical 5h primary quota, not arbitrary upstream monthly windows.
+
+## Impact
+
+- Code: `app/core/usage/__init__.py`, `app/modules/accounts/mappers.py`, `app/modules/proxy/load_balancer.py`
+- Tests: `tests/integration/test_accounts_api_extended.py`, `tests/unit/test_load_balancer.py`
+- API/UI effect: free accounts stop surfacing fake primary reset state from monthly usage snapshots.

--- a/openspec/changes/ignore-free-monthly-primary-reset/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/ignore-free-monthly-primary-reset/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Usage refresh cools down repeated auth-like failures
+
+Background usage refresh MUST apply a cooldown to accounts that repeatedly fail usage refresh with ambiguous `401` or `403` responses. Accounts in that cooldown window MUST be skipped until the cooldown expires or a later successful refresh clears it.
+
+#### Scenario: Zero-capacity monthly primary does not keep free accounts rate-limited
+- **GIVEN** a free-plan account whose persisted status is `rate_limited`
+- **AND** its latest primary usage row is a zero-capacity non-5h window (for example a monthly upstream snapshot)
+- **AND** its latest weekly usage row reports available quota
+- **WHEN** codex-lb derives account status for account summaries or proxy runtime state
+- **THEN** the non-5h primary row is ignored for rate-limit recovery
+- **AND** the account is treated as `active`
+- **AND** only the weekly quota window remains visible to downstream account views

--- a/openspec/changes/ignore-free-monthly-primary-reset/tasks.md
+++ b/openspec/changes/ignore-free-monthly-primary-reset/tasks.md
@@ -1,0 +1,16 @@
+## 1. Spec And Regression Coverage
+
+- [x] 1.1 Add an OpenSpec delta for zero-capacity monthly primary windows.
+- [x] 1.2 Add an `/api/accounts` regression that reproduces a free account stuck in `rate_limited` from a monthly primary snapshot.
+- [x] 1.3 Add a load-balancer state regression that proves non-5h zero-capacity primary windows are ignored.
+
+## 2. Implementation
+
+- [x] 2.1 Add a shared helper that identifies the canonical primary-window duration.
+- [x] 2.2 Use that helper when deciding whether zero-capacity primary rows may still drive rate-limit recovery.
+- [x] 2.3 Keep the existing free-plan weekly remap behavior unchanged.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused pytest coverage for the touched account/load-balancer paths.
+- [x] 3.2 Run `openspec validate` for the new change.

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -940,6 +940,44 @@ async def test_accounts_list_keeps_free_rate_limited_until_weekly_quota_availabl
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_keeps_rate_limited_without_reset_signal(async_client, db_setup):
+    account = _make_account("acc_free_rate_limited_no_reset", "free-no-reset@example.com", plan_type="free")
+    account.status = AccountStatus.RATE_LIMITED
+    account.reset_at = None
+    account.blocked_at = int(utcnow().timestamp())
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(account)
+        await usage_repo.add_entry(
+            "acc_free_rate_limited_no_reset",
+            24.0,
+            window="primary",
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            "acc_free_rate_limited_no_reset",
+            24.0,
+            window="secondary",
+            window_minutes=10080,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account_payload = accounts["acc_free_rate_limited_no_reset"]
+    assert account_payload["status"] == "rate_limited"
+    assert account_payload["usage"]["primaryRemainingPercent"] is None
+    assert account_payload["usage"]["secondaryRemainingPercent"] == pytest.approx(76.0)
+    assert account_payload["windowMinutesPrimary"] is None
+    assert account_payload["windowMinutesSecondary"] == 10080
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_prefers_newer_weekly_primary_over_stale_secondary(async_client, db_setup):
     now = utcnow()
     stale_reset = 1735689600

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -829,6 +829,37 @@ async def test_accounts_list_ignores_hidden_zero_capacity_primary_for_status(asy
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_ignores_hidden_zero_capacity_primary_without_weekly_for_active_account(
+    async_client, db_setup
+):
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(
+            _make_account("acc_free_active_primary_only", "free-primary-only@example.com", plan_type="free")
+        )
+        await usage_repo.add_entry(
+            "acc_free_active_primary_only",
+            100.0,
+            window="primary",
+            window_minutes=43200,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account = accounts["acc_free_active_primary_only"]
+    assert account["status"] == "active"
+    assert account["usage"]["primaryRemainingPercent"] is None
+    assert account["usage"]["secondaryRemainingPercent"] is None
+    assert account["windowMinutesPrimary"] is None
+    assert account["windowMinutesSecondary"] is None
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_recovers_zero_capacity_rate_limited_status(async_client, db_setup):
     expired_reset = int((utcnow() - timedelta(minutes=5)).timestamp())
     account = _make_account("acc_free_recovered_primary", "free-recovered@example.com", plan_type="free")

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -978,6 +978,46 @@ async def test_accounts_list_keeps_rate_limited_without_reset_signal(async_clien
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_keeps_quota_exceeded_reset_when_ignoring_monthly_primary(async_client, db_setup):
+    future_reset = int((utcnow() + timedelta(days=14)).timestamp())
+    account = _make_account("acc_free_quota_exceeded_monthly", "free-quota-monthly@example.com", plan_type="free")
+    account.status = AccountStatus.QUOTA_EXCEEDED
+    account.reset_at = future_reset
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(account)
+        await usage_repo.add_entry(
+            "acc_free_quota_exceeded_monthly",
+            100.0,
+            window="primary",
+            reset_at=future_reset,
+            window_minutes=43200,
+        )
+        await usage_repo.add_entry(
+            "acc_free_quota_exceeded_monthly",
+            24.0,
+            window="secondary",
+            reset_at=future_reset,
+            window_minutes=10080,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account_payload = accounts["acc_free_quota_exceeded_monthly"]
+    assert account_payload["status"] == "quota_exceeded"
+    assert account_payload["usage"]["primaryRemainingPercent"] is None
+    assert account_payload["usage"]["secondaryRemainingPercent"] == pytest.approx(76.0)
+    assert account_payload["windowMinutesPrimary"] is None
+    assert account_payload["windowMinutesSecondary"] == 10080
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_prefers_newer_weekly_primary_over_stale_secondary(async_client, db_setup):
     now = utcnow()
     stale_reset = 1735689600

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -938,6 +938,39 @@ async def test_accounts_list_ignores_zero_capacity_monthly_primary_status(async_
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_recovers_weekly_only_primary_rate_limited_status(async_client, db_setup):
+    future_reset = int((utcnow() + timedelta(days=7)).timestamp())
+    account = _make_account("acc_free_weekly_primary_only", "free-weekly-primary@example.com", plan_type="free")
+    account.status = AccountStatus.RATE_LIMITED
+    account.reset_at = future_reset
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(account)
+        await usage_repo.add_entry(
+            "acc_free_weekly_primary_only",
+            24.0,
+            window="primary",
+            reset_at=future_reset,
+            window_minutes=10080,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account_payload = accounts["acc_free_weekly_primary_only"]
+    assert account_payload["status"] == "active"
+    assert account_payload["usage"]["primaryRemainingPercent"] is None
+    assert account_payload["usage"]["secondaryRemainingPercent"] == pytest.approx(76.0)
+    assert account_payload["windowMinutesPrimary"] is None
+    assert account_payload["windowMinutesSecondary"] == 10080
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_keeps_legacy_unknown_primary_rate_limited_until_known_window(async_client, db_setup):
     future_reset = int((utcnow() + timedelta(days=14)).timestamp())
     account = _make_account("acc_free_legacy_unknown_primary", "free-legacy@example.com", plan_type="free")

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -907,6 +907,39 @@ async def test_accounts_list_ignores_zero_capacity_monthly_primary_status(async_
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_keeps_free_rate_limited_until_weekly_quota_available(async_client, db_setup):
+    future_reset = int((utcnow() + timedelta(days=14)).timestamp())
+    account = _make_account("acc_free_monthly_without_weekly", "free-monthly-no-weekly@example.com", plan_type="free")
+    account.status = AccountStatus.RATE_LIMITED
+    account.reset_at = future_reset
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(account)
+        await usage_repo.add_entry(
+            "acc_free_monthly_without_weekly",
+            100.0,
+            window="primary",
+            reset_at=future_reset,
+            window_minutes=43200,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account_payload = accounts["acc_free_monthly_without_weekly"]
+    assert account_payload["status"] == "rate_limited"
+    assert account_payload["usage"]["primaryRemainingPercent"] is None
+    assert account_payload["usage"]["secondaryRemainingPercent"] is None
+    assert account_payload["windowMinutesPrimary"] is None
+    assert account_payload["windowMinutesSecondary"] is None
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_prefers_newer_weekly_primary_over_stale_secondary(async_client, db_setup):
     now = utcnow()
     stale_reset = 1735689600

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -867,6 +867,46 @@ async def test_accounts_list_recovers_zero_capacity_rate_limited_status(async_cl
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_ignores_zero_capacity_monthly_primary_status(async_client, db_setup):
+    future_reset = int((utcnow() + timedelta(days=14)).timestamp())
+    account = _make_account("acc_free_monthly_primary", "free-monthly@example.com", plan_type="free")
+    account.status = AccountStatus.RATE_LIMITED
+    account.reset_at = future_reset
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(account)
+        await usage_repo.add_entry(
+            "acc_free_monthly_primary",
+            100.0,
+            window="primary",
+            reset_at=future_reset,
+            window_minutes=43200,
+        )
+        await usage_repo.add_entry(
+            "acc_free_monthly_primary",
+            24.0,
+            window="secondary",
+            reset_at=future_reset,
+            window_minutes=10080,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account_payload = accounts["acc_free_monthly_primary"]
+    assert account_payload["status"] == "active"
+    assert account_payload["usage"]["primaryRemainingPercent"] is None
+    assert account_payload["usage"]["secondaryRemainingPercent"] == pytest.approx(76.0)
+    assert account_payload["windowMinutesPrimary"] is None
+    assert account_payload["windowMinutesSecondary"] == 10080
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_prefers_newer_weekly_primary_over_stale_secondary(async_client, db_setup):
     now = utcnow()
     stale_reset = 1735689600

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -938,6 +938,46 @@ async def test_accounts_list_ignores_zero_capacity_monthly_primary_status(async_
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_keeps_legacy_unknown_primary_rate_limited_until_known_window(async_client, db_setup):
+    future_reset = int((utcnow() + timedelta(days=14)).timestamp())
+    account = _make_account("acc_free_legacy_unknown_primary", "free-legacy@example.com", plan_type="free")
+    account.status = AccountStatus.RATE_LIMITED
+    account.reset_at = future_reset
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(account)
+        await usage_repo.add_entry(
+            "acc_free_legacy_unknown_primary",
+            100.0,
+            window="primary",
+            reset_at=future_reset,
+            window_minutes=None,
+        )
+        await usage_repo.add_entry(
+            "acc_free_legacy_unknown_primary",
+            24.0,
+            window="secondary",
+            reset_at=future_reset,
+            window_minutes=10080,
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    account_payload = accounts["acc_free_legacy_unknown_primary"]
+    assert account_payload["status"] == "rate_limited"
+    assert account_payload["usage"]["primaryRemainingPercent"] is None
+    assert account_payload["usage"]["secondaryRemainingPercent"] == pytest.approx(76.0)
+    assert account_payload["windowMinutesPrimary"] is None
+    assert account_payload["windowMinutesSecondary"] == 10080
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_keeps_free_rate_limited_until_weekly_quota_available(async_client, db_setup):
     future_reset = int((utcnow() + timedelta(days=14)).timestamp())
     account = _make_account("acc_free_monthly_without_weekly", "free-monthly-no-weekly@example.com", plan_type="free")

--- a/tests/unit/test_account_mappers.py
+++ b/tests/unit/test_account_mappers.py
@@ -53,10 +53,12 @@ def test_effective_status_uses_secondary_credits_to_reactivate_quota_exceeded_ac
     assert (
         _effective_status_from_usage(
             account,
-            primary,
-            primary.used_percent,
-            secondary,
-            secondary.used_percent,
+            status_seed=account.status,
+            primary_usage=primary,
+            primary_used_percent=primary.used_percent,
+            secondary_usage=secondary,
+            secondary_used_percent=secondary.used_percent,
+            runtime_reset=float(account.reset_at) if account.reset_at else None,
         )
         == AccountStatus.ACTIVE
     )
@@ -70,10 +72,12 @@ def test_effective_status_uses_primary_credits_when_secondary_has_no_credit_fiel
     assert (
         _effective_status_from_usage(
             account,
-            primary,
-            primary.used_percent,
-            secondary,
-            secondary.used_percent,
+            status_seed=account.status,
+            primary_usage=primary,
+            primary_used_percent=primary.used_percent,
+            secondary_usage=secondary,
+            secondary_used_percent=secondary.used_percent,
+            runtime_reset=float(account.reset_at) if account.reset_at else None,
         )
         == AccountStatus.ACTIVE
     )
@@ -87,10 +91,12 @@ def test_effective_status_keeps_primary_rate_limit_precedence_with_usable_credit
     assert (
         _effective_status_from_usage(
             account,
-            primary,
-            primary.used_percent,
-            secondary,
-            secondary.used_percent,
+            status_seed=account.status,
+            primary_usage=primary,
+            primary_used_percent=primary.used_percent,
+            secondary_usage=secondary,
+            secondary_used_percent=secondary.used_percent,
+            runtime_reset=float(account.reset_at) if account.reset_at else None,
         )
         == AccountStatus.RATE_LIMITED
     )
@@ -104,10 +110,12 @@ def test_effective_status_keeps_paused_account_paused_with_usable_credits() -> N
     assert (
         _effective_status_from_usage(
             account,
-            primary,
-            primary.used_percent,
-            secondary,
-            secondary.used_percent,
+            status_seed=account.status,
+            primary_usage=primary,
+            primary_used_percent=primary.used_percent,
+            secondary_usage=secondary,
+            secondary_used_percent=secondary.used_percent,
+            runtime_reset=float(account.reset_at) if account.reset_at else None,
         )
         == AccountStatus.PAUSED
     )

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -668,6 +668,34 @@ def test_state_from_account_ignores_zero_capacity_monthly_primary_window(monkeyp
     assert state.secondary_reset_at == future_reset
 
 
+def test_state_from_account_ignores_zero_capacity_primary_for_active_free_account(monkeypatch):
+    now = 1_700_000_000.0
+    future_reset = int(now + 14 * 24 * 3600)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_test_account(status=AccountStatus.ACTIVE, reset_at=None)
+    account.plan_type = "free"
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=100.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=43200,
+        ),
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent is None
+    assert state.reset_at is None
+
+
 def test_state_from_account_preserves_free_rate_limit_without_weekly_usage_signal(monkeypatch):
     now = 1_700_000_000.0
     future_reset = int(now + 14 * 24 * 3600)

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -565,7 +565,7 @@ def _make_test_usage(
     used_percent: float = 10.0,
     reset_at: int | None = None,
     recorded_at: datetime | None = None,
-    window_minutes: int = 10080,
+    window_minutes: int | None = 10080,
     credits_has: bool | None = None,
     credits_unlimited: bool | None = None,
     credits_balance: float | None = None,
@@ -637,6 +637,7 @@ def test_state_from_account_ignores_zero_capacity_monthly_primary_window(monkeyp
     future_reset = int(now + 14 * 24 * 3600)
     monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
     monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
 
     account = _make_test_account(status=AccountStatus.RATE_LIMITED, reset_at=future_reset)
     account.plan_type = "free"
@@ -665,6 +666,65 @@ def test_state_from_account_ignores_zero_capacity_monthly_primary_window(monkeyp
     assert state.reset_at is None
     assert state.secondary_used_percent == 10.0
     assert state.secondary_reset_at == future_reset
+
+
+def test_state_from_account_preserves_free_rate_limit_without_weekly_usage_signal(monkeypatch):
+    now = 1_700_000_000.0
+    future_reset = int(now + 14 * 24 * 3600)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_test_account(status=AccountStatus.RATE_LIMITED, reset_at=future_reset)
+    account.plan_type = "free"
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=100.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=43200,
+        ),
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.reset_at == future_reset
+
+
+def test_state_from_account_preserves_free_rate_limit_for_legacy_unknown_primary_window(monkeypatch):
+    now = 1_700_000_000.0
+    future_reset = int(now + 14 * 24 * 3600)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    account = _make_test_account(status=AccountStatus.RATE_LIMITED, reset_at=future_reset)
+    account.plan_type = "free"
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=100.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=None,
+        ),
+        secondary_entry=_make_test_usage(
+            window="secondary",
+            used_percent=10.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=10080,
+        ),
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.reset_at == future_reset
 
 
 def test_state_from_account_recovers_quota_exceeded_on_restart_without_blocked_at_when_usage_shows_new_reset_window(

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -565,6 +565,7 @@ def _make_test_usage(
     used_percent: float = 10.0,
     reset_at: int | None = None,
     recorded_at: datetime | None = None,
+    window_minutes: int = 10080,
     credits_has: bool | None = None,
     credits_unlimited: bool | None = None,
     credits_balance: float | None = None,
@@ -576,7 +577,7 @@ def _make_test_usage(
         window=window,
         used_percent=used_percent,
         reset_at=reset_at,
-        window_minutes=10080,
+        window_minutes=window_minutes,
         credits_has=credits_has,
         credits_unlimited=credits_unlimited,
         credits_balance=credits_balance,
@@ -629,6 +630,41 @@ def test_state_from_account_zeroes_stale_exhausted_secondary_usage_after_reset(m
 
     assert state.secondary_used_percent == 0.0
     assert state.secondary_reset_at is None
+
+
+def test_state_from_account_ignores_zero_capacity_monthly_primary_window(monkeypatch):
+    now = 1_700_000_000.0
+    future_reset = int(now + 14 * 24 * 3600)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    account = _make_test_account(status=AccountStatus.RATE_LIMITED, reset_at=future_reset)
+    account.plan_type = "free"
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=100.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=43200,
+        ),
+        secondary_entry=_make_test_usage(
+            window="secondary",
+            used_percent=10.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=10080,
+        ),
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent is None
+    assert state.reset_at is None
+    assert state.secondary_used_percent == 10.0
+    assert state.secondary_reset_at == future_reset
 
 
 def test_state_from_account_recovers_quota_exceeded_on_restart_without_blocked_at_when_usage_shows_new_reset_window(


### PR DESCRIPTION
## Superseded

This PR has been absorbed into #909 so the free-account quota policy for #883 lands in one reviewable branch.

The #909 branch now includes this PR's stale-primary-row and recovery guards alongside the canonical monthly-only free-account window normalization.

Relationship:

- Superseded by #909.
- Do not merge this PR separately.
- Issue closure moved to #909.

## Previous scope

- Keep stale free-plan primary/5h usage from making `/api/accounts` report a free account as exhausted.
- Hide zero-capacity primary rows for active free accounts when the weekly row is missing.
- Preserve legacy unknown-window primary rows as `rate_limited` until the primary window is known.
- Align load-balancer routing with account summary recovery behavior.
