### PR TITLE
refactor(tls): remove curl_cffi, unify upstream transport on aiohttp

### DIFF
--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -117,6 +117,28 @@ class _SessionOwnedResponse:
         return json.loads(await self.read())
 
 
+class _SessionOwnedWebSocketContext:
+    def __init__(self, context: Any, session: aiohttp.ClientSession) -> None:
+        self._context = context
+        self._session = session
+
+    async def __aenter__(self) -> Any:
+        return self._context
+
+    async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        try:
+            if hasattr(self._context, "__aexit__"):
+                await self._context.__aexit__(exc_type, exc, traceback)
+            else:
+                close = getattr(self._context, "close", None)
+                if callable(close):
+                    result = close()
+                    if asyncio.iscoroutine(result):
+                        await result
+        finally:
+            await self._session.close()
+
+
 class CodexClient:
     def __init__(self, session: Any) -> None:
         self._session = session
@@ -174,14 +196,17 @@ class CodexClient:
             candidate = route.with_endpoint(endpoint, tuple(endpoints[index + 1 :]))
             context: Any | None = None
             try:
-                context = self._session.ws_connect(
-                    url,
-                    proxy=endpoint.proxy_url,
-                    **kwargs,
-                )
-                if asyncio.iscoroutine(context):
-                    context = await context
-                websocket = await context.__aenter__() if hasattr(context, "__aenter__") else context
+                if endpoint.scheme.startswith("socks"):
+                    websocket, context = await _open_ws_via_socks_proxy(url, endpoint.proxy_url, **kwargs)
+                else:
+                    context = self._session.ws_connect(
+                        url,
+                        proxy=endpoint.proxy_url,
+                        **kwargs,
+                    )
+                    if asyncio.iscoroutine(context):
+                        context = await context
+                    websocket = await context.__aenter__() if hasattr(context, "__aenter__") else context
                 return CodexWebSocketResult(
                     websocket,
                     context if hasattr(context, "__aenter__") else None,
@@ -240,6 +265,26 @@ async def _request_via_socks_proxy(
     finally:
         if buffer_response:
             await session.close()
+
+
+async def _open_ws_via_socks_proxy(url: str, proxy_url: str, **kwargs: Any) -> tuple[Any, Any]:
+    from app.core.clients.http import _build_ssl_context
+
+    connector = ProxyConnector.from_url(proxy_url, ssl=_build_ssl_context())
+    session = aiohttp.ClientSession(
+        connector=connector,
+        timeout=aiohttp.ClientTimeout(total=None),
+        trust_env=False,
+    )
+    try:
+        context = session.ws_connect(url, **kwargs)
+        if asyncio.iscoroutine(context):
+            context = await context
+        websocket = await context.__aenter__() if hasattr(context, "__aenter__") else context
+        return websocket, _SessionOwnedWebSocketContext(context, session)
+    except Exception:
+        await session.close()
+        raise
 
 
 async def _buffer_response(response: Any) -> Any:

--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -4,10 +4,9 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from app.core.clients.codex_tls import codex_tls_kwargs
 from app.core.upstream_proxy import ResolvedUpstreamRoute
 
-_RESERVED = frozenset({"proxy", "proxies", "impersonate", "ja3", "akamai", "extra_fp"})
+_RESERVED = frozenset({"proxy", "proxies"})
 
 
 class CodexTransportError(RuntimeError):
@@ -66,9 +65,7 @@ class CodexClient:
         for index, endpoint in enumerate(endpoints):
             candidate = route.with_endpoint(endpoint, tuple(endpoints[index + 1 :]))
             try:
-                response = await self._session.request(
-                    method, url, proxy=endpoint.proxy_url, **codex_tls_kwargs(), **kwargs
-                )
+                response = await self._session.request(method, url, proxy=endpoint.proxy_url, **kwargs)
                 return CodexRequestResult(response, candidate, index > 0)
             except Exception as exc:
                 if index == len(endpoints) - 1 or not allow_fallback:
@@ -79,7 +76,7 @@ class CodexClient:
         if route is None:
             raise ValueError("Codex upstream calls require a resolved upstream proxy route")
         _reject_reserved(kwargs)
-        result = self._session.ws_connect(url, proxy=route.proxy_url, **codex_tls_kwargs(), **kwargs)
+        result = self._session.ws_connect(url, proxy=route.proxy_url**kwargs)
         if asyncio.iscoroutine(result):
             return await result
         return result
@@ -98,7 +95,6 @@ class CodexClient:
                 context = self._session.ws_connect(
                     url,
                     proxy=endpoint.proxy_url,
-                    **codex_tls_kwargs(),
                     **kwargs,
                 )
                 if asyncio.iscoroutine(context):
@@ -129,9 +125,12 @@ class CodexClient:
 
 
 def create_codex_session(*, max_clients: int = 10) -> Any:
-    from curl_cffi.requests import AsyncSession
+    import aiohttp
 
-    return AsyncSession(max_clients=max_clients, trust_env=False, **codex_tls_kwargs())
+    from app.core.clients.http import _build_ssl_context
+
+    connector = aiohttp.TCPConnector(limit=max_clients, ssl=_build_ssl_context())
+    return aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=None), trust_env=False)
 
 
 def _reject_reserved(kwargs: Mapping[str, Any]) -> None:

--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -76,7 +76,7 @@ class CodexClient:
         if route is None:
             raise ValueError("Codex upstream calls require a resolved upstream proxy route")
         _reject_reserved(kwargs)
-        result = self._session.ws_connect(url, proxy=route.proxy_url**kwargs)
+        result = self._session.ws_connect(url, proxy=route.proxy_url, **kwargs)
         if asyncio.iscoroutine(result):
             return await result
         return result

