### PR TITLE
ci: skip unrelated CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,77 @@ permissions:
   pull-requests: read
 
 jobs:
+  # Detect changed areas so PRs can skip unrelated expensive jobs.
+  # Pushes to main and merge queue events still run the full suite.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      frontend: ${{ steps.force.outputs.full_suite || steps.filter.outputs.frontend }}
+      backend: ${{ steps.force.outputs.full_suite || steps.filter.outputs.backend }}
+      helm: ${{ steps.force.outputs.full_suite || steps.filter.outputs.helm }}
+      docker: ${{ steps.force.outputs.full_suite || steps.filter.outputs.docker }}
+      migrations: ${{ steps.force.outputs.full_suite || steps.filter.outputs.migrations }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Detect full-suite events
+        id: force
+        run: |
+          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "full_suite=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "full_suite=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Detect file changes
+        id: filter
+        if: steps.force.outputs.full_suite != 'true'
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
+            backend:
+              - '.github/scripts/**'
+              - 'app/**'
+              - 'tests/**'
+              - 'config/**'
+              - 'scripts/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
+            helm:
+              - 'deploy/helm/**'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
+            docker:
+              - 'Dockerfile'
+              - 'Dockerfile.*'
+              - '.dockerignore'
+              - 'docker-compose*.yml'
+              - 'app/**'
+              - 'config/**'
+              - 'frontend/**'
+              - 'scripts/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/ci.yml'
+            migrations:
+              - 'app/db/alembic/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/ci.yml'
+
   contributors:
     name: Contributors attribution
     runs-on: ubuntu-24.04
@@ -34,6 +105,8 @@ jobs:
   frontend-lint:
     name: Frontend lint (eslint)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
 
     steps:
       - name: Checkout repository
@@ -45,6 +118,16 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run frontend lint
         run: make frontend-lint
@@ -52,6 +135,8 @@ jobs:
   frontend-typecheck:
     name: Frontend type check (tsc)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
 
     steps:
       - name: Checkout repository
@@ -63,6 +148,16 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run frontend type check
         run: make frontend-typecheck
@@ -70,6 +165,8 @@ jobs:
   frontend-test:
     name: Frontend tests (vitest + coverage)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
 
     steps:
       - name: Checkout repository
@@ -81,6 +178,16 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run frontend tests with coverage
         run: make frontend-test
@@ -88,6 +195,8 @@ jobs:
   frontend-build:
     name: Frontend build (vite)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
 
     steps:
       - name: Checkout repository
@@ -100,12 +209,24 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - name: Cache Bun dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Build frontend
         run: make frontend-build
 
   lint:
     name: Lint (ruff)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
 
     steps:
       - name: Checkout repository
@@ -125,6 +246,8 @@ jobs:
   typecheck:
     name: Type check (ty)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
 
     steps:
       - name: Checkout repository
@@ -145,6 +268,8 @@ jobs:
     name: Tests (pytest, ${{ matrix.slice.name }})
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -167,6 +292,16 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - name: Cache Bun dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
@@ -180,6 +315,8 @@ jobs:
     name: Tests (pytest, PostgreSQL)
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     services:
       postgres:
         image: postgres:16
@@ -195,7 +332,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      POSTGRES_TEST_DATABASE_URL: postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
+      CODEX_LB_TEST_DATABASE_URL: postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
       PYTHONFAULTHANDLER: "1"
 
     steps:
@@ -203,6 +340,21 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
@@ -216,6 +368,8 @@ jobs:
   migration-check:
     name: Migration check (alembic)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.migrations == 'true' || needs.changes.outputs.backend == 'true'
 
     steps:
       - name: Checkout repository
@@ -235,6 +389,8 @@ jobs:
   migration-check-postgres:
     name: Migration check (alembic, PostgreSQL)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.migrations == 'true' || needs.changes.outputs.backend == 'true'
     services:
       postgres:
         image: postgres:16
@@ -268,6 +424,8 @@ jobs:
   package:
     name: Package (build)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true'
 
     steps:
       - name: Checkout repository
@@ -279,6 +437,16 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: "1.3.14"
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
@@ -292,6 +460,8 @@ jobs:
   docker:
     name: Docker build
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
     permissions:
       actions: read
       contents: read
@@ -306,10 +476,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Build Docker image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: Dockerfile
@@ -349,6 +519,8 @@ jobs:
   helm-lint:
     name: Helm lint + template + kubeconform
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.helm == 'true'
 
     steps:
       - name: Checkout repository
@@ -359,23 +531,35 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
+      - name: Cache kubeconform
+        id: cache-kubeconform
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: .cache/ci-tools/kubeconform
+          key: kubeconform-0.7.0-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install kubeconform
         run: |
           set -euo pipefail
           KUBECONFORM_VERSION="0.7.0"
-          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-          ARCH=$(uname -m)
-          case "$ARCH" in
-            x86_64) ARCH="amd64" ;;
-            aarch64) ARCH="arm64" ;;
-          esac
-          ASSET="kubeconform-${OS}-${ARCH}.tar.gz"
-          BASE_URL="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}"
-          curl -fsSLO "${BASE_URL}/CHECKSUMS"
-          curl -fsSLO "${BASE_URL}/${ASSET}"
-          grep "  ${ASSET}$" CHECKSUMS | sha256sum -c -
-          tar xzf "${ASSET}" -C /tmp
-          sudo mv /tmp/kubeconform /usr/local/bin/kubeconform
+          TOOL_DIR=".cache/ci-tools/kubeconform"
+          TOOL_PATH="${TOOL_DIR}/kubeconform"
+          if [[ ! -x "${TOOL_PATH}" ]]; then
+            mkdir -p "${TOOL_DIR}"
+            OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+            ARCH=$(uname -m)
+            case "$ARCH" in
+              x86_64) ARCH="amd64" ;;
+              aarch64) ARCH="arm64" ;;
+            esac
+            ASSET="kubeconform-${OS}-${ARCH}.tar.gz"
+            BASE_URL="https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}"
+            curl -fsSLO "${BASE_URL}/CHECKSUMS"
+            curl -fsSLO "${BASE_URL}/${ASSET}"
+            grep "  ${ASSET}$" CHECKSUMS | sha256sum -c -
+            tar xzf "${ASSET}" -C "${TOOL_DIR}" kubeconform
+          fi
+          sudo install -m 0755 "${TOOL_PATH}" /usr/local/bin/kubeconform
 
       - name: Helm lint + template + kubeconform
         run: make helm-check
