### PR TITLE
fix(dashboard): correct weekly credits pace display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /app
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade \
-        libc-bin libc6 libcap2 libsystemd0 libudev1 sed \
+        libc-bin libc6 libcap2 libssl3t64 libsystemd0 libudev1 openssl openssl-provider-legacy sed \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip uninstall -y pip setuptools wheel || true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,9 @@ WORKDIR /app
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade \
-        libc-bin libc6 libcap2 libssl3t64 libsystemd0 libudev1 openssl openssl-provider-legacy sed \
+        libc-bin libc6 libcap2 libssl3t64 libsystemd0 libudev1 openssl sed \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip uninstall -y pip setuptools wheel || true \

--- a/app/modules/dashboard/weekly_pace.py
+++ b/app/modules/dashboard/weekly_pace.py
@@ -15,6 +15,13 @@ PRO_WEEKLY_CAPACITY_CREDITS = 50_400.0
 RECENT_BURN_WINDOW = timedelta(hours=6)
 MIN_FRESHNESS_SECONDS = 300.0
 FRESHNESS_MISSED_REFRESH_CYCLES = 3.0
+PACE_ELIGIBLE_ACCOUNT_STATUSES = frozenset(
+    (
+        AccountStatus.ACTIVE,
+        AccountStatus.RATE_LIMITED,
+        AccountStatus.QUOTA_EXCEEDED,
+    )
+)
 
 
 @dataclass