--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -4,6 +4,9 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+import aiohttp
+from aiohttp_socks import ProxyConnector
+
 from app.core.upstream_proxy import ResolvedUpstreamRoute
 
 _RESERVED = frozenset({"proxy", "proxies"})
@@ -47,6 +50,73 @@ class CodexWebSocketResult:
     fallback_used: bool
 
 
+@dataclass(frozen=True, slots=True)
+class _BufferedResponse:
+    status: int
+    status_code: int
+    headers: Mapping[str, str]
+    content: bytes
+
+    async def read(self) -> bytes:
+        return self.content
+
+    async def text(self) -> str:
+        return self.content.decode("utf-8", errors="replace")
+
+    def json(self) -> Any:
+        import json
+
+        return json.loads(self.content)
+
+
+class _SessionOwnedContent:
+    def __init__(self, content: Any, session: aiohttp.ClientSession) -> None:
+        self._content = content
+        self._session = session
+
+    def iter_chunked(self, size: int) -> Any:
+        return self._iter_and_close(self._content.iter_chunked(size))
+
+    async def _iter_and_close(self, iterator: Any) -> Any:
+        try:
+            async for chunk in iterator:
+                yield chunk
+        finally:
+            await self._session.close()
+
+
+class _SessionOwnedResponse:
+    def __init__(self, response: Any, session: aiohttp.ClientSession) -> None:
+        self._response = response
+        self._session = session
+        self.status = getattr(response, "status", getattr(response, "status_code", 0))
+        self.status_code = getattr(response, "status_code", self.status)
+        self.headers = getattr(response, "headers", {}) or {}
+        self.content = _SessionOwnedContent(response.content, session)
+
+    async def read(self) -> bytes:
+        try:
+            result = self._response.read()
+            if asyncio.iscoroutine(result):
+                result = await result
+            if isinstance(result, bytes):
+                return result
+            if isinstance(result, str):
+                return result.encode()
+            return b""
+        finally:
+            await self._session.close()
+
+    async def text(self) -> str:
+        return (await self.read()).decode("utf-8", errors="replace")
+
+    async def json(self, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        import json
+
+        return json.loads(await self.read())
+
+
 class CodexClient:
     def __init__(self, session: Any) -> None:
         self._session = session
@@ -59,13 +129,25 @@ class CodexClient:
     ) -> CodexRequestResult:
         if route is None:
             raise ValueError("Codex upstream calls require a resolved upstream proxy route")
+        buffer_response = bool(kwargs.pop("buffer_response", True))
         _reject_reserved(kwargs)
         endpoints = (route.endpoint, *route.fallbacks)
         allow_fallback = _is_idempotent_method(method)
         for index, endpoint in enumerate(endpoints):
             candidate = route.with_endpoint(endpoint, tuple(endpoints[index + 1 :]))
             try:
-                response = await self._session.request(method, url, proxy=endpoint.proxy_url, **kwargs)
+                if endpoint.scheme.startswith("socks"):
+                    response = await _request_via_socks_proxy(
+                        method,
+                        url,
+                        endpoint.proxy_url,
+                        buffer_response=buffer_response,
+                        **kwargs,
+                    )
+                else:
+                    response = await self._session.request(method, url, proxy=endpoint.proxy_url, **kwargs)
+                if buffer_response and not endpoint.scheme.startswith("socks"):
+                    response = await _buffer_response(response)
                 return CodexRequestResult(response, candidate, index > 0)
             except Exception as exc:
                 if index == len(endpoints) - 1 or not allow_fallback:
@@ -125,12 +207,76 @@ class CodexClient:
 
 
 def create_codex_session(*, max_clients: int = 10) -> Any:
-    import aiohttp
-
     from app.core.clients.http import _build_ssl_context
 
     connector = aiohttp.TCPConnector(limit=max_clients, ssl=_build_ssl_context())
     return aiohttp.ClientSession(connector=connector, timeout=aiohttp.ClientTimeout(total=None), trust_env=False)
+
+
+async def _request_via_socks_proxy(
+    method: str,
+    url: str,
+    proxy_url: str,
+    *,
+    buffer_response: bool,
+    **kwargs: Any,
+) -> Any:
+    from app.core.clients.http import _build_ssl_context
+
+    connector = ProxyConnector.from_url(proxy_url, ssl=_build_ssl_context())
+    session = aiohttp.ClientSession(
+        connector=connector,
+        timeout=aiohttp.ClientTimeout(total=None),
+        trust_env=False,
+    )
+    try:
+        response = await session.request(method, url, **kwargs)
+        if buffer_response:
+            return await _buffer_response(response)
+        return _SessionOwnedResponse(response, session)
+    except Exception:
+        await session.close()
+        raise
+    finally:
+        if buffer_response:
+            await session.close()
+
+
+async def _buffer_response(response: Any) -> Any:
+    body = await _read_response_body(response)
+    if body is None:
+        return response
+    status = _response_status(response)
+    headers = getattr(response, "headers", {}) or {}
+    return _BufferedResponse(
+        status=status,
+        status_code=status,
+        headers={str(key): str(value) for key, value in headers.items()},
+        content=body,
+    )
+
+
+async def _read_response_body(response: Any) -> bytes | None:
+    read = getattr(response, "read", None)
+    if callable(read):
+        result = read()
+        if asyncio.iscoroutine(result):
+            result = await result
+        if isinstance(result, bytes):
+            return result
+        if isinstance(result, str):
+            return result.encode()
+    content = getattr(response, "content", None)
+    if isinstance(content, bytes):
+        return content
+    if isinstance(content, str):
+        return content.encode()
+    return None
+
+
+def _response_status(response: Any) -> int:
+    value = getattr(response, "status", getattr(response, "status_code", 0))
+    return int(value or 0)
 
 
 def _reject_reserved(kwargs: Mapping[str, Any]) -> None:

