### PR TITLE
ci(release): gate beta PRs on releasable commits

### DIFF
--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -80,7 +80,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m scripts.prepare_beta_release
+          python -m scripts.prepare_beta_release \
+            --changelog-path "${RUNNER_TEMP}/beta-release-changelog.md"
 
       - name: Detect changes
         if: steps.release_pr.outputs.found == 'true' && steps.prepare.outputs.should_create != 'false'
@@ -122,16 +123,29 @@ jobs:
           VERSION: ${{ steps.prepare.outputs.version }}
           BASE_VERSION: ${{ steps.prepare.outputs.base_version }}
           PYPI_VERSION: ${{ steps.prepare.outputs.pypi_version }}
+          PREVIOUS_TAG: ${{ steps.prepare.outputs.previous_tag }}
+          CHANGELOG_PATH: ${{ steps.prepare.outputs.changelog_path }}
           RELEASE_PR: ${{ steps.release_pr.outputs.number }}
         run: |
           set -euo pipefail
           body_file="${RUNNER_TEMP}/beta-release-pr.md"
-          cat > "${body_file}" <<EOF
+          if [ ! -s "${CHANGELOG_PATH}" ]; then
+            echo "::error::Missing generated beta changelog at ${CHANGELOG_PATH}"
+            exit 1
+          fi
+
+          {
+          cat <<EOF
           ## Summary
           - Prepares beta release ${TAG} for the ${BASE_VERSION} stable train.
           - Updates release-managed version files only; release-please remains the stable release owner.
           - Merging this PR will publish ${TAG} as a GitHub prerelease and trigger package/image/chart publishing.
           - Synced automatically from release-please PR #${RELEASE_PR}; no manual beta workflow dispatch is required.
+
+          ## Changes since ${PREVIOUS_TAG:-the previous release}
+          EOF
+          cat "${CHANGELOG_PATH}"
+          cat <<EOF
 
           ## Install after publish
           \`\`\`bash
@@ -143,6 +157,7 @@ jobs:
           ## Promotion
           Merge the normal release-please PR to promote this beta-tested train to ${BASE_VERSION}.
           EOF
+          } > "${body_file}"
 
           existing_pr="$(gh pr list --base main --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')"
           if [ -n "${existing_pr}" ]; then

--- a/openspec/changes/beta-release-please-parity/proposal.md
+++ b/openspec/changes/beta-release-please-parity/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+After merging a beta release PR (e.g. beta.2), the Sync Beta Release PR
+workflow immediately opens the next beta PR (beta.3) even when zero meaningful
+commits exist between the latest beta tag and HEAD. This creates a releasable
+PR with no content, unlike release-please which only opens or updates its PR
+when Conventional Commit changes accumulate on main.
+
+Additionally, the beta PR body contains a static template instead of an
+accumulated changelog, making it hard to tell what a given beta release will
+ship before merging the PR.
+
+## What Changes
+
+- `scripts/prepare_beta_release.py` skips beta PR creation when no releasable
+  Conventional Commits exist since the latest beta tag.
+- `prepare-beta-release.yml` includes a generated changelog section in the beta
+  PR body.
+- A beta PR body is updated on each subsequent main push that adds releasable
+  commits.
+
+## Capabilities
+
+### Modified Capabilities
+
+- CI/CD release automation: beta release sync workflow gains content-gated
+  creation and changelog body generation.
+
+## Impact
+
+- Code: `scripts/prepare_beta_release.py`, `scripts/release_versions.py`,
+  `.github/workflows/prepare-beta-release.yml`.
+- Tests: `tests/unit/test_release_versions.py`.

--- a/openspec/changes/beta-release-please-parity/specs/release-automation/spec.md
+++ b/openspec/changes/beta-release-please-parity/specs/release-automation/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Beta release PR creation parity
+
+The beta release sync workflow SHALL only create or update an automation-managed beta release PR when the latest beta tag does not cover all releasable Conventional Commit changes on `main`.
+
+#### Scenario: Latest beta tag is followed only by non-releasable CI changes
+
+- **GIVEN** the latest beta tag is `v1.20.0-beta.2`
+- **AND** `main` contains only `ci:`, `chore:`, `docs:`, `test:`, or other non-releasable commits after that tag
+- **WHEN** the beta release sync workflow evaluates the next beta release
+- **THEN** the workflow does not create or update a `v1.20.0-beta.3` PR
+- **AND** the workflow reports that the latest beta tag already covers all releasable commits
+
+#### Scenario: Latest beta tag is followed by a releasable change
+
+- **GIVEN** the latest beta tag is `v1.20.0-beta.2`
+- **AND** `main` contains a releasable Conventional Commit after that tag, such as `feat:`, `fix:`, `perf:`, `deps:`, `revert:`, or a breaking-change commit
+- **WHEN** the beta release sync workflow evaluates the next beta release
+- **THEN** the workflow creates or updates the next beta release PR
+- **AND** the beta release PR targets `v1.20.0-beta.3`
+
+### Requirement: Beta release PR changelog
+
+The beta release sync workflow SHALL include a generated changelog section in the automation-managed beta release PR body.
+
+#### Scenario: Beta PR contains releasable changes since the previous beta tag
+
+- **GIVEN** the latest beta tag is `v1.20.0-beta.2`
+- **AND** `main` contains a releasable Conventional Commit after that tag
+- **WHEN** the beta release sync workflow opens or updates the next beta release PR
+- **THEN** the PR body includes a `Changes since v1.20.0-beta.2` section
+- **AND** the section lists the releasable Conventional Commit subjects included in that beta PR

--- a/openspec/changes/beta-release-please-parity/tasks.md
+++ b/openspec/changes/beta-release-please-parity/tasks.md
@@ -1,0 +1,21 @@
+## 1. Beta PR creation parity
+
+- [x] 1.1 Add helper coverage for releasable Conventional Commit detection.
+- [x] 1.2 Skip beta PR creation when the latest beta tag already covers all
+      releasable changes and HEAD only contains non-releasable release/meta
+      commits.
+- [x] 1.3 Keep creating/updating beta PRs when feat/fix/perf/deps/revert or
+      breaking-change commits exist after the latest beta tag.
+
+## 2. Beta PR changelog
+
+- [x] 2.1 Generate beta PR changelog text from commits between the latest beta
+      tag and HEAD.
+- [x] 2.2 Include the changelog in the beta PR body whenever the sync workflow
+      creates or updates the beta PR.
+
+## 3. Verification
+
+- [x] 3.1 Run unit tests for release version helpers.
+- [x] 3.2 Validate OpenSpec change strictly.
+- [x] 3.3 Run repo lint/typecheck gates required for release automation changes.

--- a/scripts/prepare_beta_release.py
+++ b/scripts/prepare_beta_release.py
@@ -9,10 +9,12 @@ from pathlib import Path
 from scripts.release_versions import (
     assert_project_versions,
     discover_release_please_base_version,
+    format_beta_changelog,
     latest_beta_tag,
+    latest_stable_tag,
     next_beta_number,
     parse_version,
-    tag_targets_head,
+    releasable_commits_since,
     update_project_versions,
     write_github_outputs,
 )
@@ -32,6 +34,11 @@ def main() -> int:
         default=0,
         help="beta serial number (defaults to highest existing beta tag + 1)",
     )
+    parser.add_argument(
+        "--changelog-path",
+        default="",
+        help="optional path to write the beta PR changelog markdown",
+    )
     args = parser.parse_args()
 
     root = Path(args.root).resolve()
@@ -41,17 +48,19 @@ def main() -> int:
         raise SystemExit(f"--base-version must be stable, got {base.version!r}")
 
     latest_beta = latest_beta_tag(root, base.version)
-    if args.beta_number == 0 and latest_beta is not None and tag_targets_head(root, latest_beta.tag):
+    previous_tag = latest_beta.tag if latest_beta is not None else latest_stable_tag(root)
+    if args.beta_number == 0 and latest_beta is not None and not releasable_commits_since(root, latest_beta.tag):
         assert_project_versions(root, latest_beta.version)
         outputs = {
             "should_create": False,
-            "reason": f"{latest_beta.tag} already covers HEAD",
+            "reason": f"{latest_beta.tag} already covers all releasable commits",
             "base_version": base.version,
             "beta_number": latest_beta.serial or 0,
             "version": latest_beta.version,
             "tag": latest_beta.tag,
             "pypi_version": latest_beta.pypi_version,
             "branch": f"release/beta-{latest_beta.version}",
+            "previous_tag": latest_beta.tag,
         }
         write_github_outputs(outputs)
         for key, value in outputs.items():
@@ -66,6 +75,16 @@ def main() -> int:
     release = parse_version(version)
     update_project_versions(root, release.version)
 
+    changelog_ref = previous_tag or "HEAD"
+    changelog = (
+        format_beta_changelog(root, changelog_ref)
+        if previous_tag is not None
+        else "Initial beta prerelease for this stable train."
+    )
+    changelog_path = args.changelog_path.strip()
+    if changelog_path:
+        Path(changelog_path).write_text(changelog + "\n", encoding="utf-8")
+
     outputs = {
         "base_version": base.version,
         "beta_number": beta_number,
@@ -73,6 +92,8 @@ def main() -> int:
         "tag": release.tag,
         "pypi_version": release.pypi_version,
         "branch": f"release/beta-{release.version}",
+        "previous_tag": previous_tag or "",
+        "changelog_path": changelog_path,
     }
     write_github_outputs(outputs)
     for key, value in outputs.items():

--- a/scripts/release_versions.py
+++ b/scripts/release_versions.py
@@ -17,6 +17,15 @@ from pathlib import Path
 
 _VERSION_RE = re.compile(r"^(?P<base>\d+\.\d+\.\d+)(?:-(?P<channel>alpha|beta|rc)\.(?P<serial>[1-9]\d*))?$")
 _TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\.[1-9]\d*)?)$")
+_CONVENTIONAL_SUBJECT_RE = re.compile(r"^(?P<type>[a-z][a-z0-9-]*)(?:\([^)]+\))?(?P<breaking>!)?: (?P<description>.+)$")
+_RELEASABLE_CONVENTIONAL_TYPES = frozenset({"deps", "feat", "fix", "perf", "revert"})
+
+
+@dataclass(frozen=True)
+class CommitMessage:
+    sha: str
+    subject: str
+    body: str
 
 
 @dataclass(frozen=True)
@@ -192,6 +201,64 @@ def run_git(root: Path, *args: str, check: bool = True) -> subprocess.CompletedP
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+
+def is_releasable_conventional_commit(subject: str, body: str = "") -> bool:
+    """Return whether a commit should open/update a release-please-style beta PR.
+
+    The beta channel should not advance for workflow-only noise such as
+    ``ci: ...`` after the previous beta tag. Match release-please's semver
+    intent rather than GitHub's broader generated release notes: feature, fix,
+    perf, dependency, revert, and breaking-change commits are releasable.
+    """
+
+    match = _CONVENTIONAL_SUBJECT_RE.fullmatch(subject.strip())
+    if not match:
+        return False
+    if match.group("breaking"):
+        return True
+    if "BREAKING CHANGE:" in body or "BREAKING-CHANGE:" in body:
+        return True
+    return match.group("type") in _RELEASABLE_CONVENTIONAL_TYPES
+
+
+def commit_messages_since(root: Path, ref: str) -> list[CommitMessage]:
+    """Return commits after *ref* in oldest-to-newest order."""
+
+    proc = run_git(root, "log", "--reverse", "--format=%H%x00%s%x00%b%x1e", f"{ref}..HEAD")
+    commits: list[CommitMessage] = []
+    for record in proc.stdout.rstrip("\x1e\n").split("\x1e"):
+        if not record.strip():
+            continue
+        parts = record.split("\x00", 2)
+        if len(parts) != 3:
+            raise ValueError(f"unexpected git log record while reading commits since {ref!r}")
+        sha, subject, body = parts
+        commits.append(CommitMessage(sha=sha, subject=subject, body=body))
+    return commits
+
+
+def releasable_commits_since(root: Path, ref: str) -> list[CommitMessage]:
+    return [
+        commit
+        for commit in commit_messages_since(root, ref)
+        if is_releasable_conventional_commit(commit.subject, commit.body)
+    ]
+
+
+def latest_stable_tag(root: Path) -> str | None:
+    proc = run_git(root, "tag", "--merged", "HEAD", "--sort=-v:refname")
+    stable_tag = re.compile(r"^v\d+\.\d+\.\d+$")
+    return next((tag for tag in proc.stdout.splitlines() if stable_tag.fullmatch(tag)), None)
+
+
+def format_beta_changelog(root: Path, ref: str) -> str:
+    commits = releasable_commits_since(root, ref)
+    if not commits:
+        return f"No releasable Conventional Commits since `{ref}`."
+
+    lines = [f"- {commit.subject} ({commit.sha[:7]})" for commit in commits]
+    return "\n".join(lines)
 
 
 def discover_release_please_base_version(root: Path) -> str:

--- a/tests/unit/test_release_versions.py
+++ b/tests/unit/test_release_versions.py
@@ -9,11 +9,14 @@ import pytest
 
 from scripts.release_versions import (
     assert_project_versions,
+    format_beta_changelog,
+    is_releasable_conventional_commit,
     latest_beta_tag,
     next_beta_number,
     parse_tag,
     parse_version,
     read_pyproject_version,
+    releasable_commits_since,
     tag_targets_head,
     update_project_versions,
 )
@@ -46,6 +49,17 @@ def init_git_repo(root: Path) -> None:
     subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
     subprocess.run(["git", "add", "."], cwd=root, check=True)
     subprocess.run(["git", "commit", "-m", "init"], cwd=root, check=True, stdout=subprocess.PIPE)
+
+
+def commit_all(root: Path, message: str) -> None:
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-m", message], cwd=root, check=True, stdout=subprocess.PIPE)
+
+
+def append_readme(root: Path, text: str) -> None:
+    readme = root / "README.md"
+    existing = readme.read_text(encoding="utf-8") if readme.exists() else ""
+    readme.write_text(existing + text + "\n", encoding="utf-8")
 
 
 def test_parse_stable_and_beta_versions() -> None:
@@ -127,8 +141,118 @@ def test_tag_targets_head_detects_covered_beta_merge(tmp_path: Path) -> None:
 
     assert tag_targets_head(tmp_path, "v1.19.0-beta.1")
 
-    (tmp_path / "README.md").write_text("new feature\n", encoding="utf-8")
-    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "commit", "-m", "feat: new feature"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
+    append_readme(tmp_path, "new feature")
+    commit_all(tmp_path, "feat: new feature")
 
     assert not tag_targets_head(tmp_path, "v1.19.0-beta.1")
+
+
+@pytest.mark.parametrize(
+    ("subject", "body", "expected"),
+    [
+        ("feat: add upstream proxy controls", "", True),
+        ("fix(proxy): preserve image tools", "", True),
+        ("perf(db): add latest usage index", "", True),
+        ("deps: bump starlette", "", True),
+        ("refactor(api)!: replace legacy envelope", "", True),
+        ("chore: release v1.20.0-beta.2", "", False),
+        ("ci: skip unrelated CI jobs", "", False),
+        ("docs(readme): clarify model availability", "", False),
+        ("refactor(api): split helpers", "", False),
+        ("custom subject", "", False),
+        ("chore: update config", "BREAKING CHANGE: config field removed", True),
+    ],
+)
+def test_is_releasable_conventional_commit(subject: str, body: str, expected: bool) -> None:
+    assert is_releasable_conventional_commit(subject, body) is expected
+
+
+def test_releasable_commits_since_ignores_post_beta_ci_only_commit(tmp_path: Path) -> None:
+    write_minimal_release_files(tmp_path, "1.20.0-beta.2")
+    init_git_repo(tmp_path)
+    subprocess.run(["git", "tag", "v1.20.0-beta.2"], cwd=tmp_path, check=True)
+
+    append_readme(tmp_path, "ci-only")
+    commit_all(tmp_path, "ci: skip unrelated CI jobs")
+
+    assert releasable_commits_since(tmp_path, "v1.20.0-beta.2") == []
+    assert format_beta_changelog(tmp_path, "v1.20.0-beta.2") == (
+        "No releasable Conventional Commits since `v1.20.0-beta.2`."
+    )
+
+
+def test_releasable_commits_since_keeps_post_beta_feature_commit(tmp_path: Path) -> None:
+    write_minimal_release_files(tmp_path, "1.20.0-beta.2")
+    init_git_repo(tmp_path)
+    subprocess.run(["git", "tag", "v1.20.0-beta.2"], cwd=tmp_path, check=True)
+
+    append_readme(tmp_path, "ci-only")
+    commit_all(tmp_path, "ci: skip unrelated CI jobs")
+    append_readme(tmp_path, "feature")
+    commit_all(tmp_path, "feat(proxy): add upstream proxy controls")
+
+    releasable = releasable_commits_since(tmp_path, "v1.20.0-beta.2")
+    assert [commit.subject for commit in releasable] == ["feat(proxy): add upstream proxy controls"]
+    assert "- feat(proxy): add upstream proxy controls (" in format_beta_changelog(tmp_path, "v1.20.0-beta.2")
+
+
+def test_prepare_beta_release_skips_ci_only_commit_after_latest_beta(tmp_path: Path) -> None:
+    write_minimal_release_files(tmp_path, "1.20.0-beta.2")
+    init_git_repo(tmp_path)
+    subprocess.run(["git", "tag", "v1.20.0-beta.2"], cwd=tmp_path, check=True)
+
+    append_readme(tmp_path, "ci-only")
+    commit_all(tmp_path, "ci: skip unrelated CI jobs")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.prepare_beta_release",
+            "--root",
+            str(tmp_path),
+            "--base-version",
+            "1.20.0",
+        ],
+        check=True,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+    assert "should_create=false" in result.stdout
+    assert "reason=v1.20.0-beta.2 already covers all releasable commits" in result.stdout
+    assert_project_versions(tmp_path, "1.20.0-beta.2")
+
+
+def test_prepare_beta_release_creates_next_beta_for_feature_commit(tmp_path: Path) -> None:
+    write_minimal_release_files(tmp_path, "1.20.0-beta.2")
+    init_git_repo(tmp_path)
+    subprocess.run(["git", "tag", "v1.20.0-beta.2"], cwd=tmp_path, check=True)
+
+    append_readme(tmp_path, "feature")
+    commit_all(tmp_path, "feat(proxy): add upstream proxy controls")
+    changelog_path = tmp_path / "beta-changelog.md"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.prepare_beta_release",
+            "--root",
+            str(tmp_path),
+            "--base-version",
+            "1.20.0",
+            "--changelog-path",
+            str(changelog_path),
+        ],
+        check=True,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+    assert "version=1.20.0-beta.3" in result.stdout
+    assert "previous_tag=v1.20.0-beta.2" in result.stdout
+    assert_project_versions(tmp_path, "1.20.0-beta.3")
+    assert "feat(proxy): add upstream proxy controls" in changelog_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Skip beta release PR creation when the latest beta tag is followed only by non-releasable Conventional Commits like `ci:` / `chore:` / `docs:`
- Generate a beta PR changelog from releasable commits between the previous release tag and `HEAD`
- Add OpenSpec coverage and regression tests for the beta.2 → beta.3 empty-release case

## Behavior
- `v1.20.0-beta.2` + only `ci: skip unrelated CI jobs` now returns `should_create=false`
- A later `feat:` / `fix:` / `perf:` / `deps:` / `revert:` / breaking change still advances to the next beta
- Beta PR bodies now include `## Changes since <tag>` with the releasable commit subjects

## Test Plan
- `uv run pytest tests/unit/test_release_versions.py`
- `uv run ruff check scripts/release_versions.py scripts/prepare_beta_release.py tests/unit/test_release_versions.py`
- `uv run ty check scripts/release_versions.py scripts/prepare_beta_release.py tests/unit/test_release_versions.py`
- `openspec validate beta-release-please-parity --strict`
- `uv run python - <<'PY' ... yaml.safe_load('.github/workflows/prepare-beta-release.yml') ... PY`
- `python -m scripts.prepare_beta_release --base-version 1.20.0` on current repo state returns `should_create=false`
