### PR TITLE
docs(readme): clarify plan-dependent model availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ opencode
 Set the env var or replace `${CODEX_LB_API_KEY}` with a key from the dashboard. If API key auth is disabled,
 local requests can omit the key, but non-local requests are still rejected until proxy authentication is configured.
 
+The `/v1` route is the simplest OpenAI-compatible setup. If your OpenClaw build uses a Codex-native provider path such as `openai-codex-responses` and needs Codex-style usage/accounting behavior, point that provider at `http://127.0.0.1:2455/backend-api/codex` instead. For third-party Codex-compatible backends, the client must allow opaque bearer-token passthrough and should only send `chatgpt-account-id` when it actually decoded one from an official ChatGPT/Codex token.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ docker run -d --name codex-lb \
 
 Point any OpenAI-compatible client at codex-lb. If [API key auth](#api-key-authentication) is enabled, pass a key from the dashboard as a Bearer token.
 
+Model availability is discovered from the upstream Codex model catalog and can vary by account plan, workspace, rollout, and upstream deprecation state. Prefer the live `GET /v1/models` or `GET /backend-api/codex/models` response over a copied static table when configuring clients or API-key model allowlists.
+
 | Logo | Client | Endpoint | Config |
 |---|--------|----------|--------|
 | <img src="https://avatars.githubusercontent.com/u/14957082?s=200" width="32" alt="OpenAI"> | **Codex CLI** | `http://127.0.0.1:2455/backend-api/codex` | `~/.codex/config.toml` |


### PR DESCRIPTION
## Summary

Clarifies two README client setup notes:

- Codex model availability is discovered from upstream and can vary by account plan, workspace, rollout, and deprecation state.
- OpenClaw can stay on the default `/v1` route, or use `/backend-api/codex` for Codex-native provider paths that need Codex-style usage/accounting behavior.

## Type of change

- [ ] `fix:` - bug fix (no behavior change beyond the bug)
- [ ] `feat:` - new user-facing feature or capability
- [ ] `refactor:` - internal refactor (no behavior change, no API change)
- [x] `docs:` - documentation only
- [ ] `chore:` / `ci:` / `build:` - tooling, CI, packaging
- [ ] `test:` - test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Closes #375, Closes #219

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable - bug fix that matches the existing spec
- [x] Not applicable - docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Add a README note that model support is plan/workspace/rollout dependent.
- Recommend using live model-list endpoints for client setup and API-key allowlists.
- Document the advanced OpenClaw `/backend-api/codex` route for Codex-native provider paths and the required bearer-token passthrough behavior.

## Test plan

```bash
git diff --check
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [ ] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is not edited by hand (release-please handles it).
