### PR TITLE
docs(proxy): explain fast mode service tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ The Helm chart auto-configures HTTP `/responses` owner handoff for multi-replica
 
 For external database, production config, ingress, observability, and more see the [Helm chart README](deploy/helm/codex-lb/README.md).
 
+Fast Mode and service-tier behavior is documented in [Responses API compatibility context](openspec/specs/responses-api-compat/context.md#fast-mode-and-service-tiers).
+
 ## Development
 
 ```bash

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -33,6 +33,58 @@ See `openspec/specs/responses-api-compat/spec.md` for normative requirements.
 - `prompt_cache_key` affinity on OpenAI-style routes is intentionally bounded by a dashboard-managed freshness window, unlike durable backend `session_id` or dashboard sticky-thread routing.
 - Codex-native direct websocket `/backend-api/codex/responses` treats upstream `previous_response_id` as an ephemeral anchor. If that anchor goes stale, the proxy must mask raw `previous_response_not_found` details and emit a sanitized `codex_previous_response_stale` classifier so compatible Codex clients can soft-reset and retry without `previous_response_id`.
 
+## Fast Mode and Service Tiers
+
+codex-lb accepts the OpenAI/Codex `service_tier` field on Responses and Chat
+Completions compatible routes. The legacy `fast` spelling is accepted as an
+alias and is forwarded upstream as the canonical `priority` tier.
+
+Fast Mode is request-level intent, not a local speed guarantee. The upstream
+Codex backend decides the actual tier for each completed response. codex-lb
+therefore records three separate values in request logs:
+
+- `requestedServiceTier`: what the client or API key asked for, after alias
+  normalization.
+- `actualServiceTier`: what upstream reported in the completed response, when
+  upstream included it.
+- `serviceTier`: the effective billable tier. This uses `actualServiceTier`
+  when present and falls back to `requestedServiceTier` only when upstream omits
+  the actual tier.
+
+If a request is sent with `service_tier: "fast"` or `service_tier: "priority"`
+and the completed row shows `requestedServiceTier: "priority"` but
+`actualServiceTier: "default"`, codex-lb forwarded the priority request and
+upstream chose the default tier. That can happen even when websocket transport
+is active.
+
+For OpenCode or Codex-compatible clients, enable Fast Mode by sending a
+Responses request with:
+
+```json
+{
+  "service_tier": "priority"
+}
+```
+
+Clients that expose Fast Mode as `fast` may keep using that spelling; codex-lb
+normalizes it to `priority` before forwarding.
+
+API keys can also force the tier for traffic that uses that key. Set the key's
+enforced service tier to `priority` or `fast`; both values are stored and
+returned as `priority`.
+
+To verify a completed Fast Mode request:
+
+1. `Transport` should be `WS` if you are verifying the websocket Codex path.
+2. `requestedServiceTier` should be `priority` when the client requested Fast
+   Mode or the API key enforced it.
+3. `actualServiceTier` is the upstream result. `default` means upstream did not
+   grant priority for that response.
+
+This distinction matters for quota and cost accounting: codex-lb prices the
+request from the effective billable `serviceTier`, not from the requested tier
+when upstream reports a different actual tier.
+
 ## Include Allowlist (Reference)
 
 - `code_interpreter_call.outputs`

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -305,8 +305,20 @@ When a request depends on hard continuity ownership, the service MUST fail close
 ### Requirement: Request logs persist requested, actual, and billable service tiers separately
 For Responses proxy traffic, the system MUST persist the operator-requested tier, the upstream-reported actual tier when available, and the effective billable tier used for pricing as separate request-log fields.
 
+The legacy `fast` alias MUST be normalized to the canonical upstream value
+`priority` before forwarding and before it is stored as the requested tier.
+The upstream-reported `response.service_tier`, when present, remains the
+authoritative actual tier even when it differs from the requested tier.
+
 #### Scenario: Upstream reports a downgraded actual tier
 - **WHEN** a client sends a Responses request with `service_tier: "priority"`
+- **AND** the upstream response later reports `service_tier: "default"`
+- **THEN** the persisted request log entry records `requested_service_tier = "priority"`
+- **AND** the persisted request log entry records `actual_service_tier = "default"`
+- **AND** the persisted request log entry records billable `service_tier = "default"`
+
+#### Scenario: Fast alias is logged as a priority request
+- **WHEN** a client sends a Responses request with `service_tier: "fast"`
 - **AND** the upstream response later reports `service_tier: "default"`
 - **THEN** the persisted request log entry records `requested_service_tier = "priority"`
 - **AND** the persisted request log entry records `actual_service_tier = "default"`


### PR DESCRIPTION
## Summary

- document how Fast Mode maps through codex-lb in the Responses API compatibility context: `fast` is accepted as an alias for the canonical upstream `priority` tier
- explain that upstream `response.service_tier` is the authoritative actual tier, so a completed request may show `requestedServiceTier: "priority"` but `actualServiceTier: "default"`
- add the same alias/logging distinction to the Responses compatibility spec

Closes #291.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [x] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

## OpenSpec

- [x] This PR includes / updates OpenSpec context/spec files
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

## Validation

Head: `a558d065d79e04bba4178f2c0d06490cf3b87695`

```bash
uv run openspec validate --specs
# Totals: 29 passed, 0 failed (29 items)
```
