### PR TITLE
fix(proxy): bypass HTTP bridge for input images

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1846,6 +1846,11 @@ async def _inline_input_image_urls(
         if not isinstance(item, dict):
             updated_input.append(item)
             continue
+        if item.get("type") == "input_image":
+            updated_item, item_changed = await _inline_content_images(item, session, connect_timeout)
+            updated_input.append(updated_item)
+            changed = changed or item_changed
+            continue
         content = item.get("content")
         updated_content, content_changed = await _inline_content_images(content, session, connect_timeout)
         if content_changed:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -185,6 +185,41 @@ def extract_input_file_ids(input_value: JsonValue) -> set[str]:
     return file_ids
 
 
+def _append_input_image_file_references(
+    references: list[InputImageFileReference],
+    value: JsonValue,
+    *,
+    item_index: int,
+    content_index: int | None,
+) -> None:
+    if is_json_mapping(value):
+        file_id = _input_image_file_reference(value)
+        if file_id is not None:
+            references.append(
+                InputImageFileReference(
+                    item_index=item_index,
+                    content_index=content_index,
+                    file_id=file_id,
+                )
+            )
+        for child in value.values():
+            _append_input_image_file_references(
+                references,
+                child,
+                item_index=item_index,
+                content_index=content_index,
+            )
+        return
+    if is_json_list(value):
+        for child in value:
+            _append_input_image_file_references(
+                references,
+                child,
+                item_index=item_index,
+                content_index=content_index,
+            )
+
+
 def extract_input_image_file_references(input_value: JsonValue) -> list[InputImageFileReference]:
     if not is_json_list(input_value):
         return []
@@ -210,17 +245,19 @@ def extract_input_image_file_references(input_value: JsonValue) -> list[InputIma
         else:
             parts = []
         for content_index, part in enumerate(parts):
-            if not is_json_mapping(part):
-                continue
-            file_id = _input_image_file_reference(part)
-            if file_id is not None:
-                references.append(
-                    InputImageFileReference(
-                        item_index=item_index,
-                        content_index=content_index,
-                        file_id=file_id,
-                    )
-                )
+            _append_input_image_file_references(
+                references,
+                part,
+                item_index=item_index,
+                content_index=content_index,
+            )
+        output = item_mapping.get("output")
+        _append_input_image_file_references(
+            references,
+            output,
+            item_index=item_index,
+            content_index=None,
+        )
     return references
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -539,6 +539,28 @@ def _fingerprint_input_items(items: Sequence[JsonValue]) -> str:
     return sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _input_part_is_image(part: JsonValue) -> bool:
+    return is_json_mapping(part) and part.get("type") == "input_image"
+
+
+def _json_value_contains_input_image_part(value: JsonValue) -> bool:
+    if _input_part_is_image(value):
+        return True
+    if isinstance(value, list):
+        return any(_json_value_contains_input_image_part(item) for item in value)
+    if is_json_mapping(value):
+        return any(_json_value_contains_input_image_part(child) for child in value.values())
+    return False
+
+
+def _responses_request_contains_input_image(payload: ResponsesRequest) -> bool:
+    """Return whether a Responses request carries any ``input_image`` part."""
+    input_value = payload.input
+    if not isinstance(input_value, list):
+        return False
+    return any(_json_value_contains_input_image_part(item) for item in input_value)
+
+
 def _response_create_text(
     payload: ResponsesRequest,
     *,
@@ -796,6 +818,14 @@ class ProxyService:
                 request_id,
             )
             runtime_config = dataclasses.replace(runtime_config, enabled=False)
+        image_request = _responses_request_contains_input_image(payload)
+        force_upstream_stream_transport = "http" if image_request else None
+        if runtime_config.enabled and image_request:
+            logger.info(
+                "stream_responses bypassing http bridge for input_image request_id=%s",
+                request_id,
+            )
+            runtime_config = dataclasses.replace(runtime_config, enabled=False)
         if not runtime_config.enabled:
             async for line in self._stream_with_retry(
                 payload,
@@ -808,6 +838,7 @@ class ProxyService:
                 suppress_text_done_events=suppress_text_done_events,
                 request_transport=_REQUEST_TRANSPORT_HTTP,
                 rewritten_file_account_id=rewritten_file_account_id,
+                upstream_stream_transport_override=force_upstream_stream_transport,
             ):
                 yield line
             return
@@ -11004,6 +11035,7 @@ class ProxyService:
         suppress_text_done_events: bool,
         request_transport: str,
         rewritten_file_account_id: str | None = None,
+        upstream_stream_transport_override: str | None = None,
     ) -> AsyncIterator[str]:
         request_id = ensure_request_id()
         start = time.monotonic()
@@ -11014,7 +11046,9 @@ class ProxyService:
             request_transport=request_transport,
         )
         prefer_earlier_reset = settings.prefer_earlier_reset_accounts
