### PR TITLE
chore: release v1.20.0-beta.3

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.20.0-beta.2"  # x-release-please-version
+__version__ = "1.20.0-beta.3"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.20.0-beta.2
-appVersion: 1.20.0-beta.2
+version: 1.20.0-beta.3
+appVersion: 1.20.0-beta.3
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.20.0-beta.2",
+  "version": "1.20.0-beta.3",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.20.0-beta.2"
+version = "1.20.0-beta.3"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.20.0-beta.2"
+version = "1.20.0-beta.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.20.0-beta.3 for the 1.20.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.20.0-beta.3 as a GitHub prerelease and trigger package/image/chart publishing.
- Synced automatically from release-please PR #806; no manual beta workflow dispatch is required.

## Install after publish
```bash
uvx --from "codex-lb==1.20.0b3" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.20.0-beta.3
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.20.0-beta.3 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.20.0.
