### PR TITLE
fix(accounts): dedupe request usage rows by request id

### DIFF
--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -76,11 +76,15 @@ class AccountsRepository:
         if account_ids:
             conditions.append(RequestLog.account_id.in_(account_ids))
 
-        latest_request_log_ids_stmt = (
-            select(func.max(RequestLog.id).label("request_log_id"))
-            .where(*conditions)
-            .group_by(RequestLog.account_id, RequestLog.request_id)
-        )
+        latest_request_log_ids_stmt = select(
+            RequestLog.id.label("request_log_id"),
+            func.row_number()
+            .over(
+                partition_by=(RequestLog.account_id, RequestLog.request_id),
+                order_by=(RequestLog.requested_at.desc(), RequestLog.id.desc()),
+            )
+            .label("request_log_rank"),
+        ).where(*conditions)
         latest_request_log_ids = latest_request_log_ids_stmt.subquery("latest_request_log_ids")
         stmt = (
             select(
@@ -92,6 +96,7 @@ class AccountsRepository:
                 func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
             )
             .join(latest_request_log_ids, RequestLog.id == latest_request_log_ids.c.request_log_id)
+            .where(latest_request_log_ids.c.request_log_rank == 1)
             .group_by(RequestLog.account_id)
         )
         result = await self._session.execute(stmt)

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -69,6 +69,19 @@ class AccountsRepository:
     ) -> dict[str, AccountRequestUsageSummary]:
         summaries: dict[str, AccountRequestUsageSummary] = {}
         output_tokens_expr = func.coalesce(RequestLog.output_tokens, RequestLog.reasoning_tokens, 0)
+        conditions: list = [
+            RequestLog.request_kind.not_in(("warmup", "limit_warmup")),
+            RequestLog.deleted_at.is_(None),
+        ]
+        if account_ids:
+            conditions.append(RequestLog.account_id.in_(account_ids))
+
+        latest_request_log_ids_stmt = (
+            select(func.max(RequestLog.id).label("request_log_id"))
+            .where(*conditions)
+            .group_by(RequestLog.account_id, RequestLog.request_id)
+        )
+        latest_request_log_ids = latest_request_log_ids_stmt.subquery("latest_request_log_ids")
         stmt = (
             select(
                 RequestLog.account_id,
@@ -78,12 +91,9 @@ class AccountsRepository:
                 func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
                 func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
             )
-            .where(RequestLog.request_kind.not_in(("warmup", "limit_warmup")))
+            .join(latest_request_log_ids, RequestLog.id == latest_request_log_ids.c.request_log_id)
             .group_by(RequestLog.account_id)
         )