@@ -383,6 +567,8 @@ jobs:
   helm-smoke-kind:
     name: Helm smoke install (kind)
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.helm == 'true'
 
     steps:
       - name: Checkout repository
@@ -393,16 +579,36 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
+      - name: Cache kind
+        id: cache-kind
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+        with:
+          path: .cache/ci-tools/kind
+          key: kind-0.30.0-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install kind
         run: |
           set -euo pipefail
           KIND_VERSION="0.30.0"
-          BASE_URL="https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}"
-          curl -fsSLO "${BASE_URL}/kind-linux-amd64"
-          curl -fsSLO "${BASE_URL}/kind-linux-amd64.sha256sum"
-          sha256sum -c ./kind-linux-amd64.sha256sum
-          chmod +x ./kind-linux-amd64
-          sudo mv ./kind-linux-amd64 /usr/local/bin/kind
+          TOOL_DIR=".cache/ci-tools/kind"
+          TOOL_PATH="${TOOL_DIR}/kind"
+          if [[ ! -x "${TOOL_PATH}" ]]; then
+            mkdir -p "${TOOL_DIR}"
+            ARCH=$(uname -m)
+            case "$ARCH" in
+              x86_64) KIND_ARCH="amd64" ;;
+              aarch64) KIND_ARCH="arm64" ;;
+              *) echo "unsupported arch: ${ARCH}"; exit 1 ;;
+            esac
+            BASE_URL="https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}"
+            ASSET="kind-linux-${KIND_ARCH}"
+            curl -fsSLo "${TOOL_DIR}/${ASSET}" "${BASE_URL}/${ASSET}"
+            curl -fsSLo "${TOOL_DIR}/${ASSET}.sha256sum" "${BASE_URL}/${ASSET}.sha256sum"
+            (cd "${TOOL_DIR}" && sha256sum -c "${ASSET}.sha256sum")
+            mv "${TOOL_DIR}/${ASSET}" "${TOOL_PATH}"
+            chmod +x "${TOOL_PATH}"
+          fi
+          sudo install -m 0755 "${TOOL_PATH}" /usr/local/bin/kind
 
       - name: Helm smoke install
         run: make helm-smoke-kind
@@ -412,6 +618,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: always()
     needs:
+      - changes
       - contributors
       - frontend-lint
       - frontend-typecheck


### PR DESCRIPTION
## Summary
- Add a `changes` gate to skip unrelated CI jobs on pull requests
- Keep push-to-main and merge queue events on the full CI suite
- Cache Bun dependencies plus kind/kubeconform tool downloads to reduce repeated setup time

## Expected impact
- Frontend-only PRs skip backend pytest, migration, Docker, and Helm jobs
- Backend-only PRs skip frontend lint/typecheck/test/build, Helm, and Docker unless relevant inputs changed
- Helm-only PRs skip app/frontend test jobs and only run Helm validation plus the required gate
- CI workflow changes still run every major job so the filter behavior is verified safely

## Test Plan
- `actionlint .github/workflows/ci.yml`
- `python ~/.hermes/skills/github/github-pr-workflow/scripts/validate-github-action-refs.py`
- `git diff --check`
- `openspec validate --specs`
