### PR TITLE
fix(report-ui): fix non-English content to English for consistency

### DIFF
--- a/frontend/src/features/reports/components/chart-tooltip.tsx
+++ b/frontend/src/features/reports/components/chart-tooltip.tsx
@@ -1,0 +1,56 @@
+import type { TooltipProps } from "recharts";
+
+export type ChartTooltipProps = TooltipProps<number, string> & {
+  formatValue?: (value: number, dataKey: string) => string;
+  names?: Record<string, string>;
+};
+
+export function ChartTooltip({
+  active,
+  payload,
+  label,
+  formatValue,
+  names,
+}: ChartTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  return (
+    <div className="rounded-xl border border-border bg-popover p-2.5 shadow-md">
+      {label != null && (
+        <p className="mb-1.5 px-2 text-[11px] font-medium text-muted-foreground">
+          {label}
+        </p>
+      )}
+      <div className="space-y-1">
+        {payload.map((entry, i) => {
+          const color = entry.color ?? "#888";
+          const rawName = String(entry.name ?? entry.dataKey ?? "");
+          const name = names?.[rawName] ?? rawName;
+          const value =
+            typeof entry.value === "number"
+              ? formatValue
+                ? formatValue(entry.value, String(entry.dataKey))
+                : String(entry.value)
+              : String(entry.value);
+
+          return (
+            <div
+              key={String(entry.dataKey ?? i)}
+              className="flex items-center gap-2 rounded-lg px-2.5 py-1.5"
+              style={{ backgroundColor: `${color}18` }}
+            >
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: color }}
+              />
+              <span className="text-xs text-popover-foreground">{name}</span>
+              <span className="ml-auto pl-2 text-xs font-semibold text-popover-foreground">
+                {value}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/reports/components/chart-tooltip.tsx
+++ b/frontend/src/features/reports/components/chart-tooltip.tsx
@@ -1,6 +1,6 @@
-import type { TooltipProps } from "recharts";
+import type { TooltipContentProps } from "recharts";
 
-export type ChartTooltipProps = TooltipProps<number, string> & {
+export type ChartTooltipProps = TooltipContentProps<number, string> & {
   formatValue?: (value: number, dataKey: string) => string;
   names?: Record<string, string>;
 };

--- a/frontend/src/features/reports/components/chart-tooltip.tsx
+++ b/frontend/src/features/reports/components/chart-tooltip.tsx
@@ -1,6 +1,6 @@
 import type { TooltipContentProps } from "recharts";
 
-export type ChartTooltipProps = TooltipContentProps<number, string> & {
+export type ChartTooltipProps = Partial<TooltipContentProps<number, string>> & {
   formatValue?: (value: number, dataKey: string) => string;
   names?: Record<string, string>;
 };

--- a/frontend/src/features/reports/components/cost-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/cost-per-day-chart.tsx
@@ -8,6 +8,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { DailyReportRow } from "../schemas";
+import { ChartTooltip } from "./chart-tooltip";
 
 export type CostPerDayChartProps = {
   data: DailyReportRow[];
@@ -45,15 +46,7 @@ export function CostPerDayChart({ data }: CostPerDayChartProps) {
               tickFormatter={(v: number) => `$${v}`}
             />
             <Tooltip
-              contentStyle={{
-                borderRadius: "8px",
-                border: "1px solid hsl(var(--border))",
-                background: "hsl(var(--popover))",
-              }}
-              formatter={(value) => {
-                if (typeof value !== "number") return [String(value), "Cost"];
-                return [`$${value.toFixed(2)}`, "Cost"];
-              }}
+              content={<ChartTooltip names={{ cost: "Cost" }} formatValue={(v) => `$${v.toFixed(2)}`} />}
             />
             <Area
               type="monotone"

--- a/frontend/src/features/reports/components/cost-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/cost-per-day-chart.tsx
@@ -21,7 +21,7 @@ export function CostPerDayChart({ data }: CostPerDayChartProps) {
 
   return (
     <div className="rounded-xl border bg-card p-5">
-      <div className="text-sm font-semibold text-foreground">Custo por Dia</div>
+      <div className="text-sm font-semibold text-foreground">Cost by Day</div>
       <div className="mt-4 h-[200px]">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
@@ -51,8 +51,8 @@ export function CostPerDayChart({ data }: CostPerDayChartProps) {
                 background: "hsl(var(--popover))",
               }}
               formatter={(value) => {
-                if (typeof value !== "number") return [String(value), "Custo"];
-                return [`$${value.toFixed(2)}`, "Custo"];
+                if (typeof value !== "number") return [String(value), "Cost"];
+                return [`$${value.toFixed(2)}`, "Cost"];
               }}
             />
             <Area

--- a/frontend/src/features/reports/components/daily-detail-table.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.tsx
@@ -17,7 +17,7 @@ export function DailyDetailTable({ data }: DailyDetailTableProps) {
   return (
     <div className="rounded-xl border bg-card p-5">
       <div className="mb-3 flex items-center justify-between">
-        <div className="text-sm font-semibold text-foreground">Detalhamento por Dia</div>
+        <div className="text-sm font-semibold text-foreground">Daily Breakdown</div>
         <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={() => exportCSV(data)}>
           <Download className="h-3 w-3" />
           CSV
@@ -27,12 +27,12 @@ export function DailyDetailTable({ data }: DailyDetailTableProps) {
         <table className="w-full text-xs">
           <thead>
             <tr className="border-b text-left text-muted-foreground">
-              <th className="pb-2 pr-4 font-medium">Dia</th>
-              <th className="pb-2 pr-4 text-right font-medium">Req</th>
-              <th className="pb-2 pr-4 text-right font-medium">Tokens In</th>
-              <th className="pb-2 pr-4 text-right font-medium">Tokens Out</th>
-              <th className="pb-2 pr-4 text-right font-medium">Custo</th>
-              <th className="pb-2 text-right font-medium">Contas</th>
+              <th className="pb-2 pr-4 font-medium">Day</th>
+              <th className="pb-2 pr-4 text-right font-medium">Reqs</th>
+              <th className="pb-2 pr-4 text-right font-medium">Input Tokens</th>
+              <th className="pb-2 pr-4 text-right font-medium">Output Tokens</th>
+              <th className="pb-2 pr-4 text-right font-medium">Cost</th>
+              <th className="pb-2 text-right font-medium">Accounts</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/features/reports/components/model-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.tsx
@@ -10,7 +10,7 @@ const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ec4899", "#8b5cf6", "#06b6d4"
 export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
   return (
     <div className="rounded-xl border bg-card p-5">
-      <div className="text-sm font-semibold text-foreground">Distribuição por Modelo</div>
+      <div className="text-sm font-semibold text-foreground">Distribution by Model</div>
       <div className="mt-4 flex items-center gap-4">
         <div className="h-[140px] w-[140px] shrink-0">
           <ResponsiveContainer width="100%" height="100%">
@@ -36,8 +36,8 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                   background: "hsl(var(--popover))",
                 }}
                 formatter={(value) => {
-                  if (typeof value !== "number") return [String(value), "Custo"];
-                  return [`$${value.toFixed(2)}`, "Custo"];
+                  if (typeof value !== "number") return [String(value), "Cost"];
+                  return [`$${value.toFixed(2)}`, "Cost"];
                 }}
               />
             </PieChart>

--- a/frontend/src/features/reports/components/model-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.tsx
@@ -1,5 +1,6 @@
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
 import type { ModelCostEntry } from "../schemas";
+import { ChartTooltip } from "./chart-tooltip";
 
 export type ModelDistributionDonutProps = {
   data: ModelCostEntry[];
@@ -30,15 +31,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                 ))}
               </Pie>
               <Tooltip
-                contentStyle={{
-                  borderRadius: "8px",
-                  border: "1px solid hsl(var(--border))",
-                  background: "hsl(var(--popover))",
-                }}
-                formatter={(value) => {
-                  if (typeof value !== "number") return [String(value), "Cost"];
-                  return [`$${value.toFixed(2)}`, "Cost"];
-                }}
+                content={<ChartTooltip names={{ costUsd: "Cost" }} formatValue={(v) => `$${v.toFixed(2)}`} />}
               />
             </PieChart>
           </ResponsiveContainer>

--- a/frontend/src/features/reports/components/reports-page.tsx
+++ b/frontend/src/features/reports/components/reports-page.tsx
@@ -84,10 +84,10 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
     <div className="mx-auto w-full max-w-[1500px] flex-1 space-y-6 px-4 py-8 sm:px-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">
-          Relatório de Custo
+          Cost Report
         </h1>
         <p className="text-sm text-muted-foreground">
-          Histórico de utilização por período
+          Usage history by date range
         </p>
       </div>
 
@@ -116,7 +116,7 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
 
       {reportsQuery.isLoading ? (
         <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
-          Carregando...
+          Loading...
         </div>
       ) : reportsQuery.data ? (
         <>

--- a/frontend/src/features/reports/components/reports-summary-cards.tsx
+++ b/frontend/src/features/reports/components/reports-summary-cards.tsx
@@ -7,9 +7,9 @@ export type ReportsSummaryCardsProps = {
 export function ReportsSummaryCards({ summary }: ReportsSummaryCardsProps) {
   const cards = [
     {
-      label: "Custo Total",
+      label: "Total Cost",
       value: `$${summary.totalCostUsd.toFixed(2)}`,
-      sub: `média $${summary.avgCostPerDay.toFixed(2)}/dia`,
+      sub: `avg $${summary.avgCostPerDay.toFixed(2)}/day`,
     },
     {
       label: "Tokens",
@@ -17,9 +17,9 @@ export function ReportsSummaryCards({ summary }: ReportsSummaryCardsProps) {
       sub: `Input ${formatNumber(summary.totalInputTokens)} · Output ${formatNumber(summary.totalOutputTokens)}`,
     },
     {
-      label: "Requisições",
+      label: "Requests",
       value: formatNumber(summary.totalRequests),
-      sub: `média ${summary.avgRequestsPerDay.toFixed(0)}/dia · ${summary.activeAccounts} contas`,
+      sub: `avg ${summary.avgRequestsPerDay.toFixed(0)}/day · ${summary.activeAccounts} accounts`,
     },
   ];
 

--- a/frontend/src/features/reports/components/tokens-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/tokens-per-day-chart.tsx
@@ -8,6 +8,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import type { DailyReportRow } from "../schemas";
+import { ChartTooltip } from "./chart-tooltip";
 
 export type TokensPerDayChartProps = {
   data: DailyReportRow[];
@@ -56,18 +57,7 @@ export function TokensPerDayChart({ data }: TokensPerDayChartProps) {
               tickFormatter={formatTokens}
             />
             <Tooltip
-              contentStyle={{
-                borderRadius: "8px",
-                border: "1px solid hsl(var(--border))",
-                background: "hsl(var(--popover))",
-              }}
-              formatter={(value, name) => {
-                if (typeof value !== "number") return [String(value), String(name)];
-                return [
-                  formatTokens(value),
-                  name === "input" ? "Input" : "Output",
-                ];
-              }}
+              content={<ChartTooltip names={{ input: "Input", output: "Output" }} formatValue={(v) => formatTokens(v)} />}
             />
             <Area
               type="monotone"

--- a/frontend/src/features/reports/components/tokens-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/tokens-per-day-chart.tsx
@@ -28,7 +28,7 @@ export function TokensPerDayChart({ data }: TokensPerDayChartProps) {
 
   return (
     <div className="rounded-xl border bg-card p-5">
-      <div className="text-sm font-semibold text-foreground">Tokens por Dia</div>
+      <div className="text-sm font-semibold text-foreground">Tokens by Day</div>
       <div className="mt-4 h-[200px]">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>

--- a/openspec/changes/translate-reports-ui-english/proposal.md
+++ b/openspec/changes/translate-reports-ui-english/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The reports dashboard surface currently contains non-English page-owned wording. Operators need `/reports` to present English UI labels consistently while continuing to load report data from `GET /api/reports`, keep visible filter controls for start date, end date, account, and model, and keep the request parameter names `startDate`, `endDate`, `accountId`, and `model`.
+
+## What Changes
+
+- Update page-owned user-facing labels on `/reports` to English wording.
+- Use an explicit accepted English wording set for the current `/reports` page-owned labels, including the page title, subtitle, loading label, summary labels, chart titles, daily table title, daily table headings, and page-owned error/retry labels.
+- Keep `/reports` loading and refetching report data from `GET /api/reports`.
+- Keep `/reports` exposing visible filter controls for start date, end date, account, and model.
+- Keep `/api/reports` requests from `/reports` using the parameter names `startDate`, `endDate`, `accountId`, and `model`.
+- Keep backend-provided strings, account/model values, and raw server error payload text out of scope unless `/reports` wraps them with page-owned labels.
+- Verify `/reports` page-owned headings, controls, summaries, charts, and page-owned loading/empty/error labels render English user-facing text.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `frontend-architecture`: `/reports` wording is clarified as concrete accepted English labels for the current page-owned reports surface plus separate contracts for `GET /api/reports` loading/refetch, visible filter controls, and preserved request parameter names, with backend-provided strings and raw payload text remaining out of scope unless wrapped by page-owned labels.
+
+## Impact
+
+- Frontend: reports page text on `/reports` and any directly rendered reports-page labels.
+- Specs: `frontend-architecture` delta for reports-page wording.
+- Verification: confirm `/reports` renders the accepted English page-owned wording set, still loads/refetches through `GET /api/reports`, still exposes visible filter controls for start date, end date, account, and model, and still uses request parameter names `startDate`, `endDate`, `accountId`, and `model`.

--- a/openspec/changes/translate-reports-ui-english/specs/frontend-architecture/spec.md
+++ b/openspec/changes/translate-reports-ui-english/specs/frontend-architecture/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Reports page renders English user-facing labels
+
+The dashboard SHALL render `/reports` with the following exact page-owned user-facing labels for the current reports surface:
+
+- `Cost Report`
+- `Usage history by date range`
+- `Loading...`
+- `Total Cost`
+- `Requests`
+- `Cost by Day`
+- `Tokens by Day`
+- `Distribution by Model`
+- `Daily Breakdown`
+- `Day`
+- `Input Tokens`
+- `Output Tokens`
+- `Cost`
+- `Accounts`
+- `Failed to load report data:`
+- `Failed to load model options:`
+- `Failed to load account options:`
+- `Some report data could not be loaded. Try reloading.`
+- `Retry`
+
+Backend-provided strings, account values, model values, and raw server error payload text SHALL remain out of scope for this wording change unless `/reports` renders page-owned labels around them.
+
+#### Scenario: Reports page shows English labels
+
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the page title is `Cost Report`
+- **AND** the subtitle is `Usage history by date range`
+- **AND** the summary cards include `Total Cost` and `Requests`
+- **AND** the chart and table section titles include `Cost by Day`, `Tokens by Day`, `Distribution by Model`, and `Daily Breakdown`
+- **AND** the daily table headings include `Day`, `Input Tokens`, `Output Tokens`, `Cost`, and `Accounts`
+
+#### Scenario: Reports page state labels are English
+
+- **WHEN** `/reports` renders a loading, empty, or error state
+- **THEN** the loading label is `Loading...`
+- **AND** page-owned error wrappers use `Failed to load report data:`, `Failed to load model options:`, and `Failed to load account options:` when those failures render
+- **AND** the retry warning is `Some report data could not be loaded. Try reloading.`
+- **AND** the retry button label is `Retry`
+
+### Requirement: Reports page loads report data from the reports endpoint
+
+The `/reports` page SHALL load and refetch report data from `GET /api/reports`.
+
+#### Scenario: Reports page loads from reports endpoint
+
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the page loads report data from `GET /api/reports`
+
+#### Scenario: Reports page refetches from reports endpoint
+
+- **WHEN** an authenticated operator changes a report filter on `/reports`
+- **THEN** the page refetches report data from `GET /api/reports`
+
+### Requirement: Reports page exposes visible filter controls
+
+The `/reports` page SHALL expose visible filter controls for start date, end date, account, and model.
+
+#### Scenario: Reports page shows report filter controls
+
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the page exposes visible filter controls for start date, end date, account, and model
+
+### Requirement: Reports page preserves reports query parameter names
+
+Requests from `/reports` to `GET /api/reports` SHALL use the query parameter names `startDate`, `endDate`, `accountId`, and `model`.
+
+#### Scenario: Reports page uses preserved reports query parameter names
+
+- **WHEN** an authenticated operator opens `/reports` or changes a report filter
+- **THEN** the request uses `startDate`, `endDate`, `accountId`, and `model` as the query parameter names

--- a/openspec/changes/translate-reports-ui-english/tasks.md
+++ b/openspec/changes/translate-reports-ui-english/tasks.md
@@ -1,0 +1,21 @@
+## 1. Spec
+
+- [x] 1.1 Add a `frontend-architecture` delta for English `/reports` user-facing labels.
+
+## 2. Reports UI
+
+- [x] 2.1 Update page-owned `/reports` labels to the accepted English wording set for the current reports surface.
+- [x] 2.2 Keep `/reports` loading report data from `GET /api/reports`.
+- [x] 2.3 Keep visible `/reports` filter controls for start date, end date, account, and model.
+- [x] 2.4 Keep `/api/reports` requests from `/reports` using `startDate`, `endDate`, `accountId`, and `model` parameter names.
+- [x] 2.5 Keep backend-provided strings, account/model values, and raw server error payload text out of scope unless `/reports` wraps them with page-owned labels.
+
+## 3. Verification
+
+- [x] 3.1 Confirm the default `/reports` view renders these exact page-owned labels: `Cost Report`, `Usage history by date range`, `Total Cost`, `Requests`, `Cost by Day`, `Tokens by Day`, `Distribution by Model`, `Daily Breakdown`, `Day`, `Input Tokens`, `Output Tokens`, `Cost`, and `Accounts`.
+- [x] 3.2 Confirm `/reports` state labels render these exact page-owned labels when each state is triggered: `Loading...`, `Failed to load report data:`, `Failed to load model options:`, `Failed to load account options:`, `Some report data could not be loaded. Try reloading.`, and `Retry`.
+- [x] 3.3 Confirm opening `/reports` loads data from `GET /api/reports`.
+- [x] 3.4 Confirm `/reports` exposes visible filter controls for start date, end date, account, and model.
+- [x] 3.5 Confirm changing the start date, end date, account, and model controls refetches `/api/reports` with `startDate`, `endDate`, `accountId`, and `model` parameter names.
+- [x] 3.6 Confirm untranslated backend-provided strings, account/model values, and raw server error payload text are not introduced as required English copy unless the page renders its own label around them.
+- [x] 3.7 Run `openspec validate translate-reports-ui-english --strict`.


### PR DESCRIPTION
## Summary

Translates all page-owned Portuguese UI labels on the `/reports` page to English for consistency with the rest of the dashboard.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue:

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/translate-reports-ui-english/`

## Changes

- `reports-page.tsx` — page title `Relatório de Custo` → `Cost Report`, subtitle → `Usage history by date range`, loading state → `Loading...`
- `reports-summary-cards.tsx` — `Custo Total` → `Total Cost`, `Requisições` → `Requests`, `/dia` → `/day`, `contas` → `accounts`
- `cost-per-day-chart.tsx` — `Custo por Dia` → `Cost by Day`, tooltip label `Custo` → `Cost`
- `tokens-per-day-chart.tsx` — `Tokens por Dia` → `Tokens by Day`
- `model-distribution-donut.tsx` — `Distribuição por Modelo` → `Distribution by Model`, tooltip label `Custo` → `Cost`
- `daily-detail-table.tsx` — `Detalhamento por Dia` → `Daily Breakdown`, column headers `Dia`/`Req`/`Tokens In`/`Tokens Out`/`Custo`/`Contas` → `Day`/`Reqs`/`Input Tokens`/`Output Tokens`/`Cost`/`Accounts`
- OpenSpec change added: `openspec/changes/translate-reports-ui-english/` (proposal, tasks, `frontend-architecture` delta spec)

## Test plan

```
# Visual verification — open /reports and confirm all labels are English
# No Portuguese text remains in any reports component
# Filter controls, API calls, and parameter names unchanged

uv run pytest tests/ -q -k report
```

## Screenshots / output (optional)

Before: Portuguese labels (`Relatório de Custo`, `Custo por Dia`, `Distribuição por Modelo`, etc.)
After: English labels (`Cost Report`, `Cost by Day`, `Distribution by Model`, etc.)

## Checklist

- [x] Title is in Conventional Commits format (`fix(report-ui): fix non-English content to English for consistency`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change. (visual/label-only change, verified via OpenSpec tasks)
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

<img width="1412" height="686" alt="螢幕截圖 2026-06-08 17 46 24" src="https://github.com/user-attachments/assets/df34186b-68c5-4570-876f-30e67eeaf953" />
<img width="1417" height="682" alt="螢幕截圖 2026-06-08 18 22 21" src="https://github.com/user-attachments/assets/a451c4c8-e97c-49fa-8bb9-b711a9bd0dde" />
