### PR TITLE
ci: gate beta release publishing on candidate validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
   merge_group:
 
 concurrency:
@@ -101,6 +102,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: python .github/scripts/check_all_contributors.py
+
+  beta-release-guard:
+    name: Beta release guard
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR base branch
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --force
+
+      - name: Require validated canonical beta release PRs
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          python -m scripts.guard_beta_release \
+            --mode pr \
+            --base-ref "origin/${BASE_REF}" \
+            --head-ref "${HEAD_REF}"
 
   frontend-lint:
     name: Frontend lint (eslint)
@@ -620,6 +648,7 @@ jobs:
     needs:
       - changes
       - contributors
+      - beta-release-guard
       - frontend-lint
       - frontend-typecheck
       - frontend-test

--- a/.github/workflows/prepare-beta-release.yml
+++ b/.github/workflows/prepare-beta-release.yml
@@ -129,6 +129,7 @@ jobs:
         run: |
           set -euo pipefail
           body_file="${RUNNER_TEMP}/beta-release-pr.md"
+          candidate_sha="$(git rev-parse HEAD)"
           if [ ! -s "${CHANGELOG_PATH}" ]; then
             echo "::error::Missing generated beta changelog at ${CHANGELOG_PATH}"
             exit 1
@@ -139,13 +140,25 @@ jobs:
           ## Summary
           - Prepares beta release ${TAG} for the ${BASE_VERSION} stable train.
           - Updates release-managed version files only; release-please remains the stable release owner.
-          - Merging this PR will publish ${TAG} as a GitHub prerelease and trigger package/image/chart publishing.
+          - Merging this PR will publish ${TAG} only after the release-candidate validation checklist below is completed for this exact candidate SHA.
           - Synced automatically from release-please PR #${RELEASE_PR}; no manual beta workflow dispatch is required.
 
           ## Changes since ${PREVIOUS_TAG:-the previous release}
           EOF
           cat "${CHANGELOG_PATH}"
           cat <<EOF