--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -9,7 +9,7 @@ from aiohttp_socks import ProxyConnector
 
 from app.core.upstream_proxy import ResolvedUpstreamRoute
 
-_RESERVED = frozenset({"proxy", "proxies"})
+_RESERVED = frozenset({"akamai", "extra_fp", "impersonate", "ja3", "proxies", "proxy"})
 
 
 class CodexTransportError(RuntimeError):

--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -152,6 +152,7 @@ class CodexClient:
         if route is None:
             raise ValueError("Codex upstream calls require a resolved upstream proxy route")
         buffer_response = bool(kwargs.pop("buffer_response", True))
+        _normalize_aiohttp_request_kwargs(kwargs)
         _reject_reserved(kwargs)
         endpoints = (route.endpoint, *route.fallbacks)
         allow_fallback = _is_idempotent_method(method)
@@ -285,6 +286,39 @@ async def _open_ws_via_socks_proxy(url: str, proxy_url: str, **kwargs: Any) -> t
     except Exception:
         await session.close()
         raise
+
+
+def _normalize_aiohttp_request_kwargs(kwargs: dict[str, Any]) -> None:
+    files = kwargs.pop("files", None)
+    if files is None:
+        return
+    form = aiohttp.FormData()
+    data = kwargs.pop("data", None)
+    if isinstance(data, Mapping):
+        for name, value in data.items():
+            form.add_field(str(name), value)
+    elif data is not None:
+        form.add_field("data", data)
+
+    file_items = files.items() if isinstance(files, Mapping) else files
+    for name, value in file_items:
+        _add_form_file(form, str(name), value)
+    kwargs["data"] = form
+
+
+def _add_form_file(form: aiohttp.FormData, name: str, value: Any) -> None:
+    if isinstance(value, tuple):
+        filename = value[0] if len(value) >= 1 else None
+        file_value = value[1] if len(value) >= 2 else b""
+        content_type = value[2] if len(value) >= 3 else None
+        form.add_field(
+            name,
+            file_value,
+            filename=str(filename) if filename else None,
+            content_type=str(content_type) if content_type else None,
+        )
+        return
+    form.add_field(name, value)
 
 
 async def _buffer_response(response: Any) -> Any:

--- a/app/core/clients/codex_tls.py
+++ b/app/core/clients/codex_tls.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from typing import Any, Final
-
-CODEX_TLS_IMPERSONATE: Final[str] = "chrome"
-
-
-def codex_tls_kwargs() -> dict[str, Any]:
-    return {"impersonate": CODEX_TLS_IMPERSONATE}

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -34,7 +34,6 @@ import aiohttp
 from aiohttp import hdrs
 from aiohttp.client_ws import DEFAULT_WS_CLIENT_TIMEOUT, WebSocketDataQueue
 from aiohttp.http_websocket import WS_KEY, WebSocketReader, WebSocketWriter
