### PR TITLE
fix: normalize responses instruction messages

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -678,6 +678,24 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "neoclaw",
+      "name": "NeoClaw",
+      "avatar_url": "https://avatars.githubusercontent.com/u/261536598?v=4",
+      "profile": "https://github.com/NeoClaw",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "abarsegov",
+      "name": "abarsegov",
+      "avatar_url": "https://avatars.githubusercontent.com/u/181010154?v=4",
+      "profile": "https://github.com/abarsegov",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -283,7 +283,10 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
     changed = False
     for item in input_value:
         item_mapping = _json_mapping_or_none(item)
-        role = item_mapping.get("role") if item_mapping is not None else None
+        if item_mapping is None:
+            input_items.append(item)
+            continue
+        role = item_mapping.get("role")
         if role not in ("system", "developer"):
             input_items.append(item)
             continue

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -271,6 +271,94 @@ def _sanitize_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
     return sanitized_input
 
 
+def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
+    if not is_json_mapping(data):
+        return data
+    input_value = data.get("input")
+    if not is_json_list(input_value):
+        return data
+
+    instruction_parts: list[str] = []
+    input_items: list[JsonValue] = []
+    changed = False
+    for item in input_value:
+        item_mapping = _json_mapping_or_none(item)
+        role = item_mapping.get("role") if item_mapping is not None else None
+        if role not in ("system", "developer"):
+            input_items.append(item)
+            continue
+        instruction_text, preserved_content = _split_responses_instruction_item_content(item_mapping)
+        if instruction_text:
+            instruction_parts.append(instruction_text)
+        if preserved_content is not None:
+            preserved_item = dict(item_mapping)
+            preserved_item["role"] = "user"
+            preserved_item["content"] = preserved_content
+            input_items.append(preserved_item)
+        changed = True
+
+    if not changed:
+        return data
+
+    normalized: MutableJsonObject = dict(data)
+    existing_instructions = normalized.get("instructions")
+    merged_instructions = _merge_responses_instructions(
+        existing_instructions if isinstance(existing_instructions, str) else "",
+        instruction_parts,
+    )
+    normalized["instructions"] = merged_instructions
+    normalized["input"] = input_items
+    return normalized
+
+
+def _merge_responses_instructions(existing: str, extra_parts: list[str]) -> str:
+    extra = "\n".join(part for part in extra_parts if part)
+    if not extra:
+        return existing
+    if existing:
+        return f"{existing}\n{extra}"
+    return extra
+
+
+def _split_responses_instruction_item_content(item: Mapping[str, JsonValue]) -> tuple[str, JsonValue | None]:
+    content = item.get("content")
+    if content is None:
+        return "", None
+    if isinstance(content, str):
+        return content, None
+    if is_json_list(content):
+        instruction_parts: list[str] = []
+        preserved_parts: list[JsonValue] = []
+        for part in _json_parts(content):
+            text = _responses_instruction_content_text(part)
+            if text is not None:
+                if text:
+                    instruction_parts.append(text)
+                continue
+            preserved_parts.append(part)
+        preserved_content: JsonValue | None = preserved_parts if preserved_parts else None
+        return "\n".join(instruction_parts), preserved_content
+    text = _responses_instruction_content_text(content)
+    if text is not None:
+        return text, None
+    return "", content
+
+
+def _responses_instruction_item_text(item: Mapping[str, JsonValue]) -> str:
+    instruction_text, _ = _split_responses_instruction_item_content(item)
+    return instruction_text
+
+
+def _responses_instruction_content_text(content: JsonValue) -> str | None:
+    if isinstance(content, str):
+        return content
+    content_mapping = _json_mapping_or_none(content)
+    if content_mapping is None:
+        return None
+    text = content_mapping.get("text")
+    return text if isinstance(text, str) else None
+
+
 def _sanitize_interleaved_reasoning_input_item(item: JsonValue) -> JsonValue | None:
     item_mapping = _json_mapping_or_none(item)
     if item_mapping is None:
@@ -457,6 +545,11 @@ class ResponsesTextControls(BaseModel):
 class ResponsesRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
 
+    @model_validator(mode="before")
+    @classmethod
+    def _move_input_instruction_messages(cls, data: JsonValue) -> JsonValue:
+        return _normalize_responses_input_instructions(data)
+
     model: str = Field(min_length=1)
     instructions: str
     input: JsonValue
@@ -551,6 +644,11 @@ class ResponsesRequest(BaseModel):
 
 class ResponsesCompactRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _move_input_instruction_messages(cls, data: JsonValue) -> JsonValue:
+        return _normalize_responses_input_instructions(data)
 
     model: str = Field(min_length=1)
     instructions: str

--- a/tests/unit/test_chat_request_mapping.py
+++ b/tests/unit/test_chat_request_mapping.py
@@ -428,10 +428,8 @@ def test_chat_response_format_json_object_preserves_instruction_roles_in_input()
     responses = req.to_responses_request()
     dumped = responses.to_payload()
 
