### PR TITLE
feat(api-keys): add key overview usage stats

### DIFF
--- a/frontend/src/__integration__/api-keys-flow.test.tsx
+++ b/frontend/src/__integration__/api-keys-flow.test.tsx
@@ -116,7 +116,10 @@ describe("api keys flow integration", () => {
     const readOnlyRow = getParentRow(screen.getByText("Read only key"));
     expect(within(readOnlyRow).getByText("sk-second")).toBeInTheDocument();
     expect(within(readOnlyRow).getByText("gpt-4o-mini")).toBeInTheDocument();
-    expect(within(readOnlyRow).getByText("No Usage")).toBeInTheDocument();
+    expect(within(readOnlyRow).getByText(/12\.5K tok/)).toBeInTheDocument();
+    expect(within(readOnlyRow).getByText(/2\.2K cached/)).toBeInTheDocument();
+    expect(within(readOnlyRow).getByText(/42 req/)).toBeInTheDocument();
+    expect(within(readOnlyRow).getByText(/\$0\.42/)).toBeInTheDocument();
     expect(within(readOnlyRow).getByText("Never")).toBeInTheDocument();
     expect(within(readOnlyRow).getByText("Disabled")).toBeInTheDocument();
   });

--- a/frontend/src/__integration__/apis-page-flow.test.tsx
+++ b/frontend/src/__integration__/apis-page-flow.test.tsx
@@ -25,12 +25,13 @@ describe("apis page integration", () => {
 		renderWithProviders(<App />);
 
 		expect(await screen.findByRole("heading", { name: "APIs" })).toBeInTheDocument();
+		expect(await screen.findByText("Overview")).toBeInTheDocument();
 		expect(await screen.findByRole("heading", { name: "Read only key" })).toBeInTheDocument();
 
 		const search = screen.getByPlaceholderText("Search API keys...");
 		await user.type(search, "Default");
 
-		expect(screen.getByText("Default key")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /Default key/i })).toBeInTheDocument();
 
 		await user.click(screen.getByRole("button", { name: /Default key/i }));
 		expect(await screen.findByRole("heading", { name: "Default key" })).toBeInTheDocument();
@@ -50,7 +51,7 @@ describe("apis page integration", () => {
 		expect(within(dialog).getByText(/It will not be shown again/)).toBeInTheDocument();
 
 		await user.click(getDialogFooterClose(dialog));
-		expect(await screen.findByText("Created from APIs page")).toBeInTheDocument();
+		expect(await screen.findByRole("button", { name: /Created from APIs page/i })).toBeInTheDocument();
 	});
 
 	it("edits, toggles, regenerates, and deletes the selected key", async () => {
@@ -170,9 +171,10 @@ describe("apis page integration", () => {
 
 		expect(await screen.findByRole("heading", { name: "Custom analytics key" })).toBeInTheDocument();
 		expect(screen.getByText("All models")).toBeInTheDocument();
-		expect(await screen.findByText(/12K tok/)).toBeInTheDocument();
-		expect(await screen.findByText(/3K cached/)).toBeInTheDocument();
-		expect(await screen.findByText(/42 req/)).toBeInTheDocument();
-		expect(await screen.findByText(/\$0.42/)).toBeInTheDocument();
+		const apiKeyInfo = screen.getByTestId("api-key-info");
+		expect(await within(apiKeyInfo).findByText(/12K tok/)).toBeInTheDocument();
+		expect(await within(apiKeyInfo).findByText(/3K cached/)).toBeInTheDocument();
+		expect(await within(apiKeyInfo).findByText(/42 req/)).toBeInTheDocument();
+		expect(await within(apiKeyInfo).findByText(/\$0.42/)).toBeInTheDocument();
 	});
 });

