### PR TITLE
fix(proxy): finalize unterminated response streams

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2169,6 +2169,10 @@ async def _stream_responses_with_session(
     last_stream_activity_at: float | None = None
     error_code: str | None = None
     error_message: str | None = None
+    failure_phase: str | None = None
+    failure_detail: str | None = None
+    failure_exception_type: str | None = None
+    retryable_same_contract: bool | None = None
     client_session = session
     payload_dict = payload.to_payload()
     if settings.image_inline_fetch_enabled:
@@ -2520,6 +2524,10 @@ async def _stream_responses_with_session(
     except StreamIdleTimeoutError:
         error_code = "stream_idle_timeout"
         error_message = "Upstream stream idle timeout"
+        failure_phase = "upstream"
+        failure_detail = "stream_idle_timeout"
+        failure_exception_type = "StreamIdleTimeoutError"
+        retryable_same_contract = False
         yield format_sse_event(
             response_failed_event(
                 "stream_idle_timeout",
@@ -2554,6 +2562,10 @@ async def _stream_responses_with_session(
             operation="stream",
             exc=exc,
         )
+        failure_phase = "upstream"
+        failure_detail = "transport_error"
+        failure_exception_type = type(exc).__name__
+        retryable_same_contract = True
         yield format_sse_event(
             response_failed_event("upstream_unavailable", error_message, response_id=get_request_id()),
         )
@@ -2566,6 +2578,10 @@ async def _stream_responses_with_session(
             operation="stream",
             exc=exc,
         )
+        failure_phase = "upstream"
+        failure_detail = "transport_error"
+        failure_exception_type = type(exc).__name__
+        retryable_same_contract = True
         yield format_sse_event(
             response_failed_event("upstream_unavailable", error_message, response_id=get_request_id()),
         )
@@ -2585,6 +2601,10 @@ async def _stream_responses_with_session(
                 if route is not None
                 else str(exc) or "Request to upstream timed out"
             )
+            failure_phase = "upstream"
+            failure_detail = "transport_error"
+            failure_exception_type = type(exc).__name__
+            retryable_same_contract = True
             yield format_sse_event(
                 response_failed_event("upstream_unavailable", error_message, response_id=get_request_id()),
             )
@@ -2598,6 +2618,10 @@ async def _stream_responses_with_session(
         ):
             error_code = "stream_idle_timeout"
             error_message = "Upstream stream idle timeout"
+            failure_phase = "upstream"
+            failure_detail = "stream_idle_timeout"
+            failure_exception_type = type(exc).__name__
+            retryable_same_contract = False
             yield format_sse_event(
                 response_failed_event(
                     "stream_idle_timeout",
@@ -2619,6 +2643,10 @@ async def _stream_responses_with_session(
                 if route is not None
                 else str(exc) or "Request to upstream timed out"
             )
+            failure_phase = "upstream"
+            failure_detail = "transport_error"
+            failure_exception_type = type(exc).__name__
+            retryable_same_contract = True
             yield format_sse_event(
                 response_failed_event(
                     "upstream_unavailable",
@@ -2629,12 +2657,40 @@ async def _stream_responses_with_session(
             return
         error_code = "upstream_request_timeout"
         error_message = "Proxy request budget exhausted"
+        failure_phase = "upstream"
+        failure_detail = "request_timeout"
+        failure_exception_type = type(exc).__name__
+        retryable_same_contract = False
         yield format_sse_event(
             response_failed_event(
                 "upstream_request_timeout",
                 "Proxy request budget exhausted",
                 response_id=get_request_id(),
             ),
+        )
+        return
+    except GeneratorExit:
+        error_code = "client_disconnected"
+        error_message = "Downstream client disconnected before response.completed"
+        failure_phase = "downstream"
+        failure_detail = "client_disconnected_before_terminal_event"
+        failure_exception_type = "GeneratorExit"
+        retryable_same_contract = False
+        raise
+    except OSError as exc:
+        error_code = "upstream_unavailable"
+        error_message = _codex_route_transport_error_message(
+            route=route,
+            route_trace=route_trace,
+            operation="stream",
+            exc=exc,
+        )
+        failure_phase = "upstream"
+        failure_detail = "transport_error"
+        failure_exception_type = type(exc).__name__
+        retryable_same_contract = True
+        yield format_sse_event(
+            response_failed_event("upstream_unavailable", error_message, response_id=get_request_id()),
         )
         return
     except Exception as exc:
@@ -2668,6 +2724,10 @@ async def _stream_responses_with_session(
             status_code=status_code,
             error_code=error_code,
             error_message=error_message,
+            failure_phase=failure_phase,
+            failure_detail=failure_detail,
+            failure_exception_type=failure_exception_type,
+            retryable_same_contract=retryable_same_contract,
         )
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -12581,11 +12581,11 @@ class ProxyService:
                 else:
                     classify_unterminated_stream(
                         error_status="error",
-                        error_code_value="client_disconnected",
-                        error_message_value="Downstream client disconnected before response.completed",
-                        failure_phase="downstream",
-                        failure_detail="stream_closed_before_terminal_event",
-                        penalize_account=False,
+                        error_code_value="stream_incomplete",
+                        error_message_value="Upstream stream ended before response.completed",
+                        failure_phase="upstream",
+                        failure_detail="upstream_eof_before_terminal_event",
+                        penalize_account=True,
                     )
             input_tokens = usage.input_tokens if usage else None
             output_tokens = usage.output_tokens if usage else None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -342,6 +342,7 @@ _REQUEST_TRANSPORT_HTTP = "http"
 _REQUEST_TRANSPORT_WEBSOCKET = "websocket"
 _API_KEY_RESERVATION_HEARTBEAT_SECONDS = 300.0
 _COMPACT_SAME_CONTRACT_RETRY_BUDGET = 1
+_RAW_HTTP_UPSTREAM_EOF_MESSAGE = "Upstream closed stream without completion"
 _ACCOUNT_RECOVERY_RETRY_CODES = frozenset(
     {
         "rate_limit_exceeded",
@@ -12063,6 +12064,8 @@ class ProxyService:
         route_trace = UpstreamProxyRouteTrace()
         route_fail_closed_reason: str | None = None
         saw_text_delta = False
+        terminal_event_seen = False
+        stream_exhausted = False
         latency_first_token_ms: int | None = None
         if tool_call_dedupe is None:
             tool_call_dedupe = _WebSocketUpstreamControl()
@@ -12072,6 +12075,35 @@ class ProxyService:
         api_key_reservation_touch_state = _ApiKeyReservationTouchState(last_touch_at=start)
         api_key_reservation_heartbeat_stop = asyncio.Event()
         api_key_reservation_heartbeat_task: asyncio.Task[None] | None = None
+
+        def mark_terminal_event_seen(event_type: str | None) -> None:
+            nonlocal terminal_event_seen
+            if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
+                terminal_event_seen = True
+
+        def classify_unterminated_stream(
+            *,
+            error_status: str,
+            error_code_value: str,
+            error_message_value: str,
+            failure_phase: str,
+            failure_detail: str,
+            exception_type: str | None = None,
+            penalize_account: bool,
+        ) -> None:
+            nonlocal status, error_code, error_message, failure_metadata
+            status = error_status
+            error_code = error_code_value
+            error_message = error_message_value
+            failure_metadata = _RequestLogFailureMetadata(
+                failure_phase=failure_phase,
+                failure_detail=failure_detail,
+                failure_exception_type=exception_type,
+            )
+            settlement.record_success = False
+            settlement.account_health_error = penalize_account
+            settlement.error = {"message": error_message}
+
         if api_key_reservation is not None:
             api_key_reservation_heartbeat_task = asyncio.create_task(
                 self._run_api_key_reservation_heartbeat(
@@ -12168,6 +12200,7 @@ class ProxyService:
             first_payload = parse_sse_data_json(first)
             event = parse_sse_event(first)
             event_type = _event_type_from_payload(event, first_payload)
+            mark_terminal_event_seen(event_type)
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 api_key_reservation_touch_state.last_touch_at = await self._maybe_touch_api_key_reservation(
                     api_key=api_key,
@@ -12235,6 +12268,14 @@ class ProxyService:
                 else:
                     error_code = code
                     error_message = error.message if error else None
+                    core_generated_eof = code == "stream_incomplete" and error_message == _RAW_HTTP_UPSTREAM_EOF_MESSAGE
+                    if core_generated_eof:
+                        failure_metadata = _RequestLogFailureMetadata(
+                            failure_phase="upstream",
+                            failure_detail="upstream_eof_before_terminal_event",
+                        )
+                        allow_retry = False
+                        allow_transient_retry = False
                     settlement.account_health_error = _should_penalize_stream_error(code)
                     if allow_retry and code == "stream_idle_timeout":
                         raise _RetryableStreamError(code, settlement.error, exclude_account=True)
@@ -12305,6 +12346,7 @@ class ProxyService:
                         error_code="upstream_error",
                         error_message=message,
                     )
+                mark_terminal_event_seen(event_type)
                 if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                     api_key_reservation_touch_state.last_touch_at = await self._maybe_touch_api_key_reservation(
                         api_key=api_key,
@@ -12384,8 +12426,16 @@ class ProxyService:
                             error_message = error.message if error else None
                             settlement.error = _upstream_error_from_openai(error)
                             settlement.record_success = False
-                            settlement.account_health_error = (
-                                _should_penalize_stream_error(error_code) and not saw_text_delta
+                            core_generated_eof = (
+                                error_code == "stream_incomplete" and error_message == _RAW_HTTP_UPSTREAM_EOF_MESSAGE
+                            )
+                            if core_generated_eof:
+                                failure_metadata = _RequestLogFailureMetadata(
+                                    failure_phase="upstream",
+                                    failure_detail="upstream_eof_before_terminal_event",
+                                )
+                            settlement.account_health_error = _should_penalize_stream_error(error_code) and (
+                                core_generated_eof or not saw_text_delta
                             )
                     if event_type in ("response.completed", "response.incomplete"):
                         response = event.response if event is not None else None
@@ -12422,6 +12472,37 @@ class ProxyService:
                 if event_type in _TEXT_DELTA_EVENT_TYPES:
                     settlement.downstream_text_visible = True
                 yield line
+            stream_exhausted = True
+            if status == "success" and not terminal_event_seen:
+                stream_incomplete_message = "Upstream stream ended before response.completed"
+                classify_unterminated_stream(
+                    error_status="error",
+                    error_code_value="stream_incomplete",
+                    error_message_value=stream_incomplete_message,
+                    failure_phase="upstream",
+                    failure_detail="upstream_eof_before_terminal_event",
+                    penalize_account=True,
+                )
+                terminal_event_seen = True
+                yield format_sse_event(
+                    response_failed_event(
+                        "stream_incomplete",
+                        stream_incomplete_message,
+                        response_id=response_id,
+                    )
+                )
+        except (asyncio.CancelledError, GeneratorExit) as exc:
+            if status == "success" and not terminal_event_seen:
+                classify_unterminated_stream(
+                    error_status="error",
+                    error_code_value="client_disconnected",
+                    error_message_value="Downstream client disconnected before response.completed",
+                    failure_phase="downstream",
+                    failure_detail="client_disconnected_before_terminal_event",
+                    exception_type=type(exc).__name__,
+                    penalize_account=False,
+                )
+            raise
         except ProxyResponseError as exc:
             response_create_lease.release()
             failure_metadata = _request_log_failure_metadata(exc)
@@ -12487,6 +12568,25 @@ class ProxyService:
                 self._cancel_api_key_reservation_heartbeat_task(api_key_reservation_heartbeat_task)
             response_create_lease.release()
             await self._load_balancer.release_account_lease(account_response_create_lease)
+            if status == "success" and not terminal_event_seen:
+                if stream_exhausted:
+                    classify_unterminated_stream(
+                        error_status="error",
+                        error_code_value="stream_incomplete",
+                        error_message_value="Upstream stream ended before response.completed",
+                        failure_phase="upstream",
+                        failure_detail="upstream_eof_before_terminal_event",
+                        penalize_account=True,
+                    )
+                else:
+                    classify_unterminated_stream(
+                        error_status="error",
+                        error_code_value="client_disconnected",
+                        error_message_value="Downstream client disconnected before response.completed",
+                        failure_phase="downstream",
+                        failure_detail="stream_closed_before_terminal_event",
+                        penalize_account=False,
+                    )
             input_tokens = usage.input_tokens if usage else None
             output_tokens = usage.output_tokens if usage else None
             cached_input_tokens = (

--- a/openspec/changes/finalize-unterminated-response-streams/.openspec.yaml
+++ b/openspec/changes/finalize-unterminated-response-streams/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/finalize-unterminated-response-streams/proposal.md
+++ b/openspec/changes/finalize-unterminated-response-streams/proposal.md
@@ -1,0 +1,24 @@
+# Finalize unterminated response streams
+
+## Why
+
+Large Codex Responses requests can bypass the HTTP bridge and use the raw HTTP
+streaming path. That path receives HTTP 200 before the SSE body is complete, so
+request logs must not treat the attempt as successful unless a terminal
+Responses event was observed.
+
+## What Changes
+
+- Track terminal SSE events in the raw streaming Responses path.
+- Classify upstream EOF before a terminal event as `stream_incomplete`, emit a
+  synthetic `response.failed`, and record an upstream failure for account health.
+- Classify downstream client cancellation before a terminal event as
+  `client_disconnected` without penalizing the upstream account.
+- Preserve normal `response.completed`, `response.failed`,
+  `response.incomplete`, and `error` terminal handling.
+
+## Impact
+
+- **Spec**: `responses-api-compat`
+- **Behavior**: raw HTTP streaming attempts no longer disappear as successful
+  request-log rows when the body ends or is cancelled before a terminal event.

--- a/openspec/changes/finalize-unterminated-response-streams/specs/responses-api-compat/spec.md
+++ b/openspec/changes/finalize-unterminated-response-streams/specs/responses-api-compat/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Raw Responses streams require a terminal SSE event for success
+
+For raw HTTP streaming Responses attempts, the proxy MUST NOT record request-log
+status `success` or mark the selected account successful unless the stream
+observed a terminal SSE event: `response.completed`, `response.failed`,
+`response.incomplete`, or `error`. This requirement applies even when the
+upstream HTTP response status was 200 because the stream body remains part of
+the request outcome.
+
+If the upstream iterator ends before a terminal event, the proxy MUST surface a
+terminal `response.failed` SSE event with error code `stream_incomplete`, record
+the request-log row as an upstream `stream_incomplete` error, and apply the
+normal transient upstream account-health signal. If the downstream client
+cancels or disconnects before a terminal event, the proxy MUST record the
+request-log row as a downstream `client_disconnected` error and MUST NOT
+penalize the upstream account.
+
+#### Scenario: Raw stream upstream EOF is not successful
+
+- **GIVEN** a raw HTTP streaming Responses request has emitted non-terminal SSE
+  data
+- **WHEN** the upstream stream ends before `response.completed`,
+  `response.failed`, `response.incomplete`, or `error`
+- **THEN** the downstream stream receives a terminal `response.failed` event
+  with error code `stream_incomplete`
+- **AND** the request log stores status `error`, error code
+  `stream_incomplete`, and upstream failure metadata
+- **AND** the selected account receives a transient upstream failure signal
+
+#### Scenario: Raw stream downstream cancellation is client-side
+
+- **GIVEN** a raw HTTP streaming Responses request has not observed a terminal
+  SSE event
+- **WHEN** the downstream client cancels or disconnects from the stream
+- **THEN** the request log stores status `error`, error code
+  `client_disconnected`, and downstream failure metadata
+- **AND** the selected account is not penalized for the client-side close

--- a/openspec/changes/finalize-unterminated-response-streams/tasks.md
+++ b/openspec/changes/finalize-unterminated-response-streams/tasks.md
@@ -1,0 +1,21 @@
+## 1. Spec Delta
+
+- [x] 1.1 Add a `responses-api-compat` requirement for raw streaming Responses
+  attempts that end before a terminal event.
+- [x] 1.2 Cover upstream EOF and downstream client cancellation separately.
+
+## 2. Implementation
+
+- [x] 2.1 Track terminal SSE events in the raw Responses streaming path.
+- [x] 2.2 Emit a synthetic `response.failed` for upstream EOF without a terminal
+  event.
+- [x] 2.3 Record downstream disconnect before terminal as a non-account-health
+  client-side failure.
+
+## 3. Verification
+
+- [x] 3.1 Add integration coverage for upstream EOF without a terminal event.
+- [x] 3.2 Run targeted stream integration tests.
+- [x] 3.3 Run the full `test_proxy_api_extended.py` integration file.
+- [x] 3.4 Run `uv run openspec validate finalize-unterminated-response-streams --strict`.
+- [x] 3.5 Run `uv run openspec validate --specs`.

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -810,6 +810,154 @@ async def test_proxy_stream_records_cached_and_reasoning_tokens(async_client, mo
 
 
 @pytest.mark.asyncio
+async def test_proxy_stream_surfaces_and_logs_upstream_eof_without_terminal(async_client, monkeypatch):
+    expected_account_id = await _import_account(async_client, "acc_stream_eof", "stream-eof@example.com")
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        event = {"type": "response.output_text.delta", "delta": "partial"}
+        yield _sse_event(event)
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"x-request-id": "req_stream_eof"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = [
+        json.loads(line[6:]) for line in lines if line.startswith("data: ") and not line.startswith("data: [DONE]")
+    ]
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert failed
+    assert failed[-1]["response"]["error"]["code"] == "stream_incomplete"
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(RequestLog)
+            .where(RequestLog.account_id == expected_account_id)
+            .order_by(RequestLog.requested_at.desc())
+        )
+        log = result.scalars().first()
+        assert log is not None
+        assert log.status == "error"
+        assert log.error_code == "stream_incomplete"
+        assert log.error_message == "Upstream stream ended before response.completed"
+        assert log.failure_phase == "upstream"
+        assert log.failure_detail == "upstream_eof_before_terminal_event"
+
+
+@pytest.mark.asyncio
+async def test_proxy_stream_classifies_core_generated_eof_failure(async_client, monkeypatch):
+    expected_account_id = await _import_account(async_client, "acc_stream_core_eof", "stream-core-eof@example.com")
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        yield _sse_event({"type": "response.output_text.delta", "delta": "partial"})
+        yield _sse_event(
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": "resp_core_eof",
+                    "error": {
+                        "code": "stream_incomplete",
+                        "message": "Upstream closed stream without completion",
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"x-request-id": "req_stream_core_eof"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event = [
+        json.loads(line[6:]) for line in lines if line.startswith("data: ") and not line.startswith("data: [DONE]")
+    ][-1]
+    assert event["type"] == "response.failed"
+    assert event["response"]["error"]["code"] == "stream_incomplete"
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(RequestLog)
+            .where(RequestLog.account_id == expected_account_id)
+            .order_by(RequestLog.requested_at.desc())
+        )
+        log = result.scalars().first()
+        assert log is not None
+        assert log.status == "error"
+        assert log.error_code == "stream_incomplete"
+        assert log.error_message == "Upstream closed stream without completion"
+        assert log.failure_phase == "upstream"
+        assert log.failure_detail == "upstream_eof_before_terminal_event"
+
+
+async def test_proxy_stream_classifies_first_core_generated_eof_failure(async_client, monkeypatch):
+    expected_account_id = await _import_account(
+        async_client,
+        "acc_stream_first_core_eof",
+        "stream-first-core-eof@example.com",
+    )
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        yield _sse_event(
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": "resp_first_core_eof",
+                    "error": {
+                        "code": "stream_incomplete",
+                        "message": "Upstream closed stream without completion",
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"x-request-id": "req_stream_first_core_eof"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event = [
+        json.loads(line[6:]) for line in lines if line.startswith("data: ") and not line.startswith("data: [DONE]")
+    ][-1]
+    assert event["type"] == "response.failed"
+    assert event["response"]["error"]["code"] == "stream_incomplete"
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(RequestLog)
+            .where(RequestLog.account_id == expected_account_id)
+            .order_by(RequestLog.requested_at.desc())
+        )
+        log = result.scalars().first()
+        assert log is not None
+        assert log.status == "error"
+        assert log.error_code == "stream_incomplete"
+        assert log.error_message == "Upstream closed stream without completion"
+        assert log.failure_phase == "upstream"
+        assert log.failure_detail == "upstream_eof_before_terminal_event"
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event(monkeypatch):
     upstream_started = asyncio.Event()
     release_upstream = asyncio.Event()

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -958,6 +958,51 @@ async def test_proxy_stream_classifies_first_core_generated_eof_failure(async_cl
 
 
 @pytest.mark.asyncio
+async def test_proxy_stream_exception_without_terminal_event_logs_as_stream_incomplete(async_client, monkeypatch):
+    expected_account_id = await _import_account(async_client, "acc_stream_exc", "stream-exception@example.com")
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, account_id, base_url, raise_for_status
+        yield _sse_event({"type": "response.output_text.delta", "delta": "partial"})
+        raise RuntimeError("upstream stream processing failed")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"x-request-id": "req_stream_exception"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    stream_lines = [line for line in lines if line.startswith("data: ") and not line.startswith("data: [DONE]")]
+    events = [json.loads(line[6:]) for line in stream_lines]
+    event = _extract_first_event(stream_lines)
+    assert event["type"] == "response.output_text.delta"
+    assert all(
+        event.get("type") != "response.failed" or event["response"]["error"]["code"] != "client_disconnected"
+        for event in events
+    )
+
+    async with SessionLocal() as session:
+        result = await session.execute(
+            select(RequestLog)
+            .where(RequestLog.account_id == expected_account_id)
+            .order_by(RequestLog.requested_at.desc())
+        )
+        log = result.scalars().first()
+        assert log is not None
+        assert log.status == "error"
+        assert log.error_code == "stream_incomplete"
+        assert log.error_message == "Upstream stream ended before response.completed"
+        assert log.failure_phase == "upstream"
+        assert log.failure_detail == "upstream_eof_before_terminal_event"
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event(monkeypatch):
     upstream_started = asyncio.Event()
     release_upstream = asyncio.Event()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3416,6 +3416,57 @@ async def test_stream_responses_via_websocket_counts_connect_and_send_against_to
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_websocket_broken_pipe_is_retryable_upstream_unavailable(monkeypatch):
+    logged_completions: list[dict[str, object]] = []
+
+    class _BrokenPipeWsResponse(_WsResponse):
+        async def send_json(self, payload: dict[str, object]) -> None:
+            self.sent_json.append(payload)
+            raise BrokenPipeError(32, "Broken pipe")
+
+    def fake_log_upstream_request_complete(**kwargs: object) -> None:
+        logged_completions.append(dict(kwargs))
+
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", fake_log_upstream_request_complete)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        }
+    )
+    websocket = _BrokenPipeWsResponse([])
+    session = _WsSession(websocket)
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_broken_pipe",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+            upstream_stream_transport_override="websocket",
+        )
+    ]
+
+    assert len(events) == 1
+    failed = json.loads(events[0].split("data: ", 1)[1])
+    assert failed["type"] == "response.failed"
+    assert failed["response"]["error"]["code"] == "upstream_unavailable"
+    assert "Broken pipe" in failed["response"]["error"]["message"]
+    assert logged_completions
+    completion = logged_completions[-1]
+    assert completion["error_code"] == "upstream_unavailable"
+    assert completion["failure_phase"] == "upstream"
+    assert completion["failure_detail"] == "transport_error"
+    assert completion["failure_exception_type"] == "BrokenPipeError"
+    assert completion["retryable_same_contract"] is True
+
+
+@pytest.mark.asyncio
 async def test_open_upstream_websocket_preserves_error_body_on_handshake_failure():
     error_body = json.dumps(
         {"error": {"message": "quota exhausted", "type": "server_error", "code": "insufficient_quota"}}

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14242,6 +14242,68 @@ async def test_stream_previous_response_not_found_proxy_error_is_masked_to_strea
 
 
 @pytest.mark.asyncio
+async def test_stream_midstream_core_eof_with_previous_response_id_fails_closed(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_midstream_core_eof")
+    request_logs.response_owner_by_id[("resp_parent", None, "sid-stream")] = account.id
+    handle_stream_error = AsyncMock()
+    record_success = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, kwargs
+        yield 'data: {"type":"response.created","response":{"id":"resp_child","status":"in_progress"}}\n\n'
+        yield (
+            'data: {"type":"response.failed","response":{"id":"resp_child","status":"failed",'
+            '"error":{"code":"stream_incomplete","message":"Upstream closed stream without completion"}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_parent",
+        }
+    )
+
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+
+    created = json.loads(chunks[0].split("data: ", 1)[1])
+    failed = json.loads(chunks[1].split("data: ", 1)[1])
+    assert created["type"] == "response.created"
+    assert failed["type"] == "response.failed"
+    assert failed["response"]["error"]["code"] == "stream_incomplete"
+    assert failed["response"]["error"]["message"] == "Upstream closed stream without completion"
+    assert request_logs.lookup_calls == [("resp_parent", None, "sid-stream")]
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+    assert request_logs.calls[0]["failure_phase"] == "upstream"
+    assert request_logs.calls[0]["failure_detail"] == "upstream_eof_before_terminal_event"
+    handle_stream_error.assert_awaited_once()
+    handle_stream_error_args = handle_stream_error.await_args
+    assert handle_stream_error_args is not None
+    assert handle_stream_error_args.args[0] == account
+    assert handle_stream_error_args.args[2] == "stream_incomplete"
+    record_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_stream_missing_tool_output_proxy_error_is_masked_to_stream_incomplete(monkeypatch, caplog):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()


### PR DESCRIPTION
## Superseded

This PR has been absorbed into #892 so Responses HTTP bridge and stream-correctness fixes land in one reviewable branch.

#892 now carries this PR's terminal-event requirement and `stream_incomplete` handling for unterminated raw HTTP Responses streams.

Relationship:

- Superseded by #892.
- Do not merge this PR separately.
- No issue closure moved because this PR did not claim one.
