### PR TITLE
fix(proxy): harden responses bridge stale cleanup

### DIFF
--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -108,6 +108,7 @@ class DurableBridgeSessionCoordinator:
         latest_turn_state: str | None,
         latest_response_id: str | None,
         allow_takeover: bool,
+        force_owner_epoch_advance: bool = False,
     ) -> DurableBridgeLookup:
         api_key_scope = durable_bridge_api_key_scope(api_key_id)
         async with self._session() as session:
@@ -123,6 +124,7 @@ class DurableBridgeSessionCoordinator:
                 latest_turn_state=latest_turn_state,
                 latest_response_id=latest_response_id,
                 allow_takeover=allow_takeover,
+                force_owner_epoch_advance=force_owner_epoch_advance,
             )
         return _to_lookup(snapshot)
 

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -216,13 +216,15 @@ class DurableBridgeRepository:
             previous_state = existing.state
             account_changed = existing.account_id != account_id
             owner_changed = existing.owner_instance_id != instance_id
-            if not owner_changed:
-                next_epoch = existing.owner_epoch
-            else:
+            if owner_changed:
                 lease_expired = existing.lease_expires_at is None or to_utc_naive(existing.lease_expires_at) <= now
                 if not allow_takeover and not lease_expired and not state_allows_takeover:
                     return _to_snapshot_required(existing)
                 next_epoch = existing.owner_epoch + 1
+            elif account_changed:
+                next_epoch = existing.owner_epoch + 1
+            else:
+                next_epoch = existing.owner_epoch
 
             async with sqlite_writer_section():
                 existing.owner_instance_id = instance_id

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -165,6 +165,7 @@ class DurableBridgeRepository:
         latest_turn_state: str | None,
         latest_response_id: str | None,
         allow_takeover: bool,
+        force_owner_epoch_advance: bool = False,
     ) -> DurableBridgeSessionSnapshot:
         session_key_hash = durable_bridge_hash(session_key_value)
         for attempt in range(2):
@@ -221,7 +222,7 @@ class DurableBridgeRepository:
                 if not allow_takeover and not lease_expired and not state_allows_takeover:
                     return _to_snapshot_required(existing)
                 next_epoch = existing.owner_epoch + 1
-            elif account_changed:
+            elif account_changed or force_owner_epoch_advance:
                 next_epoch = existing.owner_epoch + 1
             else:
                 next_epoch = existing.owner_epoch

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -308,18 +308,19 @@ class DurableBridgeRepository:
         owner_epoch: int,
         draining: bool,
     ) -> DurableBridgeSessionSnapshot | None:
-        row = await self._session.get(HttpBridgeSessionRecord, session_id)
-        if row is None:
-            return None
-        if row.owner_instance_id != instance_id or row.owner_epoch != owner_epoch:
-            return _to_snapshot(row)
-        now = utcnow()
-        row.owner_instance_id = None
-        row.lease_expires_at = now
-        row.last_seen_at = now
-        row.state = HttpBridgeSessionState.DRAINING if draining else HttpBridgeSessionState.CLOSED
-        row.closed_at = None if draining else now
-        await self._commit_writer_section()
+        async with sqlite_writer_section():
+            row = await self._session.get(HttpBridgeSessionRecord, session_id, populate_existing=True)
+            if row is None:
+                return None
+            if row.owner_instance_id != instance_id or row.owner_epoch != owner_epoch:
+                return _to_snapshot(row)
+            now = utcnow()
+            row.owner_instance_id = None
+            row.lease_expires_at = now
+            row.last_seen_at = now
+            row.state = HttpBridgeSessionState.DRAINING if draining else HttpBridgeSessionState.CLOSED
+            row.closed_at = None if draining else now
+            await self._session.commit()
         await self._session.refresh(row)
         return _to_snapshot(row)
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6752,9 +6752,10 @@ class ProxyService:
                         expected_session=existing,
                         mark_closed=not retiring_with_visible_requests,
                     )
-                    if detached is not None and not retiring_with_visible_requests:
+                    if detached is not None:
                         force_durable_takeover = True
-                        self._schedule_http_bridge_session_closes([detached], reason="registry_detach")
+                        if not retiring_with_visible_requests:
+                            self._schedule_http_bridge_session_closes([detached], reason="registry_detach")
                     existing = None
 
                 if shutdown_state.is_bridge_drain_active() and not _http_bridge_can_recover_during_drain(
@@ -7405,10 +7406,11 @@ class ProxyService:
                             expected_session=session,
                             mark_closed=not retiring_with_visible_requests,
                         )
-                    if not retiring_with_visible_requests:
+                    if detached is not None:
                         force_durable_takeover_after_detach = True
+                    if detached is not None and not retiring_with_visible_requests:
                         self._schedule_http_bridge_session_closes(
-                            [detached or session],
+                            [detached],
                             reason="registry_detach",
                         )
                 continue

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7566,23 +7566,6 @@ class ProxyService:
                 context="idle_prune",
             )
             if pending_count is None:
-                visible_pending_count = sum(
-                    1
-                    for request_state in session.pending_requests
-                    if _http_bridge_request_counts_against_queue(request_state)
-                )
-                if visible_pending_count or session.queued_request_count:
-                    continue
-                if now - session.last_used_at < session.idle_ttl_seconds:
-                    continue
-                logger.warning(
-                    "http_bridge_prune_unresponsive_idle_session bridge_kind=%s bridge_key=%s account_id=%s model=%s",
-                    key.affinity_kind,
-                    _hash_identifier(key.affinity_key),
-                    session.account.id,
-                    session.request_model,
-                )
-                stale_keys.append(key)
                 continue
             if pending_count:
                 continue

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7798,20 +7798,28 @@ class ProxyService:
     ) -> None:
         current_instance = get_settings().http_responses_session_bridge_instance_id
         try:
-            lookup = await self._durable_bridge.claim_live_session(
-                session_key_kind=session.key.affinity_kind,
-                session_key_value=session.key.affinity_key,
-                api_key_id=session.key.api_key_id,
-                instance_id=current_instance,
-                lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
-                account_id=session.account.id,
-                model=session.request_model,
-                service_tier=None,
-                latest_turn_state=session.downstream_turn_state,
-                latest_response_id=None,
-                allow_takeover=allow_takeover,
-                force_owner_epoch_advance=force_owner_epoch_advance,
-            )
+            lookup: DurableBridgeLookup | None = None
+            for claim_attempt in range(2):
+                lookup = await self._durable_bridge.claim_live_session(
+                    session_key_kind=session.key.affinity_kind,
+                    session_key_value=session.key.affinity_key,
+                    api_key_id=session.key.api_key_id,
+                    instance_id=current_instance,
+                    lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
+                    account_id=session.account.id,
+                    model=session.request_model,
+                    service_tier=None,
+                    latest_turn_state=session.downstream_turn_state,
+                    latest_response_id=None,
+                    allow_takeover=allow_takeover,
+                    force_owner_epoch_advance=force_owner_epoch_advance or claim_attempt > 0,
+                )
+                if lookup.owner_instance_id == current_instance:
+                    break
+                if not allow_takeover or claim_attempt > 0:
+                    break
+                await asyncio.sleep(0)
+            assert lookup is not None
             if lookup.owner_instance_id != current_instance:
                 _log_http_bridge_event(
                     "owner_mismatch_retry",

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -6599,6 +6599,7 @@ class ProxyService:
             force_durable_takeover = force_durable_takeover_after_detach
             missing_turn_state_alias = False
             used_session_header_fallback = False
+            sessions_to_close_before_create: list[_HTTPBridgeSession] = []
             session_to_return_after_close: _HTTPBridgeSession | None = None
             preserve_durable_canonical_key = (
                 incoming_turn_state is not None
@@ -7272,7 +7273,7 @@ class ProxyService:
                             )
                             detached = self._detach_http_bridge_session_locked(lru_key, expected_session=lru_session)
                             if detached is not None:
-                                self._schedule_http_bridge_session_closes([detached], reason="registry_detach")
+                                sessions_to_close_before_create.append(detached)
                         if len(self._http_bridge_sessions) + len(self._http_bridge_inflight_sessions) >= max_sessions:
                             if self._http_bridge_inflight_sessions:
                                 capacity_wait_future = next(iter(self._http_bridge_inflight_sessions.values()))
@@ -7299,6 +7300,9 @@ class ProxyService:
                             inflight_future = asyncio.get_running_loop().create_future()
                             self._http_bridge_inflight_sessions[key] = inflight_future
                             owns_creation = True
+
+            for session_to_close in sessions_to_close_before_create:
+                await self._close_http_bridge_session_bounded(session_to_close, reason="registry_detach")
 
             if session_to_return_after_close is not None:
                 return session_to_return_after_close

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7450,6 +7450,7 @@ class ProxyService:
                 await self._claim_durable_http_bridge_session(
                     created_session,
                     allow_takeover=force_durable_takeover or _http_bridge_allow_durable_takeover(durable_lookup),
+                    force_owner_epoch_advance=force_durable_takeover,
                 )
                 async with self._http_bridge_lock:
                     current_future = self._http_bridge_inflight_sessions.get(key)
@@ -7793,6 +7794,7 @@ class ProxyService:
         session: "_HTTPBridgeSession",
         *,
         allow_takeover: bool,
+        force_owner_epoch_advance: bool = False,
     ) -> None:
         current_instance = get_settings().http_responses_session_bridge_instance_id
         try:
@@ -7808,6 +7810,7 @@ class ProxyService:
                 latest_turn_state=session.downstream_turn_state,
                 latest_response_id=None,
                 allow_takeover=allow_takeover,