@@ -85,7 +92,7 @@ def build_weekly_credit_pace(
             continue
 
         account = accounts_by_id.get(summary.account_id)
-        if account is None or account.status in (AccountStatus.DEACTIVATED, AccountStatus.PAUSED):
+        if account is None or account.status not in PACE_ELIGIBLE_ACCOUNT_STATUSES:
             inactive_account_count += 1
             continue
 

--- a/app/modules/dashboard/weekly_pace.py
+++ b/app/modules/dashboard/weekly_pace.py
@@ -85,7 +85,7 @@ def build_weekly_credit_pace(
             continue
 
         account = accounts_by_id.get(summary.account_id)
-        if account is None or account.status != AccountStatus.ACTIVE:
+        if account is None or account.status in (AccountStatus.DEACTIVATED, AccountStatus.PAUSED):
             inactive_account_count += 1
             continue
 

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
@@ -42,8 +42,8 @@ describe("WeeklyCreditsPaceCard", () => {
     expect(screen.getByText("Pace gap")).toBeInTheDocument();
     expect(screen.getByText("50%")).toBeInTheDocument();
     expect(screen.getByText("14%")).toBeInTheDocument();
-    expect(screen.getByText("3.57x recent/scheduled")).toBeInTheDocument();
-    expect(screen.getByText("Recovery options")).toBeInTheDocument();
+    expect(screen.getByText("36% over planned usage")).toBeInTheDocument();
+    expect(screen.getByText("Recommendations")).toBeInTheDocument();
     expect(screen.getByText("Pause")).toBeInTheDocument();
     expect(screen.getByText("2d 12h until reset")).toBeInTheDocument();
     expect(screen.getByText("Throttle")).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe("WeeklyCreditsPaceCard", () => {
     expect(screen.getByText("Schedule marker")).toBeInTheDocument();
   });
 
-  it("hides recovery options when the pool is on the safe side of schedule", () => {
+  it("hides recommendations when the pool is on the safe side of schedule", () => {
     render(
       <WeeklyCreditsPaceCard
         pace={{
@@ -78,7 +78,7 @@ describe("WeeklyCreditsPaceCard", () => {
       />,
     );
 
-    expect(screen.queryByText("Recovery options")).not.toBeInTheDocument();
+    expect(screen.queryByText("Recommendations")).not.toBeInTheDocument();
     expect(screen.queryByText("No pause needed")).not.toBeInTheDocument();
     expect(screen.getByText("8% below planned usage")).toBeInTheDocument();
     expect(screen.queryByText("80K credits projected low-water mark")).not.toBeInTheDocument();
@@ -99,7 +99,7 @@ describe("WeeklyCreditsPaceCard", () => {
     expect(screen.getByText("0.53x Pro weekly pool (~1 account)")).toBeInTheDocument();
   });
 
-  it("shows schedule gap without recovery when recent forecast is safe", () => {
+  it("shows recommendations for a current schedule gap even when recent forecast is safe", () => {
     render(
       <WeeklyCreditsPaceCard
         pace={{
@@ -114,13 +114,19 @@ describe("WeeklyCreditsPaceCard", () => {
           proAccountEquivalentToCoverOverPlan: null,
           proAccountsToCoverOverPlan: null,
           forecastBurnRateCreditsPerHour: 0,
+          scheduledBurnRateCreditsPerHour: 1_032,
           status: "ahead",
         }}
       />,
     );
 
-    expect(screen.queryByText("Pause")).not.toBeInTheDocument();
+    expect(screen.getByText("Recommendations")).toBeInTheDocument();
+    expect(screen.getByText("Pause")).toBeInTheDocument();
+    expect(screen.getByText("3h to return to schedule")).toBeInTheDocument();
     expect(screen.queryByText("Throttle")).not.toBeInTheDocument();
+    expect(screen.getByText("Add capacity")).toBeInTheDocument();
+    expect(screen.getByText("0.061x Pro weekly pool (~1 account)")).toBeInTheDocument();
+    expect(screen.getByText("36% over planned usage")).toBeInTheDocument();
     expect(screen.getByText("3.1K credits over planned usage now")).toBeInTheDocument();
     expect(screen.getByText("No weekly shortfall projected at recent pace")).toBeInTheDocument();
   });

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
@@ -50,7 +50,7 @@ describe("WeeklyCreditsPaceCard", () => {
     expect(screen.getByText("Reduce ongoing weekly-credit load by ~72%")).toBeInTheDocument();
     expect(screen.getByText("Add capacity")).toBeInTheDocument();
     expect(screen.getByText("7.1x Pro weekly pool (~8 accounts)")).toBeInTheDocument();
-    expect(screen.getByText("360K credits behind schedule now")).toBeInTheDocument();
+    expect(screen.getByText("360K credits over planned usage now")).toBeInTheDocument();
     expect(screen.getByText("360K credits projected short before reset")).toBeInTheDocument();
     expect(screen.queryByText("500K")).not.toBeInTheDocument();
     expect(screen.getByText("Schedule marker")).toBeInTheDocument();
@@ -80,7 +80,7 @@ describe("WeeklyCreditsPaceCard", () => {
 
     expect(screen.queryByText("Recovery options")).not.toBeInTheDocument();
     expect(screen.queryByText("No pause needed")).not.toBeInTheDocument();
-    expect(screen.getByText("8% below schedule")).toBeInTheDocument();
+    expect(screen.getByText("8% below planned usage")).toBeInTheDocument();
     expect(screen.queryByText("80K credits projected low-water mark")).not.toBeInTheDocument();
   });
 
@@ -121,7 +121,7 @@ describe("WeeklyCreditsPaceCard", () => {
 
     expect(screen.queryByText("Pause")).not.toBeInTheDocument();
     expect(screen.queryByText("Throttle")).not.toBeInTheDocument();
-    expect(screen.getByText("3.1K credits behind schedule now")).toBeInTheDocument();
+    expect(screen.getByText("3.1K credits over planned usage now")).toBeInTheDocument();
     expect(screen.getByText("No weekly shortfall projected at recent pace")).toBeInTheDocument();
   });
 

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
@@ -121,8 +121,8 @@ describe("WeeklyCreditsPaceCard", () => {
     );
 
     expect(screen.getByText("Recommendations")).toBeInTheDocument();
-    expect(screen.getByText("Pause")).toBeInTheDocument();
-    expect(screen.getByText("3h to return to schedule")).toBeInTheDocument();
+    expect(screen.queryByText("Pause")).not.toBeInTheDocument();
+    expect(screen.queryByText("3h to return to schedule")).not.toBeInTheDocument();
     expect(screen.queryByText("Throttle")).not.toBeInTheDocument();
     expect(screen.getByText("Add capacity")).toBeInTheDocument();
     expect(screen.getByText("0.061x Pro weekly pool (~1 account)")).toBeInTheDocument();

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.test.tsx
@@ -131,6 +131,25 @@ describe("WeeklyCreditsPaceCard", () => {
     expect(screen.getByText("No weekly shortfall projected at recent pace")).toBeInTheDocument();
   });
 
+  it("keeps a danger label when recent burn projects a shortfall below schedule", () => {
+    render(
+      <WeeklyCreditsPaceCard
+        pace={{
+          ...BASE_PACE,
+          deltaPercent: -5,
+          scheduleGapCredits: 0,
+          overPlanCredits: 0,
+          projectedShortfallCredits: 42_000,
+          status: "danger",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Recent burn shortfall")).toBeInTheDocument();
+    expect(screen.queryByText("5% below planned usage")).not.toBeInTheDocument();
+    expect(screen.getByText("42K credits projected short before reset")).toBeInTheDocument();
+  });
+
   it("does not render fake pace when data is unavailable", () => {
     const { container } = render(<WeeklyCreditsPaceCard pace={null} />);
 

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
@@ -4,6 +4,8 @@ import type { WeeklyCreditPace } from "@/features/dashboard/utils";
 import { cn } from "@/lib/utils";
 import { formatCompactNumber } from "@/utils/formatters";
 
+const PRO_WEEKLY_CAPACITY_CREDITS = 50_400;
+
 export type WeeklyCreditsPaceCardProps = {
   pace: WeeklyCreditPace | null;
 };
@@ -30,9 +32,6 @@ function formatProAccountEquivalent(value: number): string {
 function statusLabel(pace: WeeklyCreditPace): string {
   if (pace.status === "on_track") return "On pace";
   const direction = pace.deltaPercent > 0 ? "over planned usage" : "below planned usage";
-  if (pace.paceMultiplier != null && pace.paceMultiplier > 0) {
-    return `${pace.paceMultiplier.toFixed(2)}x recent/scheduled`;
-  }
   return `${formatSignedPercent(pace.deltaPercent)} ${direction}`;
 }
 
@@ -76,6 +75,9 @@ function formatDurationHours(hours: number): string {
 
 function breakEvenLine(pace: WeeklyCreditPace): string {
   if (pace.projectedShortfallCredits <= 0) {
+    if (pace.scheduleGapCredits > 0 && pace.scheduledBurnRateCreditsPerHour > 0) {
+      return `${formatDurationHours(pace.scheduleGapCredits / pace.scheduledBurnRateCreditsPerHour)} to return to schedule`;
+    }
     return "No pause needed";
   }
   if (pace.pauseForBreakEvenHours == null) {
@@ -85,12 +87,17 @@ function breakEvenLine(pace: WeeklyCreditPace): string {
 }
 
 function proAccountsLine(pace: WeeklyCreditPace): string | null {
-  if (!pace.proAccountsToCoverOverPlan || pace.proAccountEquivalentToCoverOverPlan == null) {
+  const gapCredits =
+    pace.projectedShortfallCredits > 0 ? pace.projectedShortfallCredits : Math.max(0, pace.scheduleGapCredits);
+  const equivalent =
+    pace.proAccountEquivalentToCoverOverPlan ?? (gapCredits > 0 ? gapCredits / PRO_WEEKLY_CAPACITY_CREDITS : null);
+  const accounts = pace.proAccountsToCoverOverPlan ?? (gapCredits > 0 ? Math.ceil(gapCredits / PRO_WEEKLY_CAPACITY_CREDITS) : null);
+
+  if (!accounts || equivalent == null) {
     return null;
   }
-  const equivalent = formatProAccountEquivalent(pace.proAccountEquivalentToCoverOverPlan);
-  const roundedLabel = pace.proAccountsToCoverOverPlan === 1 ? "account" : "accounts";
-  return `${equivalent}x Pro weekly pool (~${pace.proAccountsToCoverOverPlan} ${roundedLabel})`;
+  const roundedLabel = accounts === 1 ? "account" : "accounts";
+  return `${formatProAccountEquivalent(equivalent)}x Pro weekly pool (~${accounts} ${roundedLabel})`;
 }
 
 function throttleLine(pace: WeeklyCreditPace): string | null {
@@ -119,7 +126,8 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
     pace.status === "danger" ? "bg-red-500" : pace.status === "ahead" ? "bg-amber-500" : "bg-primary";
   const throttle = throttleLine(pace);
   const proAccounts = proAccountsLine(pace);
-  const showRecovery = pace.projectedShortfallCredits > 0 || Boolean(throttle) || Boolean(proAccounts);
+  const showRecommendations =
+    pace.scheduleGapCredits > 0 || pace.projectedShortfallCredits > 0 || Boolean(throttle) || Boolean(proAccounts);
 
   return (
     <section className="rounded-xl border bg-card p-5" aria-label="Weekly credits pace">
@@ -171,9 +179,9 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
           </div>
         </div>
 
-        {showRecovery ? (
+        {showRecommendations ? (
           <div className="rounded-lg border bg-background/60 px-3 py-2 text-xs">
-            <p className="font-medium">Recovery options</p>
+            <p className="font-medium">Recommendations</p>
             <div className="mt-2 grid gap-1.5">
               <div className="flex items-baseline justify-between gap-3">
                 <span className="shrink-0 text-muted-foreground">Pause</span>

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
@@ -73,12 +73,9 @@ function formatDurationHours(hours: number): string {
   return `${minutesPart}m`;
 }
 
-function breakEvenLine(pace: WeeklyCreditPace): string {
+function breakEvenLine(pace: WeeklyCreditPace): string | null {
   if (pace.projectedShortfallCredits <= 0) {
-    if (pace.scheduleGapCredits > 0 && pace.scheduledBurnRateCreditsPerHour > 0) {
-      return `${formatDurationHours(pace.scheduleGapCredits / pace.scheduledBurnRateCreditsPerHour)} to return to schedule`;
-    }
-    return "No pause needed";
+    return null;
   }
   if (pace.pauseForBreakEvenHours == null) {
     return "Until reset";
@@ -126,8 +123,13 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
     pace.status === "danger" ? "bg-red-500" : pace.status === "ahead" ? "bg-amber-500" : "bg-primary";
   const throttle = throttleLine(pace);
   const proAccounts = proAccountsLine(pace);
+  const breakEven = breakEvenLine(pace);
   const showRecommendations =
-    pace.scheduleGapCredits > 0 || pace.projectedShortfallCredits > 0 || Boolean(throttle) || Boolean(proAccounts);
+    pace.scheduleGapCredits > 0 ||
+    pace.projectedShortfallCredits > 0 ||
+    Boolean(breakEven) ||
+    Boolean(throttle) ||
+    Boolean(proAccounts);
 
   return (
     <section className="rounded-xl border bg-card p-5" aria-label="Weekly credits pace">
@@ -183,10 +185,12 @@ export function WeeklyCreditsPaceCard({ pace }: WeeklyCreditsPaceCardProps) {
           <div className="rounded-lg border bg-background/60 px-3 py-2 text-xs">
             <p className="font-medium">Recommendations</p>
             <div className="mt-2 grid gap-1.5">
-              <div className="flex items-baseline justify-between gap-3">
-                <span className="shrink-0 text-muted-foreground">Pause</span>
-                <span className="min-w-0 text-right tabular-nums">{breakEvenLine(pace)}</span>
-              </div>
+              {breakEven ? (
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="shrink-0 text-muted-foreground">Pause</span>
+                  <span className="min-w-0 text-right tabular-nums">{breakEven}</span>
+                </div>
+              ) : null}
               {throttle ? (
                 <div className="flex items-baseline justify-between gap-3">
                   <span className="shrink-0 text-muted-foreground">Throttle</span>

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
@@ -29,7 +29,7 @@ function formatProAccountEquivalent(value: number): string {
 
 function statusLabel(pace: WeeklyCreditPace): string {
   if (pace.status === "on_track") return "On pace";
-  const direction = pace.deltaPercent > 0 ? "above schedule" : "below schedule";
+  const direction = pace.deltaPercent > 0 ? "over planned usage" : "below planned usage";
   if (pace.paceMultiplier != null && pace.paceMultiplier > 0) {
     return `${pace.paceMultiplier.toFixed(2)}x recent/scheduled`;
   }
@@ -38,10 +38,10 @@ function statusLabel(pace: WeeklyCreditPace): string {
 
 function scheduleGapLine(pace: WeeklyCreditPace): string {
   if (pace.scheduleGapCredits > 0) {
-    return `${formatCompactNumber(pace.scheduleGapCredits)} credits behind schedule now`;
+    return `${formatCompactNumber(pace.scheduleGapCredits)} credits over planned usage now`;
   }
   if (pace.deltaPercent < 0) {
-    return `${formatSignedPercent(pace.deltaPercent)} ahead of schedule now`;
+    return `${formatSignedPercent(pace.deltaPercent)} below planned usage now`;
   }
   return "On the current linear weekly schedule";
 }

--- a/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
+++ b/frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx
@@ -31,6 +31,9 @@ function formatProAccountEquivalent(value: number): string {
 
 function statusLabel(pace: WeeklyCreditPace): string {
   if (pace.status === "on_track") return "On pace";
+  if (pace.status === "danger" && pace.projectedShortfallCredits > 0 && pace.deltaPercent <= 0) {
+    return "Recent burn shortfall";
+  }
   const direction = pace.deltaPercent > 0 ? "over planned usage" : "below planned usage";
   return `${formatSignedPercent(pace.deltaPercent)} ${direction}`;
 }

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/proposal.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/proposal.md
@@ -14,8 +14,8 @@ is over the planned burn for this point in the week.
 
 - Count fresh weekly usage rows from `rate_limited` and `quota_exceeded`
   accounts in weekly pace totals and forecasts.
-- Continue excluding paused, deactivated, missing, and stale accounts from the
-  pace pool.
+- Continue excluding reauth-required, paused, deactivated, missing, and stale
+  accounts from the pace pool.
 - Label positive schedule gaps as over planned usage instead of "behind
   schedule".
 - Cover a fresh `quota_exceeded` account at 100% weekly usage in the dashboard

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/proposal.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/proposal.md
@@ -5,12 +5,19 @@ persisted status is `quota_exceeded` or `rate_limited`. A fully used weekly
 account is therefore removed from the pool exactly when its zero remaining
 credits should increase the pace gap and recovery warning.
 
+The same card also labels positive `scheduleGapCredits` as "behind schedule".
+That is easy to read as slower-than-planned consumption, even though the metric
+means actual remaining credits are below scheduled remaining credits and usage
+is over the planned burn for this point in the week.
+
 ## What Changes
 
 - Count fresh weekly usage rows from `rate_limited` and `quota_exceeded`
   accounts in weekly pace totals and forecasts.
 - Continue excluding paused, deactivated, missing, and stale accounts from the
   pace pool.
+- Label positive schedule gaps as over planned usage instead of "behind
+  schedule".
 - Cover a fresh `quota_exceeded` account at 100% weekly usage in the dashboard
   projections integration test.
 
@@ -18,4 +25,5 @@ credits should increase the pace gap and recovery warning.
 
 - Modified capability: `frontend-architecture`
 - Backend: dashboard weekly pace filtering
-- Tests: dashboard projections weekly pace coverage
+- Frontend: weekly credits pace card copy
+- Tests: dashboard projections and pace-card coverage

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/proposal.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The dashboard weekly credits pace card currently excludes accounts whose
+persisted status is `quota_exceeded` or `rate_limited`. A fully used weekly
+account is therefore removed from the pool exactly when its zero remaining
+credits should increase the pace gap and recovery warning.
+
+## What Changes
+
+- Count fresh weekly usage rows from `rate_limited` and `quota_exceeded`
+  accounts in weekly pace totals and forecasts.
+- Continue excluding paused, deactivated, missing, and stale accounts from the
+  pace pool.
+- Cover a fresh `quota_exceeded` account at 100% weekly usage in the dashboard
+  projections integration test.
+
+## Impact
+
+- Modified capability: `frontend-architecture`
+- Backend: dashboard weekly pace filtering
+- Tests: dashboard projections weekly pace coverage

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/specs/frontend-architecture/spec.md
@@ -9,9 +9,9 @@ The dashboard SHALL show weekly quota pace when account weekly capacity credits,
 - **WHEN** multiple accounts have weekly quota data with different `resetAtSecondary` values
 - **THEN** the system computes each account's expected remaining weekly credits from that account's own reset time and window length before summing totals
 
-#### Scenario: Weekly credits pace excludes hard-inactive or stale usage rows
+#### Scenario: Weekly credits pace excludes hard-blocked or stale usage rows
 
-- **WHEN** an account is paused, deactivated, missing from the account table, or its latest weekly usage sample is older than the freshness window derived from the usage refresh interval
+- **WHEN** an account is `reauth_required`, paused, deactivated, missing from the account table, or its latest weekly usage sample is older than the freshness window derived from the usage refresh interval
 - **THEN** the account is not included in weekly pace totals or forecasts
 - **AND** the response reports the excluded stale account count separately from the included account count
 
@@ -46,5 +46,5 @@ The dashboard SHALL show weekly quota pace when account weekly capacity credits,
 
 #### Scenario: No valid weekly credit data hides pace
 
-- **WHEN** no account has complete, fresh, non-paused, non-deactivated weekly credits pace data
+- **WHEN** no account has complete, fresh weekly credits pace data for an `active`, `rate_limited`, or `quota_exceeded` account
 - **THEN** the dashboard does not render a fake weekly pace value

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/specs/frontend-architecture/spec.md
@@ -27,6 +27,7 @@ The dashboard SHALL show weekly quota pace when account weekly capacity credits,
 - **THEN** the response reports `scheduleGapCredits` for the current deficit against the linear schedule
 - **AND** the response reports `projectedShortfallCredits` only for a future shortfall forecast based on recent burn
 - **AND** the dashboard labels the two concepts separately
+- **AND** the dashboard describes the current deficit as over planned usage, fewer credits remaining than scheduled, or equivalent over-consumption wording rather than "behind schedule"
 
 #### Scenario: Forecast burn uses recent weekly usage slope
 

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/specs/frontend-architecture/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard weekly credits pace
+
+The dashboard SHALL show weekly quota pace when account weekly capacity credits, remaining credits, reset time, and window length are available. The pace calculation MUST use credit totals rather than averaging per-account percentages, because weekly ChatGPT quota credits are not the same unit as raw request tokens. The dashboard MUST prefer the backend-provided `weeklyCreditPace` object from `GET /api/dashboard/overview` when present, and MAY fall back to a local calculation only for older responses that do not include that field.
+
+#### Scenario: Weekly credits pace uses account reset deadlines
+
+- **WHEN** multiple accounts have weekly quota data with different `resetAtSecondary` values
+- **THEN** the system computes each account's expected remaining weekly credits from that account's own reset time and window length before summing totals
+
+#### Scenario: Weekly credits pace excludes hard-inactive or stale usage rows
+
+- **WHEN** an account is paused, deactivated, missing from the account table, or its latest weekly usage sample is older than the freshness window derived from the usage refresh interval
+- **THEN** the account is not included in weekly pace totals or forecasts
+- **AND** the response reports the excluded stale account count separately from the included account count
+
+#### Scenario: Exhausted accounts still count in weekly credits pace
+
+- **WHEN** an account is `rate_limited` or `quota_exceeded`
+- **AND** it has complete, fresh weekly capacity, remaining credits, reset time, and window length
+- **THEN** the account is included in weekly pace totals and forecasts
+
+#### Scenario: Current schedule gap is separate from forecast shortfall
+
+- **WHEN** actual remaining weekly credits are lower than scheduled remaining weekly credits
+- **THEN** the response reports `scheduleGapCredits` for the current deficit against the linear schedule
+- **AND** the response reports `projectedShortfallCredits` only for a future shortfall forecast based on recent burn
+- **AND** the dashboard labels the two concepts separately
+
+#### Scenario: Forecast burn uses recent weekly usage slope
+
+- **WHEN** an account has high cumulative weekly usage from earlier in the window but no recent increase in weekly used percent
+- **THEN** the projected shortfall forecast is based on the recent slope and does not assume the earlier full-window average continues
+
+#### Scenario: Near-reset depletion is not a false alarm
+
+- **WHEN** an account has consumed 99% of its weekly quota and 99% of its weekly window has elapsed
+- **THEN** the weekly pace treats that account as on pace rather than over plan
+
+#### Scenario: Missing weekly credit data is omitted
+
+- **WHEN** an account is missing weekly capacity credits, remaining credits, reset time, or window length
+- **THEN** that account is omitted from weekly pace calculation
+
+#### Scenario: No valid weekly credit data hides pace
+
+- **WHEN** no account has complete, fresh, non-paused, non-deactivated weekly credits pace data
+- **THEN** the dashboard does not render a fake weekly pace value

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/tasks.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/tasks.md
@@ -5,11 +5,12 @@
 ## 2. Implementation
 
 - [x] 2.1 Include `rate_limited` and `quota_exceeded` accounts in backend weekly pace when their weekly usage data is fresh and complete.
-- [x] 2.2 Keep paused, deactivated, missing, and stale accounts excluded from weekly pace.
+- [x] 2.2 Keep reauth-required, paused, deactivated, missing, and stale accounts excluded from weekly pace.
 - [x] 2.3 Replace inverted "behind schedule" pace-card wording with over-planned-usage wording.
 
 ## 3. Verification
 
 - [x] 3.1 Add integration coverage for a fresh `quota_exceeded` account at 100% weekly usage.
 - [x] 3.2 Update weekly credits pace card tests for the clarified wording.
-- [x] 3.3 Run targeted dashboard tests, ruff, frontend tests, and OpenSpec validation.
+- [x] 3.3 Add integration coverage proving a fresh `reauth_required` account is excluded.
+- [x] 3.4 Run targeted dashboard tests, ruff, frontend tests, and OpenSpec validation.

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/tasks.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/tasks.md
@@ -6,8 +6,10 @@
 
 - [x] 2.1 Include `rate_limited` and `quota_exceeded` accounts in backend weekly pace when their weekly usage data is fresh and complete.
 - [x] 2.2 Keep paused, deactivated, missing, and stale accounts excluded from weekly pace.
+- [x] 2.3 Replace inverted "behind schedule" pace-card wording with over-planned-usage wording.
 
 ## 3. Verification
 
 - [x] 3.1 Add integration coverage for a fresh `quota_exceeded` account at 100% weekly usage.
-- [x] 3.2 Run targeted dashboard tests, ruff, and OpenSpec validation.
+- [x] 3.2 Update weekly credits pace card tests for the clarified wording.
+- [x] 3.3 Run targeted dashboard tests, ruff, frontend tests, and OpenSpec validation.

--- a/openspec/changes/fix-weekly-pace-exhausted-accounts/tasks.md
+++ b/openspec/changes/fix-weekly-pace-exhausted-accounts/tasks.md
@@ -1,0 +1,13 @@
+## 1. Spec
+
+- [x] 1.1 Clarify that exhausted but fresh weekly accounts remain in pace totals.
+
+## 2. Implementation
+
+- [x] 2.1 Include `rate_limited` and `quota_exceeded` accounts in backend weekly pace when their weekly usage data is fresh and complete.
+- [x] 2.2 Keep paused, deactivated, missing, and stale accounts excluded from weekly pace.
+
+## 3. Verification
+
+- [x] 3.1 Add integration coverage for a fresh `quota_exceeded` account at 100% weekly usage.
+- [x] 3.2 Run targeted dashboard tests, ruff, and OpenSpec validation.

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -368,6 +368,14 @@ async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_st
                 status=AccountStatus.DEACTIVATED,
             )
         )
+        await accounts_repo.upsert(
+            _make_account(
+                "acc_reauth_fresh",
+                "reauth@example.com",
+                plan_type="pro",
+                status=AccountStatus.REAUTH_REQUIRED,
+            )
+        )
 
         await usage_repo.add_entry(
             "acc_active_fresh",
@@ -401,6 +409,14 @@ async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_st
             reset_at=reset_at,
             recorded_at=fixed_now - timedelta(minutes=1),
         )
+        await usage_repo.add_entry(
+            "acc_reauth_fresh",
+            100.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=reset_at,
+            recorded_at=fixed_now - timedelta(minutes=1),
+        )
 
     response = await async_client.get("/api/dashboard/projections")
     assert response.status_code == 200
@@ -409,7 +425,7 @@ async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_st
     pace = payload["weeklyCreditPace"]
     assert pace["accountCount"] == 2
     assert pace["staleAccountCount"] == 1
-    assert pace["inactiveAccountCount"] == 1
+    assert pace["inactiveAccountCount"] == 2
     assert pace["totalFullCredits"] == pytest.approx(100_800.0)
     assert pace["actualUsedPercent"] == pytest.approx(60.0)
     assert pace["scheduledUsedPercent"] == pytest.approx(42.857, abs=0.01)

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -351,6 +351,14 @@ async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_st
         usage_repo = UsageRepository(session)
 
         await accounts_repo.upsert(_make_account("acc_active_fresh", "fresh@example.com", plan_type="pro"))
+        await accounts_repo.upsert(
+            _make_account(
+                "acc_quota_exceeded_fresh",
+                "quota@example.com",
+                plan_type="pro",
+                status=AccountStatus.QUOTA_EXCEEDED,
+            )
+        )
         await accounts_repo.upsert(_make_account("acc_active_stale", "stale@example.com", plan_type="pro"))
         await accounts_repo.upsert(
             _make_account(
@@ -364,6 +372,14 @@ async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_st
         await usage_repo.add_entry(
             "acc_active_fresh",
             20.0,
+            window="secondary",
+            window_minutes=10080,
+            reset_at=reset_at,
+            recorded_at=fixed_now - timedelta(minutes=1),
+        )
+        await usage_repo.add_entry(
+            "acc_quota_exceeded_fresh",
+            100.0,
             window="secondary",
             window_minutes=10080,
             reset_at=reset_at,
@@ -391,14 +407,14 @@ async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_st
     payload = response.json()
 
     pace = payload["weeklyCreditPace"]
-    assert pace["accountCount"] == 1
+    assert pace["accountCount"] == 2
     assert pace["staleAccountCount"] == 1
     assert pace["inactiveAccountCount"] == 1
-    assert pace["totalFullCredits"] == pytest.approx(50_400.0)
-    assert pace["actualUsedPercent"] == pytest.approx(20.0)
+    assert pace["totalFullCredits"] == pytest.approx(100_800.0)
+    assert pace["actualUsedPercent"] == pytest.approx(60.0)
     assert pace["scheduledUsedPercent"] == pytest.approx(42.857, abs=0.01)
-    assert pace["scheduleGapCredits"] == 0
-    assert pace["status"] == "behind"
+    assert pace["scheduleGapCredits"] == pytest.approx(17_280.0, abs=1.0)
+    assert pace["status"] == "ahead"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Correct the Weekly credits pace card when weekly usage is exhausted. The backend now counts fresh `rate_limited` and `quota_exceeded` accounts in the pace pool, keeps hard-blocked `reauth_required` accounts out, and the UI no longer describes over-consumption as being "behind schedule".

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Closes #954

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-weekly-pace-exhausted-accounts/`

## Changes

- Include `rate_limited` and `quota_exceeded` accounts in backend weekly pace when their weekly usage data is fresh and complete.
- Continue excluding `reauth_required`, paused, deactivated, missing, and stale accounts from weekly pace totals.
- Replace the inverted `credits behind schedule now` copy with `credits over planned usage now`.
- Add integration coverage for a fresh `quota_exceeded` account at 100% weekly usage, regression coverage for excluding fresh `reauth_required`, and component coverage for the clarified copy.

## Test plan

```bash
uv run pytest tests/integration/test_dashboard_overview.py -k 'weekly_credit_pace'
uv run ruff check app/modules/dashboard/weekly_pace.py tests/integration/test_dashboard_overview.py
bun run --cwd frontend test src/features/dashboard/components/weekly-credits-pace-card.test.tsx
bun run --cwd frontend lint
bun run --cwd frontend typecheck
openspec validate fix-weekly-pace-exhausted-accounts --strict
openspec validate --specs --strict
git diff --check origin/main..HEAD
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