-    assert dumped["instructions"] == ""
+    assert dumped["instructions"] == "Return JSON.\nKeep it short."
     assert dumped["input"] == [
-        {"role": "system", "content": [{"type": "input_text", "text": "Return JSON."}]},
-        {"role": "developer", "content": [{"type": "input_text", "text": "Keep it short."}]},
         {"role": "user", "content": [{"type": "input_text", "text": "Say hello."}]},
     ]
     assert dumped["text"] == {"format": {"type": "json_object"}}

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -548,8 +548,41 @@ def test_responses_input_system_message_moves_to_instructions():
     request = ResponsesRequest.model_validate(payload)
 
     assert request.instructions == "primary\nsys\ndev"
+    assert request.input == [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+
+
+def test_responses_input_system_message_keeps_user_text_parts():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "primary",
+        "input": [
+            {
+                "type": "message",
+                "role": "system",
+                "content": [{"type": "input_text", "text": "sys"}],
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "hello"},
+                    {"type": "input_file", "file_id": "file_123"},
+                ],
+            },
+        ],
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.instructions == "primary\nsys"
     assert request.input == [
-        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "hello"},
+                {"type": "input_file", "file_id": "file_123"},
+            ],
+        }
     ]
 
 

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -535,6 +535,99 @@ def test_v1_system_message_moves_to_instructions():
     assert request.input == [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
 
 
+def test_responses_input_system_message_moves_to_instructions():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "primary",
+        "input": [
+            {"type": "message", "role": "system", "content": [{"type": "input_text", "text": "sys"}]},
+            {"type": "message", "role": "developer", "content": "dev"},
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.instructions == "primary\nsys\ndev"
+    assert request.input == [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+    ]
+
+
+def test_responses_input_system_message_preserves_non_text_parts():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "primary",
+        "input": [
+            {
+                "type": "message",
+                "role": "system",
+                "content": [
+                    {"type": "input_text", "text": "sys"},
+                    {"type": "input_file", "file_id": "file_123"},
+                    {"type": "input_image", "image_url": "sediment://file_456"},
+                ],
+            },
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.instructions == "primary\nsys"
+    assert request.input == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {"type": "input_file", "file_id": "file_123"},
+                {"type": "input_image", "image_url": "sediment://file_456"},
+            ],
+        },
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+    assert extract_input_file_ids(request.input) == {"file_123", "file_456"}
+    assert [ref.file_id for ref in extract_input_image_file_references(request.input)] == ["file_456"]
+
+
+def test_responses_input_developer_message_preserves_single_non_text_part():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "primary",
+        "input": [
+            {
+                "type": "message",
+                "role": "developer",
+                "content": {"type": "input_file", "file_id": "file_123"},
+            }
+        ],
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.instructions == "primary"
+    assert request.input == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": {"type": "input_file", "file_id": "file_123"},
+        }
+    ]
+    assert extract_input_file_ids(request.input) == {"file_123"}
+
+
+def test_responses_compact_input_system_message_moves_to_instructions():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "primary",
+        "input": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "compact me"},
+        ],
+    }
+    request = ResponsesCompactRequest.model_validate(payload)
+
+    assert request.instructions == "primary\nsys"
+    assert request.input == [{"role": "user", "content": "compact me"}]
+
+
 def test_v1_instructions_merge():
     payload = {
         "model": "gpt-5.1",

--- a/tests/unit/test_prompt_cache_key_derivation.py
+++ b/tests/unit/test_prompt_cache_key_derivation.py
@@ -142,7 +142,9 @@ class TestExtractInstructionInput:
                 ]
             ),
         )
-        assert _extract_instruction_input(payload) == "Return JSON.\nKeep it short."
+        assert payload.instructions == "Return JSON.\nKeep it short."
+        assert payload.input == [{"role": "user", "content": "hello"}]
+        assert _extract_instruction_input(payload) is None
 
     def test_ignores_string_input(self):
         payload = ResponsesRequest(model="gpt-5.4", instructions="", input="hello")


### PR DESCRIPTION
## Summary

Normalize Responses API instruction messages when clients send `system` or `developer` items inside `input`. The request validator now moves those instruction items into top-level `instructions` before forwarding the payload, avoiding upstream rejection while preserving the remaining input order.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: N/A

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
 shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Add request validation that extracts `system` / `developer` Responses `input` items into top-level `instructions`.
- Preserve existing non-instruction `input` items and their order.
- Apply the normalization to both regular Responses requests and compact request validation.
- Add unit coverage for regular and compact Responses request normalization.

## Test plan

uv run pytest -q tests/unit/test_openai_requests.py -k 'responses_input_system_message_moves_to_instructions or responses_compact_input_system_message_moves_to_instructions or v1_system_message_moves_to_instructions or v1_instructions_merge or v1_input_string_passthrough'

Relevant output:

5 passed, 78 deselected in 0.10s

## Screenshots / output (optional)

N/A

## Checklist

- [x] Title is in Conventional Commits format (<type>(<scope>)?: <subject>).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [ ] Ran uv run pre-commit run local-ci --hook-stage manual --all-files or the relevant make <target> subset locally.
- [ ] If touching specs: openspec validate --specs passes and /opsx:verify is clean.
- [x] CHANGELOG is not edited by hand (release-please handles it)
