### PR TITLE
Normalize HTTP stream error events for responses API

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1077,7 +1077,18 @@ def _normalize_stream_event_payload(payload: dict[str, JsonValue]) -> dict[str, 
     return payload
 
 
-def _normalize_stream_payload_for_http_block(event_block: str) -> tuple[str, str | None]:
+def _normalize_stream_payload_for_http_block(
+    event_block: str,
+    *,
+    enforce_openai_sdk_contract: bool = True,
+) -> tuple[str, str | None]:
+    if not enforce_openai_sdk_contract:
+        payload = parse_sse_data_json(event_block)
+        if payload is None:
+            return event_block, None
+        event_type = payload.get("type")
+        return event_block, event_type if isinstance(event_type, str) else None
+
     payload = parse_sse_data_json(event_block)
     if payload is None:
         return event_block, None
@@ -2127,6 +2138,7 @@ async def stream_responses(
     codex_client: CodexClient | None = None,
     route_trace: UpstreamProxyRouteTrace | None = None,
     allow_direct_egress: bool = True,
+    enforce_openai_sdk_contract: bool = True,
 ) -> AsyncIterator[str]:
     effective_allow_direct_egress = allow_direct_egress or (route is None and session is not None)
     async with lease_http_session(session) as client_session:
@@ -2143,6 +2155,7 @@ async def stream_responses(
             codex_client=codex_client,
             route_trace=route_trace,
             allow_direct_egress=effective_allow_direct_egress,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         ):
             yield event_block
 
@@ -2160,6 +2173,7 @@ async def _stream_responses_with_session(
     codex_client: CodexClient | None = None,
     route_trace: UpstreamProxyRouteTrace | None = None,
     allow_direct_egress: bool = True,
+    enforce_openai_sdk_contract: bool = True,
 ) -> AsyncIterator[str]:
     settings = get_settings()
     upstream_base = (base_url or settings.upstream_base_url).rstrip("/")
@@ -2298,14 +2312,24 @@ async def _stream_responses_with_session(
                 ):
                     last_stream_activity_at = time.monotonic()
                     event_block = _normalize_sse_event_block(event_block)
-                    event_block, normalized_event_type = _normalize_stream_payload_for_http_block(event_block)
+                    event_block, normalized_event_type = _normalize_stream_payload_for_http_block(
+                        event_block,
+                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                    )
                     event = parse_sse_event(event_block)
                     if event:
-                        if event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
+                        if event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES or (
+                            event.type == "error" and not enforce_openai_sdk_contract
+                        ):
                             seen_terminal = True
                     elif (
                         isinstance(normalized_event_type, str)
-                        and normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                        and (
+                            normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                            or (
+                                normalized_event_type == "error" and not enforce_openai_sdk_contract
+                            )
+                        )
                     ):
                         seen_terminal = True
                     archive_text(
@@ -2381,14 +2405,24 @@ async def _stream_responses_with_session(
             ):
                 last_stream_activity_at = time.monotonic()
                 event_block = _normalize_sse_event_block(event_block)
-                event_block, normalized_event_type = _normalize_stream_payload_for_http_block(event_block)
+                event_block, normalized_event_type = _normalize_stream_payload_for_http_block(
+                    event_block,
+                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                )
                 event = parse_sse_event(event_block)
                 if event:
-                    if event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
+                    if event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES or (
+                        event.type == "error" and not enforce_openai_sdk_contract
+                    ):
                         seen_terminal = True
                 elif (
                     isinstance(normalized_event_type, str)
-                    and normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                    and (
+                        normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                        or (
+                            normalized_event_type == "error" and not enforce_openai_sdk_contract
+                        )
+                    )
                 ):
                     seen_terminal = True
                 archive_text(

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -72,7 +72,7 @@ from app.core.types import JsonObject, JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute
 from app.core.utils.json_guards import is_json_mapping
 from app.core.utils.request_id import get_request_id
-from app.core.utils.sse import format_sse_event
+from app.core.utils.sse import format_sse_event, parse_sse_data_json
 
 IGNORE_INBOUND_HEADERS = {
     "authorization",
@@ -1075,6 +1075,19 @@ def _normalize_stream_event_payload(payload: dict[str, JsonValue]) -> dict[str, 
             ),
         )
     return payload
+
+
+def _normalize_stream_payload_for_http_block(event_block: str) -> tuple[str, str | None]:
+    payload = parse_sse_data_json(event_block)
+    if payload is None:
+        return event_block, None
+    normalized = _normalize_stream_event_payload(payload)
+    if normalized is payload:
+        event_type = normalized.get("type")
+        return event_block, event_type if isinstance(event_type, str) else None
+    normalized_type = normalized.get("type")
+    event_type = normalized_type if isinstance(normalized_type, str) else None
+    return format_sse_event(normalized), event_type
 
 
 def _to_websocket_upstream_url(url: str) -> str:
@@ -2285,8 +2298,15 @@ async def _stream_responses_with_session(
                 ):
                     last_stream_activity_at = time.monotonic()
                     event_block = _normalize_sse_event_block(event_block)
+                    event_block, normalized_event_type = _normalize_stream_payload_for_http_block(event_block)
                     event = parse_sse_event(event_block)
-                    if event and event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
+                    if event:
+                        if event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
+                            seen_terminal = True
+                    elif (
+                        isinstance(normalized_event_type, str)
+                        and normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                    ):
                         seen_terminal = True
                     archive_text(
                         direction="server_to_codex",
@@ -2361,11 +2381,16 @@ async def _stream_responses_with_session(
             ):
                 last_stream_activity_at = time.monotonic()
                 event_block = _normalize_sse_event_block(event_block)
+                event_block, normalized_event_type = _normalize_stream_payload_for_http_block(event_block)
                 event = parse_sse_event(event_block)
                 if event:
-                    event_type = event.type
-                    if event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
+                    if event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES:
                         seen_terminal = True
+                elif (
+                    isinstance(normalized_event_type, str)
+                    and normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                ):
+                    seen_terminal = True
                 archive_text(
                     direction="server_to_codex",
                     kind="responses",

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2322,14 +2322,9 @@ async def _stream_responses_with_session(
                             event.type == "error" and not enforce_openai_sdk_contract
                         ):
                             seen_terminal = True
-                    elif (
-                        isinstance(normalized_event_type, str)
-                        and (
-                            normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
-                            or (
-                                normalized_event_type == "error" and not enforce_openai_sdk_contract
-                            )
-                        )
+                    elif isinstance(normalized_event_type, str) and (
+                        normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                        or (normalized_event_type == "error" and not enforce_openai_sdk_contract)
                     ):
                         seen_terminal = True
                     archive_text(
@@ -2415,14 +2410,9 @@ async def _stream_responses_with_session(
                         event.type == "error" and not enforce_openai_sdk_contract
                     ):
                         seen_terminal = True
-                elif (
-                    isinstance(normalized_event_type, str)
-                    and (
-                        normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
-                        or (
-                            normalized_event_type == "error" and not enforce_openai_sdk_contract
-                        )
-                    )
+                elif isinstance(normalized_event_type, str) and (
+                    normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
+                    or (normalized_event_type == "error" and not enforce_openai_sdk_contract)
                 ):
                     seen_terminal = True
                 archive_text(

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import sqlite3
@@ -156,8 +157,7 @@ def _startup_sqlite_check_mode(raw_mode: str) -> SqliteIntegrityCheckMode | None
 
 
 async def _shielded(awaitable: Awaitable[object]) -> None:
-    with anyio.CancelScope(shield=True):
-        await awaitable
+    await asyncio.shield(awaitable)
 
 
 async def _safe_rollback(session: AsyncSession) -> None:

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -157,7 +157,12 @@ def _startup_sqlite_check_mode(raw_mode: str) -> SqliteIntegrityCheckMode | None
 
 
 async def _shielded(awaitable: Awaitable[object]) -> None:
-    await asyncio.shield(awaitable)
+    task = asyncio.ensure_future(awaitable)
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
 
 
 async def _safe_rollback(session: AsyncSession) -> None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2113,7 +2113,7 @@ async def _stream_responses(
         )
     stream, startup_error = await _probe_stream_startup_error(
         stream,
-        convert_event_errors=bridge_active,
+        convert_event_errors=bridge_active and enforce_openai_sdk_contract,
         timeout_seconds=(
             _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS if prefer_http_bridge else _STREAM_STARTUP_ERROR_PROBE_SECONDS
         ),

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2097,6 +2097,7 @@ async def _stream_responses(
             forwarded_request=forwarded_request,
             forwarded_affinity_kind=forwarded_affinity_kind,
             forwarded_affinity_key=forwarded_affinity_key,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
     else:
         stream = context.service.stream_responses(
@@ -2108,6 +2109,7 @@ async def _stream_responses(
             api_key=api_key,
             api_key_reservation=reservation,
             suppress_text_done_events=suppress_text_done_events,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
     stream, startup_error = await _probe_stream_startup_error(
         stream,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3298,6 +3298,10 @@ async def _normalize_public_responses_stream(
         if normalized_payload is None:
             continue
         event_type = normalized_payload.get("type")
+        if not enforce_openai_sdk_contract and event_type == "error":
+            terminal_seen = True
+            yield event_block
+            continue
 
         if enforce_openai_sdk_contract and not created_emitted and isinstance(event_type, str):
             if event_type == "response.created":

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3336,6 +3336,14 @@ async def _normalize_public_responses_stream(
                     yield formatted_payload
                 return
 
+        if enforce_openai_sdk_contract and event_type == "error":
+            for formatted_payload in _public_response_failed_event_blocks_from_error(
+                normalized_payload,
+                include_created=not created_emitted,
+            ):
+                yield formatted_payload
+            return
+
         _collect_output_item_event(normalized_payload, output_items)
         if event_type == "response.output_text.delta":
             seen_text_delta_keys.add(_text_delta_stream_key(normalized_payload))
@@ -3389,12 +3397,22 @@ def _public_response_failed_event_blocks_from_error(
     if error is None:
         error = _default_error_envelope().error
     assert error is not None
+    message = error.message
+    raw_message = payload.get("message")
+    if isinstance(raw_message, str) and raw_message.strip():
+        if not message or message == "Upstream error":
+            message = raw_message.strip()
+    error_type = error.type
+    if not error_type:
+        raw_error_type = payload.get("error_type")
+        if isinstance(raw_error_type, str) and raw_error_type.strip():
+            error_type = raw_error_type.strip()
     failed_payload = cast(
         dict[str, JsonValue],
         response_failed_event(
             error.code or "upstream_error",
-            error.message or "Upstream error",
-            error.type or "server_error",
+            message or "Upstream error",
+            error_type or "server_error",
             response_id=f"resp_{error.code or 'upstream_error'}",
             error_param=error.param,
         ),

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -10861,7 +10861,12 @@ class ProxyService:
             return await asyncio.shield(task)
         except asyncio.CancelledError:
             settlement.usage_settlement_transferred = True
-            self._track_stream_usage_settlement_task(task, api_key=api_key, request_id=request_id)
+            self._track_stream_usage_settlement_task(
+                task,
+                api_key=api_key,
+                api_key_reservation=api_key_reservation,
+                request_id=request_id,
+            )
             raise
 
     async def _settle_stream_api_key_usage_owned(
@@ -10912,6 +10917,7 @@ class ProxyService:
         task: asyncio.Task[bool],
         *,
         api_key: ApiKeyData,
+        api_key_reservation: ApiKeyUsageReservationData,
         request_id: str,
     ) -> None:
         self._background_cleanup_tasks.add(task)
@@ -10919,7 +10925,7 @@ class ProxyService:
         def _settlement_done(done_task: asyncio.Task[bool]) -> None:
             self._background_cleanup_tasks.discard(done_task)
             try:
-                done_task.result()
+                settled = done_task.result()
             except asyncio.CancelledError:
                 logger.warning(
                     "Stream API key settlement task cancelled key_id=%s request_id=%s",
@@ -10933,6 +10939,18 @@ class ProxyService:
                     request_id,
                     exc_info=(type(exc), exc, exc.__traceback__),
                 )
+            else:
+                if not settled:
+                    release_coro = self._release_unsettled_stream_api_key_usage(
+                        api_key=api_key,
+                        api_key_reservation=api_key_reservation,
+                        request_id=request_id,
+                    )
+                    self._schedule_cancel_safe_cleanup(
+                        release_coro,
+                        action="release_stream_api_key_reservation_after_failed_settlement",
+                        request_id=request_id,
+                    )
 
         task.add_done_callback(_settlement_done)
 
@@ -12286,6 +12304,7 @@ class ProxyService:
             first_payload = parse_sse_data_json(first)
             event = parse_sse_event(first)
             event_type = _event_type_from_payload(event, first_payload)
+            preserve_raw_sse_line = not enforce_openai_sdk_contract and event_type == "error"
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 api_key_reservation_touch_state.last_touch_at = await self._maybe_touch_api_key_reservation(
                     api_key=api_key,
@@ -12323,13 +12342,17 @@ class ProxyService:
                     and _websocket_event_error_code(event_type, first_payload) is None
                 ):
                     code = "upstream_error"
-                rewritten_error = _rewrite_previous_response_stream_error(
-                    previous_response_id=payload.previous_response_id,
-                    preferred_account_id=preferred_account_id,
-                    error_code=code,
-                    error_type=error.type if error else None,
-                    error_message=error.message if error else None,
-                    error_param=error.param if error else None,
+                rewritten_error = (
+                    None
+                    if preserve_raw_sse_line
+                    else _rewrite_previous_response_stream_error(
+                        previous_response_id=payload.previous_response_id,
+                        preferred_account_id=preferred_account_id,
+                        error_code=code,
+                        error_type=error.type if error else None,
+                        error_message=error.message if error else None,
+                        error_param=error.param if error else None,
+                    )
                 )
                 status = "error"
                 settlement.error = _upstream_error_from_openai(error)
@@ -12396,7 +12419,7 @@ class ProxyService:
                 ):
                     suppressed_duplicate_tool_call = True
                 else:
-                    if first_payload is not None:
+                    if first_payload is not None and not preserve_raw_sse_line:
                         first = format_sse_event(first_payload)
                     if latency_first_token_ms is None and event_type in _TEXT_DELTA_EVENT_TYPES:
                         latency_first_token_ms = int((time.monotonic() - request_started_at) * 1000)
@@ -12411,6 +12434,7 @@ class ProxyService:
                 event_payload = parse_sse_data_json(line)
                 event = parse_sse_event(line)
                 event_type = _event_type_from_payload(event, event_payload)
+                preserve_raw_sse_line = not enforce_openai_sdk_contract and event_type == "error"
                 if (
                     enforce_openai_sdk_contract
                     and event_type == "error"
@@ -12471,13 +12495,17 @@ class ProxyService:
                             and _websocket_event_error_code(event_type, event_payload) is None
                         ):
                             raw_error_code = "upstream_error"
-                        rewritten_error = _rewrite_previous_response_stream_error(
-                            previous_response_id=payload.previous_response_id,
-                            preferred_account_id=preferred_account_id,
-                            error_code=raw_error_code,
-                            error_type=error.type if error else None,
-                            error_message=error.message if error else None,
-                            error_param=error.param if error else None,
+                        rewritten_error = (
+                            None
+                            if preserve_raw_sse_line
+                            else _rewrite_previous_response_stream_error(
+                                previous_response_id=payload.previous_response_id,
+                                preferred_account_id=preferred_account_id,
+                                error_code=raw_error_code,
+                                error_type=error.type if error else None,
+                                error_message=error.message if error else None,
+                                error_param=error.param if error else None,
+                            )
                         )
                         if rewritten_error is not None:
                             response_id = (
@@ -12539,7 +12567,7 @@ class ProxyService:
                 ):
                     suppressed_duplicate_tool_call = True
                     continue
-                if event_payload is not None:
+                if event_payload is not None and not preserve_raw_sse_line:
                     line = format_sse_event(event_payload)
                 settlement.downstream_visible = True
                 if event_type in _TEXT_DELTA_EVENT_TYPES:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -12150,10 +12150,10 @@ class ProxyService:
                         "route": route,
                         "allow_direct_egress": route is None,
                         "route_trace": route_trace,
+                        "upstream_stream_transport_override": upstream_stream_transport,
+                        "enforce_openai_sdk_contract": enforce_openai_sdk_contract,
                     },
                     raise_for_status=True,
-                    upstream_stream_transport_override=upstream_stream_transport,
-                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
             else:
                 stream = _call_stream_with_supported_optional_kwargs(
@@ -12166,9 +12166,9 @@ class ProxyService:
                         "route": route,
                         "allow_direct_egress": route is None,
                         "route_trace": route_trace,
+                        "enforce_openai_sdk_contract": enforce_openai_sdk_contract,
                     },
                     raise_for_status=True,
-                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
             iterator = stream.__aiter__()
             try:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -11097,7 +11097,6 @@ class ProxyService:
         rewritten_file_account_id: str | None = None,
         upstream_stream_transport_override: str | None = None,
         enforce_openai_sdk_contract: bool = True,
-        upstream_stream_transport_override: str | None = None,
     ) -> AsyncIterator[str]:
         request_id = ensure_request_id()
         start = time.monotonic()
@@ -12394,7 +12393,12 @@ class ProxyService:
                 event_payload = parse_sse_data_json(line)
                 event = parse_sse_event(line)
                 event_type = _event_type_from_payload(event, event_payload)
-                if event_type == "error" and (event is None or event.error is None) and isinstance(event_payload, dict):
+                if (
+                    enforce_openai_sdk_contract
+                    and event_type == "error"
+                    and (event is None or event.error is None)
+                    and isinstance(event_payload, dict)
+                ):
                     message_value = event_payload.get("message")
                     message = (
                         message_value.strip()

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -734,6 +734,7 @@ class ProxyService:
         api_key_reservation: ApiKeyUsageReservationData | None = None,
         suppress_text_done_events: bool = False,
         request_transport: str = _REQUEST_TRANSPORT_HTTP,
+        enforce_openai_sdk_contract: bool = True,
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream", payload, headers)
         filtered = filter_inbound_headers(headers)
@@ -747,6 +748,7 @@ class ProxyService:
             api_key_reservation=api_key_reservation,
             suppress_text_done_events=suppress_text_done_events,
             request_transport=request_transport,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
 
     def stream_http_responses(
@@ -764,6 +766,7 @@ class ProxyService:
         forwarded_request: bool = False,
         forwarded_affinity_kind: str | None = None,
         forwarded_affinity_key: str | None = None,
+        enforce_openai_sdk_contract: bool = True,
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream_http", payload, headers)
         proxy_api_authorization = _header_value_case_insensitive(headers, "authorization")
@@ -782,6 +785,7 @@ class ProxyService:
             proxy_api_authorization=proxy_api_authorization,
             forwarded_affinity_kind=forwarded_affinity_kind,
             forwarded_affinity_key=forwarded_affinity_key,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
 
     async def _stream_http_bridge_or_retry(
@@ -800,6 +804,7 @@ class ProxyService:
         proxy_api_authorization: str | None = None,
         forwarded_affinity_kind: str | None = None,
         forwarded_affinity_key: str | None = None,
+        enforce_openai_sdk_contract: bool = True,
     ) -> AsyncIterator[str]:
         dashboard_settings = await get_settings_cache().get()
         runtime_config = _http_bridge_runtime_config(dashboard_settings, get_settings())
@@ -839,6 +844,7 @@ class ProxyService:
                 request_transport=_REQUEST_TRANSPORT_HTTP,
                 rewritten_file_account_id=rewritten_file_account_id,
                 upstream_stream_transport_override=force_upstream_stream_transport,
+                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             ):
                 yield line
             return
@@ -863,6 +869,7 @@ class ProxyService:
             forwarded_affinity_kind=forwarded_affinity_kind,
             forwarded_affinity_key=forwarded_affinity_key,
             rewritten_file_account_id=rewritten_file_account_id,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         ):
             yield line
 
@@ -11036,6 +11043,8 @@ class ProxyService:
         request_transport: str,
         rewritten_file_account_id: str | None = None,
         upstream_stream_transport_override: str | None = None,
+        enforce_openai_sdk_contract: bool = True,
+        upstream_stream_transport_override: str | None = None,
     ) -> AsyncIterator[str]:
         request_id = ensure_request_id()
         start = time.monotonic()
@@ -11517,6 +11526,7 @@ class ProxyService:
                                 request_transport=request_transport,
                                 preferred_account_id=preferred_account_id,
                                 tool_call_dedupe=tool_call_dedupe,
+                                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                             ):
                                 yield line
                         except (_TransientStreamError, ProxyResponseError) as tex:
@@ -11816,6 +11826,7 @@ class ProxyService:
                                 upstream_stream_transport=upstream_stream_transport,
                                 request_transport=request_transport,
                                 tool_call_dedupe=tool_call_dedupe,
+                                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                             ):
                                 yield line
                         except ProxyResponseError as retry_exc:
@@ -12076,6 +12087,7 @@ class ProxyService:
         request_transport: str,
         preferred_account_id: str | None = None,
         tool_call_dedupe: _WebSocketUpstreamControl | None = None,
+        enforce_openai_sdk_contract: bool = True,
     ) -> AsyncIterator[str]:
         account_id_value = account.id
         access_token = self._encryptor.decrypt(account.access_token_encrypted)
@@ -12140,6 +12152,7 @@ class ProxyService:
                     },
                     raise_for_status=True,
                     upstream_stream_transport_override=upstream_stream_transport,
+                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
             else:
                 stream = _call_stream_with_supported_optional_kwargs(
@@ -12154,6 +12167,7 @@ class ProxyService:
                         "route_trace": route_trace,
                     },
                     raise_for_status=True,
+                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
             iterator = stream.__aiter__()
             try:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -897,7 +897,7 @@ class ProxyService:
         rewritten_file_account_id: str | None = None,
         enforce_openai_sdk_contract: bool = True,
     ) -> AsyncIterator[str]:
-        del suppress_text_done_events, enforce_openai_sdk_contract
+        del suppress_text_done_events
         request_id = ensure_request_id()
         dashboard_settings = await get_settings_cache().get()
         runtime_config = _http_bridge_runtime_config(dashboard_settings, get_settings())
@@ -994,6 +994,7 @@ class ProxyService:
                     api_key=api_key,
                     api_key_reservation=api_key_reservation,
                     request_id=request_id,
+                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
                 del _fresh_request_state
                 _log_http_bridge_event(
@@ -1033,6 +1034,7 @@ class ProxyService:
             api_key=api_key,
             api_key_reservation=api_key_reservation,
             request_id=request_id,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
         if downstream_turn_state is not None:
             request_state.session_id = _normalize_session_id(downstream_turn_state)
@@ -1161,6 +1163,7 @@ class ProxyService:
                 api_key=api_key,
                 api_key_reservation=api_key_reservation,
                 request_id=request_id,
+                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             )
             if downstream_turn_state is not None:
                 request_state.session_id = _normalize_session_id(downstream_turn_state)
@@ -1323,6 +1326,7 @@ class ProxyService:
                         api_key=api_key,
                         api_key_reservation=retry_api_key_reservation,
                         request_id=request_id,
+                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                     )
                     if downstream_turn_state is not None:
                         retry_request_state.session_id = _normalize_session_id(downstream_turn_state)
@@ -1416,6 +1420,7 @@ class ProxyService:
                 api_key=api_key,
                 api_key_reservation=api_key_reservation,
                 request_id=request_id,
+                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             )
             request_state.transport = _REQUEST_TRANSPORT_HTTP
             request_state.request_stage = _http_bridge_request_stage(
@@ -1466,6 +1471,7 @@ class ProxyService:
                     api_key=api_key,
                     api_key_reservation=api_key_reservation,
                     request_id=request_id,
+                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
                 if downstream_turn_state is not None:
                     request_state.session_id = _normalize_session_id(downstream_turn_state)
@@ -1737,6 +1743,7 @@ class ProxyService:
                     api_key=api_key,
                     api_key_reservation=retry_api_key_reservation,
                     request_id=request_id,
+                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
                 if downstream_turn_state is not None:
                     retry_request_state.session_id = _normalize_session_id(downstream_turn_state)
@@ -5195,6 +5202,7 @@ class ProxyService:
         api_key: ApiKeyData | None,
         api_key_reservation: ApiKeyUsageReservationData | None,
         request_id: str | None = None,
+        enforce_openai_sdk_contract: bool = True,
     ) -> tuple[_WebSocketRequestState, str]:
         return self._prepare_response_bridge_request_state(
             payload,
@@ -5206,6 +5214,7 @@ class ProxyService:
             client_metadata=_response_create_client_metadata(payload.to_payload(), headers=headers),
             session_id=_owner_lookup_session_id_from_headers(headers),
             request_log_id=request_id or get_request_id() or ensure_request_id(None),
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
 
     def _prepare_response_bridge_request_state(
@@ -5221,6 +5230,7 @@ class ProxyService:
         session_id: str | None = None,
         request_id: str | None = None,
         request_log_id: str | None = None,
+        enforce_openai_sdk_contract: bool = True,
     ) -> tuple[_WebSocketRequestState, str]:
         deduped_replayed_input_count: int | None = None
         deduped_replayed_input_fingerprint: str | None = None
@@ -5270,6 +5280,7 @@ class ProxyService:
             session_id=_normalize_session_id(session_id),
             input_item_count=input_item_count,
             input_full_fingerprint=input_full_fingerprint,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
         if deduped_replayed_input_count is not None:
             request_state.input_item_count = deduped_replayed_input_count
@@ -9105,16 +9116,17 @@ class ProxyService:
             http_status = _http_error_status_from_payload(payload)
             if status_request_state is not None:
                 status_request_state.error_http_status_override = http_status
-            (
-                event_block,
-                payload,
-                event,
-                event_type,
-            ) = _normalize_http_bridge_error_event(
-                event=event,
-                payload=payload,
-                request_state=terminal_request_state or matched_request_state,
-            )
+            if status_request_state is None or status_request_state.enforce_openai_sdk_contract:
+                (
+                    event_block,
+                    payload,
+                    event,
+                    event_type,
+                ) = _normalize_http_bridge_error_event(
+                    event=event,
+                    payload=payload,
+                    request_state=terminal_request_state or matched_request_state,
+                )
 
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
             await _release_websocket_response_create_gate(created_request_state, session.response_create_gate)
@@ -10848,6 +10860,7 @@ class ProxyService:
         try:
             return await asyncio.shield(task)
         except asyncio.CancelledError:
+            settlement.usage_settlement_transferred = True
             self._track_stream_usage_settlement_task(task, api_key=api_key, request_id=request_id)
             raise
 
@@ -12105,7 +12118,12 @@ class ProxyService:
         finally:
             for account_lease in account_leases:
                 await self._load_balancer.release_account_lease(account_lease)
-            if not settled and api_key is not None and api_key_reservation is not None:
+            if (
+                not settled
+                and not settlement.usage_settlement_transferred
+                and api_key is not None
+                and api_key_reservation is not None
+            ):
                 release_coro = self._release_unsettled_stream_api_key_usage(
                     api_key=api_key,
                     api_key_reservation=api_key_reservation,
@@ -13558,6 +13576,7 @@ class _StreamSettlement:
     downstream_visible: bool = False
     downstream_text_visible: bool = False
     response_id: str | None = None
+    usage_settlement_transferred: bool = False
 
 
 def _stream_settlement_error_payload(settlement: _StreamSettlement) -> UpstreamError:
@@ -13798,6 +13817,7 @@ class _WebSocketRequestState:
     suppress_next_created_downstream: bool = False
     replay_downstream_response_id: str | None = None
     draining_until_terminal: bool = False
+    enforce_openai_sdk_contract: bool = True
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -895,8 +895,9 @@ class ProxyService:
         forwarded_affinity_kind: str | None = None,
         forwarded_affinity_key: str | None = None,
         rewritten_file_account_id: str | None = None,
+        enforce_openai_sdk_contract: bool = True,
     ) -> AsyncIterator[str]:
-        del suppress_text_done_events
+        del suppress_text_done_events, enforce_openai_sdk_contract
         request_id = ensure_request_id()
         dashboard_settings = await get_settings_cache().get()
         runtime_config = _http_bridge_runtime_config(dashboard_settings, get_settings())

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -668,7 +668,7 @@ class ProxyService:
         self._http_bridge_previous_response_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
         self._websocket_previous_response_account_index: dict[tuple[str, str | None, str | None], str] = {}
         self._websocket_continuity_index: dict[tuple[str, str | None], _WebSocketContinuityState] = {}
-        self._background_cleanup_tasks: set[asyncio.Task[None]] = set()
+        self._background_cleanup_tasks: set[asyncio.Task[Any]] = set()
         # In-memory pin from upstream-issued file_id -> codex-lb account_id.
         # Used so ``finalize_file`` for a given ``file_id`` is routed to
         # the same account that handled ``create_file``. Cross-instance
@@ -10836,40 +10836,92 @@ class ProxyService:
         if api_key is None or api_key_reservation is None:
             return True
 
+        task = asyncio.create_task(
+            self._settle_stream_api_key_usage_owned(
+                api_key,
+                api_key_reservation,
+                settlement,
+                request_id,
+            ),
+            name=f"proxy-stream-usage-settle-{request_id}",
+        )
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            self._track_stream_usage_settlement_task(task, api_key=api_key, request_id=request_id)
+            raise
+
+    async def _settle_stream_api_key_usage_owned(
+        self,
+        api_key: ApiKeyData,
+        api_key_reservation: ApiKeyUsageReservationData,
+        settlement: _StreamSettlement,
+        request_id: str,
+    ) -> bool:
+        """Settle stream reservation in a task that owns its repository session."""
+
         reservation_id = api_key_reservation.reservation_id
         model_name = api_key_reservation.model or settlement.model or ""
 
         settled: bool = False
-        with anyio.CancelScope(shield=True):
-            try:
-                async with self._repo_factory() as repos:
-                    api_keys_service = ApiKeysService(repos.api_keys)
-                    if (
-                        settlement.status == "success"
-                        and settlement.input_tokens is not None
-                        and settlement.output_tokens is not None
-                    ):
-                        await api_keys_service.finalize_usage_reservation(
-                            reservation_id,
-                            model=model_name,
-                            input_tokens=settlement.input_tokens,
-                            output_tokens=settlement.output_tokens,
-                            cached_input_tokens=settlement.cached_input_tokens or 0,
-                            service_tier=settlement.service_tier,
-                        )
-                    else:
-                        await api_keys_service.release_usage_reservation(reservation_id)
-                settled = True
-            except Exception:
-                logger.warning(
-                    "Failed to settle stream API key reservation key_id=%s request_id=%s",
-                    api_key.id,
-                    request_id,
-                    exc_info=True,
-                )
-                settled = False
+        try:
+            async with self._repo_factory() as repos:
+                api_keys_service = ApiKeysService(repos.api_keys)
+                if (
+                    settlement.status == "success"
+                    and settlement.input_tokens is not None
+                    and settlement.output_tokens is not None
+                ):
+                    await api_keys_service.finalize_usage_reservation(
+                        reservation_id,
+                        model=model_name,
+                        input_tokens=settlement.input_tokens,
+                        output_tokens=settlement.output_tokens,
+                        cached_input_tokens=settlement.cached_input_tokens or 0,
+                        service_tier=settlement.service_tier,
+                    )
+                else:
+                    await api_keys_service.release_usage_reservation(reservation_id)
+            settled = True
+        except Exception:
+            logger.warning(
+                "Failed to settle stream API key reservation key_id=%s request_id=%s",
+                api_key.id,
+                request_id,
+                exc_info=True,
+            )
+            settled = False
 
         return settled
+
+    def _track_stream_usage_settlement_task(
+        self,
+        task: asyncio.Task[bool],
+        *,
+        api_key: ApiKeyData,
+        request_id: str,
+    ) -> None:
+        self._background_cleanup_tasks.add(task)
+
+        def _settlement_done(done_task: asyncio.Task[bool]) -> None:
+            self._background_cleanup_tasks.discard(done_task)
+            try:
+                done_task.result()
+            except asyncio.CancelledError:
+                logger.warning(
+                    "Stream API key settlement task cancelled key_id=%s request_id=%s",
+                    api_key.id,
+                    request_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Stream API key settlement task failed key_id=%s request_id=%s",
+                    api_key.id,
+                    request_id,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+
+        task.add_done_callback(_settlement_done)
 
     def _schedule_cancel_safe_cleanup(
         self,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -994,8 +994,8 @@ class ProxyService:
                     api_key=api_key,
                     api_key_reservation=api_key_reservation,
                     request_id=request_id,
-                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
+                _fresh_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
                 del _fresh_request_state
                 _log_http_bridge_event(
                     "fresh_reattach_anchor_injected",
@@ -1034,8 +1034,8 @@ class ProxyService:
             api_key=api_key,
             api_key_reservation=api_key_reservation,
             request_id=request_id,
-            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
+        request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
         if downstream_turn_state is not None:
             request_state.session_id = _normalize_session_id(downstream_turn_state)
         if previous_response_trimmed_input_count is not None:
@@ -1163,8 +1163,8 @@ class ProxyService:
                 api_key=api_key,
                 api_key_reservation=api_key_reservation,
                 request_id=request_id,
-                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             )
+            request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             if downstream_turn_state is not None:
                 request_state.session_id = _normalize_session_id(downstream_turn_state)
             request_state.transport = _REQUEST_TRANSPORT_HTTP
@@ -1326,8 +1326,8 @@ class ProxyService:
                         api_key=api_key,
                         api_key_reservation=retry_api_key_reservation,
                         request_id=request_id,
-                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                     )
+                    retry_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
                     if downstream_turn_state is not None:
                         retry_request_state.session_id = _normalize_session_id(downstream_turn_state)
                     retry_request_state.transport = _REQUEST_TRANSPORT_HTTP
@@ -1420,8 +1420,8 @@ class ProxyService:
                 api_key=api_key,
                 api_key_reservation=api_key_reservation,
                 request_id=request_id,
-                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             )
+            request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.transport = _REQUEST_TRANSPORT_HTTP
             request_state.request_stage = _http_bridge_request_stage(
                 headers=headers,
@@ -1471,8 +1471,8 @@ class ProxyService:
                     api_key=api_key,
                     api_key_reservation=api_key_reservation,
                     request_id=request_id,
-                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
+                request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
                 if downstream_turn_state is not None:
                     request_state.session_id = _normalize_session_id(downstream_turn_state)
                 request_state.transport = _REQUEST_TRANSPORT_HTTP
@@ -1743,8 +1743,8 @@ class ProxyService:
                     api_key=api_key,
                     api_key_reservation=retry_api_key_reservation,
                     request_id=request_id,
-                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
+                retry_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
                 if downstream_turn_state is not None:
                     retry_request_state.session_id = _normalize_session_id(downstream_turn_state)
                 retry_request_state.transport = _REQUEST_TRANSPORT_HTTP

--- a/openspec/changes/preserve-http-stream-error-shape/proposal.md
+++ b/openspec/changes/preserve-http-stream-error-shape/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The codex-native backend stream endpoint `POST /backend-api/codex/responses` supports a compatibility
+mode (`enforce_openai_sdk_contract`) where stream shaping may convert raw upstream events into
+the OpenAI SDK-compatible Responses stream form. A bug report for PR #896 shows that when this
+flag is `false`, upstream HTTP SSE error frames are still being normalized into OpenAI `response.failed`,
+which mutates the raw backend stream shape.
+
+## What Changes
+
+- Keep the existing default normalization behavior when contract enforcement is enabled.
+- Preserve raw upstream SSE event blocks when `enforce_openai_sdk_contract=False` for
+  `/backend-api/codex/responses` HTTP streaming.
+- Add a regression test for raw-error passthrough on the HTTP transport.
+- Add OpenSpec coverage for the behavior under `responses-api-compat`.
+
+## Impact
+
+- Upstream `type: "error"` stream frames keep their native `sequence_number`/`error_type` fields when
+  raw-stream mode is explicitly requested.
+- OpenSpec now documents the contract-mode boundary so future changes preserve this behavior.

--- a/openspec/changes/preserve-http-stream-error-shape/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-http-stream-error-shape/specs/responses-api-compat/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Preserve raw backend stream error frames when contract mode is disabled
+
+The proxy MUST preserve raw backend stream error frames when contract mode is
+disabled. When the proxy serves `POST /backend-api/codex/responses` with
+`enforce_openai_sdk_contract=False`, it MUST forward upstream HTTP SSE frames
+with `type: "error"` unchanged on the stream. In this mode, no
+`response.failed` synthesis is allowed before `yield` for those upstream frames.
+
+#### Scenario: Raw backend error passthrough
+
+- **GIVEN** a streaming HTTP upstream response emits:
+  `data: {"type":"error","sequence_number":"error","error_type":"server_error",...}`
+- **AND** request handling sets `enforce_openai_sdk_contract=False`
+- **WHEN** the proxy forwards that upstream event in the public stream
+- **THEN** the downstream event MUST remain an `error` event
+- **AND** `sequence_number`, `error_type`, and message fields from upstream must remain unchanged
+- **AND** the event SHOULD NOT be rewritten into `response.failed` in the same stream step
+
+### Requirement: Keep default contract shaping enabled unless explicitly disabled
+
+The proxy MUST keep default contract shaping enabled unless explicitly
+disabled. For backward-compatible behavior, when
+`enforce_openai_sdk_contract` is omitted or `True`, current error-shaping
+behavior MUST remain in place and convert error-type SSE frames as defined by
+existing `responses-api-compat` contracts.
+
+#### Scenario: Default public contract still emits response.failed
+
+- **GIVEN** a streaming HTTP upstream response emits:
+  `data: {"type":"error","sequence_number":"error","error_type":"server_error",...}`
+- **AND** request handling omits `enforce_openai_sdk_contract` or sets it to `True`
+- **WHEN** the proxy forwards that upstream event
+- **THEN** the downstream event MUST be normalized to `response.failed`

--- a/openspec/changes/preserve-http-stream-error-shape/tasks.md
+++ b/openspec/changes/preserve-http-stream-error-shape/tasks.md
@@ -1,0 +1,15 @@
+## 1. OpenSpec
+
+- [x] Add `responses-api-compat` delta describing raw upstream SSE error preservation when
+  `enforce_openai_sdk_contract=False` on `/backend-api/codex/responses`.
+
+## 2. Code
+
+- [x] Thread `enforce_openai_sdk_contract` through proxy API/service/core stream forwarding for HTTP transport.
+- [x] Preserve raw upstream SSE event blocks in `_normalize_stream_payload_for_http_block`
+  when `enforce_openai_sdk_contract=False`.
+
+## 3. Tests
+
+- [x] Add regression test in `tests/unit/test_proxy_utils.py` proving raw error-event shape is preserved
+  in HTTP streaming when contract enforcement is disabled.

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -597,3 +597,48 @@ async def test_get_background_session_falls_back_to_main_pool_when_not_initializ
     async with session_module.get_background_session() as session:
         assert session is not None
         assert isinstance(session, session_module.AsyncSession)
+
+
+@pytest.mark.asyncio
+async def test_safe_close_outlives_caller_cancellation() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    closed = asyncio.Event()
+
+    class FakeSession:
+        async def close(self) -> None:
+            started.set()
+            await release.wait()
+            closed.set()
+
+    task = asyncio.create_task(session_module._safe_close(cast(session_module.AsyncSession, FakeSession())))
+    await started.wait()
+    task.cancel()
+    await task
+
+    release.set()
+    await asyncio.wait_for(closed.wait(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_safe_rollback_outlives_caller_cancellation() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    rolled_back = asyncio.Event()
+
+    class FakeSession:
+        def in_transaction(self) -> bool:
+            return True
+
+        async def rollback(self) -> None:
+            started.set()
+            await release.wait()
+            rolled_back.set()
+
+    task = asyncio.create_task(session_module._safe_rollback(cast(session_module.AsyncSession, FakeSession())))
+    await started.wait()
+    task.cancel()
+    await task
+
+    release.set()
+    await asyncio.wait_for(rolled_back.wait(), timeout=1.0)

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -604,6 +604,7 @@ async def test_safe_close_outlives_caller_cancellation() -> None:
     started = asyncio.Event()
     release = asyncio.Event()
     closed = asyncio.Event()
+    cleanup_done = asyncio.Event()
 
     class FakeSession:
         async def close(self) -> None:
@@ -611,13 +612,22 @@ async def test_safe_close_outlives_caller_cancellation() -> None:
             await release.wait()
             closed.set()
 
-    task = asyncio.create_task(session_module._safe_close(cast(session_module.AsyncSession, FakeSession())))
-    await started.wait()
-    task.cancel()
-    await task
+    async def run_cleanup() -> None:
+        try:
+            await session_module._safe_close(cast(session_module.AsyncSession, FakeSession()))
+        finally:
+            cleanup_done.set()
 
-    release.set()
-    await asyncio.wait_for(closed.wait(), timeout=1.0)
+    async with asyncio.TaskGroup() as group:
+        task = group.create_task(run_cleanup())
+        await started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not cleanup_done.is_set()
+        release.set()
+
+    assert closed.is_set()
+    assert cleanup_done.is_set()
 
 
 @pytest.mark.asyncio
@@ -625,6 +635,7 @@ async def test_safe_rollback_outlives_caller_cancellation() -> None:
     started = asyncio.Event()
     release = asyncio.Event()
     rolled_back = asyncio.Event()
+    cleanup_done = asyncio.Event()
 
     class FakeSession:
         def in_transaction(self) -> bool:
@@ -635,10 +646,19 @@ async def test_safe_rollback_outlives_caller_cancellation() -> None:
             await release.wait()
             rolled_back.set()
 
-    task = asyncio.create_task(session_module._safe_rollback(cast(session_module.AsyncSession, FakeSession())))
-    await started.wait()
-    task.cancel()
-    await task
+    async def run_cleanup() -> None:
+        try:
+            await session_module._safe_rollback(cast(session_module.AsyncSession, FakeSession()))
+        finally:
+            cleanup_done.set()
 
-    release.set()
-    await asyncio.wait_for(rolled_back.wait(), timeout=1.0)
+    async with asyncio.TaskGroup() as group:
+        task = group.create_task(run_cleanup())
+        await started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not cleanup_done.is_set()
+        release.set()
+
+    assert rolled_back.is_set()
+    assert cleanup_done.is_set()

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -828,6 +828,23 @@ async def test_normalize_public_responses_stream_codex_route_preserves_codex_eve
 
 
 @pytest.mark.asyncio
+async def test_normalize_public_responses_stream_codex_route_preserves_raw_error_frame() -> None:
+    raw_error = (
+        'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
+        '"message":"OpenCode stream failed"}\n\n'
+    )
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(raw_error),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert blocks == [raw_error, "data: [DONE]\n\n"]
+
+
+@pytest.mark.asyncio
 async def test_normalize_public_responses_stream_codex_route_truncated_stream_does_not_synthesize_created() -> None:
     """`enforce_openai_sdk_contract=False` appends a terminal failure for
     truncated upstream streams without injecting an SDK-only created envelope."""

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4406,6 +4406,64 @@ async def test_stream_responses_http_transport_keeps_http(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_http_transport_preserves_raw_error_shape_when_contract_disabled(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 75.0
+        log_upstream_request_summary = False
+        upstream_stream_transport = "http"
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(
+        proxy_module,
+        "get_model_registry",
+        lambda: SimpleNamespace(prefers_websockets=lambda model: model == "gpt-5.4"),
+    )
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    session = _SseSession(
+        _SsePostResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp_http_error"}}\n\n',
+                (
+                    b'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
+                    b'"message":"OpenCode stream failed"}\n\n'
+                ),
+            ]
+        )
+    )
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert session.calls
+    assert len(events) == 2
+    parsed_error = parse_sse_data_json(events[1])
+    assert parsed_error is not None
+    assert parsed_error["type"] == "error"
+    assert parsed_error["sequence_number"] == "error"
+    assert parsed_error["error_type"] == "server_error"
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_http_transport_normalizes_error_sequence_number_to_response_failed(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5604,6 +5604,7 @@ async def test_stream_with_retry_honors_explicit_upstream_transport_override(mon
         raise_for_status=False,
         upstream_stream_transport_override=None,
     ):
+        del payload, headers, access_token, account_id, base_url, raise_for_status
         captured["override"] = upstream_stream_transport_override
         yield 'data: {"type":"response.completed","response":{"id":"resp_transport_override"}}\n\n'
 
@@ -5636,6 +5637,70 @@ async def test_stream_with_retry_honors_explicit_upstream_transport_override(mon
 
     assert chunks
     assert captured["override"] == "http"
+
+
+@pytest.mark.asyncio
+async def test_service_stream_responses_preserves_raw_codex_error_after_created(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_stream_raw_error")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        enforce_openai_sdk_contract=True,
+    ):
+        del payload, headers, access_token, account_id, base_url, raise_for_status
+        captured["enforce_openai_sdk_contract"] = enforce_openai_sdk_contract
+        yield 'data: {"type":"response.created","response":{"id":"resp_raw_error"}}\n\n'
+        yield (
+            'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
+            '"message":"OpenCode stream failed"}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+        }
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service.stream_responses(
+            payload,
+            {"session_id": "sid-stream"},
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    assert captured["enforce_openai_sdk_contract"] is False
+    assert len(chunks) >= 2
+    error_payload = parse_sse_data_json(chunks[1])
+    assert error_payload is not None
+    assert error_payload["type"] == "error"
+    assert error_payload["sequence_number"] == "error"
+    assert error_payload["error_type"] == "server_error"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -828,6 +828,47 @@ async def test_stream_responses_streams_post_startup_proxy_error_as_sse(monkeypa
     assert "rate_limit_exceeded" in body
 
 
+@pytest.mark.asyncio
+async def test_probe_stream_startup_error_preserves_event_error_when_conversion_disabled():
+    raw_error = (
+        'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
+        '"message":"native upstream error"}\n\n'
+    )
+
+    async def stream():
+        yield raw_error
+
+    probed, startup_error = await proxy_api._probe_stream_startup_error(
+        stream(),
+        convert_event_errors=False,
+    )
+
+    assert startup_error is None
+    assert [chunk async for chunk in probed] == [raw_error]
+
+
+@pytest.mark.asyncio
+async def test_probe_stream_startup_error_converts_event_error_when_contract_enabled():
+    raw_error = (
+        'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
+        '"message":"native upstream error"}\n\n'
+    )
+
+    async def stream():
+        yield raw_error
+
+    probed, startup_error = await proxy_api._probe_stream_startup_error(
+        stream(),
+        convert_event_errors=True,
+    )
+
+    assert startup_error is not None
+    assert not isinstance(startup_error, proxy_module.ProxyResponseError)
+    assert startup_error.error is not None
+    assert startup_error.error.code == "upstream_error"
+    assert [chunk async for chunk in probed] == []
+
+
 def test_has_native_codex_transport_headers_requires_allowlisted_originator():
     assert proxy_module._has_native_codex_transport_headers({"originator": "codex_cli_rs"}) is True
     assert proxy_module._has_native_codex_transport_headers({"originator": "codex_exec"}) is True

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5675,6 +5675,10 @@ async def test_service_stream_responses_preserves_raw_codex_error_after_created(
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     account = _make_account("acc_stream_raw_error")
     captured: dict[str, object] = {}
+    raw_error_line = (
+        'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
+        '"message":"OpenCode stream failed"}\n\n'
+    )
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
@@ -5698,10 +5702,7 @@ async def test_service_stream_responses_preserves_raw_codex_error_after_created(
         del payload, headers, access_token, account_id, base_url, raise_for_status
         captured["enforce_openai_sdk_contract"] = enforce_openai_sdk_contract
         yield 'data: {"type":"response.created","response":{"id":"resp_raw_error"}}\n\n'
-        yield (
-            'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
-            '"message":"OpenCode stream failed"}\n\n'
-        )
+        yield raw_error_line
 
     monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
 
@@ -5725,6 +5726,7 @@ async def test_service_stream_responses_preserves_raw_codex_error_after_created(
 
     assert captured["enforce_openai_sdk_contract"] is False
     assert len(chunks) >= 2
+    assert chunks[1] == raw_error_line
     error_payload = parse_sse_data_json(chunks[1])
     assert error_payload is not None
     assert error_payload["type"] == "error"
@@ -11282,6 +11284,81 @@ async def test_stream_api_key_settlement_outlives_caller_cancel_and_closes_repo(
         }
     ]
     assert settlement.usage_settlement_transferred is True
+
+
+@pytest.mark.asyncio
+async def test_stream_api_key_background_settlement_failure_falls_back_to_release(monkeypatch):
+    started = asyncio.Event()
+    release_finalize = asyncio.Event()
+    released: list[str] = []
+    repo = SimpleNamespace(api_keys=object())
+
+    @asynccontextmanager
+    async def repo_factory() -> AsyncIterator[SimpleNamespace]:
+        yield repo
+
+    class FakeApiKeysService:
+        def __init__(self, api_keys_repository: object) -> None:
+            assert api_keys_repository is repo.api_keys
+
+        async def finalize_usage_reservation(self, reservation_id: str, **kwargs: object) -> None:
+            del reservation_id, kwargs
+            started.set()
+            await release_finalize.wait()
+            raise RuntimeError("temporary finalize failure")
+
+        async def release_usage_reservation(self, reservation_id: str) -> None:
+            released.append(reservation_id)
+
+    monkeypatch.setattr(proxy_service, "ApiKeysService", FakeApiKeysService)
+
+    service = proxy_service.ProxyService(cast(proxy_service.ProxyRepoFactory, repo_factory))
+    api_key = ApiKeyData(
+        id="key_stream_failed_background",
+        name="stream failed background",
+        key_prefix="sk-bgfail",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_stream_failed_background",
+        key_id=api_key.id,
+        model="gpt-5.5",
+    )
+    settlement = proxy_service._StreamSettlement(
+        status="success",
+        model="gpt-5.5",
+        input_tokens=12,
+        output_tokens=34,
+    )
+
+    caller = asyncio.create_task(
+        service._settle_stream_api_key_usage(
+            api_key,
+            reservation,
+            settlement,
+            request_id="req_stream_failed_background",
+        )
+    )
+    await started.wait()
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    release_finalize.set()
+    for _ in range(50):
+        if not service._background_cleanup_tasks:
+            break
+        await asyncio.sleep(0)
+
+    assert service._background_cleanup_tasks == set()
+    assert released == ["resv_stream_failed_background"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4406,6 +4406,66 @@ async def test_stream_responses_http_transport_keeps_http(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_http_transport_normalizes_error_sequence_number_to_response_failed(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 75.0
+        log_upstream_request_summary = False
+        upstream_stream_transport = "http"
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(
+        proxy_module,
+        "get_model_registry",
+        lambda: SimpleNamespace(prefers_websockets=lambda model: model == "gpt-5.4"),
+    )
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    session = _SseSession(
+        _SsePostResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp_http_error"}}\n\n',
+                (
+                    b'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
+                    b'"message":"OpenCode stream failed"}\n\n'
+                ),
+            ]
+        )
+    )
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.4", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    assert session.calls
+    assert len(events) == 2
+    failed_payload = parse_sse_data_json(events[1])
+    assert failed_payload is not None
+    assert failed_payload["type"] == "response.failed"
+    failed_response = cast(dict[str, JsonValue], failed_payload["response"])
+    failed_error = cast(dict[str, JsonValue], failed_response["error"])
+    assert failed_error["code"] == "server_error"
+    assert failed_error["type"] == "server_error"
+    assert failed_error["message"] == "OpenCode stream failed"
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_auto_transport_keeps_http_for_bare_session_affinity(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5733,6 +5733,54 @@ async def test_service_stream_responses_preserves_raw_codex_error_after_created(
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_preserves_raw_error_event_when_sdk_contract_disabled():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_raw_error",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+        enforce_openai_sdk_contract=False,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-raw-error", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.4",
+        account=_make_account("acc_bridge_raw_error"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    raw_payload = {
+        "type": "error",
+        "sequence_number": "error",
+        "error_type": "server_error",
+        "message": "OpenCode stream failed",
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(raw_payload, separators=(",", ":")))
+
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    forwarded = await asyncio.wait_for(event_queue.get(), timeout=1.0)
+    assert forwarded is not None
+    assert parse_sse_data_json(forwarded) == raw_payload
+    assert await asyncio.wait_for(event_queue.get(), timeout=1.0) is None
+
+
+@pytest.mark.asyncio
 async def test_service_stream_responses_does_not_infer_previous_response_id_from_session_scope(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
@@ -11233,6 +11281,87 @@ async def test_stream_api_key_settlement_outlives_caller_cancel_and_closes_repo(
             "service_tier": "default",
         }
     ]
+    assert settlement.usage_settlement_transferred is True
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_skips_release_after_settlement_transfers_on_cancel(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_stream_cancel_transfer")
+    api_key = ApiKeyData(
+        id="key_stream_cancel_transfer",
+        name="stream cancel transfer",
+        key_prefix="sk-transfer",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_stream_cancel_transfer",
+        key_id=api_key.id,
+        model="gpt-5.4",
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+
+    async def fake_stream_once(*args: object, **kwargs: object) -> AsyncIterator[str]:
+        del args, kwargs
+        if False:
+            yield ""
+
+    async def fake_settle(
+        api_key_arg: ApiKeyData | None,
+        reservation_arg: proxy_service.ApiKeyUsageReservationData | None,
+        settlement: proxy_service._StreamSettlement,
+        request_id: str,
+    ) -> bool:
+        del api_key_arg, reservation_arg, request_id
+        settlement.usage_settlement_transferred = True
+        raise asyncio.CancelledError
+
+    release_unsettled = AsyncMock()
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", fake_settle)
+    monkeypatch.setattr(service, "_release_unsettled_stream_api_key_usage", release_unsettled)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+        }
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-stream-cancel-transfer"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=api_key,
+            api_key_reservation=reservation,
+            suppress_text_done_events=False,
+            request_transport="http",
+        ):
+            pass
+
+    release_unsettled.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7,8 +7,9 @@ import ssl
 import time
 from collections import deque
 from collections.abc import Mapping, Sequence
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from typing import Any, Protocol, Self, cast
+from typing import Any, AsyncIterator, Protocol, Self, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -11006,6 +11007,97 @@ async def test_proxy_responses_websocket_downstream_disconnect_does_not_penalize
     assert request_logs.calls[0]["status"] == "cancelled"
     assert request_logs.calls[0]["error_code"] == "client_disconnected"
     assert request_logs.calls[0]["session_id"] == "turn_client_disconnect_live"
+
+
+@pytest.mark.asyncio
+async def test_stream_api_key_settlement_outlives_caller_cancel_and_closes_repo(monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    closed = asyncio.Event()
+    finalized: list[dict[str, object]] = []
+    repo = SimpleNamespace(api_keys=object())
+
+    @asynccontextmanager
+    async def repo_factory() -> AsyncIterator[SimpleNamespace]:
+        try:
+            yield repo
+        finally:
+            closed.set()
+
+    class FakeApiKeysService:
+        def __init__(self, api_keys_repository: object) -> None:
+            assert api_keys_repository is repo.api_keys
+
+        async def finalize_usage_reservation(self, reservation_id: str, **kwargs: object) -> None:
+            started.set()
+            await release.wait()
+            finalized.append({"reservation_id": reservation_id, **kwargs})
+
+        async def release_usage_reservation(self, reservation_id: str) -> None:
+            finalized.append({"reservation_id": reservation_id, "released": True})
+
+    monkeypatch.setattr(proxy_service, "ApiKeysService", FakeApiKeysService)
+
+    service = proxy_service.ProxyService(cast(proxy_service.ProxyRepoFactory, repo_factory))
+    api_key = ApiKeyData(
+        id="key_stream_cancel",
+        name="stream cancel",
+        key_prefix="sk-cancel",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_stream_cancel",
+        key_id=api_key.id,
+        model="gpt-5.5",
+    )
+    settlement = proxy_service._StreamSettlement(
+        status="success",
+        model="gpt-5.5",
+        service_tier="default",
+        input_tokens=12,
+        output_tokens=34,
+        cached_input_tokens=5,
+    )
+
+    caller = asyncio.create_task(
+        service._settle_stream_api_key_usage(
+            api_key,
+            reservation,
+            settlement,
+            request_id="req_stream_cancel",
+        )
+    )
+    await started.wait()
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    assert service._background_cleanup_tasks
+    release.set()
+    await asyncio.wait_for(closed.wait(), timeout=1.0)
+    for _ in range(20):
+        if not service._background_cleanup_tasks:
+            break
+        await asyncio.sleep(0)
+
+    assert service._background_cleanup_tasks == set()
+    assert finalized == [
+        {
+            "reservation_id": "resv_stream_cancel",
+            "model": "gpt-5.5",
+            "input_tokens": 12,
+            "output_tokens": 34,
+            "cached_input_tokens": 5,
+            "service_tier": "default",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3411,6 +3411,35 @@ async def test_stream_responses_websocket_normalizes_typeless_error_code_to_upst
     assert failed_error["message"] == "generic upstream failure"
 
 
+@pytest.mark.asyncio
+async def test_public_responses_stream_normalizes_raw_error_after_created():
+    async def raw_stream() -> AsyncIterator[str]:
+        yield 'data: {"type":"response.created","response":{"id":"resp_public_error"}}\n\n'
+        yield (
+            'data: {"type":"error","sequence_number":"error","error_type":"server_error",'
+            '"message":"OpenCode stream failed"}\n\n'
+        )
+
+    events = [
+        parse_sse_data_json(event_block)
+        async for event_block in proxy_api._normalize_public_responses_stream(
+            raw_stream(),
+            enforce_openai_sdk_contract=True,
+        )
+    ]
+
+    assert len(events) == 2
+    assert events[0] is not None
+    assert events[0]["type"] == "response.created"
+    assert events[1] is not None
+    assert events[1]["type"] == "response.failed"
+    response = cast(dict[str, JsonValue], events[1]["response"])
+    error = cast(dict[str, JsonValue], response["error"])
+    assert error["code"] == "upstream_error"
+    assert error["type"] == "server_error"
+    assert error["message"] == "OpenCode stream failed"
+
+
 def test_normalize_http_bridge_error_event_preserves_explicit_error_code_from_parsed_event():
     event = parse_sse_event(
         'data: {"type":"error","error":{"code":"error","type":"server_error","message":"explicit"}}\n\n'


### PR DESCRIPTION
## Superseded

This PR has been absorbed into #892 so Responses HTTP bridge and stream-correctness fixes land in one reviewable branch.

#892 now carries this PR's raw error-shape preservation, cancellation-safe API-key stream settlement, and request/session cleanup hardening.

Relationship:

- Superseded by #892.
- Do not merge this PR separately.
- No issue closure moved because this PR did not claim one.
