### PR TITLE
ci: narrow PostgreSQL pytest coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      CODEX_LB_TEST_DATABASE_URL: postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
+      POSTGRES_TEST_DATABASE_URL: postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
       PYTHONFAULTHANDLER: "1"
 
     steps:
@@ -203,11 +203,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
-        with:
-          bun-version: "1.3.14"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 PYTEST_ARGS := -q -ra -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread --durations=20
 POSTGRES_TEST_DATABASE_URL ?= postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
+POSTGRES_PYTEST_TARGETS := \
+	tests/integration/test_migrations.py::test_postgresql_migration_contract_policy_and_drift_match \
+	tests/integration/test_migrations.py::test_postgresql_upgrade_head_from_empty_database \
+	tests/integration/test_migrations.py::test_postgresql_startup_migration_auto_remap_legacy_head \
+	tests/integration/test_usage_repository.py::test_latest_by_account_primary_query_plan_uses_normalized_window_index_postgresql \
+	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql
 SHELL := /bin/bash
 
 .PHONY: help
@@ -61,11 +67,11 @@ test-e2e: frontend-build
 	uv sync --dev --frozen
 	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) tests/e2e
 
-test-postgres: frontend-build
+test-postgres:
 	uv sync --dev --frozen
 	CODEX_LB_TEST_DATABASE_URL="$(POSTGRES_TEST_DATABASE_URL)" \
 	  PYTHONFAULTHANDLER=1 \
-	  uv run pytest $(PYTEST_ARGS)
+	  uv run pytest $(PYTEST_ARGS) $(POSTGRES_PYTEST_TARGETS)
 
 .PHONY: migration-check migration-check-postgres
 migration-check:


### PR DESCRIPTION
## Summary

- keep the PostgreSQL pytest lane focused on PostgreSQL-specific coverage instead of replaying the full unit/integration/e2e suite under PostgreSQL
- remove the frontend build/Bun setup dependency from `make test-postgres`
- keep the database URL configurable through `POSTGRES_TEST_DATABASE_URL` while the Make target maps it to `CODEX_LB_TEST_DATABASE_URL` for pytest

This is the shared CI prerequisite split out of #902 so unrelated PRs do not keep paying the old PostgreSQL job cost while the usage-history cache work waits for review.

## Benchmark

- old shape: #904 PostgreSQL job ran from 2026-06-03T14:25:22Z to 2026-06-03T14:39:51Z (14m29s)
- narrowed shape: #902 PostgreSQL job ran from 2026-06-03T12:51:10Z to 2026-06-03T12:51:53Z (43s)

## Validation

- `make -n test-postgres` expands to the five PostgreSQL-specific pytest nodeids
- `uv run pytest --collect-only -q tests/integration/test_migrations.py::test_postgresql_migration_contract_policy_and_drift_match tests/integration/test_migrations.py::test_postgresql_upgrade_head_from_empty_database tests/integration/test_migrations.py::test_postgresql_startup_migration_auto_remap_legacy_head tests/integration/test_usage_repository.py::test_latest_by_account_primary_query_plan_uses_normalized_window_index_postgresql tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql` (`5 tests collected`)
