### PR TITLE
ci: narrow PostgreSQL pytest coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      CODEX_LB_TEST_DATABASE_URL: postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
+      POSTGRES_TEST_DATABASE_URL: postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
       PYTHONFAULTHANDLER: "1"
 
     steps:
@@ -203,11 +203,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
-        with:
-          bun-version: "1.3.14"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 PYTEST_ARGS := -q -ra -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread --durations=20
 POSTGRES_TEST_DATABASE_URL ?= postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
+POSTGRES_PYTEST_TARGETS := \
+	tests/integration/test_migrations.py::test_postgresql_migration_contract_policy_and_drift_match \
+	tests/integration/test_migrations.py::test_postgresql_upgrade_head_from_empty_database \
+	tests/integration/test_migrations.py::test_postgresql_startup_migration_auto_remap_legacy_head \
+	tests/integration/test_usage_repository.py::test_latest_by_account_primary_query_plan_uses_normalized_window_index_postgresql \
+	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_enabled_serializes_concurrent_same_email \
+	tests/integration/test_proxy_api_extended.py::test_proxy_stream_usage_limit_returns_http_error \
+	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql
 SHELL := /bin/bash
 
 .PHONY: help
@@ -61,11 +69,11 @@ test-e2e: frontend-build
 	uv sync --dev --frozen
 	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) tests/e2e
 
-test-postgres: frontend-build
+test-postgres:
 	uv sync --dev --frozen
-	CODEX_LB_TEST_DATABASE_URL="$(POSTGRES_TEST_DATABASE_URL)" \
+	CODEX_LB_TEST_DATABASE_URL="$${CODEX_LB_TEST_DATABASE_URL:-$(POSTGRES_TEST_DATABASE_URL)}" \
 	  PYTHONFAULTHANDLER=1 \
-	  uv run pytest $(PYTEST_ARGS)
+	  uv run pytest $(PYTEST_ARGS) $(POSTGRES_PYTEST_TARGETS)
 
 .PHONY: migration-check migration-check-postgres
 migration-check:


### PR DESCRIPTION
## Summary

- Narrow `make test-postgres` to the tests that exercise live PostgreSQL behavior instead of replaying the entire pytest suite.
- Remove the unused Bun setup/frontend build path from the PostgreSQL pytest job.
- Keep the PostgreSQL database URL configurable through `POSTGRES_TEST_DATABASE_URL`.
- Keep the live PostgreSQL merge-by-email concurrency and stream usage-limit regressions in the narrowed target list so backend-specific coverage stays in CI.

## Maintainer Update

- Rebuilt the branch as a single clean commit on current `main`; current head is `ed587c141ffe579baebce957b39c7a81af53673f`.
- GitHub CI has restarted for the new head and is still pending.
- This remains the dedicated CI-only PR for PostgreSQL pytest narrowing; sibling feature PRs #902 and #901 should not carry these Makefile/workflow changes.

## Benchmark

Before: recent `Tests (pytest, PostgreSQL)` CI runs took about 13.5-14.5 minutes, with the time spent in `Run tests` rather than container/setup work. Example public run:
https://github.com/Soju06/codex-lb/actions/runs/26875436465

That run's PostgreSQL pytest job reported `3221 passed, 7 skipped` and spent roughly 804s in `Run tests`.

After: the first corrected CI run completed `Tests (pytest, PostgreSQL)` in 53s total, with 12s spent in `Run tests`:
https://github.com/Soju06/codex-lb/actions/runs/26877575961/job/79268927040

Local benchmark with a fresh disposable `postgres:16` container:

```text
7 passed in 7.75s
elapsed=0:09.28
```

The target now collects exactly these PostgreSQL-focused tests:

```text
tests/integration/test_migrations.py::test_postgresql_migration_contract_policy_and_drift_match
tests/integration/test_migrations.py::test_postgresql_upgrade_head_from_empty_database
tests/integration/test_migrations.py::test_postgresql_startup_migration_auto_remap_legacy_head
tests/integration/test_usage_repository.py::test_latest_by_account_primary_query_plan_uses_normalized_window_index_postgresql
tests/integration/test_repositories.py::test_accounts_upsert_with_merge_enabled_serializes_concurrent_same_email
tests/integration/test_proxy_api_extended.py::test_proxy_stream_usage_limit_returns_http_error
tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql
```

## Validation

```bash
make -n test-postgres
uv run pytest --collect-only -q tests/integration/test_migrations.py::test_postgresql_migration_contract_policy_and_drift_match tests/integration/test_migrations.py::test_postgresql_upgrade_head_from_empty_database tests/integration/test_migrations.py::test_postgresql_startup_migration_auto_remap_legacy_head tests/integration/test_usage_repository.py::test_latest_by_account_primary_query_plan_uses_normalized_window_index_postgresql tests/integration/test_repositories.py::test_accounts_upsert_with_merge_enabled_serializes_concurrent_same_email tests/integration/test_proxy_api_extended.py::test_proxy_stream_usage_limit_returns_http_error tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql
```