+
+          ## Release-candidate validation
+          Validated candidate: ${candidate_sha}
+
+          Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.
+
+          - [ ] Backend/unit/integration gates
+          - [ ] Frontend tests/build
+          - [ ] Wheel/package validation
+          - [ ] Docker/container smoke
+          - [ ] Live upstream/account smoke
+          - [ ] Live upstream/account smoke not required
 
           ## Install after publish
           \`\`\`bash

--- a/.github/workflows/publish-beta-release.yml
+++ b/.github/workflows/publish-beta-release.yml
@@ -48,6 +48,10 @@ jobs:
         shell: bash
         run: python -m scripts.verify_release_version --require-channel beta
 
+      - name: Require release-candidate validation evidence
+        shell: bash
+        run: python -m scripts.guard_beta_release --mode publish
+
       - name: Create GitHub prerelease
         shell: bash
         env:

--- a/openspec/changes/require-beta-candidate-validation/proposal.md
+++ b/openspec/changes/require-beta-candidate-validation/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+A replacement release PR merged beta version metadata from a non-canonical `fix/*`
+branch. That left `main` saying `1.20.0-beta.3` while the beta publish workflow
+did not create `v1.20.0-beta.3` artifacts because publishing is gated on
+`release/beta-*` branches. More importantly, beta artifacts must never be
+published merely because version metadata reached `main`; the exact release
+candidate must be validated first.
+
+## What Changes
+
+- Add a CI beta release guard for pull requests that change release-managed
+  version files to a beta version.
+- Require beta metadata PRs to keep all release-managed version files consistent,
+  come from the canonical repository's `release/beta-X.Y.Z-beta.N` branch, and
+  include checked release-candidate validation evidence for the exact PR head SHA.
+- Require the published merge commit tree to match that validated PR head, so a
+  stale candidate cannot publish after `main` advances.
+- Re-run CI on PR body edits so completing or refreshing the validation checklist
+  updates the required guard result.
+- Add the same validation evidence check to the beta publish workflow before it
+  creates tags or GitHub prereleases.
+- Add an unchecked validation checklist to automation-generated beta release PRs
+  so the PR cannot merge or publish until validation is recorded.
+
+## Capabilities
+
+### Modified Capabilities
+
+- Release management: beta release PRs become candidate-validation gated.
+- Release automation: beta publish refuses unvalidated, stale-tree, forked, or
+  otherwise non-canonical beta PRs.
+
+## Impact
+
+- Code: `scripts/guard_beta_release.py`.
+- Workflows: `.github/workflows/ci.yml`, `.github/workflows/prepare-beta-release.yml`,
+  `.github/workflows/publish-beta-release.yml`.
+- Tests: `tests/unit/test_guard_beta_release.py`.

--- a/openspec/changes/require-beta-candidate-validation/specs/release-management/spec.md
+++ b/openspec/changes/require-beta-candidate-validation/specs/release-management/spec.md
@@ -1,0 +1,99 @@
+## MODIFIED Requirements
+
+### Requirement: Beta releases are prepared through release PRs
+
+Beta releases SHALL be prepared by an automatically maintained pull request against `main` that updates the release-managed version files to `X.Y.Z-beta.N`. The beta preparation flow SHALL run after release-please completes and after pushes to `main`, SHALL derive `X.Y.Z` from the open release-please PR branch, and SHALL do nothing when there is no open release-please PR. Beta release PRs SHALL NOT update `.github/release-please-manifest.json` because stable version ownership remains with release-please.
+
+#### Scenario: automation syncs the next beta from the release-please PR
+
+- **GIVEN** release-please has opened or updated `release-please--branches--main` with `pyproject.toml` version `1.19.0`
+- **WHEN** the beta PR sync workflow runs
+- **THEN** it creates or updates a pull request that sets release-managed files to `1.19.0-beta.N`
+- **AND** `N` is one higher than the highest existing `v1.19.0-beta.N` tag
+- **AND** `.github/release-please-manifest.json` remains unchanged
+
+#### Scenario: automation is idle without a release-please PR
+
+- **GIVEN** there is no open release-please PR targeting `main`
+- **WHEN** the beta PR sync workflow runs
+- **THEN** it exits without creating a beta release pull request
+
+#### Scenario: automation ignores forked release-please branch names
+
+- **GIVEN** a fork has an open pull request whose head branch is named `release-please--branches--main`
+- **WHEN** the beta PR sync workflow looks for the release-please PR
+- **THEN** it ignores that pull request unless the head repository owner is the canonical repository owner
+- **AND** it requests enough open pull requests to avoid missing the canonical release-please PR during high-PR-volume periods
+
+#### Scenario: merged beta release already covers main
+
+- **GIVEN** tag `v1.19.0-beta.1` points to `HEAD`
+- **AND** release-managed files all contain `1.19.0-beta.1`
+- **WHEN** the beta PR sync workflow runs for base version `1.19.0`
+- **THEN** it exits without creating `1.19.0-beta.2`
+
+#### Scenario: automation-generated beta PR starts unvalidated
+
+- **GIVEN** the beta PR sync workflow creates or updates `release/beta-1.20.0-beta.3`
+- **WHEN** it writes the pull request body
+- **THEN** the body includes a `Release-candidate validation` section
+- **AND** the section records the exact beta PR head SHA as the validated candidate placeholder
+- **AND** backend, frontend, wheel/package, Docker/container, and live upstream/account smoke checklist items start unchecked
+
+### Requirement: Merged beta release PRs publish GitHub prereleases
+
+When a pull request from the canonical repository's `release/beta-*` branch is merged into `main`, the release automation SHALL require `RELEASE_PLEASE_TOKEN` rather than falling back to `GITHUB_TOKEN`, verify that all release-managed version files agree on a beta version, require release-candidate validation evidence for the exact merged pull request head SHA, verify that the published merge commit tree matches that validated head tree, create the matching `vX.Y.Z-beta.N` tag at the merge commit, and publish a GitHub prerelease for that tag. Re-running the workflow after the tag already exists SHALL be safe and SHALL NOT create a second tag.
+
+#### Scenario: beta PR merge publishes a prerelease tag
+
+- **GIVEN** a merged pull request from `release/beta-1.19.0-beta.1`
+- **AND** release-managed files all contain `1.19.0-beta.1`
+- **AND** the pull request body contains checked release-candidate validation evidence for the exact merged pull request head SHA
+- **AND** the merge commit tree matches the validated pull request head tree
+- **AND** `RELEASE_PLEASE_TOKEN` is configured
+- **WHEN** the beta publish workflow runs
+- **THEN** it creates tag `v1.19.0-beta.1` at the merge commit
+- **AND** it creates a GitHub prerelease for `v1.19.0-beta.1`
+
+#### Scenario: inconsistent release metadata is blocked
+
+- **GIVEN** a pull request changes one or more release-managed version files
+- **AND** the release-managed files do not all contain the same version
+- **WHEN** the CI beta release guard runs
+- **THEN** it fails before deciding whether the change is stable or beta
+- **AND** it reports the mismatched release-managed file versions
+
+#### Scenario: non-canonical beta metadata PR is blocked
+
+- **GIVEN** a pull request changes release-managed files to `1.20.0-beta.3`
+- **AND** the pull request head branch is `fix/pr-938-release-ci`
+- **WHEN** the CI beta release guard runs
+- **THEN** it fails before the pull request can satisfy the required CI rollup
+- **AND** it reports that the expected head branch is `release/beta-1.20.0-beta.3`
+
+#### Scenario: forked beta metadata PR is blocked
+
+- **GIVEN** a pull request changes release-managed files to `1.20.0-beta.3`
+- **AND** the pull request head branch is `release/beta-1.20.0-beta.3`
+- **BUT** the pull request head repository is a fork rather than the canonical repository
+- **WHEN** the CI beta release guard or beta publish guard runs
+- **THEN** it fails before the pull request can merge or publish
+- **AND** it reports the expected and actual head repositories
+
+#### Scenario: beta publish refuses missing validation evidence
+
+- **GIVEN** a merged pull request from `release/beta-1.20.0-beta.3`
+- **AND** release-managed files all contain `1.20.0-beta.3`
+- **BUT** the pull request body lacks checked release-candidate validation evidence for the exact pull request head SHA
+- **WHEN** the beta publish workflow runs
+- **THEN** it fails before creating the `v1.20.0-beta.3` tag
+- **AND** it does not create a GitHub prerelease or publish artifacts
+
+#### Scenario: beta publish refuses a stale validated tree
+
+- **GIVEN** a merged pull request from `release/beta-1.20.0-beta.3`
+- **AND** the pull request body contains checked release-candidate validation evidence for the pull request head SHA
+- **BUT** the merge commit tree differs from the validated pull request head tree
+- **WHEN** the beta publish workflow runs
+- **THEN** it fails before creating the `v1.20.0-beta.3` tag
+- **AND** it reports that the beta PR must be updated onto the final base and revalidated

--- a/openspec/changes/require-beta-candidate-validation/tasks.md
+++ b/openspec/changes/require-beta-candidate-validation/tasks.md
@@ -1,0 +1,39 @@
+## 1. Pull request guard
+
+- [x] 1.1 Detect PRs that change release-managed version files to a beta version.
+- [x] 1.2 Fail release-managed version changes unless all managed files agree
+      before deciding whether the change targets a beta version.
+- [x] 1.3 Fail beta PRs unless the head branch is the canonical
+      `release/beta-X.Y.Z-beta.N` branch for the target version.
+- [x] 1.4 Fail those PRs unless the head repository is the canonical repository.
+- [x] 1.5 Fail those PRs unless the PR body records checked validation evidence
+      for the exact PR head SHA.
+- [x] 1.6 Re-run the guard on PR body edits so validation checklist updates are
+      reflected before merge.
+
+## 2. Publish guard
+
+- [x] 2.1 Re-check the canonical branch and validation evidence in
+      `publish-beta-release.yml` before creating a tag or GitHub prerelease.
+- [x] 2.2 Require the published merge commit tree to match the validated PR head
+      tree before tag creation, so `main` cannot advance after validation.
+- [x] 2.3 Reject merged beta PRs whose head repository is not the canonical
+      repository, even if the fork used the canonical beta branch name.
+- [x] 2.4 Keep the publish check stdlib-only so it can run before dependency
+      installation or artifact publishing.
+
+## 3. Beta PR template
+
+- [x] 3.1 Add an unchecked release-candidate validation checklist to
+      automation-generated beta PR bodies.
+- [x] 3.2 Include the exact candidate SHA in that template so stale validation is
+      detected when the release PR branch changes.
+
+## 4. Verification
+
+- [x] 4.1 Add unit tests for non-canonical branch rejection, forked canonical
+      branch rejection, missing evidence, stale SHA evidence, and passing
+      validated canonical PRs.
+- [x] 4.2 Run focused ruff and pytest checks for the guard implementation.
+- [x] 4.3 Validate the OpenSpec change strictly.
+- [ ] 4.4 Confirm GitHub CI and Codex review on the PR head.

--- a/scripts/guard_beta_release.py
+++ b/scripts/guard_beta_release.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Guard beta release PRs and publishing against unvalidated candidates.
+
+This script is intentionally stdlib-only so it can run early in GitHub Actions,
+before project dependencies are installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+from scripts.release_versions import ReleaseVersion, parse_version, read_project_versions, read_pyproject_version
+
+RELEASE_MANAGED_FILES = (
+    "pyproject.toml",
+    "app/__init__.py",
+    "frontend/package.json",
+    "deploy/helm/codex-lb/Chart.yaml",
+    "uv.lock",
+)
+
+_REQUIRED_EVIDENCE_LABELS = (
+    "backend/unit/integration gates",
+    "frontend tests/build",
+    "wheel/package validation",
+    "docker/container smoke",
+)
+
+_LIVE_SMOKE_ACCEPTED_LABELS = (
+    "live upstream/account smoke",
+    "live upstream/account smoke not required",
+)
+
+_SHA_RE = re.compile(r"\b[0-9a-f]{40}\b", re.IGNORECASE)
+
+
+class GuardError(RuntimeError):
+    """Raised when the release guard should fail the workflow."""
+
+
+def run_git(root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def load_event(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    event_path = Path(path)
+    if not event_path.exists():
+        return {}
+    return json.loads(event_path.read_text(encoding="utf-8"))
+
+
+def pull_request(event: dict[str, Any]) -> dict[str, Any] | None:
+    pr = event.get("pull_request")
+    return pr if isinstance(pr, dict) else None
+
+
+def _repo_full_name(value: object) -> str:
+    if not isinstance(value, Mapping):
+        return ""
+    repo = cast(Mapping[str, Any], value)
+    full_name = repo.get("full_name")
+    if isinstance(full_name, str) and full_name:
+        return full_name
+    owner = repo.get("owner")
+    owner_repo = cast(Mapping[str, Any], owner) if isinstance(owner, Mapping) else {}
+    owner_login = owner_repo.get("login")
+    name = repo.get("name")
+    if isinstance(owner_login, str) and owner_login and isinstance(name, str) and name:
+        return f"{owner_login}/{name}"
+    return ""
+
+
+def canonical_repository(event: dict[str, Any], pr: dict[str, Any]) -> str:
+    base = pr.get("base")
+    if isinstance(base, dict):
+        base_repo = _repo_full_name(base.get("repo"))
+        if base_repo:
+            return base_repo
+    event_repo = _repo_full_name(event.get("repository"))
+    if event_repo:
+        return event_repo
+    return os.environ.get("GITHUB_REPOSITORY", "").strip()
+
+
+def require_canonical_head_repository(event: dict[str, Any], pr: dict[str, Any]) -> None:
+    head = pr.get("head")
+    head_repo = _repo_full_name(head.get("repo") if isinstance(head, dict) else None)
+    expected_repo = canonical_repository(event, pr)
+    if not expected_repo:
+        raise GuardError("Could not determine the canonical repository for beta release branch ownership.")
+    if not head_repo:
+        raise GuardError("Could not determine the beta release PR head repository.")
+    if head_repo.casefold() != expected_repo.casefold():
+        raise GuardError(
+            "Beta release metadata changes must come from the canonical repository release branch.\n"
+            f"Expected head repository: {expected_repo}\n"
+            f"Actual head repository: {head_repo}"
+        )
+
+
+def changed_release_files(root: Path, base_ref: str) -> list[str]:
+    proc = run_git(root, "diff", "--name-only", f"{base_ref}...HEAD", "--", *RELEASE_MANAGED_FILES)
+    changed = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return sorted(set(changed))
+
+
+def read_consistent_release_version(root: Path) -> ReleaseVersion:
+    versions = read_project_versions(root)
+    unique_versions = set(versions.values())
+    if len(unique_versions) != 1:
+        detail = ", ".join(f"{name}={version!r}" for name, version in sorted(versions.items()))
+        raise GuardError(f"Release-managed version files must agree before beta release gating: {detail}")
+    return parse_version(next(iter(unique_versions)))
+
+
+def _normalized_body(body: str) -> str:
+    return re.sub(r"\s+", " ", body.casefold())
+
+
+def require_validation_evidence(body: str, expected_sha: str) -> None:
+    normalized = _normalized_body(body)
+    missing: list[str] = []
+
+    if "release-candidate validation" not in normalized:
+        missing.append("a `Release-candidate validation` section")
+
+    sha_matches = [match.group(0).lower() for match in _SHA_RE.finditer(body)]
+    if expected_sha.lower() not in sha_matches:
+        missing.append(f"the exact validated candidate SHA `{expected_sha}`")
+
+    for label in _REQUIRED_EVIDENCE_LABELS:
+        checked_pattern = re.compile(rf"- \[x\] [^\n]*{re.escape(label)}", re.IGNORECASE)
+        if not checked_pattern.search(body):
+            missing.append(f"checked evidence item `{label}`")
+
+    if not any(
+        re.search(rf"- \[x\] [^\n]*{re.escape(label)}", body, flags=re.IGNORECASE)
+        for label in _LIVE_SMOKE_ACCEPTED_LABELS
+    ):
+        missing.append("checked evidence item for live upstream/account smoke, or an explicit not-required entry")
+
+    if missing:
+        detail = "\n".join(f"- {item}" for item in missing)
+        raise GuardError(
+            "Beta release PRs cannot publish until release-candidate validation evidence is recorded.\n"
+            f"Missing:\n{detail}"
+        )
+
+
+def guard_pull_request(root: Path, event: dict[str, Any], base_ref: str, head_ref: str) -> None:
+    pr = pull_request(event)
+    if pr is None and os.environ.get("GITHUB_EVENT_NAME"):
+        print("No pull_request payload; beta release PR guard is a no-op for this event.")
+        return
+
+    if pr is not None:
+        head_ref = head_ref or str(pr.get("head", {}).get("ref") or "")
+        expected_sha = str(pr.get("head", {}).get("sha") or "")
+        body = str(pr.get("body") or "")
+    else:
+        expected_sha = run_git(root, "rev-parse", "HEAD").stdout.strip()
+        body = os.environ.get("BETA_RELEASE_PR_BODY", "")
+
+    changed = changed_release_files(root, base_ref)
+    if not changed:
+        print("No release-managed version files changed; beta release PR guard passed.")
+        return
+
+    release = read_consistent_release_version(root)
+    if release.channel != "beta":
+        print(f"Release-managed files changed for non-beta version {release.version}; beta guard passed.")
+        return
+
+    canonical_branch = f"release/beta-{release.version}"
+    if head_ref != canonical_branch:
+        raise GuardError(
+            "Beta release metadata changes must come from the canonical beta release branch.\n"
+            f"Expected head branch: {canonical_branch}\n"
+            f"Actual head branch: {head_ref or '<unknown>'}\n"
+            f"Changed release files: {', '.join(changed)}"
+        )
+    if pr is not None:
+        require_canonical_head_repository(event, pr)
+
+    if not expected_sha:
+        raise GuardError("Could not determine the PR head SHA for beta release validation evidence.")
+
+    require_validation_evidence(body, expected_sha)
+    print(f"Beta release PR guard passed for {canonical_branch} at {expected_sha}.")
+
+
+def _commit_tree(root: Path, commit: str) -> str:
+    proc = run_git(root, "rev-parse", f"{commit}^{{tree}}", check=False)
+    if proc.returncode == 0:
+        return proc.stdout.strip()
+
+    # GitHub's pull_request.closed checkout is normally on the merge commit, so
+    # the PR head commit may not be present locally. Fetch by object id before
+    # deciding the validated candidate cannot be compared.
+    fetch = run_git(root, "fetch", "origin", commit, "--depth=1", check=False)
+    if fetch.returncode != 0:
+        raise GuardError(
+            f"Could not fetch validated candidate commit {commit} to compare release trees: {fetch.stderr.strip()}"
+        )
+    proc = run_git(root, "rev-parse", f"{commit}^{{tree}}", check=False)
+    if proc.returncode != 0:
+        raise GuardError(f"Could not resolve tree for commit {commit}: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def require_published_tree_matches_validated_candidate(root: Path, *, published_sha: str, validated_sha: str) -> None:
+    published_tree = _commit_tree(root, published_sha)
+    validated_tree = _commit_tree(root, validated_sha)
+    if published_tree != validated_tree:
+        raise GuardError(
+            "Refusing to publish because the merge commit tree differs from the validated candidate head.\n"
+            f"Published commit: {published_sha} tree {published_tree}\n"
+            f"Validated candidate: {validated_sha} tree {validated_tree}\n"
+            "Update the beta PR onto the final base and rerun release-candidate validation for the new head."
+        )
+
+
+def guard_publish(root: Path, event: dict[str, Any]) -> None:
+    pr = pull_request(event)
+    if pr is None:
+        raise GuardError("Publish guard requires a pull_request event payload.")
+
+    if pr.get("merged") is not True:
+        print("Pull request was not merged; beta publish guard is a no-op.")
+        return
+
+    raw_head = pr.get("head")
+    head: dict[str, Any] = raw_head if isinstance(raw_head, dict) else {}
+    head_ref = str(head.get("ref") or "")
+    head_sha = str(head.get("sha") or "")
+    body = str(pr.get("body") or "")
+    published_sha = str(pr.get("merge_commit_sha") or "") or run_git(root, "rev-parse", "HEAD").stdout.strip()
+    release = parse_version(read_pyproject_version(root))
+    if release.channel != "beta":
+        raise GuardError(f"Publish Beta Release expected beta metadata, got {release.version}.")
+
+    canonical_branch = f"release/beta-{release.version}"
+    if head_ref != canonical_branch:
+        raise GuardError(
+            "Refusing to publish beta release from a non-canonical branch.\n"
+            f"Expected head branch: {canonical_branch}\n"
+            f"Actual head branch: {head_ref or '<unknown>'}"
+        )
+    require_canonical_head_repository(event, pr)
+    if not head_sha:
+        raise GuardError("Could not determine merged beta PR head SHA.")
+
+    require_validation_evidence(body, head_sha)
+    require_published_tree_matches_validated_candidate(root, published_sha=published_sha, validated_sha=head_sha)
+    print(
+        f"Beta publish guard passed for {canonical_branch}; validated candidate {head_sha} "
+        f"matches published commit {published_sha}."
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--mode", choices=["pr", "publish"], default="pr")
+    parser.add_argument("--base-ref", default="origin/main", help="base ref for PR diff checks")
+    parser.add_argument("--head-ref", default=os.environ.get("GITHUB_HEAD_REF", ""), help="PR head branch name")
+    parser.add_argument("--event-path", default=os.environ.get("GITHUB_EVENT_PATH", ""), help="GitHub event JSON path")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    event = load_event(args.event_path)
+    try:
+        if args.mode == "pr":
+            guard_pull_request(root, event, args.base_ref, args.head_ref)
+        else:
+            guard_publish(root, event)
+    except GuardError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_guard_beta_release.py
+++ b/tests/unit/test_guard_beta_release.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.release_versions import update_project_versions
+
+
+def write_minimal_release_files(root: Path, version: str = "1.20.0") -> None:
+    (root / "app").mkdir(parents=True)
+    (root / "frontend").mkdir(parents=True)
+    (root / "deploy" / "helm" / "codex-lb").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(f'[project]\nname = "codex-lb"\nversion = "{version}"\n', encoding="utf-8")
+    (root / "app" / "__init__.py").write_text(f'__version__ = "{version}"\n', encoding="utf-8")
+    (root / "frontend" / "package.json").write_text(
+        json.dumps({"name": "frontend", "version": version}) + "\n",
+        encoding="utf-8",
+    )
+    (root / "deploy" / "helm" / "codex-lb" / "Chart.yaml").write_text(
+        f"apiVersion: v2\nname: codex-lb\nversion: {version}\nappVersion: {version}\n",
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text(
+        f'[[package]]\nname = "codex-lb"\nversion = "{version}"\nsource = {{ editable = "." }}\n',
+        encoding="utf-8",
+    )
+
+
+def git(root: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=root, text=True).strip()
+
+
+def init_repo_with_beta_commit(root: Path, version: str = "1.20.0-beta.3") -> str:
+    write_minimal_release_files(root)
+    git(root, "init")
+    git(root, "config", "user.email", "test@example.com")
+    git(root, "config", "user.name", "Test")
+    git(root, "add", ".")
+    git(root, "commit", "-m", "init")
+    git(root, "branch", "-M", "main")
+    update_project_versions(root, version)
+    git(root, "add", ".")
+    git(root, "commit", "-m", f"chore: release v{version}")
+    return git(root, "rev-parse", "HEAD")
+
+
+def event_file(
+    tmp_path: Path,
+    *,
+    head_ref: str,
+    head_sha: str,
+    body: str,
+    merged: bool = False,
+    merge_commit_sha: str | None = None,
+    head_repo: str = "Soju06/codex-lb",
+    base_repo: str = "Soju06/codex-lb",
+) -> Path:
+    head_owner, head_name = head_repo.split("/", 1)
+    base_owner, base_name = base_repo.split("/", 1)
+    event = {
+        "repository": {"full_name": base_repo},
+        "pull_request": {
+            "body": body,
+            "head": {
+                "ref": head_ref,
+                "sha": head_sha,
+                "repo": {"full_name": head_repo, "owner": {"login": head_owner}, "name": head_name},
+            },
+            "base": {"repo": {"full_name": base_repo, "owner": {"login": base_owner}, "name": base_name}},
+            "merged": merged,
+            "merge_commit_sha": merge_commit_sha,
+        },
+    }
+    path = tmp_path / "event.json"
+    path.write_text(json.dumps(event), encoding="utf-8")
+    return path
+
+
+def validation_body(sha: str) -> str:
+    return f"""## Release-candidate validation
+Validated candidate: {sha}
+
+- [x] Backend/unit/integration gates
+- [x] Frontend tests/build
+- [x] Wheel/package validation
+- [x] Docker/container smoke
+- [x] Live upstream/account smoke not required
+"""
+
+
+def run_guard(project_root: Path, repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "scripts.guard_beta_release", "--root", str(repo_root), *args],
+        cwd=project_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_pr_guard_rejects_beta_metadata_from_noncanonical_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sha = init_repo_with_beta_commit(repo)
+    event = event_file(tmp_path, head_ref="fix/pr-938-release-ci", head_sha=sha, body=validation_body(sha))
+
+    result = run_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        "HEAD~1",
+        "--head-ref",
+        "fix/pr-938-release-ci",
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 1
+    assert "canonical beta release branch" in result.stderr
+    assert "release/beta-1.20.0-beta.3" in result.stderr
+
+
+def test_pr_guard_rejects_inconsistent_release_managed_beta_metadata(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    write_minimal_release_files(repo)
+    git(repo, "init")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "init")
+    git(repo, "branch", "-M", "main")
+    (repo / "app" / "__init__.py").write_text('__version__ = "1.20.0-beta.3"\n', encoding="utf-8")
+    git(repo, "add", "app/__init__.py")
+    git(repo, "commit", "-m", "chore: drift app version to beta")
+    sha = git(repo, "rev-parse", "HEAD")
+    branch = "fix/pr-938-release-ci"
+    event = event_file(tmp_path, head_ref=branch, head_sha=sha, body=validation_body(sha))
+
+    result = run_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        "HEAD~1",
+        "--head-ref",
+        branch,
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 1
+    assert "Release-managed version files must agree" in result.stderr
+    assert "app/__init__.py='1.20.0-beta.3'" in result.stderr
+    assert "pyproject.toml='1.20.0'" in result.stderr
+
+
+def test_pr_guard_rejects_canonical_beta_pr_without_validation_evidence(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sha = init_repo_with_beta_commit(repo)
+    branch = "release/beta-1.20.0-beta.3"
+    event = event_file(tmp_path, head_ref=branch, head_sha=sha, body="## Summary\nRelease beta3")
+
+    result = run_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        "HEAD~1",
+        "--head-ref",
+        branch,
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 1
+    assert "release-candidate validation evidence" in result.stderr
+    assert sha in result.stderr
+
+
+def test_pr_guard_accepts_validated_canonical_beta_pr(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sha = init_repo_with_beta_commit(repo)
+    branch = "release/beta-1.20.0-beta.3"
+    event = event_file(tmp_path, head_ref=branch, head_sha=sha, body=validation_body(sha))
+
+    result = run_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        "HEAD~1",
+        "--head-ref",
+        branch,
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Beta release PR guard passed" in result.stdout
+
+
+def test_pr_guard_rejects_forked_canonical_beta_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sha = init_repo_with_beta_commit(repo)
+    branch = "release/beta-1.20.0-beta.3"
+    event = event_file(
+        tmp_path,
+        head_ref=branch,
+        head_sha=sha,
+        body=validation_body(sha),
+        head_repo="evil-fork/codex-lb",
+    )
+
+    result = run_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        "HEAD~1",
+        "--head-ref",
+        branch,
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 1
+    assert "canonical repository release branch" in result.stderr
+    assert "Expected head repository: Soju06/codex-lb" in result.stderr
+    assert "Actual head repository: evil-fork/codex-lb" in result.stderr
+
+
+def test_publish_guard_rejects_stale_candidate_sha_evidence(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sha = init_repo_with_beta_commit(repo)
+    branch = "release/beta-1.20.0-beta.3"
+    stale_sha = "0" * 40
+    event = event_file(tmp_path, head_ref=branch, head_sha=sha, body=validation_body(stale_sha), merged=True)
+
+    result = run_guard(Path(__file__).resolve().parents[2], repo, "--mode", "publish", "--event-path", str(event))
+
+    assert result.returncode == 1
+    assert "validation evidence" in result.stderr
+    assert sha in result.stderr
+
+
+def test_publish_guard_accepts_validated_merged_canonical_beta_pr(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sha = init_repo_with_beta_commit(repo)
+    branch = "release/beta-1.20.0-beta.3"
+    event = event_file(tmp_path, head_ref=branch, head_sha=sha, body=validation_body(sha), merged=True)
+
+    result = run_guard(Path(__file__).resolve().parents[2], repo, "--mode", "publish", "--event-path", str(event))
+
+    assert result.returncode == 0, result.stderr
+    assert "Beta publish guard passed" in result.stdout
+
+
+def test_publish_guard_rejects_forked_canonical_beta_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sha = init_repo_with_beta_commit(repo)
+    branch = "release/beta-1.20.0-beta.3"
+    event = event_file(
+        tmp_path,
+        head_ref=branch,
+        head_sha=sha,
+        body=validation_body(sha),
+        merged=True,
+        head_repo="evil-fork/codex-lb",
+    )
+
+    result = run_guard(Path(__file__).resolve().parents[2], repo, "--mode", "publish", "--event-path", str(event))
+
+    assert result.returncode == 1
+    assert "canonical repository release branch" in result.stderr
+    assert "Expected head repository: Soju06/codex-lb" in result.stderr
+    assert "Actual head repository: evil-fork/codex-lb" in result.stderr
+
+
+def test_publish_guard_rejects_merge_tree_that_differs_from_validated_head(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    head_sha = init_repo_with_beta_commit(repo)
+    (repo / "README.md").write_text("main advanced after validation\n", encoding="utf-8")
+    git(repo, "add", "README.md")
+    git(repo, "commit", "-m", "fix: advance main after beta validation")
+    merge_sha = git(repo, "rev-parse", "HEAD")
+    branch = "release/beta-1.20.0-beta.3"
+    event = event_file(
+        tmp_path,
+        head_ref=branch,
+        head_sha=head_sha,
+        body=validation_body(head_sha),
+        merged=True,
+        merge_commit_sha=merge_sha,
+    )
+
+    result = run_guard(Path(__file__).resolve().parents[2], repo, "--mode", "publish", "--event-path", str(event))
+
+    assert result.returncode == 1
+    assert "merge commit tree differs from the validated candidate head" in result.stderr
+    assert head_sha in result.stderr
+    assert merge_sha in result.stderr


### PR DESCRIPTION
## Summary
- Adds a beta release guard that blocks beta version metadata PRs unless they come from the canonical `release/beta-X.Y.Z-beta.N` branch
- Requires release-candidate validation evidence for the exact beta PR head SHA before the PR can satisfy CI or publish artifacts
- Adds the same guard to `publish-beta-release.yml` before tag/GitHub prerelease creation
- Updates the auto-generated beta PR body with an unchecked validation checklist and OpenSpec coverage

## Why
A replacement release PR can otherwise land beta version metadata on `main` without satisfying the `release/beta-*` publish path, and version metadata alone is not a tested release candidate. This makes "no test, no release" enforceable in CI and in the publish workflow itself.

## Test Plan
- `uv run ruff format scripts/guard_beta_release.py tests/unit/test_guard_beta_release.py`
- `uv run ruff check scripts/guard_beta_release.py tests/unit/test_guard_beta_release.py`
- `uv run ty check scripts/guard_beta_release.py tests/unit/test_guard_beta_release.py`
- `uv run pytest tests/unit/test_guard_beta_release.py tests/unit/test_release_versions.py -q`
- `openspec validate require-beta-candidate-validation --strict`
- `openspec validate --specs`
