### PR TITLE
docs(images): clarify single-image request contract

### DIFF
--- a/openspec/specs/images-api-compat/spec.md
+++ b/openspec/specs/images-api-compat/spec.md
@@ -1,7 +1,9 @@
 # images-api-compat Specification
 
 ## Purpose
-TBD - created by archiving change add-images-api-compat. Update Purpose after archive.
+Define the OpenAI-compatible Images API adapter that exposes public `gpt-image-*`
+requests while routing through the existing Responses `image_generation` tool
+pipeline.
 ## Requirements
 ### Requirement: OpenAI-compatible image generation endpoint
 
@@ -10,7 +12,7 @@ The system SHALL expose `POST /v1/images/generations` and accept the OpenAI Imag
 #### Scenario: Compatible image generation request returns a JSON envelope
 
 - **WHEN** a client sends `POST /v1/images/generations` with `model=gpt-image-2`, a non-empty `prompt`, and no `stream`
-- **THEN** the service returns 200 with a JSON body of shape `{created, data: [{b64_json, revised_prompt}], usage}` containing exactly `n` (or 1 by default) entries
+- **THEN** the service returns 200 with a JSON body of shape `{created, data: [{b64_json, revised_prompt}], usage}` containing exactly one entry
 
 #### Scenario: Unsupported model is rejected
 
@@ -30,7 +32,8 @@ The system SHALL expose `POST /v1/images/generations` and accept the OpenAI Imag
 #### Scenario: Multi-image requests are rejected until upstream support arrives
 
 - **WHEN** a client sends `/v1/images/generations` or `/v1/images/edits` with `n > 1`
-- **THEN** the service returns 400 with OpenAI `invalid_request_error` and `param: n`, with a message that explains the upstream `image_generation` tool does not yet support multi-image responses. Operators may raise the cap by overriding `images_max_n`.
+- **THEN** the service returns 400 with OpenAI `invalid_request_error` and `param: n`, with a message that explains the upstream `image_generation` tool does not yet support multi-image responses
+- **AND** no settings override SHALL raise the accepted request `n` above 1 until codex-lb implements client-side fan-out or upstream exposes first-class multi-image support
 
 #### Scenario: Missing model defaults to images_default_model
 
@@ -97,4 +100,3 @@ The system SHALL apply API-key allowed-model policy and model-scoped usage limit
 
 - **WHEN** an `/v1/images/*` request completes successfully against an internal host Responses model (for example `gpt-5.5`)
 - **THEN** the resulting `request_logs` row has `model` equal to the publicly requested value (for example `gpt-image-2`) so dashboards and usage views surface the user-visible model rather than the internal host model
-


### PR DESCRIPTION
## Summary
- clarify that `/v1/images/*` currently accepts exactly one requested image per request
- remove the stale `images_max_n` override language from the active OpenSpec contract
- define multi-image support as future fan-out/upstream-support work before implementation

References #620

## Test plan
- `openspec validate --specs images-api-compat`
- `uv run pytest tests/unit/test_images_schemas.py tests/unit/test_images_translation.py tests/integration/test_proxy_images.py -q`
- `git diff --check`