### PR TITLE
feat(accounts): add account list sort controls

### DIFF
--- a/frontend/src/features/accounts/components/account-list.test.tsx
+++ b/frontend/src/features/accounts/components/account-list.test.tsx
@@ -337,6 +337,67 @@ describe("AccountList", () => {
     ]);
   });
 
+  it("keeps unknown resets last when sorting by latest reset", () => {
+    render(
+      <AccountList
+        accounts={[
+          {
+            accountId: "acc-unknown",
+            email: "unknown@example.com",
+            displayName: "Unknown",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            additionalQuotas: [],
+          },
+          {
+            accountId: "acc-stale",
+            email: "stale@example.com",
+            displayName: "Stale",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T11:30:00.000Z",
+            additionalQuotas: [],
+          },
+          {
+            accountId: "acc-latest",
+            email: "latest@example.com",
+            displayName: "Latest",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T12:40:00.000Z",
+            additionalQuotas: [],
+          },
+          {
+            accountId: "acc-earlier",
+            email: "earlier@example.com",
+            displayName: "Earlier",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T12:10:00.000Z",
+            additionalQuotas: [],
+          },
+        ]}
+        selectedAccountId={null}
+        onSelect={() => {}}
+        onOpenImport={() => {}}
+        onOpenOauth={() => {}}
+        sortMode="reset_latest"
+        onSortModeChange={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByText(/^(Latest|Earlier|Stale|Unknown)$/).map((el) => el.textContent)).toEqual([
+      "Latest",
+      "Earlier",
+      "Stale",
+      "Unknown",
+    ]);
+  });
+
   it("shows empty state when no items match filter", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/features/accounts/components/account-list.test.tsx
+++ b/frontend/src/features/accounts/components/account-list.test.tsx
@@ -217,6 +217,126 @@ describe("AccountList", () => {
     ]);
   });
 