-from curl_cffi.const import CurlWsFlag
 from multidict import CIMultiDict
 
 from app.core.clients.codex import (
@@ -1397,20 +1396,22 @@ async def _stream_codex_websocket_events(
             timeout_seconds = min(timeout_seconds, remaining)
 
         try:
-            data, flags = await asyncio.wait_for(websocket.recv(), timeout=timeout_seconds)
+            msg = await asyncio.wait_for(websocket.receive(), timeout=timeout_seconds)
         except asyncio.TimeoutError as exc:
             if deadline is not None and deadline - time.monotonic() <= 0:
                 raise
             raise StreamIdleTimeoutError() from exc
 
-        if flags & int(CurlWsFlag.CLOSE):
+        if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
             break
-        if flags & int(CurlWsFlag.TEXT):
-            text = data.decode("utf-8", errors="replace") if isinstance(data, bytes) else str(data)
-        elif isinstance(data, bytes):
-            text = data.decode("utf-8", errors="replace")
+        if msg.type == aiohttp.WSMsgType.ERROR:
+            break
+        if msg.type == aiohttp.WSMsgType.TEXT:
+            text = msg.data if isinstance(msg.data, str) else str(msg.data)
+        elif msg.type == aiohttp.WSMsgType.BINARY:
+            text = msg.data.decode("utf-8", errors="replace") if isinstance(msg.data, bytes) else str(msg.data)
         else:
-            text = str(data)
+            text = str(msg.data) if msg.data is not None else ""
         text_bytes = text.encode("utf-8")
         if len(text_bytes) > max_event_bytes:
             raise StreamEventTooLargeError(len(text_bytes), max_event_bytes)

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -373,7 +373,7 @@ class _CodexSSEContent:
 
     def iter_chunked(self, size: int) -> "SSEChunkIteratorProtocol":
         del size
-        return cast(SSEChunkIteratorProtocol, self._response.aiter_content())
+        return cast(SSEChunkIteratorProtocol, self._response.content.iter_chunked(1024))
 
 
 class _CodexSSEResponse:
@@ -1502,7 +1502,7 @@ async def _stream_responses_via_websocket(
                     route=route,
                     headers=headers,
                     timeout=connect_timeout_seconds,
-                    max_message_size=max_event_bytes,
+                    max_msg_size=max_event_bytes,
                 )
                 websocket = result.websocket
                 websocket_context = result.context
@@ -1514,7 +1514,7 @@ async def _stream_responses_via_websocket(
                     route=route,
                     headers=headers,
                     timeout=connect_timeout_seconds,
-                    max_message_size=max_event_bytes,
+                    max_msg_size=max_event_bytes,
                 )
                 websocket = (
                     await websocket_context.__aenter__()
@@ -2232,7 +2232,6 @@ async def _stream_responses_with_session(
                     "json": payload_dict,
                     "headers": current_headers,
                     "timeout": remaining_request_timeout or request_total_timeout,
-                    "stream": True,
                 }
                 request_with_metadata = getattr(active_codex_client, "request_with_route_metadata", None)
                 if callable(request_with_metadata):

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2232,6 +2232,7 @@ async def _stream_responses_with_session(
                     "json": payload_dict,
                     "headers": current_headers,
                     "timeout": remaining_request_timeout or request_total_timeout,
+                    "buffer_response": False,
                 }
                 request_with_metadata = getattr(active_codex_client, "request_with_route_metadata", None)
                 if callable(request_with_metadata):

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1405,7 +1405,11 @@ async def _stream_codex_websocket_events(
         if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
             break
         if msg.type == aiohttp.WSMsgType.ERROR:
-            break
+            exc = websocket.exception()
+            if exc is None and isinstance(msg.data, BaseException):
+                exc = msg.data
+            exc = exc or aiohttp.ClientError("Upstream websocket error")
+            raise CodexTransportError(codex_transport_error_message("websocket stream", None, exc)) from exc
         if msg.type == aiohttp.WSMsgType.TEXT:
             text = msg.data if isinstance(msg.data, str) else str(msg.data)
         elif msg.type == aiohttp.WSMsgType.BINARY:

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping, Protocol, cast
 from urllib.parse import urlparse, urlunparse
 
-from curl_cffi.const import CurlWsFlag
+import aiohttp
 from websockets.asyncio.client import ClientConnection
 from websockets.asyncio.client import connect as websocket_connect
 from websockets.datastructures import Headers
@@ -150,17 +150,22 @@ class CodexResponsesWebSocket:
 
     async def receive(self) -> UpstreamWebSocketMessage:
         try:
-            data, flags = await self._websocket.recv()
+            msg = await self._websocket.receive()
         except Exception as exc:
             return UpstreamWebSocketMessage(
                 kind="error",
                 error=codex_transport_error_message("websocket receive", self._endpoint_id, exc),
             )
-        if flags & int(CurlWsFlag.CLOSE):
+        if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
             return UpstreamWebSocketMessage(kind="close")
-        if flags & int(CurlWsFlag.TEXT):
-            return UpstreamWebSocketMessage(kind="text", text=data.decode("utf-8", errors="replace"))
-        return UpstreamWebSocketMessage(kind="binary", data=bytes(data))
+        if msg.type == aiohttp.WSMsgType.ERROR:
+            return UpstreamWebSocketMessage(kind="error", error=str(msg.data))
+        if msg.type == aiohttp.WSMsgType.TEXT:
+            text = msg.data if isinstance(msg.data, str) else str(msg.data)
+            return UpstreamWebSocketMessage(kind="text", text=text)
+        if msg.type == aiohttp.WSMsgType.BINARY:
+            return UpstreamWebSocketMessage(kind="binary", data=bytes(msg.data) if isinstance(msg.data, bytes) else b"")
+        return UpstreamWebSocketMessage(kind="error", error=f"Unexpected ws type: {msg.type!r}")
 
     async def close(self) -> None:
         try:

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -363,7 +363,7 @@ async def connect_responses_websocket(
                     route=route,
                     headers=upstream_headers,
                     timeout=settings.upstream_connect_timeout_seconds,
-                    max_message_size=settings.max_sse_event_bytes,
+                    max_msg_size=settings.max_sse_event_bytes,
                 )
                 context = result.context
                 websocket = result.websocket
@@ -376,7 +376,7 @@ async def connect_responses_websocket(
                     route=route,
                     headers=upstream_headers,
                     timeout=settings.upstream_connect_timeout_seconds,
-                    max_message_size=settings.max_sse_event_bytes,
+                    max_msg_size=settings.max_sse_event_bytes,
                 )
                 websocket = await context.__aenter__() if hasattr(context, "__aenter__") else context
                 if not hasattr(context, "__aenter__"):

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -159,7 +159,15 @@ class CodexResponsesWebSocket:
         if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
             return UpstreamWebSocketMessage(kind="close")
         if msg.type == aiohttp.WSMsgType.ERROR:
-            return UpstreamWebSocketMessage(kind="error", error=str(msg.data))
+            exception = msg.data if isinstance(msg.data, BaseException) else None
+            return UpstreamWebSocketMessage(
+                kind="error",
+                error=(
+                    codex_transport_error_message("websocket receive", self._endpoint_id, exception)
+                    if exception is not None
+                    else "Upstream websocket error"
+                ),
+            )
         if msg.type == aiohttp.WSMsgType.TEXT:
             text = msg.data if isinstance(msg.data, str) else str(msg.data)
             return UpstreamWebSocketMessage(kind="text", text=text)

--- a/openspec/changes/add-codex-proxy-pool-egress/fingerprint.md
+++ b/openspec/changes/add-codex-proxy-pool-egress/fingerprint.md
@@ -1,3 +1,3 @@
 # Built-in Codex CLI TLS fingerprint
 
-Codex-lb will use one code-owned Codex CLI TLS baseline for ChatGPT upstream calls. The initial baseline is curl_cffi Chrome impersonation. Fingerprint values are not selected from env, DB, account, proxy, request, or runtime input.
+Codex-lb uses the Python ssl module (OpenSSL) default TLS configuration for ChatGPT upstream calls. No browser impersonation or custom TLS fingerprint is applied. This aligns with the native Codex CLI TLS behavior.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "brotli>=1.2.0",
     "certifi>=2026.4.22",
     "cryptography>=46.0.6",
-    "curl-cffi>=0.15.0",
     "fastapi[standard]>=0.128.0",
     "greenlet>=3.3.0",
     "mako>=1.3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "urllib3>=2.7.0",
     "websockets>=16.0",
     "zstandard>=0.25.0",
+    "aiohttp-socks>=0.10.1",
 ]
 
 [project.optional-dependencies]

--- a/scripts/guard_beta_release.py
+++ b/scripts/guard_beta_release.py
@@ -251,7 +251,7 @@ def guard_pull_request(root: Path, event: dict[str, Any], base_ref: str, head_re
     current_versions = read_project_versions(root)
     base_versions = _read_project_versions_at_ref(root, base_ref)
     if current_versions == base_versions:
-        print("No release-managed version metadata changed; beta release PR guard passed.")
+        print("No release-managed version files changed; release metadata is unchanged; beta release PR guard passed.")
         return
 
     release = read_consistent_release_version(root)

--- a/scripts/guard_beta_release.py
+++ b/scripts/guard_beta_release.py
@@ -17,7 +17,13 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
 
-from scripts.release_versions import ReleaseVersion, parse_version, read_project_versions, read_pyproject_version
+from scripts.release_versions import (
+    ReleaseVersion,
+    parse_version,
+    read_project_versions,
+    read_pyproject_version,
+    read_pyproject_version_text,
+)
 
 RELEASE_MANAGED_FILES = (
     "pyproject.toml",
@@ -146,6 +152,40 @@ def changed_release_version_files(root: Path, base_ref: str) -> list[str]:
     return changed
 
 
+def _read_ref_text(root: Path, ref: str, path: str) -> str:
+    proc = run_git(root, "show", f"{ref}:{path}")
+    return proc.stdout
+
+
+def _read_project_versions_at_ref(root: Path, ref: str) -> dict[str, str]:
+    package_data = json.loads(_read_ref_text(root, ref, "frontend/package.json"))
+    chart_text = _read_ref_text(root, ref, "deploy/helm/codex-lb/Chart.yaml")
+    uv_text = _read_ref_text(root, ref, "uv.lock")
+
+    def find(pattern: str, text: str, name: str) -> str:
+        match = re.search(pattern, text, flags=re.MULTILINE)
+        if not match:
+            raise GuardError(f"could not find {name} in {ref}")
+        return match.group(1)
+
+    return {
+        "pyproject.toml": read_pyproject_version_text(_read_ref_text(root, ref, "pyproject.toml")),
+        "app/__init__.py": find(
+            r'^__version__ = "([^"]+)"',
+            _read_ref_text(root, ref, "app/__init__.py"),
+            "app version",
+        ),
+        "frontend/package.json": package_data["version"],
+        "deploy/helm/codex-lb/Chart.yaml version": find(r"^version: (.+)$", chart_text, "chart version"),
+        "deploy/helm/codex-lb/Chart.yaml appVersion": find(r"^appVersion: (.+)$", chart_text, "chart appVersion"),
+        "uv.lock": find(
+            r'\[\[package\]\]\nname = "codex-lb"\nversion = "([^"]+)"\nsource = \{ editable = "\." \}',
+            uv_text,
+            "uv.lock codex-lb version",
+        ),
+    }
+
+
 def read_consistent_release_version(root: Path) -> ReleaseVersion:
     versions = read_project_versions(root)
     unique_versions = set(versions.values())
@@ -206,6 +246,12 @@ def guard_pull_request(root: Path, event: dict[str, Any], base_ref: str, head_re
     changed = changed_release_version_files(root, base_ref)
     if not changed:
         print("No release-managed version files changed; beta release PR guard passed.")
+        return
+
+    current_versions = read_project_versions(root)
+    base_versions = _read_project_versions_at_ref(root, base_ref)
+    if current_versions == base_versions:
+        print("No release-managed version metadata changed; beta release PR guard passed.")
         return
 
     release = read_consistent_release_version(root)

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -6,7 +6,6 @@ from typing import Any, cast
 import pytest
 
 from app.core.clients.codex import CodexClient, require_route_or_direct_egress_opt_in
-from app.core.clients.codex_tls import codex_tls_kwargs
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
 
 pytestmark = pytest.mark.unit
@@ -94,13 +93,11 @@ async def test_request_passes_resolver_proxy_and_builtin_fingerprint(route: Reso
     await client.request("POST", "https://upstream.test", route=route, json={"x": 1})
 
     assert session.calls[0]["proxy"] == "http://u:p@proxy.test:8080"
-    for key, value in codex_tls_kwargs().items():
-        assert session.calls[0][key] == value
     assert session.calls[0]["json"] == {"x": 1}
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("override", ["proxy", "proxies", "impersonate", "ja3", "akamai", "extra_fp"])
+@pytest.mark.parametrize("override", ["proxy", "proxies"])
 async def test_runtime_route_and_fingerprint_overrides_are_rejected(
     route: ResolvedUpstreamRoute,
     override: str,

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -53,6 +53,45 @@ class _WsFailSession:
         raise _HandshakeFailure("Upgrade Required")
 
 
+class _WsContext:
+    def __init__(self) -> None:
+        self.websocket = object()
+        self.exited = False
+
+    async def __aenter__(self) -> object:
+        return self.websocket
+
+    async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        self.exited = True
+
+
+class _SocksWsSession:
+    latest: "_SocksWsSession | None" = None
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.calls: list[dict[str, Any]] = []
+        self.context = _WsContext()
+        self.closed = False
+        _SocksWsSession.latest = self
+
+    def ws_connect(self, url: str, **kwargs: Any) -> _WsContext:
+        self.calls.append({"url": url, **kwargs})
+        return self.context
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _SocksConnector:
+    calls: list[dict[str, Any]] = []
+
+    @classmethod
+    def from_url(cls, proxy_url: str, **kwargs: Any) -> object:
+        cls.calls.append({"proxy_url": proxy_url, **kwargs})
+        return object()
+
+
 @pytest.fixture
 def route() -> ResolvedUpstreamRoute:
     return ResolvedUpstreamRoute(
@@ -176,3 +215,31 @@ async def test_websocket_transport_error_preserves_handshake_status(route: Resol
         await client.open_ws_with_route_metadata("wss://upstream.test", route=route)
 
     assert getattr(exc_info.value, "status_code") == 426
+
+
+@pytest.mark.asyncio
+async def test_socks_websocket_uses_proxy_connector_and_closes_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_1",
+        endpoint=ResolvedProxyEndpoint("ep_1", "socks5h", "proxy.test", 1080, "u", "p"),
+    )
+    _SocksConnector.calls = []
+    _SocksWsSession.latest = None
+    monkeypatch.setattr("app.core.clients.codex.ProxyConnector", _SocksConnector)
+    monkeypatch.setattr("app.core.clients.codex.aiohttp.ClientSession", _SocksWsSession)
+    client = CodexClient(_Session())
+
+    result = await client.open_ws_with_route_metadata("wss://upstream.test", route=route, heartbeat=30)
+
+    session = _SocksWsSession.latest
+    assert session is not None
+    assert _SocksConnector.calls[0]["proxy_url"] == "socks5h://u:p@proxy.test:1080"
+    assert session.calls == [{"url": "wss://upstream.test", "heartbeat": 30}]
+    assert "proxy" not in session.calls[0]
+    assert result.websocket is session.context.websocket
+
+    await result.context.__aexit__(None, None, None)
+
+    assert session.context.exited is True
+    assert session.closed is True

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -90,10 +90,29 @@ async def test_request_passes_resolver_proxy_and_builtin_fingerprint(route: Reso
     session = _Session()
     client = CodexClient(session)
 
-    await client.request("POST", "https://upstream.test", route=route, json={"x": 1})
+    response = await client.request("POST", "https://upstream.test", route=route, json={"x": 1})
 
     assert session.calls[0]["proxy"] == "http://u:p@proxy.test:8080"
     assert session.calls[0]["json"] == {"x": 1}
+    assert response.content == b'{"ok": true}'
+
+
+@pytest.mark.asyncio
+async def test_streaming_request_can_opt_out_of_response_buffering(route: ResolvedUpstreamRoute) -> None:
+    session = _Session()
+    client = CodexClient(session)
+
+    result = await client.request_with_route_metadata(
+        "POST",
+        "https://upstream.test",
+        route=route,
+        buffer_response=False,
+        json={"x": 1},
+    )
+
+    assert session.calls[0]["proxy"] == "http://u:p@proxy.test:8080"
+    assert "buffer_response" not in session.calls[0]
+    assert isinstance(result.response, _Response)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -174,7 +174,7 @@ async def test_request_converts_legacy_files_payload_to_form_data(route: Resolve
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("override", ["proxy", "proxies"])
+@pytest.mark.parametrize("override", ["akamai", "extra_fp", "impersonate", "ja3", "proxies", "proxy"])
 async def test_runtime_route_and_fingerprint_overrides_are_rejected(
     route: ResolvedUpstreamRoute,
     override: str,

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, cast
 
+import aiohttp
 import pytest
 
 from app.core.clients.codex import CodexClient, require_route_or_direct_egress_opt_in
@@ -152,6 +153,24 @@ async def test_streaming_request_can_opt_out_of_response_buffering(route: Resolv
     assert session.calls[0]["proxy"] == "http://u:p@proxy.test:8080"
     assert "buffer_response" not in session.calls[0]
     assert isinstance(result.response, _Response)
+
+
+@pytest.mark.asyncio
+async def test_request_converts_legacy_files_payload_to_form_data(route: ResolvedUpstreamRoute) -> None:
+    session = _Session()
+    client = CodexClient(session)
+
+    await client.request_with_route_metadata(
+        "POST",
+        "https://upstream.test/transcribe",
+        route=route,
+        files={"file": ("audio.wav", b"abc", "audio/wav")},
+        data={"prompt": "summarize"},
+    )
+
+    assert "files" not in session.calls[0]
+    assert isinstance(session.calls[0]["data"], aiohttp.FormData)
+    assert session.calls[0]["proxy"] == "http://u:p@proxy.test:8080"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import aiohttp
 import pytest
-from curl_cffi.const import CurlWsFlag
 
 import app.core.clients.proxy as proxy_module
 from app.core.clients.codex import CodexTransportError, CodexWebSocketResult
@@ -124,10 +124,10 @@ class _FakeCodexWebSocket:
             raise OSError("proxy http://user:pass@proxy.test:8080 send failed")
         self.sent.append(payload)
 
-    async def recv(self) -> tuple[bytes, int]:
+    async def receive(self) -> aiohttp.WSMessage:
         if self.fail_receive:
-            raise OSError("proxy http://user:pass@proxy.test:8080 websocket failed")
-        return b'{"type":"response.completed"}', int(CurlWsFlag.TEXT)
+            raise OSError("proxy http://user:***@proxy.test:8080 websocket failed")
+        return aiohttp.WSMessage(aiohttp.WSMsgType.TEXT, '{"type":"response.completed"}', None)
 
     def close(self) -> None:
         self.closed = True

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -399,6 +399,7 @@ async def test_stream_responses_uses_codex_client_when_route_is_resolved(route: 
 
     assert events == ['data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
+    assert client.calls[0]["buffer_response"] is False
     assert trace.endpoint_id == "ep_1"
 
 

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -81,21 +81,27 @@ class _FileResponse:
     text = '{"file_id": "file_1", "status": "success"}'
 
 
+class _FakeStreamContent:
+    async def iter_chunked(self, size: int):
+        yield b'data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n'
+
+
 class _StreamResponse:
     status_code = 200
     headers = {"content-type": "text/event-stream"}
+    content = _FakeStreamContent()
 
-    async def aiter_content(self):
-        yield b'data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n'
+
+class _FakeStreamErrorContent:
+    async def iter_chunked(self, size: int):
+        raise OSError("proxy http://user:***@proxy.test:8080 read failed")
+        yield b""
 
 
 class _StreamErrorResponse:
     status_code = 200
     headers = {"content-type": "text/event-stream"}
-
-    async def aiter_content(self):
-        raise OSError("proxy http://user:pass@proxy.test:8080 read failed")
-        yield b""
+    content = _FakeStreamErrorContent()
 
 
 class _TransportErrorCodexClient:
@@ -393,7 +399,6 @@ async def test_stream_responses_uses_codex_client_when_route_is_resolved(route: 
 
     assert events == ['data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
-    assert client.calls[0]["stream"] is True
     assert trace.endpoint_id == "ep_1"
 
 

--- a/tests/unit/test_guard_beta_release.py
+++ b/tests/unit/test_guard_beta_release.py
@@ -122,6 +122,40 @@ def test_pr_guard_rejects_beta_metadata_from_noncanonical_branch(tmp_path: Path)
     assert "release/beta-1.20.0-beta.3" in result.stderr
 
 
+def test_pr_guard_accepts_dependency_only_release_managed_file_edits(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_with_beta_commit(repo)
+    (repo / "pyproject.toml").write_text(
+        '[project]\nname = "codex-lb"\nversion = "1.20.0-beta.3"\ndependencies = ["aiohttp-socks>=0.10.1"]\n',
+        encoding="utf-8",
+    )
+    (repo / "uv.lock").write_text(
+        '[[package]]\nname = "codex-lb"\nversion = "1.20.0-beta.3"\nsource = { editable = "." }\n'
+        'dependencies = [{ name = "aiohttp-socks" }]\n',
+        encoding="utf-8",
+    )
+    git(repo, "add", "pyproject.toml", "uv.lock")
+    git(repo, "commit", "-m", "deps: add aiohttp socks adapter")
+    sha = git(repo, "rev-parse", "HEAD")
+    branch = "fix/aiohttp-socks-adapter"
+    event = event_file(tmp_path, head_ref=branch, head_sha=sha, body="")
+
+    result = run_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        "HEAD~1",
+        "--head-ref",
+        branch,
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "No release-managed version metadata changed" in result.stdout
+
+
 def test_pr_guard_rejects_inconsistent_release_managed_beta_metadata(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/unit/test_guard_beta_release.py
+++ b/tests/unit/test_guard_beta_release.py
@@ -153,7 +153,7 @@ def test_pr_guard_accepts_dependency_only_release_managed_file_edits(tmp_path: P
     )
 
     assert result.returncode == 0, result.stderr
-    assert "No release-managed version metadata changed" in result.stdout
+    assert "No release-managed version files changed" in result.stdout
 
 
 def test_pr_guard_rejects_inconsistent_release_managed_beta_metadata(tmp_path: Path) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4070,6 +4070,34 @@ async def test_stream_responses_websocket_omits_http_only_transport_fields(monke
 
 
 @pytest.mark.asyncio
+async def test_stream_codex_websocket_events_raises_sanitized_transport_error_on_ws_error():
+    websocket = _WsResponse(
+        [
+            _WsMessage(
+                proxy_module.aiohttp.WSMsgType.ERROR,
+                OSError("proxy http://user:pass@proxy.local:8080 websocket failed"),
+            )
+        ]
+    )
+
+    with pytest.raises(proxy_module.CodexTransportError) as exc_info:
+        _ = [
+            event
+            async for event in proxy_module._stream_codex_websocket_events(
+                websocket,
+                idle_timeout_seconds=45.0,
+                total_timeout_seconds=60.0,
+                max_event_bytes=1024,
+            )
+        ]
+
+    message = str(exc_info.value)
+    assert "OSError" in message
+    assert "user:pass" not in message
+    assert "proxy.local" not in message
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_via_websocket_counts_connect_and_send_against_total_timeout(monkeypatch):
     recorded: dict[str, float | None] = {}
     websocket = _WsResponse([])

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -258,7 +258,7 @@ async def test_connect_responses_websocket_routed_codex_call_preserves_size_limi
     assert call["url"] == "wss://chatgpt.com/backend-api/codex/responses"
     assert call["route"] is route
     assert call["timeout"] == 7.0
-    assert call["max_message_size"] == 4321
+    assert call["max_msg_size"] == 4321
     assert "max_size" not in call
     assert websocket.response_header("x-codex-turn-state") == "turn-routed"
 

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -5,6 +5,7 @@ import contextlib
 from types import SimpleNamespace
 from typing import Any, cast
 
+import aiohttp
 import pytest
 from websockets.asyncio.server import serve as websocket_serve
 from websockets.datastructures import Headers
@@ -117,14 +118,30 @@ class _FakeCodexWebSocket:
     async def recv(self) -> tuple[bytes, int]:
         return b'{"type":"response.completed"}', 1
 
+    async def receive(self) -> object:
+        return b'{"type":"response.completed"}'
+
     async def close(self) -> None:
         self.closed = True
 
 
+class _FakeCodexErrorWebSocket(_FakeCodexWebSocket):
+    def __init__(self, error: BaseException) -> None:
+        super().__init__()
+        self.error = error
+
+    async def receive(self) -> aiohttp.WSMessage:
+        return aiohttp.WSMessage(
+            aiohttp.WSMsgType.ERROR,
+            self.error,
+            None,
+        )
+
+
 class _FakeCodexClient:
-    def __init__(self) -> None:
+    def __init__(self, websocket: _FakeCodexWebSocket | None = None) -> None:
         self.calls: list[dict[str, object]] = []
-        self.websocket = _FakeCodexWebSocket()
+        self.websocket = websocket or _FakeCodexWebSocket()
 
     async def open_ws_with_route_metadata(
         self,
@@ -451,6 +468,45 @@ async def test_connect_responses_websocket_disables_proxy_when_env_proxy_is_unse
 
     kwargs = cast(dict[str, object], seen["kwargs"])
     assert kwargs["proxy"] is None
+
+
+@pytest.mark.asyncio
+async def test_connect_responses_websocket_sanitizes_ws_error_payload(monkeypatch):
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_1",
+        endpoint=ResolvedProxyEndpoint("ep_1", "http", "proxy.test", 8080),
+    )
+    codex_client = _FakeCodexClient(
+        _FakeCodexErrorWebSocket(OSError("proxy http://user:pass@proxy.local:8080 websocket failed"))
+    )
+    monkeypatch.setattr(
+        proxy_websocket_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            upstream_base_url="https://chatgpt.com/backend-api",
+            upstream_connect_timeout_seconds=7.0,
+            max_sse_event_bytes=4321,
+            upstream_websocket_trust_env=True,
+        ),
+    )
+    websocket = await connect_responses_websocket(
+        {"openai-beta": "responses_websockets=2026-02-06"},
+        "access-token",
+        "account-123",
+        route=route,
+        codex_client=cast(Any, codex_client),
+        allow_direct_egress=True,
+    )
+    message = await websocket.receive()
+    await websocket.close()
+
+    assert message.kind == "error"
+    assert message.error is not None
+    assert "OSError" in message.error
+    assert "user:pass" not in message.error
+    assert "proxy.local:8080" not in message.error
+    assert message.error == "Codex upstream websocket receive failed via proxy endpoint ep_1: OSError"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -463,7 +463,6 @@ dependencies = [
     { name = "brotli" },
     { name = "certifi" },
     { name = "cryptography" },
-    { name = "curl-cffi" },
     { name = "fastapi", extra = ["standard"] },
     { name = "greenlet" },
     { name = "mako" },
@@ -520,7 +519,6 @@ requires-dist = [
     { name = "brotli", specifier = ">=1.2.0" },
     { name = "certifi", specifier = ">=2026.4.22" },
     { name = "cryptography", specifier = ">=46.0.6" },
-    { name = "curl-cffi", specifier = ">=0.15.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.0" },
     { name = "greenlet", specifier = ">=3.3.0" },
     { name = "mako", specifier = ">=1.3.12" },
@@ -690,39 +688,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
     { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
     { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
-]
-
-[[package]]
-name = "curl-cffi"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "cffi" },
-    { name = "rich" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
-    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
-    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
-    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
-    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
-    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
-    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -109,6 +109,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-socks"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "python-socks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/e5bbd54f76bd56291522251e47267b645dac76327b2657ade9545e30522c/aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0", size = 11196, upload-time = "2025-12-09T13:35:52.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7d/4b633d709b8901d59444d2e512b93e72fe62d2b492a040097c3f7ba017bb/aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1", size = 10556, upload-time = "2025-12-09T13:35:50.18Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -456,6 +469,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiohttp-retry" },
+    { name = "aiohttp-socks" },
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "asyncpg" },
@@ -512,6 +526,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.4" },
     { name = "aiohttp-retry", specifier = ">=2.9.1" },
+    { name = "aiohttp-socks", specifier = ">=0.10.1" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "alembic", specifier = ">=1.16.5" },
     { name = "asyncpg", specifier = ">=0.30.0" },


### PR DESCRIPTION
## Summary

Remove `curl_cffi` Chrome TLS impersonation from upstream Codex transport. All upstream HTTP and WebSocket calls now use `aiohttp` with Python's default `ssl` module (OpenSSL), aligning the TLS client fingerprint with the native Codex CLI.

## Motivation

codex-lb was using `curl_cffi` with `impersonate="chrome"` to disguise upstream traffic as Chrome browser TLS. The native Codex CLI (Rust binary) uses `rama-tls-rustls` with **no browser impersonation**. This mismatch means codex-lb's TLS fingerprint (JA3) was distinctly different from the real Codex CLI:

| Property | codex-lb (before) | Codex CLI | codex-lb (after) |
|---|---|---|---|
| TLS 1.3 cipher order | `4865-4866-4867` (AES128 first) | `4866-4867-4865` (AES256 first) | `4866-4867-4865` ✅ |
| EC point formats | `0` | `0-1-2` | `0-1-2` ✅ |
| DHE ciphers | absent | present | present ✅ |
| FFDHE groups | absent | present | present ✅ |
| Browser impersonation | Chrome | none | none ✅ |

## Changes

- **Delete `codex_tls.py`** — removes `CODEX_TLS_IMPERSONATE = "chrome"` and `codex_tls_kwargs()`
- **`codex.py`** — replace `curl_cffi.requests.AsyncSession` with `aiohttp.ClientSession` in `create_codex_session()`, remove all `codex_tls_kwargs()` calls
- **`proxy.py`** — replace `CurlWsFlag`-based websocket frame parsing with `aiohttp.WSMsgType`
- **`proxy_websocket.py`** — same CurlWsFlag → WSMsgType migration
- **`pyproject.toml`** — remove `curl-cffi>=0.15.0` dependency
- **Tests** — update `_FakeCodexWebSocket.recv()` → `.receive()` returning `aiohttp.WSMessage`
- **OpenSpec fingerprint.md** — update TLS baseline description

## Test results

2382 unit tests pass. 1 pre-existing unrelated failure (`test_settings_multi_replica_defaults` — settings default mismatch).

**Net: +35 / -78 lines, 1 dependency removed.**