### PR TITLE
fix(proxy): preserve codex image generation tools

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -658,6 +658,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "mastertyko",
+      "name": "mastertyko",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11311479?v=4",
+      "profile": "https://github.com/mastertyko",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
       <td align="center" valign="top" width="14.28%"><a href="https://rtx09x.github.io/"><img src="https://avatars.githubusercontent.com/u/187954595?v=4?s=100" width="100px;" alt="Rudra Tiwari"/><br /><sub><b>Rudra Tiwari</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=Rtx09x" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/wuchao05"><img src="https://avatars.githubusercontent.com/u/97175999?v=4?s=100" width="100px;" alt="Wu Chao"/><br /><sub><b>Wu Chao</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=wuchao05" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/zwd0313"><img src="https://avatars.githubusercontent.com/u/159164983?v=4?s=100" width="100px;" alt="zwd0313"/><br /><sub><b>zwd0313</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=zwd0313" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mastertyko"><img src="https://avatars.githubusercontent.com/u/11311479?v=4?s=100" width="100px;" alt="mastertyko"/><br /><sub><b>mastertyko</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=mastertyko" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=mastertyko" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -481,7 +481,6 @@ async def responses(
         responses_payload = normalize_responses_request_payload(
             payload,
             openai_compat=openai_compat_payload,
-            codex_tool_compat=True,
         )
     except ClientPayloadError as exc:
         error = openai_client_payload_error(exc)

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -15,7 +15,6 @@ from app.core.openai.strict_schema import (
 )
 from app.core.openai.v1_requests import V1ResponsesRequest
 from app.core.types import JsonValue
-from app.core.utils.json_guards import is_json_list, is_json_mapping
 from app.core.utils.request_id import get_request_id
 from app.modules.api_keys.service import ApiKeyData
 
@@ -353,45 +352,14 @@ def normalize_responses_request_payload(
     payload: dict[str, JsonValue],
     *,
     openai_compat: bool,
-    codex_tool_compat: bool = False,
 ) -> ResponsesRequest:
-    effective_payload = _sanitize_backend_codex_tool_advertisements(payload) if codex_tool_compat else payload
     if openai_compat:
-        responses = V1ResponsesRequest.model_validate(effective_payload).to_responses_request()
+        responses = V1ResponsesRequest.model_validate(payload).to_responses_request()
     else:
-        responses = ResponsesRequest.model_validate(effective_payload)
+        responses = ResponsesRequest.model_validate(payload)
     enforce_strict_text_format(responses)
     enforce_strict_function_tools_format(responses.tools)
     return responses
-
-
-def _sanitize_backend_codex_tool_advertisements(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:
-    tools_value = payload.get("tools")
-    if not is_json_list(tools_value):
-        return payload
-    if _explicitly_requests_image_generation(payload.get("tool_choice"), tools_value):
-        return payload
-
-    sanitized_tools: list[JsonValue] = []
-    removed_any = False
-    for tool in tools_value:
-        if is_json_mapping(tool) and tool.get("type") == "image_generation":
-            removed_any = True
-            continue
-        sanitized_tools.append(tool)
-
-    if not removed_any:
-        return payload
-
-    sanitized_payload = dict(payload)
-    sanitized_payload["tools"] = sanitized_tools
-    return sanitized_payload
-
-
-def _explicitly_requests_image_generation(tool_choice: JsonValue | None, tools: list[JsonValue]) -> bool:
-    if tool_choice == "required":
-        return all(is_json_mapping(tool) and tool.get("type") == "image_generation" for tool in tools)
-    return is_json_mapping(tool_choice) and tool_choice.get("type") == "image_generation"
 
 
 def enforce_strict_text_format(request: ResponsesRequest) -> None:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -5052,7 +5052,6 @@ class ProxyService:
         responses_payload = normalize_responses_request_payload(
             payload,
             openai_compat=openai_cache_affinity,
-            codex_tool_compat=codex_session_affinity,
         )
         previous_response_trimmed_input_count: int | None = None
         previous_response_trimmed_input_fingerprint: str | None = None

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -585,6 +585,13 @@ def _responses_request_contains_input_image(payload: ResponsesRequest) -> bool:
     return any(_json_value_contains_input_image_part(item) for item in input_value)
 
 
+def _responses_request_uses_image_generation(payload: ResponsesRequest) -> bool:
+    tools = payload.tools
+    if not isinstance(tools, list):
+        return False
+    return any(is_json_mapping(tool) and tool.get("type") == "image_generation" for tool in tools)
+
+
 def _response_create_text(
     payload: ResponsesRequest,
     *,
@@ -843,10 +850,14 @@ class ProxyService:
             )
             runtime_config = dataclasses.replace(runtime_config, enabled=False)
         image_request = _responses_request_contains_input_image(payload)
+        image_generation_request = _responses_request_uses_image_generation(payload)
         force_upstream_stream_transport = "http" if image_request else None
-        if runtime_config.enabled and image_request:
+        if runtime_config.enabled and (image_request or image_generation_request):
             logger.info(
-                "stream_responses bypassing http bridge for input_image request_id=%s",
+                "stream_responses bypassing http bridge for image-capable request input_image=%s "
+                "image_generation=%s request_id=%s",
+                image_request,
+                image_generation_request,
                 request_id,
             )
             runtime_config = dataclasses.replace(runtime_config, enabled=False)

--- a/openspec/changes/restore-codex-image-generation-tool/proposal.md
+++ b/openspec/changes/restore-codex-image-generation-tool/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Codex Desktop can expose the built-in `image_gen` surface through backend
+Codex Responses requests that advertise the upstream `image_generation` tool.
+codex-lb currently strips that tool on `/backend-api/codex/responses` unless
+the request forces `tool_choice`, so ordinary Codex turns lose the descriptor
+that enables image-generation flows even though public `/v1/responses` and
+`/v1/images/*` already prove upstream accepts the tool.
+
+## What Changes
+
+- Preserve backend Codex `image_generation` tool entries during request
+  normalization and upstream forwarding.
+- Keep public `/v1/*` Responses behavior unchanged.
+- Keep image-generation requests on the HTTP/SSE upstream transport path so
+  large image payloads avoid websocket frame limits.
+- Add regression coverage for backend Codex normalization with ambient
+  `image_generation` descriptors.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: backend Codex Responses routes preserve
+  `image_generation` tool descriptors instead of stripping them.
+
+## Impact
+
+- Code: `app/modules/proxy/request_policy.py`.
+- Specs: `openspec/specs/responses-api-compat/spec.md` and this change delta.
+- Tests: request-normalization regression coverage.

--- a/openspec/changes/restore-codex-image-generation-tool/specs/responses-api-compat/spec.md
+++ b/openspec/changes/restore-codex-image-generation-tool/specs/responses-api-compat/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Backend Codex Responses preserve image_generation tools
+
+The service MUST accept HTTP and websocket `/backend-api/codex/responses`
+request-create payloads that include top-level `tools` entries with
+`type: "image_generation"`. The service MUST preserve those `image_generation`
+tool entries during shared Responses validation and upstream forwarding so
+Codex clients can expose and use the built-in image-generation surface. The
+service MUST continue preserving all other tool entries and the existing
+built-in tool forwarding policy for public `/v1/*` routes.
+
+#### Scenario: Backend Codex HTTP request preserves advertised image_generation tool
+
+- **WHEN** a client sends `POST /backend-api/codex/responses` with
+  `tools=[{"type":"image_generation"},{"type":"function","name":"x"}]`
+- **THEN** the request is accepted instead of failing with
+  `invalid_request_error`
+- **AND** the upstream Responses payload preserves the `image_generation` tool
+- **AND** the remaining `function` tool is preserved
+
+#### Scenario: Backend Codex websocket create preserves image_generation tool
+
+- **WHEN** a websocket `response.create` payload for
+  `/backend-api/codex/responses` includes a top-level
+  `{"type":"image_generation"}` tool entry
+- **THEN** the backend Codex websocket request is accepted
+- **AND** the forwarded upstream `response.create` payload preserves that
+  `image_generation` tool entry

--- a/openspec/changes/restore-codex-image-generation-tool/tasks.md
+++ b/openspec/changes/restore-codex-image-generation-tool/tasks.md
@@ -1,0 +1,9 @@
+- [x] 1. Update Responses compatibility spec to preserve backend Codex `image_generation` tools.
+- [x] 2. Add failing regression coverage for backend Codex request normalization preserving `image_generation`.
+- [x] 3. Implement the minimal request-policy change.
+- [x] 4. Verify focused tests and live codex-lb image-generation surfaces.
+- [x] 5. Attempt OpenSpec validation.
+  - `openspec validate --specs`, `uv run openspec validate --specs`,
+    `uvx openspec validate --specs`, and `npx openspec validate --specs`
+    were attempted from this checkout, but the OpenSpec CLI is unavailable in
+    the local environment/package registries. See `verify-report.md`.

--- a/openspec/changes/restore-codex-image-generation-tool/verify-report.md
+++ b/openspec/changes/restore-codex-image-generation-tool/verify-report.md
@@ -1,0 +1,54 @@
+# Verify Report
+
+## Summary
+
+The implementation was verified on a clean branch based on current upstream
+`main` with focused regression tests, broader targeted proxy/images/model
+tests, lint, a secrets scan, and diff whitespace checks.
+
+Additional local runtime smoke against the same application change confirmed
+that `/backend-api/codex/responses` forwards `image_generation` and that
+`/v1/images/generations` can return PNG image data without an exported
+`OPENAI_API_KEY`.
+
+OpenSpec validation was attempted but could not be executed in this local
+environment because the `openspec` command is unavailable and no runnable
+package was resolvable via `uvx` or `npx`.
+
+## Commands
+
+- `.venv/bin/python -m pytest tests/unit/test_proxy_utils.py tests/integration/test_openai_compat_features.py tests/integration/test_proxy_websocket_responses.py tests/integration/test_v1_models.py tests/integration/test_account_auth_export.py tests/unit/test_images_translation.py -q`
+  - Result: `605 passed in 50.95s`
+- `.venv/bin/python -m ruff check app/modules/proxy/request_policy.py app/modules/proxy/api.py app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/integration/test_openai_compat_features.py tests/integration/test_proxy_websocket_responses.py tests/integration/test_v1_models.py tests/integration/test_account_auth_export.py tests/unit/test_images_translation.py`
+  - Result: `All checks passed!`
+- `git diff --check`
+  - Result: passed with no output.
+- `detect-secrets scan -n <changed files>`
+  - Result: no findings.
+- Additional local runtime smoke: `/backend-api/codex/responses`
+  - Result: HTTP 200 and upstream response included `tools[].type =
+    "image_generation"` plus `tool_usage.image_gen`.
+- Additional local runtime smoke: `/v1/images/generations`
+  - Result: ran with `env -u OPENAI_API_KEY` and returned PNG image data.
+
+## OpenSpec Validation Attempt
+
+Attempted commands:
+
+- `openspec validate --specs`
+- `uv run openspec validate --specs`
+- `uvx openspec validate --specs`
+- `npx --yes openspec validate --specs`
+- `npx --yes openspec@0.0.0 validate --specs`
+
+Observed result:
+
+- `openspec` is not present on PATH.
+- `uv run openspec` cannot spawn an executable.
+- `uvx openspec` cannot resolve a package.
+- `npx openspec` resolves metadata for an `openspec@0.0.0` package but cannot
+  determine an executable.
+- `@openspec/cli` and `@open-spec/cli` are not present in the npm registry.
+
+This OpenSpec CLI gate remains deferred to an environment where the project
+maintainers have the OpenSpec executable available.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -870,28 +870,29 @@ Top-level error normalization MUST NOT treat the event discriminator `type: "err
 - **AND** the downstream payload does not contain `previous_response_not_found`
 - **AND** the downstream payload does not expose the missing previous response id
 
-### Requirement: Backend Codex Responses tolerate advertised image_generation tools
+### Requirement: Backend Codex Responses preserve advertised image_generation tools
 The service MUST accept HTTP and websocket `/backend-api/codex/responses`
 request-create payloads that include top-level `tools` entries with
-`type: "image_generation"`. Before shared Responses validation and upstream
-forwarding, the service MUST remove only those advertised top-level
-`image_generation` tool entries while preserving all other tool entries and the
-existing built-in tool forwarding policy for public `/v1/*` routes.
+`type: "image_generation"`. During shared Responses validation and upstream
+forwarding, the service MUST preserve those top-level `image_generation` tool
+entries so Codex clients can expose and use the built-in image-generation
+surface. The service MUST also preserve all other tool entries and the existing
+built-in tool forwarding policy for public `/v1/*` routes.
 
-#### Scenario: Backend Codex HTTP request strips advertised image_generation tool
+#### Scenario: Backend Codex HTTP request preserves advertised image_generation tool
 - **WHEN** a client sends `POST /backend-api/codex/responses` with
   `tools=[{"type":"image_generation"},{"type":"function","name":"x"}]`
 - **THEN** the request is accepted instead of failing with
   `invalid_request_error`
-- **AND** the upstream Responses payload omits the `image_generation` tool
+- **AND** the upstream Responses payload preserves the `image_generation` tool
 - **AND** the remaining `function` tool is preserved
 
-#### Scenario: Backend Codex websocket create strips advertised image_generation tool
+#### Scenario: Backend Codex websocket create preserves advertised image_generation tool
 - **WHEN** a websocket `response.create` payload for
   `/backend-api/codex/responses` includes a top-level
   `{"type":"image_generation"}` tool entry
 - **THEN** the backend Codex websocket request is accepted
-- **AND** the forwarded upstream `response.create` payload omits that
+- **AND** the forwarded upstream `response.create` payload preserves that
   `image_generation` tool entry
 
 #### Scenario: Public v1 Responses built-in forwarding policy remains unchanged

--- a/tests/integration/test_openai_compat_features.py
+++ b/tests/integration/test_openai_compat_features.py
@@ -426,7 +426,7 @@ async def test_backend_responses_allows_web_search(async_client, monkeypatch, to
 
 
 @pytest.mark.asyncio
-async def test_backend_responses_strip_image_generation_tool_advertisement(async_client, monkeypatch):
+async def test_backend_responses_preserves_image_generation_tool_advertisement(async_client, monkeypatch):
     await _import_account(async_client, "acc_backend_image_gen", "backend-image-gen@example.com")
 
     seen = {}
@@ -450,7 +450,7 @@ async def test_backend_responses_strip_image_generation_tool_advertisement(async
     }
     resp = await async_client.post("/backend-api/codex/responses", json=request_payload)
     assert resp.status_code == 200
-    assert seen["payload"].tools == [function_tool]
+    assert seen["payload"].tools == [{"type": "image_generation", "output_format": "png"}, function_tool]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -855,7 +855,7 @@ def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
     assert log_calls[0]["status"] == "success"
 
 
-def test_backend_responses_websocket_strips_image_generation_tool_advertisement(app_instance, monkeypatch):
+def test_backend_responses_websocket_preserves_image_generation_tool_advertisement(app_instance, monkeypatch):
     upstream_messages = [
         _FakeUpstreamMessage(
             "text",
@@ -966,7 +966,7 @@ def test_backend_responses_websocket_strips_image_generation_tool_advertisement(
             "model": "gpt-5.4",
             "instructions": "",
             "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
-            "tools": [function_tool],
+            "tools": [{"type": "image_generation", "output_format": "png"}, function_tool],
             "store": False,
             "include": [],
             "type": "response.create",

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -549,6 +549,7 @@ async def test_backend_codex_models_uses_bootstrap_models_when_registry_not_popu
     slugs = {item["slug"] for item in payload["models"]}
     assert slugs == BOOTSTRAP_MODEL_SLUGS
     assert "gpt-5.5-pro" not in slugs
+    assert all(not slug.startswith("gpt-image-") for slug in slugs)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -453,7 +453,7 @@ def test_apply_api_key_enforcement_normalizes_minimal_without_api_key():
     assert payload.reasoning.effort == "low"
 
 
-def test_normalize_responses_request_payload_strips_backend_codex_image_generation_tools():
+def test_normalize_responses_request_payload_preserves_backend_codex_image_generation_with_function_tools():
     function_tool = {
         "type": "function",
         "name": "lookup_weather",
@@ -469,11 +469,32 @@ def test_normalize_responses_request_payload_strips_backend_codex_image_generati
     request = proxy_request_policy.normalize_responses_request_payload(
         payload,
         openai_compat=True,
-        codex_tool_compat=True,
     )
 
-    assert request.tools == [function_tool]
+    assert request.tools == [{"type": "image_generation", "output_format": "png"}, function_tool]
     assert payload["tools"] == [{"type": "image_generation", "output_format": "png"}, function_tool]
+
+
+def test_normalize_responses_request_payload_preserves_backend_codex_image_generation_tools():
+    image_tool = {"type": "image_generation", "output_format": "png"}
+    function_tool = {
+        "type": "function",
+        "name": "lookup_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    }
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [],
+        "tools": [image_tool, function_tool],
+    }
+
+    request = proxy_request_policy.normalize_responses_request_payload(
+        payload,
+        openai_compat=True,
+    )
+
+    assert request.tools == [image_tool, function_tool]
 
 
 def test_normalize_responses_request_payload_without_codex_compat_preserves_image_generation():
@@ -487,7 +508,6 @@ def test_normalize_responses_request_payload_without_codex_compat_preserves_imag
     request = proxy_request_policy.normalize_responses_request_payload(
         payload,
         openai_compat=True,
-        codex_tool_compat=False,
     )
 
     assert request.tools == [{"type": "image_generation", "output_format": "png"}]
@@ -506,7 +526,6 @@ def test_normalize_responses_request_payload_preserves_explicit_image_generation
     request = proxy_request_policy.normalize_responses_request_payload(
         payload,
         openai_compat=True,
-        codex_tool_compat=True,
     )
 
     assert request.tools == [image_tool]
@@ -526,14 +545,13 @@ def test_normalize_responses_request_payload_preserves_required_image_generation
     request = proxy_request_policy.normalize_responses_request_payload(
         payload,
         openai_compat=True,
-        codex_tool_compat=True,
     )
 
     assert request.tools == [image_tool]
     assert request.tool_choice == "required"
 
 
-def test_normalize_responses_request_payload_strips_required_image_generation_advertisement_with_function_tool():
+def test_normalize_responses_request_payload_preserves_required_image_generation_with_function_tool():
     image_tool = {"type": "image_generation", "output_format": "png"}
     function_tool = {
         "type": "function",
@@ -553,10 +571,9 @@ def test_normalize_responses_request_payload_strips_required_image_generation_ad
     request = proxy_request_policy.normalize_responses_request_payload(
         payload,
         openai_compat=True,
-        codex_tool_compat=True,
     )
 
-    assert request.tools == [function_tool]
+    assert request.tools == [image_tool, function_tool]
     assert request.tool_choice == "required"
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1368,6 +1368,69 @@ async def test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image(monke
 
 
 @pytest.mark.asyncio
+async def test_stream_http_bridge_or_retry_bypasses_bridge_for_image_generation_tool(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "draw",
+            "input": [{"role": "user", "content": "draw"}],
+            "tools": [{"type": "image_generation"}],
+        }
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+
+    calls: list[str] = []
+
+    async def fake_stream_with_retry(payload, headers, **kwargs):
+        del payload, headers, kwargs
+        calls.append("retry")
+        yield "data: retry\n\n"
+
+    async def fake_stream_via_http_bridge(payload, headers, **kwargs):
+        del payload, headers, kwargs
+        calls.append("bridge")
+        yield "data: bridge\n\n"
+
+    monkeypatch.setattr(service, "_stream_with_retry", fake_stream_with_retry)
+    monkeypatch.setattr(service, "_stream_via_http_bridge", fake_stream_via_http_bridge)
+
+    output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload=payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert output == ["data: retry\n\n"]
+    assert calls == ["retry"]
+
+
+@pytest.mark.asyncio
 async def test_stream_http_bridge_or_retry_forces_http_for_input_image_when_bridge_disabled(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))


### PR DESCRIPTION

## Summary

Preserves backend Codex `image_generation` tool entries during Responses request normalization so Codex Desktop can expose and use the built-in `image_gen` tool again.

Current `main` accepts backend Codex payloads that include `image_generation`, but the Codex compatibility path strips ambient tool advertisements before upstream forwarding. That keeps the real Codex image-generation surface from becoming callable in ordinary Codex Desktop turns.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #839

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/restore-codex-image-generation-tool/`

## Changes

- Remove the backend Codex-only sanitizer that stripped top-level `tools[].type == "image_generation"`.
- Preserve `image_generation` tools for HTTP and websocket `/backend-api/codex/responses` create payloads.
- Keep strict function-tool validation intact.
- Update Responses API compatibility specs and add regression coverage for the restored behavior.
- Add a model catalog guard to avoid exposing `gpt-image-*` model slugs through backend Codex models.

## Test plan

```bash
.venv/bin/python -m pytest tests/unit/test_proxy_utils.py tests/integration/test_openai_compat_features.py tests/integration/test_proxy_websocket_responses.py tests/integration/test_v1_models.py tests/integration/test_account_auth_export.py tests/unit/test_images_translation.py -q
# 605 passed in 50.95s

.venv/bin/python -m ruff check app/modules/proxy/request_policy.py app/modules/proxy/api.py app/modules/proxy/service.py tests/unit/test_proxy_utils.py tests/integration/test_openai_compat_features.py tests/integration/test_proxy_websocket_responses.py tests/integration/test_v1_models.py tests/integration/test_account_auth_export.py tests/unit/test_images_translation.py
# All checks passed!

git diff --check
# passed

detect-secrets scan -n <changed files>
# {}

uv run openspec validate restore-codex-image-generation-tool --strict
# Change 'restore-codex-image-generation-tool' is valid

uv run openspec validate --specs
# 30 passed, 0 failed
```

OpenSpec validation was re-run from the PR branch at `24cbcfe67084d2d4a16931446a4a3af8067d4aca` in a maintainer checkout and passed for both the change and the full spec set.

## Screenshots / output

Local runtime smoke confirmed:

- `/backend-api/codex/responses` accepted and forwarded `tools[].type == "image_generation"`.
- The upstream response included `tool_usage.image_gen`.
- `/v1/images/generations` returned PNG image data with `env -u OPENAI_API_KEY`.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant focused lint/test subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is not edited by hand.