+  it("sorts accounts by name", () => {
+    render(
+      <AccountList
+        accounts={[
+          {
+            accountId: "acc-z",
+            email: "z@example.com",
+            displayName: "Zeta",
+            planType: "pro",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T12:30:00.000Z",
+            additionalQuotas: [],
+          },
+          {
+            accountId: "acc-a",
+            email: "a@example.com",
+            displayName: "Alpha",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T12:10:00.000Z",
+            additionalQuotas: [],
+          },
+        ]}
+        selectedAccountId={null}
+        onSelect={() => {}}
+        onOpenImport={() => {}}
+        onOpenOauth={() => {}}
+        sortMode="name_asc"
+        onSortModeChange={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByText(/^(Alpha|Zeta)$/).map((el) => el.textContent)).toEqual([
+      "Alpha",
+      "Zeta",
+    ]);
+  });
+
+  it("supports reverse name sorting", () => {
+    render(
+      <AccountList
+        accounts={[
+          {
+            accountId: "acc-b",
+            email: "b@example.com",
+            displayName: "Beta",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T12:10:00.000Z",
+            additionalQuotas: [],
+          },
+          {
+            accountId: "acc-a",
+            email: "a@example.com",
+            displayName: "Alpha",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T12:20:00.000Z",
+            additionalQuotas: [],
+          },
+        ]}
+        selectedAccountId={null}
+        onSelect={() => {}}
+        onOpenImport={() => {}}
+        onOpenOauth={() => {}}
+        sortMode="name_desc"
+        onSortModeChange={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByText(/^(Alpha|Beta)$/).map((el) => el.textContent)).toEqual([
+      "Beta",
+      "Alpha",
+    ]);
+  });
+
+  it("can sort by latest reset first", () => {
+    render(
+      <AccountList
+        accounts={[
+          {
+            accountId: "acc-a",
+            email: "a@example.com",
+            displayName: "Alpha",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T12:10:00.000Z",
+            additionalQuotas: [],
+          },
+          {
+            accountId: "acc-z",
+            email: "z@example.com",
+            displayName: "Zeta",
+            planType: "plus",
+            status: "active",
+            limitWarmupEnabled: false,
+            resetAtPrimary: "2026-01-01T12:40:00.000Z",
+            additionalQuotas: [],
+          },
+        ]}
+        selectedAccountId={null}
+        onSelect={() => {}}
+        onOpenImport={() => {}}
+        onOpenOauth={() => {}}
+        sortMode="reset_latest"
+        onSortModeChange={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByText(/^(Zeta|Alpha)$/).map((el) => el.textContent)).toEqual([
+      "Zeta",
+      "Alpha",
+    ]);
+  });
+
   it("shows empty state when no items match filter", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/features/accounts/components/account-list.tsx
+++ b/frontend/src/features/accounts/components/account-list.tsx
@@ -70,8 +70,8 @@ export function AccountList({
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        <div className="relative min-w-0 flex-1">
+      <div className="grid grid-cols-2 gap-2">
+        <div className="relative col-span-2 min-w-0">
           <Search className="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" aria-hidden />
           <Input
             placeholder="Search accounts..."
@@ -81,7 +81,7 @@ export function AccountList({
           />
         </div>
         <Select value={statusFilter} onValueChange={setStatusFilter}>
-          <SelectTrigger size="sm" className="w-32 shrink-0">
+          <SelectTrigger size="sm" className="w-full min-w-0">
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
@@ -98,7 +98,7 @@ export function AccountList({
         >
           <SelectTrigger
             size="sm"
-            className="w-44 shrink-0"
+            className="w-full min-w-0"
             aria-label="Sort accounts"
           >
             <SelectValue placeholder="Sort accounts" />

--- a/frontend/src/features/accounts/components/account-list.tsx
+++ b/frontend/src/features/accounts/components/account-list.tsx
@@ -13,7 +13,12 @@ import {
 import { AccountListItem } from "@/features/accounts/components/account-list-item";
 import { WindowsOauthHelp } from "@/features/accounts/components/windows-oauth-help";
 import type { AccountSummary } from "@/features/accounts/schemas";
-import { sortAccountsForDisplay } from "@/features/accounts/sorting";
+import {
+  ACCOUNT_SORT_OPTIONS,
+  DEFAULT_ACCOUNT_SORT_MODE,
+  sortAccountsForDisplay,
+  type AccountSortMode,
+} from "@/features/accounts/sorting";
 import { useAccountQuotaDisplayStore } from "@/hooks/use-account-quota-display";
 import { formatSlug } from "@/utils/formatters";
 
@@ -25,6 +30,8 @@ export type AccountListProps = {
   onSelect: (accountId: string) => void;
   onOpenImport: () => void;
   onOpenOauth: () => void;
+  sortMode?: AccountSortMode;
+  onSortModeChange?: (sortMode: AccountSortMode) => void;
 };
 
 export function AccountList({
@@ -33,15 +40,18 @@ export function AccountList({
   onSelect,
   onOpenImport,
   onOpenOauth,
+  sortMode,
+  onSortModeChange,
 }: AccountListProps) {
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [helpOpen, setHelpOpen] = useState(false);
   const quotaDisplay = useAccountQuotaDisplayStore((s) => s.quotaDisplay);
+  const activeSortMode = sortMode ?? DEFAULT_ACCOUNT_SORT_MODE;
 
   const filtered = useMemo(() => {
     const needle = search.trim().toLowerCase();
-    return sortAccountsForDisplay(accounts, quotaDisplay).filter((account) => {
+    return sortAccountsForDisplay(accounts, quotaDisplay, activeSortMode).filter((account) => {
       if (statusFilter !== "all" && account.status !== statusFilter) {
         return false;
       }
@@ -56,7 +66,7 @@ export function AccountList({
         account.planType.toLowerCase().includes(needle)
       );
     });
-  }, [accounts, quotaDisplay, search, statusFilter]);
+  }, [accounts, quotaDisplay, search, statusFilter, activeSortMode]);
 
   return (
     <div className="space-y-3">
@@ -78,6 +88,25 @@ export function AccountList({
             {STATUS_FILTER_OPTIONS.map((option) => (
               <SelectItem key={option} value={option}>
                 {option === "all" ? "All statuses" : formatSlug(option)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={activeSortMode}
+          onValueChange={(nextMode) => onSortModeChange?.(nextMode as AccountSortMode)}
+        >
+          <SelectTrigger
+            size="sm"
+            className="w-44 shrink-0"
+            aria-label="Sort accounts"
+          >
+            <SelectValue placeholder="Sort accounts" />
+          </SelectTrigger>
+          <SelectContent>
+            {ACCOUNT_SORT_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
               </SelectItem>
             ))}
           </SelectContent>

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -12,7 +12,11 @@ import { AccountsSkeleton } from "@/features/accounts/components/accounts-skelet
 import { ImportDialog } from "@/features/accounts/components/import-dialog";
 import { AuthExportDialog } from "@/features/accounts/components/auth-export-dialog";
 import { useAccounts } from "@/features/accounts/hooks/use-accounts";
-import { sortAccountsForDisplay } from "@/features/accounts/sorting";
+import {
+  DEFAULT_ACCOUNT_SORT_MODE,
+  sortAccountsForDisplay,
+  type AccountSortMode,
+} from "@/features/accounts/sorting";
 import { useOauth } from "@/features/accounts/hooks/use-oauth";
 import { useAccountQuotaDisplayStore } from "@/hooks/use-account-quota-display";
 import type { AccountAuthExportResponse } from "@/features/accounts/schemas";
@@ -26,6 +30,7 @@ const OauthDialog = lazy(() =>
 
 export function AccountsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [accountSortMode, setAccountSortMode] = useState<AccountSortMode>(DEFAULT_ACCOUNT_SORT_MODE);
   const {
     accountsQuery,
     importMutation,
@@ -50,8 +55,8 @@ export function AccountsPage() {
   );
   const quotaDisplay = useAccountQuotaDisplayStore((s) => s.quotaDisplay);
   const sortedAccounts = useMemo(
-    () => sortAccountsForDisplay(accounts, quotaDisplay),
-    [accounts, quotaDisplay],
+    () => sortAccountsForDisplay(accounts, quotaDisplay, accountSortMode),
+    [accounts, quotaDisplay, accountSortMode],
   );
   const selectedAccountId = searchParams.get("selected");
 
@@ -128,6 +133,8 @@ export function AccountsPage() {
               accounts={accounts}
               selectedAccountId={resolvedSelectedAccountId}
               onSelect={handleSelectAccount}
+              sortMode={accountSortMode}
+              onSortModeChange={setAccountSortMode}
               onOpenImport={() => importDialog.show()}
               onOpenOauth={() => oauthDialog.show()}
             />

--- a/frontend/src/features/accounts/sorting.ts
+++ b/frontend/src/features/accounts/sorting.ts
@@ -38,6 +38,18 @@ function accountResetTimestamp(account: AccountSummary, quotaDisplay: AccountQuo
   return resets.length > 0 ? Math.min(...resets) : Number.POSITIVE_INFINITY;
 }
 
+function compareResetTimestamps(leftReset: number, rightReset: number, direction: "asc" | "desc"): number {
+  const leftFinite = Number.isFinite(leftReset);
+  const rightFinite = Number.isFinite(rightReset);
+  if (leftFinite !== rightFinite) {
+    return leftFinite ? -1 : 1;
+  }
+  if (leftReset === rightReset) {
+    return 0;
+  }
+  return direction === "desc" ? rightReset - leftReset : leftReset - rightReset;
+}
+
 export function sortAccountsForDisplay(
   accounts: AccountSummary[],
   quotaDisplay: AccountQuotaDisplayPreference,
@@ -49,8 +61,13 @@ export function sortAccountsForDisplay(
       if (sortMode === "reset_latest" || sortMode === "reset_soonest") {
         const leftReset = accountResetTimestamp(left, quotaDisplay);
         const rightReset = accountResetTimestamp(right, quotaDisplay);
-        if (leftReset !== rightReset) {
-          return sortMode === "reset_latest" ? rightReset - leftReset : leftReset - rightReset;
+        const resetComparison = compareResetTimestamps(
+          leftReset,
+          rightReset,
+          sortMode === "reset_latest" ? "desc" : "asc",
+        );
+        if (resetComparison !== 0) {
+          return resetComparison;
         }
       } else {
         const leftLabel = accountSortLabel(left);
@@ -65,8 +82,9 @@ export function sortAccountsForDisplay(
 
       const leftReset = accountResetTimestamp(left, quotaDisplay);
       const rightReset = accountResetTimestamp(right, quotaDisplay);
-      if (leftReset !== rightReset) {
-        return leftReset - rightReset;
+      const resetComparison = compareResetTimestamps(leftReset, rightReset, "asc");
+      if (resetComparison !== 0) {
+        return resetComparison;
       }
       const labelComparison = accountSortLabel(left).localeCompare(accountSortLabel(right));
       if (labelComparison !== 0) {

--- a/frontend/src/features/accounts/sorting.ts
+++ b/frontend/src/features/accounts/sorting.ts
@@ -2,6 +2,17 @@ import type { AccountSummary } from "@/features/accounts/schemas";
 import type { AccountQuotaDisplayPreference } from "@/hooks/use-account-quota-display";
 import { parseDate } from "@/utils/formatters";
 
+export type AccountSortMode = "reset_soonest" | "reset_latest" | "name_asc" | "name_desc";
+
+export const ACCOUNT_SORT_OPTIONS: readonly { value: AccountSortMode; label: string }[] = [
+  { value: "reset_soonest", label: "Reset time (soonest)" },
+  { value: "reset_latest", label: "Reset time (latest)" },
+  { value: "name_asc", label: "Name (A-Z)" },
+  { value: "name_desc", label: "Name (Z-A)" },
+] as const;
+
+export const DEFAULT_ACCOUNT_SORT_MODE: AccountSortMode = "reset_soonest";
+
 function visibleQuotaResetTimestamps(
   account: AccountSummary,
   quotaDisplay: AccountQuotaDisplayPreference,
@@ -30,10 +41,28 @@ function accountResetTimestamp(account: AccountSummary, quotaDisplay: AccountQuo
 export function sortAccountsForDisplay(
   accounts: AccountSummary[],
   quotaDisplay: AccountQuotaDisplayPreference,
+  sortMode: AccountSortMode = DEFAULT_ACCOUNT_SORT_MODE,
 ): AccountSummary[] {
   return accounts
     .slice()
     .sort((left, right) => {
+      if (sortMode === "reset_latest" || sortMode === "reset_soonest") {
+        const leftReset = accountResetTimestamp(left, quotaDisplay);
+        const rightReset = accountResetTimestamp(right, quotaDisplay);
+        if (leftReset !== rightReset) {
+          return sortMode === "reset_latest" ? rightReset - leftReset : leftReset - rightReset;
+        }
+      } else {
+        const leftLabel = accountSortLabel(left);
+        const rightLabel = accountSortLabel(right);
+        const labelComparison = sortMode === "name_asc"
+          ? leftLabel.localeCompare(rightLabel)
+          : rightLabel.localeCompare(leftLabel);
+        if (labelComparison !== 0) {
+          return labelComparison;
+        }
+      }
+
       const leftReset = accountResetTimestamp(left, quotaDisplay);
       const rightReset = accountResetTimestamp(right, quotaDisplay);
       if (leftReset !== rightReset) {

--- a/openspec/changes/add-account-list-sort-modes/proposal.md
+++ b/openspec/changes/add-account-list-sort-modes/proposal.md
@@ -1,0 +1,25 @@
+# Add account list sort modes
+
+## Why
+
+Operators need to inspect accounts by reset timing or account name without
+losing the existing reset-soonest default. The dashboard-visible sort behavior
+needs a stable contract so future account-list changes do not reorder stale or
+unknown reset rows ahead of accounts with real upcoming resets.
+
+## What Changes
+
+- Document the Accounts page sort selector modes for reset time and account
+  name.
+- Keep reset-soonest as the default ordering.
+- Require unknown or elapsed reset timestamps to sort after finite upcoming
+  reset timestamps in both reset-time modes.
+
+## Issue Trace
+
+- Closes #851
+
+## Impact
+
+- **Spec**: `frontend-architecture`
+- **Behavior**: account-list ordering and selected-account fallback ordering

--- a/openspec/changes/add-account-list-sort-modes/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-account-list-sort-modes/specs/frontend-architecture/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Accounts list supports explicit sort modes
+
+The Accounts page account list SHALL expose sort modes for reset time
+soonest-first, reset time latest-first, account name ascending, and account name
+descending. The default sort mode SHALL remain reset time soonest-first. The
+same selected sort mode SHALL apply to both the rendered account list and the
+page-level selected-account fallback.
+
+#### Scenario: Reset soonest remains the default
+
+- **WHEN** the account list renders without an explicit sort mode
+- **THEN** accounts with the earliest upcoming visible quota reset sort first
+
+#### Scenario: Reset latest sorts finite resets descending
+
+- **WHEN** a user selects reset time latest-first
+- **THEN** accounts with later upcoming visible quota resets sort before
+  accounts with earlier upcoming visible quota resets
+- **AND** accounts without an upcoming visible reset timestamp sort after
+  accounts with finite upcoming reset timestamps
+
+#### Scenario: Name sort modes order by account label
+
+- **WHEN** a user selects account name ascending or descending
+- **THEN** the account list orders accounts by display name, email, or account
+  identifier in the selected direction

--- a/openspec/changes/add-account-list-sort-modes/tasks.md
+++ b/openspec/changes/add-account-list-sort-modes/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec Delta
+
+- [x] 1.1 Add an Accounts page sort-mode requirement.
+- [x] 1.2 Cover reset-soonest, reset-latest, and name sort semantics.
+- [x] 1.3 Specify that unknown or elapsed reset timestamps sort last in reset-time modes.
+
+## 2. Verification
+
+- [x] 2.1 Validate the OpenSpec change with `uv run openspec validate add-account-list-sort-modes --strict`.
+- [x] 2.2 Run focused account-list tests.
+- [x] 2.3 Run frontend typecheck.


### PR DESCRIPTION
## Summary

- add an account-list sort selector with reset-time and name sort modes
- keep the existing reset-soonest behavior as the default
- keep unknown or elapsed reset timestamps after finite upcoming resets in both reset-time modes
- use the selected sort mode for both the visible account list and the page-level selected-account fallback
- document the dashboard-visible sort semantics in OpenSpec
- add focused account-list coverage for the new sort modes

Closes #851.

## Validation

- `cd frontend && bun run test src/features/accounts/components/account-list.test.tsx` (`10 passed`)
- `cd frontend && bun run typecheck`
- `uv run openspec validate add-account-list-sort-modes --strict`
