### PR TITLE
fix(frontend): disable browser translation on dashboard

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <meta name="google" content="notranslate" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -9,8 +10,8 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <title>Codex LB</title>
   </head>
-  <body>
-    <div id="root"></div>
+  <body translate="no">
+    <div id="root" translate="no"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/openspec/changes/disable-dashboard-browser-translation/proposal.md
+++ b/openspec/changes/disable-dashboard-browser-translation/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+Chrome's built-in Translate action and the Google Translate extension can mutate React-owned dashboard text nodes by injecting translation markup. That conflicts with React reconciliation and can freeze the SPA.
+
+## What Changes
+
+- Mark the dashboard HTML document, body, and React root as non-translatable.
+- Add Google's `notranslate` meta tag so browser translation tools do not rewrite dashboard DOM text nodes.
+
+## Impact
+
+- Prevents browser translation from modifying the live React dashboard DOM.
+- Keeps the dashboard usable for operators affected by Google Translate injection.
+- Does not add built-in localization; a first-party i18n UI remains a separate feature.

--- a/openspec/changes/disable-dashboard-browser-translation/specs/frontend-architecture/spec.md
+++ b/openspec/changes/disable-dashboard-browser-translation/specs/frontend-architecture/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard HTML shell avoids browser translation DOM mutation
+
+The dashboard HTML shell SHALL opt out of browser/extension translation for the React-owned document surface so external translation tools do not inject markup into React-managed text nodes.
+
+#### Scenario: Dashboard opts out of Google Translate DOM rewriting
+
+- **WHEN** the browser loads the dashboard HTML shell
+- **THEN** the document advertises `notranslate` metadata for Google Translate
+- **AND** the document, body, and React root are marked with `translate="no"`

--- a/openspec/changes/disable-dashboard-browser-translation/tasks.md
+++ b/openspec/changes/disable-dashboard-browser-translation/tasks.md
@@ -1,0 +1,10 @@
+## 1. Dashboard HTML
+
+- [x] 1.1 Add document-level `translate="no"` to the dashboard HTML shell.
+- [x] 1.2 Add Google `notranslate` metadata.
+- [x] 1.3 Add `translate="no"` to the React root container.
+
+## 2. Validation
+
+- [x] 2.1 Run the frontend production build.
+- [x] 2.2 Run OpenSpec validation for this change.


### PR DESCRIPTION
## Summary

- mark the dashboard document, body, and React root as non-translatable
- add Google Translate's `notranslate` meta tag so Chrome/extension translation does not mutate React-owned text nodes

Closes #906.

## Validation

```bash
cd frontend
bun install --frozen-lockfile
bun run build
uv run openspec validate disable-dashboard-browser-translation --strict
```