-        upstream_stream_transport = _resolve_upstream_stream_transport(settings.upstream_stream_transport)
+        upstream_stream_transport = upstream_stream_transport_override
+        if upstream_stream_transport is None:
+            upstream_stream_transport = _resolve_upstream_stream_transport(settings.upstream_stream_transport)
         if request_transport == _REQUEST_TRANSPORT_HTTP and upstream_stream_transport == "websocket":
             # HTTP/SSE clients can retry a half-rendered turn after an upstream
             # websocket close, making the same visible message restart. Keep

--- a/openspec/changes/bypass-http-bridge-input-images/proposal.md
+++ b/openspec/changes/bypass-http-bridge-input-images/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Inline `input_image` requests can expose upstream validation errors that the
+HTTP responses bridge cannot reliably surface before its response-created gate
+or request budget expires. During beta live validation, a tiny inline PNG was
+rejected quickly on the raw HTTP path but held a bridge pending slot until local
+timeouts on the WebSocket bridge path.
+
+## What Changes
+
+- Bypass the HTTP responses bridge for Responses requests containing any
+  `input_image` part, sending those requests over the existing raw HTTP stream
+  path instead
+- Preserve the existing unsupported uploaded-image rejection for
+  `input_image.file_id` and `sediment://` references before forwarding
+- Keep bridge behavior unchanged for text-only and file-only Responses requests
+
+## Impact
+
+- Valid inline images continue to work while using upstream HTTP error semantics
+  for invalid image payloads
+- Invalid inline images fail fast instead of occupying bridge pending slots until
+  timeout
+- Image requests lose HTTP bridge prompt-cache/session reuse, intentionally
+  favoring correctness over cache affinity for this media path

--- a/openspec/changes/bypass-http-bridge-input-images/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bypass-http-bridge-input-images/specs/responses-api-compat/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Responses input images bypass the HTTP bridge
+
+The service MUST bypass the HTTP responses bridge when a `/v1/responses`,
+`/backend-api/codex/responses`, `/responses/compact`, or `/v1/responses/compact`
+request contains any `input_image` part in top-level input items, nested
+message content, or tool output content, and send the request over the raw HTTP
+Responses stream path. This bypass MUST happen after rejecting unsupported
+uploaded-image references and MUST be limited to the current request; subsequent
+text-only requests MAY continue using the HTTP responses bridge.
+
+The raw HTTP path is the source of truth for image validation and upstream image
+error semantics. The bridge MUST NOT hold image requests waiting for
+`response.created` when upstream rejects an invalid inline image payload.
+
+#### Scenario: Nested input_image bypasses bridge
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** a Responses request contains a nested content part with `type = "input_image"`
+- **THEN** the request is sent through the raw HTTP stream path
+- **AND** the HTTP responses bridge is not used for that request
+
+#### Scenario: Image bypass does not disable future text bridge use
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** an image-bearing request bypasses the bridge
+- **THEN** the bypass applies only to that request
+- **AND** a later text-only request can still use the HTTP responses bridge

