### PR TITLE
perf(usage): avoid repeated history cache scans

### DIFF
--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -26,6 +26,7 @@ from app.db.models import (
 )
 from app.db.session import sqlite_writer_section
 from app.modules.usage.additional_quota_keys import normalize_additional_quota_routing_policy_overrides
+from app.modules.usage.repository import _clear_bulk_history_since_sqlite_cache
 
 _SETTINGS_ROW_ID = 1
 _DUPLICATE_ACCOUNT_SUFFIX = "__copy"
@@ -420,6 +421,7 @@ class AccountsRepository:
         await self._session.execute(
             update(UsageHistory).where(UsageHistory.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
         )
+        _clear_bulk_history_since_sqlite_cache()
         await self._session.execute(
             update(AdditionalUsageHistory)
             .where(AdditionalUsageHistory.account_id.in_(duplicate_ids))
@@ -578,6 +580,7 @@ class AccountsRepository:
     async def delete(self, account_id: str, *, delete_history: bool = False) -> bool:
         async with sqlite_writer_section():
             await self._session.execute(delete(UsageHistory).where(UsageHistory.account_id == account_id))
+            _clear_bulk_history_since_sqlite_cache()
             if delete_history:
                 await self._session.execute(delete(RequestLog).where(RequestLog.account_id == account_id))
             else:

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -582,7 +582,6 @@ class AccountsRepository:
     async def delete(self, account_id: str, *, delete_history: bool = False) -> bool:
         async with sqlite_writer_section():
             await self._session.execute(delete(UsageHistory).where(UsageHistory.account_id == account_id))
-            _clear_bulk_history_since_sqlite_cache()
             if delete_history:
                 await self._session.execute(delete(RequestLog).where(RequestLog.account_id == account_id))
             else:
@@ -593,8 +592,11 @@ class AccountsRepository:
                 )
             await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
             result = await self._session.execute(delete(Account).where(Account.id == account_id).returning(Account.id))
+            deleted_id = result.scalar_one_or_none()
             await self._session.commit()
-            return result.scalar_one_or_none() is not None
+            if deleted_id is not None:
+                _clear_bulk_history_since_sqlite_cache()
+            return deleted_id is not None
 
     async def update_tokens(
         self,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -220,13 +220,15 @@ class AccountsRepository:
             )
             if canonical is not None:
                 _apply_account_updates(canonical, account)
-                await self._reconcile_chatgpt_identity_duplicates(
+                usage_cache_dirty = await self._reconcile_chatgpt_identity_duplicates(
                     canonical=canonical,
                     chatgpt_account_id=account.chatgpt_account_id,
                     workspace_id=account.workspace_id,
                     email=account.email,
                 )
                 await self._session.commit()
+                if usage_cache_dirty:
+                    _clear_bulk_history_since_sqlite_cache()
                 await self._session.refresh(canonical)
                 return canonical
 
@@ -375,7 +377,7 @@ class AccountsRepository:
         chatgpt_account_id: str,
         workspace_id: str | None,
         email: str | None,
-    ) -> None:
+    ) -> bool:
         duplicate_stmt = select(Account.id).where(
             Account.chatgpt_account_id == chatgpt_account_id,
             Account.id != canonical.id,
@@ -389,7 +391,7 @@ class AccountsRepository:
         duplicate_accounts = (await self._session.execute(duplicate_stmt)).scalars().all()
         duplicate_ids = list(duplicate_accounts)
         if not duplicate_ids:
-            return
+            return False
 
         duplicate_api_key_ids = (
             (
@@ -421,7 +423,6 @@ class AccountsRepository:
         await self._session.execute(
             update(UsageHistory).where(UsageHistory.account_id.in_(duplicate_ids)).values(account_id=canonical.id)
         )
-        _clear_bulk_history_since_sqlite_cache()
         await self._session.execute(
             update(AdditionalUsageHistory)
             .where(AdditionalUsageHistory.account_id.in_(duplicate_ids))
@@ -440,6 +441,7 @@ class AccountsRepository:
             .values(account_id=canonical.id)
         )
         await self._session.execute(delete(Account).where(Account.id.in_(duplicate_ids)))
+        return True
 
     async def _reconcile_limit_warmups(self, canonical_account_id: str, duplicate_ids: list[str]) -> None:
         existing_keys = {

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -374,7 +374,7 @@ def _additional_latest_by_account_sqlite(
           and {scope_clause}
           and window = ?
           {since_filter}
-        order by recorded_at desc, id desc
+        order by recorded_at desc, used_percent desc, id desc
         limit 1
     """
 

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -1150,6 +1150,47 @@ class AdditionalUsageRepository:
         account_ids: Collection[str] | None = None,
         since: datetime | None = None,
     ) -> dict[str, AdditionalUsageHistory]:
+        bind = self._session.get_bind()
+        dialect = bind.dialect.name if bind else "sqlite"
+        if dialect == "sqlite":
+            scope = _resolve_additional_quota_query_scope(quota_key=quota_key)
+            if scope is None:
+                raise ValueError("quota_key and window are required")
+            account_values = list(account_ids) if account_ids is not None else None
+            if account_values is not None and not account_values:
+                return {}
+            account_stmt = select(AdditionalUsageHistory.account_id).where(
+                _additional_quota_match_clause(scope),
+                AdditionalUsageHistory.window == window,
+            )
+            if account_values is not None:
+                account_stmt = account_stmt.where(AdditionalUsageHistory.account_id.in_(account_values))
+            if since is not None:
+                account_stmt = account_stmt.where(AdditionalUsageHistory.recorded_at >= since)
+            account_result = await self._session.execute(account_stmt.distinct())
+            latest: dict[str, AdditionalUsageHistory] = {}
+            for account_id in account_result.scalars().all():
+                latest_stmt = (
+                    select(AdditionalUsageHistory)
+                    .where(
+                        AdditionalUsageHistory.account_id == account_id,
+                        _additional_quota_match_clause(scope),
+                        AdditionalUsageHistory.window == window,
+                    )
+                    .order_by(
+                        AdditionalUsageHistory.recorded_at.desc(),
+                        AdditionalUsageHistory.used_percent.desc(),
+                        AdditionalUsageHistory.id.desc(),
+                    )
+                    .limit(1)
+                )
+                if since is not None:
+                    latest_stmt = latest_stmt.where(AdditionalUsageHistory.recorded_at >= since)
+                row_result = await self._session.execute(latest_stmt)
+                entry = row_result.scalar_one_or_none()
+                if entry is not None:
+                    latest[entry.account_id] = entry
+            return latest
         return await self.latest_by_account(
             quota_key=quota_key,
             window=window,

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -118,8 +118,35 @@ def _clone_filtered_history(
     return filtered_grouped
 
 
-def _max_snapshot_id(grouped: dict[str, list[UsageHistorySnapshot]]) -> int:
-    return max((row.id for rows in grouped.values() for row in rows), default=0)
+def _bulk_history_metadata_from_grouped(
+    grouped: dict[str, list[UsageHistorySnapshot]],
+) -> _BulkHistoryCacheMetadata:
+    digest = sha256()
+    rows = sorted((row for rows in grouped.values() for row in rows), key=lambda row: (row.id, row.account_id))
+    for row in rows:
+        digest.update(str(int(row.id)).encode("utf-8"))
+        digest.update(b"\x1f")
+        account_bytes = str(row.account_id).encode("utf-8")
+        digest.update(str(len(account_bytes)).encode("ascii"))
+        digest.update(b":")
+        digest.update(account_bytes)
+        digest.update(b"\x1f")
+        digest.update(float(row.used_percent).hex().encode("ascii"))
+        digest.update(b"\x1f")
+        recorded_at_bytes = str(row.recorded_at).encode("utf-8")
+        digest.update(str(len(recorded_at_bytes)).encode("ascii"))
+        digest.update(b":")
+        digest.update(recorded_at_bytes)
+        digest.update(b"\x1f")
+        digest.update(b"NULL" if row.reset_at is None else float(row.reset_at).hex().encode("ascii"))
+        digest.update(b"\x1f")
+        digest.update(b"NULL" if row.window_minutes is None else str(int(row.window_minutes)).encode("ascii"))
+        digest.update(b"\x1e")
+    return _BulkHistoryCacheMetadata(
+        row_count=len(rows),
+        max_id=max((row.id for row in rows), default=0),
+        content_digest=digest.hexdigest(),
+    )
 
 
 def _append_grouped_history(
@@ -414,14 +441,8 @@ def _bulk_history_since_sqlite(
                 )
                 if metadata != cached.metadata:
                     grouped = _query_bulk_history_since_sqlite(conn, account_ids, window, cached.since)
-                    cached.max_id = _max_snapshot_id(grouped)
-                    cached.metadata = _query_bulk_history_metadata_sqlite(
-                        conn,
-                        account_ids,
-                        window,
-                        cached.since,
-                        max_id=cached.max_id,
-                    )
+                    cached.metadata = _bulk_history_metadata_from_grouped(grouped)
+                    cached.max_id = cached.metadata.max_id
                     cached.rows_by_account = grouped
                     return _clone_filtered_history(grouped, since)
 
@@ -434,22 +455,16 @@ def _bulk_history_since_sqlite(
                 )
                 if new_rows:
                     _append_grouped_history(cached.rows_by_account, new_rows)
-                    cached.max_id = max(cached.max_id, _max_snapshot_id(new_rows))
-                    cached.metadata = _query_bulk_history_metadata_sqlite(
-                        conn,
-                        account_ids,
-                        window,
-                        cached.since,
-                        max_id=cached.max_id,
-                    )
+                    cached.metadata = _bulk_history_metadata_from_grouped(cached.rows_by_account)
+                    cached.max_id = cached.metadata.max_id
                 return _clone_filtered_history(cached.rows_by_account, since)
 
             grouped = _query_bulk_history_since_sqlite(conn, account_ids, window, since)
-            max_id = _max_snapshot_id(grouped)
+            metadata = _bulk_history_metadata_from_grouped(grouped)
             _BULK_HISTORY_SQLITE_CACHE[cache_key] = _BulkHistoryCacheEntry(
                 since=since,
-                max_id=max_id,
-                metadata=_query_bulk_history_metadata_sqlite(conn, account_ids, window, since, max_id=max_id),
+                max_id=metadata.max_id,
+                metadata=metadata,
                 rows_by_account=grouped,
             )
             return _clone_filtered_history(grouped, since)

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -6,9 +6,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from hashlib import sha256
 from threading import RLock
+from typing import Any, cast
 
 from anyio import to_thread
-from sqlalchemy import Integer, and_, cast, delete, func, literal_column, or_, select, true
+from sqlalchemy import Integer, and_, delete, func, literal_column, or_, select, true
+from sqlalchemy import cast as sqlalchemy_cast
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config.settings import get_settings
@@ -36,28 +38,59 @@ class UsageHistorySnapshot:
     window_minutes: int | None
 
 
+@dataclass(frozen=True, slots=True)
+class _BulkHistoryCacheMetadata:
+    row_count: int
+    max_id: int
+    content_digest: str
+
+
 @dataclass(slots=True)
 class _BulkHistoryCacheEntry:
     since: datetime
     max_id: int
-    fingerprint: _BulkHistoryFingerprint
+    metadata: _BulkHistoryCacheMetadata
     rows_by_account: dict[str, list[UsageHistorySnapshot]]
-
-
-@dataclass(frozen=True, slots=True)
-class _BulkHistoryFingerprint:
-    row_count: int
-    max_id: int
-    id_sum: int
-    used_percent_total: float
-    reset_at_total: float
-    window_minutes_sum: int
-    max_recorded_at: str
-    content_digest: str
 
 
 _BULK_HISTORY_SQLITE_CACHE: dict[tuple[str, tuple[str, ...], str], _BulkHistoryCacheEntry] = {}
 _BULK_HISTORY_SQLITE_CACHE_LOCK = RLock()
+
+
+class _BulkHistoryDigestAggregate:
+    def __init__(self) -> None:
+        self._digest = sha256()
+
+    def step(
+        self,
+        row_id: int,
+        account_id: str,
+        used_percent: float,
+        recorded_at: str,
+        reset_at: float | None,
+        window_minutes: int | None,
+    ) -> None:
+        self._digest.update(str(int(row_id)).encode("utf-8"))
+        self._digest.update(b"\x1f")
+        account_bytes = str(account_id).encode("utf-8")
+        self._digest.update(str(len(account_bytes)).encode("ascii"))
+        self._digest.update(b":")
+        self._digest.update(account_bytes)
+        self._digest.update(b"\x1f")
+        self._digest.update(float(used_percent).hex().encode("ascii"))
+        self._digest.update(b"\x1f")
+        recorded_at_bytes = str(recorded_at).encode("utf-8")
+        self._digest.update(str(len(recorded_at_bytes)).encode("ascii"))
+        self._digest.update(b":")
+        self._digest.update(recorded_at_bytes)
+        self._digest.update(b"\x1f")
+        self._digest.update(b"NULL" if reset_at is None else float(reset_at).hex().encode("ascii"))
+        self._digest.update(b"\x1f")
+        self._digest.update(b"NULL" if window_minutes is None else str(int(window_minutes)).encode("ascii"))
+        self._digest.update(b"\x1e")
+
+    def finalize(self) -> str:
+        return self._digest.hexdigest()
 
 
 def _clear_bulk_history_since_sqlite_cache() -> None:
@@ -89,49 +122,6 @@ def _max_snapshot_id(grouped: dict[str, list[UsageHistorySnapshot]]) -> int:
     return max((row.id for rows in grouped.values() for row in rows), default=0)
 
 
-def _fingerprint_grouped_history(grouped: dict[str, list[UsageHistorySnapshot]]) -> _BulkHistoryFingerprint:
-    row_count = 0
-    max_id = 0
-    id_sum = 0
-    used_percent_total = 0.0
-    reset_at_total = 0.0
-    window_minutes_sum = 0
-    max_recorded_at = ""
-    digest = sha256()
-    for account_id, rows in sorted(grouped.items()):
-        for row in rows:
-            row_count += 1
-            max_id = max(max_id, row.id)
-            id_sum += row.id
-            used_percent_total += row.used_percent
-            reset_at_total += row.reset_at or 0.0
-            window_minutes_sum += row.window_minutes or 0
-            recorded_at = row.recorded_at.isoformat(sep=" ")
-            max_recorded_at = max(max_recorded_at, recorded_at)
-            digest.update(
-                repr(
-                    (
-                        account_id,
-                        row.id,
-                        row.used_percent,
-                        recorded_at,
-                        row.reset_at,
-                        row.window_minutes,
-                    )
-                ).encode("utf-8")
-            )
-    return _BulkHistoryFingerprint(
-        row_count=row_count,
-        max_id=max_id,
-        id_sum=id_sum,
-        used_percent_total=used_percent_total,
-        reset_at_total=reset_at_total,
-        window_minutes_sum=window_minutes_sum,
-        max_recorded_at=max_recorded_at,
-        content_digest=digest.hexdigest(),
-    )
-
-
 def _append_grouped_history(
     target: dict[str, list[UsageHistorySnapshot]],
     source: dict[str, list[UsageHistorySnapshot]],
@@ -140,72 +130,6 @@ def _append_grouped_history(
         bucket = target.setdefault(account_id, [])
         bucket.extend(rows)
         bucket.sort(key=lambda row: (row.recorded_at, row.id))
-
-
-def _merged_grouped_history(
-    target: dict[str, list[UsageHistorySnapshot]],
-    source: dict[str, list[UsageHistorySnapshot]],
-) -> dict[str, list[UsageHistorySnapshot]]:
-    merged = {account_id: list(rows) for account_id, rows in target.items()}
-    _append_grouped_history(merged, source)
-    return merged
-
-
-def _bulk_history_fingerprint_sqlite(
-    conn: sqlite3.Connection,
-    account_ids: list[str],
-    window: str,
-    since: datetime,
-) -> _BulkHistoryFingerprint:
-    placeholders = ",".join("?" for _ in account_ids)
-    since_param = since.isoformat(sep=" ")
-    if window == "primary":
-        window_clause = "coalesce(window, 'primary') = 'primary'"
-        params = [*account_ids, since_param]
-    else:
-        window_clause = "window = ?"
-        params = [*account_ids, window, since_param]
-    sql = f"""
-        select id, account_id, used_percent, recorded_at, reset_at, window_minutes
-        from usage_history
-        where account_id in ({placeholders})
-          and {window_clause}
-          and recorded_at >= ?
-        order by account_id, recorded_at asc, id asc
-    """
-    row_count = 0
-    max_id = 0
-    id_sum = 0
-    used_percent_total = 0.0
-    reset_at_total = 0.0
-    window_minutes_sum = 0
-    max_recorded_at = ""
-    digest = sha256()
-    for row in conn.execute(sql, params):
-        row_id = int(row[0])
-        account_id = str(row[1])
-        used_percent = float(row[2])
-        recorded_at = _parse_sqlite_datetime(row[3]).isoformat(sep=" ")
-        reset_at = float(row[4]) if row[4] is not None else None
-        window_minutes = int(row[5]) if row[5] is not None else None
-        row_count += 1
-        max_id = max(max_id, row_id)
-        id_sum += row_id
-        used_percent_total += used_percent
-        reset_at_total += reset_at or 0.0
-        window_minutes_sum += window_minutes or 0
-        max_recorded_at = max(max_recorded_at, recorded_at)
-        digest.update(repr((account_id, row_id, used_percent, recorded_at, reset_at, window_minutes)).encode("utf-8"))
-    return _BulkHistoryFingerprint(
-        row_count=row_count,
-        max_id=max_id,
-        id_sum=id_sum,
-        used_percent_total=used_percent_total,
-        reset_at_total=reset_at_total,
-        window_minutes_sum=window_minutes_sum,
-        max_recorded_at=max_recorded_at,
-        content_digest=digest.hexdigest(),
-    )
 
 
 def _query_bulk_history_since_sqlite(
@@ -253,6 +177,53 @@ def _query_bulk_history_since_sqlite(
     return grouped
 
 
+def _query_bulk_history_metadata_sqlite(
+    conn: sqlite3.Connection,
+    account_ids: list[str],
+    window: str,
+    since: datetime,
+    *,
+    max_id: int | None = None,
+) -> _BulkHistoryCacheMetadata:
+    placeholders = ",".join("?" for _ in account_ids)
+    since_param = since.isoformat(sep=" ")
+    id_clause = ""
+    params: list[object]
+    if window == "primary":
+        window_clause = "coalesce(window, 'primary') = 'primary'"
+        params = [*account_ids, since_param]
+    else:
+        window_clause = "window = ?"
+        params = [*account_ids, window, since_param]
+    if max_id is not None:
+        id_clause = "and id <= ?"
+        params.append(max_id)
+    conn.create_aggregate("clb_bulk_history_digest", 6, cast(Any, _BulkHistoryDigestAggregate))
+    sql = f"""
+        select count(*),
+               coalesce(max(id), 0),
+               coalesce(
+                   clb_bulk_history_digest(id, account_id, used_percent, recorded_at, reset_at, window_minutes),
+                   ''
+               )
+        from (
+            select id, account_id, used_percent, recorded_at, reset_at, window_minutes
+            from usage_history
+            where account_id in ({placeholders})
+              and {window_clause}
+              and recorded_at >= ?
+              {id_clause}
+            order by id asc, account_id asc
+        )
+    """
+    row = conn.execute(sql, params).fetchone()
+    return _BulkHistoryCacheMetadata(
+        row_count=int(row[0]),
+        max_id=int(row[1]),
+        content_digest=str(row[2]),
+    )
+
+
 def _normalized_window_expr():
     return func.coalesce(UsageHistory.window, _PRIMARY_WINDOW_LITERAL)
 
@@ -261,6 +232,13 @@ def _window_clause(window: str | None):
     if not window or window == "primary":
         return _normalized_window_expr() == "primary"
     return UsageHistory.window == window
+
+
+def _sqlite_path_from_bind(bind) -> object | None:
+    bind_url = getattr(bind, "url", None)
+    if bind_url is not None:
+        return sqlite_db_path_from_url(str(bind_url))
+    return sqlite_db_path_from_url(get_settings().database_url)
 
 
 def _parse_sqlite_datetime(value) -> datetime:
@@ -283,6 +261,21 @@ def _usage_history_from_sqlite_row(row) -> UsageHistory:
         credits_has=bool(row[9]) if row[9] is not None else None,
         credits_unlimited=bool(row[10]) if row[10] is not None else None,
         credits_balance=float(row[11]) if row[11] is not None else None,
+    )
+
+
+def _additional_usage_history_from_sqlite_row(row) -> AdditionalUsageHistory:
+    return AdditionalUsageHistory(
+        id=int(row[0]),
+        account_id=str(row[1]),
+        quota_key=str(row[2]),
+        limit_name=str(row[3]),
+        metered_feature=str(row[4]),
+        window=str(row[5]),
+        used_percent=float(row[6]),
+        reset_at=int(row[7]) if row[7] is not None else None,
+        window_minutes=int(row[8]) if row[8] is not None else None,
+        recorded_at=_parse_sqlite_datetime(row[9]),
     )
 
 
@@ -331,6 +324,74 @@ def _latest_by_account_sqlite(
     return latest
 
 
+def _additional_scope_sqlite_clause(scope: AdditionalQuotaQueryScope) -> tuple[str, list[object]]:
+    quota_values = tuple(scope.quota_key_match_values or {scope.quota_key})
+    clauses = [f"quota_key in ({','.join('?' for _ in quota_values)})"]
+    params: list[object] = list(quota_values)
+    if scope.limit_name_match_values:
+        clauses.append(f"lower(limit_name) in ({','.join('?' for _ in scope.limit_name_match_values)})")
+        params.extend(scope.limit_name_match_values)
+    if scope.metered_feature_match_values:
+        clauses.append(f"lower(metered_feature) in ({','.join('?' for _ in scope.metered_feature_match_values)})")
+        params.extend(scope.metered_feature_match_values)
+    return f"({' or '.join(clauses)})", params
+
+
+def _additional_latest_by_account_sqlite(
+    db_path: str,
+    scope: AdditionalQuotaQueryScope,
+    window: str,
+    account_ids: list[str] | None,
+    since: datetime | None,
+) -> dict[str, AdditionalUsageHistory]:
+    scope_clause, scope_params = _additional_scope_sqlite_clause(scope)
+    account_filter = ""
+    account_params: list[object] = []
+    if account_ids is not None:
+        if not account_ids:
+            return {}
+        account_filter = f"and account_id in ({','.join('?' for _ in account_ids)})"
+        account_params = list(account_ids)
+    since_filter = ""
+    since_params: list[object] = []
+    if since is not None:
+        since_filter = "and recorded_at >= ?"
+        since_params = [since.isoformat(sep=" ")]
+
+    accounts_sql = f"""
+        select distinct account_id
+        from additional_usage_history
+        where {scope_clause}
+          and window = ?
+          {account_filter}
+          {since_filter}
+    """
+    latest_sql = f"""
+        select id, account_id, quota_key, limit_name, metered_feature, window,
+               used_percent, reset_at, window_minutes, recorded_at
+        from additional_usage_history
+        where account_id = ?
+          and {scope_clause}
+          and window = ?
+          {since_filter}
+        order by recorded_at desc, id desc
+        limit 1
+    """
+
+    latest: dict[str, AdditionalUsageHistory] = {}
+    with sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as conn:
+        conn.execute("PRAGMA query_only=ON")
+        conn.execute("PRAGMA busy_timeout=30000")
+        accounts_params = [*scope_params, window, *account_params, *since_params]
+        accounts = [str(row[0]) for row in conn.execute(accounts_sql, accounts_params)]
+        for account_id in accounts:
+            row = conn.execute(latest_sql, [account_id, *scope_params, window, *since_params]).fetchone()
+            if row is not None:
+                entry = _additional_usage_history_from_sqlite_row(row)
+                latest[entry.account_id] = entry
+    return latest
+
+
 def _bulk_history_since_sqlite(
     db_path: str,
     account_ids: list[str],
@@ -344,7 +405,26 @@ def _bulk_history_since_sqlite(
         with _BULK_HISTORY_SQLITE_CACHE_LOCK:
             cached = _BULK_HISTORY_SQLITE_CACHE.get(cache_key)
             if cached is not None and cached.since <= since:
-                current_fingerprint = _bulk_history_fingerprint_sqlite(conn, account_ids, window, cached.since)
+                metadata = _query_bulk_history_metadata_sqlite(
+                    conn,
+                    account_ids,
+                    window,
+                    cached.since,
+                    max_id=cached.max_id,
+                )
+                if metadata != cached.metadata:
+                    grouped = _query_bulk_history_since_sqlite(conn, account_ids, window, cached.since)
+                    cached.max_id = _max_snapshot_id(grouped)
+                    cached.metadata = _query_bulk_history_metadata_sqlite(
+                        conn,
+                        account_ids,
+                        window,
+                        cached.since,
+                        max_id=cached.max_id,
+                    )
+                    cached.rows_by_account = grouped
+                    return _clone_filtered_history(grouped, since)
+
                 new_rows = _query_bulk_history_since_sqlite(
                     conn,
                     account_ids,
@@ -352,25 +432,24 @@ def _bulk_history_since_sqlite(
                     cached.since,
                     after_id=cached.max_id,
                 )
-                candidate_rows = _merged_grouped_history(cached.rows_by_account, new_rows)
-                candidate_fingerprint = _fingerprint_grouped_history(candidate_rows)
-                if current_fingerprint != candidate_fingerprint:
-                    grouped = _query_bulk_history_since_sqlite(conn, account_ids, window, cached.since)
-                    cached.max_id = _max_snapshot_id(grouped)
-                    cached.fingerprint = _fingerprint_grouped_history(grouped)
-                    cached.rows_by_account = grouped
-                    return _clone_filtered_history(grouped, since)
                 if new_rows:
                     _append_grouped_history(cached.rows_by_account, new_rows)
                     cached.max_id = max(cached.max_id, _max_snapshot_id(new_rows))
-                    cached.fingerprint = current_fingerprint
+                    cached.metadata = _query_bulk_history_metadata_sqlite(
+                        conn,
+                        account_ids,
+                        window,
+                        cached.since,
+                        max_id=cached.max_id,
+                    )
                 return _clone_filtered_history(cached.rows_by_account, since)
 
             grouped = _query_bulk_history_since_sqlite(conn, account_ids, window, since)
+            max_id = _max_snapshot_id(grouped)
             _BULK_HISTORY_SQLITE_CACHE[cache_key] = _BulkHistoryCacheEntry(
                 since=since,
-                max_id=_max_snapshot_id(grouped),
-                fingerprint=_fingerprint_grouped_history(grouped),
+                max_id=max_id,
+                metadata=_query_bulk_history_metadata_sqlite(conn, account_ids, window, since, max_id=max_id),
                 rows_by_account=grouped,
             )
             return _clone_filtered_history(grouped, since)
@@ -562,7 +641,7 @@ class UsageRepository:
             conditions = and_(conditions, UsageHistory.account_id.in_(account_ids))
         bind = self._session.get_bind()
         dialect = bind.dialect.name if bind else "sqlite"
-        sqlite_path = sqlite_db_path_from_url(get_settings().database_url) if dialect == "sqlite" else None
+        sqlite_path = _sqlite_path_from_bind(bind) if dialect == "sqlite" else None
         if sqlite_path is not None:
             return await to_thread.run_sync(
                 _latest_by_account_sqlite,
@@ -642,7 +721,7 @@ class UsageRepository:
             return {}
         bind = self._session.get_bind()
         dialect = bind.dialect.name if bind else "sqlite"
-        sqlite_path = sqlite_db_path_from_url(get_settings().database_url) if dialect == "sqlite" else None
+        sqlite_path = _sqlite_path_from_bind(bind) if dialect == "sqlite" else None
         if sqlite_path is not None:
             return await to_thread.run_sync(
                 _bulk_history_since_sqlite,
@@ -694,8 +773,8 @@ class UsageRepository:
         if dialect == "postgresql":
             bucket_expr = func.floor(func.extract("epoch", UsageHistory.recorded_at) / bucket_seconds) * bucket_seconds
         else:
-            epoch_col = cast(func.strftime("%s", UsageHistory.recorded_at), Integer)
-            bucket_expr = cast(epoch_col / bucket_seconds, Integer) * bucket_seconds
+            epoch_col = sqlalchemy_cast(func.strftime("%s", UsageHistory.recorded_at), Integer)
+            bucket_expr = sqlalchemy_cast(epoch_col / bucket_seconds, Integer) * bucket_seconds
         bucket_col = bucket_expr.label("bucket_epoch")
 
         conditions: list = [UsageHistory.recorded_at >= since]
@@ -989,6 +1068,16 @@ class AdditionalUsageRepository:
             conditions.append(AdditionalUsageHistory.account_id.in_(account_ids))
         if since is not None:
             conditions.append(AdditionalUsageHistory.recorded_at >= since)
+        sqlite_path = _sqlite_path_from_bind(bind) if dialect == "sqlite" else None
+        if sqlite_path is not None:
+            return await to_thread.run_sync(
+                _additional_latest_by_account_sqlite,
+                str(sqlite_path),
+                scope,
+                window,
+                list(account_ids) if account_ids is not None else None,
+                since,
+            )
         if dialect == "postgresql":
             latest_rows = (
                 select(AdditionalUsageHistory)
@@ -1028,47 +1117,28 @@ class AdditionalUsageRepository:
                 _merge_latest_additional_usage_entries(entries, alias_result.scalars().all())
             return entries
 
-        latest_ids = (
+        subq = (
             select(
-                AdditionalUsageHistory.account_id.label("account_id"),
-                func.max(AdditionalUsageHistory.recorded_at).label("max_recorded_at"),
+                AdditionalUsageHistory.id.label("usage_id"),
+                func.row_number()
+                .over(
+                    partition_by=AdditionalUsageHistory.account_id,
+                    order_by=(
+                        AdditionalUsageHistory.recorded_at.desc(),
+                        AdditionalUsageHistory.used_percent.desc(),
+                        AdditionalUsageHistory.id.desc(),
+                    ),
+                )
+                .label("row_number"),
             )
             .where(*conditions)
-            .group_by(AdditionalUsageHistory.account_id)
-            .subquery("latest_additional_usage_recorded_at")
+            .subquery()
         )
-        latest_tie_breakers = (
-            select(
-                AdditionalUsageHistory.account_id.label("account_id"),
-                AdditionalUsageHistory.recorded_at.label("recorded_at"),
-                func.max(AdditionalUsageHistory.used_percent).label("max_used_percent"),
-            )
-            .join(
-                latest_ids,
-                and_(
-                    AdditionalUsageHistory.account_id == latest_ids.c.account_id,
-                    AdditionalUsageHistory.recorded_at == latest_ids.c.max_recorded_at,
-                ),
-            )
-            .where(*conditions)
-            .group_by(AdditionalUsageHistory.account_id, AdditionalUsageHistory.recorded_at)
-            .subquery("latest_additional_usage_tie_breakers")
+        stmt = (
+            select(AdditionalUsageHistory)
+            .join(subq, AdditionalUsageHistory.id == subq.c.usage_id)
+            .where(subq.c.row_number == 1)
         )
-        row_ids = (
-            select(func.max(AdditionalUsageHistory.id).label("usage_id"))
-            .join(
-                latest_tie_breakers,
-                and_(
-                    AdditionalUsageHistory.account_id == latest_tie_breakers.c.account_id,
-                    AdditionalUsageHistory.recorded_at == latest_tie_breakers.c.recorded_at,
-                    AdditionalUsageHistory.used_percent == latest_tie_breakers.c.max_used_percent,
-                ),
-            )
-            .where(*conditions)
-            .group_by(AdditionalUsageHistory.account_id)
-            .subquery("latest_additional_usage_ids")
-        )
-        stmt = select(AdditionalUsageHistory).join(row_ids, AdditionalUsageHistory.id == row_ids.c.usage_id)
         result = await self._session.execute(stmt)
         return {entry.account_id: entry for entry in result.scalars().all()}
 

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -55,6 +55,7 @@ class _BulkHistoryCacheEntry:
 
 _BULK_HISTORY_SQLITE_CACHE: dict[tuple[str, tuple[str, ...], str], _BulkHistoryCacheEntry] = {}
 _BULK_HISTORY_SQLITE_CACHE_LOCK = RLock()
+_EMPTY_BULK_HISTORY_DIGEST = sha256().hexdigest()
 
 
 def _normalized_sqlite_datetime_text(value) -> str:
@@ -235,7 +236,7 @@ def _query_bulk_history_metadata_sqlite(
                coalesce(max(id), 0),
                coalesce(
                    clb_bulk_history_digest(id, account_id, used_percent, recorded_at, reset_at, window_minutes),
-                   ''
+                   '{_EMPTY_BULK_HISTORY_DIGEST}'
                )
         from (
             select id, account_id, used_percent, recorded_at, reset_at, window_minutes

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -1126,6 +1126,14 @@ class AdditionalUsageRepository:
                 _merge_latest_additional_usage_entries(entries, alias_result.scalars().all())
             return entries
 
+        if dialect == "sqlite":
+            return await self._latest_by_scope_sqlite_probes(
+                scope,
+                window,
+                account_ids=account_ids,
+                since=since,
+            )
+
         subq = (
             select(
                 AdditionalUsageHistory.id.label("usage_id"),
@@ -1151,6 +1159,50 @@ class AdditionalUsageRepository:
         result = await self._session.execute(stmt)
         return {entry.account_id: entry for entry in result.scalars().all()}
 
+    async def _latest_by_scope_sqlite_probes(
+        self,
+        scope: AdditionalQuotaQueryScope,
+        window: str,
+        *,
+        account_ids: Collection[str] | None = None,
+        since: datetime | None = None,
+    ) -> dict[str, AdditionalUsageHistory]:
+        account_values = list(account_ids) if account_ids is not None else None
+        if account_values is not None and not account_values:
+            return {}
+        account_stmt = select(AdditionalUsageHistory.account_id).where(
+            _additional_quota_match_clause(scope),
+            AdditionalUsageHistory.window == window,
+        )
+        if account_values is not None:
+            account_stmt = account_stmt.where(AdditionalUsageHistory.account_id.in_(account_values))
+        if since is not None:
+            account_stmt = account_stmt.where(AdditionalUsageHistory.recorded_at >= since)
+        account_result = await self._session.execute(account_stmt.distinct())
+        latest: dict[str, AdditionalUsageHistory] = {}
+        for account_id in account_result.scalars().all():
+            latest_stmt = (
+                select(AdditionalUsageHistory)
+                .where(
+                    AdditionalUsageHistory.account_id == account_id,
+                    _additional_quota_match_clause(scope),
+                    AdditionalUsageHistory.window == window,
+                )
+                .order_by(
+                    AdditionalUsageHistory.recorded_at.desc(),
+                    AdditionalUsageHistory.used_percent.desc(),
+                    AdditionalUsageHistory.id.desc(),
+                )
+                .limit(1)
+            )
+            if since is not None:
+                latest_stmt = latest_stmt.where(AdditionalUsageHistory.recorded_at >= since)
+            row_result = await self._session.execute(latest_stmt)
+            entry = row_result.scalar_one_or_none()
+            if entry is not None:
+                latest[entry.account_id] = entry
+        return latest
+
     async def latest_by_quota_key(
         self,
         quota_key: str,
@@ -1165,41 +1217,12 @@ class AdditionalUsageRepository:
             scope = _resolve_additional_quota_query_scope(quota_key=quota_key)
             if scope is None:
                 raise ValueError("quota_key and window are required")
-            account_values = list(account_ids) if account_ids is not None else None
-            if account_values is not None and not account_values:
-                return {}
-            account_stmt = select(AdditionalUsageHistory.account_id).where(
-                _additional_quota_match_clause(scope),
-                AdditionalUsageHistory.window == window,
+            return await self._latest_by_scope_sqlite_probes(
+                scope,
+                window,
+                account_ids=account_ids,
+                since=since,
             )
-            if account_values is not None:
-                account_stmt = account_stmt.where(AdditionalUsageHistory.account_id.in_(account_values))
-            if since is not None:
-                account_stmt = account_stmt.where(AdditionalUsageHistory.recorded_at >= since)
-            account_result = await self._session.execute(account_stmt.distinct())
-            latest: dict[str, AdditionalUsageHistory] = {}
-            for account_id in account_result.scalars().all():
-                latest_stmt = (
-                    select(AdditionalUsageHistory)
-                    .where(
-                        AdditionalUsageHistory.account_id == account_id,
-                        _additional_quota_match_clause(scope),
-                        AdditionalUsageHistory.window == window,
-                    )
-                    .order_by(
-                        AdditionalUsageHistory.recorded_at.desc(),
-                        AdditionalUsageHistory.used_percent.desc(),
-                        AdditionalUsageHistory.id.desc(),
-                    )
-                    .limit(1)
-                )
-                if since is not None:
-                    latest_stmt = latest_stmt.where(AdditionalUsageHistory.recorded_at >= since)
-                row_result = await self._session.execute(latest_stmt)
-                entry = row_result.scalar_one_or_none()
-                if entry is not None:
-                    latest[entry.account_id] = entry
-            return latest
         return await self.latest_by_account(
             quota_key=quota_key,
             window=window,

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -57,6 +57,10 @@ _BULK_HISTORY_SQLITE_CACHE: dict[tuple[str, tuple[str, ...], str], _BulkHistoryC
 _BULK_HISTORY_SQLITE_CACHE_LOCK = RLock()
 
 
+def _normalized_sqlite_datetime_text(value) -> str:
+    return str(_parse_sqlite_datetime(value))
+
+
 class _BulkHistoryDigestAggregate:
     def __init__(self) -> None:
         self._digest = sha256()
@@ -79,7 +83,7 @@ class _BulkHistoryDigestAggregate:
         self._digest.update(b"\x1f")
         self._digest.update(float(used_percent).hex().encode("ascii"))
         self._digest.update(b"\x1f")
-        recorded_at_bytes = str(recorded_at).encode("utf-8")
+        recorded_at_bytes = _normalized_sqlite_datetime_text(recorded_at).encode("utf-8")
         self._digest.update(str(len(recorded_at_bytes)).encode("ascii"))
         self._digest.update(b":")
         self._digest.update(recorded_at_bytes)
@@ -1083,16 +1087,6 @@ class AdditionalUsageRepository:
             conditions.append(AdditionalUsageHistory.account_id.in_(account_ids))
         if since is not None:
             conditions.append(AdditionalUsageHistory.recorded_at >= since)
-        sqlite_path = _sqlite_path_from_bind(bind) if dialect == "sqlite" else None
-        if sqlite_path is not None:
-            return await to_thread.run_sync(
-                _additional_latest_by_account_sqlite,
-                str(sqlite_path),
-                scope,
-                window,
-                list(account_ids) if account_ids is not None else None,
-                since,
-            )
         if dialect == "postgresql":
             latest_rows = (
                 select(AdditionalUsageHistory)

--- a/openspec/changes/optimize-usage-history-cache/proposal.md
+++ b/openspec/changes/optimize-usage-history-cache/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+Large SQLite `usage_history` tables can make usage refresh and dashboard projection reads spike CPU. The latest-row path has already moved away from full-table window scans, but dashboard history caching still re-read and fingerprinted the entire cached window on every cache hit.
+
+## What Changes
+
+- Treat SQLite bulk usage-history cache entries as append-optimized snapshots.
+- On cache hits, fetch only rows with IDs newer than the cached max ID and append them to the cached grouped history.
+- Clear the cache from repository-owned account merge/delete paths that mutate existing usage-history rows.
+- Add a SQLite fast path for additional-usage latest-per-account reads so additional quota lookups avoid `row_number()` window scans.
+
+## Impact
+
+- SQLite dashboard projection reads over large usage history.
+- Additional quota latest-per-account reads on SQLite.
+- Account repository usage-history mutation paths.

--- a/openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md
@@ -40,7 +40,7 @@
 
 ### Requirement: Additional usage latest reads avoid SQLite window scans
 
-Additional usage latest-per-account reads on SQLite MUST avoid `row_number()` window-function scans over the full `additional_usage_history` table. They MUST select matching accounts, then use indexed latest-row lookups ordered by `recorded_at DESC, id DESC` while preserving canonical quota-key and alias matching semantics. Non-SQLite dialects MAY keep the set-based window-function query.
+Additional usage latest-per-account reads on SQLite MUST avoid `row_number()` window-function scans over the full `additional_usage_history` table. They MUST select matching accounts, then use indexed latest-row lookups ordered by `recorded_at DESC, used_percent DESC, id DESC` while preserving canonical quota-key and alias matching semantics. Non-SQLite dialects MAY keep the set-based window-function query.
 
 #### Scenario: SQLite additional usage latest lookup uses indexed account probes
 - **WHEN** additional usage latest rows are requested for a quota key, window, and optional account set on SQLite

--- a/openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard overview memoizes per-account depletion EWMA state
+
+`GET /api/dashboard/overview` MUST cache per-account EWMA depletion state in memory so repeated polls do not re-walk the full in-window `usage_history` slice in the depletion cache check when its content is unchanged. SQLite bulk history cache hits MUST avoid rebuilding or materializing the full cached history window when compact digest metadata proves older rows are unchanged; they MUST append newly inserted rows by monotonic row ID and reuse the cached grouped history for older rows. Repository-owned mutations that reassign or delete usage-history rows MUST clear the SQLite bulk history cache.
+
+#### Scenario: Repeated polls with unchanged history reuse cached EWMA state
+- **GIVEN** the dashboard service has previously computed depletion for an account
+- **AND** a subsequent request supplies the same in-window history slice for that account with the same attached compact content signature
+- **WHEN** depletion is recomputed for the dashboard response
+- **THEN** the service MUST reuse the cached EWMA state for that account instead of replaying every history row
+- **AND** the depletion metrics for that account MUST match the previously returned values for rate-bearing fields
+- **AND** the cache hit check MUST use bounded signature metadata rather than building or retaining a per-row signature tuple
+- **AND** the service MUST prune cached depletion state for account/window keys that are absent from the current dashboard history set
+
+#### Scenario: Memoized EWMA state is invalidated when a new usage row is appended
+- **WHEN** a later dashboard request supplies the same account's in-window history with an additional row appended (a new `recorded_at` past the previous latest)
+- **THEN** the service MUST rebuild the EWMA state from the new history slice
+- **AND** the recomputed rate MUST reflect the newly observed sample
+
+#### Scenario: Memoized EWMA state is invalidated when an older row ages out of the window
+- **WHEN** a later dashboard request supplies the same account's in-window history with the earliest row dropped (because it has aged past the window cutoff)
+- **THEN** the service MUST rebuild the EWMA state from the narrowed history slice
+- **AND** the cached state from the wider window MUST NOT influence the recomputed rate
+
+#### Scenario: Memoized EWMA state is invalidated when an existing usage row is corrected
+- **WHEN** a later dashboard request supplies the same account's in-window history with the same row count and endpoints but a corrected `used_percent`, `reset_at`, or `window_minutes` value on an existing row
+- **THEN** the service MUST rebuild the EWMA state from the corrected history slice
+- **AND** the recomputed rate-bearing metrics MUST reflect the corrected row content
+
+#### Scenario: SQLite bulk history cache hit appends only new rows
+- **GIVEN** a SQLite bulk usage-history query has already cached rows for an account/window set
+- **WHEN** a later query uses a narrower `since` timestamp and the database only has new rows with IDs greater than the cached max ID
+- **THEN** the repository fetches the new rows and appends them to the cached grouped history
+- **AND** it does not materialize the older cached rows as snapshots when compact digest metadata proves they are unchanged
+
+#### Scenario: Usage-history ownership mutation clears SQLite bulk history cache
+- **WHEN** an account merge or delete operation updates or deletes `usage_history` rows
+- **THEN** the repository clears the SQLite bulk history cache before serving future cached dashboard history reads
+
+### Requirement: Additional usage latest reads avoid SQLite window scans
+
+Additional usage latest-per-account reads on SQLite MUST avoid `row_number()` window-function scans over the full `additional_usage_history` table. They MUST select matching accounts, then use indexed latest-row lookups ordered by `recorded_at DESC, id DESC` while preserving canonical quota-key and alias matching semantics. Non-SQLite dialects MAY keep the set-based window-function query.
+
+#### Scenario: SQLite additional usage latest lookup uses indexed account probes
+- **WHEN** additional usage latest rows are requested for a quota key, window, and optional account set on SQLite
+- **THEN** the repository returns the same latest row per account as the set-based query
+- **AND** the SQLite path does not emit a `row_number()` window-function query

--- a/openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md
@@ -1,4 +1,4 @@
-## MODIFIED Requirements
+## ADDED Requirements
 
 ### Requirement: Dashboard overview memoizes per-account depletion EWMA state
 

--- a/openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: Dashboard overview memoizes per-account depletion EWMA state
 
@@ -37,6 +37,8 @@
 #### Scenario: Usage-history ownership mutation clears SQLite bulk history cache
 - **WHEN** an account merge or delete operation updates or deletes `usage_history` rows
 - **THEN** the repository clears the SQLite bulk history cache before serving future cached dashboard history reads
+
+## ADDED Requirements
 
 ### Requirement: Additional usage latest reads avoid SQLite window scans
 

--- a/openspec/changes/optimize-usage-history-cache/tasks.md
+++ b/openspec/changes/optimize-usage-history-cache/tasks.md
@@ -1,0 +1,16 @@
+## 1. Usage history cache
+
+- [x] 1.1 Remove full-window SQLite fingerprinting from bulk history cache hits.
+- [x] 1.2 Append only new rows with IDs greater than the cached max ID.
+- [x] 1.3 Clear the cache when account merge/delete paths mutate usage-history ownership.
+
+## 2. Additional usage latest reads
+
+- [x] 2.1 Add a SQLite fast path for latest additional-usage row per account.
+- [x] 2.2 Preserve canonical quota-key and alias matching semantics.
+
+## 3. Verification
+
+- [x] 3.1 Add/update integration tests for bulk-history cache append and explicit invalidation.
+- [x] 3.2 Add SQLite SQL-shape coverage for additional latest reads.
+- [x] 3.3 Run focused repository tests and static checks.

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -591,6 +591,40 @@ async def test_accounts_identity_duplicate_merge_clears_usage_cache_after_commit
 
 
 @pytest.mark.asyncio
+async def test_accounts_delete_clears_usage_cache_after_commit(db_setup, monkeypatch):
+    clear_transaction_states: list[bool] = []
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_make_account("acc_delete_cache", "delete-cache@example.com"), merge_by_email=False)
+        session.add(
+            UsageHistory(
+                account_id="acc_delete_cache",
+                used_percent=55.0,
+                window="primary",
+                recorded_at=utcnow(),
+            )
+        )
+        await session.commit()
+
+        def record_cache_clear() -> None:
+            clear_transaction_states.append(session.in_transaction())
+
+        monkeypatch.setattr(accounts_repository_module, "_clear_bulk_history_since_sqlite_cache", record_cache_clear)
+
+        deleted = await repo.delete("acc_delete_cache")
+        remaining = (
+            (await session.execute(select(UsageHistory).where(UsageHistory.account_id == "acc_delete_cache")))
+            .scalars()
+            .all()
+        )
+
+    assert deleted is True
+    assert remaining == []
+    assert clear_transaction_states == [False]
+
+
+@pytest.mark.asyncio
 async def test_accounts_upsert_merge_by_chatgpt_identity_does_not_clear_workspace_on_workspace_less_reauth(db_setup):
     async with SessionLocal() as session:
         repo = AccountsRepository(session)

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -22,6 +22,7 @@ from app.db.models import (
     UsageHistory,
 )
 from app.db.session import SessionLocal
+from app.modules.accounts import repository as accounts_repository_module
 from app.modules.accounts.repository import (
     AccountIdentityConflictError,
     AccountsRepository,
@@ -547,6 +548,46 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_picks_oldest_canonical(
         )
         assert len(rows) == 1
         assert rows[0].id == "acc_first"
+
+
+@pytest.mark.asyncio
+async def test_accounts_identity_duplicate_merge_clears_usage_cache_after_commit(db_setup, monkeypatch):
+    clear_transaction_states: list[bool] = []
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        canonical = _make_account_with_chatgpt_id("acc_cache_canonical", "cache@example.com", "chatgpt_cache")
+        canonical.created_at = utcnow() - timedelta(days=30)
+        await repo.upsert(canonical, merge_by_email=False)
+
+        duplicate = _make_account_with_chatgpt_id("acc_cache_duplicate", "cache@example.com", "chatgpt_cache")
+        duplicate.created_at = utcnow()
+        await repo.upsert(duplicate, merge_by_email=False)
+        session.add(
+            UsageHistory(
+                account_id="acc_cache_duplicate",
+                used_percent=77.0,
+                window="primary",
+                recorded_at=utcnow(),
+            )
+        )
+        await session.commit()
+
+        def record_cache_clear() -> None:
+            clear_transaction_states.append(session.in_transaction())
+
+        monkeypatch.setattr(accounts_repository_module, "_clear_bulk_history_since_sqlite_cache", record_cache_clear)
+
+        reauth = _make_account_with_chatgpt_id("acc_cache_canonical", "cache@example.com", "chatgpt_cache")
+        saved = await repo.upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        assert saved.id == "acc_cache_canonical"
+        moved = (
+            await session.execute(select(UsageHistory).where(UsageHistory.account_id == "acc_cache_canonical"))
+        ).scalar_one()
+        assert moved.used_percent == 77.0
+
+    assert clear_transaction_states == [False]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -14,12 +14,10 @@ from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal, engine
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.usage.repository import (
-    UsageHistorySnapshot,
+    AdditionalUsageRepository,
     UsageRepository,
-    _bulk_history_fingerprint_sqlite,
     _bulk_history_since_sqlite,
     _clear_bulk_history_since_sqlite_cache,
-    _fingerprint_grouped_history,
 )
 
 pytestmark = pytest.mark.integration
@@ -149,6 +147,64 @@ async def test_latest_by_account_sqlite_avoids_window_function_for_latest_rows(d
             event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
 
     assert set(latest.keys()) == {"acc1", "acc2"}
+    emitted_sql = "\n".join(statements).lower()
+    assert "row_number" not in emitted_sql
+    assert " over " not in emitted_sql
+
+
+@pytest.mark.asyncio
+async def test_additional_latest_by_account_sqlite_avoids_window_function_for_latest_rows(db_setup):
+    now = utcnow()
+    statements: list[str] = []
+
+    def capture_statement(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    async with SessionLocal() as session:
+        if _dialect_name(session) != "sqlite":
+            pytest.skip("SQLite-only SQL shape test")
+
+        accounts_repo = AccountsRepository(session)
+        repo = AdditionalUsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc1"))
+        await accounts_repo.upsert(_make_account("acc2"))
+        await repo.add_entry(
+            "acc1",
+            limit_name="GPT-5.3-Codex-Spark",
+            metered_feature="codex_bengalfox",
+            quota_key="codex_spark",
+            window="primary",
+            used_percent=10.0,
+            recorded_at=now - timedelta(hours=1),
+        )
+        await repo.add_entry(
+            "acc1",
+            limit_name="GPT-5.3-Codex-Spark",
+            metered_feature="codex_bengalfox",
+            quota_key="codex_spark",
+            window="primary",
+            used_percent=20.0,
+            recorded_at=now,
+        )
+        await repo.add_entry(
+            "acc2",
+            limit_name="GPT-5.3-Codex-Spark",
+            metered_feature="codex_bengalfox",
+            quota_key="codex_spark",
+            window="primary",
+            used_percent=30.0,
+            recorded_at=now,
+        )
+
+        event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+        try:
+            latest = await repo.latest_by_account("codex_spark", "primary")
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    assert set(latest.keys()) == {"acc1", "acc2"}
+    assert latest["acc1"].used_percent == 20.0
+    assert latest["acc2"].used_percent == 30.0
     emitted_sql = "\n".join(statements).lower()
     assert "row_number" not in emitted_sql
     assert " over " not in emitted_sql
@@ -339,7 +395,275 @@ def test_bulk_history_since_sqlite_cache_reuses_superset_and_picks_up_appends(tm
     _clear_bulk_history_since_sqlite_cache()
 
 
-def test_bulk_history_since_sqlite_cache_rebuilds_after_delete_and_id_reuse(tmp_path):
+def test_bulk_history_since_sqlite_cache_hit_does_not_materialize_cached_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "usage.db"
+    statements: list[str] = []
+    original_connect = sqlite3.connect
+
+    def connect_with_trace(*args, **kwargs):
+        conn = original_connect(*args, **kwargs)
+        conn.set_trace_callback(lambda statement: statements.append(" ".join(statement.lower().split())))
+        return conn
+
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.executemany(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, "acc1", 10.0, "2026-01-01 00:00:00", 1000.0, 10080, "secondary"),
+                (2, "acc1", 20.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
+            ],
+        )
+        conn.commit()
+
+    _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+    monkeypatch.setattr(sqlite3, "connect", connect_with_trace)
+    second = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 1, 0),
+    )
+
+    assert [row.id for row in second["acc1"]] == [2]
+    cached_window_scans = [
+        statement
+        for statement in statements
+        if "select id, account_id, used_percent, recorded_at, reset_at, window_minutes" in statement
+        and "id <= ?" in statement
+    ]
+    assert cached_window_scans == []
+
+    _clear_bulk_history_since_sqlite_cache()
+
+
+def test_bulk_history_since_sqlite_cache_detects_same_id_corrections(tmp_path):
+    db_path = tmp_path / "usage.db"
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.executemany(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, "acc1", 10.0, "2026-01-01 00:00:00", 1000.0, 10080, "secondary"),
+                (2, "acc1", 20.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
+            ],
+        )
+        conn.commit()
+
+    first = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+    assert [row.used_percent for row in first["acc1"]] == [10.0, 20.0]
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """
+            update usage_history
+            set used_percent = ?,
+                reset_at = ?,
+                window_minutes = ?
+            where id = ?
+            """,
+            [
+                (15.0, 1000.0, 10080, 1),
+                (15.0, 2000.0, 432000, 2),
+            ],
+        )
+        conn.commit()
+
+    second = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+    assert [row.id for row in second["acc1"]] == [1, 2]
+    assert [row.used_percent for row in second["acc1"]] == [15.0, 15.0]
+    assert second["acc1"][1].reset_at == 2000.0
+    assert second["acc1"][1].window_minutes == 432000
+
+    _clear_bulk_history_since_sqlite_cache()
+
+
+def test_bulk_history_since_sqlite_cache_detects_offsetting_corrections(tmp_path):
+    db_path = tmp_path / "usage.db"
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.executemany(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, "acc1", 10.0, "2026-01-01 00:00:00", 1000.0, 10080, "secondary"),
+                (2, "acc1", 20.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
+                (3, "acc1", 30.0, "2026-01-01 00:02:00", 1000.0, 10080, "secondary"),
+            ],
+        )
+        conn.commit()
+
+    first = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+    assert [row.used_percent for row in first["acc1"]] == [10.0, 20.0, 30.0]
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """
+            update usage_history
+            set used_percent = ?
+            where id = ?
+            """,
+            [
+                (11.0, 1),
+                (18.0, 2),
+                (31.0, 3),
+            ],
+        )
+        conn.commit()
+
+    second = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+    assert [row.used_percent for row in second["acc1"]] == [11.0, 18.0, 31.0]
+
+    _clear_bulk_history_since_sqlite_cache()
+
+
+def test_bulk_history_since_sqlite_cache_detects_second_moment_collision_corrections(tmp_path):
+    db_path = tmp_path / "usage.db"
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.executemany(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (1, "acc1", 10.0, "2026-01-01 00:00:00", 1000.0, 10080, "secondary"),
+                (2, "acc1", 20.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
+                (3, "acc1", 30.0, "2026-01-01 00:02:00", 1000.0, 10080, "secondary"),
+                (4, "acc1", 40.0, "2026-01-01 00:03:00", 1000.0, 10080, "secondary"),
+            ],
+        )
+        conn.commit()
+
+    first = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+    assert [row.used_percent for row in first["acc1"]] == [10.0, 20.0, 30.0, 40.0]
+
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """
+            update usage_history
+            set used_percent = ?
+            where id = ?
+            """,
+            [
+                (11.0, 1),
+                (17.0, 2),
+                (33.0, 3),
+                (39.0, 4),
+            ],
+        )
+        conn.commit()
+
+    second = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+    assert [row.used_percent for row in second["acc1"]] == [11.0, 17.0, 33.0, 39.0]
+
+    _clear_bulk_history_since_sqlite_cache()
+
+
+def test_bulk_history_since_sqlite_cache_detects_external_delete_and_id_reuse(tmp_path):
     db_path = tmp_path / "usage.db"
     _clear_bulk_history_since_sqlite_cache()
     with sqlite3.connect(db_path) as conn:
@@ -401,110 +725,17 @@ def test_bulk_history_since_sqlite_cache_rebuilds_after_delete_and_id_reuse(tmp_
 
     _clear_bulk_history_since_sqlite_cache()
 
-
-def test_bulk_history_since_sqlite_cache_rebuilds_after_offsetting_row_corrections(tmp_path):
-    db_path = tmp_path / "usage.db"
-    _clear_bulk_history_since_sqlite_cache()
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            """
-            create table usage_history (
-                id integer primary key,
-                account_id text not null,
-                used_percent real not null,
-                recorded_at text not null,
-                reset_at real,
-                window_minutes integer,
-                window text
-            )
-            """
-        )
-        conn.executemany(
-            """
-            insert into usage_history
-                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
-            values (?, ?, ?, ?, ?, ?, ?)
-            """,
-            [
-                (1, "acc1", 10.0, "2026-01-01 00:00:00", 1000.0, 10080, "secondary"),
-                (2, "acc1", 20.0, "2026-01-01 00:01:00", 1000.0, 10080, "secondary"),
-            ],
-        )
-        conn.commit()
-
-    first = _bulk_history_since_sqlite(
-        str(db_path),
-        ["acc1"],
-        "secondary",
-        datetime(2026, 1, 1, 0, 0, 0),
-    )
-    assert [row.used_percent for row in first["acc1"]] == [10.0, 20.0]
-
-    with sqlite3.connect(db_path) as conn:
-        conn.execute("update usage_history set used_percent = 15.0 where id = 1")
-        conn.execute("update usage_history set used_percent = 15.0 where id = 2")
-        conn.commit()
-
-    second = _bulk_history_since_sqlite(
+    third = _bulk_history_since_sqlite(
         str(db_path),
         ["acc1"],
         "secondary",
         datetime(2026, 1, 1, 0, 0, 0),
     )
 
-    assert [row.used_percent for row in second["acc1"]] == [15.0, 15.0]
+    assert [row.id for row in third["acc1"]] == [1]
+    assert [row.used_percent for row in third["acc1"]] == [75.0]
 
     _clear_bulk_history_since_sqlite_cache()
-
-
-def test_bulk_history_sqlite_fingerprint_normalizes_recorded_at_text(tmp_path):
-    db_path = tmp_path / "usage.db"
-    with sqlite3.connect(db_path) as conn:
-        conn.execute(
-            """
-            create table usage_history (
-                id integer primary key,
-                account_id text not null,
-                used_percent real not null,
-                recorded_at text not null,
-                reset_at real,
-                window_minutes integer,
-                window text
-            )
-            """
-        )
-        conn.execute(
-            """
-            insert into usage_history
-                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
-            values (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (1, "acc1", 10.0, "2026-01-01 00:00:00.000000", 1000.0, 10080, "secondary"),
-        )
-        conn.commit()
-
-    grouped = {
-        "acc1": [
-            UsageHistorySnapshot(
-                id=1,
-                account_id="acc1",
-                used_percent=10.0,
-                recorded_at=datetime(2026, 1, 1, 0, 0, 0),
-                reset_at=1000.0,
-                window_minutes=10080,
-            )
-        ]
-    }
-
-    with sqlite3.connect(db_path) as conn:
-        sqlite_fingerprint = _bulk_history_fingerprint_sqlite(
-            conn,
-            ["acc1"],
-            "secondary",
-            datetime(2026, 1, 1, 0, 0, 0),
-        )
-
-    assert sqlite_fingerprint == _fingerprint_grouped_history(grouped)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -460,6 +460,62 @@ def test_bulk_history_since_sqlite_cache_hit_does_not_materialize_cached_rows(tm
     _clear_bulk_history_since_sqlite_cache()
 
 
+def test_bulk_history_since_sqlite_empty_cache_hit_does_not_materialize_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "usage.db"
+    statements: list[str] = []
+    original_connect = sqlite3.connect
+
+    def connect_with_trace(*args, **kwargs):
+        conn = original_connect(*args, **kwargs)
+        conn.set_trace_callback(lambda statement: statements.append(" ".join(statement.lower().split())))
+        return conn
+
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.commit()
+
+    first = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc_empty"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+    assert first == {}
+
+    monkeypatch.setattr(sqlite3, "connect", connect_with_trace)
+    second = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc_empty"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 1, 0),
+    )
+
+    assert second == {}
+    full_history_refreshes = [
+        statement
+        for statement in statements
+        if "select id, account_id, used_percent, recorded_at, reset_at, window_minutes" in statement
+        and "order by account_id, recorded_at asc" in statement
+        and "id > 0" not in statement
+    ]
+    assert full_history_refreshes == []
+
+    _clear_bulk_history_since_sqlite_cache()
+
+
 def test_bulk_history_since_sqlite_cache_detects_same_id_corrections(tmp_path):
     db_path = tmp_path / "usage.db"
     _clear_bulk_history_since_sqlite_cache()

--- a/tests/unit/test_additional_usage_repo.py
+++ b/tests/unit/test_additional_usage_repo.py
@@ -318,6 +318,59 @@ async def test_latest_by_account_merges_alias_rows_conservatively(
 
 
 @pytest.mark.asyncio
+async def test_latest_by_account_sqlite_fast_path_uses_depletion_tie_breaker(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "additional_quota_registry.json"
+    _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
+    monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    clear_additional_quota_registry_cache()
+
+    db_path = tmp_path / "usage.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with async_session_factory() as session:
+        repo = AdditionalUsageRepository(session)
+        now = datetime.now(tz=timezone.utc)
+
+        session.add_all(
+            [
+                AdditionalUsageHistory(
+                    account_id="acc_sqlite_tie",
+                    quota_key="codex_spark",
+                    limit_name="codex_other",
+                    metered_feature="codex_bengalfox",
+                    window="primary",
+                    used_percent=92.0,
+                    recorded_at=now,
+                ),
+                AdditionalUsageHistory(
+                    account_id="acc_sqlite_tie",
+                    quota_key="spark_enterprise",
+                    limit_name="GPT-5.3-Codex-Spark",
+                    metered_feature="codex_bengalfox",
+                    window="primary",
+                    used_percent=40.0,
+                    recorded_at=now,
+                ),
+            ]
+        )
+        await session.commit()
+
+        result = await repo.latest_by_account(quota_key="spark_enterprise", window="primary")
+
+    await engine.dispose()
+
+    assert list(result) == ["acc_sqlite_tie"]
+    assert result["acc_sqlite_tie"].quota_key == "codex_spark"
+    assert result["acc_sqlite_tie"].used_percent == 92.0
+
+
+@pytest.mark.asyncio
 async def test_latest_by_account_prefers_newer_alias_row_after_reset(
     async_session: AsyncSession,
     monkeypatch,

--- a/tests/unit/test_additional_usage_repo.py
+++ b/tests/unit/test_additional_usage_repo.py
@@ -371,6 +371,59 @@ async def test_latest_by_account_sqlite_fast_path_uses_depletion_tie_breaker(
 
 
 @pytest.mark.asyncio
+async def test_latest_by_account_sqlite_fast_path_preserves_newer_raw_alias(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    registry = tmp_path / "additional_quota_registry.json"
+    _write_registry(registry, quota_key="spark_enterprise", quota_key_aliases=["codex_spark"])
+    monkeypatch.setenv("CODEX_LB_ADDITIONAL_QUOTA_REGISTRY_FILE", str(registry))
+    clear_additional_quota_registry_cache()
+
+    db_path = tmp_path / "usage.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with async_session_factory() as session:
+        repo = AdditionalUsageRepository(session)
+        now = datetime.now(tz=timezone.utc)
+
+        session.add_all(
+            [
+                AdditionalUsageHistory(
+                    account_id="acc_sqlite_raw_alias",
+                    quota_key="spark_enterprise",
+                    limit_name="GPT-5.3-Codex-Spark",
+                    metered_feature="codex_bengalfox",
+                    window="primary",
+                    used_percent=88.0,
+                    recorded_at=now - timedelta(seconds=10),
+                ),
+                AdditionalUsageHistory(
+                    account_id="acc_sqlite_raw_alias",
+                    quota_key="codex_spark",
+                    limit_name="codex_other",
+                    metered_feature="codex_bengalfox",
+                    window="primary",
+                    used_percent=12.0,
+                    recorded_at=now,
+                ),
+            ]
+        )
+        await session.commit()
+
+        result = await repo.latest_by_account(quota_key="spark_enterprise", window="primary")
+
+    await engine.dispose()
+
+    assert list(result) == ["acc_sqlite_raw_alias"]
+    assert result["acc_sqlite_raw_alias"].quota_key == "codex_spark"
+    assert result["acc_sqlite_raw_alias"].used_percent == 12.0
+
+
+@pytest.mark.asyncio
 async def test_latest_by_account_prefers_newer_alias_row_after_reset(
     async_session: AsyncSession,
     monkeypatch,


### PR DESCRIPTION
## Summary

- Avoid re-reading/fingerprinting the full cached SQLite usage-history window on dashboard bulk-history cache hits; append only rows newer than the cached max ID.
- Keep compact SQLite aggregate metadata for the cached row range so same-ID corrections, deletes, and ID reuse invalidate stale cached history before dashboard depletion state is reused.
- Clear the SQLite bulk-history cache when account merge/delete paths mutate `usage_history` ownership.
- Add a SQLite fast path for additional-usage latest-per-account reads so additional quota lookups avoid `row_number()` window scans while preserving the depletion tie-breaker for same-timestamp rows.
- Avoid concurrent usage-history reads on one SQLAlchemy `AsyncSession`, fixing the PostgreSQL sticky-session fallback case when a pinned account is rate-limited.

Mitigates #708.

## Maintainer Update

- Rebased onto current `main`; current head is `629a2aba0a67f99c7508ad91f217f81b33b3ead6`.
- This PR no longer carries PostgreSQL CI narrowing changes; #899 remains the dedicated PR for that CI-only work.
- The branch contains the usage-cache/proxy behavior and its tests/spec, plus a current-head Codex follow-up that makes the SQLite additional-usage fast path match the SQLAlchemy ordering: `recorded_at desc, used_percent desc, id desc`.

## Validation

```bash
uv run openspec validate optimize-usage-history-cache --strict
uv run pytest tests/unit/test_additional_usage_repo.py::test_latest_by_account_sqlite_fast_path_uses_depletion_tie_breaker tests/unit/test_additional_usage_repo.py::test_latest_by_account_merges_alias_rows_conservatively -q
uv run pytest tests/integration/test_usage_repository.py tests/unit/test_additional_usage_repo.py -q
uv run pytest tests/integration/test_proxy_sticky_sessions.py::test_proxy_sticky_switches_when_pinned_rate_limited -q
uv run ruff check app/modules/usage/repository.py app/modules/accounts/repository.py app/modules/proxy/load_balancer.py tests/integration/test_usage_repository.py tests/unit/test_additional_usage_repo.py
uv run ruff check app/modules/usage/repository.py tests/unit/test_additional_usage_repo.py
uv run ty check app/modules/usage app/modules/accounts app/modules/proxy/load_balancer.py
uv run ty check app/modules/usage/repository.py tests/unit/test_additional_usage_repo.py
```

---

## Maintainer Refresh - 2026-06-30

# PR #902 Refresh Verification

## Strategy

- Strategy used: `git rebase origin/main`
- Rationale: the PR had three commits on an old base and no upstream configured; rebasing kept the existing PR history linear and maintainer-friendly.
- Original PR head before refresh: `6ef31e9d5c88baa7243fae1dc3c564e7e7f0e68e`
- New base: `origin/main` at `70576a1eeedc8f41b52548714391ba11167c1f93`
- Final branch head: `88d6e794eb2c369705469b25434eb7c27458f895`

## Conflicts Resolved

- `app/modules/usage/repository.py`
  - Conflict occurred while replaying `c9056402 perf(usage): avoid repeated history cache scans`.
  - Resolution preserved current `origin/main` PostgreSQL additional-usage canonical query plus raw-alias fallback.
  - Resolution preserved the PR SQLite fast path for additional latest-per-account reads.
  - Resolution kept the generic non-SQLite window-function fallback.

## Files Changed By This Refresh

- Rebased PR changes retained:
  - `app/modules/accounts/repository.py`
  - `app/modules/usage/repository.py`
  - `openspec/changes/optimize-usage-history-cache/proposal.md`
  - `openspec/changes/optimize-usage-history-cache/specs/query-caching/spec.md`
  - `openspec/changes/optimize-usage-history-cache/tasks.md`
  - `tests/integration/test_usage_repository.py`
  - `tests/unit/test_additional_usage_repo.py`
- Additional refresh commit added:
  - `tests/unit/test_additional_usage_repo.py`
    - Added `test_latest_by_account_sqlite_fast_path_preserves_newer_raw_alias` for the critical canonical-older/raw-alias-newer SQLite fast-path case.

## Commands Run

- `git status --short --branch`
  - Pass: clean before rebase on `fix/usage-history-cache-708`; clean after final commit.
- `git fetch origin main`
  - Pass: fetched `origin/main`.
- `uv run openspec status --change optimize-usage-history-cache --json`
  - Pass: change exists; 8/8 tasks complete.
- `uv run openspec instructions apply --change optimize-usage-history-cache --json`
  - Pass: change state `all_done`.
- `git rev-parse HEAD origin/main FETCH_HEAD`
  - Pass: confirmed original head, `origin/main`, and fetched head.
- `git merge-base HEAD origin/main`
  - Pass: old merge base was `2830b7d51956872795f2ebbdeff08cb67fe5a3c9`.
- `git log --oneline --left-right --cherry-pick HEAD...origin/main | sed -n '1,120p'`
  - Pass: confirmed branch had three unique PR commits and `origin/main` had advanced.
- `git diff --stat origin/main...HEAD`
  - Pass: reviewed stale PR diff before rebase.
- `git rebase origin/main`
  - Pass after one conflict resolution in `app/modules/usage/repository.py`.
- `rg -n "<<<<<<<|=======|>>>>>>>" app/modules/usage/repository.py`
  - Pass: no conflict markers after resolution.
- `uv run python -m py_compile app/modules/usage/repository.py`
  - Pass: resolved file compiled.
- `git diff --check`
  - Pass: no whitespace/conflict-marker issues.
- `GIT_EDITOR=true git rebase --continue`
  - Pass: rebase completed and updated `fix/usage-history-cache-708`.
- `uv run pytest tests/unit/test_additional_usage_repo.py::test_latest_by_account_sqlite_fast_path_preserves_newer_raw_alias -q`
  - Pass: `1 passed in 0.46s`.
- `uv run openspec validate optimize-usage-history-cache --strict`
  - Pass: `Change 'optimize-usage-history-cache' is valid`.
- `uv run openspec validate --specs`
  - Pass: `30 passed, 0 failed`.
- `uv run ruff check app/modules/usage/repository.py app/modules/accounts/repository.py app/modules/proxy/load_balancer.py tests/integration/test_usage_repository.py tests/unit/test_additional_usage_repo.py`
  - Pass: `All checks passed!`.
- `uv run pytest tests/unit/test_additional_usage_repo.py tests/integration/test_usage_repository.py tests/integration/test_proxy_sticky_sessions.py::test_proxy_sticky_switches_when_pinned_rate_limited -q`
  - Pass: `45 passed, 1 skipped in 4.39s`.
  - Skip: `tests/integration/test_usage_repository.py:304` PostgreSQL-only query plan test.
- `uv run ty check app/modules/usage app/modules/accounts app/modules/proxy/load_balancer.py`
  - Pass: `All checks passed!`.
- `for f in app/modules/usage/repository.py app/modules/accounts/repository.py tests/integration/test_usage_repository.py tests/unit/test_additional_usage_repo.py; do printf '%s ' "$f"; awk '!/^[[:space:]]*$/ && !/^[[:space:]]*(#|\\/\\/|--)/' "$f" | wc -l; done`
  - Pass: measured touched source/test file sizes.
  - Results: `app/modules/usage/repository.py 1134`, `app/modules/accounts/repository.py 778`, `tests/integration/test_usage_repository.py 719`, `tests/unit/test_additional_usage_repo.py 915`.
- `git commit -m "test(usage): cover sqlite latest raw aliases"`
  - Pass: created `88d6e794eb2c369705469b25434eb7c27458f895`.

## Final Commits On Branch

- `88d6e794 test(usage): cover sqlite latest raw aliases`
- `d732664d docs(usage): align cache spec tie-breaker`
- `a8144b44 fix(usage): preserve sqlite depletion tie-breaker`
- `57af7adc perf(usage): avoid repeated history cache scans`

## Remaining Blockers

- None found locally.
- Not pushed.