-        if account_ids:
-            stmt = stmt.where(RequestLog.account_id.in_(account_ids))
-
         result = await self._session.execute(stmt)
         for (
             account_id,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -80,7 +80,11 @@ class AccountsRepository:
             RequestLog.id.label("request_log_id"),
             func.row_number()
             .over(
-                partition_by=(RequestLog.account_id, RequestLog.request_id),
+                partition_by=(
+                    RequestLog.account_id,
+                    RequestLog.request_id,
+                    RequestLog.requested_at,
+                ),
                 order_by=(RequestLog.requested_at.desc(), RequestLog.id.desc()),
             )
             .label("request_log_rank"),

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -817,6 +817,57 @@ async def test_accounts_list_request_usage_deduplicates_request_id_rows(async_cl
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_request_usage_deduplicates_by_request_time(async_client, db_setup):
+    requested_at = utcnow()
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_replayed_time", "replayed-time@example.com"))
+
+        newer_attempt = await logs_repo.add_log(
+            account_id="acc_replayed_time",
+            request_id="req_repeat_time",
+            model="gpt-5.1-codex",
+            input_tokens=8_000,
+            output_tokens=2_000,
+            cached_input_tokens=1_000,
+            latency_ms=180,
+            status="success",
+            error_code=None,
+            requested_at=requested_at,
+        )
+        older_backfill = await logs_repo.add_log(
+            account_id="acc_replayed_time",
+            request_id="req_repeat_time",
+            model="gpt-5.1-codex",
+            input_tokens=50_000,
+            output_tokens=20_000,
+            cached_input_tokens=10_000,
+            latency_ms=140,
+            status="success",
+            error_code=None,
+            requested_at=requested_at - timedelta(minutes=5),
+        )
+        await session.execute(update(RequestLog).where(RequestLog.id == newer_attempt.id).values(cost_usd=3.0))
+        await session.execute(update(RequestLog).where(RequestLog.id == older_backfill.id).values(cost_usd=9.0))
+        await session.commit()
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    request_usage = accounts["acc_replayed_time"]["requestUsage"]
+    assert request_usage is not None
+    assert request_usage["requestCount"] == 1
+    assert request_usage["totalTokens"] == 10_000
+    assert request_usage["cachedInputTokens"] == 1_000
+    assert request_usage["totalCostUsd"] == pytest.approx(3.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_maps_weekly_only_primary_to_secondary(async_client, db_setup):
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -770,6 +770,53 @@ async def test_accounts_list_request_usage_uses_persisted_cost(async_client, db_
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_request_usage_deduplicates_request_id_rows(async_client, db_setup):
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_replayed", "replayed@example.com"))
+
+        first_attempt = await logs_repo.add_log(
+            account_id="acc_replayed",
+            request_id="req_repeat_1",
+            model="gpt-5.1-codex",
+            input_tokens=50_000,
+            output_tokens=20_000,
+            cached_input_tokens=10_000,
+            latency_ms=180,
+            status="success",
+            error_code=None,
+        )
+        second_attempt = await logs_repo.add_log(
+            account_id="acc_replayed",
+            request_id="req_repeat_1",
+            model="gpt-5.1-codex",
+            input_tokens=5_000,
+            output_tokens=1_000,
+            cached_input_tokens=0,
+            latency_ms=140,
+            status="success",
+            error_code=None,
+        )
+        await session.execute(update(RequestLog).where(RequestLog.id == first_attempt.id).values(cost_usd=5.0))
+        await session.execute(update(RequestLog).where(RequestLog.id == second_attempt.id).values(cost_usd=2.0))
+        await session.commit()
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = {item["accountId"]: item for item in payload["accounts"]}
+
+    request_usage = accounts["acc_replayed"]["requestUsage"]
+    assert request_usage is not None
+    assert request_usage["requestCount"] == 1
+    assert request_usage["totalTokens"] == 6_000
+    assert request_usage["cachedInputTokens"] == 0
+    assert request_usage["totalCostUsd"] == pytest.approx(2.0, abs=1e-6)
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_maps_weekly_only_primary_to_secondary(async_client, db_setup):
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -771,6 +771,8 @@ async def test_accounts_list_request_usage_uses_persisted_cost(async_client, db_
 
 @pytest.mark.asyncio
 async def test_accounts_list_request_usage_deduplicates_request_id_rows(async_client, db_setup):
+    requested_at = utcnow()
+
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)
         logs_repo = RequestLogsRepository(session)
@@ -787,6 +789,7 @@ async def test_accounts_list_request_usage_deduplicates_request_id_rows(async_cl
             latency_ms=180,
             status="success",
             error_code=None,
+            requested_at=requested_at,
         )
         second_attempt = await logs_repo.add_log(
             account_id="acc_replayed",
@@ -798,6 +801,7 @@ async def test_accounts_list_request_usage_deduplicates_request_id_rows(async_cl
             latency_ms=140,
             status="success",
             error_code=None,
+            requested_at=requested_at,
         )
         await session.execute(update(RequestLog).where(RequestLog.id == first_attempt.id).values(cost_usd=5.0))
         await session.execute(update(RequestLog).where(RequestLog.id == second_attempt.id).values(cost_usd=2.0))
@@ -817,8 +821,9 @@ async def test_accounts_list_request_usage_deduplicates_request_id_rows(async_cl
 
 
 @pytest.mark.asyncio
-async def test_accounts_list_request_usage_deduplicates_by_request_time(async_client, db_setup):
+async def test_accounts_list_request_usage_counts_repeated_request_id_by_requested_at(async_client, db_setup):
     requested_at = utcnow()
+    repeated_request_time = requested_at + timedelta(seconds=30)
 
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)
@@ -836,7 +841,7 @@ async def test_accounts_list_request_usage_deduplicates_by_request_time(async_cl
             latency_ms=180,
             status="success",
             error_code=None,
-            requested_at=requested_at,
+            requested_at=repeated_request_time,
         )
         older_backfill = await logs_repo.add_log(
             account_id="acc_replayed_time",
@@ -848,7 +853,7 @@ async def test_accounts_list_request_usage_deduplicates_by_request_time(async_cl
             latency_ms=140,
             status="success",
             error_code=None,
-            requested_at=requested_at - timedelta(minutes=5),
+            requested_at=requested_at,
         )
         await session.execute(update(RequestLog).where(RequestLog.id == newer_attempt.id).values(cost_usd=3.0))
         await session.execute(update(RequestLog).where(RequestLog.id == older_backfill.id).values(cost_usd=9.0))
@@ -861,10 +866,10 @@ async def test_accounts_list_request_usage_deduplicates_by_request_time(async_cl
 
     request_usage = accounts["acc_replayed_time"]["requestUsage"]
     assert request_usage is not None
-    assert request_usage["requestCount"] == 1
-    assert request_usage["totalTokens"] == 10_000
-    assert request_usage["cachedInputTokens"] == 1_000
-    assert request_usage["totalCostUsd"] == pytest.approx(3.0, abs=1e-6)
+    assert request_usage["requestCount"] == 2
+    assert request_usage["totalTokens"] == 80_000
+    assert request_usage["cachedInputTokens"] == 11_000
+    assert request_usage["totalCostUsd"] == pytest.approx(12.0, abs=1e-6)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- dedupe account request-usage aggregation only for exact repeated rows with the same `(account_id, request_id, requested_at)`
- keep separate real calls counted when clients or gateways reuse the same `x-request-id`/`request-id` at different request times
- keep warmup and deleted request-log filtering intact before aggregation

Addresses #841. The issue report shows high cached-token/cost rows, so this keeps the PR scoped to the request-usage duplicate-row failure mode instead of claiming full closure without stronger evidence.

## Validation

Head: `e01a6b67b239586c5bf5b218d0a98d6629f6e8dd`

```bash
uv run pytest tests/integration/test_accounts_api_extended.py -k request_usage -q
uv run ruff check app/modules/accounts/repository.py tests/integration/test_accounts_api_extended.py
uv run ruff format --check app/modules/accounts/repository.py tests/integration/test_accounts_api_extended.py
uv run ty check app/modules/accounts/repository.py tests/integration/test_accounts_api_extended.py
```