--- a/openspec/changes/bypass-http-bridge-input-images/tasks.md
+++ b/openspec/changes/bypass-http-bridge-input-images/tasks.md
@@ -1,0 +1,5 @@
+- [x] Add regression coverage that bridge-enabled `/v1/responses` requests with nested `input_image` parts bypass the HTTP responses bridge
+- [x] Route image-bearing Responses requests over raw HTTP while leaving text-only bridge routing intact
+- [x] Preserve existing unsupported `input_image.file_id` / `sediment://` rejection tests
+- [x] Validate OpenSpec and targeted proxy tests
+- [x] Rebuild candidate image and repeat live image smoke with short client timeout

--- a/tests/unit/test_input_image_proxy.py
+++ b/tests/unit/test_input_image_proxy.py
@@ -117,6 +117,33 @@ async def test_fetch_image_data_url_size_limit(monkeypatch):
     assert data_url is None
 
 
+@pytest.mark.asyncio
+async def test_inline_input_image_urls_rewrites_top_level_external_image(monkeypatch):
+    async def resolve_ips(host: str, *, timeout_seconds: float):
+        return ["93.184.216.34"]
+
+    monkeypatch.setattr(proxy_module, "_resolve_global_ips", resolve_ips)
+    response = FakeResponse(200, {"Content-Type": "image/png"}, [b"abc"])
+    session = FakeSession(response)
+
+    inlined = await proxy_module._inline_input_image_urls(
+        {
+            "model": "gpt-5.5",
+            "input": [
+                {
+                    "type": "input_image",
+                    "image_url": "https://example.com/a.png",
+                }
+            ],
+        },
+        cast(proxy_module.ImageFetchSession, session),
+        1.0,
+    )
+
+    image_item = cast(dict[str, object], cast(list[object], inlined["input"])[0])
+    assert image_item["image_url"] == "data:image/png;base64," + base64.b64encode(b"abc").decode("ascii")
+
+
 @pytest.mark.parametrize(
     ("url", "expected"),
     [

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -982,6 +982,14 @@ def test_extract_input_image_file_references_collects_multi_message_paths():
             ],
         },
         {"type": "input_image", "image_url": "sediment://file_b"},
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [
+                {"type": "input_text", "text": "tool image"},
+                {"type": "input_image", "file_id": "file_tool"},
+            ],
+        },
     ]
 
     references = extract_input_image_file_references(input_value)