+                force_owner_epoch_advance=force_owner_epoch_advance,
             )
             if lookup.owner_instance_id != current_instance:
                 _log_http_bridge_event(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -8645,14 +8645,7 @@ class ProxyService:
         if not should_reconnect:
             return False
 
-        session.closed = True
-        try:
-            await session.upstream.close()
-        except Exception:
-            logger.debug(
-                "Failed to close HTTP bridge upstream for reconnect",
-                exc_info=True,
-            )
+        await self._close_http_bridge_session(session)
         return True
 
     async def _retire_stale_pending_http_bridge_session(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7301,8 +7301,13 @@ class ProxyService:
                             self._http_bridge_inflight_sessions[key] = inflight_future
                             owns_creation = True
 
-            for session_to_close in sessions_to_close_before_create:
-                await self._close_http_bridge_session_bounded(session_to_close, reason="registry_detach")
+            try:
+                for session_to_close in sessions_to_close_before_create:
+                    await self._close_http_bridge_session_bounded(session_to_close, reason="registry_detach")
+            except BaseException as exc:
+                if owns_creation:
+                    await self._fail_http_bridge_inflight_session_creation(key, inflight_future, exc)
+                raise
 
             if session_to_return_after_close is not None:
                 return session_to_return_after_close

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -320,6 +320,8 @@ def _log_http_bridge_startup_wait_timeout(
 # A blocked prewarm holds the response_create_gate semaphore and prevents
 # the real request from being sent, leading to an indefinite :keepalive hang.
 _PREWARM_RESPONSE_TIMEOUT_SECONDS = 2.0
+_HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS = 5.0
+_HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD = 100
 # Maximum consecutive keepalive frames sent before terminating the stream.
 # 6 × 10s (default interval) = 60s.  Combined with the 0.5s startup-probe
 # window this ensures the client sees a terminal event within ≈70s when the
@@ -6221,6 +6223,157 @@ class ProxyService:
             )
             return max(visible_pending_count, session.queued_request_count)
 
+    def _http_bridge_pending_count_nowait(
+        self,
+        session: "_HTTPBridgeSession",
+        *,
+        context: str,
+    ) -> int | None:
+        try:
+            session.pending_lock.acquire_nowait()
+        except (anyio.WouldBlock, RuntimeError):
+            logger.warning(
+                "http_bridge_pending_count_unavailable context=%s bridge_kind=%s bridge_key=%s account_id=%s model=%s",
+                context,
+                session.key.affinity_kind,
+                _hash_identifier(session.key.affinity_key),
+                session.account.id,
+                session.request_model,
+            )
+            return None
+        try:
+            visible_pending_count = sum(
+                1
+                for request_state in session.pending_requests
+                if _http_bridge_request_counts_against_queue(request_state)
+            )
+            return max(visible_pending_count, session.queued_request_count)
+        finally:
+            session.pending_lock.release()
+
+    async def _close_http_bridge_session_bounded(
+        self,
+        session: "_HTTPBridgeSession",
+        *,
+        reason: str,
+    ) -> None:
+        close_task = asyncio.create_task(
+            self._close_http_bridge_session(session),
+            name=f"http-bridge-close-{_hash_identifier(session.key.affinity_key)}",
+        )
+
+        def _track_close_task_after_interruption(*, interruption: str) -> None:
+            if close_task.done():
+                return
+            self._background_cleanup_tasks.add(close_task)
+
+            def _close_done(done_task: asyncio.Task[None]) -> None:
+                self._background_cleanup_tasks.discard(done_task)
+                try:
+                    done_task.result()
+                except asyncio.CancelledError:
+                    logger.warning(
+                        "http_bridge_session_close_cancelled_after_%s reason=%s bridge_kind=%s "
+                        "bridge_key=%s account_id=%s model=%s",
+                        interruption,
+                        reason,
+                        session.key.affinity_kind,
+                        _hash_identifier(session.key.affinity_key),
+                        session.account.id,
+                        session.request_model,
+                    )
+                except Exception:
+                    logger.warning(
+                        "http_bridge_session_close_failed_after_%s reason=%s bridge_kind=%s "
+                        "bridge_key=%s account_id=%s model=%s",
+                        interruption,
+                        reason,
+                        session.key.affinity_kind,
+                        _hash_identifier(session.key.affinity_key),
+                        session.account.id,
+                        session.request_model,
+                        exc_info=True,
+                    )
+
+            close_task.add_done_callback(_close_done)
+
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(close_task),
+                timeout=_HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            _track_close_task_after_interruption(interruption="timeout")
+            logger.warning(
+                "http_bridge_session_close_timeout reason=%s bridge_kind=%s bridge_key=%s "
+                "account_id=%s model=%s timeout_seconds=%.1f background_cleanup_tasks=%d",
+                reason,
+                session.key.affinity_kind,
+                _hash_identifier(session.key.affinity_key),
+                session.account.id,
+                session.request_model,
+                _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS,
+                len(self._background_cleanup_tasks),
+            )
+        except asyncio.CancelledError:
+            _track_close_task_after_interruption(interruption="cancellation")
+            raise
+        except Exception:
+            logger.warning(
+                "http_bridge_session_close_failed reason=%s bridge_kind=%s bridge_key=%s account_id=%s model=%s",
+                reason,
+                session.key.affinity_kind,
+                _hash_identifier(session.key.affinity_key),
+                session.account.id,
+                session.request_model,
+                exc_info=True,
+            )
+
+    def _schedule_http_bridge_session_closes(
+        self,
+        sessions: list["_HTTPBridgeSession"],
+        *,
+        reason: str,
+    ) -> None:
+        for session in sessions:
+            if len(self._background_cleanup_tasks) >= _HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD:
+                logger.warning(
+                    "http_bridge_background_cleanup_backlog action=session_close count=%d threshold=%d reason=%s",
+                    len(self._background_cleanup_tasks),
+                    _HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD,
+                    reason,
+                )
+            self._schedule_cancel_safe_cleanup(
+                self._close_http_bridge_session_bounded(session, reason=reason),
+                action="http_bridge_session_close",
+                request_id=_hash_identifier(session.key.affinity_key),
+            )
+
+    async def _drain_http_bridge_background_cleanup_tasks(self, *, reason: str) -> None:
+        tasks = [
+            task
+            for task in self._background_cleanup_tasks
+            if not task.done()
+            and (
+                task.get_name().startswith("proxy-http_bridge_session_close-")
+                or task.get_name().startswith("http-bridge-close-")
+            )
+        ]
+        if not tasks:
+            return
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*(asyncio.shield(task) for task in tasks), return_exceptions=True),
+                timeout=_HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "http_bridge_background_cleanup_drain_timeout reason=%s count=%d timeout_seconds=%.1f",
+                reason,
+                len(tasks),
+                _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS,
+            )
+
     async def _select_account_with_budget_compatible(
         self,
         deadline: float,
@@ -6435,15 +6588,15 @@ class ProxyService:
             else None
         )
         old_account_id: str | None = None
+        force_durable_takeover_after_detach = False
         while True:
-            sessions_to_close: list[_HTTPBridgeSession] = []
             inflight_future: asyncio.Future[_HTTPBridgeSession] | None = None
             capacity_wait_future: asyncio.Future[_HTTPBridgeSession] | None = None
             owns_creation = False
             continuity_error: ProxyResponseError | None = None
             owner_mismatch_error: ProxyResponseError | None = None
             owner_forward: _HTTPBridgeOwnerForward | None = None
-            force_durable_takeover = False
+            force_durable_takeover = force_durable_takeover_after_detach
             missing_turn_state_alias = False
             used_session_header_fallback = False
             session_to_return_after_close: _HTTPBridgeSession | None = None
@@ -6536,7 +6689,14 @@ class ProxyService:
                             key = _HTTPBridgeSessionKey("turn_state_header", incoming_turn_state, api_key_id)
                             missing_turn_state_alias = True
 
-                await self._prune_http_bridge_sessions_locked()
+                pruned_sessions = self._prune_http_bridge_sessions_locked()
+                if pruned_sessions:
+                    if any(session.key == key for session in pruned_sessions):
+                        force_durable_takeover = True
+                    self._schedule_http_bridge_session_closes(
+                        pruned_sessions,
+                        reason="registry_detach",
+                    )
 
                 existing = self._http_bridge_sessions.get(key)
                 if (
@@ -6568,7 +6728,10 @@ class ProxyService:
                             key,
                             account_id=existing.account.id,
                             model=existing.request_model,
-                            pending_count=await self._http_bridge_pending_count(existing),
+                            pending_count=self._http_bridge_pending_count_nowait(
+                                existing,
+                                context="reuse_log",
+                            ),
                             cache_key_family=key.affinity_kind,
                             model_class=_extract_model_class(existing.request_model)
                             if existing.request_model
@@ -6576,19 +6739,22 @@ class ProxyService:
                         )
                         return existing
                     old_account_id = existing.account.id
-                    self._http_bridge_sessions.pop(key, None)
-                    self._unregister_http_bridge_turn_states_locked(existing)
-                    existing.closed = True
-                    sessions_to_close.append(existing)
+                    detached = self._detach_http_bridge_session_locked(key, expected_session=existing)
+                    if detached is not None:
+                        force_durable_takeover = True
+                        self._schedule_http_bridge_session_closes([detached], reason="registry_detach")
                     existing = None
                 if existing is not None and not existing.closed and existing.account.status == AccountStatus.ACTIVE:
                     old_account_id = existing.account.id
                     retiring_with_visible_requests = _http_bridge_session_retiring_with_visible_requests(existing)
-                    self._http_bridge_sessions.pop(key, None)
-                    self._unregister_http_bridge_turn_states_locked(existing)
-                    if not retiring_with_visible_requests:
-                        existing.closed = True
-                        sessions_to_close.append(existing)
+                    detached = self._detach_http_bridge_session_locked(
+                        key,
+                        expected_session=existing,
+                        mark_closed=not retiring_with_visible_requests,
+                    )
+                    if detached is not None and not retiring_with_visible_requests:
+                        force_durable_takeover = True
+                        self._schedule_http_bridge_session_closes([detached], reason="registry_detach")
                     existing = None
 
                 if shutdown_state.is_bridge_drain_active() and not _http_bridge_can_recover_during_drain(
@@ -6948,8 +7114,10 @@ class ProxyService:
                         cache_key_family=key.affinity_kind,
                         model_class=_extract_model_class(existing.request_model) if existing.request_model else None,
                     )
-                    self._http_bridge_sessions.pop(key, None)
-                    sessions_to_close.append(existing)
+                    detached = self._detach_http_bridge_session_locked(key, expected_session=existing)
+                    if detached is not None:
+                        force_durable_takeover = True
+                        self._schedule_http_bridge_session_closes([detached], reason="registry_detach")
 
                 if owner_mismatch_error is None:
                     inflight_future = self._http_bridge_inflight_sessions.get(key)
@@ -6993,7 +7161,10 @@ class ProxyService:
                                         key,
                                         account_id=previous_session.account.id,
                                         model=previous_session.request_model,
-                                        pending_count=await self._http_bridge_pending_count(previous_session),
+                                        pending_count=self._http_bridge_pending_count_nowait(
+                                            previous_session,
+                                            context="previous_response_reuse_log",
+                                        ),
                                         cache_key_family=key.affinity_kind,
                                         model_class=_extract_model_class(previous_session.request_model)
                                         if previous_session.request_model
@@ -7073,7 +7244,12 @@ class ProxyService:
                         ):
                             evictable_sessions: list[tuple[_HTTPBridgeSessionKey, _HTTPBridgeSession]] = []
                             for candidate_key, candidate_session in self._http_bridge_sessions.items():
-                                pending_count = await self._http_bridge_pending_count(candidate_session)
+                                pending_count = self._http_bridge_pending_count_nowait(
+                                    candidate_session,
+                                    context="capacity_evict_scan",
+                                )
+                                if pending_count is None:
+                                    continue
                                 if pending_count:
                                     continue
                                 evictable_sessions.append((candidate_key, candidate_session))
@@ -7093,8 +7269,9 @@ class ProxyService:
                                 if lru_session.request_model
                                 else None,
                             )
-                            self._http_bridge_sessions.pop(lru_key, None)
-                            sessions_to_close.append(lru_session)
+                            detached = self._detach_http_bridge_session_locked(lru_key, expected_session=lru_session)
+                            if detached is not None:
+                                self._schedule_http_bridge_session_closes([detached], reason="registry_detach")
                         if len(self._http_bridge_sessions) + len(self._http_bridge_inflight_sessions) >= max_sessions:
                             if self._http_bridge_inflight_sessions:
                                 capacity_wait_future = next(iter(self._http_bridge_inflight_sessions.values()))
