### PR TITLE
fix(frontend): guard React DOM against translation mutations

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,8 +1,7 @@
 <!doctype html>
-<html lang="en" translate="no">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="google" content="notranslate" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -10,8 +9,8 @@
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <title>Codex LB</title>
   </head>
-  <body translate="no">
-    <div id="root" translate="no"></div>
+  <body>
+    <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,9 +7,11 @@ import App from "./App.tsx";
 import { useDashboardPreferencesStore } from "@/hooks/use-dashboard-preferences";
 import { queryClient } from "@/lib/query-client";
 import { useThemeStore } from "@/hooks/use-theme";
+import { installExternalDomMutationGuard } from "@/utils/external-dom-mutation-guard";
 
 import "./index.css";
 
+installExternalDomMutationGuard();
 useThemeStore.getState().initializeTheme();
 useDashboardPreferencesStore.getState().initializePreferences();
 

--- a/frontend/src/utils/external-dom-mutation-guard.test.ts
+++ b/frontend/src/utils/external-dom-mutation-guard.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installExternalDomMutationGuard } from "@/utils/external-dom-mutation-guard";
+
+describe("installExternalDomMutationGuard", () => {
+  let originalRemoveChild: typeof Node.prototype.removeChild;
+  let originalInsertBefore: typeof Node.prototype.insertBefore;
+
+  beforeEach(() => {
+    vi.resetModules();
+    originalRemoveChild = Node.prototype.removeChild;
+    originalInsertBefore = Node.prototype.insertBefore;
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    Node.prototype.removeChild = originalRemoveChild;
+    Node.prototype.insertBefore = originalInsertBefore;
+    vi.restoreAllMocks();
+  });
+
+  it("returns externally moved children instead of throwing on removeChild", async () => {
+    const { installExternalDomMutationGuard } = await import("@/utils/external-dom-mutation-guard");
+    const parent = document.createElement("div");
+    const otherParent = document.createElement("div");
+    const child = document.createElement("span");
+    otherParent.appendChild(child);
+
+    installExternalDomMutationGuard();
+
+    expect(parent.removeChild(child)).toBe(child);
+    expect(console.error).toHaveBeenCalledWith(
+      "Ignoring external DOM mutation before removeChild",
+      child,
+      parent,
+    );
+  });
+
+  it("returns new nodes instead of throwing when insertBefore reference moved", async () => {
+    const { installExternalDomMutationGuard } = await import("@/utils/external-dom-mutation-guard");
+    const parent = document.createElement("div");
+    const otherParent = document.createElement("div");
+    const reference = document.createElement("span");
+    const newNode = document.createElement("strong");
+    otherParent.appendChild(reference);
+
+    installExternalDomMutationGuard();
+
+    expect(parent.insertBefore(newNode, reference)).toBe(newNode);
+    expect(parent.contains(newNode)).toBe(false);
+    expect(console.error).toHaveBeenCalledWith(
+      "Ignoring external DOM mutation before insertBefore",
+      reference,
+      parent,
+    );
+  });
+
+  it("leaves valid DOM operations intact", async () => {
+    const { installExternalDomMutationGuard } = await import("@/utils/external-dom-mutation-guard");
+    const parent = document.createElement("div");
+    const child = document.createElement("span");
+    const newNode = document.createElement("strong");
+    parent.appendChild(child);
+
+    installExternalDomMutationGuard();
+
+    expect(parent.insertBefore(newNode, child)).toBe(newNode);
+    expect(parent.firstChild).toBe(newNode);
+    expect(parent.removeChild(child)).toBe(child);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("installs only once", () => {
+    installExternalDomMutationGuard();
+    const removeChild = Node.prototype.removeChild;
+    const insertBefore = Node.prototype.insertBefore;
+
+    installExternalDomMutationGuard();
+
+    expect(Node.prototype.removeChild).toBe(removeChild);
+    expect(Node.prototype.insertBefore).toBe(insertBefore);
+  });
+});

--- a/frontend/src/utils/external-dom-mutation-guard.ts
+++ b/frontend/src/utils/external-dom-mutation-guard.ts
@@ -1,0 +1,27 @@
+let installed = false;
+
+export function installExternalDomMutationGuard(): void {
+  if (installed || typeof Node !== "function" || !Node.prototype) {
+    return;
+  }
+  installed = true;
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  const originalInsertBefore = Node.prototype.insertBefore;
+
+  Node.prototype.removeChild = function removeChildGuard<T extends Node>(child: T): T {
+    if (child.parentNode !== this) {
+      console.error("Ignoring external DOM mutation before removeChild", child, this);
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  Node.prototype.insertBefore = function insertBeforeGuard<T extends Node>(newNode: T, referenceNode: Node | null): T {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      console.error("Ignoring external DOM mutation before insertBefore", referenceNode, this);
+      return newNode;
+    }
+    return originalInsertBefore.call(this, newNode, referenceNode) as T;
+  };
+}

--- a/openspec/changes/disable-dashboard-browser-translation/proposal.md
+++ b/openspec/changes/disable-dashboard-browser-translation/proposal.md
@@ -4,11 +4,11 @@ Chrome's built-in Translate action and the Google Translate extension can mutate
 
 ## What Changes
 
-- Mark the dashboard HTML document, body, and React root as non-translatable.
-- Add Google's `notranslate` meta tag so browser translation tools do not rewrite dashboard DOM text nodes.
+- Allow browser translation tools to translate dashboard text.
+- Install a small startup guard around DOM `removeChild`/`insertBefore` so externally moved nodes are logged and ignored instead of crashing React reconciliation.
 
 ## Impact
 
-- Prevents browser translation from modifying the live React dashboard DOM.
+- Keeps the dashboard from crashing if browser translation or another extension mutates React-owned DOM.
 - Keeps the dashboard usable for operators affected by Google Translate injection.
 - Does not add built-in localization; a first-party i18n UI remains a separate feature.

--- a/openspec/changes/disable-dashboard-browser-translation/specs/frontend-architecture/spec.md
+++ b/openspec/changes/disable-dashboard-browser-translation/specs/frontend-architecture/spec.md
@@ -1,11 +1,16 @@
 ## MODIFIED Requirements
 
-### Requirement: Dashboard HTML shell avoids browser translation DOM mutation
+### Requirement: Dashboard tolerates browser translation DOM mutation
 
-The dashboard HTML shell SHALL opt out of browser/extension translation for the React-owned document surface so external translation tools do not inject markup into React-managed text nodes.
+The dashboard HTML shell SHALL allow browser/extension translation while protecting React reconciliation from external DOM node moves.
 
-#### Scenario: Dashboard opts out of Google Translate DOM rewriting
+#### Scenario: Dashboard permits browser translation
 
 - **WHEN** the browser loads the dashboard HTML shell
-- **THEN** the document advertises `notranslate` metadata for Google Translate
-- **AND** the document, body, and React root are marked with `translate="no"`
+- **THEN** the document, body, and React root do not opt out of browser translation
+
+#### Scenario: Dashboard tolerates externally moved React nodes
+
+- **WHEN** an extension moves a React-owned DOM node before React removes or inserts around it
+- **THEN** the dashboard startup guard logs the external mutation
+- **AND** the guarded DOM operation returns without throwing a reconciliation-stopping exception

--- a/openspec/changes/disable-dashboard-browser-translation/tasks.md
+++ b/openspec/changes/disable-dashboard-browser-translation/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Dashboard HTML
 
-- [x] 1.1 Add document-level `translate="no"` to the dashboard HTML shell.
-- [x] 1.2 Add Google `notranslate` metadata.
-- [x] 1.3 Add `translate="no"` to the React root container.
+- [x] 1.1 Allow browser translation in the dashboard HTML shell.
+- [x] 1.2 Install a startup DOM mutation guard for externally moved React nodes.
 
 ## 2. Validation
 
 - [x] 2.1 Run the frontend production build.
 - [x] 2.2 Run OpenSpec validation for this change.
+- [x] 2.3 Add unit coverage for guarded `removeChild` and `insertBefore` behavior.


### PR DESCRIPTION
## Summary

Follow-up to #908 and https://github.com/Soju06/codex-lb/pull/908#issuecomment-4615440627.

- allow browser translation again by removing the document/root `translate="no"` and Google `notranslate` opt-outs
- add a startup guard for externally moved React DOM nodes, based on the React issue workaround linked in the review comment
- keep valid `removeChild`/`insertBefore` operations unchanged
- log and return safely when browser translation/extensions move nodes before React reconciles them
- update the browser-translation OpenSpec change and add unit coverage

## Why

#908 disabled browser translation to avoid React crashes when Google Translate or extensions rewrite React-owned DOM. The linked React workaround gives us a better user-facing tradeoff: keep translation available, but guard the DOM operations that otherwise throw when an external tool moves nodes.

## Validation

```bash
cd frontend && bun run test -- src/utils/external-dom-mutation-guard.test.ts
cd frontend && bun run typecheck
cd frontend && bun run lint
cd frontend && bun run build
uv run openspec validate disable-dashboard-browser-translation --strict
git diff --check
```

Local result on `f45c603258015ae879db09c0daf5162bc675149d`: guard unit tests passed (4 tests), frontend typecheck/lint/build passed, OpenSpec strict validation passed, and the HTML/OpenSpec grep no longer finds `translate="no"` or `notranslate`.

GitHub CI is green for current head `f45c603258015ae879db09c0daf5162bc675149d`, including `CI Required`, CodeQL, Trivy, and GitGuardian.