@@ -989,4 +997,26 @@ def test_extract_input_image_file_references_collects_multi_message_paths():
     assert [(reference.item_index, reference.content_index, reference.file_id) for reference in references] == [
         (0, 1, "file_a"),
         (1, None, "file_b"),
+        (2, None, "file_tool"),
+    ]
+
+
+def test_extract_input_image_file_references_collects_tool_output_paths():
+    input_value: list[JsonValue] = [
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [
+                {"type": "input_text", "text": "ignore"},
+                {"type": "input_image", "file_id": "file_tool"},
+                {"type": "input_image", "image_url": "sediment://file_nested"},
+            ],
+        }
+    ]
+
+    references = extract_input_image_file_references(input_value)
+
+    assert [(reference.item_index, reference.content_index, reference.file_id) for reference in references] == [
+        (0, None, "file_tool"),
+        (0, None, "file_nested"),
     ]

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1204,6 +1204,68 @@ async def test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image(monke
 
 
 @pytest.mark.asyncio
+async def test_stream_http_bridge_or_retry_forces_http_for_input_image_when_bridge_disabled(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.http_responses_stream_request_budget_seconds = 180.0
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=False,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [{"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="}],
+        }
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+
+    captured: dict[str, str | None] = {}
+
+    async def fake_stream_with_retry(payload, headers, **kwargs):
+        del payload, headers
+        captured["override"] = kwargs.get("upstream_stream_transport_override")
+        yield "data: retry\n\n"
+
+    async def fake_stream_via_http_bridge(payload, headers, **kwargs):
+        raise AssertionError("disabled bridge must not be used")
+        yield "data: bridge\n\n"
+
+    monkeypatch.setattr(service, "_stream_with_retry", fake_stream_with_retry)
+    monkeypatch.setattr(service, "_stream_via_http_bridge", fake_stream_via_http_bridge)
+
+    output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload=payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert output == ["data: retry\n\n"]
+    assert captured["override"] == "http"
+
+
+@pytest.mark.asyncio
 async def test_stream_http_bridge_or_retry_bypasses_bridge_for_large_payload(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -998,6 +998,211 @@ def test_ws_transport_payload_budget_uses_settings_limit() -> None:
     )
 
 
+def test_responses_request_contains_input_image_detects_supported_shapes() -> None:
+    top_level = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [{"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="}],
+        }
+    )
+    content_object = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [
+                {
+                    "role": "user",
+                    "content": {"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="},
+                }
+            ],
+        }
+    )
+    tool_output = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [
+                        {"type": "input_text", "text": "tool saw an image"},
+                        {"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="},
+                    ],
+                }
+            ],
+        }
+    )
+    text_only = ResponsesRequest.model_validate({"model": "gpt-5.5", "instructions": "hi", "input": "hello"})
+
+    assert proxy_service._responses_request_contains_input_image(top_level) is True
+    assert proxy_service._responses_request_contains_input_image(content_object) is True
+    assert proxy_service._responses_request_contains_input_image(tool_output) is True
+    assert proxy_service._responses_request_contains_input_image(text_only) is False
+
+
+@pytest.mark.asyncio
+async def test_core_inline_input_image_urls_converts_top_level_input_image(monkeypatch):
+    data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
+
+    async def fake_fetch_image_data_url(_session, image_url, _timeout):
+        assert image_url == "https://example.com/top.png"
+        return data_url
+
+    monkeypatch.setattr(proxy_module, "_fetch_image_data_url", fake_fetch_image_data_url)
+
+    payload: proxy_module.JsonObject = {
+        "model": "gpt-5.5",
+        "input": [{"type": "input_image", "image_url": "https://example.com/top.png"}],
+    }
+
+    inlined = await proxy_module._inline_input_image_urls(payload, cast(proxy_module.ImageFetchSession, object()), 5.0)
+
+    assert inlined["input"] == [{"type": "input_image", "image_url": data_url}]
+
+
+@pytest.mark.asyncio
+async def test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.http_responses_stream_request_budget_seconds = 180.0
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe"},
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,iVBORw0KGgo=",
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+
+    calls: list[tuple[str, object, str | None, float | None, str | None]] = []
+
+    async def fake_stream_with_retry(
+        payload,
+        headers,
+        *,
+        rewritten_file_account_id: str | None = None,
+        **kwargs,
+    ):
+        del headers
+        budget = proxy_service._stream_request_budget_seconds(
+            settings,
+            request_transport=kwargs["request_transport"],
+        )
+        calls.append(
+            (
+                "retry",
+                payload,
+                rewritten_file_account_id,
+                budget,
+                kwargs.get("upstream_stream_transport_override"),
+            )
+        )
+        yield "data: retry\n\n"
+
+    async def fake_stream_via_http_bridge(payload, headers, **kwargs):
+        del payload, headers, kwargs
+        calls.append(("bridge", None, None, None, None))
+        yield "data: bridge\n\n"
+
+    monkeypatch.setattr(service, "_stream_with_retry", fake_stream_with_retry)
+    monkeypatch.setattr(service, "_stream_via_http_bridge", fake_stream_via_http_bridge)
+
+    output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload=payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert output == ["data: retry\n\n"]
+    assert calls == [("retry", payload, None, 180.0, "http")]
+
+    text_payload = ResponsesRequest.model_validate({"model": "gpt-5.5", "instructions": "hi", "input": "hello"})
+    text_output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload=text_payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert text_output == ["data: bridge\n\n"]
+    assert calls[-1] == ("bridge", None, None, None, None)
+
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=False,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    calls.clear()
+    disabled_bridge_output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload=payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert disabled_bridge_output == ["data: retry\n\n"]
+    assert calls == [("retry", payload, None, 180.0, "http")]
+
+
 @pytest.mark.asyncio
 async def test_stream_http_bridge_or_retry_bypasses_bridge_for_large_payload(monkeypatch):
     request_logs = _RequestLogsRecorder()
