### PR TITLE
feat(frontend): add upstream proxy controls

### DIFF
--- a/frontend/src/features/accounts/components/account-detail.tsx
+++ b/frontend/src/features/accounts/components/account-detail.tsx
@@ -4,6 +4,7 @@ import { isEmailLabel } from "@/components/blur-email";
 import { usePrivacyStore } from "@/hooks/use-privacy";
 import { AccountAliasForm } from "@/features/accounts/components/account-alias-form";
 import { AccountActions } from "@/features/accounts/components/account-actions";
+import { AccountProxyBinding } from "@/features/accounts/components/account-proxy-binding";
 import { AccountTokenInfo } from "@/features/accounts/components/account-token-info";
 import { AccountUsagePanel } from "@/features/accounts/components/account-usage-panel";
 import type {
@@ -11,6 +12,7 @@ import type {
   AccountSummary,
 } from "@/features/accounts/schemas";
 import { useAccountTrends } from "@/features/accounts/hooks/use-accounts";
+import type { AccountProxyBindingRequest, UpstreamProxyAdmin } from "@/features/settings/schemas";
 import { formatCompactAccountId } from "@/utils/account-identifiers";
 import { formatSlug } from "@/utils/formatters";
 
@@ -30,6 +32,8 @@ export type AccountDetailProps = {
     routingPolicy: AccountRoutingPolicy,
   ) => void;
   onSecurityWorkAuthorizedChange: (accountId: string, enabled: boolean) => void;
+  upstreamProxyAdmin?: UpstreamProxyAdmin | null;
+  onProxyBindingSave?: (accountId: string, payload: AccountProxyBindingRequest) => Promise<unknown>;
 };
 
 export function AccountDetail({
@@ -45,6 +49,8 @@ export function AccountDetail({
   onLimitWarmupChange,
   onRoutingPolicyChange,
   onSecurityWorkAuthorizedChange,
+  upstreamProxyAdmin = null,
+  onProxyBindingSave,
 }: AccountDetailProps) {
   const { data: trends } = useAccountTrends(account?.accountId ?? null);
   const blurred = usePrivacyStore((s) => s.blurred);
@@ -115,6 +121,14 @@ export function AccountDetail({
       </div>
 
       <AccountAliasForm account={account} busy={busy} onSetAlias={onSetAlias} />
+      {onProxyBindingSave ? (
+        <AccountProxyBinding
+          account={account}
+          admin={upstreamProxyAdmin}
+          busy={busy}
+          onSave={onProxyBindingSave}
+        />
+      ) : null}
       <AccountUsagePanel account={account} trends={trends} />
       <AccountTokenInfo account={account} />
       <AccountActions

--- a/frontend/src/features/accounts/components/account-proxy-binding.test.tsx
+++ b/frontend/src/features/accounts/components/account-proxy-binding.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AccountProxyBinding } from "@/features/accounts/components/account-proxy-binding";
+import { createAccountSummary, createUpstreamProxyAdmin } from "@/test/mocks/factories";
+
+describe("AccountProxyBinding", () => {
+  it("saves a selected account proxy pool binding", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const account = createAccountSummary({ accountId: "acc_primary" });
+    const admin = createUpstreamProxyAdmin();
+
+    render(<AccountProxyBinding account={account} admin={admin} busy={false} onSave={onSave} />);
+
+    await user.click(screen.getByRole("button", { name: "Save binding" }));
+
+    expect(onSave).toHaveBeenCalledWith("acc_primary", {
+      poolId: "pool_primary",
+      isActive: true,
+    });
+  });
+
+  it("can disable an existing binding", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const account = createAccountSummary({ accountId: "acc_primary" });
+    const admin = createUpstreamProxyAdmin({
+      bindings: [{ accountId: "acc_primary", poolId: "pool_primary", isActive: true }],
+    });
+
+    render(<AccountProxyBinding account={account} admin={admin} busy={false} onSave={onSave} />);
+
+    await user.click(screen.getByRole("switch", { name: "Enable account proxy binding" }));
+
+    expect(onSave).toHaveBeenCalledWith("acc_primary", {
+      poolId: "pool_primary",
+      isActive: false,
+    });
+  });
+});

--- a/frontend/src/features/accounts/components/account-proxy-binding.tsx
+++ b/frontend/src/features/accounts/components/account-proxy-binding.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useState } from "react";
+import { Network } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import type { AccountSummary } from "@/features/accounts/schemas";
+import type { AccountProxyBindingRequest, UpstreamProxyAdmin } from "@/features/settings/schemas";
+
+export type AccountProxyBindingProps = {
+  account: AccountSummary;
+  admin: UpstreamProxyAdmin | null;
+  busy: boolean;
+  onSave: (accountId: string, payload: AccountProxyBindingRequest) => Promise<unknown>;
+};
+
+export function AccountProxyBinding({ account, admin, busy, onSave }: AccountProxyBindingProps) {
+  const binding = admin?.bindings.find((item) => item.accountId === account.accountId) ?? null;
+  const initialPoolId = binding?.poolId ?? admin?.pools[0]?.id ?? "";
+  const [selectedPoolId, setSelectedPoolId] = useState(initialPoolId);
+  const poolsById = useMemo(() => new Map((admin?.pools ?? []).map((pool) => [pool.id, pool])), [admin?.pools]);
+  const selectedPool = poolsById.get(selectedPoolId) ?? null;
+  const active = binding?.isActive ?? false;
+
+  if (!admin) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-xl border bg-card p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+            <Network className="h-4 w-4 text-primary" aria-hidden="true" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold">Account proxy binding</h3>
+            <p className="text-xs text-muted-foreground">
+              Route this account's ChatGPT upstream traffic through a specific proxy pool.
+            </p>
+          </div>
+        </div>
+        <Switch
+          aria-label="Enable account proxy binding"
+          checked={active}
+          disabled={busy || !binding}
+          onCheckedChange={(checked) => {
+            const poolId = binding?.poolId ?? selectedPoolId;
+            if (!poolId) return;
+            void onSave(account.accountId, { poolId, isActive: checked });
+          }}
+        />
+      </div>
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+        <Select value={selectedPoolId} onValueChange={setSelectedPoolId} disabled={busy || admin.pools.length === 0}>
+          <SelectTrigger className="h-8 text-xs" aria-label="Account proxy pool">
+            <SelectValue placeholder="Select proxy pool" />
+          </SelectTrigger>
+          <SelectContent>
+            {admin.pools.map((pool) => (
+              <SelectItem key={pool.id} value={pool.id}>{pool.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 text-xs sm:w-28"
+          disabled={busy || !selectedPoolId}
+          onClick={() => void onSave(account.accountId, { poolId: selectedPoolId, isActive: true })}
+        >
+          Save binding
+        </Button>
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        {binding
+          ? `Current binding: ${poolsById.get(binding.poolId)?.name ?? binding.poolId} (${binding.isActive ? "active" : "disabled"}).`
+          : "No account-specific proxy pool binding is configured."}
+        {selectedPool ? ` Selected pool has ${selectedPool.endpointIds.length} endpoint(s).` : ""}
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/features/accounts/components/accounts-page.test.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.test.tsx
@@ -32,6 +32,17 @@ vi.mock("@/features/accounts/hooks/use-oauth", () => ({
   })),
 }));
 
+vi.mock("@/features/settings/hooks/use-settings", () => ({
+  useUpstreamProxyAdmin: vi.fn(() => ({
+    upstreamProxyQuery: { data: null, error: null },
+    accountBindingMutation: {
+      isPending: false,
+      error: null,
+      mutateAsync: vi.fn(),
+    },
+  })),
+}));
+
 const { useAccounts } = await import("@/features/accounts/hooks/use-accounts");
 const mockedUseAccounts = useAccounts as unknown as ReturnType<typeof vi.fn>;
 

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -14,6 +14,7 @@ import { AuthExportDialog } from "@/features/accounts/components/auth-export-dia
 import { useAccounts } from "@/features/accounts/hooks/use-accounts";
 import { sortAccountsForDisplay } from "@/features/accounts/sorting";
 import { useOauth } from "@/features/accounts/hooks/use-oauth";
+import { useUpstreamProxyAdmin } from "@/features/settings/hooks/use-settings";
 import { useAccountQuotaDisplayStore } from "@/hooks/use-account-quota-display";
 import type { AccountAuthExportResponse } from "@/features/accounts/schemas";
 import { getErrorMessageOrNull } from "@/utils/errors";
@@ -38,6 +39,7 @@ export function AccountsPage() {
     routingPolicyMutation,
     exportAuthMutation,
   } = useAccounts();
+  const { upstreamProxyQuery, accountBindingMutation } = useUpstreamProxyAdmin();
   const oauth = useOauth();
 
   const importDialog = useDialogState();
@@ -98,7 +100,8 @@ export function AccountsPage() {
     deleteMutation.isPending ||
     routingPolicyMutation.isPending ||
     exportAuthMutation.isPending ||
-    updateMutation.isPending;
+    updateMutation.isPending ||
+    accountBindingMutation.isPending;
 
   const mutationError =
     getErrorMessageOrNull(importMutation.error) ||
@@ -109,7 +112,9 @@ export function AccountsPage() {
     getErrorMessageOrNull(deleteMutation.error) ||
     getErrorMessageOrNull(routingPolicyMutation.error) ||
     getErrorMessageOrNull(exportAuthMutation.error) ||
-    getErrorMessageOrNull(updateMutation.error);
+    getErrorMessageOrNull(updateMutation.error) ||
+    getErrorMessageOrNull(upstreamProxyQuery.error) ||
+    getErrorMessageOrNull(accountBindingMutation.error);
 
   return (
     <div className="animate-fade-in-up space-y-6">
@@ -170,6 +175,10 @@ export function AccountsPage() {
                 accountId,
                 securityWorkAuthorized: enabled,
               })
+            }
+            upstreamProxyAdmin={upstreamProxyQuery.data ?? null}
+            onProxyBindingSave={(accountId, payload) =>
+              accountBindingMutation.mutateAsync({ accountId, payload })
             }
           />
         </div>

--- a/frontend/src/features/settings/api.ts
+++ b/frontend/src/features/settings/api.ts
@@ -1,10 +1,19 @@
-import { get, put } from "@/lib/api-client";
+import { get, post, put } from "@/lib/api-client";
 import {
+  AccountProxyBindingRequestSchema,
+  AccountProxyBindingSchema,
   DashboardSettingsSchema,
   SettingsUpdateRequestSchema,
+  UpstreamProxyAdminSchema,
+  UpstreamProxyEndpointCreateRequestSchema,
+  UpstreamProxyEndpointSchema,
+  UpstreamProxyPoolCreateRequestSchema,
+  UpstreamProxyPoolMemberRequestSchema,
+  UpstreamProxyPoolSchema,
 } from "@/features/settings/schemas";
 
 const SETTINGS_PATH = "/api/settings";
+const UPSTREAM_PROXY_PATH = `${SETTINGS_PATH}/upstream-proxy`;
 
 export function getSettings() {
   return get(SETTINGS_PATH, DashboardSettingsSchema);
@@ -13,6 +22,38 @@ export function getSettings() {
 export function updateSettings(payload: unknown) {
   const validated = SettingsUpdateRequestSchema.parse(payload);
   return put(SETTINGS_PATH, DashboardSettingsSchema, {
+    body: validated,
+  });
+}
+
+export function getUpstreamProxyAdmin() {
+  return get(UPSTREAM_PROXY_PATH, UpstreamProxyAdminSchema);
+}
+
+export function createUpstreamProxyEndpoint(payload: unknown) {
+  const validated = UpstreamProxyEndpointCreateRequestSchema.parse(payload);
+  return post(`${UPSTREAM_PROXY_PATH}/endpoints`, UpstreamProxyEndpointSchema, {
+    body: validated,
+  });
+}
+
+export function createUpstreamProxyPool(payload: unknown) {
+  const validated = UpstreamProxyPoolCreateRequestSchema.parse(payload);
+  return post(`${UPSTREAM_PROXY_PATH}/pools`, UpstreamProxyPoolSchema, {
+    body: validated,
+  });
+}
+
+export function addUpstreamProxyPoolMember(poolId: string, payload: unknown) {
+  const validated = UpstreamProxyPoolMemberRequestSchema.parse(payload);
+  return post(`${UPSTREAM_PROXY_PATH}/pools/${encodeURIComponent(poolId)}/members`, UpstreamProxyPoolSchema, {
+    body: validated,
+  });
+}
+
+export function putAccountProxyBinding(accountId: string, payload: unknown) {
+  const validated = AccountProxyBindingRequestSchema.parse(payload);
+  return put(`${UPSTREAM_PROXY_PATH}/accounts/${encodeURIComponent(accountId)}/binding`, AccountProxyBindingSchema, {
     body: validated,
   });
 }

--- a/frontend/src/features/settings/components/routing-settings.test.tsx
+++ b/frontend/src/features/settings/components/routing-settings.test.tsx
@@ -31,6 +31,8 @@ const LIMIT_WARMUP_DEFAULTS = {
 const BASE_SETTINGS: DashboardSettings = {
   stickyThreadsEnabled: false,
   upstreamStreamTransport: "default",
+  upstreamProxyRoutingEnabled: false,
+  upstreamProxyDefaultPoolId: null,
   preferEarlierResetAccounts: true,
   preferEarlierResetWindow: "secondary",
   routingStrategy: "usage_weighted",

--- a/frontend/src/features/settings/components/session-settings.test.tsx
+++ b/frontend/src/features/settings/components/session-settings.test.tsx
@@ -20,6 +20,8 @@ const ADDITIONAL_QUOTA_DEFAULTS = {
 const baseSettings = {
   stickyThreadsEnabled: true,
   upstreamStreamTransport: "default" as const,
+  upstreamProxyRoutingEnabled: false,
+  upstreamProxyDefaultPoolId: null,
   preferEarlierResetAccounts: false,
   preferEarlierResetWindow: "secondary" as const,
   routingStrategy: "usage_weighted" as const,

--- a/frontend/src/features/settings/components/settings-page.tsx
+++ b/frontend/src/features/settings/components/settings-page.tsx
@@ -14,9 +14,10 @@ import { PasswordSettings } from "@/features/settings/components/password-settin
 import { RoutingSettings } from "@/features/settings/components/routing-settings";
 import { SessionSettings } from "@/features/settings/components/session-settings";
 import { SettingsSkeleton } from "@/features/settings/components/settings-skeleton";
+import { UpstreamProxySettings } from "@/features/settings/components/upstream-proxy-settings";
 import { StickySessionsSection } from "@/features/sticky-sessions/components/sticky-sessions-section";
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
-import { useSettings } from "@/features/settings/hooks/use-settings";
+import { useSettings, useUpstreamProxyAdmin } from "@/features/settings/hooks/use-settings";
 import type { SettingsUpdateRequest } from "@/features/settings/schemas";
 import { getErrorMessageOrNull } from "@/utils/errors";
 
@@ -27,13 +28,29 @@ const TotpSettings = lazy(() =>
 export function SettingsPage() {
   const { settingsQuery, updateSettingsMutation } = useSettings();
   const { accountsQuery } = useAccounts();
+  const {
+    upstreamProxyQuery,
+    createEndpointMutation,
+    createPoolMutation,
+    addPoolMemberMutation,
+  } = useUpstreamProxyAdmin();
   const authMode = useAuthStore((state) => state.authMode);
   const passwordManagementEnabled = useAuthStore((state) => state.passwordManagementEnabled);
   const passwordSessionActive = useAuthStore((state) => state.passwordSessionActive);
 
   const settings = settingsQuery.data;
-  const busy = updateSettingsMutation.isPending;
-  const error = getErrorMessageOrNull(settingsQuery.error) || getErrorMessageOrNull(updateSettingsMutation.error);
+  const busy =
+    updateSettingsMutation.isPending ||
+    createEndpointMutation.isPending ||
+    createPoolMutation.isPending ||
+    addPoolMemberMutation.isPending;
+  const error =
+    getErrorMessageOrNull(settingsQuery.error) ||
+    getErrorMessageOrNull(upstreamProxyQuery.error) ||
+    getErrorMessageOrNull(updateSettingsMutation.error) ||
+    getErrorMessageOrNull(createEndpointMutation.error) ||
+    getErrorMessageOrNull(createPoolMutation.error) ||
+    getErrorMessageOrNull(addPoolMemberMutation.error);
 
   const handleSave = async (payload: SettingsUpdateRequest) => {
     await updateSettingsMutation.mutateAsync(payload);
@@ -86,6 +103,18 @@ export function SettingsPage() {
               busy={busy}
               onSave={handleSave}
             />
+            {upstreamProxyQuery.data ? (
+              <UpstreamProxySettings
+                admin={upstreamProxyQuery.data}
+                busy={busy}
+                onSaveSettings={handleSave}
+                onCreateEndpoint={(payload) => createEndpointMutation.mutateAsync(payload)}
+                onCreatePool={(payload) => createPoolMutation.mutateAsync(payload)}
+                onAddPoolMember={(poolId, payload) =>
+                  addPoolMemberMutation.mutateAsync({ poolId, payload })
+                }
+              />
+            ) : null}
             <ImportSettings settings={settings} busy={busy} onSave={handleSave} />
             <PasswordSettings disabled={busy} />
             {passwordManagementEnabled ? (

--- a/frontend/src/features/settings/components/totp-settings.test.tsx
+++ b/frontend/src/features/settings/components/totp-settings.test.tsx
@@ -33,6 +33,8 @@ const ADDITIONAL_QUOTA_DEFAULTS = {
 const baseSettings = {
   stickyThreadsEnabled: true,
   upstreamStreamTransport: "default" as const,
+  upstreamProxyRoutingEnabled: false,
+  upstreamProxyDefaultPoolId: null,
   preferEarlierResetAccounts: false,
   preferEarlierResetWindow: "secondary" as const,
   routingStrategy: "usage_weighted" as const,
@@ -136,6 +138,8 @@ describe("TotpSettings", () => {
     const saveSettings: Record<string, unknown> = { ...baseSettings };
     delete saveSettings.additionalQuotaPolicies;
     delete saveSettings.totpConfigured;
+    delete saveSettings.upstreamProxyRoutingEnabled;
+    delete saveSettings.upstreamProxyDefaultPoolId;
 
     renderWithClient(<TotpSettings settings={baseSettings} onSave={onSave} />);
 

--- a/frontend/src/features/settings/components/upstream-proxy-settings.test.tsx
+++ b/frontend/src/features/settings/components/upstream-proxy-settings.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { UpstreamProxySettings } from "@/features/settings/components/upstream-proxy-settings";
+import { createUpstreamProxyAdmin } from "@/test/mocks/factories";
+
+describe("UpstreamProxySettings", () => {
+  it("saves routing toggles and creates endpoints", async () => {
+    const user = userEvent.setup();
+    const onSaveSettings = vi.fn().mockResolvedValue(undefined);
+    const onCreateEndpoint = vi.fn().mockResolvedValue(undefined);
+    const admin = createUpstreamProxyAdmin();
+
+    render(
+      <UpstreamProxySettings
+        admin={admin}
+        busy={false}
+        onSaveSettings={onSaveSettings}
+        onCreateEndpoint={onCreateEndpoint}
+        onCreatePool={vi.fn().mockResolvedValue(undefined)}
+        onAddPoolMember={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await user.click(screen.getByRole("switch", { name: "Enable upstream proxy routing" }));
+    expect(onSaveSettings).toHaveBeenCalledWith({ upstreamProxyRoutingEnabled: true });
+
+    await user.type(screen.getByLabelText("Proxy endpoint name"), "Backup proxy");
+    await user.type(screen.getByLabelText("Proxy endpoint host"), "backup.proxy.test");
+    await user.clear(screen.getByLabelText("Proxy endpoint port"));
+    await user.type(screen.getByLabelText("Proxy endpoint port"), "8081");
+    await user.click(screen.getByRole("button", { name: "Create endpoint" }));
+
+    expect(onCreateEndpoint).toHaveBeenCalledWith({
+      name: "Backup proxy",
+      scheme: "http",
+      host: "backup.proxy.test",
+      port: 8081,
+      username: null,
+      password: null,
+      isActive: true,
+    });
+  });
+
+  it("creates pools and blocks duplicate member submissions", async () => {
+    const user = userEvent.setup();
+    const onCreatePool = vi.fn().mockResolvedValue(undefined);
+    const onAddPoolMember = vi.fn().mockResolvedValue(undefined);
+    const admin = createUpstreamProxyAdmin();
+
+    render(
+      <UpstreamProxySettings
+        admin={admin}
+        busy={false}
+        onSaveSettings={vi.fn().mockResolvedValue(undefined)}
+        onCreateEndpoint={vi.fn().mockResolvedValue(undefined)}
+        onCreatePool={onCreatePool}
+        onAddPoolMember={onAddPoolMember}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Proxy pool name"), "Codex pool");
+    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("button", { name: "Create pool" }));
+
+    expect(onCreatePool).toHaveBeenCalledWith({
+      name: "Codex pool",
+      endpointIds: ["ep_primary"],
+      isActive: true,
+    });
+    expect(screen.getByText(/Endpoint is already in Primary pool/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add member" })).toBeDisabled();
+    expect(onAddPoolMember).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/settings/components/upstream-proxy-settings.tsx
+++ b/frontend/src/features/settings/components/upstream-proxy-settings.tsx
@@ -1,0 +1,257 @@
+import { useState } from "react";
+import { Network } from "lucide-react";
+
+import { AlertMessage } from "@/components/alert-message";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import type { SettingsUpdateRequest, UpstreamProxyAdmin } from "@/features/settings/schemas";
+import type {
+  UpstreamProxyEndpointCreateRequest,
+  UpstreamProxyPoolCreateRequest,
+  UpstreamProxyPoolMemberRequest,
+} from "@/features/settings/schemas";
+
+const NO_POOL_VALUE = "__none__";
+
+export type UpstreamProxySettingsProps = {
+  admin: UpstreamProxyAdmin;
+  busy: boolean;
+  onSaveSettings: (payload: SettingsUpdateRequest) => Promise<void>;
+  onCreateEndpoint: (payload: UpstreamProxyEndpointCreateRequest) => Promise<unknown>;
+  onCreatePool: (payload: UpstreamProxyPoolCreateRequest) => Promise<unknown>;
+  onAddPoolMember: (poolId: string, payload: UpstreamProxyPoolMemberRequest) => Promise<unknown>;
+};
+
+export function UpstreamProxySettings({
+  admin,
+  busy,
+  onSaveSettings,
+  onCreateEndpoint,
+  onCreatePool,
+  onAddPoolMember,
+}: UpstreamProxySettingsProps) {
+  const [endpointName, setEndpointName] = useState("");
+  const [endpointScheme, setEndpointScheme] = useState<UpstreamProxyEndpointCreateRequest["scheme"]>("http");
+  const [endpointHost, setEndpointHost] = useState("");
+  const [endpointPort, setEndpointPort] = useState("8080");
+  const [endpointUsername, setEndpointUsername] = useState("");
+  const [endpointPassword, setEndpointPassword] = useState("");
+  const [poolName, setPoolName] = useState("");
+  const [selectedEndpointIds, setSelectedEndpointIds] = useState<Set<string>>(new Set());
+  const [memberPoolId, setMemberPoolId] = useState(admin.pools[0]?.id ?? "");
+  const [memberEndpointId, setMemberEndpointId] = useState(admin.endpoints[0]?.id ?? "");
+
+  const endpointPortNumber = Number(endpointPort);
+  const endpointValid =
+    endpointName.trim().length > 0 &&
+    endpointHost.trim().length > 0 &&
+    Number.isInteger(endpointPortNumber) &&
+    endpointPortNumber >= 1 &&
+    endpointPortNumber <= 65535;
+  const poolValid = poolName.trim().length > 0;
+  const selectedMemberPool = admin.pools.find((pool) => pool.id === memberPoolId) ?? null;
+  const memberEndpointAlreadyPresent = selectedMemberPool?.endpointIds.includes(memberEndpointId) ?? false;
+  const memberValid = Boolean(memberPoolId && memberEndpointId && !memberEndpointAlreadyPresent);
+
+  const toggleEndpointSelection = (endpointId: string, checked: boolean) => {
+    setSelectedEndpointIds((current) => {
+      const next = new Set(current);
+      if (checked) {
+        next.add(endpointId);
+      } else {
+        next.delete(endpointId);
+      }
+      return next;
+    });
+  };
+
+  const submitEndpoint = async () => {
+    if (!endpointValid) {
+      return;
+    }
+    await onCreateEndpoint({
+      name: endpointName.trim(),
+      scheme: endpointScheme,
+      host: endpointHost.trim(),
+      port: endpointPortNumber,
+      username: endpointUsername.trim() || null,
+      password: endpointPassword || null,
+      isActive: true,
+    });
+    setEndpointName("");
+    setEndpointHost("");
+    setEndpointUsername("");
+    setEndpointPassword("");
+  };
+
+  const submitPool = async () => {
+    if (!poolValid) {
+      return;
+    }
+    await onCreatePool({
+      name: poolName.trim(),
+      endpointIds: [...selectedEndpointIds],
+      isActive: true,
+    });
+    setPoolName("");
+    setSelectedEndpointIds(new Set());
+  };
+
+  const submitMember = async () => {
+    if (!memberValid) {
+      return;
+    }
+    await onAddPoolMember(memberPoolId, {
+      endpointId: memberEndpointId,
+      sortOrder: selectedMemberPool?.endpointIds.length ?? 0,
+      weight: 1,
+      isActive: true,
+    });
+  };
+
+  return (
+    <section className="rounded-xl border bg-card p-5">
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
+              <Network className="h-4 w-4 text-primary" aria-hidden="true" />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold">Upstream proxy routing</h3>
+              <p className="text-xs text-muted-foreground">
+                Configure proxy pools used for account-bound ChatGPT upstream traffic.
+              </p>
+            </div>
+          </div>
+          <Switch
+            aria-label="Enable upstream proxy routing"
+            checked={admin.routingEnabled}
+            disabled={busy}
+            onCheckedChange={(checked) =>
+              void onSaveSettings({ upstreamProxyRoutingEnabled: checked })
+            }
+          />
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-lg border p-3">
+            <p className="text-sm font-medium">Default pool</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Used only when routing is enabled and an account has no explicit binding.
+            </p>
+            <Select
+              value={admin.defaultPoolId ?? NO_POOL_VALUE}
+              onValueChange={(value) =>
+                void onSaveSettings({ upstreamProxyDefaultPoolId: value === NO_POOL_VALUE ? null : value })
+              }
+              disabled={busy}
+            >
+              <SelectTrigger className="mt-3 h-8 text-xs" aria-label="Default proxy pool">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_POOL_VALUE}>No default pool</SelectItem>
+                {admin.pools.map((pool) => (
+                  <SelectItem key={pool.id} value={pool.id}>{pool.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="rounded-lg border p-3">
+            <p className="text-sm font-medium">Current pools</p>
+            <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+              {admin.pools.length === 0 ? <p>No proxy pools configured.</p> : null}
+              {admin.pools.map((pool) => (
+                <p key={pool.id}>
+                  <span className="font-medium text-foreground">{pool.name}</span>{" "}
+                  {pool.isActive ? "active" : "inactive"} · {pool.endpointIds.length} endpoint(s)
+                </p>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-3 lg:grid-cols-3">
+          <div className="space-y-2 rounded-lg border p-3">
+            <p className="text-sm font-medium">Create endpoint</p>
+            <Input aria-label="Proxy endpoint name" className="h-8 text-xs" placeholder="Endpoint name" value={endpointName} disabled={busy} onChange={(event) => setEndpointName(event.target.value)} />
+            <div className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2">
+              <Select value={endpointScheme} onValueChange={(value) => setEndpointScheme(value as UpstreamProxyEndpointCreateRequest["scheme"])} disabled={busy}>
+                <SelectTrigger className="h-8 text-xs" aria-label="Proxy endpoint scheme"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="http">http</SelectItem>
+                  <SelectItem value="https">https</SelectItem>
+                  <SelectItem value="socks5">socks5</SelectItem>
+                  <SelectItem value="socks5h">socks5h</SelectItem>
+                </SelectContent>
+              </Select>
+              <Input aria-label="Proxy endpoint host" className="h-8 text-xs" placeholder="Host" value={endpointHost} disabled={busy} onChange={(event) => setEndpointHost(event.target.value)} />
+            </div>
+            <Input aria-label="Proxy endpoint port" className="h-8 text-xs" inputMode="numeric" placeholder="Port" value={endpointPort} disabled={busy} onChange={(event) => setEndpointPort(event.target.value)} />
+            <Input aria-label="Proxy endpoint username" className="h-8 text-xs" placeholder="Username (optional)" value={endpointUsername} disabled={busy} onChange={(event) => setEndpointUsername(event.target.value)} />
+            <Input aria-label="Proxy endpoint password" className="h-8 text-xs" placeholder="Password (optional)" type="password" value={endpointPassword} disabled={busy} onChange={(event) => setEndpointPassword(event.target.value)} />
+            <Button type="button" size="sm" className="h-8 w-full text-xs" disabled={busy || !endpointValid} onClick={() => void submitEndpoint()}>
+              Create endpoint
+            </Button>
+          </div>
+
+          <div className="space-y-2 rounded-lg border p-3">
+            <p className="text-sm font-medium">Create pool</p>
+            <Input aria-label="Proxy pool name" className="h-8 text-xs" placeholder="Pool name" value={poolName} disabled={busy} onChange={(event) => setPoolName(event.target.value)} />
+            <div className="max-h-40 space-y-2 overflow-auto rounded-md border p-2">
+              {admin.endpoints.length === 0 ? <p className="text-xs text-muted-foreground">Create an endpoint first.</p> : null}
+              {admin.endpoints.map((endpoint) => (
+                <label key={endpoint.id} className="flex items-center gap-2 text-xs">
+                  <Checkbox
+                    checked={selectedEndpointIds.has(endpoint.id)}
+                    disabled={busy}
+                    onCheckedChange={(checked) => toggleEndpointSelection(endpoint.id, checked === true)}
+                  />
+                  <span>{endpoint.name} · {endpoint.scheme}://{endpoint.host}:{endpoint.port}</span>
+                </label>
+              ))}
+            </div>
+            <Button type="button" size="sm" className="h-8 w-full text-xs" disabled={busy || !poolValid} onClick={() => void submitPool()}>
+              Create pool
+            </Button>
+          </div>
+
+          <div className="space-y-2 rounded-lg border p-3">
+            <p className="text-sm font-medium">Add pool member</p>
+            <Select value={memberPoolId} onValueChange={setMemberPoolId} disabled={busy || admin.pools.length === 0}>
+              <SelectTrigger className="h-8 text-xs" aria-label="Pool member pool"><SelectValue placeholder="Select pool" /></SelectTrigger>
+              <SelectContent>{admin.pools.map((pool) => <SelectItem key={pool.id} value={pool.id}>{pool.name}</SelectItem>)}</SelectContent>
+            </Select>
+            <Select value={memberEndpointId} onValueChange={setMemberEndpointId} disabled={busy || admin.endpoints.length === 0}>
+              <SelectTrigger className="h-8 text-xs" aria-label="Pool member endpoint"><SelectValue placeholder="Select endpoint" /></SelectTrigger>
+              <SelectContent>{admin.endpoints.map((endpoint) => <SelectItem key={endpoint.id} value={endpoint.id}>{endpoint.name}</SelectItem>)}</SelectContent>
+            </Select>
+            {memberEndpointAlreadyPresent ? (
+              <AlertMessage variant="warning">Endpoint is already in {selectedMemberPool?.name}.</AlertMessage>
+            ) : null}
+            <Button type="button" size="sm" className="h-8 w-full text-xs" disabled={busy || !memberValid} onClick={() => void submitMember()}>
+              Add member
+            </Button>
+          </div>
+        </div>
+
+        <div className="rounded-lg border p-3">
+          <p className="text-sm font-medium">Endpoints</p>
+          <div className="mt-2 grid gap-2 md:grid-cols-2">
+            {admin.endpoints.length === 0 ? <p className="text-xs text-muted-foreground">No proxy endpoints configured.</p> : null}
+            {admin.endpoints.map((endpoint) => (
+              <div key={endpoint.id} className="rounded-md bg-muted/50 px-2 py-1.5 text-xs">
+                <span className="font-medium">{endpoint.name}</span> · {endpoint.scheme}://{endpoint.username ? `${endpoint.username}@` : ""}{endpoint.host}:{endpoint.port}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/settings/hooks/use-settings.ts
+++ b/frontend/src/features/settings/hooks/use-settings.ts
@@ -1,8 +1,22 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
-import { getSettings, updateSettings } from "@/features/settings/api";
+import {
+  addUpstreamProxyPoolMember,
+  createUpstreamProxyEndpoint,
+  createUpstreamProxyPool,
+  getSettings,
+  getUpstreamProxyAdmin,
+  putAccountProxyBinding,
+  updateSettings,
+} from "@/features/settings/api";
 import type { SettingsUpdateRequest } from "@/features/settings/schemas";
+import type {
+  AccountProxyBindingRequest,
+  UpstreamProxyEndpointCreateRequest,
+  UpstreamProxyPoolCreateRequest,
+  UpstreamProxyPoolMemberRequest,
+} from "@/features/settings/schemas";
 
 export function useSettings() {
   const queryClient = useQueryClient();
@@ -17,6 +31,7 @@ export function useSettings() {
     onSuccess: () => {
       toast.success("Settings saved");
       void queryClient.invalidateQueries({ queryKey: ["settings", "detail"] });
+      void queryClient.invalidateQueries({ queryKey: ["settings", "upstream-proxy"] });
     },
     onError: (error: Error) => {
       toast.error(error.message || "Failed to save settings");
@@ -26,5 +41,73 @@ export function useSettings() {
   return {
     settingsQuery,
     updateSettingsMutation,
+  };
+}
+
+export function useUpstreamProxyAdmin() {
+  const queryClient = useQueryClient();
+
+  const upstreamProxyQuery = useQuery({
+    queryKey: ["settings", "upstream-proxy"],
+    queryFn: getUpstreamProxyAdmin,
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["settings", "upstream-proxy"] });
+    void queryClient.invalidateQueries({ queryKey: ["settings", "detail"] });
+  };
+
+  const createEndpointMutation = useMutation({
+    mutationFn: (payload: UpstreamProxyEndpointCreateRequest) => createUpstreamProxyEndpoint(payload),
+    onSuccess: () => {
+      toast.success("Proxy endpoint created");
+      invalidate();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Proxy endpoint creation failed");
+    },
+  });
+
+  const createPoolMutation = useMutation({
+    mutationFn: (payload: UpstreamProxyPoolCreateRequest) => createUpstreamProxyPool(payload),
+    onSuccess: () => {
+      toast.success("Proxy pool created");
+      invalidate();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Proxy pool creation failed");
+    },
+  });
+
+  const addPoolMemberMutation = useMutation({
+    mutationFn: ({ poolId, payload }: { poolId: string; payload: UpstreamProxyPoolMemberRequest }) =>
+      addUpstreamProxyPoolMember(poolId, payload),
+    onSuccess: () => {
+      toast.success("Proxy pool member added");
+      invalidate();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Proxy pool update failed");
+    },
+  });
+
+  const accountBindingMutation = useMutation({
+    mutationFn: ({ accountId, payload }: { accountId: string; payload: AccountProxyBindingRequest }) =>
+      putAccountProxyBinding(accountId, payload),
+    onSuccess: () => {
+      toast.success("Account proxy binding saved");
+      invalidate();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Account proxy binding failed");
+    },
+  });
+
+  return {
+    upstreamProxyQuery,
+    createEndpointMutation,
+    createPoolMutation,
+    addPoolMemberMutation,
+    accountBindingMutation,
   };
 }

--- a/frontend/src/features/settings/schemas.test.ts
+++ b/frontend/src/features/settings/schemas.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   DashboardSettingsSchema,
   SettingsUpdateRequestSchema,
+  UpstreamProxyAdminSchema,
 } from "@/features/settings/schemas";
 
 describe("DashboardSettingsSchema", () => {
@@ -10,6 +11,8 @@ describe("DashboardSettingsSchema", () => {
     const parsed = DashboardSettingsSchema.parse({
       stickyThreadsEnabled: true,
       upstreamStreamTransport: "default",
+      upstreamProxyRoutingEnabled: true,
+      upstreamProxyDefaultPoolId: "pool_1",
       preferEarlierResetAccounts: false,
       routingStrategy: "relative_availability",
       preferEarlierResetWindow: "secondary",
@@ -36,6 +39,8 @@ describe("DashboardSettingsSchema", () => {
 
     expect(parsed.stickyThreadsEnabled).toBe(true);
     expect(parsed.upstreamStreamTransport).toBe("default");
+    expect(parsed.upstreamProxyRoutingEnabled).toBe(true);
+    expect(parsed.upstreamProxyDefaultPoolId).toBe("pool_1");
     expect(parsed.routingStrategy).toBe("relative_availability");
     expect(parsed.preferEarlierResetWindow).toBe("secondary");
     expect(parsed.relativeAvailabilityPower).toBe(2);
@@ -64,6 +69,8 @@ describe("DashboardSettingsSchema", () => {
     });
 
     expect(parsed.upstreamStreamTransport).toBe("default");
+    expect(parsed.upstreamProxyRoutingEnabled).toBe(false);
+    expect(parsed.upstreamProxyDefaultPoolId).toBeNull();
     expect(parsed.routingStrategy).toBe("usage_weighted");
     expect(parsed.singleAccountId).toBeNull();
     expect(parsed.openaiCacheAffinityMaxAgeSeconds).toBe(300);
@@ -121,6 +128,8 @@ describe("SettingsUpdateRequestSchema", () => {
     const parsed = SettingsUpdateRequestSchema.parse({
       stickyThreadsEnabled: false,
       upstreamStreamTransport: "websocket",
+      upstreamProxyRoutingEnabled: true,
+      upstreamProxyDefaultPoolId: null,
       preferEarlierResetAccounts: true,
       routingStrategy: "relative_availability",
       preferEarlierResetWindow: "secondary",
@@ -151,6 +160,8 @@ describe("SettingsUpdateRequestSchema", () => {
     expect(parsed.warmupModel).toBe("gpt-5.4-nano");
     expect(parsed.upstreamStreamTransport).toBe("websocket");
     expect(parsed.preferEarlierResetWindow).toBe("secondary");
+    expect(parsed.upstreamProxyRoutingEnabled).toBe(true);
+    expect(parsed.upstreamProxyDefaultPoolId).toBeNull();
     expect(parsed.importWithoutOverwrite).toBe(true);
     expect(parsed.routingStrategy).toBe("relative_availability");
     expect(parsed.relativeAvailabilityPower).toBe(1.5);
@@ -179,6 +190,8 @@ describe("SettingsUpdateRequestSchema", () => {
     });
 
     expect(parsed.upstreamStreamTransport).toBeUndefined();
+    expect(parsed.upstreamProxyRoutingEnabled).toBeUndefined();
+    expect(parsed.upstreamProxyDefaultPoolId).toBeUndefined();
     expect(parsed.importWithoutOverwrite).toBeUndefined();
     expect(parsed.totpRequiredOnLogin).toBeUndefined();
     expect(parsed.apiKeyAuthEnabled).toBeUndefined();
@@ -234,5 +247,39 @@ describe("SettingsUpdateRequestSchema", () => {
         limitWarmupPrompt: "p".repeat(513),
       }).success,
     ).toBe(false);
+  });
+});
+
+describe("UpstreamProxyAdminSchema", () => {
+  it("parses upstream proxy admin state", () => {
+    const parsed = UpstreamProxyAdminSchema.parse({
+      routingEnabled: true,
+      defaultPoolId: "pool_1",
+      endpoints: [
+        {
+          id: "ep_1",
+          name: "Proxy A",
+          scheme: "http",
+          host: "proxy.test",
+          port: 8080,
+          username: null,
+          isActive: true,
+        },
+      ],
+      pools: [
+        {
+          id: "pool_1",
+          name: "Pool A",
+          isActive: true,
+          endpointIds: ["ep_1"],
+        },
+      ],
+      bindings: [{ accountId: "acc_1", poolId: "pool_1", isActive: true }],
+    });
+
+    expect(parsed.routingEnabled).toBe(true);
+    expect(parsed.endpoints[0]?.host).toBe("proxy.test");
+    expect(parsed.pools[0]?.endpointIds).toEqual(["ep_1"]);
+    expect(parsed.bindings[0]?.accountId).toBe("acc_1");
   });
 });

--- a/frontend/src/features/settings/schemas.ts
+++ b/frontend/src/features/settings/schemas.ts
@@ -41,6 +41,8 @@ export const DashboardSettingsSchema = z
     stickyThreadsEnabled: z.boolean(),
     upstreamStreamTransport:
       UpstreamStreamTransportSchema.optional().default("default"),
+    upstreamProxyRoutingEnabled: z.boolean().optional().default(false),
+    upstreamProxyDefaultPoolId: z.string().nullable().optional().default(null),
     preferEarlierResetAccounts: z.boolean(),
     preferEarlierResetWindow: z.enum(["primary", "secondary"]).optional().default("secondary"),
     routingStrategy: RoutingStrategySchema.optional().default("usage_weighted"),
@@ -112,9 +114,12 @@ export const DashboardSettingsSchema = z
     };
   });
 
+
 export const SettingsUpdateRequestSchema = z.object({
   stickyThreadsEnabled: z.boolean().optional(),
   upstreamStreamTransport: UpstreamStreamTransportSchema.optional(),
+  upstreamProxyRoutingEnabled: z.boolean().optional(),
+  upstreamProxyDefaultPoolId: z.string().nullable().optional(),
   preferEarlierResetAccounts: z.boolean().optional(),
   preferEarlierResetWindow: z.enum(["primary", "secondary"]).optional(),
   routingStrategy: RoutingStrategySchema.optional(),
@@ -163,3 +168,71 @@ export type DashboardSettings = Omit<
   Partial<StickyThresholdValues>;
 export type SettingsUpdateRequest = z.infer<typeof SettingsUpdateRequestSchema>;
 export type AdditionalQuotaRoutingPolicy = z.infer<typeof AdditionalQuotaRoutingPolicySchema>;
+
+export const UpstreamProxyEndpointSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  scheme: z.enum(["http", "https", "socks5", "socks5h"]),
+  host: z.string(),
+  port: z.number().int(),
+  username: z.string().nullable().optional(),
+  isActive: z.boolean(),
+});
+
+export const UpstreamProxyEndpointCreateRequestSchema = z.object({
+  name: z.string().trim().min(1).max(128),
+  scheme: z.enum(["http", "https", "socks5", "socks5h"]),
+  host: z.string().trim().min(1).max(255),
+  port: z.number().int().min(1).max(65535),
+  username: z.string().trim().max(255).nullable().optional(),
+  password: z.string().max(1024).nullable().optional(),
+  isActive: z.boolean().optional().default(true),
+});
+
+export const UpstreamProxyPoolSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  isActive: z.boolean(),
+  endpointIds: z.array(z.string()),
+});
+
+export const UpstreamProxyPoolCreateRequestSchema = z.object({
+  name: z.string().trim().min(1).max(128),
+  endpointIds: z.array(z.string()).default([]),
+  isActive: z.boolean().optional().default(true),
+});
+
+export const UpstreamProxyPoolMemberRequestSchema = z.object({
+  endpointId: z.string().min(1),
+  sortOrder: z.number().int().optional().default(0),
+  weight: z.number().int().min(1).optional().default(1),
+  isActive: z.boolean().optional().default(true),
+});
+
+export const AccountProxyBindingSchema = z.object({
+  accountId: z.string(),
+  poolId: z.string(),
+  isActive: z.boolean(),
+});
+
+export const AccountProxyBindingRequestSchema = z.object({
+  poolId: z.string().min(1),
+  isActive: z.boolean().optional().default(true),
+});
+
+export const UpstreamProxyAdminSchema = z.object({
+  routingEnabled: z.boolean(),
+  defaultPoolId: z.string().nullable(),
+  endpoints: z.array(UpstreamProxyEndpointSchema),
+  pools: z.array(UpstreamProxyPoolSchema),
+  bindings: z.array(AccountProxyBindingSchema),
+});
+
+export type UpstreamProxyEndpoint = z.infer<typeof UpstreamProxyEndpointSchema>;
+export type UpstreamProxyEndpointCreateRequest = z.infer<typeof UpstreamProxyEndpointCreateRequestSchema>;
+export type UpstreamProxyPool = z.infer<typeof UpstreamProxyPoolSchema>;
+export type UpstreamProxyPoolCreateRequest = z.infer<typeof UpstreamProxyPoolCreateRequestSchema>;
+export type UpstreamProxyPoolMemberRequest = z.infer<typeof UpstreamProxyPoolMemberRequestSchema>;
+export type AccountProxyBinding = z.infer<typeof AccountProxyBindingSchema>;
+export type AccountProxyBindingRequest = z.infer<typeof AccountProxyBindingRequestSchema>;
+export type UpstreamProxyAdmin = z.infer<typeof UpstreamProxyAdminSchema>;

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -43,8 +43,8 @@ import {
 	RequestLogSchema,
 	RequestLogsResponseSchema,
 } from "@/features/dashboard/schemas";
-import type { DashboardSettings } from "@/features/settings/schemas";
-import { DashboardSettingsSchema } from "@/features/settings/schemas";
+import type { DashboardSettings, UpstreamProxyAdmin } from "@/features/settings/schemas";
+import { DashboardSettingsSchema, UpstreamProxyAdminSchema } from "@/features/settings/schemas";
 import type {
 	QuotaPlannerDecision,
 	QuotaPlannerForecast,
@@ -72,6 +72,7 @@ export type {
 	RequestLogsResponse,
 	RequestLogFilterOptions,
 	DashboardSettings,
+	UpstreamProxyAdmin,
 	OauthStartResponse,
 	OauthStatusResponse,
 	ApiKey,
@@ -412,6 +413,8 @@ export function createDashboardSettings(
 	return DashboardSettingsSchema.parse({
 		stickyThreadsEnabled: true,
 		upstreamStreamTransport: "default",
+		upstreamProxyRoutingEnabled: false,
+		upstreamProxyDefaultPoolId: null,
 		preferEarlierResetAccounts: false,
 		preferEarlierResetWindow: "secondary",
 		routingStrategy: "usage_weighted",
@@ -512,6 +515,36 @@ export function createQuotaPlannerWarmupActionResponse(
 		reason: "synthetic_traffic_disabled",
 		requestId: null,
 		executedAt: null,
+		...overrides,
+	});
+}
+
+export function createUpstreamProxyAdmin(
+	overrides: Partial<UpstreamProxyAdmin> = {},
+): UpstreamProxyAdmin {
+	return UpstreamProxyAdminSchema.parse({
+		routingEnabled: false,
+		defaultPoolId: null,
+		endpoints: [
+			{
+				id: "ep_primary",
+				name: "Primary proxy",
+				scheme: "http",
+				host: "proxy-primary.test",
+				port: 8080,
+				username: "operator",
+				isActive: true,
+			},
+		],
+		pools: [
+			{
+				id: "pool_primary",
+				name: "Primary pool",
+				isActive: true,
+				endpointIds: ["ep_primary"],
+			},
+		],
+		bindings: [],
 		...overrides,
 	});
 }

--- a/frontend/src/test/mocks/handler-coverage.test.ts
+++ b/frontend/src/test/mocks/handler-coverage.test.ts
@@ -60,6 +60,11 @@ const EXPECTED_ENDPOINTS = [
 	// settings
 	"GET /api/settings",
 	"PUT /api/settings",
+	"GET /api/settings/upstream-proxy",
+	"POST /api/settings/upstream-proxy/endpoints",
+	"POST /api/settings/upstream-proxy/pools",
+	"POST /api/settings/upstream-proxy/pools/:poolId/members",
+	"PUT /api/settings/upstream-proxy/accounts/:accountId/binding",
 	"GET /api/sticky-sessions",
 	"POST /api/sticky-sessions/delete",
 	"POST /api/sticky-sessions/delete-filtered",

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -30,6 +30,7 @@ import {
   createQuotaPlannerSettings,
   createQuotaPlannerWarmupActionResponse,
   createRequestLogFilterOptions,
+  createUpstreamProxyAdmin,
   createRequestLogsResponse,
   type DashboardAuthSession,
   type DashboardSettings,
@@ -37,6 +38,7 @@ import {
   type QuotaPlannerForecast,
   type QuotaPlannerSettings,
   type RequestLogEntry,
+  type UpstreamProxyAdmin,
 } from "@/test/mocks/factories";
 
 const MODEL_OPTION_DELIMITER = ":::";
@@ -99,6 +101,8 @@ const SettingsPayloadSchema = z
     upstreamStreamTransport: z
       .enum(["default", "auto", "http", "websocket"])
       .optional(),
+    upstreamProxyRoutingEnabled: z.boolean().optional(),
+    upstreamProxyDefaultPoolId: z.string().nullable().optional(),
     preferEarlierResetAccounts: z.boolean().optional(),
     routingStrategy: z
       .enum([
@@ -175,6 +179,7 @@ type MockState = {
   settings: DashboardSettings;
   quotaPlannerSettings: QuotaPlannerSettings;
   quotaPlannerDecisions: QuotaPlannerDecision[];
+  upstreamProxyAdmin: UpstreamProxyAdmin;
   quotaPlannerForecast: QuotaPlannerForecast;
   apiKeys: ApiKey[];
   firewallEntries: Array<{ ipAddress: string; createdAt: string }>;
@@ -197,6 +202,7 @@ function createInitialState(): MockState {
     settings: createDashboardSettings(),
     quotaPlannerSettings: createQuotaPlannerSettings(),
     quotaPlannerDecisions: [createQuotaPlannerDecision()],
+    upstreamProxyAdmin: createUpstreamProxyAdmin(),
     quotaPlannerForecast: createQuotaPlannerForecast(),
     apiKeys: createDefaultApiKeys(),
     firewallEntries: [],
@@ -746,6 +752,169 @@ export const handlers = [
     return HttpResponse.json(state.settings);
   }),
 
+
+
+  http.get("/api/settings/upstream-proxy", () => {
+    return HttpResponse.json(state.upstreamProxyAdmin);
+  }),
+
+  http.post("/api/settings/upstream-proxy/endpoints", async ({ request }) => {
+    const payload = await parseJsonBody(
+      request,
+      z
+        .object({
+          name: z.string().min(1),
+          scheme: z.enum(["http", "https", "socks5", "socks5h"]),
+          host: z.string().min(1),
+          port: z.number().int(),
+          username: z.string().nullable().optional(),
+          isActive: z.boolean().optional(),
+        })
+        .passthrough(),
+    );
+    if (!payload) {
+      return HttpResponse.json(
+        {
+          error: {
+            code: "invalid_proxy_endpoint",
+            message: "Invalid proxy endpoint",
+          },
+        },
+        { status: 400 },
+      );
+    }
+    const endpoint = {
+      id: `ep_${state.upstreamProxyAdmin.endpoints.length + 1}`,
+      name: payload.name,
+      scheme: payload.scheme,
+      host: payload.host,
+      port: payload.port,
+      username: payload.username ?? null,
+      isActive: payload.isActive ?? true,
+    };
+    state.upstreamProxyAdmin = {
+      ...state.upstreamProxyAdmin,
+      endpoints: [...state.upstreamProxyAdmin.endpoints, endpoint],
+    };
+    return HttpResponse.json(endpoint);
+  }),
+
+  http.post("/api/settings/upstream-proxy/pools", async ({ request }) => {
+    const payload = await parseJsonBody(
+      request,
+      z
+        .object({
+          name: z.string().min(1),
+          endpointIds: z.array(z.string()).optional(),
+          isActive: z.boolean().optional(),
+        })
+        .passthrough(),
+    );
+    if (!payload) {
+      return HttpResponse.json(
+        { error: { code: "invalid_proxy_pool", message: "Invalid proxy pool" } },
+        { status: 400 },
+      );
+    }
+    const pool = {
+      id: `pool_${state.upstreamProxyAdmin.pools.length + 1}`,
+      name: payload.name,
+      isActive: payload.isActive ?? true,
+      endpointIds: payload.endpointIds ?? [],
+    };
+    state.upstreamProxyAdmin = {
+      ...state.upstreamProxyAdmin,
+      pools: [...state.upstreamProxyAdmin.pools, pool],
+    };
+    return HttpResponse.json(pool);
+  }),
+
+  http.post(
+    "/api/settings/upstream-proxy/pools/:poolId/members",
+    async ({ params, request }) => {
+      const poolId = String(params.poolId);
+      const payload = await parseJsonBody(
+        request,
+        z.object({ endpointId: z.string().min(1) }).passthrough(),
+      );
+      const pool = state.upstreamProxyAdmin.pools.find(
+        (item) => item.id === poolId,
+      );
+      if (!pool || !payload) {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "proxy_pool_not_found",
+              message: "Proxy pool not found",
+            },
+          },
+          { status: 404 },
+        );
+      }
+      if (pool.endpointIds.includes(payload.endpointId)) {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "proxy_pool_member_duplicate",
+              message: "Proxy endpoint is already a member of this pool",
+            },
+          },
+          { status: 400 },
+        );
+      }
+      const updatedPool = {
+        ...pool,
+        endpointIds: [...pool.endpointIds, payload.endpointId],
+      };
+      state.upstreamProxyAdmin = {
+        ...state.upstreamProxyAdmin,
+        pools: state.upstreamProxyAdmin.pools.map((item) =>
+          item.id === poolId ? updatedPool : item,
+        ),
+      };
+      return HttpResponse.json(updatedPool);
+    },
+  ),
+
+  http.put(
+    "/api/settings/upstream-proxy/accounts/:accountId/binding",
+    async ({ params, request }) => {
+      const accountId = String(params.accountId);
+      const payload = await parseJsonBody(
+        request,
+        z
+          .object({ poolId: z.string().min(1), isActive: z.boolean().optional() })
+          .passthrough(),
+      );
+      if (!payload) {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "invalid_proxy_binding",
+              message: "Invalid proxy binding",
+            },
+          },
+          { status: 400 },
+        );
+      }
+      const binding = {
+        accountId,
+        poolId: payload.poolId,
+        isActive: payload.isActive ?? true,
+      };
+      state.upstreamProxyAdmin = {
+        ...state.upstreamProxyAdmin,
+        bindings: [
+          ...state.upstreamProxyAdmin.bindings.filter(
+            (item) => item.accountId !== accountId,
+          ),
+          binding,
+        ],
+      };
+      return HttpResponse.json(binding);
+    },
+  ),
+
   http.get("/api/firewall/ips", () => {
     return HttpResponse.json({
       mode:
@@ -872,6 +1041,21 @@ export const handlers = [
       ...state.settings,
       ...payload,
     });
+    if (
+      payload.upstreamProxyRoutingEnabled !== undefined ||
+      payload.upstreamProxyDefaultPoolId !== undefined
+    ) {
+      state.upstreamProxyAdmin = {
+        ...state.upstreamProxyAdmin,
+        routingEnabled:
+          payload.upstreamProxyRoutingEnabled ??
+          state.upstreamProxyAdmin.routingEnabled,
+        defaultPoolId:
+          payload.upstreamProxyDefaultPoolId !== undefined
+            ? payload.upstreamProxyDefaultPoolId
+            : state.upstreamProxyAdmin.defaultPoolId,
+      };
+    }
     return HttpResponse.json(state.settings);
   }),
 

--- a/openspec/changes/add-upstream-proxy-dashboard-controls/proposal.md
+++ b/openspec/changes/add-upstream-proxy-dashboard-controls/proposal.md
@@ -1,0 +1,15 @@
+# Change: add upstream proxy dashboard controls
+
+## Why
+The backend upstream proxy routing API is merged, but operators cannot safely configure endpoint pools, default routing, or per-account bindings from the dashboard. This leaves the account-bound proxy safety feature effectively API-only.
+
+## What changes
+- Add frontend schemas and API calls for upstream proxy admin state and mutations.
+- Add settings UI controls for routing enablement, default pool selection, endpoint creation, pool creation, and pool membership.
+- Add account-level proxy pool binding controls so operators can route all ChatGPT traffic for an account through its configured pool.
+- Add dashboard tests and mock handlers for the new operator flows.
+
+## Non-goals
+- Editing/deleting existing proxy endpoints or pools.
+- Showing proxy credentials after creation.
+- Runtime TLS fingerprint/profile controls.

--- a/openspec/changes/add-upstream-proxy-dashboard-controls/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-upstream-proxy-dashboard-controls/specs/frontend-architecture/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Dashboard settings must expose upstream proxy routing controls
+The settings dashboard MUST allow operators to inspect upstream proxy routing state, enable or disable routing, choose the default proxy pool, create proxy endpoints, create proxy pools, and add endpoints to pools.
+
+#### Scenario: Operator creates a pool from existing endpoints
+- **GIVEN** the upstream proxy admin API returns at least one endpoint
+- **WHEN** an operator creates a pool and selects endpoint members
+- **THEN** the dashboard MUST call the pool creation API with the selected endpoint ids
+- **AND** refresh the displayed upstream proxy admin state.
+
+### Requirement: Dashboard accounts must expose account proxy bindings
+The accounts dashboard MUST allow operators to bind an account to a proxy pool and disable an existing account binding.
+
+#### Scenario: Operator binds an account to a pool
+- **GIVEN** upstream proxy routing has at least one proxy pool
+- **WHEN** an operator selects a pool for an account and saves the binding
+- **THEN** the dashboard MUST call the account binding API for that account
+- **AND** display the selected pool as the account binding.

--- a/openspec/changes/add-upstream-proxy-dashboard-controls/tasks.md
+++ b/openspec/changes/add-upstream-proxy-dashboard-controls/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+## 1. Spec and API modeling
+- [x] Add frontend-facing requirements for upstream proxy controls.
+- [x] Add TypeScript schemas and API helpers for upstream proxy admin endpoints.
+
+## 2. Settings control plane
+- [x] Render routing enablement/default pool controls in settings.
+- [x] Render endpoint and pool creation forms.
+- [x] Render pool membership controls with duplicate-safe feedback.
+
+## 3. Account bindings
+- [x] Render per-account proxy pool binding controls.
+- [x] Support enabling/disabling an account binding from the accounts page.
+
+## 4. Verification
+- [x] Add MSW mock state and component/schema tests.
+- [x] Run OpenSpec and frontend validation.


### PR DESCRIPTION
## Summary
- add dashboard schemas/API/hooks for upstream proxy admin endpoints
- add Settings UI for routing enablement, default pool, endpoint/pool/member management
- add Accounts UI for per-account proxy pool binding and disabling

## OpenSpec
- openspec/changes/add-upstream-proxy-dashboard-controls/

## Validation
- uv run openspec validate add-upstream-proxy-dashboard-controls --strict
- uv run openspec validate --specs
- cd frontend && bun run lint
- cd frontend && bun run typecheck
- cd frontend && bun run build
- cd frontend && bun run test src/features/settings/components/routing-settings.test.tsx src/features/settings/components/upstream-proxy-settings.test.tsx src/features/accounts/components/account-proxy-binding.test.tsx src/features/settings/schemas.test.ts
- cd frontend && bun run test src/features/accounts/components/account-list.test.tsx src/features/accounts/components/account-list-item.test.tsx src/features/accounts/components/account-proxy-binding.test.tsx src/features/settings/components/upstream-proxy-settings.test.tsx src/features/settings/schemas.test.ts