### PR TITLE
feat(accounts): add dashboard action for account force-probe

### DIFF
--- a/frontend/src/features/accounts/api.ts
+++ b/frontend/src/features/accounts/api.ts
@@ -13,6 +13,8 @@ import {
   AccountRoutingPolicyUpdateRequestSchema,
   AccountRoutingPolicyUpdateResponseSchema,
   AccountTrendsResponseSchema,
+  AccountProbeRequestSchema,
+  AccountProbeResponseSchema,
   ManualOauthCallbackRequestSchema,
   ManualOauthCallbackResponseSchema,
   OauthCompleteRequestSchema,
@@ -96,6 +98,15 @@ export function getAccountTrends(accountId: string) {
   return get(
     `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/trends`,
     AccountTrendsResponseSchema,
+  );
+}
+
+export function probeAccount(accountId: string, payload?: unknown) {
+  const validated = payload === undefined ? undefined : AccountProbeRequestSchema.parse(payload);
+  return post(
+    `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/probe`,
+    AccountProbeResponseSchema,
+    validated ? { body: validated } : undefined,
   );
 }
 

--- a/frontend/src/features/accounts/components/account-actions.test.tsx
+++ b/frontend/src/features/accounts/components/account-actions.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { AccountActions } from "@/features/accounts/components/account-actions";
@@ -15,6 +16,7 @@ describe("AccountActions", () => {
         busy={false}
         onPause={vi.fn()}
         onResume={vi.fn()}
+        onProbe={vi.fn()}
         onDelete={vi.fn()}
         onReauth={vi.fn()}
         onExportAuth={vi.fn()}
@@ -40,6 +42,7 @@ describe("AccountActions", () => {
         busy={false}
         onPause={vi.fn()}
         onResume={vi.fn()}
+        onProbe={vi.fn()}
         onDelete={vi.fn()}
         onReauth={onReauth}
         onExportAuth={vi.fn()}
@@ -58,5 +61,52 @@ describe("AccountActions", () => {
     expect(
       screen.queryByRole("combobox", { name: "Routing policy" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("fires the per-account probe callback for active accounts", async () => {
+    const user = userEvent.setup();
+    const account = createAccountSummary();
+    const onProbe = vi.fn();
+
+    render(
+      <AccountActions
+        account={account}
+        busy={false}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onProbe={onProbe}
+        onDelete={vi.fn()}
+        onReauth={vi.fn()}
+        onExportAuth={vi.fn()}
+        onSecurityWorkAuthorizedChange={vi.fn()}
+        onLimitWarmupChange={vi.fn()}
+        onRoutingPolicyChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Force probe" }));
+
+    expect(onProbe).toHaveBeenCalledWith(account.accountId);
+    expect(onProbe).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables force probe for paused accounts", () => {
+    render(
+      <AccountActions
+        account={createAccountSummary({ status: "paused" })}
+        busy={false}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onProbe={vi.fn()}
+        onDelete={vi.fn()}
+        onReauth={vi.fn()}
+        onExportAuth={vi.fn()}
+        onSecurityWorkAuthorizedChange={vi.fn()}
+        onLimitWarmupChange={vi.fn()}
+        onRoutingPolicyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Force probe" })).toBeDisabled();
   });
 });

--- a/frontend/src/features/accounts/components/account-actions.test.tsx
+++ b/frontend/src/features/accounts/components/account-actions.test.tsx
@@ -90,23 +90,35 @@ describe("AccountActions", () => {
     expect(onProbe).toHaveBeenCalledTimes(1);
   });
 
-  it("disables force probe for paused accounts", () => {
-    render(
-      <AccountActions
-        account={createAccountSummary({ status: "paused" })}
-        busy={false}
-        onPause={vi.fn()}
-        onResume={vi.fn()}
-        onProbe={vi.fn()}
-        onDelete={vi.fn()}
-        onReauth={vi.fn()}
-        onExportAuth={vi.fn()}
-        onSecurityWorkAuthorizedChange={vi.fn()}
-        onLimitWarmupChange={vi.fn()}
-        onRoutingPolicyChange={vi.fn()}
-      />,
-    );
+  it.each(["paused", "deactivated"] as const)(
+    "disables force probe for %s accounts",
+    async (status) => {
+      const user = userEvent.setup();
+      const account = createAccountSummary({ status });
+      const onProbe = vi.fn();
 
-    expect(screen.getByRole("button", { name: "Force probe" })).toBeDisabled();
-  });
+      render(
+        <AccountActions
+          account={account}
+          busy={false}
+          onPause={vi.fn()}
+          onResume={vi.fn()}
+          onProbe={onProbe}
+          onDelete={vi.fn()}
+          onReauth={vi.fn()}
+          onExportAuth={vi.fn()}
+          onSecurityWorkAuthorizedChange={vi.fn()}
+          onLimitWarmupChange={vi.fn()}
+          onRoutingPolicyChange={vi.fn()}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: "Force probe" });
+      expect(button).toBeDisabled();
+
+      await user.click(button);
+
+      expect(onProbe).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/frontend/src/features/accounts/components/account-actions.tsx
+++ b/frontend/src/features/accounts/components/account-actions.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   Download,
   Pause,
   Play,
@@ -28,6 +29,7 @@ export type AccountActionsProps = {
   busy: boolean;
   onPause: (accountId: string) => void;
   onResume: (accountId: string) => void;
+  onProbe: (accountId: string) => void;
   onDelete: (accountId: string) => void;
   onReauth: () => void;
   onExportAuth: (accountId: string) => void;
@@ -44,6 +46,7 @@ export function AccountActions({
   busy,
   onPause,
   onResume,
+  onProbe,
   onDelete,
   onReauth,
   onExportAuth,
@@ -53,6 +56,8 @@ export function AccountActions({
 }: AccountActionsProps) {
   const showOperatorRecoveryAction =
     account.status === "reauth_required" || account.status === "deactivated";
+  const probeDisabled =
+    busy || account.status === "paused" || showOperatorRecoveryAction;
 
   return (
     <div className="space-y-3 border-t pt-4">
@@ -141,6 +146,18 @@ export function AccountActions({
             Re-authenticate
           </Button>
         ) : null}
+
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 gap-1.5 text-xs"
+          onClick={() => onProbe(account.accountId)}
+          disabled={probeDisabled}
+        >
+          <Activity className="h-3.5 w-3.5" />
+          Force probe
+        </Button>
 
         <Button
           type="button"

--- a/frontend/src/features/accounts/components/account-detail.test.tsx
+++ b/frontend/src/features/accounts/components/account-detail.test.tsx
@@ -24,6 +24,7 @@ describe("AccountDetail", () => {
         busy={false}
         onPause={vi.fn()}
         onResume={vi.fn()}
+        onProbe={vi.fn()}
         onSetAlias={vi.fn().mockResolvedValue(undefined)}
         onDelete={vi.fn()}
         onReauth={vi.fn()}

--- a/frontend/src/features/accounts/components/account-detail.tsx
+++ b/frontend/src/features/accounts/components/account-detail.tsx
@@ -22,6 +22,7 @@ export type AccountDetailProps = {
   busy: boolean;
   onPause: (accountId: string) => void;
   onResume: (accountId: string) => void;
+  onProbe: (accountId: string) => void;
   onSetAlias: (accountId: string, alias: string | null) => Promise<unknown>;
   onDelete: (accountId: string) => void;
   onReauth: () => void;
@@ -42,6 +43,7 @@ export function AccountDetail({
   busy,
   onPause,
   onResume,
+  onProbe,
   onSetAlias,
   onDelete,
   onReauth,
@@ -136,6 +138,7 @@ export function AccountDetail({
         busy={busy}
         onPause={onPause}
         onResume={onResume}
+        onProbe={onProbe}
         onDelete={onDelete}
         onReauth={onReauth}
         onExportAuth={onExportAuth}

--- a/frontend/src/features/accounts/components/accounts-page.test.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.test.tsx
@@ -104,6 +104,7 @@ describe("AccountsPage", () => {
       importMutation: idleMutation(),
       pauseMutation: idleMutation(),
       resumeMutation: idleMutation(),
+      probeMutation: idleMutation(),
       deleteMutation: idleMutation(),
       exportAuthMutation: idleMutation(),
       setAliasMutation: idleMutation(),

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -33,6 +33,7 @@ export function AccountsPage() {
     pauseMutation,
     resumeMutation,
     setAliasMutation,
+    probeMutation,
     limitWarmupMutation,
     updateMutation,
     deleteMutation,
@@ -96,6 +97,7 @@ export function AccountsPage() {
     pauseMutation.isPending ||
     resumeMutation.isPending ||
     setAliasMutation.isPending ||
+    probeMutation.isPending ||
     limitWarmupMutation.isPending ||
     deleteMutation.isPending ||
     routingPolicyMutation.isPending ||
@@ -108,6 +110,7 @@ export function AccountsPage() {
     getErrorMessageOrNull(pauseMutation.error) ||
     getErrorMessageOrNull(resumeMutation.error) ||
     getErrorMessageOrNull(setAliasMutation.error) ||
+    getErrorMessageOrNull(probeMutation.error) ||
     getErrorMessageOrNull(limitWarmupMutation.error) ||
     getErrorMessageOrNull(deleteMutation.error) ||
     getErrorMessageOrNull(routingPolicyMutation.error) ||
@@ -150,6 +153,9 @@ export function AccountsPage() {
             busy={mutationBusy}
             onPause={(accountId) => void pauseMutation.mutateAsync(accountId)}
             onResume={(accountId) => void resumeMutation.mutateAsync(accountId)}
+            onProbe={(accountId) =>
+              void probeMutation.mutateAsync({ accountId })
+            }
             onSetAlias={(accountId, alias) =>
               setAliasMutation.mutateAsync({ accountId, alias })
             }

--- a/frontend/src/features/accounts/hooks/use-accounts.test.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.test.ts
@@ -36,6 +36,9 @@ describe("useAccounts", () => {
 
     await result.current.pauseMutation.mutateAsync(firstAccountId as string);
     await result.current.resumeMutation.mutateAsync(firstAccountId as string);
+    await result.current.probeMutation.mutateAsync({
+      accountId: firstAccountId as string,
+    });
     const routingPolicyResult = await result.current.routingPolicyMutation.mutateAsync({
       accountId: firstAccountId as string,
       routingPolicy: "preserve",
@@ -49,6 +52,7 @@ describe("useAccounts", () => {
 
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "list"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "trends"] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "projections"] });
     });
@@ -69,6 +73,7 @@ describe("useAccounts", () => {
     await result.current.exportAuthMutation.mutateAsync(firstAccountId as string);
 
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["accounts", "list"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["accounts", "trends"] });
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "projections"] });
   });

--- a/frontend/src/features/accounts/hooks/use-accounts.test.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.test.ts
@@ -53,6 +53,9 @@ describe("useAccounts", () => {
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "list"] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "trends"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["accounts", "trends", firstAccountId],
+      });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "projections"] });
     });

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -9,6 +9,7 @@ import {
   listAccounts,
   pauseAccount,
   reactivateAccount,
+  probeAccount,
   setAccountAlias,
   updateAccount,
   updateAccountLimitWarmup,
@@ -18,6 +19,7 @@ import type { AccountRoutingPolicy } from "@/features/accounts/schemas";
 
 function invalidateAccountRelatedQueries(queryClient: ReturnType<typeof useQueryClient>) {
   void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
+  void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
   void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
   void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
 }
@@ -87,6 +89,18 @@ export function useAccountMutations() {
     },
   });
 
+  const probeMutation = useMutation({
+    mutationFn: ({ accountId, model }: { accountId: string; model?: string }) =>
+      probeAccount(accountId, model ? { model } : undefined),
+    onSuccess: () => {
+      toast.success("Account probed");
+      invalidateAccountRelatedQueries(queryClient);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Probe failed");
+    },
+  });
+
   const limitWarmupMutation = useMutation({
     mutationFn: ({ accountId, enabled }: { accountId: string; enabled: boolean }) =>
       updateAccountLimitWarmup(accountId, enabled),
@@ -146,6 +160,7 @@ export function useAccountMutations() {
     resumeMutation,
     setAliasMutation,
     deleteMutation,
+    probeMutation,
     exportAuthMutation,
     limitWarmupMutation,
     routingPolicyMutation,

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -17,11 +17,14 @@ import {
 } from "@/features/accounts/api";
 import type { AccountRoutingPolicy } from "@/features/accounts/schemas";
 
-function invalidateAccountRelatedQueries(queryClient: ReturnType<typeof useQueryClient>) {
+function invalidateAccountRelatedQueries(queryClient: ReturnType<typeof useQueryClient>, accountId?: string) {
   void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
   void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
   void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
   void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+  if (accountId) {
+    void queryClient.invalidateQueries({ queryKey: ["accounts", "trends", accountId] });
+  }
 }
 
 /**
@@ -92,9 +95,9 @@ export function useAccountMutations() {
   const probeMutation = useMutation({
     mutationFn: ({ accountId, model }: { accountId: string; model?: string }) =>
       probeAccount(accountId, model ? { model } : undefined),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       toast.success("Account probed");
-      invalidateAccountRelatedQueries(queryClient);
+      invalidateAccountRelatedQueries(queryClient, variables.accountId);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Probe failed");

--- a/frontend/src/features/accounts/schemas.test.ts
+++ b/frontend/src/features/accounts/schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   AccountAuthExportResponseSchema,
+  AccountProbeResponseSchema,
   AccountSummarySchema,
   ImportStateSchema,
   OAuthStateSchema,
@@ -160,5 +161,24 @@ describe("ImportStateSchema", () => {
         message: "Imported 1 account",
       }).success,
     ).toBe(true);
+  });
+});
+
+describe("AccountProbeResponseSchema", () => {
+  it("parses probe response payloads", () => {
+    const parsed = AccountProbeResponseSchema.parse({
+      status: "probed",
+      accountId: "acc-1",
+      probeStatusCode: 200,
+      primaryUsedPercentBefore: 80,
+      primaryUsedPercentAfter: 79,
+      secondaryUsedPercentBefore: 50,
+      secondaryUsedPercentAfter: 49,
+      accountStatusBefore: "active",
+      accountStatusAfter: "active",
+    });
+
+    expect(parsed.probeStatusCode).toBe(200);
+    expect(parsed.accountId).toBe("acc-1");
   });
 });

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -165,6 +165,22 @@ export const AccountActionResponseSchema = z.object({
   status: z.string(),
 });
 
+export const AccountProbeRequestSchema = z.object({
+  model: z.string().min(1).optional(),
+});
+
+export const AccountProbeResponseSchema = z.object({
+  status: z.string(),
+  accountId: z.string(),
+  probeStatusCode: z.number().int().nullable(),
+  primaryUsedPercentBefore: z.number().nullable(),
+  primaryUsedPercentAfter: z.number().nullable(),
+  secondaryUsedPercentBefore: z.number().nullable(),
+  secondaryUsedPercentAfter: z.number().nullable(),
+  accountStatusBefore: z.string(),
+  accountStatusAfter: z.string(),
+});
+
 export const AccountRoutingPolicySchema = z.enum(["normal", "burn_first", "preserve"]);
 
 export const AccountAliasRequestSchema = z.object({
@@ -285,6 +301,7 @@ export type AccountAdditionalWindow = z.infer<
 export type AccountAdditionalQuota = z.infer<
   typeof AccountAdditionalQuotaSchema
 >;
+export type AccountProbeResponse = z.infer<typeof AccountProbeResponseSchema>;
 export type AccountTrendsResponse = z.infer<typeof AccountTrendsResponseSchema>;
 export type OpenCodeAuthJson = z.infer<typeof OpenCodeAuthJsonSchema>;
 export type CodexAuthJson = z.infer<typeof CodexAuthJsonSchema>;

--- a/frontend/src/test/mocks/handler-coverage.test.ts
+++ b/frontend/src/test/mocks/handler-coverage.test.ts
@@ -35,6 +35,7 @@ const EXPECTED_ENDPOINTS = [
 	"PATCH /api/accounts/:accountId",
 	"POST /api/accounts/:accountId/pause",
 	"POST /api/accounts/:accountId/reactivate",
+	"POST /api/accounts/:accountId/probe",
 	"PUT /api/accounts/:accountId/alias",
 	"PUT /api/accounts/:accountId/limit-warmup",
 	"PUT /api/accounts/:accountId/routing-policy",

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -610,6 +610,28 @@ export const handlers = [
     return HttpResponse.json(createAccountTrends(accountId));
   }),
 
+  http.post("/api/accounts/:accountId/probe", ({ params }) => {
+    const accountId = String(params.accountId);
+    const account = findAccount(accountId);
+    if (!account) {
+      return HttpResponse.json(
+        { error: { code: "account_not_found", message: "Account not found" } },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json({
+      status: "probed",
+      accountId,
+      probeStatusCode: 200,
+      primaryUsedPercentBefore: account.usage?.primaryRemainingPercent ?? null,
+      primaryUsedPercentAfter: account.usage?.primaryRemainingPercent ?? null,
+      secondaryUsedPercentBefore: account.usage?.secondaryRemainingPercent ?? null,
+      secondaryUsedPercentAfter: account.usage?.secondaryRemainingPercent ?? null,
+      accountStatusBefore: account.status,
+      accountStatusAfter: account.status,
+    });
+  }),
+
 	http.post("/api/accounts/:accountId/export/auth", ({ params }) => {
 		const accountId = String(params.accountId);
 		const account = findAccount(accountId);

--- a/openspec/changes/add-account-probe-endpoint/proposal.md
+++ b/openspec/changes/add-account-probe-endpoint/proposal.md
@@ -22,5 +22,5 @@ This change adds the per-account "force-probe" admin endpoint requested in upstr
 - Operators get a first-class manual recovery action for stuck-rate-limited accounts after OpenAI reset events. Closes the chicken-and-egg trap that #677 describes (LB excludes blocked accounts from selection, so blocked accounts can never wake the upstream limiter via organic traffic).
 - Single endpoint, single concern. No changes to selector decision logic, the proxy pipeline, the existing usage refresh cadence, or persistence beyond what `UsageUpdater.refresh_accounts` already writes.
 - The probe consumes a tiny amount of upstream quota (one `responses.create` with `max_output_tokens=1`) per invocation. The endpoint requires dashboard auth, so casual misuse is not a concern.
-- No frontend / dashboard button in this change. UI button is a follow-up so the API surface can land cleanly with a focused review.
+- Dashboard account actions expose a Force probe button for eligible accounts and keep it disabled for paused or deactivated accounts.
 - No change to public client surfaces (`/backend-api/codex/responses`, `/v1/responses`, etc.). The new endpoint lives under the existing dashboard `/api/accounts/*` namespace.

--- a/openspec/changes/add-account-probe-endpoint/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/add-account-probe-endpoint/specs/usage-refresh-policy/spec.md
@@ -17,6 +17,15 @@ The dashboard MUST expose an admin-only endpoint that sends a single minimal `re
 - **THEN** the endpoint responds `409` with code `account_not_probable`
 - **AND** no upstream request is sent
 
+#### Scenario: Dashboard exposes Force probe only for probeable statuses
+
+- **WHEN** the dashboard renders account actions for an account
+- **AND** the account `status` is `active`, `rate_limited`, or `quota_exceeded`
+- **THEN** the dashboard exposes a Force probe action for that account
+- **AND** invoking the action refreshes the account list, dashboard overview, projections, and that account's trends
+- **BUT WHEN** the account `status` is `paused` or `deactivated`
+- **THEN** the Force probe action is disabled or hidden
+
 #### Scenario: Probe returns 404 for unknown account
 - **WHEN** an operator POSTs to `/api/accounts/{account_id}/probe`
 - **AND** no account with that id exists


### PR DESCRIPTION
## Summary
- Wire the existing per-account probe backend endpoint (`POST /api/accounts/{accountId}/probe`) into the Accounts dashboard.
- Add the frontend schema/client method, mutation, and MSW handler coverage for force-probe.
- Add a Force probe button to the account detail action surface while preserving the newer routing policy, Trusted Access, limit warm-up, and upstream proxy controls from current `main`.
- Refresh account list, account trends, per-account trend detail, and dashboard queries after a successful force-probe.
- Keep Force probe disabled for paused, deactivated, and re-auth-required accounts that the backend rejects.

## Stack relationship
- Remains separate from #892 because this is a dashboard/account-control feature, while #892 is the Responses HTTP bridge admission/stream contract bundle.
- Remains separate from #887 because this does not touch model catalog visibility or public model metadata.
- Does not absorb or supersede another open PR.

Closes #677

## Validation
- `uv run openspec validate add-account-probe-endpoint --strict`
- `cd frontend && bun run test src/features/accounts/components/account-actions.test.tsx src/features/accounts/components/account-detail.test.tsx src/features/accounts/hooks/use-accounts.test.ts src/features/accounts/schemas.test.ts src/test/mocks/handler-coverage.test.ts`
- `cd frontend && bun run test src/features/accounts/components/accounts-page.test.tsx`
- `cd frontend && bun run test:coverage`
- `cd frontend && bun run typecheck`
- `cd frontend && bun run lint`

Current head: `6aec65730b15f4a934db0daf6c3ed5e14a4d8fb4`
GitHub CI: pending on current head after the test-fixture fix push.