@@ -5144,6 +5349,68 @@ async def test_service_stream_responses_forces_http_upstream_for_http_stream_cli
     )
 
     chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+
+    assert chunks
+    assert captured["override"] == "http"
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_honors_explicit_upstream_transport_override(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    setattr(settings, "upstream_stream_transport", "default")
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_explicit_stream_transport_override")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        upstream_stream_transport_override=None,
+    ):
+        captured["override"] = upstream_stream_transport_override
+        yield 'data: {"type":"response.completed","response":{"id":"resp_transport_override"}}\n\n'
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+        }
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-stream"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
 
     assert chunks
     assert captured["override"] == "http"
@@ -16131,6 +16398,80 @@ async def test_stream_http_bridge_or_retry_rejects_input_image_file_id(monkeypat
     assert info.value.status_code == 400
     assert _proxy_error_code(info.value) == "unsupported_input_image_format"
     assert "data: URLs" in (_proxy_error_message(info.value) or "")
+
+
+def test_raise_for_unsupported_input_image_references_rejects_tool_output_file_id():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [{"type": "input_image", "file_id": "file_pic"}],
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as info:
+        service._raise_for_unsupported_input_image_references(payload)
+
+    assert info.value.status_code == 400
+    assert _proxy_error_code(info.value) == "unsupported_input_image_format"
+
+
+@pytest.mark.asyncio
+async def test_stream_http_bridge_or_retry_rejects_tool_output_input_image_file_id(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [{"type": "input_image", "file_id": "file_pic"}],
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as info:
+        async for _ in service._stream_http_bridge_or_retry(
+            payload=payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        ):
+            pass
+
+    assert info.value.status_code == 400
+    assert _proxy_error_code(info.value) == "unsupported_input_image_format"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Bypass the HTTP responses bridge for Responses requests that contain `input_image` parts and force those requests onto the upstream HTTP stream path
- Detect top-level images, nested message-content images, and tool-output image parts
- Reject unsupported `input_image.file_id` / `sediment://` references even when they appear inside tool-output image parts
- Preserve raw-path external image URL inlining for top-level `input_image` items
- Add regression coverage for image-shape detection, bridge bypass, preserving later text-only bridge behavior, and top-level external image URL inlining
- Add OpenSpec coverage for the image bridge bypass behavior

## Why

During live beta validation, an invalid inline image failed quickly on the raw HTTP path but could occupy a HTTP bridge pending slot until local bridge timeouts. Image-bearing requests should favor upstream HTTP image validation and error semantics over bridge prompt-cache/session affinity.

## Test Plan

- `uv run ruff check app/core/openai/requests.py app/core/clients/proxy.py app/modules/proxy/service.py tests/unit/test_openai_requests.py tests/unit/test_input_image_proxy.py tests/unit/test_proxy_utils.py`
- `uv run pytest tests/unit/test_openai_requests.py::test_extract_input_image_file_references_collects_multi_message_paths -q`
- `uv run pytest tests/unit/test_proxy_utils.py::test_responses_request_contains_input_image_detects_supported_shapes -q`
- `uv run pytest tests/unit/test_proxy_utils.py::test_raise_for_unsupported_input_image_references_rejects_tool_output_file_id -q`
- `uv run pytest tests/unit/test_proxy_utils.py::test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image -q`
- `uv run pytest tests/unit/test_openai_requests.py tests/unit/test_input_image_proxy.py tests/unit/test_proxy_utils.py -q`
- `uv run ty check app/core/openai/requests.py app/core/clients/proxy.py app/modules/proxy/service.py tests/unit/test_openai_requests.py tests/unit/test_input_image_proxy.py tests/unit/test_proxy_utils.py`
- `uv run openspec validate bypass-http-bridge-input-images --strict`

## Live Validation

Validated against the beta candidate environment before splitting this into a clean main-based PR:

- invalid 1x1 inline PNG returns `400 invalid_value` in ~0.5s instead of timing out
- valid 64x64 inline PNG completes successfully with output `Red`
- text-only requests continue to use the HTTP responses bridge
