### PR TITLE
chore: release v1.20.0-beta.3

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.20.0-beta.2"  # x-release-please-version
+__version__ = "1.20.0-beta.3"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/app/db/alembic/versions/20260607_000000_merge_weekly_monthly_useragent_heads.py
+++ b/app/db/alembic/versions/20260607_000000_merge_weekly_monthly_useragent_heads.py
@@ -1,0 +1,28 @@
+"""merge weekly pace, monthly quota, and useragent heads
+
+Revision ID: 20260607_000000_merge_weekly_monthly_useragent_heads
+Revises:
+- 20260603_000000_add_weekly_pace_working_days
+- 20260603_000000_free_account_monthly_window
+- 20260604_010000_merge_useragent_and_reauth_heads
+Create Date: 2026-06-07 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+revision = "20260607_000000_merge_weekly_monthly_useragent_heads"
+down_revision = (
+    "20260603_000000_add_weekly_pace_working_days",
+    "20260603_000000_free_account_monthly_window",
+    "20260604_010000_merge_useragent_and_reauth_heads",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.20.0-beta.2
-appVersion: 1.20.0-beta.2
+version: 1.20.0-beta.3
+appVersion: 1.20.0-beta.3
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.20.0-beta.2",
+  "version": "1.20.0-beta.3",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/frontend/src/features/accounts/components/account-list.test.tsx
+++ b/frontend/src/features/accounts/components/account-list.test.tsx
@@ -464,7 +464,7 @@ describe("AccountList", () => {
       />,
     );
 
-    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("combobox", { name: "Filter accounts by status" }));
     await user.click(screen.getByRole("option", { name: "Reauth required" }));
 
     expect(screen.queryByText("active@example.com")).not.toBeInTheDocument();

--- a/frontend/src/features/accounts/components/account-list.tsx
+++ b/frontend/src/features/accounts/components/account-list.tsx
@@ -81,7 +81,11 @@ export function AccountList({
           />
         </div>
         <Select value={statusFilter} onValueChange={setStatusFilter}>
-          <SelectTrigger size="sm" className="w-full min-w-0">
+          <SelectTrigger
+            size="sm"
+            className="w-full min-w-0"
+            aria-label="Filter accounts by status"
+          >
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.20.0-beta.2"
+version = "1.20.0-beta.3"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -812,28 +812,35 @@ async def test_free_account_monthly_migration_renames_only_free_usage_windows(tm
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with session_factory() as session:
-            accounts_repo = AccountsRepository(session)
-            free_account = _make_account("acc_free_monthly_migration", "free-monthly@example.com", "free")
-            paid_account = _make_account("acc_paid_monthly_migration", "paid-monthly@example.com", "plus")
-            await accounts_repo.upsert(free_account)
-            await accounts_repo.upsert(paid_account)
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO accounts (
+                        id, email, plan_type,
+                        access_token_encrypted, refresh_token_encrypted, id_token_encrypted,
+                        last_refresh, status
+                    )
+                    VALUES
+                      ('acc_free_monthly_migration', 'free-monthly@example.com', 'free',
+                       x'01', x'02', x'03', '2026-01-01 00:00:00', 'active'),
+                      ('acc_paid_monthly_migration', 'paid-monthly@example.com', 'plus',
+                       x'04', x'05', x'06', '2026-01-01 00:00:00', 'active')
+                    """
+                )
+            )
             await session.execute(
                 text(
                     """
                     INSERT INTO usage_history (account_id, recorded_at, window, used_percent)
                     VALUES
-                      (:free_account_id, CURRENT_TIMESTAMP, 'primary', 10.0),
-                      (:free_account_id, CURRENT_TIMESTAMP, 'secondary', 20.0),
-                      (:free_account_id, CURRENT_TIMESTAMP, NULL, 25.0),
-                      (:paid_account_id, CURRENT_TIMESTAMP, 'primary', 30.0),
-                      (:paid_account_id, CURRENT_TIMESTAMP, 'secondary', 40.0),
-                      (:paid_account_id, CURRENT_TIMESTAMP, NULL, 45.0)
+                      ('acc_free_monthly_migration', CURRENT_TIMESTAMP, 'primary', 10.0),
+                      ('acc_free_monthly_migration', CURRENT_TIMESTAMP, 'secondary', 20.0),
+                      ('acc_free_monthly_migration', CURRENT_TIMESTAMP, NULL, 25.0),
+                      ('acc_paid_monthly_migration', CURRENT_TIMESTAMP, 'primary', 30.0),
+                      ('acc_paid_monthly_migration', CURRENT_TIMESTAMP, 'secondary', 40.0),
+                      ('acc_paid_monthly_migration', CURRENT_TIMESTAMP, NULL, 45.0)
                     """
-                ),
-                {
-                    "free_account_id": free_account.id,
-                    "paid_account_id": paid_account.id,
-                },
+                )
             )
             await session.commit()
 

--- a/uv.lock
+++ b/uv.lock
@@ -451,7 +451,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.20.0-beta.2"
+version = "1.20.0-beta.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Replaces #938 with the same `v1.20.0-beta.3` release metadata plus CI unblock fixes
- Adds an Alembic merge node so current migration heads collapse to one release head
- Gives the account-list status filter an explicit accessible name and updates the test to target the correct combobox
- Keeps the free-account monthly migration regression pinned to the historical schema instead of using the current repository before later dashboard columns exist

## Why this branch
#938 has `maintainerCanModify=false`, so I couldn't push these CI fixes directly to the original release branch.

## Test Plan
- `make migration-check`
- `PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/unit/test_db_migrate.py tests/integration/test_migrations.py -q`
- `uv run ruff check app/db/alembic/versions/20260607_000000_merge_weekly_monthly_useragent_heads.py tests/integration/test_migrations.py`
- `cd frontend && npx --yes bun@1.3.14 run test src/features/accounts/components/account-list.test.tsx`
- `cd frontend && npx --yes bun@1.3.14 run typecheck`
- `git diff --check`