@@ -7121,14 +7298,6 @@ class ProxyService:
                             inflight_future = asyncio.get_running_loop().create_future()
                             self._http_bridge_inflight_sessions[key] = inflight_future
                             owns_creation = True
-
-            try:
-                for stale_session in sessions_to_close:
-                    await self._close_http_bridge_session(stale_session)
-            except BaseException as exc:
-                if owns_creation:
-                    await self._fail_http_bridge_inflight_session_creation(key, inflight_future, exc)
-                raise
 
             if session_to_return_after_close is not None:
                 return session_to_return_after_close
@@ -7231,12 +7400,17 @@ class ProxyService:
                     old_account_id = session.account.id
                     retiring_with_visible_requests = _http_bridge_session_retiring_with_visible_requests(session)
                     async with self._http_bridge_lock:
-                        if self._http_bridge_sessions.get(key) is session:
-                            self._http_bridge_sessions.pop(key, None)
-                        self._unregister_http_bridge_turn_states_locked(session)
+                        detached = self._detach_http_bridge_session_locked(
+                            key,
+                            expected_session=session,
+                            mark_closed=not retiring_with_visible_requests,
+                        )
                     if not retiring_with_visible_requests:
-                        session.closed = True
-                        await self._close_http_bridge_session(session)
+                        force_durable_takeover_after_detach = True
+                        self._schedule_http_bridge_session_closes(
+                            [detached or session],
+                            reason="registry_detach",
+                        )
                 continue
 
             created_session: _HTTPBridgeSession | None = None
@@ -7358,6 +7532,7 @@ class ProxyService:
 
         for session in sessions_to_close:
             await self._close_http_bridge_session(session)
+        await self._drain_http_bridge_background_cleanup_tasks(reason="shutdown")
 
     async def mark_http_bridge_draining(self) -> None:
         try:
@@ -7367,21 +7542,44 @@ class ProxyService:
         except Exception:
             logger.warning("Failed to mark durable HTTP bridge sessions draining", exc_info=True)
 
-    async def _prune_http_bridge_sessions_locked(self) -> None:
+    def _prune_http_bridge_sessions_locked(self) -> list["_HTTPBridgeSession"]:
         now = time.monotonic()
         stale_keys: list[_HTTPBridgeSessionKey] = []
         for key, session in self._http_bridge_sessions.items():
             if session.closed:
                 stale_keys.append(key)
                 continue
-            pending_count = await self._http_bridge_pending_count(session)
+            pending_count = self._http_bridge_pending_count_nowait(
+                session,
+                context="idle_prune",
+            )
+            if pending_count is None:
+                visible_pending_count = sum(
+                    1
+                    for request_state in session.pending_requests
+                    if _http_bridge_request_counts_against_queue(request_state)
+                )
+                if visible_pending_count or session.queued_request_count:
+                    continue
+                if now - session.last_used_at < session.idle_ttl_seconds:
+                    continue
+                logger.warning(
+                    "http_bridge_prune_unresponsive_idle_session bridge_kind=%s bridge_key=%s account_id=%s model=%s",
+                    key.affinity_kind,
+                    _hash_identifier(key.affinity_key),
+                    session.account.id,
+                    session.request_model,
+                )
+                stale_keys.append(key)
+                continue
             if pending_count:
                 continue
             if now - session.last_used_at < session.idle_ttl_seconds:
                 continue
             stale_keys.append(key)
+        sessions_to_close: list[_HTTPBridgeSession] = []
         for key in stale_keys:
-            session = self._http_bridge_sessions.pop(key, None)
+            session = self._detach_http_bridge_session_locked(key)
             if session is not None:
                 _log_http_bridge_event(
                     "evict_idle",
@@ -7391,7 +7589,8 @@ class ProxyService:
                     cache_key_family=key.affinity_kind,
                     model_class=_extract_model_class(session.request_model) if session.request_model else None,
                 )
-                await self._close_http_bridge_session(session, turn_state_lock_held=True)
+                sessions_to_close.append(session)
+        return sessions_to_close
 
     async def _close_http_bridge_session(
         self,
@@ -7406,6 +7605,23 @@ class ProxyService:
         else:
             await self._unregister_http_bridge_turn_states(session)
             await self._unregister_http_bridge_previous_response_ids(session)
+        account_lease = getattr(session, "account_lease", None)
+        try:
+            await self._load_balancer.release_account_lease(account_lease)
+        except Exception:
+            logger.warning("Failed to release HTTP bridge account lease during close", exc_info=True)
+        finally:
+            session.account_lease = None
+        if session.durable_session_id is not None and session.durable_owner_epoch is not None:
+            try:
+                await self._durable_bridge.release_live_session(
+                    session_id=session.durable_session_id,
+                    instance_id=get_settings().http_responses_session_bridge_instance_id,
+                    owner_epoch=session.durable_owner_epoch,
+                    draining=shutdown_state.is_bridge_drain_active(),
+                )
+            except Exception:
+                logger.warning("Failed to release durable HTTP bridge session", exc_info=True)
         if session.upstream_reader is not None:
             await _await_cancelled_task(session.upstream_reader, label="http bridge upstream reader")
         try:
@@ -7428,18 +7644,6 @@ class ProxyService:
                 api_key=None,
                 response_create_gate=response_create_gate,
             )
