### PR TITLE
fix(models): add OpenAI data alias to Codex models

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1682,23 +1682,29 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
 
     if not models:
         await _release_reservation(reservation)
-        return JSONResponse(content=CodexModelsResponse(models=[]).model_dump(mode="json"))
+        return JSONResponse(content=CodexModelsResponse(models=[], data=[]).model_dump(mode="json"))
 
     entries: list[CodexModelEntry] = []
+    data: list[ModelListItem] = []
+    created = int(time.time())
     for slug, model in models.items():
         if visibility_allowed_models is None:
             if not is_public_model(model, allowed_models):
                 continue
-            entries.append(_to_codex_model_entry(model))
+            entry = _to_codex_model_entry(model)
+            entries.append(entry)
+            if entry.visibility == "list":
+                data.append(_to_model_list_item(slug, model, created=created))
             continue
-        entries.append(
-            _to_codex_model_entry(
-                model,
-                visibility="list" if slug in visibility_allowed_models else "hide",
-            )
+        entry = _to_codex_model_entry(
+            model,
+            visibility="list" if slug in visibility_allowed_models else "hide",
         )
+        entries.append(entry)
+        if entry.visibility == "list":
+            data.append(_to_model_list_item(slug, model, created=created))
     await _release_reservation(reservation)
-    return JSONResponse(content=CodexModelsResponse(models=entries).model_dump(mode="json"))
+    return JSONResponse(content=CodexModelsResponse(models=entries, data=data).model_dump(mode="json"))
 
 
 async def _build_models_response(api_key: ApiKeyData | None) -> Response:
@@ -1722,28 +1728,7 @@ async def _build_models_response(api_key: ApiKeyData | None) -> Response:
     for slug, model in models.items():
         if not is_public_model(model, allowed_models):
             continue
-        items.append(
-            ModelListItem.model_validate(
-                {
-                    "id": slug,
-                    "created": created,
-                    "owned_by": "codex-lb",
-                    "metadata": _to_model_metadata(model),
-                    "api_types": ["chat_completions"],
-                    "capabilities": _v1_model_capabilities(model),
-                    "context_length": _v1_input_context_window(model),
-                    "contextLength": _v1_input_context_window(model),
-                    "max_output_tokens": _v1_max_output_tokens(model),
-                    "maxOutputTokens": _v1_max_output_tokens(model),
-                    "supports_reasoning": _v1_supports_reasoning(model),
-                    "supportsReasoning": _v1_supports_reasoning(model),
-                    "supports_images": _v1_supports_vision(model),
-                    "supportsImages": _v1_supports_vision(model),
-                    "supports_vision": _v1_supports_vision(model),
-                    "supportsVision": _v1_supports_vision(model),
-                }
-            )
-        )
+        items.append(_to_model_list_item(slug, model, created=created))
     await _release_reservation(reservation)
     return JSONResponse(content=ModelListResponse(data=items).model_dump(mode="json"))
 
@@ -1762,6 +1747,29 @@ def _canonical_model_set(models: Iterable[str]) -> set[str]:
 
 def _canonical_model_slug(model: str) -> str:
     return resolve_model_alias(model) or model
+
+
+def _to_model_list_item(slug: str, model: UpstreamModel, *, created: int) -> ModelListItem:
+    return ModelListItem.model_validate(
+        {
+            "id": slug,
+            "created": created,
+            "owned_by": "codex-lb",
+            "metadata": _to_model_metadata(model),
+            "api_types": ["chat_completions"],
+            "capabilities": _v1_model_capabilities(model),
+            "context_length": _v1_input_context_window(model),
+            "contextLength": _v1_input_context_window(model),
+            "max_output_tokens": _v1_max_output_tokens(model),
+            "maxOutputTokens": _v1_max_output_tokens(model),
+            "supports_reasoning": _v1_supports_reasoning(model),
+            "supportsReasoning": _v1_supports_reasoning(model),
+            "supports_images": _v1_supports_vision(model),
+            "supportsImages": _v1_supports_vision(model),
+            "supports_vision": _v1_supports_vision(model),
+            "supportsVision": _v1_supports_vision(model),
+        }
+    )
 
 
 def _codex_model_visibility_allowed_models(api_key: ApiKeyData | None) -> set[str] | None:

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -155,10 +155,6 @@ class CodexModelEntry(BaseModel):
     visibility: str = "list"
 
 
-class CodexModelsResponse(BaseModel):
-    models: list[CodexModelEntry]
-
-
 class ModelMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -199,6 +195,12 @@ class ModelListResponse(BaseModel):
 
     object: str = "list"
     data: list[ModelListItem]
+
+
+class CodexModelsResponse(BaseModel):
+    models: list[CodexModelEntry]
+    object: str = "list"
+    data: list[ModelListItem] = []
 
 
 class V1UsageLimitResponse(BaseModel):

--- a/openspec/changes/add-codex-models-data-alias/proposal.md
+++ b/openspec/changes/add-codex-models-data-alias/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Some OpenAI-compatible clients, including JetBrains IDE provider setup, probe the configured base URL by requesting `GET /backend-api/codex/models` and deserializing an OpenAI-style model list with a top-level `data` field. codex-lb's Codex-native endpoint only returned `models`, so those clients rejected the otherwise valid response before they could use the provider.
+
+## What Changes
+
+- Preserve the Codex-native `models` payload for `/backend-api/codex/models`.
+- Add an OpenAI-compatible top-level `object: "list"` and `data` model list alias to the same response.
+- Keep `data` limited to entries whose Codex visibility is `list`, so hidden Codex catalog entries remain hidden from generic OpenAI-style clients.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `model-catalog-compat`: `/backend-api/codex/models` remains Codex-native while also exposing an OpenAI-style `data` alias for generic client probes.
+
+## Impact
+
+- Code: `app/modules/proxy/api.py`, `app/modules/proxy/schemas.py`
+- Tests: `tests/integration/test_v1_models.py`
+- Compatibility: JetBrains/OpenAI-style model-list deserializers can read `/backend-api/codex/models` without losing Codex-native clients.

--- a/openspec/changes/add-codex-models-data-alias/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/add-codex-models-data-alias/specs/model-catalog-compat/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Native Codex model catalog stays backend-faithful
+
+When serving `GET /backend-api/codex/models`, the system MUST keep Codex-native model catalog semantics unchanged: the top-level `context_window` field remains the backend compact/input budget unless an explicit operator override applies, and upstream raw fields such as `max_context_window` remain available when upstream provides them. The `/v1/models` compatibility metadata MUST NOT mutate the native Codex endpoint.
+
+#### Scenario: Codex model catalog also exposes OpenAI data alias
+
+- **WHEN** a client requests `GET /backend-api/codex/models`
+- **THEN** the response keeps the Codex-native `models` list
+- **AND** the response includes `object: "list"` and an OpenAI-compatible `data` list
+- **AND** `data` contains model entries whose Codex visibility is `list`
+- **AND** `data` excludes entries whose Codex visibility is `hide`

--- a/openspec/changes/add-codex-models-data-alias/tasks.md
+++ b/openspec/changes/add-codex-models-data-alias/tasks.md
@@ -1,0 +1,16 @@
+## 1. Spec And Regression Coverage
+
+- [x] 1.1 Add an OpenSpec delta for the `/backend-api/codex/models` `data` alias.
+- [x] 1.2 Add integration coverage proving the Codex-native `models` payload remains present.
+- [x] 1.3 Add integration coverage proving `data` is OpenAI-style and excludes Codex-hidden entries.
+
+## 2. Implementation
+
+- [x] 2.1 Add `data` to the Codex models response schema.
+- [x] 2.2 Reuse the `/v1/models` model-list item mapping for the compatibility alias.
+- [x] 2.3 Preserve existing Codex-native `models` behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run targeted model endpoint tests.
+- [x] 3.2 Run OpenSpec validation for this change.

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -218,6 +218,39 @@ async def test_backend_codex_models_returns_format1(async_client):
     assert isinstance(payload["models"], list)
     slugs = {m["slug"] for m in payload["models"]}
     assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(slugs)
+    assert payload["object"] == "list"
+    data_ids = {m["id"] for m in payload["data"]}
+    assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(data_ids)
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_models_data_keeps_only_list_visible_models(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model(
+            "gpt-visible",
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "list",
+            },
+        ),
+        _make_upstream_model(
+            "gpt-hidden",
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "hide",
+            },
+        ),
+    ]
+    await registry.update({"plus": models, "pro": models})
+
+    resp = await async_client.get("/backend-api/codex/models")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert {m["slug"] for m in payload["models"]} == {"gpt-visible", "gpt-hidden"}
+    assert {m["id"] for m in payload["data"]} == {"gpt-visible"}
+    assert payload["data"][0]["object"] == "model"
+    assert payload["data"][0]["owned_by"] == "codex-lb"
 
 
 @pytest.mark.asyncio
@@ -548,6 +581,9 @@ async def test_backend_codex_models_uses_bootstrap_models_when_registry_not_popu
     payload = resp.json()
     slugs = {item["slug"] for item in payload["models"]}
     assert slugs == BOOTSTRAP_MODEL_SLUGS
+    data_ids = {item["id"] for item in payload["data"]}
+    assert data_ids.issubset(BOOTSTRAP_MODEL_SLUGS)
+    assert data_ids
     assert "gpt-5.5-pro" not in slugs
 
 


### PR DESCRIPTION
## Superseded

This PR has been absorbed into #887 so model catalog compatibility lands in one reviewable branch.

#887 now carries the `/backend-api/codex/models` OpenAI-compatible `object`/`data` alias together with the public model visibility filtering and speed-tier metadata work.

Relationship:

- Superseded by #887.
- Do not merge this PR separately.
- Issue closure moved to #887.