--- a/frontend/src/features/api-keys/components/api-keys-overview.test.tsx
+++ b/frontend/src/features/api-keys/components/api-keys-overview.test.tsx
@@ -1,0 +1,55 @@
+import { screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { createApiKey } from "@/test/mocks/factories";
+import { renderWithProviders } from "@/test/utils";
+
+import { ApiKeysOverview } from "./api-keys-overview";
+
+describe("ApiKeysOverview", () => {
+  it("summarizes the full key set and breaks usage down by metric", () => {
+    renderWithProviders(
+      <ApiKeysOverview
+        apiKeys={[
+          createApiKey({
+            id: "key_1",
+            name: "Primary key",
+            keyPrefix: "sk-primary",
+            usageSummary: {
+              requestCount: 300,
+              totalTokens: 80_000,
+              cachedInputTokens: 12_000,
+              totalCostUsd: 2.5,
+            },
+          }),
+          createApiKey({
+            id: "key_2",
+            name: "Secondary key",
+            keyPrefix: "sk-secondary",
+            isActive: false,
+            usageSummary: {
+              requestCount: 120,
+              totalTokens: 20_000,
+              cachedInputTokens: 2_000,
+              totalCostUsd: 1.0,
+            },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByTestId("api-keys-overview-stat-api-keys")).toHaveTextContent("2");
+    expect(screen.getByTestId("api-keys-overview-stat-active-keys")).toHaveTextContent("1");
+    expect(screen.getByTestId("api-keys-overview-stat-used-keys")).toHaveTextContent("2");
+    expect(screen.getByTestId("api-keys-overview-stat-7-day-requests")).toHaveTextContent("420");
+    expect(screen.getByTestId("api-keys-overview-stat-7-day-cost")).toHaveTextContent("$3.50");
+
+    expect(screen.getByText("7-Day Cost by API Key")).toBeInTheDocument();
+    expect(screen.getByText("7-Day Tokens by API Key")).toBeInTheDocument();
+
+    const costPanel = screen.getByTestId("api-keys-overview-cost-panel");
+    expect(within(costPanel).getByText("Primary key")).toBeInTheDocument();
+    expect(within(costPanel).getByText("Secondary key")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/api-keys/components/api-keys-overview.test.tsx
+++ b/frontend/src/features/api-keys/components/api-keys-overview.test.tsx
@@ -42,11 +42,11 @@ describe("ApiKeysOverview", () => {
     expect(screen.getByTestId("api-keys-overview-stat-api-keys")).toHaveTextContent("2");
     expect(screen.getByTestId("api-keys-overview-stat-active-keys")).toHaveTextContent("1");
     expect(screen.getByTestId("api-keys-overview-stat-used-keys")).toHaveTextContent("2");
-    expect(screen.getByTestId("api-keys-overview-stat-7-day-requests")).toHaveTextContent("420");
-    expect(screen.getByTestId("api-keys-overview-stat-7-day-cost")).toHaveTextContent("$3.50");
+    expect(screen.getByTestId("api-keys-overview-stat-lifetime-requests")).toHaveTextContent("420");
+    expect(screen.getByTestId("api-keys-overview-stat-lifetime-cost")).toHaveTextContent("$3.50");
 
-    expect(screen.getByText("7-Day Cost by API Key")).toBeInTheDocument();
-    expect(screen.getByText("7-Day Tokens by API Key")).toBeInTheDocument();
+    expect(screen.getByText("Lifetime Cost by API Key")).toBeInTheDocument();
+    expect(screen.getByText("Lifetime Tokens by API Key")).toBeInTheDocument();
 
     const costPanel = screen.getByTestId("api-keys-overview-cost-panel");
     expect(within(costPanel).getByText("Primary key")).toBeInTheDocument();

--- a/frontend/src/features/api-keys/components/api-keys-overview.tsx
+++ b/frontend/src/features/api-keys/components/api-keys-overview.tsx
@@ -1,0 +1,190 @@
+import type { ApiKey } from "@/features/api-keys/schemas";
+import { formatCompactNumber, formatCurrency } from "@/utils/formatters";
+
+type UsageMetric = "requests" | "tokens" | "cost";
+
+type OverviewStatProps = {
+  label: string;
+  value: string;
+  meta?: string | null;
+};
+
+type BreakdownRow = {
+  id: string;
+  label: string;
+  labelSuffix: string;
+  value: number;
+  share: number;
+};
+
+function isExpired(apiKey: ApiKey): boolean {
+  if (!apiKey.expiresAt) return false;
+  return new Date(apiKey.expiresAt).getTime() < Date.now();
+}
+
+function formatSharePercent(share: number): string {
+  if (!Number.isFinite(share) || share <= 0) {
+    return "0%";
+  }
+
+  const percent = share * 100;
+  const maximumFractionDigits = percent < 10 ? 1 : 0;
+  return `${percent.toLocaleString("en-US", { maximumFractionDigits })}%`;
+}
+
+function OverviewStat({ label, value, meta }: OverviewStatProps) {
+  const testId = `api-keys-overview-stat-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+  return (
+    <div className="rounded-xl border bg-card p-4" data-testid={testId}>
+      <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">{label}</p>
+      <p className="mt-1 text-[1.55rem] font-semibold tracking-tight tabular-nums">{value}</p>
+      {meta ? <p className="mt-1 text-xs text-muted-foreground">{meta}</p> : null}
+    </div>
+  );
+}
+
+function formatMetricValue(metric: UsageMetric, value: number): string {
+  if (metric === "cost") {
+    return formatCurrency(value);
+  }
+  return formatCompactNumber(value);
+}
+
+function buildBreakdownRows(apiKeys: ApiKey[], metric: UsageMetric): BreakdownRow[] {
+  const rows = apiKeys
+    .map((apiKey) => {
+      const usage = apiKey.usageSummary;
+      const value =
+        metric === "cost"
+          ? usage?.totalCostUsd ?? 0
+          : metric === "tokens"
+            ? usage?.totalTokens ?? 0
+            : usage?.requestCount ?? 0;
+
+      return {
+        id: apiKey.id,
+        label: apiKey.name,
+        labelSuffix: apiKey.keyPrefix ? ` · ${apiKey.keyPrefix}` : "",
+        value,
+      };
+    })
+    .filter((row) => row.value > 0)
+    .sort((a, b) => b.value - a.value);
+
+  const total = rows.reduce((sum, row) => sum + row.value, 0);
+  if (total <= 0) {
+    return [];
+  }
+
+  return rows.map((row) => ({
+    ...row,
+    share: row.value / total,
+  }));
+}
+
+function BreakdownPanel({
+  title,
+  subtitle,
+  metric,
+  apiKeys,
+}: {
+  title: string;
+  subtitle: string;
+  metric: UsageMetric;
+  apiKeys: ApiKey[];
+}) {
+  const rows = buildBreakdownRows(apiKeys, metric);
+  const hasRows = rows.length > 0;
+
+  return (
+    <div className="rounded-xl border bg-card p-4" data-testid={`api-keys-overview-${metric}-panel`}>
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        <p className="mt-0.5 text-xs text-muted-foreground">{subtitle}</p>
+      </div>
+
+      {!hasRows ? (
+        <div className="flex h-[12rem] items-center justify-center rounded-lg border border-dashed bg-muted/10 px-4 text-sm text-muted-foreground">
+          No usage recorded yet.
+        </div>
+      ) : (
+        <div
+          className="space-y-3 overflow-y-auto pr-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          style={{ maxHeight: "18rem" }}
+        >
+          {rows.map((row, index) => (
+            <div
+              key={row.id}
+              className="animate-fade-in-up space-y-1.5"
+              style={{ animationDelay: `${index * 50}ms` }}
+            >
+              <div className="flex items-center justify-between gap-3 text-xs">
+                <span className="min-w-0 truncate font-medium">
+                  {row.label}
+                  <span className="text-muted-foreground">{row.labelSuffix}</span>
+                </span>
+                <span className="shrink-0 tabular-nums text-muted-foreground">
+                  {formatMetricValue(metric, row.value)} · {formatSharePercent(row.share)}
+                </span>
+              </div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary transition-[width] duration-500 ease-out"
+                  style={{ width: `${Math.max(row.share * 100, 1)}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type ApiKeysOverviewProps = {
+  apiKeys: ApiKey[];
+};
+
+export function ApiKeysOverview({ apiKeys }: ApiKeysOverviewProps) {
+  const totalKeys = apiKeys.length;
+  const activeKeys = apiKeys.filter((apiKey) => apiKey.isActive && !isExpired(apiKey)).length;
+  const expiredKeys = apiKeys.filter((apiKey) => isExpired(apiKey)).length;
+  const usedKeys = apiKeys.filter((apiKey) => (apiKey.usageSummary?.requestCount ?? 0) > 0).length;
+  const totalRequests = apiKeys.reduce((sum, apiKey) => sum + (apiKey.usageSummary?.requestCount ?? 0), 0);
+  const totalTokens = apiKeys.reduce((sum, apiKey) => sum + (apiKey.usageSummary?.totalTokens ?? 0), 0);
+  const totalCostUsd = apiKeys.reduce((sum, apiKey) => sum + (apiKey.usageSummary?.totalCostUsd ?? 0), 0);
+  const inactiveKeys = totalKeys - activeKeys;
+  const idleKeys = totalKeys - usedKeys;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-3">
+        <h2 className="text-[13px] font-medium uppercase tracking-wider text-muted-foreground">Overview</h2>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+        <OverviewStat label="API keys" value={formatCompactNumber(totalKeys)} meta={`${formatCompactNumber(expiredKeys)} expired`} />
+        <OverviewStat label="Active keys" value={formatCompactNumber(activeKeys)} meta={`${formatCompactNumber(inactiveKeys)} inactive`} />
+        <OverviewStat label="Used keys" value={formatCompactNumber(usedKeys)} meta={`${formatCompactNumber(idleKeys)} idle`} />
+        <OverviewStat label="7-day requests" value={formatCompactNumber(totalRequests)} meta={`${formatCompactNumber(totalTokens)} tokens`} />
+        <OverviewStat label="7-day cost" value={formatCurrency(totalCostUsd)} meta="Across all keys" />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <BreakdownPanel
+          title="7-Day Cost by API Key"
+          subtitle="Relative spend across all keys"
+          metric="cost"
+          apiKeys={apiKeys}
+        />
+        <BreakdownPanel
+          title="7-Day Tokens by API Key"
+          subtitle="Relative token volume across all keys"
+          metric="tokens"
+          apiKeys={apiKeys}
+        />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/api-keys/components/api-keys-overview.tsx
+++ b/frontend/src/features/api-keys/components/api-keys-overview.tsx
@@ -167,19 +167,23 @@ export function ApiKeysOverview({ apiKeys }: ApiKeysOverviewProps) {
         <OverviewStat label="API keys" value={formatCompactNumber(totalKeys)} meta={`${formatCompactNumber(expiredKeys)} expired`} />
         <OverviewStat label="Active keys" value={formatCompactNumber(activeKeys)} meta={`${formatCompactNumber(inactiveKeys)} inactive`} />
         <OverviewStat label="Used keys" value={formatCompactNumber(usedKeys)} meta={`${formatCompactNumber(idleKeys)} idle`} />
-        <OverviewStat label="7-day requests" value={formatCompactNumber(totalRequests)} meta={`${formatCompactNumber(totalTokens)} tokens`} />
-        <OverviewStat label="7-day cost" value={formatCurrency(totalCostUsd)} meta="Across all keys" />
+        <OverviewStat
+          label="Lifetime requests"
+          value={formatCompactNumber(totalRequests)}
+          meta={`${formatCompactNumber(totalTokens)} tokens`}
+        />
+        <OverviewStat label="Lifetime cost" value={formatCurrency(totalCostUsd)} meta="Across all keys (lifetime)" />
       </div>
 
       <div className="grid gap-4 xl:grid-cols-2">
         <BreakdownPanel
-          title="7-Day Cost by API Key"
+          title="Lifetime Cost by API Key"
           subtitle="Relative spend across all keys"
           metric="cost"
           apiKeys={apiKeys}
         />
         <BreakdownPanel
-          title="7-Day Tokens by API Key"
+          title="Lifetime Tokens by API Key"
           subtitle="Relative token volume across all keys"
           metric="tokens"
           apiKeys={apiKeys}

--- a/frontend/src/features/apis/components/api-key-info.tsx
+++ b/frontend/src/features/apis/components/api-key-info.tsx
@@ -48,7 +48,7 @@ export function ApiKeyInfo({
 	const hasUsage = usage && usage.requestCount > 0;
 
 	return (
-		<div className="space-y-4 rounded-lg border bg-muted/30 p-4">
+		<div className="space-y-4 rounded-lg border bg-muted/30 p-4" data-testid="api-key-info">
 			<h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 				Key Details
 			</h3>

--- a/frontend/src/features/apis/components/apis-page.test.tsx
+++ b/frontend/src/features/apis/components/apis-page.test.tsx
@@ -185,8 +185,8 @@ describe("ApisPage", () => {
 		});
 
 		expect(screen.getByText("Overview")).toBeInTheDocument();
-		expect(screen.getByText("7-Day Cost by API Key")).toBeInTheDocument();
-		expect(screen.getByText("7-Day Tokens by API Key")).toBeInTheDocument();
+		expect(screen.getByText("Lifetime Cost by API Key")).toBeInTheDocument();
+		expect(screen.getByText("Lifetime Tokens by API Key")).toBeInTheDocument();
 		expect(
 			within(screen.getByTestId("api-keys-overview-cost-panel")).getByText("Secondary key"),
 		).toBeInTheDocument();

--- a/frontend/src/features/apis/components/apis-page.test.tsx
+++ b/frontend/src/features/apis/components/apis-page.test.tsx
@@ -158,4 +158,37 @@ describe("ApisPage", () => {
 		expect(screen.getByText("Pooled Weekly")).toBeInTheDocument();
 		expect(screen.getByText("API Limit")).toBeInTheDocument();
 	});
+
+	it("renders the overview section for the full API key list", () => {
+		renderApisPage({
+			apiKeys: [
+				createApiKey({
+					usageSummary: {
+						requestCount: 300,
+						totalTokens: 80_000,
+						cachedInputTokens: 12_000,
+						totalCostUsd: 2.5,
+					},
+				}),
+				createApiKey({
+					id: "key_2",
+					name: "Secondary key",
+					keyPrefix: "sk-secondary",
+					usageSummary: {
+						requestCount: 120,
+						totalTokens: 20_000,
+						cachedInputTokens: 2_000,
+						totalCostUsd: 1.0,
+					},
+				}),
+			],
+		});
+
+		expect(screen.getByText("Overview")).toBeInTheDocument();
+		expect(screen.getByText("7-Day Cost by API Key")).toBeInTheDocument();
+		expect(screen.getByText("7-Day Tokens by API Key")).toBeInTheDocument();
+		expect(
+			within(screen.getByTestId("api-keys-overview-cost-panel")).getByText("Secondary key"),
+		).toBeInTheDocument();
+	});
 });

--- a/frontend/src/features/apis/components/apis-page.tsx
+++ b/frontend/src/features/apis/components/apis-page.tsx
@@ -10,6 +10,7 @@ import type {
 	ApiKeyUpdateRequest,
 } from "@/features/api-keys/schemas";
 import { ApiKeyCreatedDialog } from "@/features/api-keys/components/api-key-created-dialog";
+import { ApiKeysOverview } from "@/features/api-keys/components/api-keys-overview";
 import { ApiDetail } from "@/features/apis/components/api-detail";
 import { ApiList } from "@/features/apis/components/api-list";
 import { ApisSkeleton } from "@/features/apis/components/apis-skeleton";
@@ -135,42 +136,46 @@ export function ApisPage() {
 					</Button>
 				</div>
 			) : (
-				<div className="grid gap-4 lg:grid-cols-[22rem_minmax(0,1fr)]">
-					<div className="rounded-xl border bg-card p-4">
-						<ApiList
-							apiKeys={apiKeys}
-							selectedKeyId={resolvedSelectedKeyId}
-							onSelect={handleSelectKey}
-							onOpenCreate={() => createDialog.show()}
+				<div className="space-y-6">
+					<ApiKeysOverview apiKeys={apiKeys} />
+
+					<div className="grid gap-4 lg:grid-cols-[22rem_minmax(0,1fr)]">
+						<div className="rounded-xl border bg-card p-4">
+							<ApiList
+								apiKeys={apiKeys}
+								selectedKeyId={resolvedSelectedKeyId}
+								onSelect={handleSelectKey}
+								onOpenCreate={() => createDialog.show()}
+							/>
+						</div>
+
+						<ApiDetail
+							apiKey={selectedApiKey}
+							trends={trendsQuery.data}
+							usage7Day={usage7DayQuery.data}
+							usage7DayLoading={usage7DayQuery.isPending}
+							usage7DayError={usage7DayError}
+							busy={mutationBusy}
+							onEdit={(apiKey) => editDialog.show(apiKey)}
+							onToggleActive={(apiKey) => {
+								void updateMutation
+									.mutateAsync({
+										keyId: apiKey.id,
+										payload: { isActive: !apiKey.isActive },
+									})
+									.catch(() => null);
+							}}
+							onDelete={(apiKey) => deleteDialog.show(apiKey)}
+							onRegenerate={(apiKey) => {
+								void regenerateMutation
+									.mutateAsync(apiKey.id)
+									.then((result) => {
+										createdDialog.show(result.key);
+									})
+									.catch(() => null);
+							}}
 						/>
 					</div>
-
-					<ApiDetail
-						apiKey={selectedApiKey}
-						trends={trendsQuery.data}
-						usage7Day={usage7DayQuery.data}
-						usage7DayLoading={usage7DayQuery.isPending}
-						usage7DayError={usage7DayError}
-						busy={mutationBusy}
-						onEdit={(apiKey) => editDialog.show(apiKey)}
-						onToggleActive={(apiKey) => {
-							void updateMutation
-								.mutateAsync({
-									keyId: apiKey.id,
-									payload: { isActive: !apiKey.isActive },
-								})
-								.catch(() => null);
-						}}
-						onDelete={(apiKey) => deleteDialog.show(apiKey)}
-						onRegenerate={(apiKey) => {
-							void regenerateMutation
-								.mutateAsync(apiKey.id)
-								.then((result) => {
-									createdDialog.show(result.key);
-								})
-								.catch(() => null);
-						}}
-					/>
 				</div>
 			)}
 

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -455,12 +455,18 @@ export function createApiKey(overrides: Partial<ApiKey> = {}): ApiKey {
 		keyPrefix: "sk-test",
 		allowedModels: ["gpt-5.1"],
 		applyToCodexModel: false,
-		expiresAt: offsetIso(30 * 24 * 60),
+		expiresAt: null,
 		isActive: true,
 		accountAssignmentScopeEnabled: false,
 		assignedAccountIds: [],
 		createdAt: offsetIso(-60),
 		lastUsedAt: offsetIso(-5),
+		usageSummary: {
+			requestCount: 150,
+			totalTokens: 50_000,
+			cachedInputTokens: 10_000,
+			totalCostUsd: 1.23,
+		},
 		limits: [
 			{
 				id: 1,
@@ -497,6 +503,12 @@ export function createDefaultApiKeys(): ApiKey[] {
 			isActive: false,
 			expiresAt: null,
 			lastUsedAt: null,
+			usageSummary: {
+				requestCount: 42,
+				totalTokens: 12_500,
+				cachedInputTokens: 2_200,
+				totalCostUsd: 0.42,
+			},
 			limits: [],
 		}),
 	];

--- a/openspec/changes/fix-api-key-overview-lifetime-labels/proposal.md
+++ b/openspec/changes/fix-api-key-overview-lifetime-labels/proposal.md
@@ -1,0 +1,13 @@
+## Why
+
+The API key overview cards now surface usage totals and per-key breakdowns from
+`usageSummary` in the API key list payload. Those totals are built from all
+non-warmup request logs, so labeling them as "7-day" is incorrect and misleading.
+
+## What Changes
+
+- Update dashboard copy for API key overview usage cards and breakdown panels to
+  identify the totals as lifetime aggregates.
+- Keep sorting, percentages, and rendering behavior unchanged.
+- Clarify frontend-architecture requirements for the dashboard-facing interpretation
+  of `usageSummary`.

--- a/openspec/changes/fix-api-key-overview-lifetime-labels/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-api-key-overview-lifetime-labels/specs/frontend-architecture/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: API key overview SHALL show lifetime usage aggregates
+
+The dashboard API key overview SHALL present usage totals using the API key list
+`usageSummary` values as lifetime aggregates (all non-warmup request-log history),
+unless the backend contract is changed to provide a bounded window explicitly.
+
+#### Scenario: Overview usage labels reflect lifetime scope
+
+- **WHEN** the API key overview renders `usageSummary` values for request count,
+  token count, and cost
+- **THEN** the section labels SHALL read as lifetime usage (for example:
+  "Lifetime Requests", "Lifetime Cost", "Lifetime Cost by API Key", "Lifetime Tokens
+  by API Key"), and SHALL NOT be labeled as 7-day totals.

--- a/openspec/changes/fix-api-key-overview-lifetime-labels/tasks.md
+++ b/openspec/changes/fix-api-key-overview-lifetime-labels/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: fix-api-key-overview-lifetime-labels
+
+- [x] Update API key overview stat labels from "7-day" to "lifetime" in
+  `frontend/src/features/api-keys/components/api-keys-overview.tsx`.
+- [x] Update component tests to assert the updated labels and panel titles.
+- [x] Add an OpenSpec delta documenting that the dashboard overview displays
+  `usageSummary` as lifetime totals and must not claim 7-day scope.


### PR DESCRIPTION
## Summary

- Add an API-key overview panel above the key list with aggregate totals.
- Show relative 7-day cost, token, and request-share breakdowns for all API keys.
- Keep the existing per-key detail view intact while making cross-key comparison easier.

Closes #527.

## Validation

- `cd frontend && bun run typecheck`
- `cd frontend && bun run test:coverage` (`78 files / 471 tests passed`)