-        if session.durable_session_id is not None and session.durable_owner_epoch is not None:
-            try:
-                await self._durable_bridge.release_live_session(
-                    session_id=session.durable_session_id,
-                    instance_id=get_settings().http_responses_session_bridge_instance_id,
-                    owner_epoch=session.durable_owner_epoch,
-                    draining=shutdown_state.is_bridge_drain_active(),
-                )
-            except Exception:
-                logger.warning("Failed to release durable HTTP bridge session", exc_info=True)
-        await self._load_balancer.release_account_lease(getattr(session, "account_lease", None))
-        session.account_lease = None
         _log_http_bridge_event(
             "close",
             session.key,
@@ -7518,22 +7722,53 @@ class ProxyService:
         async with self._http_bridge_lock:
             self._unregister_http_bridge_previous_response_ids_locked(session)
 
+    def _detach_http_bridge_session_locked(
+        self,
+        key: "_HTTPBridgeSessionKey",
+        *,
+        expected_session: "_HTTPBridgeSession | None" = None,
+        mark_closed: bool = True,
+    ) -> "_HTTPBridgeSession | None":
+        session = self._http_bridge_sessions.get(key)
+        if session is None:
+            return None
+        if expected_session is not None and session is not expected_session:
+            return None
+        self._http_bridge_sessions.pop(key, None)
+        if mark_closed:
+            session.closed = True
+        self._unregister_http_bridge_turn_states_locked(session)
+        self._unregister_http_bridge_previous_response_ids_locked(session)
+        return session
+
     def _unregister_http_bridge_turn_states_locked(self, session: "_HTTPBridgeSession") -> None:
         aliases = tuple(session.downstream_turn_state_aliases)
+        current_session = self._http_bridge_sessions.get(session.key)
         for alias in aliases:
-            self._http_bridge_turn_state_index.pop(
-                _http_bridge_turn_state_alias_key(alias, session.key.api_key_id),
-                None,
-            )
+            alias_key = _http_bridge_turn_state_alias_key(alias, session.key.api_key_id)
+            if (
+                current_session is not None
+                and current_session is not session
+                and alias in current_session.downstream_turn_state_aliases
+            ):
+                continue
+            if self._http_bridge_turn_state_index.get(alias_key) == session.key:
+                self._http_bridge_turn_state_index.pop(alias_key, None)
         session.downstream_turn_state_aliases.clear()
 
     def _unregister_http_bridge_previous_response_ids_locked(self, session: "_HTTPBridgeSession") -> None:
         response_ids = tuple(session.previous_response_ids)
+        current_session = self._http_bridge_sessions.get(session.key)
         for response_id in response_ids:
-            self._http_bridge_previous_response_index.pop(
-                _http_bridge_previous_response_alias_key(response_id, session.key.api_key_id),
-                None,
-            )
+            alias_key = _http_bridge_previous_response_alias_key(response_id, session.key.api_key_id)
+            if (
+                current_session is not None
+                and current_session is not session
+                and response_id in current_session.previous_response_ids
+            ):
+                continue
+            if self._http_bridge_previous_response_index.get(alias_key) == session.key:
+                self._http_bridge_previous_response_index.pop(alias_key, None)
         session.previous_response_ids.clear()
 
     def _promote_http_bridge_session_to_codex_affinity(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7617,8 +7617,14 @@ class ProxyService:
                 )
             except Exception:
                 logger.warning("Failed to release durable HTTP bridge session", exc_info=True)
-        if session.upstream_reader is not None:
-            await _await_cancelled_task(session.upstream_reader, label="http bridge upstream reader")
+        upstream_reader = session.upstream_reader
+        if upstream_reader is not None:
+            if upstream_reader is asyncio.current_task():
+                session.upstream_reader = None
+            else:
+                await _await_cancelled_task(upstream_reader, label="http bridge upstream reader")
+                if session.upstream_reader is upstream_reader:
+                    session.upstream_reader = None
         try:
             await session.upstream.close()
         except Exception:

--- a/openspec/changes/harden-http-bridge-session-lifecycle/proposal.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Live validation on server 113 reproduced a `/v1/responses` hang where
+`/v1/chat/completions` and websocket/backend routes kept working, while HTTP
+Responses requests logged API-key policy enforcement and then never reached
+HTTP bridge account selection or bridge create/reuse logging. Restarting the
+process clears the condition, pointing to in-memory HTTP bridge session
+lifecycle state rather than upstream model availability.
+
+The current bridge lifecycle can prune and close stale sessions while holding
+the global HTTP bridge session lock. Those cleanup paths await per-session
+pending locks, upstream-reader cancellation, websocket close, durable session
+release, and account lease release. A single wedged stale/pending session can
+therefore block unrelated new `/v1/responses` HTTP bridge requests before they
+reach account selection.
+
+## What Changes
+
+- Refactor HTTP bridge session pruning so the global bridge lock only mutates
+  in-memory maps and collects sessions to close; potentially blocking cleanup
+  runs outside that lock.
+- Keep stale-session pending inspection bounded so a wedged per-session lock
+  cannot block unrelated bridge session creation indefinitely.
+- Ensure stale-session close paths are best-effort and bounded enough that
+  new HTTP Responses work can either create/reuse a bridge session or fail
+  locally with an explicit overload/continuity error instead of silently
+  hanging.
+- Add regression coverage for stale/pending bridge sessions that previously
+  could block fresh `/v1/responses` bridge startup before account selection.
+
+## Impact
+
+- `/v1/responses` HTTP bridge traffic becomes resilient to stale local bridge
+  session state without changing public Responses request/response schemas.
+- Existing direct chat-completions and websocket behavior is preserved.
+- Stale bridge sessions may be closed asynchronously/best-effort rather than
+  synchronously under the session map lock.

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -21,10 +21,10 @@ progress. Requests that cannot safely proceed because a hard-continuity session
 is unavailable MUST fail closed with an explicit local overload or continuity
 error rather than silently hanging.
 
-When a replacement bridge session claims the same durable key with a different
-account, the durable owner generation MUST advance so that a late cleanup from
-the stale local session cannot release or close the replacement session's
-durable ownership.
+When a replacement bridge session claims the same durable key after stale local
+session detachment, the durable owner generation MUST advance so that a late
+cleanup from the stale local session cannot release or close the replacement
+session's durable ownership.
 
 #### Scenario: wedged stale pending lock does not block fresh soft request
 
@@ -51,7 +51,7 @@ durable ownership.
 #### Scenario: stale durable release cannot fence out replacement owner
 
 - **GIVEN** a stale bridge session for a durable key is replaced by a new local
-  session on a different account
+  session after local detachment
 - **WHEN** the stale session's bounded background close releases durable
   ownership after the replacement has claimed the same durable key
 - **THEN** the stale release does not clear the replacement owner's durable

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -21,6 +21,11 @@ progress. Requests that cannot safely proceed because a hard-continuity session
 is unavailable MUST fail closed with an explicit local overload or continuity
 error rather than silently hanging.
 
+When a replacement bridge session claims the same durable key with a different
+account, the durable owner generation MUST advance so that a late cleanup from
+the stale local session cannot release or close the replacement session's
+durable ownership.
+
 #### Scenario: wedged stale pending lock does not block fresh soft request
 
 - **GIVEN** the HTTP responses bridge has an idle or stale local session whose
@@ -42,3 +47,14 @@ error rather than silently hanging.
 - **THEN** the global bridge registry lock is already released
 - **AND** unrelated bridge startup requests can continue to inspect or mutate
   the registry
+
+#### Scenario: stale durable release cannot fence out replacement owner
+
+- **GIVEN** a stale bridge session for a durable key is replaced by a new local
+  session on a different account
+- **WHEN** the stale session's bounded background close releases durable
+  ownership after the replacement has claimed the same durable key
+- **THEN** the stale release does not clear the replacement owner's durable
+  lease
+- **AND** follow-up requests for the replacement session do not receive a
+  spurious bridge owner mismatch caused by the stale close

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -30,6 +30,12 @@ its durable ownership later after draining. After a detached retiring session
 finishes draining its visible requests, it MUST release its durable ownership
 and account lease instead of only closing the upstream websocket.
 
+When bridge capacity eviction removes an idle local session to admit a
+replacement session, the evicted session's close MUST be awaited through a
+bounded path before the replacement selects an account, so the evicted
+session's account lease cannot cause a spurious no-account or local-capacity
+failure.
+
 #### Scenario: wedged stale pending lock does not block fresh soft request
 
 - **GIVEN** the HTTP responses bridge has an idle or stale local session whose
@@ -72,3 +78,13 @@ and account lease instead of only closing the upstream websocket.
 - **AND** the service releases the old session's account lease
 - **AND** the detached session no longer holds bridge capacity until process
   exit
+
+#### Scenario: LRU eviction releases lease before replacement account selection
+
+- **GIVEN** the bridge is at local session capacity and an idle session is
+  selected for LRU eviction
+- **WHEN** a replacement bridge session is created after that eviction
+- **THEN** the evicted session is closed through a bounded path before the
+  replacement selects an account
+- **AND** the evicted session's account lease does not cause the replacement to
+  fail with a spurious no-account or local-capacity error

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge stale-session cleanup is bounded
+
+The HTTP responses bridge MUST NOT hold the global bridge session registry lock
+while awaiting operations that can block on a stale session's upstream websocket,
+per-session pending lock, durable session repository, account lease release, or
+other external cleanup work.
+
+When stale bridge sessions are discovered during `/v1/responses`,
+`/backend-api/codex/responses`, `/v1/responses/compact`, or
+`/backend-api/codex/responses/compact` startup, the registry lock MAY be used to
+remove closed or idle sessions from in-memory indexes, but potentially blocking
+session close/fail-pending work MUST run after the lock is released or under a
+bounded cleanup path. A wedged stale session MUST NOT prevent unrelated soft
+HTTP Responses work from creating or reusing another bridge session.
+
+If cleanup cannot complete within the bounded cleanup path, the service MUST log
+a low-cardinality local bridge cleanup warning and continue protecting registry
+progress. Requests that cannot safely proceed because a hard-continuity session
+is unavailable MUST fail closed with an explicit local overload or continuity
+error rather than silently hanging.
+
+#### Scenario: wedged stale pending lock does not block fresh soft request
+
+- **GIVEN** the HTTP responses bridge has an idle or stale local session whose
+  pending-request lock does not complete promptly
+- **WHEN** a new soft-affinity `/v1/responses` request starts bridge session
+  selection
+- **THEN** the global bridge registry lock is not held indefinitely by stale
+  cleanup
+- **AND** the new request either creates/reuses an eligible bridge session or
+  returns an explicit bounded local error
+- **AND** it does not hang before account selection or bridge create/reuse
+  logging
+
+#### Scenario: stale close runs outside registry lock
+
+- **GIVEN** bridge startup identifies an idle stale session that must be closed
+- **WHEN** closing that session awaits upstream-reader cancellation, websocket
+  close, durable release, or account lease release
+- **THEN** the global bridge registry lock is already released
+- **AND** unrelated bridge startup requests can continue to inspect or mutate
+  the registry

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -26,7 +26,9 @@ session detachment, the durable owner generation MUST advance so that a late
 cleanup from the stale local session cannot release or close the replacement
 session's durable ownership. This MUST also apply when the detached local
 session is retiring but still has visible in-flight requests and will release
-its durable ownership later after draining.
+its durable ownership later after draining. After a detached retiring session
+finishes draining its visible requests, it MUST release its durable ownership
+and account lease instead of only closing the upstream websocket.
 
 #### Scenario: wedged stale pending lock does not block fresh soft request
 
@@ -60,3 +62,13 @@ its durable ownership later after draining.
   lease
 - **AND** follow-up requests for the replacement session do not receive a
   spurious bridge owner mismatch caused by the stale close
+
+#### Scenario: detached retiring session releases resources after drain
+
+- **GIVEN** a retiring bridge session was detached while visible requests were
+  still draining
+- **WHEN** those visible requests drain and the session is retired
+- **THEN** the service releases the old session's durable ownership
+- **AND** the service releases the old session's account lease
+- **AND** the detached session no longer holds bridge capacity until process
+  exit

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -15,6 +15,11 @@ session close/fail-pending work MUST run after the lock is released or under a
 bounded cleanup path. A wedged stale session MUST NOT prevent unrelated soft
 HTTP Responses work from creating or reusing another bridge session.
 
+Idle pruning MUST make pending-request decisions only while holding the
+session's pending-request lock. If that lock cannot be acquired immediately,
+the service MUST skip pruning that session instead of inferring that it is idle
+from unlocked pending-request state.
+
 If cleanup cannot complete within the bounded cleanup path, the service MUST log
 a low-cardinality local bridge cleanup warning and continue protecting registry
 progress. Requests that cannot safely proceed because a hard-continuity session
@@ -49,6 +54,8 @@ requests MUST NOT wait on an orphaned creation future that can never complete.
   selection
 - **THEN** the global bridge registry lock is not held indefinitely by stale
   cleanup
+- **AND** the stale session is not pruned based on unlocked pending-request
+  state
 - **AND** the new request either creates/reuses an eligible bridge session or
   returns an explicit bounded local error
 - **AND** it does not hang before account selection or bridge create/reuse

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -24,7 +24,9 @@ error rather than silently hanging.
 When a replacement bridge session claims the same durable key after stale local
 session detachment, the durable owner generation MUST advance so that a late
 cleanup from the stale local session cannot release or close the replacement
-session's durable ownership.
+session's durable ownership. This MUST also apply when the detached local
+session is retiring but still has visible in-flight requests and will release
+its durable ownership later after draining.
 
 #### Scenario: wedged stale pending lock does not block fresh soft request
 
@@ -50,8 +52,8 @@ session's durable ownership.
 
 #### Scenario: stale durable release cannot fence out replacement owner
 
-- **GIVEN** a stale bridge session for a durable key is replaced by a new local
-  session after local detachment
+- **GIVEN** a stale or retiring bridge session for a durable key is replaced by
+  a new local session after local detachment
 - **WHEN** the stale session's bounded background close releases durable
   ownership after the replacement has claimed the same durable key
 - **THEN** the stale release does not clear the replacement owner's durable

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -36,6 +36,11 @@ bounded path before the replacement selects an account, so the evicted
 session's account lease cannot cause a spurious no-account or local-capacity
 failure.
 
+If a request is cancelled while awaiting that pre-creation eviction close after
+registering replacement session creation as in-flight, the service MUST fail or
+remove the in-flight creation marker before propagating cancellation. Later
+requests MUST NOT wait on an orphaned creation future that can never complete.
+
 #### Scenario: wedged stale pending lock does not block fresh soft request
 
 - **GIVEN** the HTTP responses bridge has an idle or stale local session whose
@@ -88,3 +93,14 @@ failure.
   replacement selects an account
 - **AND** the evicted session's account lease does not cause the replacement to
   fail with a spurious no-account or local-capacity error
+
+#### Scenario: cancellation during LRU close clears in-flight creation
+
+- **GIVEN** the bridge is at local session capacity and an idle session is
+  detached for LRU eviction before replacement creation
+- **WHEN** the replacement request is cancelled while the bounded eviction close
+  is still awaiting cleanup
+- **THEN** the replacement in-flight creation marker is removed or failed before
+  cancellation is propagated
+- **AND** later requests for the same bridge key do not wait on that abandoned
+  creation marker

--- a/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/specs/responses-api-compat/spec.md
@@ -34,6 +34,9 @@ session is retiring but still has visible in-flight requests and will release
 its durable ownership later after draining. After a detached retiring session
 finishes draining its visible requests, it MUST release its durable ownership
 and account lease instead of only closing the upstream websocket.
+If that retirement is initiated by the upstream-reader task after processing
+the terminal upstream event, session close MUST NOT cancel or await the current
+upstream-reader task itself.
 
 When bridge capacity eviction removes an idle local session to admit a
 replacement session, the evicted session's close MUST be awaited through a
@@ -88,6 +91,8 @@ requests MUST NOT wait on an orphaned creation future that can never complete.
 - **WHEN** those visible requests drain and the session is retired
 - **THEN** the service releases the old session's durable ownership
 - **AND** the service releases the old session's account lease
+- **AND** upstream-reader-owned retirement does not self-cancel the current
+  upstream reader task
 - **AND** the detached session no longer holds bridge capacity until process
   exit
 

--- a/openspec/changes/harden-http-bridge-session-lifecycle/tasks.md
+++ b/openspec/changes/harden-http-bridge-session-lifecycle/tasks.md
@@ -1,0 +1,5 @@
+- [x] Add normative HTTP bridge lifecycle requirements for bounded stale cleanup and no stale cleanup awaits under the global bridge lock
+- [x] Refactor bridge stale-session pruning/close so unrelated bridge requests cannot hang behind a wedged stale session
+- [x] Add regression tests covering stale pending/session locks and fresh HTTP bridge startup progress/fail-fast behavior
+- [x] Run targeted proxy tests and OpenSpec validation
+- [x] Run final cleanup/review gates required by Ultragoal

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -6497,7 +6497,8 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
 
     monkeypatch.setattr(proxy_module.ProxyService, "_create_http_bridge_session", fake_create_http_bridge_session)
 
-    key = proxy_module._HTTPBridgeSessionKey("session_header", "shared-session", "key-assignments")
+    session_header = f"shared-session-{stale_account_id}"
+    key = proxy_module._HTTPBridgeSessionKey("session_header", session_header, "key-assignments")
     stale_api_key = _make_api_key_data(key_id="key-assignments", assigned_account_ids=[stale_account_id])
     refreshed_api_key = _make_api_key_data(key_id="key-assignments", assigned_account_ids=[fresh_account_id])
 
@@ -6505,9 +6506,9 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
         creator = asyncio.create_task(
             service._get_or_create_http_bridge_session(
                 key,
-                headers={"session_id": "shared-session"},
+                headers={"session_id": session_header},
                 affinity=proxy_module._AffinityPolicy(
-                    key="shared-session",
+                    key=session_header,
                     kind=proxy_module.StickySessionKind.CODEX_SESSION,
                 ),
                 api_key=stale_api_key,
@@ -6520,9 +6521,9 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
         follower = asyncio.create_task(
             service._get_or_create_http_bridge_session(
                 key,
-                headers={"session_id": "shared-session"},
+                headers={"session_id": session_header},
                 affinity=proxy_module._AffinityPolicy(
-                    key="shared-session",
+                    key=session_header,
                     kind=proxy_module.StickySessionKind.CODEX_SESSION,
                 ),
                 api_key=refreshed_api_key,

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -6448,6 +6448,7 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
     create_started = asyncio.Event()
     release_create = asyncio.Event()
     create_calls: list[list[str]] = []
+    durable_claims: list[tuple[str, bool]] = []
     stale_account_id = await _import_account(
         async_client,
         "acc_http_bridge_stale",
@@ -6490,12 +6491,32 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
             await _wait_for_event(release_create)
             session = cast(proxy_module._HTTPBridgeSession, _make_dummy_bridge_session(key))
             cast(Any, session).account = SimpleNamespace(id=stale_account_id, status=AccountStatus.ACTIVE)
+            session.queued_request_count = 1
+            session.upstream_control.retire_after_drain = True
             return session
         session = cast(proxy_module._HTTPBridgeSession, _make_dummy_bridge_session(key))
         cast(Any, session).account = SimpleNamespace(id=fresh_account_id, status=AccountStatus.ACTIVE)
         return session
 
     monkeypatch.setattr(proxy_module.ProxyService, "_create_http_bridge_session", fake_create_http_bridge_session)
+
+    async def fake_claim_durable_http_bridge_session(
+        self,
+        session,
+        *,
+        allow_takeover,
+        force_owner_epoch_advance=False,
+    ):
+        del self, allow_takeover
+        durable_claims.append((session.account.id, force_owner_epoch_advance))
+        session.durable_session_id = "durable-session"
+        session.durable_owner_epoch = 2 if force_owner_epoch_advance else 1
+
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_claim_durable_http_bridge_session",
+        fake_claim_durable_http_bridge_session,
+    )
 
     session_header = f"shared-session-{stale_account_id}"
     key = proxy_module._HTTPBridgeSessionKey("session_header", session_header, "key-assignments")
@@ -6540,6 +6561,7 @@ async def test_v1_responses_http_bridge_singleflight_follower_replaces_session_w
         assert follower_session.account.id == fresh_account_id
         assert service._http_bridge_sessions[key] is follower_session
         assert create_calls == [[stale_account_id], [fresh_account_id]]
+        assert durable_claims == [(stale_account_id, False), (fresh_account_id, True)]
     finally:
         service._http_bridge_sessions.clear()
         service._http_bridge_inflight_sessions.clear()

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -1495,12 +1495,12 @@ async def test_v1_responses_http_bridge_codex_session_uses_extended_idle_ttl(asy
 
     session.last_used_at = time.monotonic() - 300.0
     async with service._http_bridge_lock:
-        await service._prune_http_bridge_sessions_locked()
+        service._prune_http_bridge_sessions_locked()
         assert key in service._http_bridge_sessions
 
     session.last_used_at = time.monotonic() - 601.0
     async with service._http_bridge_lock:
-        await service._prune_http_bridge_sessions_locked()
+        service._prune_http_bridge_sessions_locked()
         assert key not in service._http_bridge_sessions
 
 

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -197,6 +197,55 @@ async def test_durable_bridge_account_change_advances_epoch_to_fence_stale_relea
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_forced_generation_advance_fences_same_account_stale_release(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-forced-generation",
+        api_key_id=None,
+        instance_id="instance-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_1",
+        latest_response_id="resp_1",
+        allow_takeover=True,
+    )
+
+    replaced = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-forced-generation",
+        api_key_id=None,
+        instance_id="instance-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_2",
+        latest_response_id="resp_2",
+        allow_takeover=True,
+        force_owner_epoch_advance=True,
+    )
+
+    stale_release = await coordinator.release_live_session(
+        session_id=claimed.session_id,
+        instance_id="instance-a",
+        owner_epoch=claimed.owner_epoch,
+        draining=False,
+    )
+
+    assert replaced.session_id == claimed.session_id
+    assert replaced.owner_instance_id == "instance-a"
+    assert replaced.owner_epoch == claimed.owner_epoch + 1
+    assert stale_release is not None
+    assert stale_release.owner_instance_id == "instance-a"
+    assert stale_release.owner_epoch == replaced.owner_epoch
+    assert stale_release.state == "active"
+
+
+@pytest.mark.asyncio
 async def test_durable_bridge_claim_takes_over_after_release(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -148,6 +148,55 @@ async def test_durable_bridge_claim_renews_same_owner_epoch(
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_account_change_advances_epoch_to_fence_stale_release(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-account-change",
+        api_key_id=None,
+        instance_id="instance-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_1",
+        latest_response_id="resp_1",
+        allow_takeover=True,
+    )
+
+    replaced = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-account-change",
+        api_key_id=None,
+        instance_id="instance-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-2",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_2",
+        latest_response_id="resp_2",
+        allow_takeover=False,
+    )
+
+    stale_release = await coordinator.release_live_session(
+        session_id=claimed.session_id,
+        instance_id="instance-a",
+        owner_epoch=claimed.owner_epoch,
+        draining=False,
+    )
+
+    assert replaced.session_id == claimed.session_id
+    assert replaced.owner_instance_id == "instance-a"
+    assert replaced.owner_epoch == claimed.owner_epoch + 1
+    assert replaced.account_id == "acc-2"
+    assert stale_release is not None
+    assert stale_release.owner_instance_id == "instance-a"
+    assert stale_release.owner_epoch == replaced.owner_epoch
+    assert stale_release.state == "active"
+
+
+@pytest.mark.asyncio
 async def test_durable_bridge_claim_takes_over_after_release(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -512,7 +512,7 @@ async def test_lifespan_shutdown_fails_bridge_capacity_waiter_and_cancels_usage_
             )
             service._http_bridge_inflight_sessions[inflight_key] = inflight_future
 
-            monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+            monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
             monkeypatch.setattr(service, "_http_bridge_pending_count", AsyncMock(return_value=1))
             monkeypatch.setattr(
                 proxy_module,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7986,9 +7986,20 @@ async def test_http_bridge_retire_after_drain_closes_session_on_cancellation(
 
 
 @pytest.mark.asyncio
-async def test_http_bridge_retire_after_drain_waits_for_queued_submission() -> None:
+async def test_http_bridge_retire_after_drain_waits_for_queued_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     close = AsyncMock()
+    release_live_session = AsyncMock()
+    release_account_lease = AsyncMock()
+    service._durable_bridge = cast(Any, SimpleNamespace(release_live_session=release_live_session))
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-retire-drain"),
+    )
     session = proxy_service._HTTPBridgeSession(
         key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_retire_queued", None),
         headers={"x-codex-turn-state": "http_turn_retire_queued"},
@@ -8010,16 +8021,35 @@ async def test_http_bridge_retire_after_drain_waits_for_queued_submission() -> N
         last_used_at=1.0,
         idle_ttl_seconds=120.0,
     )
+    lease = proxy_service.AccountLease(
+        lease_id="lease-retire-drain",
+        account_id=session.account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    session.account_lease = lease
+    session.durable_session_id = "durable-retire-drain"
+    session.durable_owner_epoch = 3
 
     assert await service._retire_http_bridge_after_drain_if_ready(session) is False
     assert session.closed is False
     close.assert_not_awaited()
+    release_live_session.assert_not_awaited()
+    release_account_lease.assert_not_awaited()
 
     async with session.pending_lock:
         session.queued_request_count = 0
 
     assert await service._retire_http_bridge_after_drain_if_ready(session) is True
     assert session.closed is True
+    release_live_session.assert_awaited_once_with(
+        session_id="durable-retire-drain",
+        instance_id="instance-retire-drain",
+        owner_epoch=3,
+        draining=False,
+    )
+    release_account_lease.assert_awaited_once_with(lease)
+    assert session.account_lease is None
     close.assert_awaited_once()
 
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -516,36 +516,30 @@ async def test_get_or_create_http_bridge_session_reuses_live_local_session_witho
 
 
 @pytest.mark.asyncio
-async def test_get_or_create_http_bridge_session_prunes_wedged_idle_session_without_hanging(
+async def test_get_or_create_http_bridge_session_skips_prune_when_pending_lock_is_wedged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     key = proxy_service._HTTPBridgeSessionKey("request", "bridge-wedged-idle", None)
-    stale_session = _make_bridge_session(key=key, key_value="bridge-wedged-idle")
-    stale_session.last_used_at = time.monotonic() - 300.0
-    stale_session.idle_ttl_seconds = 1.0
-    replacement_session = _make_bridge_session(key=key, key_value="bridge-wedged-idle")
-    replacement_session.last_used_at = time.monotonic()
-    service._http_bridge_sessions[key] = stale_session
+    existing_session = _make_bridge_session(key=key, key_value="bridge-wedged-idle")
+    existing_session.last_used_at = time.monotonic() - 300.0
+    existing_session.idle_ttl_seconds = 1.0
+    service._http_bridge_sessions[key] = existing_session
     lock_acquired = asyncio.Event()
     release_lock = asyncio.Event()
 
     async def hold_pending_lock() -> None:
-        async with stale_session.pending_lock:
+        async with existing_session.pending_lock:
             lock_acquired.set()
             await release_lock.wait()
 
     lock_holder = asyncio.create_task(hold_pending_lock())
     await asyncio.wait_for(lock_acquired.wait(), timeout=1.0)
 
-    monkeypatch.setattr(
-        service,
-        "_create_http_bridge_session",
-        AsyncMock(return_value=replacement_session),
-    )
+    create_http_bridge_session = AsyncMock()
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
-    close_started = asyncio.Event()
-    close_http_bridge_session = AsyncMock(side_effect=lambda *_args, **_kwargs: close_started.set())
+    close_http_bridge_session = AsyncMock()
     monkeypatch.setattr(service, "_close_http_bridge_session", close_http_bridge_session)
     monkeypatch.setattr(
         proxy_service,
@@ -570,11 +564,11 @@ async def test_get_or_create_http_bridge_session_prunes_wedged_idle_session_with
         release_lock.set()
         await asyncio.wait_for(lock_holder, timeout=1.0)
 
-    await asyncio.wait_for(close_started.wait(), timeout=1.0)
-    assert resolved is replacement_session
-    assert stale_session.closed is True
-    assert service._http_bridge_sessions[key] is replacement_session
-    close_http_bridge_session.assert_awaited_once_with(stale_session)
+    assert resolved is existing_session
+    assert existing_session.closed is False
+    assert service._http_bridge_sessions[key] is existing_session
+    close_http_bridge_session.assert_not_awaited()
+    create_http_bridge_session.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6906,6 +6906,67 @@ async def test_get_or_create_http_bridge_session_immediate_capacity_exhaustion_i
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_closes_lru_before_replacement_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    existing_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-lru-existing", None)
+    existing = _make_bridge_session(key=existing_key, key_value="sid-lru-existing")
+    service._http_bridge_sessions[existing_key] = existing
+    new_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-lru-new", None)
+    events: list[str] = []
+
+    async def close_http_bridge_session_bounded(
+        session: proxy_service._HTTPBridgeSession,
+        *,
+        reason: str,
+    ) -> None:
+        assert session is existing
+        assert reason == "registry_detach"
+        events.append("close")
+        session.closed = True
+
+    async def create_http_bridge_session(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **_: object,
+    ) -> proxy_service._HTTPBridgeSession:
+        assert events == ["close"]
+        events.append("create")
+        return _make_bridge_session(key=key, key_value=key.affinity_key)
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", close_http_bridge_session_bounded)
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    result = await service._get_or_create_http_bridge_session(
+        new_key,
+        headers={"x-codex-session-id": "sid-lru-new"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-lru-new",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+        max_sessions=1,
+    )
+
+    assert events == ["close", "create"]
+    assert result.key == new_key
+    assert existing_key not in service._http_bridge_sessions
+    assert service._http_bridge_sessions[new_key] is result
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_capacity_scan_does_not_wait_on_wedged_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6967,6 +6967,70 @@ async def test_get_or_create_http_bridge_session_closes_lru_before_replacement_c
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_cancel_during_lru_close_cleans_inflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    existing_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-lru-cancel-existing", None)
+    existing = _make_bridge_session(key=existing_key, key_value="sid-lru-cancel-existing")
+    service._http_bridge_sessions[existing_key] = existing
+    new_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-lru-cancel-new", None)
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    async def close_http_bridge_session_bounded(
+        session: proxy_service._HTTPBridgeSession,
+        *,
+        reason: str,
+    ) -> None:
+        assert session is existing
+        assert reason == "registry_detach"
+        close_started.set()
+        await release_close.wait()
+
+    create_http_bridge_session = AsyncMock()
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", close_http_bridge_session_bounded)
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    task = asyncio.create_task(
+        service._get_or_create_http_bridge_session(
+            new_key,
+            headers={"x-codex-session-id": "sid-lru-cancel-new"},
+            affinity=proxy_service._AffinityPolicy(
+                key="sid-lru-cancel-new",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=1,
+        )
+    )
+    await asyncio.wait_for(close_started.wait(), timeout=1.0)
+    assert new_key in service._http_bridge_inflight_sessions
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release_close.set()
+
+    assert new_key not in service._http_bridge_inflight_sessions
+    assert existing_key not in service._http_bridge_sessions
+    create_http_bridge_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_capacity_scan_does_not_wait_on_wedged_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -10,7 +10,7 @@ from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import aiohttp
 import anyio
@@ -33,12 +33,14 @@ def _make_app_settings(*, bridge_enabled: bool = True, **overrides: Any) -> Sett
 
 def _make_bridge_session(
     *,
+    key: proxy_service._HTTPBridgeSessionKey | None = None,
     key_value: str = "bridge-test",
     pending_requests: deque[proxy_service._WebSocketRequestState] | None = None,
     queued_request_count: int = 0,
 ) -> proxy_service._HTTPBridgeSession:
+    session_key = key or proxy_service._HTTPBridgeSessionKey("session_header", key_value, None)
     return proxy_service._HTTPBridgeSession(
-        key=proxy_service._HTTPBridgeSessionKey("session_header", key_value, None),
+        key=session_key,
         headers={"x-codex-session-id": key_value},
         affinity=proxy_service._AffinityPolicy(
             key=key_value,
@@ -55,6 +57,14 @@ def _make_bridge_session(
         last_used_at=1.0,
         idle_ttl_seconds=120.0,
     )
+
+
+async def _wait_for_close_await(close_session: AsyncMock, session: proxy_service._HTTPBridgeSession) -> None:
+    for _ in range(10):
+        if any(call.args == (session,) for call in close_session.await_args_list):
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("expected HTTP bridge session close to be awaited")
 
 
 def _make_api_key(
@@ -476,7 +486,7 @@ async def test_get_or_create_http_bridge_session_reuses_live_local_session_witho
     monkeypatch.setattr(
         service,
         "_prune_http_bridge_sessions_locked",
-        AsyncMock(),
+        Mock(return_value=[]),
     )
     monkeypatch.setattr(
         proxy_service,
@@ -503,6 +513,113 @@ async def test_get_or_create_http_bridge_session_reuses_live_local_session_witho
     assert reused is existing
     assert reused.request_model == "gpt-5.4"
     assert reused.last_used_at > 1.0
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_prunes_wedged_idle_session_without_hanging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("request", "bridge-wedged-idle", None)
+    stale_session = _make_bridge_session(key=key, key_value="bridge-wedged-idle")
+    stale_session.last_used_at = time.monotonic() - 300.0
+    stale_session.idle_ttl_seconds = 1.0
+    replacement_session = _make_bridge_session(key=key, key_value="bridge-wedged-idle")
+    replacement_session.last_used_at = time.monotonic()
+    service._http_bridge_sessions[key] = stale_session
+    lock_acquired = asyncio.Event()
+    release_lock = asyncio.Event()
+
+    async def hold_pending_lock() -> None:
+        async with stale_session.pending_lock:
+            lock_acquired.set()
+            await release_lock.wait()
+
+    lock_holder = asyncio.create_task(hold_pending_lock())
+    await asyncio.wait_for(lock_acquired.wait(), timeout=1.0)
+
+    monkeypatch.setattr(
+        service,
+        "_create_http_bridge_session",
+        AsyncMock(return_value=replacement_session),
+    )
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    close_started = asyncio.Event()
+    close_http_bridge_session = AsyncMock(side_effect=lambda *_args, **_kwargs: close_started.set())
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_http_bridge_session)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(),
+    )
+
+    try:
+        resolved = await asyncio.wait_for(
+            service._get_or_create_http_bridge_session(
+                key,
+                headers={},
+                affinity=proxy_service._AffinityPolicy(key="bridge-wedged-idle"),
+                api_key=None,
+                request_model="gpt-5.4",
+                idle_ttl_seconds=120.0,
+                max_sessions=8,
+            ),
+            timeout=1.0,
+        )
+    finally:
+        release_lock.set()
+        await asyncio.wait_for(lock_holder, timeout=1.0)
+
+    await asyncio.wait_for(close_started.wait(), timeout=1.0)
+    assert resolved is replacement_session
+    assert stale_session.closed is True
+    assert service._http_bridge_sessions[key] is replacement_session
+    close_http_bridge_session.assert_awaited_once_with(stale_session)
+
+
+@pytest.mark.asyncio
+async def test_prune_http_bridge_session_skips_wedged_session_with_visible_pending_request() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("request", "bridge-wedged-visible", None)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-wedged-visible",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    session = _make_bridge_session(
+        key=key,
+        key_value="bridge-wedged-visible",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    session.last_used_at = time.monotonic() - 300.0
+    session.idle_ttl_seconds = 1.0
+    service._http_bridge_sessions[key] = session
+    lock_acquired = asyncio.Event()
+    release_lock = asyncio.Event()
+
+    async def hold_pending_lock() -> None:
+        async with session.pending_lock:
+            lock_acquired.set()
+            await release_lock.wait()
+
+    lock_holder = asyncio.create_task(hold_pending_lock())
+    await asyncio.wait_for(lock_acquired.wait(), timeout=1.0)
+    try:
+        async with service._http_bridge_lock:
+            sessions_to_close = service._prune_http_bridge_sessions_locked()
+    finally:
+        release_lock.set()
+        await asyncio.wait_for(lock_holder, timeout=1.0)
+
+    assert sessions_to_close == []
+    assert service._http_bridge_sessions[key] is session
+    assert session.closed is False
 
 
 @pytest.mark.asyncio
@@ -542,7 +659,7 @@ async def test_get_or_create_http_bridge_session_replaces_live_session_when_acco
         idle_ttl_seconds=120.0,
     )
     service._http_bridge_sessions[key] = stale_session
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(
         service,
         "_create_http_bridge_session",
@@ -576,7 +693,7 @@ async def test_get_or_create_http_bridge_session_replaces_live_session_when_acco
     assert reused is replacement_session
     assert service._http_bridge_sessions[key] is replacement_session
     assert stale_session.closed is True
-    assert any(call.args == (stale_session,) for call in close_session.await_args_list)
+    await _wait_for_close_await(close_session, stale_session)
 
 
 @pytest.mark.asyncio
@@ -620,7 +737,7 @@ async def test_get_or_create_http_bridge_session_replaces_prompt_cache_session_p
         idle_ttl_seconds=120.0,
     )
     service._http_bridge_sessions[key] = stale_session
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(
         service,
         "_create_http_bridge_session",
@@ -654,7 +771,7 @@ async def test_get_or_create_http_bridge_session_replaces_prompt_cache_session_p
     assert reused is replacement_session
     assert service._http_bridge_sessions[key] is replacement_session
     assert stale_session.closed is True
-    assert any(call.args == (stale_session,) for call in close_session.await_args_list)
+    await _wait_for_close_await(close_session, stale_session)
 
 
 @pytest.mark.asyncio
@@ -686,7 +803,7 @@ async def test_get_or_create_http_bridge_session_registers_turn_state_alias_with
     service._http_bridge_previous_response_index[
         proxy_service._http_bridge_previous_response_alias_key("resp_prev_1", "key-1")
     ] = prompt_cache_key
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
     monkeypatch.setattr(
@@ -2643,6 +2760,254 @@ async def test_close_http_bridge_session_fails_pending_downstream_requests() -> 
     assert await asyncio.wait_for(event_queue.get(), timeout=1.0) is None
     assert list(session.pending_requests) == []
     assert session.queued_request_count == 0
+
+
+@pytest.mark.asyncio
+async def test_close_http_bridge_session_releases_lease_before_pending_cleanup_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="close-wedged-pending")
+    lease = proxy_service.AccountLease(
+        lease_id="lease-close-wedged-pending",
+        account_id=session.account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    session.account_lease = lease
+    lock_acquired = asyncio.Event()
+    release_lock = asyncio.Event()
+    lease_released = asyncio.Event()
+
+    async def hold_pending_lock() -> None:
+        async with session.pending_lock:
+            lock_acquired.set()
+            await release_lock.wait()
+
+    async def release_account_lease(account_lease: proxy_service.AccountLease | None) -> None:
+        assert account_lease is lease
+        lease_released.set()
+
+    lock_holder = asyncio.create_task(hold_pending_lock())
+    await asyncio.wait_for(lock_acquired.wait(), timeout=1.0)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+
+    close_task = asyncio.create_task(service._close_http_bridge_session(session))
+    try:
+        await asyncio.wait_for(lease_released.wait(), timeout=1.0)
+        assert session.account_lease is None
+        assert not close_task.done()
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+    finally:
+        release_lock.set()
+        await asyncio.wait_for(lock_holder, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_close_http_bridge_session_continues_when_lease_release_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    close = AsyncMock()
+    session = _make_bridge_session(key_value="close-lease-release-fails")
+    session.upstream = cast(UpstreamResponsesWebSocket, SimpleNamespace(close=close))
+    lease = proxy_service.AccountLease(
+        lease_id="lease-close-release-fails",
+        account_id=session.account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    session.account_lease = lease
+
+    async def release_account_lease(_account_lease: proxy_service.AccountLease | None) -> None:
+        raise RuntimeError("release failed")
+
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+
+    await service._close_http_bridge_session(session)
+
+    assert session.account_lease is None
+    close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_http_bridge_session_bounded_timeout_keeps_close_task_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="close-timeout-continues")
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    close_finished = asyncio.Event()
+    close_cancelled = False
+
+    async def close_http_bridge_session(target: proxy_service._HTTPBridgeSession) -> None:
+        nonlocal close_cancelled
+        assert target is session
+        close_started.set()
+        try:
+            await release_close.wait()
+        except asyncio.CancelledError:
+            close_cancelled = True
+            raise
+        finally:
+            close_finished.set()
+
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_http_bridge_session)
+
+    await service._close_http_bridge_session_bounded(session, reason="test")
+
+    await asyncio.wait_for(close_started.wait(), timeout=1.0)
+    assert close_cancelled is False
+    assert service._background_cleanup_tasks
+
+    release_close.set()
+    await asyncio.wait_for(close_finished.wait(), timeout=1.0)
+    for _ in range(10):
+        if not service._background_cleanup_tasks:
+            break
+        await asyncio.sleep(0)
+    assert service._background_cleanup_tasks == set()
+    assert close_cancelled is False
+
+
+@pytest.mark.asyncio
+async def test_close_http_bridge_session_bounded_cancellation_keeps_close_task_tracked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="close-cancel-continues")
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+    close_finished = asyncio.Event()
+    close_cancelled = False
+
+    async def close_http_bridge_session(target: proxy_service._HTTPBridgeSession) -> None:
+        nonlocal close_cancelled
+        assert target is session
+        close_started.set()
+        try:
+            await release_close.wait()
+        except asyncio.CancelledError:
+            close_cancelled = True
+            raise
+        finally:
+            close_finished.set()
+
+    monkeypatch.setattr(service, "_close_http_bridge_session", close_http_bridge_session)
+    bounded_task = asyncio.create_task(service._close_http_bridge_session_bounded(session, reason="test"))
+    await asyncio.wait_for(close_started.wait(), timeout=1.0)
+
+    bounded_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await bounded_task
+
+    assert close_cancelled is False
+    assert service._background_cleanup_tasks
+    release_close.set()
+    await asyncio.wait_for(close_finished.wait(), timeout=1.0)
+    for _ in range(10):
+        if not service._background_cleanup_tasks:
+            break
+        await asyncio.sleep(0)
+    assert service._background_cleanup_tasks == set()
+    assert close_cancelled is False
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_unregister_aliases_preserves_new_owner_mapping() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    old_session = _make_bridge_session(key_value="old-alias-owner")
+    new_key = proxy_service._HTTPBridgeSessionKey("session_header", "new-alias-owner", None)
+    turn_state = "http_turn_shared_alias"
+    previous_response_id = "resp_shared_alias"
+    old_session.downstream_turn_state_aliases.add(turn_state)
+    old_session.previous_response_ids.add(previous_response_id)
+    turn_state_alias_key = proxy_service._http_bridge_turn_state_alias_key(turn_state, None)
+    previous_response_alias_key = proxy_service._http_bridge_previous_response_alias_key(previous_response_id, None)
+    service._http_bridge_turn_state_index[turn_state_alias_key] = new_key
+    service._http_bridge_previous_response_index[previous_response_alias_key] = new_key
+
+    await service._unregister_http_bridge_turn_states(old_session)
+    await service._unregister_http_bridge_previous_response_ids(old_session)
+
+    assert service._http_bridge_turn_state_index[turn_state_alias_key] == new_key
+    assert service._http_bridge_previous_response_index[previous_response_alias_key] == new_key
+    assert old_session.downstream_turn_state_aliases == set()
+    assert old_session.previous_response_ids == set()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_unregister_aliases_removes_same_key_alias_not_owned_by_new_generation() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "same-key-alias-owner", None)
+    old_session = _make_bridge_session(key=key, key_value="same-key-alias-owner")
+    new_session = _make_bridge_session(key=key, key_value="same-key-alias-owner")
+    turn_state = "http_turn_same_key_alias"
+    previous_response_id = "resp_same_key_alias"
+    old_session.downstream_turn_state_aliases.add(turn_state)
+    old_session.previous_response_ids.add(previous_response_id)
+    turn_state_alias_key = proxy_service._http_bridge_turn_state_alias_key(turn_state, None)
+    previous_response_alias_key = proxy_service._http_bridge_previous_response_alias_key(previous_response_id, None)
+    service._http_bridge_sessions[key] = new_session
+    service._http_bridge_turn_state_index[turn_state_alias_key] = key
+    service._http_bridge_previous_response_index[previous_response_alias_key] = key
+
+    await service._unregister_http_bridge_turn_states(old_session)
+    await service._unregister_http_bridge_previous_response_ids(old_session)
+
+    assert turn_state_alias_key not in service._http_bridge_turn_state_index
+    assert previous_response_alias_key not in service._http_bridge_previous_response_index
+    assert old_session.downstream_turn_state_aliases == set()
+    assert old_session.previous_response_ids == set()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_unregister_aliases_preserves_same_key_alias_owned_by_new_generation() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "same-key-owned-alias", None)
+    old_session = _make_bridge_session(key=key, key_value="same-key-owned-alias")
+    new_session = _make_bridge_session(key=key, key_value="same-key-owned-alias")
+    turn_state = "http_turn_same_key_owned_alias"
+    previous_response_id = "resp_same_key_owned_alias"
+    old_session.downstream_turn_state_aliases.add(turn_state)
+    old_session.previous_response_ids.add(previous_response_id)
+    new_session.downstream_turn_state_aliases.add(turn_state)
+    new_session.previous_response_ids.add(previous_response_id)
+    turn_state_alias_key = proxy_service._http_bridge_turn_state_alias_key(turn_state, None)
+    previous_response_alias_key = proxy_service._http_bridge_previous_response_alias_key(previous_response_id, None)
+    service._http_bridge_sessions[key] = new_session
+    service._http_bridge_turn_state_index[turn_state_alias_key] = key
+    service._http_bridge_previous_response_index[previous_response_alias_key] = key
+
+    await service._unregister_http_bridge_turn_states(old_session)
+    await service._unregister_http_bridge_previous_response_ids(old_session)
+
+    assert service._http_bridge_turn_state_index[turn_state_alias_key] == key
+    assert service._http_bridge_previous_response_index[previous_response_alias_key] == key
+    assert old_session.downstream_turn_state_aliases == set()
+    assert old_session.previous_response_ids == set()
+
+
+def test_http_bridge_drain_detach_removes_old_previous_response_alias() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "drain-detach-alias-owner", None)
+    old_session = _make_bridge_session(key=key, key_value="drain-detach-alias-owner")
+    previous_response_id = "resp_drain_detach_old"
+    old_session.previous_response_ids.add(previous_response_id)
+    previous_response_alias_key = proxy_service._http_bridge_previous_response_alias_key(previous_response_id, None)
+    service._http_bridge_sessions[key] = old_session
+    service._http_bridge_previous_response_index[previous_response_alias_key] = key
+
+    detached = service._detach_http_bridge_session_locked(key, expected_session=old_session, mark_closed=False)
+
+    assert detached is old_session
+    assert old_session.closed is False
+    assert previous_response_alias_key not in service._http_bridge_previous_response_index
+    assert old_session.previous_response_ids == set()
 
 
 @pytest.mark.asyncio
@@ -5109,7 +5474,7 @@ async def test_get_or_create_http_bridge_session_returns_owner_forward_for_hard_
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_123", None)
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(
         proxy_service,
         "get_settings",
@@ -5193,7 +5558,7 @@ async def test_get_or_create_http_bridge_session_preserves_explicit_forwarded_af
         captured["key"] = create_key
         return created_session
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", fake_create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
@@ -5278,7 +5643,7 @@ async def test_get_or_create_http_bridge_session_falls_back_to_session_header_wh
         captured["key"] = create_key
         return created_session
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", fake_create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
@@ -5363,7 +5728,7 @@ async def test_get_or_create_http_bridge_session_preserves_durable_canonical_pro
         captured["key"] = create_key
         return created_session
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", fake_create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
@@ -5435,7 +5800,7 @@ async def test_get_or_create_http_bridge_session_recovers_from_previous_response
     service._http_bridge_previous_response_index[
         proxy_service._http_bridge_previous_response_alias_key("resp_prev_1", None)
     ] = recovered_key
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
     monkeypatch.setattr(
@@ -5511,7 +5876,7 @@ async def test_get_or_create_http_bridge_session_closes_stale_session_before_pre
     service._http_bridge_previous_response_index[
         proxy_service._http_bridge_previous_response_alias_key("resp_prev_1", "key-1")
     ] = recovered_key
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     close_session = AsyncMock(wraps=service._close_http_bridge_session)
     monkeypatch.setattr(service, "_close_http_bridge_session", close_session)
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
@@ -5542,6 +5907,10 @@ async def test_get_or_create_http_bridge_session_closes_stale_session_before_pre
 
     assert resolved is recovered_session
     assert stale_session.closed is True
+    for _ in range(10):
+        if any(call.args == (stale_session,) for call in close_session.await_args_list):
+            break
+        await asyncio.sleep(0)
     assert any(call.args == (stale_session,) for call in close_session.await_args_list)
 
 
@@ -5594,7 +5963,7 @@ async def test_get_or_create_http_bridge_session_drops_stale_previous_response_m
     alias_key = proxy_service._http_bridge_previous_response_alias_key("resp_prev_1", None)
     service._http_bridge_sessions[stale_key] = stale_session
     service._http_bridge_previous_response_index[alias_key] = stale_key
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     create_http_bridge_session = AsyncMock(return_value=created_session)
     monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
@@ -5651,7 +6020,7 @@ async def test_get_or_create_http_bridge_session_allows_local_rebind_for_previou
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     create_http_bridge_session = AsyncMock(return_value=created_session)
     monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
@@ -5706,7 +6075,7 @@ async def test_get_or_create_http_bridge_session_allows_local_rebind_for_bootstr
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     create_http_bridge_session = AsyncMock(return_value=created_session)
     monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
@@ -5784,7 +6153,7 @@ async def test_get_or_create_http_bridge_session_recovers_locally_when_owner_end
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     create_http_bridge_session = AsyncMock(return_value=created_session)
     monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     claim_durable = AsyncMock()
@@ -5838,7 +6207,7 @@ async def test_get_or_create_http_bridge_session_recovers_locally_when_stale_own
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
     claim_durable = AsyncMock()
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
@@ -5904,7 +6273,7 @@ async def test_get_or_create_http_bridge_session_recovers_locally_when_owner_end
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
     claim_durable = AsyncMock()
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
@@ -5970,7 +6339,7 @@ async def test_get_or_create_http_bridge_session_recovers_locally_without_anchor
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
     claim_durable = AsyncMock()
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
@@ -6035,7 +6404,7 @@ async def test_get_or_create_http_bridge_session_prompt_cache_takes_over_stale_s
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
     claim_durable = AsyncMock()
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
@@ -6124,7 +6493,7 @@ async def test_get_or_create_http_bridge_session_discards_local_session_when_dur
     service._http_bridge_sessions[key] = existing_session
     close_session = AsyncMock()
     monkeypatch.setattr(service, "_close_http_bridge_session", close_session)
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
@@ -6166,7 +6535,7 @@ async def test_get_or_create_http_bridge_session_discards_local_session_when_dur
     )
 
     assert resolved is created_session
-    close_session.assert_awaited_once_with(existing_session)
+    await _wait_for_close_await(close_session, existing_session)
 
 
 @pytest.mark.asyncio
@@ -6196,7 +6565,7 @@ async def test_get_or_create_http_bridge_session_does_not_publish_before_durable
     close_session = AsyncMock()
 
     monkeypatch.setattr(service, "_close_http_bridge_session", close_session)
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
     monkeypatch.setattr(
         service,
@@ -6258,7 +6627,7 @@ async def test_get_or_create_http_bridge_session_waiter_propagates_terminal_infl
     )
     service._http_bridge_inflight_sessions[key] = inflight_future
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
     monkeypatch.setattr(
@@ -6299,7 +6668,7 @@ async def test_get_or_create_http_bridge_session_inflight_wait_times_out(
     settings = _make_app_settings()
     settings.proxy_admission_wait_timeout_seconds = 0.01
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
@@ -6382,7 +6751,7 @@ async def test_close_all_http_bridge_sessions_fails_capacity_waiters_instead_of_
     inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
     service._http_bridge_inflight_sessions[inflight_key] = inflight_future
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_http_bridge_pending_count", AsyncMock(return_value=1))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
@@ -6456,7 +6825,7 @@ async def test_get_or_create_http_bridge_session_capacity_wait_times_out(
     settings = _make_app_settings()
     settings.proxy_admission_wait_timeout_seconds = 0.01
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_http_bridge_pending_count", AsyncMock(return_value=1))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
@@ -6507,7 +6876,7 @@ async def test_get_or_create_http_bridge_session_immediate_capacity_exhaustion_i
     existing = _make_bridge_session(key_value="sid-capacity-full", queued_request_count=1)
     service._http_bridge_sessions[existing_key] = existing
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_http_bridge_pending_count", AsyncMock(return_value=1))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
@@ -6534,6 +6903,63 @@ async def test_get_or_create_http_bridge_session_immediate_capacity_exhaustion_i
 
     assert exc_info.value.status_code == 429
     assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_capacity_scan_does_not_wait_on_wedged_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    existing_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-wedged", None)
+    existing = _make_bridge_session(key=existing_key, key_value="sid-capacity-wedged")
+    service._http_bridge_sessions[existing_key] = existing
+    lock_acquired = asyncio.Event()
+    release_lock = asyncio.Event()
+
+    async def hold_pending_lock() -> None:
+        async with existing.pending_lock:
+            lock_acquired.set()
+            await release_lock.wait()
+
+    lock_holder = asyncio.create_task(hold_pending_lock())
+    await asyncio.wait_for(lock_acquired.wait(), timeout=1.0)
+
+    create_http_bridge_session = AsyncMock()
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ("instance-a",))),
+    )
+
+    try:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            await asyncio.wait_for(
+                service._get_or_create_http_bridge_session(
+                    proxy_service._HTTPBridgeSessionKey("session_header", "sid-capacity-new", None),
+                    headers={"x-codex-session-id": "sid-capacity-new"},
+                    affinity=proxy_service._AffinityPolicy(
+                        key="sid-capacity-new",
+                        kind=proxy_service.StickySessionKind.CODEX_SESSION,
+                    ),
+                    api_key=None,
+                    request_model="gpt-5.4",
+                    idle_ttl_seconds=120.0,
+                    max_sessions=1,
+                ),
+                timeout=1.0,
+            )
+    finally:
+        release_lock.set()
+        await asyncio.wait_for(lock_holder, timeout=1.0)
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.payload["error"]["code"] == "capacity_exhausted_active_sessions"
+    create_http_bridge_session.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -6643,7 +7069,7 @@ async def test_get_or_create_http_bridge_session_cancel_during_stale_close_clean
         await release_close.wait()
 
     monkeypatch.setattr(service, "_close_http_bridge_session", close_stale_session)
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(proxy_service, "_http_bridge_should_wait_for_registration", AsyncMock(return_value=False))
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
@@ -6652,7 +7078,8 @@ async def test_get_or_create_http_bridge_session_cancel_during_stale_close_clean
         "_active_http_bridge_instance_ring",
         AsyncMock(return_value=("instance-a", ("instance-a",))),
     )
-    create_http_bridge_session = AsyncMock()
+    replacement = _make_bridge_session(key=key, key_value="sid-stale-close-cancel")
+    create_http_bridge_session = AsyncMock(return_value=replacement)
     monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
 
@@ -6671,15 +7098,13 @@ async def test_get_or_create_http_bridge_session_cancel_during_stale_close_clean
         )
     )
     await asyncio.wait_for(close_started.wait(), timeout=1.0)
-    assert key in service._http_bridge_inflight_sessions
-
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    resolved = await asyncio.wait_for(task, timeout=1.0)
     release_close.set()
+    await asyncio.sleep(0)
 
+    assert resolved is replacement
     assert key not in service._http_bridge_inflight_sessions
-    create_http_bridge_session.assert_not_awaited()
+    create_http_bridge_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -6699,7 +7124,7 @@ async def test_get_or_create_http_bridge_session_late_owner_after_inflight_evict
         await finish_create.wait()
         return created
 
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     close_http_bridge_session = AsyncMock()
@@ -6893,7 +7318,7 @@ async def test_get_or_create_http_bridge_session_hard_continuity_lookup_failure_
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     create_http_bridge_session = AsyncMock(return_value=created_session)
     monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
@@ -8769,7 +9194,7 @@ async def test_get_or_create_http_bridge_session_soft_mismatch_rebinds_locally(
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
     monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
     monkeypatch.setattr(
@@ -9006,7 +9431,7 @@ async def test_get_or_create_http_bridge_session_prompt_cache_mismatch_stays_loc
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "cache-key", None)
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-b"))
     monkeypatch.setattr(
@@ -9053,7 +9478,7 @@ async def test_get_or_create_http_bridge_session_sticky_thread_mismatch_forwards
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     key = proxy_service._HTTPBridgeSessionKey("sticky_thread", "thread-key", None)
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-b"))
     monkeypatch.setattr(
@@ -9086,7 +9511,7 @@ async def test_get_or_create_http_bridge_session_prevents_forward_loops(
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_123", None)
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     create_http_bridge_session = AsyncMock()
     monkeypatch.setattr(service, "_create_http_bridge_session", create_http_bridge_session)
     claim_durable = AsyncMock()
@@ -9159,7 +9584,7 @@ async def test_get_or_create_http_bridge_session_replaces_live_session_when_scop
         idle_ttl_seconds=120.0,
     )
     service._http_bridge_sessions[key] = stale_session
-    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", AsyncMock())
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
     monkeypatch.setattr(
         service,
         "_create_http_bridge_session",
@@ -9197,7 +9622,7 @@ async def test_get_or_create_http_bridge_session_replaces_live_session_when_scop
     assert reused is replacement_session
     assert service._http_bridge_sessions[key] is replacement_session
     assert stale_session.closed is True
-    assert any(call.args == (stale_session,) for call in close_session.await_args_list)
+    await _wait_for_close_await(close_session, stale_session)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -8173,6 +8173,70 @@ async def test_http_bridge_retire_after_drain_waits_for_queued_submission(
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_retire_after_drain_does_not_cancel_current_upstream_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    close = AsyncMock()
+    release_live_session = AsyncMock()
+    release_account_lease = AsyncMock()
+    service._durable_bridge = cast(Any, SimpleNamespace(release_live_session=release_live_session))
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-reader-retire"),
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_reader_retire", None),
+        headers={"x-codex-turn-state": "http_turn_reader_retire"},
+        affinity=proxy_service._AffinityPolicy(
+            key="http_turn_reader_retire",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.5",
+        account=cast(Any, SimpleNamespace(id="acc-reader-retire", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=close)),
+        upstream_control=proxy_service._WebSocketUpstreamControl(
+            reconnect_requested=True,
+            retire_after_drain=True,
+        ),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    lease = proxy_service.AccountLease(
+        lease_id="lease-reader-retire",
+        account_id=session.account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    session.account_lease = lease
+    session.durable_session_id = "durable-reader-retire"
+    session.durable_owner_epoch = 7
+    current_task = asyncio.current_task()
+    assert current_task is not None
+    session.upstream_reader = current_task
+
+    assert await service._retire_http_bridge_after_drain_if_ready(session) is True
+
+    assert session.closed is True
+    assert session.upstream_reader is None
+    close.assert_awaited_once()
+    release_live_session.assert_awaited_once_with(
+        session_id="durable-reader-retire",
+        instance_id="instance-reader-retire",
+        owner_epoch=7,
+        draining=False,
+    )
+    release_account_lease.assert_awaited_once_with(lease)
+    assert session.account_lease is None
+
+
+@pytest.mark.asyncio
 async def test_submit_http_bridge_request_starts_api_key_reservation_heartbeat(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Prevent stale `/v1/responses` HTTP bridge cleanup from awaiting pending locks or close work while holding the global bridge registry lock.
- Detach stale sessions synchronously, preserve alias ownership across same-key generations, and run bounded/tracked background close cleanup.
- Release account and durable ownership before best-effort pending/upstream cleanup so wedged closes do not block replacement sessions.
- Add OpenSpec change `harden-http-bridge-session-lifecycle` with regression coverage for stale cleanup, alias preservation, and bounded close behavior.

## Testing
- `.venv/bin/python -m pytest tests/unit/test_proxy_http_bridge.py -q`
- `.venv/bin/python -m pytest tests/integration/test_http_responses_bridge.py -q`
- `.venv/bin/python -m ruff check app/modules/proxy/service.py tests/unit/test_proxy_http_bridge.py tests/integration/test_http_responses_bridge.py`
- `openspec validate harden-http-bridge-session-lifecycle --strict`
- `openspec validate --specs`

## Notes
- No issue linked; this follows the server 113 `/v1/responses` hang investigation.
