### PR TITLE
Draft: add Agent Load Balancer provider foundation

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -62,6 +62,7 @@ RoutingStrategy = Literal[
     "sequential_drain",
     "reset_drain",
     "single_account",
+    "ordered_fallback",
 ]
 TrafficClass = Literal["foreground", "opportunistic"]
 UsageWeightedOrder = Literal["secondary_first", "primary_first"]
@@ -370,6 +371,7 @@ def select_account(
     bypass_quota_exceeded_account_ids: Collection[str] | None = None,
     primary_first_usage_weighted: bool = False,
     routing_costs: RoutingCostsByAccount | None = None,
+    ordered_account_ids: Collection[str] | None = None,
 ) -> SelectionResult:
     """Select an eligible account by applying availability checks and routing strategy.
 
@@ -586,6 +588,12 @@ def select_account(
         selected = min(candidate_pool, key=lambda state: state.account_id)
         return SelectionResult(selected, None)
 
+    if routing_strategy == "ordered_fallback":
+        ordered_pool = _ordered_fallback_pool(available, ordered_account_ids)
+        if not ordered_pool:
+            return SelectionResult(None, "No ordered fallback accounts are available")
+        return SelectionResult(ordered_pool[0], None)
+
     if routing_strategy == "sequential_drain":
         candidate_pool = [state for state in available if not _usage_exhausted(state)]
         if not candidate_pool:
@@ -658,6 +666,31 @@ def select_account(
                 key=_reset_first_sort_key if effective_prefer_earlier_reset else _usage_sort_key_with_cost,
             )
     return SelectionResult(selected, None)
+
+
+def _ordered_fallback_pool(
+    available: Iterable[AccountState],
+    ordered_account_ids: Collection[str] | None,
+) -> list[AccountState]:
+    order = _normalized_ordered_account_ids(ordered_account_ids)
+    if not order:
+        return []
+    available_by_id = {
+        state.account_id: state for state in available if state.account_id in order and not _usage_exhausted(state)
+    }
+    return [available_by_id[account_id] for account_id in order if account_id in available_by_id]
+
+
+def _normalized_ordered_account_ids(ordered_account_ids: Collection[str] | None) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw_account_id in ordered_account_ids or ():
+        account_id = raw_account_id.strip()
+        if not account_id or account_id in seen:
+            continue
+        seen.add(account_id)
+        ordered.append(account_id)
+    return tuple(ordered)
 
 
 def _remaining_secondary_credits(state: AccountState) -> float:

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -35,6 +35,16 @@ class ProxyRateLimitError(AppError):
     code = "rate_limit_exceeded"
     error_type = "rate_limit_error"
 
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        retry_after: str | int | None = None,
+        code: str | None = None,
+    ) -> None:
+        self.retry_after = str(retry_after) if retry_after is not None else None
+        super().__init__(message, code=code)
+
 
 class ProxyUpstreamError(AppError):
     status_code = 503
@@ -77,3 +87,8 @@ class DashboardRateLimitError(AppError):
     def __init__(self, message: str, *, retry_after: int, code: str | None = None) -> None:
         self.retry_after = retry_after
         super().__init__(message, code=code)
+
+
+class DashboardUpstreamError(AppError):
+    status_code = 502
+    code = "upstream_error"

--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -19,6 +19,7 @@ from app.core.exceptions import (
     DashboardConflictError,
     DashboardNotFoundError,
     DashboardRateLimitError,
+    DashboardUpstreamError,
     DashboardValidationError,
     ProxyAuthError,
     ProxyModelNotAllowed,
@@ -43,6 +44,7 @@ _DASHBOARD_EXCEPTION_TYPES: tuple[type[AppError], ...] = (
     DashboardBadRequestError,
     DashboardValidationError,
     DashboardRateLimitError,
+    DashboardUpstreamError,
 )
 
 
@@ -67,6 +69,10 @@ def add_exception_handlers(app: FastAPI) -> None:
         @app.exception_handler(exc_cls)
         async def _openai_domain_handler(request: Request, exc: AppError) -> JSONResponse:
             error_type = getattr(exc, "error_type", "server_error")
+            headers: dict[str, str] | None = None
+            retry_after = getattr(exc, "retry_after", None)
+            if isinstance(retry_after, str) and retry_after:
+                headers = {"Retry-After": retry_after}
             log_error_response(
                 logger,
                 request,
@@ -78,6 +84,7 @@ def add_exception_handlers(app: FastAPI) -> None:
             return JSONResponse(
                 status_code=exc.status_code,
                 content=openai_error(exc.code, exc.message, error_type=error_type),
+                headers=headers,
             )
 
     # --- Domain exceptions: Dashboard envelope ---

--- a/app/db/alembic/versions/20260609_000000_add_agent_provider_accounts.py
+++ b/app/db/alembic/versions/20260609_000000_add_agent_provider_accounts.py
@@ -1,0 +1,90 @@
+"""add agent provider account storage
+
+Revision ID: 20260609_000000_add_agent_provider_accounts
+Revises: 20260607_000000_merge_weekly_monthly_useragent_heads
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260609_000000_add_agent_provider_accounts"
+down_revision = "20260607_000000_merge_weekly_monthly_useragent_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("agent_provider_accounts"):
+        op.create_table(
+            "agent_provider_accounts",
+            sa.Column("id", sa.String(), nullable=False),
+            sa.Column("provider_id", sa.String(), nullable=False),
+            sa.Column("external_account_id", sa.String(), nullable=True),
+            sa.Column("display_name", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), server_default=sa.text("'active'"), nullable=False),
+            sa.Column("auth_mode", sa.String(), nullable=False),
+            sa.Column("api_key_encrypted", sa.LargeBinary(), nullable=True),
+            sa.Column("credential_fingerprint", sa.String(), nullable=True),
+            sa.Column("project_id", sa.String(), nullable=True),
+            sa.Column("location", sa.String(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("provider_id", "external_account_id", name="uq_agent_provider_accounts_external"),
+            sa.UniqueConstraint("provider_id", "credential_fingerprint", name="uq_agent_provider_accounts_credential"),
+        )
+        op.create_index(
+            "idx_agent_provider_accounts_provider_status",
+            "agent_provider_accounts",
+            ["provider_id", "status", "display_name"],
+        )
+    if not inspector.has_table("agent_provider_quota_windows"):
+        op.create_table(
+            "agent_provider_quota_windows",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("account_id", sa.String(), nullable=False),
+            sa.Column("dimension", sa.String(), nullable=False),
+            sa.Column("used", sa.Integer(), server_default=sa.text("0"), nullable=False),
+            sa.Column("limit", sa.Integer(), nullable=True),
+            sa.Column("reset_at", sa.DateTime(), nullable=True),
+            sa.Column("recorded_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(["account_id"], ["agent_provider_accounts.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("account_id", "dimension", name="uq_agent_provider_quota_windows_account_dimension"),
+        )
+        op.create_index(
+            "idx_agent_provider_quota_windows_account_dimension",
+            "agent_provider_quota_windows",
+            ["account_id", "dimension"],
+        )
+    if not inspector.has_table("agent_provider_routing_settings"):
+        op.create_table(
+            "agent_provider_routing_settings",
+            sa.Column("provider_id", sa.String(), nullable=False),
+            sa.Column("strategy", sa.String(), server_default=sa.text("'capacity_weighted'"), nullable=False),
+            sa.Column("single_account_id", sa.String(), nullable=True),
+            sa.Column("quota_threshold_pct", sa.Float(), server_default=sa.text("100.0"), nullable=False),
+            sa.Column("round_robin_cursor", sa.String(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(["single_account_id"], ["agent_provider_accounts.id"], ondelete="SET NULL"),
+            sa.PrimaryKeyConstraint("provider_id"),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("agent_provider_routing_settings"):
+        op.drop_table("agent_provider_routing_settings")
+    if inspector.has_table("agent_provider_quota_windows"):
+        op.drop_index("idx_agent_provider_quota_windows_account_dimension", table_name="agent_provider_quota_windows")
+        op.drop_table("agent_provider_quota_windows")
+    if inspector.has_table("agent_provider_accounts"):
+        op.drop_index("idx_agent_provider_accounts_provider_status", table_name="agent_provider_accounts")
+        op.drop_table("agent_provider_accounts")

--- a/app/db/alembic/versions/20260609_010000_add_manual_account_priority.py
+++ b/app/db/alembic/versions/20260609_010000_add_manual_account_priority.py
@@ -1,0 +1,63 @@
+"""add manual account priority setting
+
+Revision ID: 20260609_010000_add_manual_account_priority
+Revises: 20260609_000000_add_agent_provider_accounts
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260609_010000_add_manual_account_priority"
+down_revision = "20260609_000000_add_agent_provider_accounts"
+branch_labels = None
+depends_on = None
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return set()
+    return {str(column["name"]) for column in inspector.get_columns(table_name) if column.get("name") is not None}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dashboard_columns = _columns(bind, "dashboard_settings")
+    if dashboard_columns and "manual_account_priority_ids_json" not in dashboard_columns:
+        with op.batch_alter_table("dashboard_settings") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "manual_account_priority_ids_json",
+                    sa.Text(),
+                    server_default=sa.text("'[]'"),
+                    nullable=False,
+                )
+            )
+    provider_columns = _columns(bind, "agent_provider_routing_settings")
+    if provider_columns and "ordered_account_ids_json" not in provider_columns:
+        with op.batch_alter_table("agent_provider_routing_settings") as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "ordered_account_ids_json",
+                    sa.Text(),
+                    server_default=sa.text("'[]'"),
+                    nullable=False,
+                )
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind, "dashboard_settings")
+    if "manual_account_priority_ids_json" not in columns:
+        pass
+    else:
+        with op.batch_alter_table("dashboard_settings") as batch_op:
+            batch_op.drop_column("manual_account_priority_ids_json")
+    if "ordered_account_ids_json" in _columns(bind, "agent_provider_routing_settings"):
+        with op.batch_alter_table("agent_provider_routing_settings") as batch_op:
+            batch_op.drop_column("ordered_account_ids_json")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -319,6 +319,99 @@ class AccountProxyBinding(Base):
     __table_args__ = (UniqueConstraint("account_id", name="uq_account_proxy_bindings_account"),)
 
 
+class AgentProviderAccount(Base):
+    __tablename__ = "agent_provider_accounts"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    provider_id: Mapped[str] = mapped_column(String, nullable=False)
+    external_account_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    display_name: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, default="active", server_default=text("'active'"), nullable=False)
+    auth_mode: Mapped[str] = mapped_column(String, nullable=False)
+    api_key_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    credential_fingerprint: Mapped[str | None] = mapped_column(String, nullable=True)
+    project_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    location: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    quota_windows: Mapped[list["AgentProviderQuotaWindow"]] = relationship(
+        "AgentProviderQuotaWindow",
+        back_populates="account",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        UniqueConstraint("provider_id", "external_account_id", name="uq_agent_provider_accounts_external"),
+        UniqueConstraint("provider_id", "credential_fingerprint", name="uq_agent_provider_accounts_credential"),
+        Index("idx_agent_provider_accounts_provider_status", "provider_id", "status", "display_name"),
+    )
+
+
+class AgentProviderRoutingSettings(Base):
+    __tablename__ = "agent_provider_routing_settings"
+
+    provider_id: Mapped[str] = mapped_column(String, primary_key=True)
+    strategy: Mapped[str] = mapped_column(
+        String,
+        default="capacity_weighted",
+        server_default=text("'capacity_weighted'"),
+        nullable=False,
+    )
+    single_account_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("agent_provider_accounts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    ordered_account_ids_json: Mapped[str] = mapped_column(
+        Text,
+        default="[]",
+        server_default=text("'[]'"),
+        nullable=False,
+    )
+    quota_threshold_pct: Mapped[float] = mapped_column(
+        Float,
+        default=100.0,
+        server_default=text("100.0"),
+        nullable=False,
+    )
+    round_robin_cursor: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class AgentProviderQuotaWindow(Base):
+    __tablename__ = "agent_provider_quota_windows"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    account_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("agent_provider_accounts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    dimension: Mapped[str] = mapped_column(String, nullable=False)
+    used: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default=text("0"))
+    limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    reset_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    recorded_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+
+    account: Mapped[AgentProviderAccount] = relationship("AgentProviderAccount", back_populates="quota_windows")
+
+    __table_args__ = (
+        UniqueConstraint("account_id", "dimension", name="uq_agent_provider_quota_windows_account_dimension"),
+        Index("idx_agent_provider_quota_windows_account_dimension", "account_id", "dimension"),
+    )
+
+
 class AccountLimitWarmup(Base):
     __tablename__ = "account_limit_warmups"
 
@@ -440,6 +533,12 @@ class DashboardSettings(Base):
         nullable=False,
     )
     single_account_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    manual_account_priority_ids_json: Mapped[str] = mapped_column(
+        Text,
+        default="[]",
+        server_default=text("'[]'"),
+        nullable=False,
+    )
     openai_cache_affinity_max_age_seconds: Mapped[int] = mapped_column(
         Integer,
         default=1800,

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -12,6 +12,18 @@ from app.db.session import get_background_session, get_session
 from app.modules.accounts.auth_manager import AuthManager
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.service import AccountsService
+from app.modules.agent_provider_accounts.repository import AgentProviderAccountsRepository
+from app.modules.agent_provider_accounts.service import AgentProviderAccountsService
+from app.modules.agent_provider_routing.repository import AgentProviderRoutingRepository
+from app.modules.agent_provider_routing.service import AgentProviderRoutingService
+from app.modules.agent_provider_runtime.service import (
+    AntigravityHarnessService,
+    AntigravityManagedAgentService,
+    ApiKeyUsagePort,
+    GeminiRuntimeService,
+    RequestLogWriterPort,
+)
+from app.modules.agent_providers.service import AgentProviderOverviewService
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeysService
 from app.modules.audit.repository import AuditRepository
@@ -48,6 +60,38 @@ class AccountsContext:
     session: AsyncSession
     repository: AccountsRepository
     service: AccountsService
+
+
+@dataclass(slots=True)
+class AgentProviderAccountsContext:
+    session: AsyncSession
+    repository: AgentProviderAccountsRepository
+    service: AgentProviderAccountsService
+
+
+@dataclass(slots=True)
+class AgentProviderRoutingContext:
+    session: AsyncSession
+    repository: AgentProviderRoutingRepository
+    service: AgentProviderRoutingService
+
+
+@dataclass(slots=True)
+class AgentProviderRuntimeContext:
+    session: AsyncSession
+    routing_repository: AgentProviderRoutingRepository
+    routing_service: AgentProviderRoutingService
+    api_keys_repository: ApiKeysRepository
+    request_logs_repository: RequestLogsRepository
+    gemini_service: GeminiRuntimeService
+    antigravity_service: AntigravityHarnessService
+    antigravity_managed_service: AntigravityManagedAgentService
+
+
+@dataclass(slots=True)
+class AgentProvidersContext:
+    session: AsyncSession
+    service: AgentProviderOverviewService
 
 
 @dataclass(slots=True)
@@ -156,6 +200,67 @@ def get_accounts_context(
         repository=repository,
         service=service,
     )
+
+
+def get_agent_provider_accounts_context(
+    session: AsyncSession = Depends(get_session),
+) -> AgentProviderAccountsContext:
+    repository = AgentProviderAccountsRepository(session)
+    service = AgentProviderAccountsService(repository)
+    return AgentProviderAccountsContext(session=session, repository=repository, service=service)
+
+
+def get_agent_provider_routing_context(
+    session: AsyncSession = Depends(get_session),
+) -> AgentProviderRoutingContext:
+    repository = AgentProviderRoutingRepository(session)
+    service = AgentProviderRoutingService(repository)
+    return AgentProviderRoutingContext(session=session, repository=repository, service=service)
+
+
+def get_agent_provider_runtime_context(
+    session: AsyncSession = Depends(get_session),
+) -> AgentProviderRuntimeContext:
+    routing_repository = AgentProviderRoutingRepository(session)
+    routing_service = AgentProviderRoutingService(routing_repository)
+    api_keys_repository = ApiKeysRepository(session)
+    request_logs_repository = RequestLogsRepository(session)
+    gemini_service = GeminiRuntimeService(
+        routing_service,
+        api_key_service=cast(ApiKeyUsagePort, ApiKeysService(api_keys_repository)),
+        request_logs=cast(RequestLogWriterPort, request_logs_repository),
+    )
+    antigravity_service = AntigravityHarnessService(
+        routing_service,
+        request_logs=cast(RequestLogWriterPort, request_logs_repository),
+    )
+    antigravity_managed_service = AntigravityManagedAgentService(
+        routing_service,
+        api_key_service=cast(ApiKeyUsagePort, ApiKeysService(api_keys_repository)),
+        request_logs=cast(RequestLogWriterPort, request_logs_repository),
+    )
+    return AgentProviderRuntimeContext(
+        session=session,
+        routing_repository=routing_repository,
+        routing_service=routing_service,
+        api_keys_repository=api_keys_repository,
+        request_logs_repository=request_logs_repository,
+        gemini_service=gemini_service,
+        antigravity_service=antigravity_service,
+        antigravity_managed_service=antigravity_managed_service,
+    )
+
+
+def get_agent_providers_context(
+    session: AsyncSession = Depends(get_session),
+) -> AgentProvidersContext:
+    service = AgentProviderOverviewService(
+        codex_accounts=AccountsRepository(session),
+        provider_accounts=AgentProviderAccountsRepository(session),
+        provider_routing=AgentProviderRoutingRepository(session),
+        request_logs=RequestLogsRepository(session),
+    )
+    return AgentProvidersContext(session=session, service=service)
 
 
 def get_audit_context(

--- a/app/main.py
+++ b/app/main.py
@@ -43,6 +43,10 @@ from app.core.resilience.memory_monitor import configure as configure_memory_mon
 from app.core.usage.refresh_scheduler import build_usage_refresh_scheduler
 from app.db.session import SessionLocal, close_db, init_background_db, init_db
 from app.modules.accounts import api as accounts_api
+from app.modules.agent_provider_accounts import api as agent_provider_accounts_api
+from app.modules.agent_provider_routing import api as agent_provider_routing_api
+from app.modules.agent_provider_runtime import api as agent_provider_runtime_api
+from app.modules.agent_providers import api as agent_providers_api
 from app.modules.api_keys import api as api_keys_api
 from app.modules.api_keys.reset_scheduler import build_api_key_limit_reset_scheduler
 from app.modules.audit import api as audit_api
@@ -394,6 +398,12 @@ def create_app() -> FastAPI:
     app.include_router(reports_api.router)
     app.include_router(conversation_archive_api.router)
     app.include_router(runtime_api.router)
+    app.include_router(agent_providers_api.router)
+    app.include_router(agent_provider_accounts_api.router)
+    app.include_router(agent_provider_routing_api.router)
+    app.include_router(agent_provider_runtime_api.router)
+    app.include_router(agent_provider_runtime_api.antigravity_router)
+    app.include_router(agent_provider_runtime_api.dashboard_router)
     app.include_router(oauth_api.router)
     app.include_router(dashboard_auth_api.router)
     app.include_router(settings_api.router)

--- a/app/modules/agent_provider_accounts/__init__.py
+++ b/app/modules/agent_provider_accounts/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-scoped account storage."""

--- a/app/modules/agent_provider_accounts/api.py
+++ b/app/modules/agent_provider_accounts/api.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi import APIRouter, Body, Depends
+
+from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.core.exceptions import DashboardBadRequestError, DashboardConflictError, DashboardNotFoundError
+from app.db.models import AgentProviderAccount
+from app.dependencies import AgentProviderAccountsContext, get_agent_provider_accounts_context
+from app.modules.agent_provider_accounts.schemas import (
+    AgentProviderAccountResponse,
+    AgentProviderAccountsResponse,
+    AgentProviderAccountUpdateRequest,
+    AntigravityProviderAccountCreateRequest,
+    GeminiProviderAccountCreateRequest,
+)
+from app.modules.agent_provider_accounts.service import (
+    AgentProviderAccountDuplicateError,
+    AgentProviderAccountNotFoundError,
+    AgentProviderAccountUpdateData,
+    AgentProviderAccountValidationError,
+    AntigravityProviderAccountCreateData,
+    GeminiProviderAccountCreateData,
+)
+from app.modules.agent_providers.schemas import AgentProviderId
+
+router = APIRouter(
+    prefix="/api/agent-providers",
+    tags=["agent-provider-accounts"],
+    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+)
+
+
+def _to_response(row: AgentProviderAccount) -> AgentProviderAccountResponse:
+    return AgentProviderAccountResponse(
+        account_id=row.id,
+        provider_id=cast(AgentProviderId, row.provider_id),
+        external_account_id=row.external_account_id,
+        display_name=row.display_name,
+        status=row.status,
+        auth_mode=row.auth_mode,
+        api_key_set=row.api_key_encrypted is not None,
+        credential_fingerprint=row.credential_fingerprint,
+        project_id=row.project_id,
+        location=row.location,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+@router.get("/{provider_id}/accounts", response_model=AgentProviderAccountsResponse)
+async def list_provider_accounts(
+    provider_id: str,
+    context: AgentProviderAccountsContext = Depends(get_agent_provider_accounts_context),
+) -> AgentProviderAccountsResponse:
+    try:
+        rows = await context.service.list_accounts(provider_id)
+    except AgentProviderAccountValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="unsupported_agent_provider") from exc
+    return AgentProviderAccountsResponse(accounts=[_to_response(row) for row in rows])
+
+
+@router.post("/gemini/accounts", response_model=AgentProviderAccountResponse)
+async def create_gemini_provider_account(
+    payload: GeminiProviderAccountCreateRequest = Body(...),
+    context: AgentProviderAccountsContext = Depends(get_agent_provider_accounts_context),
+) -> AgentProviderAccountResponse:
+    try:
+        row = await context.service.create_gemini_account(
+            GeminiProviderAccountCreateData(
+                display_name=payload.display_name,
+                api_key=payload.api_key,
+                external_account_id=payload.external_account_id,
+                project_id=payload.project_id,
+                location=payload.location,
+            )
+        )
+    except AgentProviderAccountValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_agent_provider_account") from exc
+    except AgentProviderAccountDuplicateError as exc:
+        raise DashboardConflictError(str(exc), code="duplicate_agent_provider_account") from exc
+    return _to_response(row)
+
+
+@router.post("/antigravity/accounts", response_model=AgentProviderAccountResponse)
+async def create_antigravity_provider_account(
+    payload: AntigravityProviderAccountCreateRequest = Body(...),
+    context: AgentProviderAccountsContext = Depends(get_agent_provider_accounts_context),
+) -> AgentProviderAccountResponse:
+    try:
+        row = await context.service.create_antigravity_account(
+            AntigravityProviderAccountCreateData(
+                display_name=payload.display_name,
+                external_account_id=payload.external_account_id,
+                auth_mode=payload.auth_mode,
+                api_key=payload.api_key,
+                project_id=payload.project_id,
+                location=payload.location,
+            )
+        )
+    except AgentProviderAccountValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_agent_provider_account") from exc
+    except AgentProviderAccountDuplicateError as exc:
+        raise DashboardConflictError(str(exc), code="duplicate_agent_provider_account") from exc
+    return _to_response(row)
+
+
+@router.patch("/{provider_id}/accounts/{account_id}", response_model=AgentProviderAccountResponse)
+async def update_provider_account(
+    provider_id: str,
+    account_id: str,
+    payload: AgentProviderAccountUpdateRequest = Body(...),
+    context: AgentProviderAccountsContext = Depends(get_agent_provider_accounts_context),
+) -> AgentProviderAccountResponse:
+    try:
+        row = await context.service.update_account(
+            provider_id,
+            account_id,
+            AgentProviderAccountUpdateData(
+                display_name=payload.display_name,
+                status=payload.status,
+                api_key=payload.api_key,
+                external_account_id=payload.external_account_id,
+                project_id=payload.project_id,
+                project_id_set="project_id" in payload.model_fields_set,
+                location=payload.location,
+                location_set="location" in payload.model_fields_set,
+            ),
+        )
+    except AgentProviderAccountNotFoundError as exc:
+        raise DashboardNotFoundError(str(exc), code="agent_provider_account_not_found") from exc
+    except AgentProviderAccountValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_agent_provider_account") from exc
+    except AgentProviderAccountDuplicateError as exc:
+        raise DashboardConflictError(str(exc), code="duplicate_agent_provider_account") from exc
+    return _to_response(row)

--- a/app/modules/agent_provider_accounts/repository.py
+++ b/app/modules/agent_provider_accounts/repository.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import AgentProviderAccount
+
+
+class AgentProviderAccountConflictError(Exception):
+    pass
+
+
+class AgentProviderAccountsRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_by_provider(self, provider_id: str) -> list[AgentProviderAccount]:
+        result = await self._session.execute(
+            select(AgentProviderAccount)
+            .where(AgentProviderAccount.provider_id == provider_id)
+            .order_by(AgentProviderAccount.display_name, AgentProviderAccount.id)
+        )
+        return list(result.scalars().all())
+
+    async def get_for_provider(self, provider_id: str, account_id: str) -> AgentProviderAccount | None:
+        result = await self._session.execute(
+            select(AgentProviderAccount).where(
+                AgentProviderAccount.provider_id == provider_id,
+                AgentProviderAccount.id == account_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create(self, row: AgentProviderAccount) -> AgentProviderAccount:
+        self._session.add(row)
+        try:
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise AgentProviderAccountConflictError from exc
+        await self._session.refresh(row)
+        return row
+
+    async def save(self, row: AgentProviderAccount) -> AgentProviderAccount:
+        self._session.add(row)
+        try:
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise AgentProviderAccountConflictError from exc
+        await self._session.refresh(row)
+        return row

--- a/app/modules/agent_provider_accounts/schemas.py
+++ b/app/modules/agent_provider_accounts/schemas.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import Field
+
+from app.modules.agent_providers.schemas import AgentProviderId
+from app.modules.shared.schemas import DashboardModel
+
+
+class AgentProviderAccountResponse(DashboardModel):
+    account_id: str
+    provider_id: AgentProviderId
+    external_account_id: str | None = None
+    display_name: str
+    status: str
+    auth_mode: str
+    api_key_set: bool
+    credential_fingerprint: str | None = None
+    project_id: str | None = None
+    location: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentProviderAccountsResponse(DashboardModel):
+    accounts: list[AgentProviderAccountResponse] = Field(default_factory=list)
+
+
+class GeminiProviderAccountCreateRequest(DashboardModel):
+    display_name: str = Field(min_length=1, max_length=120)
+    api_key: str = Field(min_length=1, max_length=4096)
+    external_account_id: str | None = Field(default=None, max_length=255)
+    project_id: str | None = Field(default=None, max_length=255)
+    location: str | None = Field(default=None, max_length=255)
+
+
+class AntigravityProviderAccountCreateRequest(DashboardModel):
+    display_name: str = Field(min_length=1, max_length=120)
+    auth_mode: str | None = Field(default=None, pattern=r"^(api_key|cli_keyring)$")
+    api_key: str | None = Field(default=None, min_length=1, max_length=4096)
+    external_account_id: str | None = Field(default=None, max_length=255)
+    project_id: str | None = Field(default=None, max_length=255)
+    location: str | None = Field(default=None, max_length=255)
+
+
+class AgentProviderAccountUpdateRequest(DashboardModel):
+    display_name: str | None = Field(default=None, min_length=1, max_length=120)
+    status: str | None = Field(default=None, pattern=r"^(active|paused)$")
+    api_key: str | None = Field(default=None, min_length=1, max_length=4096)
+    external_account_id: str | None = Field(default=None, max_length=255)
+    project_id: str | None = Field(default=None, max_length=255)
+    location: str | None = Field(default=None, max_length=255)

--- a/app/modules/agent_provider_accounts/service.py
+++ b/app/modules/agent_provider_accounts/service.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Protocol
+
+from app.core.crypto import TokenEncryptor
+from app.db.models import AgentProviderAccount
+from app.modules.agent_provider_accounts.repository import (
+    AgentProviderAccountConflictError,
+)
+
+SUPPORTED_PROVIDER_IDS = {"codex", "gemini", "antigravity"}
+
+
+class AgentProviderAccountValidationError(Exception):
+    pass
+
+
+class AgentProviderAccountDuplicateError(Exception):
+    pass
+
+
+class AgentProviderAccountNotFoundError(Exception):
+    pass
+
+
+class AgentProviderAccountsRepositoryPort(Protocol):
+    async def list_by_provider(self, provider_id: str) -> list[AgentProviderAccount]: ...
+
+    async def get_for_provider(self, provider_id: str, account_id: str) -> AgentProviderAccount | None: ...
+
+    async def create(self, row: AgentProviderAccount) -> AgentProviderAccount: ...
+
+    async def save(self, row: AgentProviderAccount) -> AgentProviderAccount: ...
+
+
+class TokenEncryptorPort(Protocol):
+    def encrypt(self, token: str) -> bytes: ...
+
+
+@dataclass(frozen=True, slots=True)
+class GeminiProviderAccountCreateData:
+    display_name: str
+    api_key: str
+    external_account_id: str | None = None
+    project_id: str | None = None
+    location: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AntigravityProviderAccountCreateData:
+    display_name: str
+    external_account_id: str | None = None
+    auth_mode: str | None = None
+    api_key: str | None = None
+    project_id: str | None = None
+    location: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProviderAccountUpdateData:
+    display_name: str | None = None
+    status: str | None = None
+    api_key: str | None = None
+    external_account_id: str | None = None
+    project_id: str | None = None
+    project_id_set: bool = False
+    location: str | None = None
+    location_set: bool = False
+
+
+class AgentProviderAccountsService:
+    def __init__(
+        self,
+        repository: AgentProviderAccountsRepositoryPort,
+        *,
+        encryptor: TokenEncryptorPort | None = None,
+    ) -> None:
+        self._repository = repository
+        self._encryptor = encryptor or TokenEncryptor()
+
+    async def list_accounts(self, provider_id: str) -> list[AgentProviderAccount]:
+        provider = _normalize_provider_id(provider_id)
+        return await self._repository.list_by_provider(provider)
+
+    async def create_gemini_account(self, payload: GeminiProviderAccountCreateData) -> AgentProviderAccount:
+        display_name = payload.display_name.strip()
+        api_key = payload.api_key.strip()
+        if not display_name:
+            raise AgentProviderAccountValidationError("display_name is required")
+        if not api_key:
+            raise AgentProviderAccountValidationError("api_key is required")
+        row = AgentProviderAccount(
+            provider_id="gemini",
+            external_account_id=_clean_optional(payload.external_account_id),
+            display_name=display_name,
+            status="active",
+            auth_mode="api_key",
+            api_key_encrypted=self._encryptor.encrypt(api_key),
+            credential_fingerprint=_credential_fingerprint(api_key),
+            project_id=_clean_optional(payload.project_id),
+            location=_clean_optional(payload.location),
+        )
+        try:
+            return await self._repository.create(row)
+        except AgentProviderAccountConflictError as exc:
+            raise AgentProviderAccountDuplicateError("Gemini provider account already exists") from exc
+
+    async def create_antigravity_account(
+        self,
+        payload: AntigravityProviderAccountCreateData,
+    ) -> AgentProviderAccount:
+        display_name = payload.display_name.strip()
+        auth_mode = _normalize_antigravity_auth_mode(payload.auth_mode, payload.api_key)
+        if not display_name:
+            raise AgentProviderAccountValidationError("display_name is required")
+        external_account_id = _clean_optional(payload.external_account_id)
+        api_key = _clean_optional(payload.api_key)
+        if auth_mode == "cli_keyring" and api_key is not None:
+            raise AgentProviderAccountValidationError("api_key is not allowed for cli_keyring accounts")
+        if auth_mode == "cli_keyring" and external_account_id is None:
+            raise AgentProviderAccountValidationError("external_account_id is required")
+        if auth_mode == "api_key" and api_key is None:
+            raise AgentProviderAccountValidationError("api_key is required")
+        row = AgentProviderAccount(
+            provider_id="antigravity",
+            external_account_id=external_account_id,
+            display_name=display_name,
+            status="active",
+            auth_mode=auth_mode,
+            api_key_encrypted=None if api_key is None else self._encryptor.encrypt(api_key),
+            credential_fingerprint=(
+                _credential_fingerprint(api_key)
+                if api_key is not None
+                else _credential_fingerprint(f"antigravity:{external_account_id}")
+            ),
+            project_id=_clean_optional(payload.project_id),
+            location=_clean_optional(payload.location),
+        )
+        try:
+            return await self._repository.create(row)
+        except AgentProviderAccountConflictError as exc:
+            raise AgentProviderAccountDuplicateError("Antigravity provider account already exists") from exc
+
+    async def update_account(
+        self,
+        provider_id: str,
+        account_id: str,
+        payload: AgentProviderAccountUpdateData,
+    ) -> AgentProviderAccount:
+        provider = _normalize_provider_id(provider_id)
+        row = await self._repository.get_for_provider(provider, account_id)
+        if row is None:
+            raise AgentProviderAccountNotFoundError("provider account not found")
+        if payload.display_name is not None:
+            row.display_name = _required_text(payload.display_name, "display_name")
+        if payload.status is not None:
+            row.status = _normalize_status(payload.status)
+        if payload.project_id is not None or payload.project_id_set:
+            row.project_id = _clean_optional(payload.project_id)
+        if payload.location is not None or payload.location_set:
+            row.location = _clean_optional(payload.location)
+        if payload.external_account_id is not None:
+            row.external_account_id = _clean_optional(payload.external_account_id)
+            if provider == "antigravity" and row.auth_mode == "cli_keyring" and row.external_account_id is None:
+                raise AgentProviderAccountValidationError("external_account_id is required")
+            if provider == "antigravity" and row.auth_mode == "cli_keyring" and row.external_account_id is not None:
+                row.credential_fingerprint = _credential_fingerprint(f"antigravity:{row.external_account_id}")
+        if payload.api_key is not None:
+            if provider == "antigravity" and row.auth_mode != "api_key":
+                raise AgentProviderAccountValidationError(
+                    "api_key can only be updated for Antigravity API-key accounts"
+                )
+            if provider not in {"gemini", "antigravity"}:
+                raise AgentProviderAccountValidationError("api_key can only be updated for API-key accounts")
+            api_key = _required_text(payload.api_key, "api_key")
+            row.api_key_encrypted = self._encryptor.encrypt(api_key)
+            row.credential_fingerprint = _credential_fingerprint(api_key)
+        try:
+            return await self._repository.save(row)
+        except AgentProviderAccountConflictError as exc:
+            raise AgentProviderAccountDuplicateError("Provider account already exists") from exc
+
+
+def _normalize_provider_id(provider_id: str) -> str:
+    normalized = provider_id.strip().lower()
+    if normalized not in SUPPORTED_PROVIDER_IDS:
+        raise AgentProviderAccountValidationError(f"Unsupported provider '{provider_id}'")
+    return normalized
+
+
+def _clean_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _required_text(value: str, field_name: str) -> str:
+    cleaned = value.strip()
+    if not cleaned:
+        raise AgentProviderAccountValidationError(f"{field_name} is required")
+    return cleaned
+
+
+def _normalize_status(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized not in {"active", "paused"}:
+        raise AgentProviderAccountValidationError("status must be active or paused")
+    return normalized
+
+
+def _normalize_antigravity_auth_mode(auth_mode: str | None, api_key: str | None) -> str:
+    if auth_mode is None:
+        return "api_key" if _clean_optional(api_key) is not None else "cli_keyring"
+    normalized = auth_mode.strip().lower()
+    if normalized not in {"api_key", "cli_keyring"}:
+        raise AgentProviderAccountValidationError("auth_mode must be api_key or cli_keyring")
+    return normalized
+
+
+def _credential_fingerprint(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()

--- a/app/modules/agent_provider_routing/__init__.py
+++ b/app/modules/agent_provider_routing/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-scoped account routing and preflight."""

--- a/app/modules/agent_provider_routing/api.py
+++ b/app/modules/agent_provider_routing/api.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi import APIRouter, Body, Depends
+
+from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.core.exceptions import DashboardBadRequestError, DashboardNotFoundError
+from app.db.models import AgentProviderAccount, AgentProviderQuotaWindow, AgentProviderRoutingSettings
+from app.dependencies import AgentProviderRoutingContext, get_agent_provider_routing_context
+from app.modules.agent_provider_routing.schemas import (
+    AgentProviderPreflightAccountState,
+    AgentProviderPreflightResponse,
+    AgentProviderQuotaWindowResponse,
+    AgentProviderQuotaWindowUpsertRequest,
+    AgentProviderRoutingSettingsResponse,
+    AgentProviderRoutingSettingsUpdateRequest,
+    ProviderRoutingStrategy,
+)
+from app.modules.agent_provider_routing.service import (
+    AgentProviderQuotaWindowUpsertData,
+    AgentProviderRoutingNotFoundError,
+    AgentProviderRoutingSettingsUpdateData,
+    AgentProviderRoutingValidationError,
+)
+from app.modules.agent_providers.schemas import AgentProviderId
+
+router = APIRouter(
+    prefix="/api/agent-providers",
+    tags=["agent-provider-routing"],
+    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+)
+
+
+def _settings_response(row: AgentProviderRoutingSettings) -> AgentProviderRoutingSettingsResponse:
+    return AgentProviderRoutingSettingsResponse(
+        provider_id=cast(AgentProviderId, row.provider_id),
+        strategy=cast(ProviderRoutingStrategy, row.strategy),
+        single_account_id=row.single_account_id,
+        ordered_account_ids=_parse_account_id_order(row.ordered_account_ids_json),
+        quota_threshold_pct=row.quota_threshold_pct,
+        round_robin_cursor=row.round_robin_cursor,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _quota_window_response(row: AgentProviderQuotaWindow) -> AgentProviderQuotaWindowResponse:
+    return AgentProviderQuotaWindowResponse(
+        dimension=row.dimension,
+        used=row.used,
+        limit=row.limit,
+        reset_at=row.reset_at,
+        recorded_at=row.recorded_at,
+    )
+
+
+def _account_state_response(row: AgentProviderAccount) -> AgentProviderPreflightAccountState:
+    return AgentProviderPreflightAccountState(
+        account_id=row.id,
+        display_name=row.display_name,
+        status=row.status,
+        quota_windows=[_quota_window_response(window) for window in row.quota_windows],
+    )
+
+
+@router.get("/{provider_id}/routing/settings", response_model=AgentProviderRoutingSettingsResponse)
+async def get_provider_routing_settings(
+    provider_id: str,
+    context: AgentProviderRoutingContext = Depends(get_agent_provider_routing_context),
+) -> AgentProviderRoutingSettingsResponse:
+    try:
+        row = await context.service.get_settings(provider_id)
+    except AgentProviderRoutingValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="unsupported_agent_provider") from exc
+    return _settings_response(row)
+
+
+@router.patch("/{provider_id}/routing/settings", response_model=AgentProviderRoutingSettingsResponse)
+async def update_provider_routing_settings(
+    provider_id: str,
+    payload: AgentProviderRoutingSettingsUpdateRequest = Body(...),
+    context: AgentProviderRoutingContext = Depends(get_agent_provider_routing_context),
+) -> AgentProviderRoutingSettingsResponse:
+    try:
+        row = await context.service.update_settings(
+            provider_id,
+            AgentProviderRoutingSettingsUpdateData(
+                strategy=payload.strategy,
+                single_account_id=payload.single_account_id,
+                single_account_id_set="single_account_id" in payload.model_fields_set,
+                ordered_account_ids=None if payload.ordered_account_ids is None else tuple(payload.ordered_account_ids),
+                quota_threshold_pct=payload.quota_threshold_pct,
+                round_robin_cursor=payload.round_robin_cursor,
+            ),
+        )
+    except AgentProviderRoutingValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_agent_provider_routing") from exc
+    return _settings_response(row)
+
+
+@router.put(
+    "/{provider_id}/accounts/{account_id}/quota-windows/{dimension}",
+    response_model=AgentProviderQuotaWindowResponse,
+)
+async def upsert_provider_quota_window(
+    provider_id: str,
+    account_id: str,
+    dimension: str,
+    payload: AgentProviderQuotaWindowUpsertRequest = Body(...),
+    context: AgentProviderRoutingContext = Depends(get_agent_provider_routing_context),
+) -> AgentProviderQuotaWindowResponse:
+    if payload.dimension != dimension:
+        raise DashboardBadRequestError("dimension path and body must match", code="invalid_agent_provider_quota")
+    try:
+        row = await context.service.upsert_quota_window(
+            provider_id,
+            account_id,
+            AgentProviderQuotaWindowUpsertData(
+                dimension=payload.dimension,
+                used=payload.used,
+                limit=payload.limit,
+                reset_at=payload.reset_at,
+            ),
+        )
+    except AgentProviderRoutingNotFoundError as exc:
+        raise DashboardNotFoundError(str(exc), code="agent_provider_account_not_found") from exc
+    except AgentProviderRoutingValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_agent_provider_quota") from exc
+    return _quota_window_response(row)
+
+
+@router.post("/{provider_id}/routing/preflight", response_model=AgentProviderPreflightResponse)
+async def preflight_provider_routing(
+    provider_id: str,
+    context: AgentProviderRoutingContext = Depends(get_agent_provider_routing_context),
+) -> AgentProviderPreflightResponse:
+    try:
+        preflight = await context.service.preflight(provider_id)
+    except AgentProviderRoutingValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="unsupported_agent_provider") from exc
+    return AgentProviderPreflightResponse(
+        provider_id=cast(AgentProviderId, preflight.provider_id),
+        selected_account_id=preflight.selected_account_id,
+        denied_reason=preflight.denied_reason,
+        candidate_account_ids=list(preflight.candidate_account_ids),
+        settings=_settings_response(preflight.settings),
+        accounts=[_account_state_response(account) for account in preflight.accounts],
+    )
+
+
+def _parse_account_id_order(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    import json
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw_account_id in parsed:
+        if not isinstance(raw_account_id, str):
+            continue
+        account_id = raw_account_id.strip()
+        if not account_id or account_id in seen:
+            continue
+        seen.add(account_id)
+        ordered.append(account_id)
+    return ordered

--- a/app/modules/agent_provider_routing/logic.py
+++ b/app/modules/agent_provider_routing/logic.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+ProviderRoutingStrategy = Literal[
+    "capacity_weighted",
+    "round_robin",
+    "sequential_drain",
+    "reset_drain",
+    "single_account",
+    "ordered_fallback",
+]
+
+SECONDS_PER_DAY = 24 * 60 * 60
+UNKNOWN_RESET_BUCKET_DAYS = 10_000
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderQuotaWindow:
+    dimension: str
+    used: int
+    limit: int | None
+    reset_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderAccountRoutingState:
+    account_id: str
+    status: str
+    quota_windows: tuple[ProviderQuotaWindow, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRoutingSettings:
+    strategy: ProviderRoutingStrategy = "capacity_weighted"
+    single_account_id: str | None = None
+    ordered_account_ids: tuple[str, ...] = field(default_factory=tuple)
+    quota_threshold_pct: float = 100.0
+    round_robin_cursor: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSelectionResult:
+    account_id: str | None
+    denied_reason: str | None
+    candidate_account_ids: tuple[str, ...]
+
+
+def select_provider_account(
+    states: list[ProviderAccountRoutingState],
+    settings: ProviderRoutingSettings,
+    *,
+    now: datetime | None = None,
+) -> ProviderSelectionResult:
+    current = now or datetime.now(timezone.utc)
+    active = [state for state in states if state.status == "active"]
+    if not active:
+        return ProviderSelectionResult(None, "no_active_provider_accounts", ())
+
+    scoped = _scope_single_account(active, settings)
+    if not scoped:
+        return ProviderSelectionResult(None, "single_account_unavailable", ())
+
+    budget_safe = [state for state in scoped if _within_budget(state, settings.quota_threshold_pct, current)]
+    if not budget_safe:
+        return ProviderSelectionResult(
+            None,
+            "provider_quota_budget_exhausted",
+            tuple(state.account_id for state in scoped),
+        )
+    if settings.strategy == "ordered_fallback":
+        if not settings.ordered_account_ids:
+            return ProviderSelectionResult(
+                None,
+                "ordered_fallback_not_configured",
+                tuple(state.account_id for state in budget_safe),
+            )
+        ordered_candidate_ids = {state.account_id for state in budget_safe}
+        if not any(account_id in ordered_candidate_ids for account_id in settings.ordered_account_ids):
+            return ProviderSelectionResult(
+                None,
+                "ordered_fallback_unavailable",
+                tuple(state.account_id for state in budget_safe),
+            )
+
+    selected = _select_from_budget_safe(budget_safe, settings, current)
+    return ProviderSelectionResult(
+        selected.account_id,
+        None,
+        tuple(state.account_id for state in budget_safe),
+    )
+
+
+def _scope_single_account(
+    states: list[ProviderAccountRoutingState],
+    settings: ProviderRoutingSettings,
+) -> list[ProviderAccountRoutingState]:
+    if settings.strategy != "single_account":
+        return states
+    if not settings.single_account_id:
+        return []
+    return [state for state in states if state.account_id == settings.single_account_id]
+
+
+def _select_from_budget_safe(
+    states: list[ProviderAccountRoutingState],
+    settings: ProviderRoutingSettings,
+    now: datetime,
+) -> ProviderAccountRoutingState:
+    if settings.strategy == "ordered_fallback":
+        ordered_state = _select_ordered_fallback(states, settings.ordered_account_ids)
+        if ordered_state is not None:
+            return ordered_state
+    if settings.strategy == "round_robin":
+        return min(
+            states,
+            key=lambda state: (_round_robin_after_cursor(state, settings.round_robin_cursor), state.account_id),
+        )
+    if settings.strategy == "sequential_drain":
+        return min(
+            states,
+            key=lambda state: (_total_limit(state), _stable_tie_breaker(state.account_id), state.account_id),
+        )
+    if settings.strategy == "reset_drain":
+        return min(states, key=lambda state: _reset_drain_key(state, now))
+    if settings.strategy == "single_account":
+        return states[0]
+    return max(
+        states,
+        key=lambda state: (_remaining_capacity(state, now), _stable_tie_breaker(state.account_id), state.account_id),
+    )
+
+
+def _select_ordered_fallback(
+    states: list[ProviderAccountRoutingState],
+    ordered_account_ids: tuple[str, ...],
+) -> ProviderAccountRoutingState | None:
+    if not ordered_account_ids:
+        return None
+    by_id = {state.account_id: state for state in states}
+    for account_id in ordered_account_ids:
+        state = by_id.get(account_id)
+        if state is not None:
+            return state
+    return None
+
+
+def _within_budget(state: ProviderAccountRoutingState, threshold_pct: float, now: datetime) -> bool:
+    if not state.quota_windows:
+        return True
+    for window in state.quota_windows:
+        if window.limit is None or window.limit <= 0:
+            continue
+        used_pct = (_effective_used(window, now) / window.limit) * 100.0
+        if used_pct >= threshold_pct:
+            return False
+    return True
+
+
+def _remaining_capacity(state: ProviderAccountRoutingState, now: datetime | None = None) -> int:
+    if not state.quota_windows:
+        return 1
+    current = now or datetime.now(timezone.utc)
+    remaining = 0
+    for window in state.quota_windows:
+        if window.limit is None or window.limit <= 0:
+            continue
+        remaining += max(0, window.limit - _effective_used(window, current))
+    return max(remaining, 1)
+
+
+def _total_limit(state: ProviderAccountRoutingState) -> int:
+    total = sum(max(0, window.limit or 0) for window in state.quota_windows)
+    return total if total > 0 else 1
+
+
+def _reset_drain_key(state: ProviderAccountRoutingState, now: datetime) -> tuple[int, int, float, str, str]:
+    reset_at = _nearest_reset_at(state)
+    reset_bucket_days = UNKNOWN_RESET_BUCKET_DAYS
+    reset_timestamp = float("inf")
+    if reset_at is not None:
+        reset_timestamp = reset_at.timestamp()
+        reset_bucket_days = max(0, int((reset_timestamp - now.timestamp()) // SECONDS_PER_DAY))
+    return (
+        reset_bucket_days,
+        -_remaining_capacity(state, now),
+        reset_timestamp,
+        _stable_tie_breaker(state.account_id),
+        state.account_id,
+    )
+
+
+def _nearest_reset_at(state: ProviderAccountRoutingState) -> datetime | None:
+    known = [window.reset_at for window in state.quota_windows if window.reset_at is not None]
+    return min(known) if known else None
+
+
+def _effective_used(window: ProviderQuotaWindow, now: datetime) -> int:
+    if window.reset_at is not None and _is_expired(window.reset_at, now):
+        return 0
+    return window.used
+
+
+def _is_expired(reset_at: datetime, now: datetime) -> bool:
+    if reset_at.tzinfo is None:
+        return reset_at <= now.replace(tzinfo=None)
+    return reset_at <= now
+
+
+def _round_robin_after_cursor(state: ProviderAccountRoutingState, cursor: str | None) -> int:
+    if cursor is None:
+        return 0
+    return 1 if state.account_id > cursor else 2
+
+
+def _stable_tie_breaker(account_id: str) -> str:
+    return hashlib.sha256(account_id.encode("utf-8")).hexdigest()

--- a/app/modules/agent_provider_routing/repository.py
+++ b/app/modules/agent_provider_routing/repository.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.db.models import AgentProviderAccount, AgentProviderQuotaWindow, AgentProviderRoutingSettings
+from app.modules.agent_provider_routing.settlement import AgentProviderUsageSettlementData
+
+
+class AgentProviderRoutingRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_or_create_settings(self, provider_id: str) -> AgentProviderRoutingSettings:
+        row = await self._session.get(AgentProviderRoutingSettings, provider_id)
+        if row is not None:
+            return row
+        row = AgentProviderRoutingSettings(provider_id=provider_id)
+        self._session.add(row)
+        try:
+            await self._session.commit()
+        except IntegrityError:
+            await self._session.rollback()
+            existing = await self._session.get(AgentProviderRoutingSettings, provider_id)
+            if existing is None:
+                raise
+            return existing
+        await self._session.refresh(row)
+        return row
+
+    async def save_settings(self, row: AgentProviderRoutingSettings) -> AgentProviderRoutingSettings:
+        self._session.add(row)
+        await self._session.commit()
+        await self._session.refresh(row)
+        return row
+
+    async def advance_round_robin_cursor(
+        self,
+        provider_id: str,
+        *,
+        expected_cursor: str | None,
+        selected_account_id: str,
+    ) -> bool:
+        cursor_condition = (
+            AgentProviderRoutingSettings.round_robin_cursor.is_(None)
+            if expected_cursor is None
+            else AgentProviderRoutingSettings.round_robin_cursor == expected_cursor
+        )
+        result = await self._session.execute(
+            update(AgentProviderRoutingSettings)
+            .where(
+                AgentProviderRoutingSettings.provider_id == provider_id,
+                cursor_condition,
+            )
+            .values(round_robin_cursor=selected_account_id)
+            .execution_options(synchronize_session=False)
+        )
+        rowcount = cast(Any, result).rowcount
+        await self._session.commit()
+        if rowcount == 0:
+            self._session.expire_all()
+        return rowcount > 0
+
+    async def list_accounts_with_quota_windows(self, provider_id: str) -> list[AgentProviderAccount]:
+        result = await self._session.execute(
+            select(AgentProviderAccount)
+            .where(AgentProviderAccount.provider_id == provider_id)
+            .options(selectinload(AgentProviderAccount.quota_windows))
+            .order_by(AgentProviderAccount.display_name, AgentProviderAccount.id)
+        )
+        return list(result.scalars().all())
+
+    async def get_account_for_provider(self, provider_id: str, account_id: str) -> AgentProviderAccount | None:
+        result = await self._session.execute(
+            select(AgentProviderAccount)
+            .where(AgentProviderAccount.provider_id == provider_id, AgentProviderAccount.id == account_id)
+            .options(selectinload(AgentProviderAccount.quota_windows))
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert_quota_window(
+        self,
+        *,
+        account: AgentProviderAccount,
+        dimension: str,
+        used: int,
+        limit: int | None,
+        reset_at,
+    ) -> AgentProviderQuotaWindow:
+        existing = next((window for window in account.quota_windows if window.dimension == dimension), None)
+        if existing is None:
+            existing = AgentProviderQuotaWindow(account_id=account.id, dimension=dimension)
+            self._session.add(existing)
+        existing.used = used
+        existing.limit = limit
+        existing.reset_at = reset_at
+        await self._session.commit()
+        await self._session.refresh(existing)
+        return existing
+
+    async def increment_quota_windows(
+        self,
+        account: AgentProviderAccount,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        changed = False
+        for window in account.quota_windows:
+            delta = _delta_for_dimension(window.dimension, usage)
+            if delta <= 0:
+                continue
+            if window.reset_at is not None and _is_expired(window.reset_at, now):
+                result = await self._session.execute(
+                    update(AgentProviderQuotaWindow)
+                    .where(
+                        AgentProviderQuotaWindow.id == window.id,
+                        AgentProviderQuotaWindow.reset_at == window.reset_at,
+                    )
+                    .values(
+                        used=delta,
+                        reset_at=_advance_reset_at(window.reset_at, now, window.dimension),
+                    )
+                    .execution_options(synchronize_session=False)
+                )
+                if cast(Any, result).rowcount == 0:
+                    await self._session.execute(
+                        update(AgentProviderQuotaWindow)
+                        .where(AgentProviderQuotaWindow.id == window.id)
+                        .values(used=AgentProviderQuotaWindow.used + delta)
+                        .execution_options(synchronize_session=False)
+                    )
+            else:
+                await self._session.execute(
+                    update(AgentProviderQuotaWindow)
+                    .where(AgentProviderQuotaWindow.id == window.id)
+                    .values(used=AgentProviderQuotaWindow.used + delta)
+                    .execution_options(synchronize_session=False)
+                )
+            changed = True
+        if changed:
+            await self._session.commit()
+
+
+def _delta_for_dimension(dimension: str, usage: AgentProviderUsageSettlementData) -> int:
+    normalized = dimension.strip().lower()
+    if normalized in {"requests", "request_count"} or normalized.startswith("requests_per_"):
+        return usage.requests
+    if normalized in {"input_tokens", "prompt_tokens"}:
+        return usage.prompt_tokens or 0
+    if normalized in {"output_tokens", "completion_tokens", "candidate_tokens", "candidates_tokens"}:
+        return usage.completion_tokens or 0
+    if normalized in {"tokens", "total_tokens"}:
+        return usage.total_tokens or 0
+    return 0
+
+
+def _is_expired(reset_at: datetime, now: datetime) -> bool:
+    if reset_at.tzinfo is None:
+        return reset_at <= now.replace(tzinfo=None)
+    return reset_at <= now
+
+
+def _advance_reset_at(reset_at: datetime, now: datetime, dimension: str) -> datetime:
+    interval = _reset_interval_for_dimension(dimension)
+    compare_now = now.replace(tzinfo=None) if reset_at.tzinfo is None else now
+    advanced = reset_at
+    while advanced <= compare_now:
+        advanced += interval
+    return advanced
+
+
+def _reset_interval_for_dimension(dimension: str) -> timedelta:
+    normalized = dimension.lower()
+    if "minute" in normalized:
+        return timedelta(minutes=1)
+    if "hour" in normalized:
+        return timedelta(hours=1)
+    if "week" in normalized:
+        return timedelta(days=7)
+    if "month" in normalized:
+        return timedelta(days=30)
+    return timedelta(days=1)

--- a/app/modules/agent_provider_routing/schemas.py
+++ b/app/modules/agent_provider_routing/schemas.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field
+
+from app.modules.agent_providers.schemas import AgentProviderId
+from app.modules.shared.schemas import DashboardModel
+
+ProviderRoutingStrategy = Literal[
+    "capacity_weighted",
+    "round_robin",
+    "sequential_drain",
+    "reset_drain",
+    "single_account",
+    "ordered_fallback",
+]
+
+
+class AgentProviderQuotaWindowResponse(DashboardModel):
+    dimension: str
+    used: int
+    limit: int | None = None
+    reset_at: datetime | None = None
+    recorded_at: datetime
+
+
+class AgentProviderQuotaWindowUpsertRequest(DashboardModel):
+    dimension: str = Field(min_length=1, max_length=120)
+    used: int = Field(ge=0)
+    limit: int | None = Field(default=None, ge=0)
+    reset_at: datetime | None = None
+
+
+class AgentProviderRoutingSettingsResponse(DashboardModel):
+    provider_id: AgentProviderId
+    strategy: ProviderRoutingStrategy
+    single_account_id: str | None = None
+    ordered_account_ids: list[str] = Field(default_factory=list)
+    quota_threshold_pct: float
+    round_robin_cursor: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentProviderRoutingSettingsUpdateRequest(DashboardModel):
+    strategy: ProviderRoutingStrategy | None = None
+    single_account_id: str | None = None
+    ordered_account_ids: list[str] | None = None
+    quota_threshold_pct: float | None = Field(default=None, ge=0.0, le=100.0)
+    round_robin_cursor: str | None = None
+
+
+class AgentProviderPreflightAccountState(DashboardModel):
+    account_id: str
+    display_name: str
+    status: str
+    quota_windows: list[AgentProviderQuotaWindowResponse] = Field(default_factory=list)
+
+
+class AgentProviderPreflightResponse(DashboardModel):
+    provider_id: AgentProviderId
+    selected_account_id: str | None = None
+    denied_reason: str | None = None
+    candidate_account_ids: list[str] = Field(default_factory=list)
+    settings: AgentProviderRoutingSettingsResponse
+    accounts: list[AgentProviderPreflightAccountState] = Field(default_factory=list)

--- a/app/modules/agent_provider_routing/service.py
+++ b/app/modules/agent_provider_routing/service.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol, cast
+
+from app.db.models import AgentProviderAccount, AgentProviderQuotaWindow, AgentProviderRoutingSettings
+from app.modules.agent_provider_accounts.service import SUPPORTED_PROVIDER_IDS
+from app.modules.agent_provider_routing.logic import (
+    ProviderAccountRoutingState,
+    ProviderQuotaWindow,
+    ProviderRoutingSettings,
+    ProviderRoutingStrategy,
+    select_provider_account,
+)
+from app.modules.agent_provider_routing.settlement import AgentProviderUsageSettlementData
+
+
+class AgentProviderRoutingValidationError(Exception):
+    pass
+
+
+class AgentProviderRoutingNotFoundError(Exception):
+    pass
+
+
+class AgentProviderRoutingRepositoryPort(Protocol):
+    async def get_or_create_settings(self, provider_id: str) -> AgentProviderRoutingSettings: ...
+
+    async def save_settings(self, row: AgentProviderRoutingSettings) -> AgentProviderRoutingSettings: ...
+
+    async def advance_round_robin_cursor(
+        self,
+        provider_id: str,
+        *,
+        expected_cursor: str | None,
+        selected_account_id: str,
+    ) -> bool: ...
+
+    async def list_accounts_with_quota_windows(self, provider_id: str) -> list[AgentProviderAccount]: ...
+
+    async def get_account_for_provider(self, provider_id: str, account_id: str) -> AgentProviderAccount | None: ...
+
+    async def upsert_quota_window(
+        self,
+        *,
+        account: AgentProviderAccount,
+        dimension: str,
+        used: int,
+        limit: int | None,
+        reset_at: datetime | None,
+    ) -> AgentProviderQuotaWindow: ...
+
+    async def increment_quota_windows(
+        self,
+        account: AgentProviderAccount,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProviderRoutingSettingsUpdateData:
+    strategy: ProviderRoutingStrategy | None = None
+    single_account_id: str | None = None
+    single_account_id_set: bool = False
+    ordered_account_ids: tuple[str, ...] | None = None
+    quota_threshold_pct: float | None = None
+    round_robin_cursor: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProviderQuotaWindowUpsertData:
+    dimension: str
+    used: int
+    limit: int | None = None
+    reset_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProviderPreflight:
+    provider_id: str
+    settings: AgentProviderRoutingSettings
+    accounts: list[AgentProviderAccount]
+    selected_account_id: str | None
+    denied_reason: str | None
+    candidate_account_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProviderSelectedAccount:
+    provider_id: str
+    settings: AgentProviderRoutingSettings
+    account: AgentProviderAccount
+    candidate_account_ids: tuple[str, ...]
+
+
+class AgentProviderRoutingService:
+    def __init__(self, repository: AgentProviderRoutingRepositoryPort) -> None:
+        self._repository = repository
+
+    async def get_settings(self, provider_id: str) -> AgentProviderRoutingSettings:
+        provider = _normalize_provider_id(provider_id)
+        return await self._repository.get_or_create_settings(provider)
+
+    async def update_settings(
+        self,
+        provider_id: str,
+        payload: AgentProviderRoutingSettingsUpdateData,
+    ) -> AgentProviderRoutingSettings:
+        provider = _normalize_provider_id(provider_id)
+        row = await self._repository.get_or_create_settings(provider)
+        strategy = payload.strategy or cast(ProviderRoutingStrategy, row.strategy)
+        if payload.quota_threshold_pct is not None and not 0.0 <= payload.quota_threshold_pct <= 100.0:
+            raise AgentProviderRoutingValidationError("quota_threshold_pct must be between 0 and 100")
+        single_account_id = (
+            _clean_optional(payload.single_account_id)
+            if payload.single_account_id_set
+            else _clean_optional(row.single_account_id)
+        )
+        if strategy == "single_account" and not single_account_id:
+            raise AgentProviderRoutingValidationError("single_account_id is required for single_account routing")
+        ordered_account_ids = (
+            _normalize_account_id_order(payload.ordered_account_ids)
+            if payload.ordered_account_ids is not None
+            else _parse_account_id_order(row.ordered_account_ids_json)
+        )
+        if strategy == "ordered_fallback" and not ordered_account_ids:
+            raise AgentProviderRoutingValidationError("ordered_account_ids is required for ordered_fallback routing")
+        if single_account_id is not None:
+            account = await self._repository.get_account_for_provider(provider, single_account_id)
+            if account is None:
+                raise AgentProviderRoutingValidationError("single_account_id is not a provider account")
+        for account_id in ordered_account_ids:
+            account = await self._repository.get_account_for_provider(provider, account_id)
+            if account is None:
+                raise AgentProviderRoutingValidationError("ordered_account_ids must be provider accounts")
+        row.strategy = strategy
+        if payload.single_account_id_set or strategy == "single_account":
+            row.single_account_id = single_account_id
+        if payload.ordered_account_ids is not None:
+            row.ordered_account_ids_json = _dump_account_id_order(ordered_account_ids)
+        if payload.quota_threshold_pct is not None:
+            row.quota_threshold_pct = payload.quota_threshold_pct
+        if payload.round_robin_cursor is not None:
+            row.round_robin_cursor = _clean_optional(payload.round_robin_cursor)
+        return await self._repository.save_settings(row)
+
+    async def upsert_quota_window(
+        self,
+        provider_id: str,
+        account_id: str,
+        payload: AgentProviderQuotaWindowUpsertData,
+    ) -> AgentProviderQuotaWindow:
+        provider = _normalize_provider_id(provider_id)
+        dimension = payload.dimension.strip()
+        if not dimension:
+            raise AgentProviderRoutingValidationError("dimension is required")
+        if payload.limit is not None and payload.used > payload.limit:
+            raise AgentProviderRoutingValidationError("used cannot exceed limit")
+        account = await self._repository.get_account_for_provider(provider, account_id)
+        if account is None:
+            raise AgentProviderRoutingNotFoundError("provider account not found")
+        return await self._repository.upsert_quota_window(
+            account=account,
+            dimension=dimension,
+            used=payload.used,
+            limit=payload.limit,
+            reset_at=payload.reset_at,
+        )
+
+    async def preflight(self, provider_id: str, *, auth_mode: str | None = None) -> AgentProviderPreflight:
+        provider = _normalize_provider_id(provider_id)
+        settings = await self._repository.get_or_create_settings(provider)
+        accounts = await self._repository.list_accounts_with_quota_windows(provider)
+        if auth_mode is not None:
+            accounts = [account for account in accounts if account.auth_mode == auth_mode]
+        result = select_provider_account(
+            [_routing_state(account) for account in accounts],
+            ProviderRoutingSettings(
+                strategy=cast(ProviderRoutingStrategy, settings.strategy),
+                single_account_id=settings.single_account_id,
+                ordered_account_ids=_parse_account_id_order(settings.ordered_account_ids_json),
+                quota_threshold_pct=settings.quota_threshold_pct,
+                round_robin_cursor=settings.round_robin_cursor,
+            ),
+        )
+        return AgentProviderPreflight(
+            provider_id=provider,
+            settings=settings,
+            accounts=accounts,
+            selected_account_id=result.account_id,
+            denied_reason=result.denied_reason,
+            candidate_account_ids=result.candidate_account_ids,
+        )
+
+    async def select_account(self, provider_id: str, *, auth_mode: str | None = None) -> AgentProviderSelectedAccount:
+        for _attempt in range(5):
+            preflight = await self.preflight(provider_id, auth_mode=auth_mode)
+            if preflight.selected_account_id is None:
+                raise AgentProviderRoutingNotFoundError(preflight.denied_reason or "provider account unavailable")
+            for account in preflight.accounts:
+                if account.id == preflight.selected_account_id:
+                    if preflight.settings.strategy == "round_robin":
+                        advanced = await self._repository.advance_round_robin_cursor(
+                            preflight.provider_id,
+                            expected_cursor=preflight.settings.round_robin_cursor,
+                            selected_account_id=account.id,
+                        )
+                        if not advanced:
+                            break
+                        preflight.settings.round_robin_cursor = account.id
+                    return AgentProviderSelectedAccount(
+                        provider_id=preflight.provider_id,
+                        settings=preflight.settings,
+                        account=account,
+                        candidate_account_ids=preflight.candidate_account_ids,
+                    )
+            else:
+                raise AgentProviderRoutingNotFoundError("selected provider account not found")
+        raise AgentProviderRoutingNotFoundError("round_robin_cursor_conflict")
+
+    async def settle_usage(
+        self,
+        provider_id: str,
+        account_id: str,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None:
+        provider = _normalize_provider_id(provider_id)
+        account = await self._repository.get_account_for_provider(provider, account_id)
+        if account is None:
+            raise AgentProviderRoutingNotFoundError("provider account not found")
+        await self._repository.increment_quota_windows(account, usage)
+
+
+def _normalize_provider_id(provider_id: str) -> str:
+    normalized = provider_id.strip().lower()
+    if normalized not in SUPPORTED_PROVIDER_IDS:
+        raise AgentProviderRoutingValidationError(f"Unsupported provider '{provider_id}'")
+    return normalized
+
+
+def _routing_state(account: AgentProviderAccount) -> ProviderAccountRoutingState:
+    return ProviderAccountRoutingState(
+        account_id=account.id,
+        status=account.status,
+        quota_windows=tuple(
+            ProviderQuotaWindow(
+                dimension=window.dimension,
+                used=window.used,
+                limit=window.limit,
+                reset_at=window.reset_at,
+            )
+            for window in account.quota_windows
+        ),
+    )
+
+
+def _clean_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _normalize_account_id_order(account_ids: tuple[str, ...] | None) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw_account_id in account_ids or ():
+        account_id = raw_account_id.strip()
+        if not account_id or account_id in seen:
+            continue
+        seen.add(account_id)
+        ordered.append(account_id)
+    return tuple(ordered)
+
+
+def _parse_account_id_order(raw: str | None) -> tuple[str, ...]:
+    if not raw:
+        return ()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    return _normalize_account_id_order(tuple(item for item in parsed if isinstance(item, str)))
+
+
+def _dump_account_id_order(account_ids: tuple[str, ...]) -> str:
+    return json.dumps(list(account_ids), separators=(",", ":"))

--- a/app/modules/agent_provider_routing/settlement.py
+++ b/app/modules/agent_provider_routing/settlement.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProviderUsageSettlementData:
+    requests: int = 1
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None

--- a/app/modules/agent_provider_runtime/__init__.py
+++ b/app/modules/agent_provider_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-owned runtime adapters."""

--- a/app/modules/agent_provider_runtime/antigravity.py
+++ b/app/modules/agent_provider_runtime/antigravity.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class AntigravityHarnessValidationError(Exception):
+    pass
+
+
+class AntigravityHarnessExecutionError(Exception):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class AntigravityHarnessRequest:
+    prompt: str
+    workspace_path: str
+    timeout_seconds: int = 300
+    add_dirs: tuple[str, ...] = ()
+    conversation_id: str | None = None
+    continue_conversation: bool = False
+    sandbox: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AntigravityHarnessCommand:
+    executable: str
+    args: tuple[str, ...]
+    cwd: Path
+    timeout_seconds: int
+    display_args: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AntigravityProcessResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+
+class AntigravityProcessRunnerPort(Protocol):
+    async def run(
+        self,
+        command: AntigravityHarnessCommand,
+        *,
+        env: Mapping[str, str],
+    ) -> AntigravityProcessResult: ...
+
+
+class AntigravitySubprocessRunner:
+    async def run(
+        self,
+        command: AntigravityHarnessCommand,
+        *,
+        env: Mapping[str, str],
+    ) -> AntigravityProcessResult:
+        started_at = time.perf_counter()
+        process = await asyncio.create_subprocess_exec(
+            command.executable,
+            *command.args,
+            cwd=str(command.cwd),
+            env=dict(env),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                process.communicate(),
+                timeout=command.timeout_seconds + 5,
+            )
+        except TimeoutError as exc:
+            process.kill()
+            await process.wait()
+            raise AntigravityHarnessExecutionError("Antigravity CLI timed out") from exc
+        except asyncio.CancelledError:
+            process.kill()
+            await process.wait()
+            raise
+        return AntigravityProcessResult(
+            exit_code=process.returncode or 0,
+            stdout=stdout_bytes.decode("utf-8", errors="replace"),
+            stderr=stderr_bytes.decode("utf-8", errors="replace"),
+            duration_ms=max(0, int((time.perf_counter() - started_at) * 1000)),
+        )
+
+
+def build_antigravity_command(
+    request: AntigravityHarnessRequest,
+    *,
+    executable: str = "agy",
+) -> AntigravityHarnessCommand:
+    prompt = request.prompt.strip()
+    if not prompt:
+        raise AntigravityHarnessValidationError("prompt is required")
+    if request.timeout_seconds < 1 or request.timeout_seconds > 1800:
+        raise AntigravityHarnessValidationError("timeout_seconds must be between 1 and 1800")
+    if request.conversation_id is not None and request.continue_conversation:
+        raise AntigravityHarnessValidationError("conversation_id cannot be combined with continue_conversation")
+
+    workspace_path = _existing_directory(request.workspace_path, base=None, field_name="workspace_path")
+    add_dirs = tuple(
+        _existing_directory(path, base=workspace_path, field_name="add_dirs").resolve() for path in request.add_dirs
+    )
+
+    args: list[str] = [
+        "--print",
+        "--print-timeout",
+        f"{request.timeout_seconds}s",
+        "--prompt",
+        prompt,
+    ]
+    display_args: list[str] = [
+        "--print",
+        "--print-timeout",
+        f"{request.timeout_seconds}s",
+        "--prompt",
+        "<redacted>",
+    ]
+    if request.conversation_id is not None:
+        conversation_id = request.conversation_id.strip()
+        if not conversation_id:
+            raise AntigravityHarnessValidationError("conversation_id cannot be blank")
+        args.extend(["--conversation", conversation_id])
+        display_args.extend(["--conversation", conversation_id])
+    elif request.continue_conversation:
+        args.append("--continue")
+        display_args.append("--continue")
+    for add_dir in add_dirs:
+        args.extend(["--add-dir", str(add_dir)])
+        display_args.extend(["--add-dir", str(add_dir)])
+    if request.sandbox is not None:
+        sandbox = request.sandbox.strip()
+        if not sandbox:
+            raise AntigravityHarnessValidationError("sandbox cannot be blank")
+        args.extend(["--sandbox", sandbox])
+        display_args.extend(["--sandbox", sandbox])
+
+    _reject_dangerous_permission_flag(args)
+    return AntigravityHarnessCommand(
+        executable=executable,
+        args=tuple(args),
+        cwd=workspace_path.resolve(),
+        timeout_seconds=request.timeout_seconds,
+        display_args=tuple(display_args),
+    )
+
+
+def antigravity_harness_env(
+    base_env: Mapping[str, str] | None = None,
+    *,
+    profile_id: str | None = None,
+) -> dict[str, str]:
+    env = dict(os.environ if base_env is None else base_env)
+    env["AGY_CLI_DISABLE_AUTO_UPDATE"] = "true"
+    if profile_id is not None and profile_id.strip():
+        env["AGY_CLI_PROFILE"] = profile_id.strip()
+        env["ANTIGRAVITY_CLI_PROFILE"] = profile_id.strip()
+    return env
+
+
+def command_preview(command: AntigravityHarnessCommand) -> tuple[str, ...]:
+    return (command.executable, *command.display_args)
+
+
+def _existing_directory(path_value: str, *, base: Path | None, field_name: str) -> Path:
+    raw = path_value.strip()
+    if not raw:
+        raise AntigravityHarnessValidationError(f"{field_name} cannot be blank")
+    path = Path(raw)
+    if not path.is_absolute():
+        if base is None:
+            raise AntigravityHarnessValidationError(f"{field_name} must be absolute")
+        path = base / path
+    if not path.is_dir():
+        raise AntigravityHarnessValidationError(f"{field_name} must be an existing directory")
+    return path
+
+
+def _reject_dangerous_permission_flag(args: Sequence[str]) -> None:
+    if "--dangerously-skip-permissions" in args:
+        raise AntigravityHarnessValidationError("dangerous Antigravity permission bypass is not allowed")

--- a/app/modules/agent_provider_runtime/api.py
+++ b/app/modules/agent_provider_runtime/api.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import cast
+
+from fastapi import APIRouter, Body, Depends, Security
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from app.core.auth.dependencies import (
+    set_dashboard_error_format,
+    set_openai_error_format,
+    validate_dashboard_session,
+    validate_proxy_api_key,
+)
+from app.core.errors import openai_error as _openai_error
+from app.core.exceptions import (
+    DashboardBadRequestError,
+    DashboardRateLimitError,
+    DashboardUpstreamError,
+    ProxyAuthError,
+    ProxyModelNotAllowed,
+    ProxyRateLimitError,
+    ProxyUpstreamError,
+)
+from app.core.types import JsonValue
+from app.dependencies import AgentProviderRuntimeContext, get_agent_provider_runtime_context
+from app.modules.agent_provider_runtime.antigravity import (
+    AntigravityHarnessExecutionError,
+    AntigravityHarnessRequest,
+    AntigravityHarnessValidationError,
+    command_preview,
+)
+from app.modules.agent_provider_runtime.schemas import (
+    AntigravityHarnessPrintRequest,
+    AntigravityHarnessPrintResponse,
+    AntigravityManagedInteractionRunRequest,
+    AntigravityManagedInteractionRunResponse,
+)
+from app.modules.agent_provider_runtime.service import (
+    AntigravityRuntimeRequestContext,
+    AntigravityRuntimeValidationError,
+    GeminiRuntimeRequestContext,
+    GeminiRuntimeValidationError,
+    invalid_request_error,
+)
+from app.modules.api_keys.service import ApiKeyData
+
+router = APIRouter(
+    prefix="/v1/gemini",
+    tags=["agent-provider-runtime"],
+    dependencies=[Depends(set_openai_error_format)],
+)
+antigravity_router = APIRouter(
+    prefix="/v1/antigravity",
+    tags=["agent-provider-runtime"],
+    dependencies=[Depends(set_openai_error_format)],
+)
+dashboard_router = APIRouter(
+    prefix="/api/agent-providers",
+    tags=["agent-provider-runtime"],
+    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+)
+
+
+@router.post("/chat/completions")
+async def create_gemini_chat_completion(
+    payload: dict[str, JsonValue] = Body(...),
+    context: AgentProviderRuntimeContext = Depends(get_agent_provider_runtime_context),
+    api_key: ApiKeyData | None = Security(validate_proxy_api_key),
+):
+    try:
+        runtime_context = GeminiRuntimeRequestContext(api_key=api_key)
+        stream = payload.get("stream") is True
+        if stream:
+            body = await context.gemini_service.stream_chat(payload, runtime_context)
+            body = await _probe_gemini_stream_startup(body)
+            return StreamingResponse(
+                body,
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
+        response = await context.gemini_service.complete_chat(payload, runtime_context)
+    except GeminiRuntimeValidationError as exc:
+        return JSONResponse(status_code=400, content=invalid_request_error(str(exc)))
+    except (ProxyAuthError, ProxyModelNotAllowed, ProxyRateLimitError, ProxyUpstreamError) as exc:
+        headers = {"Retry-After": exc.retry_after} if isinstance(exc, ProxyRateLimitError) and exc.retry_after else None
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=_openai_error(exc.code, exc.message, error_type=exc.error_type),
+            headers=headers,
+        )
+    return JSONResponse(content=response)
+
+
+@antigravity_router.post("/interactions")
+async def create_antigravity_interaction(
+    payload: dict[str, JsonValue] = Body(...),
+    context: AgentProviderRuntimeContext = Depends(get_agent_provider_runtime_context),
+    api_key: ApiKeyData | None = Security(validate_proxy_api_key),
+):
+    try:
+        response = await context.antigravity_managed_service.create_interaction(
+            payload,
+            AntigravityRuntimeRequestContext(api_key=api_key),
+        )
+    except AntigravityRuntimeValidationError as exc:
+        return JSONResponse(status_code=400, content=invalid_request_error(str(exc)))
+    return JSONResponse(content=response)
+
+
+@dashboard_router.post(
+    "/antigravity/interactions/run",
+    response_model=AntigravityManagedInteractionRunResponse,
+)
+async def run_antigravity_managed_interaction(
+    payload: AntigravityManagedInteractionRunRequest = Body(...),
+    context: AgentProviderRuntimeContext = Depends(get_agent_provider_runtime_context),
+) -> AntigravityManagedInteractionRunResponse:
+    try:
+        request_payload: dict[str, JsonValue] = {
+            "agent": payload.agent,
+            "input": payload.input,
+            "environment": payload.environment,
+        }
+        if payload.tools:
+            request_payload["tools"] = cast(JsonValue, payload.tools)
+        response = await context.antigravity_managed_service.create_interaction(request_payload)
+    except AntigravityRuntimeValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_antigravity_interaction_request") from exc
+    except ProxyRateLimitError as exc:
+        raise DashboardRateLimitError(str(exc), retry_after=0, code="antigravity_interaction_unavailable") from exc
+    except Exception as exc:
+        raise DashboardUpstreamError(str(exc), code="antigravity_interaction_failed") from exc
+    return AntigravityManagedInteractionRunResponse(
+        provider_id="antigravity",
+        agent=payload.agent,
+        output_text=_antigravity_output_text(response),
+        response=response,
+    )
+
+
+@dashboard_router.post("/antigravity/harness/print", response_model=AntigravityHarnessPrintResponse)
+async def run_antigravity_harness_print(
+    payload: AntigravityHarnessPrintRequest = Body(...),
+    context: AgentProviderRuntimeContext = Depends(get_agent_provider_runtime_context),
+) -> AntigravityHarnessPrintResponse:
+    try:
+        result = await context.antigravity_service.print_prompt(
+            AntigravityHarnessRequest(
+                prompt=payload.prompt,
+                workspace_path=payload.workspace_path,
+                timeout_seconds=payload.timeout_seconds,
+                add_dirs=tuple(payload.add_dirs),
+                conversation_id=payload.conversation_id,
+                continue_conversation=payload.continue_conversation,
+                sandbox=payload.sandbox,
+            )
+        )
+    except AntigravityHarnessValidationError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_antigravity_harness_request") from exc
+    except AntigravityHarnessExecutionError as exc:
+        raise DashboardUpstreamError(str(exc), code="antigravity_harness_failed") from exc
+    return AntigravityHarnessPrintResponse(
+        provider_id="antigravity",
+        account_id=result.account.id,
+        external_account_id=result.account.external_account_id,
+        command=list(command_preview(result.command)),
+        cwd=str(result.command.cwd),
+        exit_code=result.process.exit_code,
+        stdout=result.process.stdout,
+        stderr=result.process.stderr,
+        duration_ms=result.process.duration_ms,
+    )
+
+
+def _antigravity_output_text(payload: dict[str, JsonValue]) -> str:
+    for key in ("output_text", "outputText", "text"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    output = payload.get("output")
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict):
+        text = output.get("text")
+        if isinstance(text, str):
+            return text
+    steps_text = _antigravity_steps_output_text(payload)
+    if steps_text:
+        return steps_text
+    outputs_text = _antigravity_outputs_text(payload)
+    if outputs_text:
+        return outputs_text
+    return ""
+
+
+def _antigravity_steps_output_text(payload: dict[str, JsonValue]) -> str:
+    steps = payload.get("steps")
+    if not isinstance(steps, list):
+        return ""
+    for step in reversed(steps):
+        if not isinstance(step, dict):
+            continue
+        step_mapping = cast(dict[str, object], step)
+        if step_mapping.get("type") != "model_output":
+            continue
+        text = _antigravity_content_text(step_mapping.get("content"))
+        if text:
+            return text
+    return ""
+
+
+def _antigravity_outputs_text(payload: dict[str, JsonValue]) -> str:
+    outputs = payload.get("outputs")
+    if not isinstance(outputs, list):
+        return ""
+    return _antigravity_content_text(outputs)
+
+
+def _antigravity_content_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        text = cast(dict[str, object], value).get("text")
+        return text if isinstance(text, str) else ""
+    if not isinstance(value, list):
+        return ""
+    texts: list[str] = []
+    for block in value:
+        if isinstance(block, str):
+            texts.append(block)
+        elif isinstance(block, dict):
+            text = cast(dict[str, object], block).get("text")
+            if isinstance(text, str):
+                texts.append(text)
+    return "".join(texts)
+
+
+async def _probe_gemini_stream_startup(body: AsyncIterator[str]) -> AsyncIterator[str]:
+    try:
+        first = await body.__anext__()
+    except StopAsyncIteration:
+        return body
+    return _prepend_gemini_stream_first(first, body)
+
+
+async def _prepend_gemini_stream_first(first: str, body: AsyncIterator[str]) -> AsyncIterator[str]:
+    yield first
+    async for chunk in body:
+        yield chunk

--- a/app/modules/agent_provider_runtime/gemini.py
+++ b/app/modules/agent_provider_runtime/gemini.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import NotRequired, TypedDict, cast
+from urllib.parse import quote
+
+from app.core.types import JsonValue
+from app.core.utils.json_guards import is_json_list, is_json_mapping
+
+GEMINI_DEVELOPER_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+
+
+class GeminiAdapterError(ValueError):
+    pass
+
+
+class OpenAIChatMessageEnvelope(TypedDict):
+    role: str
+    content: str | None
+    tool_calls: NotRequired[list["OpenAIToolCallEnvelope"]]
+
+
+class OpenAIFunctionEnvelope(TypedDict):
+    name: str
+    arguments: str
+
+
+class OpenAIToolCallEnvelope(TypedDict):
+    id: str
+    type: str
+    function: OpenAIFunctionEnvelope
+    index: NotRequired[int]
+    gemini_thought_signature: NotRequired[str]
+
+
+class OpenAIChatChoiceEnvelope(TypedDict):
+    index: int
+    message: OpenAIChatMessageEnvelope
+    finish_reason: str | None
+
+
+class OpenAIChatDeltaEnvelope(TypedDict):
+    content: NotRequired[str]
+    tool_calls: NotRequired[list[OpenAIToolCallEnvelope]]
+
+
+class OpenAIChatChunkChoiceEnvelope(TypedDict):
+    index: int
+    delta: OpenAIChatDeltaEnvelope
+    finish_reason: str | None
+
+
+class OpenAIUsageEnvelope(TypedDict):
+    prompt_tokens: int | None
+    completion_tokens: int | None
+    total_tokens: int | None
+
+
+class OpenAIChatCompletionEnvelope(TypedDict):
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: list[OpenAIChatChoiceEnvelope]
+    usage: NotRequired[OpenAIUsageEnvelope]
+
+
+class OpenAIChatCompletionChunkEnvelope(TypedDict):
+    id: str
+    object: str
+    created: int
+    model: str
+    choices: list[OpenAIChatChunkChoiceEnvelope]
+
+
+@dataclass(frozen=True, slots=True)
+class GeminiChatRequest:
+    model: str
+    messages: list[Mapping[str, JsonValue]]
+    stream: bool = False
+    temperature: float | None = None
+    top_p: float | None = None
+    max_tokens: int | None = None
+    stop: str | list[str] | None = None
+    tools: list[JsonValue] | None = None
+    response_format: JsonValue | None = None
+
+
+def build_generate_content_url(
+    model: str,
+    *,
+    stream: bool = False,
+    base_url: str = GEMINI_DEVELOPER_API_BASE_URL,
+) -> str:
+    action = "streamGenerateContent?alt=sse" if stream else "generateContent"
+    return f"{base_url.rstrip('/')}/models/{quote(model, safe='')}:{action}"
+
+
+def build_generate_content_payload(request: GeminiChatRequest) -> dict[str, JsonValue]:
+    if not request.model.strip():
+        raise GeminiAdapterError("Gemini model is required")
+    system_parts: list[dict[str, JsonValue]] = []
+    contents: list[dict[str, JsonValue]] = []
+    tool_call_names_by_id: dict[str, str] = {}
+    for message in request.messages:
+        role = _message_role(message)
+        if role in ("system", "developer"):
+            system_parts.extend(_message_parts(message))
+            continue
+        if role == "assistant":
+            parts = _assistant_message_parts(message, tool_call_names_by_id)
+        elif role == "tool":
+            parts = _tool_response_parts(message, tool_call_names_by_id)
+        else:
+            parts = _message_parts(message)
+        gemini_role = "model" if role == "assistant" else "user"
+        contents.append({"role": gemini_role, "parts": cast(JsonValue, parts)})
+    if not contents:
+        raise GeminiAdapterError("Gemini request requires at least one user or assistant message")
+
+    payload: dict[str, JsonValue] = {"contents": cast(JsonValue, contents)}
+    if system_parts:
+        payload["systemInstruction"] = {"parts": cast(JsonValue, system_parts)}
+
+    generation_config = _generation_config(request)
+    if generation_config:
+        payload["generationConfig"] = cast(JsonValue, generation_config)
+
+    tools = _tools_payload(request.tools or [])
+    if tools:
+        payload["tools"] = cast(JsonValue, tools)
+
+    return payload
+
+
+def generate_content_to_chat_completion(
+    payload: Mapping[str, JsonValue],
+    *,
+    model: str,
+    created: int | None = None,
+) -> OpenAIChatCompletionEnvelope:
+    finish_reason = _finish_reason(payload)
+    tool_calls = _tool_calls(payload)
+    message: OpenAIChatMessageEnvelope = {
+        "role": "assistant",
+        "content": _response_text(payload) if not tool_calls else None,
+    }
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    response: OpenAIChatCompletionEnvelope = {
+        "id": _response_id(payload),
+        "object": "chat.completion",
+        "created": created if created is not None else int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+    usage = _usage_payload(payload)
+    if usage:
+        response["usage"] = usage
+    return response
+
+
+def generate_content_to_chat_completion_chunk(
+    payload: Mapping[str, JsonValue],
+    *,
+    model: str,
+    created: int | None = None,
+) -> OpenAIChatCompletionChunkEnvelope:
+    tool_calls = _tool_calls(payload, include_index=True)
+    delta: OpenAIChatDeltaEnvelope = {}
+    if tool_calls:
+        delta["tool_calls"] = tool_calls
+    else:
+        delta["content"] = _response_text(payload)
+    return {
+        "id": _response_id(payload),
+        "object": "chat.completion.chunk",
+        "created": created if created is not None else int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": delta,
+                "finish_reason": _finish_reason(payload),
+            }
+        ],
+    }
+
+
+def parse_gemini_sse_data_lines(lines: Iterable[str]) -> list[dict[str, JsonValue]]:
+    events: list[dict[str, JsonValue]] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith("data:"):
+            continue
+        data = stripped.removeprefix("data:").strip()
+        if not data or data == "[DONE]":
+            continue
+        decoded = json.loads(data)
+        if not isinstance(decoded, dict):
+            raise GeminiAdapterError("Gemini SSE data must decode to an object")
+        events.append(cast(dict[str, JsonValue], decoded))
+    return events
+
+
+def chat_completion_chunk_to_sse(chunk: Mapping[str, JsonValue]) -> str:
+    return f"data: {json.dumps(chunk, separators=(',', ':'))}\n\n"
+
+
+def _message_role(message: Mapping[str, JsonValue]) -> str:
+    role = message.get("role")
+    if not isinstance(role, str):
+        raise GeminiAdapterError("Message role must be a string")
+    if role not in {"system", "developer", "user", "assistant", "tool"}:
+        raise GeminiAdapterError(f"Unsupported Gemini message role: {role}")
+    return role
+
+
+def _message_parts(message: Mapping[str, JsonValue]) -> list[dict[str, JsonValue]]:
+    content = message.get("content")
+    if isinstance(content, str):
+        return [{"text": content}]
+    if is_json_list(content):
+        parts: list[dict[str, JsonValue]] = []
+        for part in content:
+            parts.extend(_content_part_to_gemini(part))
+        if not parts:
+            raise GeminiAdapterError("Message content parts cannot be empty")
+        return parts
+    if content is None:
+        return [{"text": ""}]
+    raise GeminiAdapterError("Gemini adapter currently supports text content only")
+
+
+def _assistant_message_parts(
+    message: Mapping[str, JsonValue],
+    tool_call_names_by_id: dict[str, str],
+) -> list[dict[str, JsonValue]]:
+    parts: list[dict[str, JsonValue]] = []
+    content = message.get("content")
+    if isinstance(content, str) and content:
+        parts.extend(_message_parts(message))
+    tool_calls = message.get("tool_calls")
+    if is_json_list(tool_calls):
+        for tool_call in tool_calls:
+            if not is_json_mapping(tool_call):
+                continue
+            function = tool_call.get("function")
+            if not is_json_mapping(function):
+                continue
+            name = function.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            call_id = tool_call.get("id")
+            if isinstance(call_id, str) and call_id:
+                tool_call_names_by_id[call_id] = name
+            function_call: dict[str, JsonValue] = {
+                "name": name,
+                "args": cast(JsonValue, _json_object_from_arguments(function.get("arguments"))),
+            }
+            if isinstance(call_id, str) and call_id:
+                function_call["id"] = call_id
+            part: dict[str, JsonValue] = {"functionCall": cast(JsonValue, function_call)}
+            thought_signature = _tool_call_thought_signature(tool_call)
+            if thought_signature is not None:
+                part["thoughtSignature"] = thought_signature
+            parts.append(part)
+    if not parts:
+        return _message_parts(message)
+    return parts
+
+
+def _tool_response_parts(
+    message: Mapping[str, JsonValue],
+    tool_call_names_by_id: Mapping[str, str],
+) -> list[dict[str, JsonValue]]:
+    tool_call_id = message.get("tool_call_id")
+    name = message.get("name")
+    if not isinstance(name, str) or not name:
+        name = tool_call_names_by_id.get(tool_call_id, "") if isinstance(tool_call_id, str) else ""
+    if not name:
+        name = "tool"
+    function_response: dict[str, JsonValue] = {
+        "name": name,
+        "response": cast(JsonValue, _json_response_from_tool_content(message.get("content"))),
+    }
+    if isinstance(tool_call_id, str) and tool_call_id:
+        function_response["id"] = tool_call_id
+    return [{"functionResponse": cast(JsonValue, function_response)}]
+
+
+def _json_object_from_arguments(value: JsonValue) -> dict[str, JsonValue]:
+    if is_json_mapping(value):
+        return dict(value)
+    if not isinstance(value, str) or not value:
+        return {}
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return dict(decoded) if is_json_mapping(decoded) else {}
+
+
+def _json_response_from_tool_content(value: JsonValue) -> dict[str, JsonValue]:
+    if is_json_mapping(value):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return {"output": value}
+        if is_json_mapping(decoded):
+            return dict(decoded)
+        return {"output": value}
+    return {"output": _tool_content_text(value)}
+
+
+def _tool_content_text(value: JsonValue) -> str:
+    if isinstance(value, str):
+        return value
+    if is_json_list(value):
+        texts: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                texts.append(item)
+            elif is_json_mapping(item):
+                text = item.get("text")
+                if isinstance(text, str):
+                    texts.append(text)
+        return "".join(texts)
+    return ""
+
+
+def _content_part_to_gemini(part: JsonValue) -> list[dict[str, JsonValue]]:
+    if isinstance(part, str):
+        return [{"text": part}]
+    if not is_json_mapping(part):
+        raise GeminiAdapterError("Content parts must be strings or objects")
+    part_type = part.get("type")
+    text = part.get("text")
+    if part_type in {"text", "input_text", "output_text"} and isinstance(text, str):
+        return [{"text": text}]
+    raise GeminiAdapterError("Gemini adapter currently supports text content parts only")
+
+
+def _generation_config(request: GeminiChatRequest) -> dict[str, JsonValue]:
+    config: dict[str, JsonValue] = {}
+    if request.temperature is not None:
+        config["temperature"] = request.temperature
+    if request.top_p is not None:
+        config["topP"] = request.top_p
+    if request.max_tokens is not None:
+        config["maxOutputTokens"] = request.max_tokens
+    if isinstance(request.stop, str):
+        config["stopSequences"] = [request.stop]
+    elif request.stop:
+        config["stopSequences"] = cast(JsonValue, request.stop)
+    if _is_json_object_response_format(request.response_format):
+        config["responseMimeType"] = "application/json"
+    return config
+
+
+def _is_json_object_response_format(value: JsonValue | None) -> bool:
+    return is_json_mapping(value) and value.get("type") == "json_object"
+
+
+def _tools_payload(tools: list[JsonValue]) -> list[dict[str, JsonValue]]:
+    declarations: list[dict[str, JsonValue]] = []
+    for tool in tools:
+        if not is_json_mapping(tool) or tool.get("type") != "function":
+            raise GeminiAdapterError("Gemini adapter supports function tools only")
+        function = tool.get("function")
+        if not is_json_mapping(function):
+            raise GeminiAdapterError("Function tool must include a function object")
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            raise GeminiAdapterError("Function tool name is required")
+        declaration: dict[str, JsonValue] = {"name": name}
+        description = function.get("description")
+        if isinstance(description, str):
+            declaration["description"] = description
+        parameters = function.get("parameters")
+        if is_json_mapping(parameters):
+            declaration["parameters"] = parameters
+        declarations.append(declaration)
+    if not declarations:
+        return []
+    return [{"functionDeclarations": cast(JsonValue, declarations)}]
+
+
+def _response_text(payload: Mapping[str, JsonValue]) -> str:
+    texts: list[str] = []
+    for part in _first_candidate_parts(payload):
+        if is_json_mapping(part):
+            text = part.get("text")
+            if isinstance(text, str):
+                texts.append(text)
+    return "".join(texts)
+
+
+def _tool_calls(payload: Mapping[str, JsonValue], *, include_index: bool = False) -> list[OpenAIToolCallEnvelope]:
+    calls: list[OpenAIToolCallEnvelope] = []
+    for index, part in enumerate(_first_candidate_parts(payload)):
+        if not is_json_mapping(part):
+            continue
+        function_call = part.get("functionCall")
+        if not is_json_mapping(function_call):
+            continue
+        name = function_call.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        args = function_call.get("args")
+        arguments = args if is_json_mapping(args) else {}
+        tool_call: OpenAIToolCallEnvelope = {
+            "id": f"call_{index}_{name}",
+            "type": "function",
+            "function": {
+                "name": name,
+                "arguments": json.dumps(arguments, separators=(",", ":")),
+            },
+        }
+        if include_index:
+            tool_call["index"] = index
+        thought_signature = part.get("thoughtSignature")
+        if isinstance(thought_signature, str) and thought_signature:
+            tool_call["gemini_thought_signature"] = thought_signature
+        calls.append(tool_call)
+    return calls
+
+
+def _tool_call_thought_signature(tool_call: Mapping[str, JsonValue]) -> str | None:
+    for key in ("gemini_thought_signature", "thoughtSignature", "thought_signature"):
+        value = tool_call.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _finish_reason(payload: Mapping[str, JsonValue]) -> str | None:
+    if _tool_calls(payload):
+        return "tool_calls"
+    candidate = _first_candidate(payload)
+    if candidate is None:
+        return None
+    finish_reason = candidate.get("finishReason")
+    if not isinstance(finish_reason, str):
+        return None
+    return {
+        "STOP": "stop",
+        "MAX_TOKENS": "length",
+        "SAFETY": "content_filter",
+        "RECITATION": "content_filter",
+    }.get(finish_reason, finish_reason.lower())
+
+
+def _response_id(payload: Mapping[str, JsonValue]) -> str:
+    response_id = payload.get("responseId")
+    if isinstance(response_id, str) and response_id:
+        return response_id
+    return "gemini-response"
+
+
+def _usage_payload(payload: Mapping[str, JsonValue]) -> OpenAIUsageEnvelope | None:
+    usage = payload.get("usageMetadata")
+    if not is_json_mapping(usage):
+        return None
+    prompt_tokens = _int_or_none(usage.get("promptTokenCount"))
+    completion_tokens = _int_or_none(usage.get("candidatesTokenCount"))
+    total_tokens = _int_or_none(usage.get("totalTokenCount"))
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+def _first_candidate_parts(payload: Mapping[str, JsonValue]) -> list[JsonValue]:
+    candidate = _first_candidate(payload)
+    if candidate is None:
+        return []
+    content = candidate.get("content")
+    if not is_json_mapping(content):
+        return []
+    parts = content.get("parts")
+    return parts if is_json_list(parts) else []
+
+
+def _first_candidate(payload: Mapping[str, JsonValue]) -> Mapping[str, JsonValue] | None:
+    candidates = payload.get("candidates")
+    if not is_json_list(candidates) or not candidates:
+        return None
+    first = candidates[0]
+    return first if is_json_mapping(first) else None
+
+
+def _int_or_none(value: JsonValue) -> int | None:
+    return value if isinstance(value, int) else None

--- a/app/modules/agent_provider_runtime/model_catalog.py
+++ b/app/modules/agent_provider_runtime/model_catalog.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProviderModel:
+    model_id: str
+    display_name: str
+    description: str
+    provider_id: str
+    protocol: str
+    lifecycle: str
+    input_token_limit: int
+    output_token_limit: int
+    input_modalities: tuple[str, ...]
+    output_modalities: tuple[str, ...] = ("text",)
+    supports_reasoning: bool = True
+    supports_tool_use: bool = True
+    supports_streaming: bool = True
+    supports_vision: bool = False
+
+
+GEMINI_MODELS: tuple[AgentProviderModel, ...] = (
+    AgentProviderModel(
+        model_id="gemini-3.5-flash",
+        display_name="Gemini 3.5 Flash",
+        description="Current stable Gemini flash model for high-speed agentic and coding workflows.",
+        provider_id="gemini",
+        protocol="gemini_api",
+        lifecycle="stable",
+        input_token_limit=1_048_576,
+        output_token_limit=65_536,
+        input_modalities=("text",),
+    ),
+    AgentProviderModel(
+        model_id="gemini-3.1-pro-preview",
+        display_name="Gemini 3.1 Pro Preview",
+        description="Preview Gemini Pro model optimized for software engineering and multi-step agent workflows.",
+        provider_id="gemini",
+        protocol="gemini_api",
+        lifecycle="preview",
+        input_token_limit=1_048_576,
+        output_token_limit=65_536,
+        input_modalities=("text",),
+    ),
+    AgentProviderModel(
+        model_id="gemini-3-flash-preview",
+        display_name="Gemini 3 Flash Preview",
+        description="Preview Gemini 3 flash model for frontier-class performance at lower cost.",
+        provider_id="gemini",
+        protocol="gemini_api",
+        lifecycle="preview",
+        input_token_limit=1_048_576,
+        output_token_limit=65_536,
+        input_modalities=("text",),
+    ),
+    AgentProviderModel(
+        model_id="gemini-3.1-flash-lite",
+        display_name="Gemini 3.1 Flash-Lite",
+        description="Stable lightweight Gemini 3.1 model for high-throughput workloads.",
+        provider_id="gemini",
+        protocol="gemini_api",
+        lifecycle="stable",
+        input_token_limit=1_048_576,
+        output_token_limit=65_536,
+        input_modalities=("text",),
+    ),
+    AgentProviderModel(
+        model_id="gemini-2.5-pro",
+        display_name="Gemini 2.5 Pro",
+        description="Stable Gemini 2.5 reasoning model for complex coding and long-context work.",
+        provider_id="gemini",
+        protocol="gemini_api",
+        lifecycle="stable",
+        input_token_limit=1_048_576,
+        output_token_limit=65_536,
+        input_modalities=("text",),
+    ),
+    AgentProviderModel(
+        model_id="gemini-2.5-flash",
+        display_name="Gemini 2.5 Flash",
+        description="Stable Gemini 2.5 price-performance model for low-latency tasks.",
+        provider_id="gemini",
+        protocol="gemini_api",
+        lifecycle="stable",
+        input_token_limit=1_048_576,
+        output_token_limit=65_536,
+        input_modalities=("text",),
+    ),
+    AgentProviderModel(
+        model_id="gemini-2.5-flash-lite",
+        display_name="Gemini 2.5 Flash-Lite",
+        description="Stable Gemini 2.5 fast, cost-efficient model for high-throughput tasks.",
+        provider_id="gemini",
+        protocol="gemini_api",
+        lifecycle="stable",
+        input_token_limit=1_048_576,
+        output_token_limit=65_536,
+        input_modalities=("text",),
+    ),
+)
+
+ANTIGRAVITY_MODELS: tuple[AgentProviderModel, ...] = (
+    AgentProviderModel(
+        model_id="antigravity-preview-05-2026",
+        display_name="Antigravity Agent Preview",
+        description=("Managed agent for autonomous multi-step workflows through the Gemini Interactions API."),
+        provider_id="antigravity",
+        protocol="interactions_api",
+        lifecycle="preview",
+        input_token_limit=1_048_576,
+        output_token_limit=65_536,
+        input_modalities=("text",),
+        supports_tool_use=False,
+        supports_streaming=False,
+        supports_vision=False,
+    ),
+)
+
+
+def list_gemini_models() -> tuple[AgentProviderModel, ...]:
+    return GEMINI_MODELS
+
+
+def list_agent_provider_models() -> tuple[AgentProviderModel, ...]:
+    return (*GEMINI_MODELS, *ANTIGRAVITY_MODELS)

--- a/app/modules/agent_provider_runtime/schemas.py
+++ b/app/modules/agent_provider_runtime/schemas.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from app.core.types import JsonValue
+from app.modules.shared.schemas import DashboardModel
+
+
+class AntigravityHarnessPrintRequest(DashboardModel):
+    prompt: str = Field(min_length=1, max_length=20000)
+    workspace_path: str = Field(min_length=1, max_length=4096)
+    timeout_seconds: int = Field(default=300, ge=1, le=1800)
+    add_dirs: list[str] = Field(default_factory=list, max_length=16)
+    conversation_id: str | None = Field(default=None, max_length=255)
+    continue_conversation: bool = False
+    sandbox: str | None = Field(default=None, max_length=120)
+
+
+class AntigravityHarnessPrintResponse(DashboardModel):
+    provider_id: str
+    account_id: str
+    external_account_id: str | None = None
+    command: list[str]
+    cwd: str
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+
+class AntigravityManagedInteractionRunRequest(DashboardModel):
+    agent: str = Field(default="antigravity-preview-05-2026", min_length=1, max_length=255)
+    input: str = Field(min_length=1, max_length=20000)
+    environment: str = Field(default="remote", min_length=1, max_length=255)
+    tools: list[dict[str, JsonValue]] = Field(default_factory=list, max_length=16)
+
+
+class AntigravityManagedInteractionRunResponse(DashboardModel):
+    provider_id: str
+    agent: str
+    output_text: str
+    response: dict[str, JsonValue]

--- a/app/modules/agent_provider_runtime/service.py
+++ b/app/modules/agent_provider_runtime/service.py
@@ -1,0 +1,1083 @@
+from __future__ import annotations
+
+import asyncio
+import codecs
+import logging
+import time
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+from aiohttp import ClientError, ClientResponse
+
+from app.core.clients.http import lease_http_session
+from app.core.crypto import TokenEncryptor
+from app.core.errors import openai_error
+from app.core.exceptions import ProxyAuthError, ProxyModelNotAllowed, ProxyRateLimitError, ProxyUpstreamError
+from app.core.types import JsonValue
+from app.core.utils.json_guards import is_json_list, is_json_mapping
+from app.core.utils.request_id import ensure_request_id
+from app.core.utils.time import utcnow
+from app.db.models import AgentProviderAccount
+from app.modules.agent_provider_routing.service import AgentProviderRoutingNotFoundError
+from app.modules.agent_provider_routing.settlement import AgentProviderUsageSettlementData
+from app.modules.agent_provider_runtime.antigravity import (
+    AntigravityHarnessCommand,
+    AntigravityHarnessExecutionError,
+    AntigravityHarnessRequest,
+    AntigravityHarnessValidationError,
+    AntigravityProcessResult,
+    AntigravityProcessRunnerPort,
+    AntigravitySubprocessRunner,
+    antigravity_harness_env,
+    build_antigravity_command,
+    command_preview,
+)
+from app.modules.agent_provider_runtime.gemini import (
+    GeminiAdapterError,
+    GeminiChatRequest,
+    build_generate_content_payload,
+    build_generate_content_url,
+    chat_completion_chunk_to_sse,
+    generate_content_to_chat_completion,
+    generate_content_to_chat_completion_chunk,
+    parse_gemini_sse_data_lines,
+)
+from app.modules.api_keys.service import (
+    ApiKeyData,
+    ApiKeyInvalidError,
+    ApiKeyRateLimitExceededError,
+    ApiKeyRequestUsageBudget,
+    ApiKeyUsageReservationData,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TokenDecryptorPort(Protocol):
+    def decrypt(self, encrypted: bytes) -> str: ...
+
+
+class AgentProviderSelectorPort(Protocol):
+    async def select_account(self, provider_id: str, *, auth_mode: str | None = None) -> Any: ...
+
+    async def settle_usage(
+        self,
+        provider_id: str,
+        account_id: str,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None: ...
+
+
+class ApiKeyUsagePort(Protocol):
+    async def enforce_limits_for_request(
+        self,
+        key_id: str,
+        *,
+        request_model: str | None,
+        request_service_tier: str | None = None,
+        request_usage_budget: ApiKeyRequestUsageBudget | None = None,
+    ) -> ApiKeyUsageReservationData: ...
+
+    async def finalize_usage_reservation(
+        self,
+        reservation_id: str,
+        *,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cached_input_tokens: int = 0,
+        service_tier: str | None = None,
+    ) -> None: ...
+
+    async def release_usage_reservation(self, reservation_id: str) -> None: ...
+
+
+class RequestLogWriterPort(Protocol):
+    async def add_log(
+        self,
+        account_id: str | None,
+        request_id: str,
+        model: str,
+        input_tokens: int | None,
+        output_tokens: int | None,
+        latency_ms: int | None,
+        status: str,
+        error_code: str | None,
+        **kwargs: Any,
+    ) -> object: ...
+
+
+class GeminiRuntimeValidationError(Exception):
+    pass
+
+
+class AntigravityRuntimeValidationError(Exception):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class AntigravityHarnessResult:
+    account: AgentProviderAccount
+    command: AntigravityHarnessCommand
+    process: AntigravityProcessResult
+
+
+@dataclass(frozen=True, slots=True)
+class GeminiRuntimeSelection:
+    account: AgentProviderAccount
+    api_key: str
+
+
+@dataclass(frozen=True, slots=True)
+class GeminiRuntimeRequestContext:
+    api_key: ApiKeyData | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AntigravityRuntimeSelection:
+    account: AgentProviderAccount
+    api_key: str
+
+
+@dataclass(frozen=True, slots=True)
+class AntigravityRuntimeRequestContext:
+    api_key: ApiKeyData | None = None
+
+
+class AntigravityHarnessService:
+    def __init__(
+        self,
+        routing_service: AgentProviderSelectorPort,
+        *,
+        runner: AntigravityProcessRunnerPort | None = None,
+        request_logs: RequestLogWriterPort | None = None,
+        executable: str = "agy",
+    ) -> None:
+        self._routing_service = routing_service
+        self._runner = runner or AntigravitySubprocessRunner()
+        self._request_logs = request_logs
+        self._executable = executable
+
+    async def print_prompt(self, request: AntigravityHarnessRequest) -> AntigravityHarnessResult:
+        command = build_antigravity_command(request, executable=self._executable)
+        request_id = ensure_request_id()
+        selected = None
+        try:
+            selected = await self._routing_service.select_account("antigravity", auth_mode="cli_keyring")
+            process = await self._runner.run(
+                command,
+                env=antigravity_harness_env(profile_id=selected.account.external_account_id),
+            )
+        except AgentProviderRoutingNotFoundError as exc:
+            raise AntigravityHarnessValidationError(str(exc) or "No Antigravity CLI profile available") from exc
+        except AntigravityHarnessExecutionError as exc:
+            await self._write_harness_log(
+                request_id=request_id,
+                command=command,
+                selection=selected,
+                status="error",
+                error_code="antigravity_cli_timeout",
+                error_message=str(exc),
+                latency_ms=None,
+            )
+            raise
+
+        status = "success" if process.exit_code == 0 else "error"
+        error_code = None if process.exit_code == 0 else "antigravity_cli_failed"
+        error_message = None if process.exit_code == 0 else process.stderr or process.stdout or "Antigravity CLI failed"
+        await self._write_harness_log(
+            request_id=request_id,
+            command=command,
+            selection=selected,
+            status=status,
+            error_code=error_code,
+            error_message=error_message,
+            latency_ms=process.duration_ms,
+        )
+        if process.exit_code == 0:
+            await self._routing_service.settle_usage(
+                "antigravity",
+                selected.account.id,
+                AgentProviderUsageSettlementData(requests=1),
+            )
+        return AntigravityHarnessResult(account=selected.account, command=command, process=process)
+
+    async def _write_harness_log(
+        self,
+        *,
+        request_id: str,
+        command: AntigravityHarnessCommand,
+        selection: Any,
+        status: str,
+        error_code: str | None,
+        error_message: str | None,
+        latency_ms: int | None,
+    ) -> None:
+        if self._request_logs is None:
+            return
+        try:
+            account = None if selection is None else selection.account
+            await self._request_logs.add_log(
+                None,
+                request_id,
+                "antigravity-cli",
+                None,
+                None,
+                latency_ms,
+                status,
+                error_code,
+                error_message=error_message,
+                requested_at=utcnow(),
+                source="antigravity",
+                transport="agy_cli",
+                plan_type="agent_provider",
+                failure_detail=(
+                    f"provider_account_id={account.id}; cwd={command.cwd}; command={' '.join(command_preview(command))}"
+                    if account is not None
+                    else f"cwd={command.cwd}; command={' '.join(command_preview(command))}"
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to write Antigravity harness request log request_id=%s",
+                request_id,
+                exc_info=True,
+            )
+
+
+class AntigravityManagedAgentService:
+    def __init__(
+        self,
+        routing_service: AgentProviderSelectorPort,
+        *,
+        decryptor: TokenDecryptorPort | None = None,
+        api_key_service: ApiKeyUsagePort | None = None,
+        request_logs: RequestLogWriterPort | None = None,
+    ) -> None:
+        self._routing_service = routing_service
+        self._decryptor = decryptor or TokenEncryptor()
+        self._api_key_service = api_key_service
+        self._request_logs = request_logs
+
+    async def select_account(self) -> AntigravityRuntimeSelection:
+        try:
+            selected = await self._routing_service.select_account("antigravity", auth_mode="api_key")
+        except AgentProviderRoutingNotFoundError as exc:
+            raise ProxyRateLimitError(str(exc) or "No Antigravity API-key account available") from exc
+        account = selected.account
+        if account.api_key_encrypted is None:
+            raise ProxyUpstreamError("Selected Antigravity account has no API key")
+        return AntigravityRuntimeSelection(account=account, api_key=self._decryptor.decrypt(account.api_key_encrypted))
+
+    async def create_interaction(
+        self,
+        payload: Mapping[str, JsonValue],
+        context: AntigravityRuntimeRequestContext | None = None,
+    ) -> dict[str, JsonValue]:
+        api_key = None if context is None else context.api_key
+        request_payload = _normalize_antigravity_interaction_payload(_interaction_payload_for_api_key(payload, api_key))
+        agent = _interaction_agent(request_payload)
+        request_id = ensure_request_id()
+        started_at = time.perf_counter()
+        reservation = await self._reserve_api_key_usage(context, model=agent)
+        selection: AntigravityRuntimeSelection | None = None
+        try:
+            selection = await self.select_account()
+            async with lease_http_session() as session:
+                try:
+                    async with session.post(
+                        "https://generativelanguage.googleapis.com/v1beta/interactions",
+                        json=request_payload,
+                        headers={
+                            "Content-Type": "application/json",
+                            "x-goog-api-key": selection.api_key,
+                            "Api-Revision": "2026-05-20",
+                        },
+                    ) as response:
+                        await _raise_for_gemini_error(response)
+                        data = await response.json()
+                except ClientError as exc:
+                    raise ProxyUpstreamError(str(exc) or "Antigravity upstream request failed") from exc
+            if not is_json_mapping(data):
+                raise ProxyUpstreamError("Antigravity upstream returned an invalid response")
+        except Exception as exc:
+            await self._release_api_key_usage(reservation)
+            await self._write_request_log(
+                request_id=request_id,
+                agent=agent,
+                context=context,
+                selection=selection,
+                status="error",
+                error_code=_error_code(exc),
+                error_message=str(exc) or None,
+                latency_ms=_elapsed_ms(started_at),
+            )
+            raise
+
+        usage = _usage_settlement_from_payload(data)
+        if usage.requests == 0:
+            usage = AgentProviderUsageSettlementData(requests=1)
+        await self._finalize_api_key_usage(reservation, model=agent, usage=usage)
+        await self._settle_provider_usage(selection, usage)
+        await self._write_request_log(
+            request_id=request_id,
+            agent=agent,
+            context=context,
+            selection=selection,
+            status="success",
+            error_code=None,
+            input_tokens=usage.prompt_tokens,
+            output_tokens=usage.completion_tokens,
+            latency_ms=_elapsed_ms(started_at),
+        )
+        return cast(dict[str, JsonValue], data)
+
+    async def complete_chat(
+        self,
+        payload: Mapping[str, JsonValue],
+        context: AntigravityRuntimeRequestContext | None = None,
+    ) -> dict[str, JsonValue]:
+        api_key = None if context is None else context.api_key
+        request = parse_chat_completion_request(_payload_for_api_key(payload, api_key))
+        if request.stream:
+            raise AntigravityRuntimeValidationError("Antigravity chat compatibility does not support streaming")
+        if request.tools:
+            raise AntigravityRuntimeValidationError("Antigravity chat compatibility does not support function tools")
+        interaction = await self.create_interaction(
+            {
+                "agent": request.model,
+                "input": _chat_messages_to_antigravity_input(request.messages),
+                "environment": "remote",
+            },
+            context,
+        )
+        return _antigravity_interaction_to_chat_completion(interaction, model=request.model)
+
+    async def _reserve_api_key_usage(
+        self,
+        context: AntigravityRuntimeRequestContext | None,
+        *,
+        model: str,
+    ) -> ApiKeyUsageReservationData | None:
+        api_key = None if context is None else context.api_key
+        if api_key is None or self._api_key_service is None:
+            return None
+        try:
+            return await self._api_key_service.enforce_limits_for_request(
+                api_key.id,
+                request_model=model,
+                request_service_tier=None,
+                request_usage_budget=None,
+            )
+        except ApiKeyRateLimitExceededError as exc:
+            message = f"{exc}. Usage resets at {exc.reset_at.isoformat()}Z."
+            raise ProxyRateLimitError(message) from exc
+        except ApiKeyInvalidError as exc:
+            raise ProxyAuthError(str(exc)) from exc
+
+    async def _finalize_api_key_usage(
+        self,
+        reservation: ApiKeyUsageReservationData | None,
+        *,
+        model: str,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None:
+        if reservation is None or self._api_key_service is None:
+            return
+        try:
+            input_tokens = usage.prompt_tokens
+            output_tokens = usage.completion_tokens
+            await self._api_key_service.finalize_usage_reservation(
+                reservation.reservation_id,
+                model=model,
+                input_tokens=input_tokens or 0,
+                output_tokens=output_tokens or 0,
+                cached_input_tokens=0,
+                service_tier=None,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to finalize Antigravity API key reservation reservation_id=%s model=%s",
+                reservation.reservation_id,
+                model,
+                exc_info=True,
+            )
+
+    async def _settle_provider_usage(
+        self,
+        selection: AntigravityRuntimeSelection,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None:
+        try:
+            await self._routing_service.settle_usage("antigravity", selection.account.id, usage)
+        except Exception:
+            logger.warning(
+                "Failed to settle Antigravity provider usage account_id=%s",
+                selection.account.id,
+                exc_info=True,
+            )
+
+    async def _release_api_key_usage(self, reservation: ApiKeyUsageReservationData | None) -> None:
+        if reservation is None or self._api_key_service is None:
+            return
+        try:
+            await self._api_key_service.release_usage_reservation(reservation.reservation_id)
+        except Exception:
+            logger.warning(
+                "Failed to release Antigravity API key reservation reservation_id=%s",
+                reservation.reservation_id,
+                exc_info=True,
+            )
+
+    async def _write_request_log(
+        self,
+        *,
+        request_id: str,
+        agent: str,
+        context: AntigravityRuntimeRequestContext | None,
+        selection: AntigravityRuntimeSelection | None,
+        status: str,
+        error_code: str | None,
+        latency_ms: int | None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        if self._request_logs is None:
+            return
+        api_key = None if context is None else context.api_key
+        try:
+            await self._request_logs.add_log(
+                None,
+                request_id,
+                agent,
+                input_tokens,
+                output_tokens,
+                latency_ms,
+                status,
+                error_code,
+                error_message=error_message,
+                requested_at=utcnow(),
+                api_key_id=None if api_key is None else api_key.id,
+                source="antigravity",
+                transport="interactions_api",
+                plan_type="agent_provider",
+                failure_detail=None if selection is None else f"provider_account_id={selection.account.id}",
+            )
+        except Exception:
+            logger.warning(
+                "Failed to write Antigravity request log request_id=%s agent=%s",
+                request_id,
+                agent,
+                exc_info=True,
+            )
+
+
+class GeminiRuntimeService:
+    def __init__(
+        self,
+        routing_service: AgentProviderSelectorPort,
+        *,
+        decryptor: TokenDecryptorPort | None = None,
+        api_key_service: ApiKeyUsagePort | None = None,
+        request_logs: RequestLogWriterPort | None = None,
+    ) -> None:
+        self._routing_service = routing_service
+        self._decryptor = decryptor or TokenEncryptor()
+        self._api_key_service = api_key_service
+        self._request_logs = request_logs
+
+    async def select_account(self) -> GeminiRuntimeSelection:
+        try:
+            selected = await self._routing_service.select_account("gemini", auth_mode="api_key")
+        except AgentProviderRoutingNotFoundError as exc:
+            raise ProxyRateLimitError(str(exc) or "No Gemini provider account available") from exc
+        account = selected.account
+        if account.api_key_encrypted is None:
+            raise ProxyUpstreamError("Selected Gemini account has no API key")
+        return GeminiRuntimeSelection(account=account, api_key=self._decryptor.decrypt(account.api_key_encrypted))
+
+    async def complete_chat(
+        self,
+        payload: Mapping[str, JsonValue],
+        context: GeminiRuntimeRequestContext | None = None,
+    ) -> dict[str, JsonValue]:
+        api_key = None if context is None else context.api_key
+        request = parse_chat_completion_request(_payload_for_api_key(payload, api_key))
+        request_id = ensure_request_id()
+        started_at = time.perf_counter()
+        reservation = await self._reserve_api_key_usage(context, model=request.model)
+        selection: GeminiRuntimeSelection | None = None
+        try:
+            selection = await self.select_account()
+            upstream_payload = build_generate_content_payload(request)
+            url = build_generate_content_url(request.model)
+            async with lease_http_session() as session:
+                try:
+                    async with session.post(
+                        url,
+                        json=upstream_payload,
+                        headers={
+                            "Content-Type": "application/json",
+                            "x-goog-api-key": selection.api_key,
+                        },
+                    ) as response:
+                        await _raise_for_gemini_error(response)
+                        data = await response.json()
+                except ClientError as exc:
+                    raise ProxyUpstreamError(str(exc) or "Gemini upstream request failed") from exc
+            if not is_json_mapping(data):
+                raise ProxyUpstreamError("Gemini upstream returned an invalid response")
+        except Exception as exc:
+            await self._release_api_key_usage(reservation)
+            await self._write_request_log(
+                request_id=request_id,
+                request=request,
+                context=context,
+                selection=selection,
+                status="error",
+                error_code=_error_code(exc),
+                error_message=str(exc) or None,
+                latency_ms=_elapsed_ms(started_at),
+            )
+            raise
+
+        usage = _usage_settlement_from_payload(data)
+        await self._finalize_api_key_usage(reservation, request=request, usage=usage)
+        await self._settle_provider_usage(selection, usage)
+        await self._write_request_log(
+            request_id=request_id,
+            request=request,
+            context=context,
+            selection=selection,
+            status="success",
+            error_code=None,
+            input_tokens=usage.prompt_tokens,
+            output_tokens=usage.completion_tokens,
+            latency_ms=_elapsed_ms(started_at),
+        )
+        return cast(dict[str, JsonValue], generate_content_to_chat_completion(data, model=request.model))
+
+    async def stream_chat(
+        self,
+        payload: Mapping[str, JsonValue],
+        context: GeminiRuntimeRequestContext | None = None,
+    ) -> AsyncIterator[str]:
+        api_key = None if context is None else context.api_key
+        request = parse_chat_completion_request(_payload_for_api_key(payload, api_key))
+        request_id = ensure_request_id()
+        reservation = await self._reserve_api_key_usage(context, model=request.model)
+
+        async def body() -> AsyncIterator[str]:
+            started_at = time.perf_counter()
+            usage_payload: Mapping[str, JsonValue] | None = None
+            selection: GeminiRuntimeSelection | None = None
+            try:
+                selection = await self.select_account()
+                upstream_payload = build_generate_content_payload(request)
+                url = build_generate_content_url(request.model, stream=True)
+                async with lease_http_session() as session:
+                    try:
+                        async with session.post(
+                            url,
+                            json=upstream_payload,
+                            headers={
+                                "Content-Type": "application/json",
+                                "x-goog-api-key": selection.api_key,
+                            },
+                        ) as response:
+                            await _raise_for_gemini_error(response)
+                            async for event in _iter_gemini_sse_events(response):
+                                if is_json_mapping(event.get("usageMetadata")):
+                                    usage_payload = event
+                                chunk = generate_content_to_chat_completion_chunk(event, model=request.model)
+                                yield chat_completion_chunk_to_sse(cast(Mapping[str, JsonValue], chunk))
+                    except ClientError as exc:
+                        raise ProxyUpstreamError(str(exc) or "Gemini upstream stream failed") from exc
+            except asyncio.CancelledError:
+                if selection is None or usage_payload is None:
+                    await self._release_api_key_usage(reservation)
+                else:
+                    usage = _usage_settlement_from_payload(usage_payload)
+                    await self._finalize_api_key_usage(reservation, request=request, usage=usage)
+                    await self._settle_provider_usage(selection, usage)
+                await self._write_request_log(
+                    request_id=request_id,
+                    request=request,
+                    context=context,
+                    selection=selection,
+                    status="error",
+                    error_code="client_cancelled",
+                    error_message="Gemini stream cancelled",
+                    latency_ms=_elapsed_ms(started_at),
+                )
+                raise
+            except Exception as exc:
+                if selection is None:
+                    await self._release_api_key_usage(reservation)
+                else:
+                    usage = _usage_settlement_from_payload(usage_payload or {})
+                    await self._finalize_api_key_usage(reservation, request=request, usage=usage)
+                    await self._settle_provider_usage(selection, usage)
+                await self._write_request_log(
+                    request_id=request_id,
+                    request=request,
+                    context=context,
+                    selection=selection,
+                    status="error",
+                    error_code=_error_code(exc),
+                    error_message=str(exc) or None,
+                    latency_ms=_elapsed_ms(started_at),
+                )
+                raise
+            usage = _usage_settlement_from_payload(usage_payload or {})
+            assert selection is not None
+            await self._finalize_api_key_usage(reservation, request=request, usage=usage)
+            await self._settle_provider_usage(selection, usage)
+            await self._write_request_log(
+                request_id=request_id,
+                request=request,
+                context=context,
+                selection=selection,
+                status="success",
+                error_code=None,
+                input_tokens=usage.prompt_tokens,
+                output_tokens=usage.completion_tokens,
+                latency_ms=_elapsed_ms(started_at),
+            )
+            yield "data: [DONE]\n\n"
+
+        return body()
+
+    async def _reserve_api_key_usage(
+        self,
+        context: GeminiRuntimeRequestContext | None,
+        *,
+        model: str,
+    ) -> ApiKeyUsageReservationData | None:
+        api_key = None if context is None else context.api_key
+        if api_key is None or self._api_key_service is None:
+            return None
+        try:
+            return await self._api_key_service.enforce_limits_for_request(
+                api_key.id,
+                request_model=model,
+                request_service_tier=None,
+                request_usage_budget=None,
+            )
+        except ApiKeyRateLimitExceededError as exc:
+            message = f"{exc}. Usage resets at {exc.reset_at.isoformat()}Z."
+            raise ProxyRateLimitError(message) from exc
+        except ApiKeyInvalidError as exc:
+            raise ProxyAuthError(str(exc)) from exc
+
+    async def _finalize_api_key_usage(
+        self,
+        reservation: ApiKeyUsageReservationData | None,
+        *,
+        request: GeminiChatRequest,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None:
+        if reservation is None or self._api_key_service is None:
+            return
+        try:
+            input_tokens = usage.prompt_tokens
+            output_tokens = usage.completion_tokens
+            await self._api_key_service.finalize_usage_reservation(
+                reservation.reservation_id,
+                model=request.model,
+                input_tokens=input_tokens or 0,
+                output_tokens=output_tokens or 0,
+                cached_input_tokens=0,
+                service_tier=None,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to finalize Gemini API key reservation reservation_id=%s model=%s",
+                reservation.reservation_id,
+                request.model,
+                exc_info=True,
+            )
+
+    async def _settle_provider_usage(
+        self,
+        selection: GeminiRuntimeSelection,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None:
+        try:
+            await self._routing_service.settle_usage("gemini", selection.account.id, usage)
+        except Exception:
+            logger.warning(
+                "Failed to settle Gemini provider usage account_id=%s",
+                selection.account.id,
+                exc_info=True,
+            )
+
+    async def _release_api_key_usage(self, reservation: ApiKeyUsageReservationData | None) -> None:
+        if reservation is None or self._api_key_service is None:
+            return
+        try:
+            await self._api_key_service.release_usage_reservation(reservation.reservation_id)
+        except Exception:
+            logger.warning(
+                "Failed to release Gemini API key reservation reservation_id=%s",
+                reservation.reservation_id,
+                exc_info=True,
+            )
+
+    async def _write_request_log(
+        self,
+        *,
+        request_id: str,
+        request: GeminiChatRequest,
+        context: GeminiRuntimeRequestContext | None,
+        selection: GeminiRuntimeSelection | None,
+        status: str,
+        error_code: str | None,
+        latency_ms: int | None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        if self._request_logs is None:
+            return
+        api_key = None if context is None else context.api_key
+        try:
+            await self._request_logs.add_log(
+                None,
+                request_id,
+                request.model,
+                input_tokens,
+                output_tokens,
+                latency_ms,
+                status,
+                error_code,
+                error_message=error_message,
+                requested_at=utcnow(),
+                api_key_id=None if api_key is None else api_key.id,
+                source="gemini",
+                transport="gemini_native",
+                plan_type="agent_provider",
+                failure_detail=None if selection is None else f"provider_account_id={selection.account.id}",
+            )
+        except Exception:
+            logger.warning(
+                "Failed to write Gemini request log request_id=%s model=%s",
+                request_id,
+                request.model,
+                exc_info=True,
+            )
+
+
+def parse_chat_completion_request(payload: Mapping[str, JsonValue]) -> GeminiChatRequest:
+    model = payload.get("model")
+    messages = payload.get("messages")
+    if not isinstance(model, str) or not model.strip():
+        raise GeminiRuntimeValidationError("model is required")
+    if not is_json_list(messages) or not all(is_json_mapping(message) for message in messages):
+        raise GeminiRuntimeValidationError("messages must be an array")
+    try:
+        return GeminiChatRequest(
+            model=model,
+            messages=cast(list[Mapping[str, JsonValue]], messages),
+            stream=payload.get("stream") is True,
+            temperature=_float_or_none(payload.get("temperature")),
+            top_p=_float_or_none(payload.get("top_p")),
+            max_tokens=_int_or_none(payload.get("max_tokens")) or _int_or_none(payload.get("max_completion_tokens")),
+            stop=_stop_or_none(payload.get("stop")),
+            tools=_tools_or_none(payload.get("tools")),
+            response_format=payload.get("response_format"),
+        )
+    except GeminiAdapterError as exc:
+        raise GeminiRuntimeValidationError(str(exc)) from exc
+
+
+def _payload_for_api_key(payload: Mapping[str, JsonValue], api_key: ApiKeyData | None) -> Mapping[str, JsonValue]:
+    model = payload.get("model")
+    if not isinstance(model, str) or not model.strip():
+        return payload
+    enforced_model = None if api_key is None else api_key.enforced_model
+    effective_model = enforced_model or model
+    if api_key is not None and api_key.allowed_models and effective_model not in api_key.allowed_models:
+        raise ProxyModelNotAllowed(f"Model is not allowed for this API key: {effective_model}")
+    if enforced_model is None:
+        return payload
+    updated = dict(payload)
+    updated["model"] = enforced_model
+    return updated
+
+
+def _interaction_payload_for_api_key(
+    payload: Mapping[str, JsonValue],
+    api_key: ApiKeyData | None,
+) -> Mapping[str, JsonValue]:
+    agent = payload.get("agent")
+    if not isinstance(agent, str) or not agent.strip():
+        return payload
+    enforced_model = None if api_key is None else api_key.enforced_model
+    effective_agent = enforced_model or agent
+    if api_key is not None and api_key.allowed_models and effective_agent not in api_key.allowed_models:
+        raise ProxyModelNotAllowed(f"Model is not allowed for this API key: {effective_agent}")
+    if enforced_model is None:
+        return payload
+    updated = dict(payload)
+    updated["agent"] = enforced_model
+    return updated
+
+
+async def _iter_gemini_sse_events(response: ClientResponse) -> AsyncIterator[dict[str, JsonValue]]:
+    buffer = ""
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    async for chunk in response.content.iter_any():
+        buffer += decoder.decode(chunk)
+        buffer = buffer.replace("\r\n", "\n").replace("\r", "\n")
+        while "\n\n" in buffer:
+            raw_event, buffer = buffer.split("\n\n", 1)
+            for event in parse_gemini_sse_data_lines(raw_event.splitlines()):
+                yield event
+    buffer += decoder.decode(b"", final=True)
+    buffer = buffer.replace("\r\n", "\n").replace("\r", "\n")
+    if buffer.strip():
+        for event in parse_gemini_sse_data_lines(buffer.splitlines()):
+            yield event
+
+
+async def _raise_for_gemini_error(response: ClientResponse) -> None:
+    if response.status < 400:
+        return
+    message = await _gemini_error_message(response)
+    if response.status == 429:
+        raise ProxyRateLimitError(message, retry_after=response.headers.get("Retry-After"))
+    raise ProxyUpstreamError(message)
+
+
+async def _gemini_error_message(response: ClientResponse) -> str:
+    try:
+        payload = await response.json()
+    except Exception:
+        text = await response.text()
+        return text or f"Gemini upstream returned HTTP {response.status}"
+    if is_json_mapping(payload):
+        error = payload.get("error")
+        if is_json_mapping(error):
+            message = error.get("message")
+            if isinstance(message, str) and message:
+                return message
+    return f"Gemini upstream returned HTTP {response.status}"
+
+
+def _float_or_none(value: JsonValue) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _int_or_none(value: JsonValue) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _stop_or_none(value: JsonValue) -> str | list[str] | None:
+    if isinstance(value, str):
+        return value
+    if is_json_list(value) and all(isinstance(item, str) for item in value):
+        return cast(list[str], value)
+    return None
+
+
+def _tools_or_none(value: JsonValue) -> list[JsonValue] | None:
+    if is_json_list(value):
+        return value
+    return None
+
+
+def invalid_request_error(message: str) -> dict[str, JsonValue]:
+    return cast(
+        dict[str, JsonValue],
+        openai_error("invalid_request_error", message, error_type="invalid_request_error"),
+    )
+
+
+def _normalize_antigravity_interaction_payload(payload: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+    agent = _interaction_agent(payload)
+    interaction_input = payload.get("input")
+    if interaction_input is None:
+        raise AntigravityRuntimeValidationError("input is required")
+    environment = payload.get("environment", "remote")
+    if not (isinstance(environment, str) and environment.strip()) and not is_json_mapping(environment):
+        raise AntigravityRuntimeValidationError("environment must be a string or object")
+    normalized: dict[str, JsonValue] = {
+        "agent": agent,
+        "input": interaction_input,
+        "environment": environment,
+    }
+    tools = payload.get("tools")
+    if tools is not None:
+        if not is_json_list(tools):
+            raise AntigravityRuntimeValidationError("tools must be an array")
+        normalized["tools"] = tools
+    return normalized
+
+
+def _interaction_agent(payload: Mapping[str, JsonValue]) -> str:
+    agent = payload.get("agent")
+    if not isinstance(agent, str) or not agent.strip():
+        raise AntigravityRuntimeValidationError("agent is required")
+    if not agent.startswith("antigravity-"):
+        raise AntigravityRuntimeValidationError("agent must be an Antigravity model")
+    return agent.strip()
+
+
+def _chat_messages_to_antigravity_input(messages: list[Mapping[str, JsonValue]]) -> str:
+    lines: list[str] = []
+    for message in messages:
+        role = message.get("role")
+        if not isinstance(role, str):
+            raise AntigravityRuntimeValidationError("message role must be a string")
+        if role == "tool":
+            raise AntigravityRuntimeValidationError("Antigravity chat compatibility does not support tool messages")
+        text = _message_text_content(message.get("content"))
+        if text:
+            lines.append(f"{role}: {text}")
+    if not lines:
+        raise AntigravityRuntimeValidationError("Antigravity request requires at least one text message")
+    return "\n\n".join(lines)
+
+
+def _message_text_content(content: JsonValue) -> str:
+    if isinstance(content, str):
+        return content
+    if is_json_list(content):
+        texts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                texts.append(part)
+            elif is_json_mapping(part):
+                text = part.get("text")
+                if isinstance(text, str):
+                    texts.append(text)
+        return "\n".join(texts)
+    return ""
+
+
+def _antigravity_interaction_to_chat_completion(
+    payload: Mapping[str, JsonValue],
+    *,
+    model: str,
+) -> dict[str, JsonValue]:
+    return {
+        "id": _antigravity_response_id(payload),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": _antigravity_output_text(payload)},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def _antigravity_response_id(payload: Mapping[str, JsonValue]) -> str:
+    for key in ("id", "name", "interactionId", "interaction_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return "antigravity-interaction"
+
+
+def _antigravity_output_text(payload: Mapping[str, JsonValue]) -> str:
+    for key in ("output_text", "outputText", "text"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    output = payload.get("output")
+    if isinstance(output, str):
+        return output
+    if is_json_mapping(output):
+        text = output.get("text")
+        if isinstance(text, str):
+            return text
+    steps_text = _antigravity_steps_output_text(payload)
+    if steps_text:
+        return steps_text
+    outputs_text = _antigravity_outputs_text(payload)
+    if outputs_text:
+        return outputs_text
+    return ""
+
+
+def _antigravity_steps_output_text(payload: Mapping[str, JsonValue]) -> str:
+    steps = payload.get("steps")
+    if not is_json_list(steps):
+        return ""
+    for step in reversed(steps):
+        if not is_json_mapping(step) or step.get("type") != "model_output":
+            continue
+        text = _antigravity_content_text(step.get("content"))
+        if text:
+            return text
+    return ""
+
+
+def _antigravity_outputs_text(payload: Mapping[str, JsonValue]) -> str:
+    outputs = payload.get("outputs")
+    if not is_json_list(outputs):
+        return ""
+    return _antigravity_content_text(outputs)
+
+
+def _antigravity_content_text(value: JsonValue) -> str:
+    if isinstance(value, str):
+        return value
+    if is_json_mapping(value):
+        text = value.get("text")
+        return text if isinstance(text, str) else ""
+    if not is_json_list(value):
+        return ""
+    texts: list[str] = []
+    for block in value:
+        if isinstance(block, str):
+            texts.append(block)
+        elif is_json_mapping(block):
+            text = block.get("text")
+            if isinstance(text, str):
+                texts.append(text)
+    return "".join(texts)
+
+
+def _error_code(exc: BaseException) -> str:
+    code = getattr(exc, "code", None)
+    if isinstance(code, str) and code:
+        return code
+    if isinstance(exc, AntigravityRuntimeValidationError):
+        return "invalid_request_error"
+    if isinstance(exc, GeminiRuntimeValidationError):
+        return "invalid_request_error"
+    return "upstream_error"
+
+
+def _elapsed_ms(started_at: float) -> int:
+    return max(0, int((time.perf_counter() - started_at) * 1000))
+
+
+def _usage_settlement_from_payload(payload: Mapping[str, JsonValue]) -> AgentProviderUsageSettlementData:
+    usage = payload.get("usageMetadata")
+    if is_json_mapping(usage):
+        return AgentProviderUsageSettlementData(
+            requests=1,
+            prompt_tokens=_int_or_none(usage.get("promptTokenCount")),
+            completion_tokens=_int_or_none(usage.get("candidatesTokenCount")),
+            total_tokens=_int_or_none(usage.get("totalTokenCount")),
+        )
+    interaction_usage = payload.get("usage")
+    if is_json_mapping(interaction_usage):
+        return AgentProviderUsageSettlementData(
+            requests=1,
+            prompt_tokens=_int_or_none(interaction_usage.get("total_input_tokens")),
+            completion_tokens=_int_or_none(interaction_usage.get("total_output_tokens")),
+            total_tokens=_int_or_none(interaction_usage.get("total_tokens")),
+        )
+    return AgentProviderUsageSettlementData()

--- a/app/modules/agent_providers/__init__.py
+++ b/app/modules/agent_providers/__init__.py
@@ -1,0 +1,1 @@
+"""Agent provider metadata surfaces."""

--- a/app/modules/agent_providers/api.py
+++ b/app/modules/agent_providers/api.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.dependencies import AgentProvidersContext, get_agent_providers_context
+from app.modules.agent_providers.schemas import (
+    AgentProviderListResponse,
+    AgentProviderOverviewResponse,
+    ProviderOverviewTimeframe,
+)
+from app.modules.agent_providers.service import list_agent_providers
+
+router = APIRouter(
+    prefix="/api/agent-providers",
+    tags=["agent-providers"],
+    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+)
+
+
+@router.get("", response_model=AgentProviderListResponse)
+async def get_agent_providers() -> AgentProviderListResponse:
+    return list_agent_providers()
+
+
+@router.get("/overview", response_model=AgentProviderOverviewResponse)
+async def get_agent_provider_overview(
+    timeframe: ProviderOverviewTimeframe = "7d",
+    context: AgentProvidersContext = Depends(get_agent_providers_context),
+) -> AgentProviderOverviewResponse:
+    return await context.service.get_overview(timeframe)

--- a/app/modules/agent_providers/schemas.py
+++ b/app/modules/agent_providers/schemas.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from app.modules.shared.schemas import DashboardModel
+
+AgentProviderId = Literal["codex", "gemini", "antigravity"]
+AgentProviderStatus = Literal["ready", "foundation", "planned"]
+AgentProviderProtocol = Literal["codex_chatgpt", "gemini_api", "vertex_ai", "antigravity_cli", "interactions_api"]
+AgentProviderAuthMode = Literal["chatgpt_oauth", "api_key", "google_cloud_adc", "cli_keyring"]
+
+
+class AgentProviderCapability(DashboardModel):
+    protocol: AgentProviderProtocol
+    status: AgentProviderStatus
+    proxyable: bool
+    streaming: bool
+    lifecycle_notes: str
+    operator_action: str
+    available_until: str | None = None
+    notes: str
+
+
+class AgentProviderSummary(DashboardModel):
+    provider_id: AgentProviderId
+    display_name: str
+    status: AgentProviderStatus
+    auth_modes: list[AgentProviderAuthMode]
+    quota_dimensions: list[str]
+    dashboard_sections: list[str]
+    capabilities: list[AgentProviderCapability]
+
+
+class AgentProviderListResponse(DashboardModel):
+    providers: list[AgentProviderSummary]
+
+
+ProviderOverviewTimeframe = Literal["1d", "7d", "30d"]
+
+
+class AgentProviderOverviewItem(DashboardModel):
+    provider_id: AgentProviderId
+    display_name: str
+    status: AgentProviderStatus
+    account_count: int
+    active_account_count: int
+    quota_window_count: int
+    request_count: int
+    success_count: int
+    error_count: int
+    input_tokens: int
+    output_tokens: int
+    cached_input_tokens: int
+
+
+class AgentProviderOverviewTotals(DashboardModel):
+    provider_count: int
+    account_count: int
+    active_account_count: int
+    quota_window_count: int
+    request_count: int
+    success_count: int
+    error_count: int
+    input_tokens: int
+    output_tokens: int
+    cached_input_tokens: int
+
+
+class AgentProviderOverviewResponse(DashboardModel):
+    timeframe: ProviderOverviewTimeframe
+    providers: list[AgentProviderOverviewItem]
+    totals: AgentProviderOverviewTotals

--- a/app/modules/agent_providers/service.py
+++ b/app/modules/agent_providers/service.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+from typing import Protocol
+
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus, AgentProviderAccount
+from app.modules.agent_providers.schemas import (
+    AgentProviderCapability,
+    AgentProviderId,
+    AgentProviderListResponse,
+    AgentProviderOverviewItem,
+    AgentProviderOverviewResponse,
+    AgentProviderOverviewTotals,
+    AgentProviderStatus,
+    AgentProviderSummary,
+    ProviderOverviewTimeframe,
+)
+from app.modules.request_logs.repository import ProviderRequestLogAggregate
+
+
+class CodexAccountsRepositoryPort(Protocol):
+    async def list_accounts(self, *, refresh_existing: bool = False) -> list[Account]: ...
+
+
+class AgentProviderAccountsRepositoryPort(Protocol):
+    async def list_by_provider(self, provider_id: str) -> list[AgentProviderAccount]: ...
+
+
+class AgentProviderRoutingRepositoryPort(Protocol):
+    async def list_accounts_with_quota_windows(self, provider_id: str) -> list[AgentProviderAccount]: ...
+
+
+class RequestLogsRepositoryPort(Protocol):
+    async def aggregate_by_provider_since(self, since: datetime) -> list[ProviderRequestLogAggregate]: ...
+
+
+def list_agent_providers() -> AgentProviderListResponse:
+    return AgentProviderListResponse(
+        providers=[
+            AgentProviderSummary(
+                provider_id="codex",
+                display_name="Codex",
+                status="ready",
+                auth_modes=["chatgpt_oauth"],
+                quota_dimensions=["primary", "secondary", "additional_quota"],
+                dashboard_sections=["accounts", "settings", "usage", "reports", "request_logs"],
+                capabilities=[
+                    AgentProviderCapability(
+                        protocol="codex_chatgpt",
+                        status="ready",
+                        proxyable=True,
+                        streaming=True,
+                        lifecycle_notes="Existing production surface remains the primary Codex runtime.",
+                        operator_action="Keep using current Codex account and routing settings.",
+                        notes="Existing Codex/ChatGPT account pool and proxy routes.",
+                    )
+                ],
+            ),
+            AgentProviderSummary(
+                provider_id="gemini",
+                display_name="Gemini",
+                status="foundation",
+                auth_modes=["api_key", "google_cloud_adc", "cli_keyring"],
+                quota_dimensions=["rpm", "tpm", "rpd", "model_family"],
+                dashboard_sections=["accounts", "settings", "usage", "reports", "request_logs"],
+                capabilities=[
+                    AgentProviderCapability(
+                        protocol="gemini_api",
+                        status="foundation",
+                        proxyable=True,
+                        streaming=True,
+                        lifecycle_notes="Uses Gemini Developer API HTTP endpoints with native streaming support.",
+                        operator_action="Add Gemini API-key accounts, then configure provider-scoped quota windows.",
+                        notes="Gemini Developer API is the first proxyable Gemini surface.",
+                    ),
+                    AgentProviderCapability(
+                        protocol="vertex_ai",
+                        status="planned",
+                        proxyable=True,
+                        streaming=True,
+                        lifecycle_notes="Requires Google Cloud project/location credential handling before use.",
+                        operator_action="Defer until Vertex project and ADC/service-account settings are modeled.",
+                        notes="Vertex AI Gemini support needs separate project/location credentials.",
+                    ),
+                    AgentProviderCapability(
+                        protocol="antigravity_cli",
+                        status="planned",
+                        proxyable=False,
+                        streaming=False,
+                        lifecycle_notes=(
+                            "Antigravity CLI is the migration target for individual Gemini CLI users after 2026-06-18."
+                        ),
+                        operator_action="Build as an agy harness/session connector, not as a raw HTTP proxy route.",
+                        available_until="2026-06-18",
+                        notes="Antigravity CLI is modeled as a harness connector, not a raw HTTP proxy target.",
+                    ),
+                ],
+            ),
+            AgentProviderSummary(
+                provider_id="antigravity",
+                display_name="Antigravity",
+                status="foundation",
+                auth_modes=["api_key", "cli_keyring"],
+                quota_dimensions=["requests", "prompt_tokens", "completion_tokens", "sessions", "wall_time"],
+                dashboard_sections=["accounts", "settings", "usage", "request_logs"],
+                capabilities=[
+                    AgentProviderCapability(
+                        protocol="interactions_api",
+                        status="foundation",
+                        proxyable=True,
+                        streaming=False,
+                        lifecycle_notes=(
+                            "Antigravity Agent runs through the Gemini Interactions API as antigravity-preview-05-2026."
+                        ),
+                        operator_action=(
+                            "Add Antigravity API-key accounts, then route antigravity-preview models through "
+                            "/v1/chat/completions or /v1/antigravity/interactions."
+                        ),
+                        available_until=None,
+                        notes="Managed Google-hosted agent surface using Api-Revision 2026-05-20.",
+                    ),
+                    AgentProviderCapability(
+                        protocol="antigravity_cli",
+                        status="foundation",
+                        proxyable=False,
+                        streaming=False,
+                        lifecycle_notes=(
+                            "Antigravity CLI uses local agy harness sessions, system keyring auth, shared settings, "
+                            "and workspace state."
+                        ),
+                        operator_action=(
+                            "Register CLI profiles and run dashboard-authenticated agy --print harness probes."
+                        ),
+                        available_until=None,
+                        notes=(
+                            "Antigravity is tracked as a CLI harness provider rather than a Gemini HTTP alias; "
+                            "settings live under ~/.gemini/antigravity-cli/."
+                        ),
+                    ),
+                ],
+            ),
+        ]
+    )
+
+
+class AgentProviderOverviewService:
+    def __init__(
+        self,
+        *,
+        codex_accounts: CodexAccountsRepositoryPort,
+        provider_accounts: AgentProviderAccountsRepositoryPort,
+        provider_routing: AgentProviderRoutingRepositoryPort,
+        request_logs: RequestLogsRepositoryPort,
+    ) -> None:
+        self._codex_accounts = codex_accounts
+        self._provider_accounts = provider_accounts
+        self._provider_routing = provider_routing
+        self._request_logs = request_logs
+
+    async def get_overview(self, timeframe: ProviderOverviewTimeframe) -> AgentProviderOverviewResponse:
+        providers = list_agent_providers().providers
+        since = utcnow() - _timeframe_delta(timeframe)
+        codex_accounts = await self._codex_accounts.list_accounts()
+        gemini_accounts = await self._provider_accounts.list_by_provider("gemini")
+        antigravity_accounts = await self._provider_accounts.list_by_provider("antigravity")
+        gemini_quota_accounts = await self._provider_routing.list_accounts_with_quota_windows("gemini")
+        antigravity_quota_accounts = await self._provider_routing.list_accounts_with_quota_windows("antigravity")
+        request_aggregates = {
+            aggregate.provider_id: aggregate
+            for aggregate in await self._request_logs.aggregate_by_provider_since(since)
+        }
+
+        account_counts: dict[str, tuple[int, int, int]] = {
+            "codex": (
+                len(codex_accounts),
+                sum(1 for account in codex_accounts if account.status == AccountStatus.ACTIVE),
+                0,
+            ),
+            "gemini": _provider_account_counts(gemini_accounts, gemini_quota_accounts),
+            "antigravity": _provider_account_counts(antigravity_accounts, antigravity_quota_accounts),
+        }
+        items = [
+            _overview_item(
+                provider_id=provider.provider_id,
+                display_name=provider.display_name,
+                status=provider.status,
+                account_counts=account_counts[provider.provider_id],
+                request_aggregate=request_aggregates.get(provider.provider_id),
+            )
+            for provider in providers
+        ]
+        return AgentProviderOverviewResponse(
+            timeframe=timeframe,
+            providers=items,
+            totals=_overview_totals(items),
+        )
+
+
+def _timeframe_delta(timeframe: ProviderOverviewTimeframe) -> timedelta:
+    if timeframe == "1d":
+        return timedelta(days=1)
+    if timeframe == "30d":
+        return timedelta(days=30)
+    return timedelta(days=7)
+
+
+def _provider_account_counts(
+    accounts: Sequence[AgentProviderAccount],
+    quota_accounts: Sequence[AgentProviderAccount],
+) -> tuple[int, int, int]:
+    return (
+        len(accounts),
+        sum(1 for account in accounts if account.status == "active"),
+        sum(len(account.quota_windows) for account in quota_accounts),
+    )
+
+
+def _overview_item(
+    *,
+    provider_id: AgentProviderId,
+    display_name: str,
+    status: AgentProviderStatus,
+    account_counts: tuple[int, int, int],
+    request_aggregate: ProviderRequestLogAggregate | None,
+) -> AgentProviderOverviewItem:
+    account_count, active_account_count, quota_window_count = account_counts
+    return AgentProviderOverviewItem(
+        provider_id=provider_id,
+        display_name=display_name,
+        status=status,
+        account_count=account_count,
+        active_account_count=active_account_count,
+        quota_window_count=quota_window_count,
+        request_count=0 if request_aggregate is None else request_aggregate.request_count,
+        success_count=0 if request_aggregate is None else request_aggregate.success_count,
+        error_count=0 if request_aggregate is None else request_aggregate.error_count,
+        input_tokens=0 if request_aggregate is None else request_aggregate.input_tokens,
+        output_tokens=0 if request_aggregate is None else request_aggregate.output_tokens,
+        cached_input_tokens=0 if request_aggregate is None else request_aggregate.cached_input_tokens,
+    )
+
+
+def _overview_totals(items: Sequence[AgentProviderOverviewItem]) -> AgentProviderOverviewTotals:
+    return AgentProviderOverviewTotals(
+        provider_count=len(items),
+        account_count=sum(item.account_count for item in items),
+        active_account_count=sum(item.active_account_count for item in items),
+        quota_window_count=sum(item.quota_window_count for item in items),
+        request_count=sum(item.request_count for item in items),
+        success_count=sum(item.success_count for item in items),
+        error_count=sum(item.error_count for item in items),
+        input_tokens=sum(item.input_tokens for item in items),
+        output_tokens=sum(item.output_tokens for item in items),
+        cached_input_tokens=sum(item.cached_input_tokens for item in items),
+    )

--- a/app/modules/dashboard/api.py
+++ b/app/modules/dashboard/api.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, Query
 from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
 from app.core.openai.model_registry import get_model_registry, is_public_model
 from app.dependencies import DashboardContext, get_dashboard_context
+from app.modules.agent_provider_runtime.model_catalog import list_agent_provider_models
 from app.modules.dashboard.schemas import (
     DashboardOverviewResponse,
     DashboardOverviewTimeframeKey,
@@ -37,11 +38,19 @@ async def get_projections(
 async def list_models() -> dict:
     registry = get_model_registry()
     models_by_slug = registry.get_models_with_fallback()
-    if not models_by_slug:
-        return {"models": []}
     models = [
-        {"id": slug, "name": model.display_name or slug}
+        {"id": slug, "name": model.display_name or slug, "provider": "codex"}
         for slug, model in models_by_slug.items()
         if is_public_model(model, None)
     ]
+    models.extend(
+        {
+            "id": model.model_id,
+            "name": model.display_name,
+            "provider": model.provider_id,
+            "protocol": model.protocol,
+            "lifecycle": model.lifecycle,
+        }
+        for model in list_agent_provider_models()
+    )
     return {"models": models}

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -47,7 +47,7 @@ from app.core.errors import (
     openai_error,
     response_failed_event,
 )
-from app.core.exceptions import ProxyAuthError, ProxyRateLimitError
+from app.core.exceptions import ProxyAuthError, ProxyRateLimitError, ProxyUpstreamError
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, bridge_public_contract_error_total
 from app.core.middleware.api_firewall import _parse_trusted_proxy_networks, resolve_connection_client_ip
 from app.core.openai.chat_requests import ChatCompletionsRequest
@@ -87,7 +87,23 @@ from app.core.utils.sse import (
 )
 from app.db.models import Account, AccountStatus
 from app.db.session import get_background_session
-from app.dependencies import ProxyContext, get_proxy_context, get_proxy_websocket_context
+from app.dependencies import (
+    AgentProviderRuntimeContext,
+    ProxyContext,
+    get_agent_provider_runtime_context,
+    get_proxy_context,
+    get_proxy_websocket_context,
+)
+from app.modules.agent_provider_runtime.model_catalog import AgentProviderModel, list_agent_provider_models
+from app.modules.agent_provider_runtime.service import (
+    AntigravityRuntimeRequestContext,
+    AntigravityRuntimeValidationError,
+    GeminiRuntimeRequestContext,
+    GeminiRuntimeValidationError,
+)
+from app.modules.agent_provider_runtime.service import (
+    invalid_request_error as agent_provider_invalid_request_error,
+)
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import (
     TRAFFIC_CLASS_OPPORTUNISTIC,
@@ -1741,10 +1757,6 @@ async def _build_models_response(api_key: ApiKeyData | None) -> Response:
     registry = get_model_registry()
     models = registry.get_models_with_fallback()
 
-    if not models:
-        await _release_reservation(reservation)
-        return JSONResponse(content=ModelListResponse(data=[]).model_dump(mode="json"))
-
     items: list[ModelListItem] = []
     for slug, model in models.items():
         if not is_public_model(model, allowed_models):
@@ -1771,6 +1783,10 @@ async def _build_models_response(api_key: ApiKeyData | None) -> Response:
                 }
             )
         )
+    for model in list_agent_provider_models():
+        if allowed_models is not None and model.model_id not in allowed_models:
+            continue
+        items.append(_to_agent_provider_model_list_item(model, created=created))
     await _release_reservation(reservation)
     return JSONResponse(content=ModelListResponse(data=items).model_dump(mode="json"))
 
@@ -1889,6 +1905,55 @@ def _v1_model_capabilities(model: UpstreamModel) -> dict[str, JsonValue]:
     }
 
 
+def _to_agent_provider_model_list_item(model: AgentProviderModel, *, created: int) -> ModelListItem:
+    return ModelListItem.model_validate(
+        {
+            "id": model.model_id,
+            "created": created,
+            "owned_by": "agent-lb",
+            "provider": model.provider_id,
+            "protocol": model.protocol,
+            "lifecycle": model.lifecycle,
+            "metadata": {
+                "display_name": model.display_name,
+                "description": model.description,
+                "context_window": model.input_token_limit,
+                "input_context_window": model.input_token_limit,
+                "max_output_tokens": model.output_token_limit,
+                "input_modalities": list(model.input_modalities),
+                "supported_reasoning_levels": [],
+                "supports_reasoning_summaries": model.supports_reasoning,
+                "supports_parallel_tool_calls": False,
+                "supported_in_api": True,
+                "priority": 100,
+            },
+            "api_types": ["chat_completions"],
+            "capabilities": {
+                "context_length": model.input_token_limit,
+                "max_output_tokens": model.output_token_limit,
+                "supports_reasoning": model.supports_reasoning,
+                "supports_images": model.supports_vision,
+                "supportsImages": model.supports_vision,
+                "supports_vision": model.supports_vision,
+                "supports_tool_use": model.supports_tool_use,
+                "supports_streaming": model.supports_streaming,
+                "input_modalities": list(model.input_modalities),
+                "output_modalities": list(model.output_modalities),
+            },
+            "context_length": model.input_token_limit,
+            "contextLength": model.input_token_limit,
+            "max_output_tokens": model.output_token_limit,
+            "maxOutputTokens": model.output_token_limit,
+            "supports_reasoning": model.supports_reasoning,
+            "supportsReasoning": model.supports_reasoning,
+            "supports_images": model.supports_vision,
+            "supportsImages": model.supports_vision,
+            "supports_vision": model.supports_vision,
+            "supportsVision": model.supports_vision,
+        }
+    )
+
+
 def _v1_supports_reasoning(model: UpstreamModel) -> bool:
     return bool(model.supported_reasoning_levels) or model.supports_reasoning_summaries
 
@@ -1943,10 +2008,15 @@ async def v1_chat_completions(
     request: Request,
     payload: ChatCompletionsRequest = Body(...),
     context: ProxyContext = Depends(get_proxy_context),
+    agent_provider_context: AgentProviderRuntimeContext = Depends(get_agent_provider_runtime_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
     cursor_compat_client = _is_cursor_compat_client(request, api_key)
     effective_model = _effective_model_for_api_key(api_key, payload.model)
+    if _is_gemini_model(effective_model):
+        return await _v1_gemini_chat_completions(request, payload, agent_provider_context, api_key)
+    if _is_antigravity_model(effective_model):
+        return await _v1_antigravity_chat_completions(payload, agent_provider_context, api_key)
     validate_model_access(api_key, effective_model)
 
     rate_limit_headers = await context.service.rate_limit_headers()
@@ -2061,6 +2131,65 @@ async def v1_chat_completions(
         status_code=200,
         headers=rate_limit_headers,
     )
+
+
+async def _v1_gemini_chat_completions(
+    request: Request,
+    payload: ChatCompletionsRequest,
+    context: AgentProviderRuntimeContext,
+    api_key: ApiKeyData | None,
+) -> Response:
+    request_payload = payload.model_dump(mode="json", exclude_none=True)
+    runtime_context = GeminiRuntimeRequestContext(api_key=api_key)
+    try:
+        if payload.stream:
+            body = await context.gemini_service.stream_chat(request_payload, runtime_context)
+            body, startup_error = await _probe_chat_stream_startup_error(body)
+            if startup_error is not None:
+                return _stream_startup_error_response(request, startup_error, headers={})
+            return StreamingResponse(
+                body,
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
+        response = await context.gemini_service.complete_chat(request_payload, runtime_context)
+    except GeminiRuntimeValidationError as exc:
+        return JSONResponse(status_code=400, content=agent_provider_invalid_request_error(str(exc)))
+    except ProxyRateLimitError as exc:
+        headers = {"Retry-After": exc.retry_after} if exc.retry_after is not None else None
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=openai_error(exc.code, exc.message, error_type=exc.error_type),
+            headers=headers,
+        )
+    except ProxyUpstreamError as exc:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=openai_error(exc.code, exc.message, error_type=exc.error_type),
+        )
+    return JSONResponse(content=response)
+
+
+def _is_gemini_model(model: str) -> bool:
+    return model.startswith("gemini-")
+
+
+async def _v1_antigravity_chat_completions(
+    payload: ChatCompletionsRequest,
+    context: AgentProviderRuntimeContext,
+    api_key: ApiKeyData | None,
+) -> Response:
+    request_payload = payload.model_dump(mode="json", exclude_none=True)
+    runtime_context = AntigravityRuntimeRequestContext(api_key=api_key)
+    try:
+        response = await context.antigravity_managed_service.complete_chat(request_payload, runtime_context)
+    except AntigravityRuntimeValidationError as exc:
+        return JSONResponse(status_code=400, content=agent_provider_invalid_request_error(str(exc)))
+    return JSONResponse(content=response)
+
+
+def _is_antigravity_model(model: str) -> bool:
+    return model.startswith("antigravity-")
 
 
 async def _stream_responses(

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -307,6 +307,7 @@ class LoadBalancer:
         lease_kind: AccountLeaseKind | None = None,
         estimated_lease_tokens: float = 0.0,
         traffic_class: TrafficClass = TRAFFIC_CLASS_FOREGROUND,
+        ordered_account_ids: Collection[str] | None = None,
     ) -> AccountSelection:
         excluded_ids = set(exclude_account_ids or ())
         scoped_account_ids = None if account_ids is None else set(account_ids)
@@ -448,6 +449,7 @@ class LoadBalancer:
                             traffic_class=traffic_class,
                             ignore_standard_quota=False,
                             routing_costs_by_account_id=effective_routing_costs,
+                            ordered_account_ids=ordered_account_ids,
                         )
 
                     selected_account_map = account_map
@@ -977,6 +979,7 @@ class LoadBalancer:
         prefer_earlier_reset_window: ResetPreferenceWindow = "secondary",
         secondary_budget_threshold_pct: float = 100.0,
         lease_kind: AccountLeaseKind | None = None,
+        ordered_account_ids: Collection[str] | None = None,
     ) -> AccountSelection:
         selection_inputs = await self._load_selection_inputs(
             model=model,
@@ -1025,6 +1028,7 @@ class LoadBalancer:
             deterministic_probe=True,
             traffic_class=TRAFFIC_CLASS_OPPORTUNISTIC,
             ignore_standard_quota=False,
+            ordered_account_ids=ordered_account_ids,
         )
         if result.account is None:
             return AccountSelection(
@@ -2385,6 +2389,7 @@ def _select_account_preferring_budget_safe(
     traffic_class: TrafficClass = TRAFFIC_CLASS_FOREGROUND,
     ignore_standard_quota: bool = False,
     routing_costs_by_account_id: RoutingCostsByAccount | None = None,
+    ordered_account_ids: Collection[str] | None = None,
 ) -> SelectionResult:
     state_list = list(states)
     state_budget_threshold = (
@@ -2398,7 +2403,7 @@ def _select_account_preferring_budget_safe(
         if apply_secondary_budget_threshold
         else (lambda state: _state_above_budget_threshold(state, budget_threshold_pct))
     )
-    if routing_strategy in ("sequential_drain", "reset_drain", "single_account"):
+    if routing_strategy in ("sequential_drain", "reset_drain", "single_account", "ordered_fallback"):
         budget_safe_states = [
             state
             for state in state_list
@@ -2416,6 +2421,7 @@ def _select_account_preferring_budget_safe(
             traffic_class=traffic_class,
             ignore_standard_quota=ignore_standard_quota,
             routing_costs=routing_costs_by_account_id,
+            ordered_account_ids=ordered_account_ids,
         )
 
     best_health_states = _best_health_tier_states(state_list)
@@ -2433,6 +2439,7 @@ def _select_account_preferring_budget_safe(
             traffic_class=traffic_class,
             ignore_standard_quota=ignore_standard_quota,
             routing_costs=routing_costs_by_account_id,
+            ordered_account_ids=ordered_account_ids,
         )
         if burn_first.account is not None:
             return burn_first
@@ -2456,6 +2463,7 @@ def _select_account_preferring_budget_safe(
             traffic_class=traffic_class,
             ignore_standard_quota=ignore_standard_quota,
             routing_costs=routing_costs_by_account_id,
+            ordered_account_ids=ordered_account_ids,
         )
         if preferred.account is not None:
             return preferred
@@ -2473,6 +2481,7 @@ def _select_account_preferring_budget_safe(
             traffic_class=traffic_class,
             ignore_standard_quota=ignore_standard_quota,
             routing_costs=routing_costs_by_account_id,
+            ordered_account_ids=ordered_account_ids,
         )
     return select_account(
         state_list,
@@ -2486,6 +2495,7 @@ def _select_account_preferring_budget_safe(
         traffic_class=traffic_class,
         ignore_standard_quota=ignore_standard_quota,
         routing_costs=routing_costs_by_account_id,
+        ordered_account_ids=ordered_account_ids,
     )
 
 

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1356,6 +1356,7 @@ class ProxyService(
             account_ids=scoped_account_ids,
             prefer_earlier_reset_window=prefer_earlier_reset_window,
             routing_strategy=_routing_strategy(settings),
+            ordered_account_ids=_manual_account_priority_ids(settings),
             budget_threshold_pct=_sticky_reallocation_primary_budget_threshold_pct(settings),
             secondary_budget_threshold_pct=_sticky_reallocation_secondary_budget_threshold_pct(settings),
             traffic_class=traffic_class,
@@ -1722,6 +1723,7 @@ class ProxyService(
                         prefer_earlier_reset_accounts=prefer_earlier_reset_accounts,
                         prefer_earlier_reset_window=prefer_earlier_reset_window,
                         routing_strategy=routing_strategy,
+                        ordered_account_ids=_manual_account_priority_ids(settings),
                         relative_availability_power=_relative_availability_power(settings),
                         relative_availability_top_k=_relative_availability_top_k(settings),
                         model=model,
@@ -1763,6 +1765,7 @@ class ProxyService(
                     prefer_earlier_reset_accounts=prefer_earlier_reset_accounts,
                     prefer_earlier_reset_window=prefer_earlier_reset_window,
                     routing_strategy=routing_strategy,
+                    ordered_account_ids=_manual_account_priority_ids(settings),
                     relative_availability_power=_relative_availability_power(settings),
                     relative_availability_top_k=_relative_availability_top_k(settings),
                     model=model,
@@ -1873,6 +1876,7 @@ class ProxyService(
             prefer_earlier_reset_accounts=settings.prefer_earlier_reset_accounts,
             prefer_earlier_reset_window=_prefer_earlier_reset_window(settings),
             routing_strategy=_routing_strategy(settings),
+            ordered_account_ids=_manual_account_priority_ids(settings),
             budget_threshold_pct=_sticky_reallocation_primary_budget_threshold_pct(settings),
             secondary_budget_threshold_pct=_sticky_reallocation_secondary_budget_threshold_pct(settings),
             lease_kind=lease_kind,
@@ -2141,6 +2145,8 @@ def _partial_output_proxy_error_event_block(
 
 def _routing_strategy(settings: DashboardSettings) -> RoutingStrategy:
     value = getattr(settings, "routing_strategy", None) or "capacity_weighted"
+    if value == "ordered_fallback":
+        return "ordered_fallback"
     if value == "single_account":
         return "single_account"
     if value == "sequential_drain":
@@ -2156,6 +2162,29 @@ def _routing_strategy(settings: DashboardSettings) -> RoutingStrategy:
     if value == "fill_first":
         return "fill_first"
     return "capacity_weighted"
+
+
+def _manual_account_priority_ids(settings: DashboardSettings) -> tuple[str, ...]:
+    raw_ids = getattr(settings, "manual_account_priority_ids_json", None)
+    if isinstance(raw_ids, str):
+        import json
+
+        try:
+            parsed = json.loads(raw_ids)
+        except json.JSONDecodeError:
+            parsed = []
+        raw_ids = parsed if isinstance(parsed, list) else []
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw_account_id in raw_ids or ():
+        if not isinstance(raw_account_id, str):
+            continue
+        account_id = raw_account_id.strip()
+        if not account_id or account_id in seen:
+            continue
+        seen.add(account_id)
+        ordered.append(account_id)
+    return tuple(ordered)
 
 
 async def _call_with_supported_optional_kwargs(

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import cast as typing_cast
 
 import anyio
-from sqlalchemy import Integer, String, and_, cast, func, literal_column, or_, select
+from sqlalchemy import Integer, String, and_, case, cast, func, literal_column, or_, select
 from sqlalchemy import exc as sa_exc
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
@@ -22,6 +22,17 @@ from app.db.session import sqlite_writer_section
 class _RequestLogFilters:
     conditions: list
     needs_related_search_joins: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderRequestLogAggregate:
+    provider_id: str
+    request_count: int
+    success_count: int
+    error_count: int
+    input_tokens: int
+    output_tokens: int
+    cached_input_tokens: int
 
 
 class RequestLogsRepository:
@@ -158,6 +169,43 @@ class RequestLogsRepository:
             cost_usd=float(row.cost_usd or 0.0),
         )
 
+    async def aggregate_by_provider_since(self, since: datetime) -> list[ProviderRequestLogAggregate]:
+        provider_expr = case(
+            (RequestLog.source == "gemini", "gemini"),
+            (RequestLog.source == "antigravity", "antigravity"),
+            else_="codex",
+        ).label("provider_id")
+        stmt = (
+            select(
+                provider_expr,
+                func.count(RequestLog.id).label("request_count"),
+                func.coalesce(func.sum(cast(RequestLog.status == "success", Integer)), 0).label("success_count"),
+                func.coalesce(func.sum(cast(RequestLog.status != "success", Integer)), 0).label("error_count"),
+                func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
+                func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
+                func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
+            )
+            .where(
+                RequestLog.requested_at >= since,
+                self._exclude_warmup_clause(),
+                RequestLog.deleted_at.is_(None),
+            )
+            .group_by(provider_expr)
+        )
+        result = await self._session.execute(stmt)
+        return [
+            ProviderRequestLogAggregate(
+                provider_id=str(row.provider_id),
+                request_count=int(row.request_count),
+                success_count=int(row.success_count),
+                error_count=int(row.error_count),
+                input_tokens=int(row.input_tokens),
+                output_tokens=int(row.output_tokens),
+                cached_input_tokens=int(row.cached_input_tokens),
+            )
+            for row in result.all()
+        ]
+
     async def top_error_since(self, since: datetime) -> str | None:
         stmt = (
             select(RequestLog.error_code, func.count(RequestLog.id).label("error_count"))
@@ -230,6 +278,7 @@ class RequestLogsRepository:
                 request_id=resolved_request_id,
                 model=model,
                 plan_type=resolved_plan_type,
+                source=source,
                 transport=transport,
                 request_kind=request_kind,
                 useragent=resolved_useragent,

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -111,6 +111,7 @@ def _dashboard_settings_response(settings) -> DashboardSettingsResponse:
         relative_availability_power=settings.relative_availability_power,
         relative_availability_top_k=settings.relative_availability_top_k,
         single_account_id=settings.single_account_id,
+        manual_account_priority_ids=list(settings.manual_account_priority_ids),
         openai_cache_affinity_max_age_seconds=settings.openai_cache_affinity_max_age_seconds,
         dashboard_session_ttl_seconds=settings.dashboard_session_ttl_seconds,
         http_responses_session_bridge_prompt_cache_idle_ttl_seconds=settings.http_responses_session_bridge_prompt_cache_idle_ttl_seconds,
@@ -328,6 +329,22 @@ async def _validate_account_id(context: SettingsContext, account_id: str) -> Non
         raise DashboardBadRequestError("Account not found", code="account_not_found")
 
 
+async def _validate_manual_account_priority_ids(context: SettingsContext, account_ids: tuple[str, ...]) -> None:
+    if not account_ids:
+        raise DashboardBadRequestError(
+            "manualAccountPriorityIds is required for ordered fallback routing",
+            code="manual_account_priority_required",
+        )
+    result = await context.session.execute(select(Account.id).where(Account.id.in_(account_ids)))
+    known_ids = {str(account_id) for account_id in result.scalars().all()}
+    missing_ids = [account_id for account_id in account_ids if account_id not in known_ids]
+    if missing_ids:
+        raise DashboardBadRequestError(
+            f"manualAccountPriorityIds contains unknown accounts: {', '.join(missing_ids)}",
+            code="manual_account_priority_unknown_account",
+        )
+
+
 def _is_missing_proxy_endpoint_error(exc: Exception) -> bool:
     message = str(exc).lower()
     return "foreign key" in message or "fk constraint" in message or "violates foreign key constraint" in message
@@ -439,6 +456,14 @@ async def update_settings(
         single_account_id = (
             payload.single_account_id if "single_account_id" in payload.model_fields_set else current.single_account_id
         )
+        manual_account_priority_ids = (
+            tuple(payload.manual_account_priority_ids)
+            if payload.manual_account_priority_ids is not None
+            else current.manual_account_priority_ids
+        )
+        routing_strategy = payload.routing_strategy or current.routing_strategy
+        if routing_strategy == "ordered_fallback":
+            await _validate_manual_account_priority_ids(context, manual_account_priority_ids)
         updated = await context.service.update_settings(
             DashboardSettingsUpdateData(
                 sticky_threads_enabled=(
@@ -463,7 +488,7 @@ async def update_settings(
                     else current.prefer_earlier_reset_accounts
                 ),
                 prefer_earlier_reset_window=payload.prefer_earlier_reset_window or current.prefer_earlier_reset_window,
-                routing_strategy=payload.routing_strategy or current.routing_strategy,
+                routing_strategy=routing_strategy,
                 relative_availability_power=(
                     payload.relative_availability_power
                     if payload.relative_availability_power is not None
@@ -475,6 +500,7 @@ async def update_settings(
                     else current.relative_availability_top_k
                 ),
                 single_account_id=single_account_id,
+                manual_account_priority_ids=manual_account_priority_ids,
                 openai_cache_affinity_max_age_seconds=(
                     payload.openai_cache_affinity_max_age_seconds
                     if payload.openai_cache_affinity_max_age_seconds is not None

--- a/app/modules/settings/repository.py
+++ b/app/modules/settings/repository.py
@@ -30,6 +30,7 @@ class SettingsRepository:
             relative_availability_power=2.0,
             relative_availability_top_k=5,
             single_account_id=None,
+            manual_account_priority_ids_json="[]",
             openai_cache_affinity_max_age_seconds=get_settings().openai_cache_affinity_max_age_seconds,
             dashboard_session_ttl_seconds=43200,
             warmup_model=get_settings().warmup_model,
@@ -77,6 +78,7 @@ class SettingsRepository:
         relative_availability_power: float | None = None,
         relative_availability_top_k: int | None = None,
         single_account_id: str | None = None,
+        manual_account_priority_ids_json: str | None = None,
         openai_cache_affinity_max_age_seconds: int | None = None,
         dashboard_session_ttl_seconds: int | None = None,
         http_responses_session_bridge_prompt_cache_idle_ttl_seconds: int | None = None,
@@ -117,6 +119,8 @@ class SettingsRepository:
             settings.relative_availability_top_k = relative_availability_top_k
         if single_account_id is not None or routing_strategy == "single_account":
             settings.single_account_id = single_account_id
+        if manual_account_priority_ids_json is not None:
+            settings.manual_account_priority_ids_json = manual_account_priority_ids_json
         if openai_cache_affinity_max_age_seconds is not None:
             settings.openai_cache_affinity_max_age_seconds = openai_cache_affinity_max_age_seconds
         if dashboard_session_ttl_seconds is not None:

--- a/app/modules/settings/schemas.py
+++ b/app/modules/settings/schemas.py
@@ -37,11 +37,12 @@ class DashboardSettingsResponse(DashboardModel):
     prefer_earlier_reset_accounts: bool
     prefer_earlier_reset_window: str = Field(pattern=r"^(primary|secondary)$")
     routing_strategy: str = Field(
-        pattern=r"^(usage_weighted|round_robin|capacity_weighted|relative_availability|fill_first|sequential_drain|reset_drain|single_account)$"
+        pattern=r"^(usage_weighted|round_robin|capacity_weighted|relative_availability|fill_first|sequential_drain|reset_drain|single_account|ordered_fallback)$"
     )
     relative_availability_power: float = Field(gt=0.0)
     relative_availability_top_k: int = Field(ge=1, le=20)
     single_account_id: str | None = None
+    manual_account_priority_ids: list[str] = Field(default_factory=list)
     openai_cache_affinity_max_age_seconds: int = Field(gt=0)
     dashboard_session_ttl_seconds: int = Field(ge=3600)
     http_responses_session_bridge_prompt_cache_idle_ttl_seconds: int = Field(gt=0)
@@ -77,11 +78,12 @@ class DashboardSettingsUpdateRequest(DashboardModel):
     prefer_earlier_reset_window: str | None = Field(default=None, pattern=r"^(primary|secondary)$")
     routing_strategy: str | None = Field(
         default=None,
-        pattern=r"^(usage_weighted|round_robin|capacity_weighted|relative_availability|fill_first|sequential_drain|reset_drain|single_account)$",
+        pattern=r"^(usage_weighted|round_robin|capacity_weighted|relative_availability|fill_first|sequential_drain|reset_drain|single_account|ordered_fallback)$",
     )
     relative_availability_power: float | None = Field(default=None, gt=0.0)
     relative_availability_top_k: int | None = Field(default=None, ge=1, le=20)
     single_account_id: str | None = Field(default=None, max_length=255)
+    manual_account_priority_ids: list[str] | None = None
     openai_cache_affinity_max_age_seconds: int | None = Field(default=None, gt=0)
     dashboard_session_ttl_seconds: int | None = Field(default=None, ge=3600)
     http_responses_session_bridge_prompt_cache_idle_ttl_seconds: int | None = Field(default=None, gt=0)
@@ -116,6 +118,23 @@ class DashboardSettingsUpdateRequest(DashboardModel):
     @classmethod
     def _normalize_weekly_pace_days(cls, value: str | None) -> str | None:
         return _normalize_weekly_pace_working_days(value)
+
+    @field_validator("manual_account_priority_ids")
+    @classmethod
+    def _normalize_manual_account_priority_ids(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for raw_account_id in value:
+            account_id = raw_account_id.strip()
+            if not account_id:
+                continue
+            if account_id in seen:
+                continue
+            seen.add(account_id)
+            ordered.append(account_id)
+        return ordered
 
 
 class RuntimeConnectAddressResponse(DashboardModel):

--- a/app/modules/settings/service.py
+++ b/app/modules/settings/service.py
@@ -22,6 +22,7 @@ class DashboardSettingsData:
     relative_availability_power: float
     relative_availability_top_k: int
     single_account_id: str | None
+    manual_account_priority_ids: tuple[str, ...]
     openai_cache_affinity_max_age_seconds: int
     dashboard_session_ttl_seconds: int
     http_responses_session_bridge_prompt_cache_idle_ttl_seconds: int
@@ -56,6 +57,7 @@ class DashboardSettingsUpdateData:
     relative_availability_power: float
     relative_availability_top_k: int
     single_account_id: str | None
+    manual_account_priority_ids: tuple[str, ...]
     openai_cache_affinity_max_age_seconds: int
     dashboard_session_ttl_seconds: int
     http_responses_session_bridge_prompt_cache_idle_ttl_seconds: int
@@ -94,6 +96,7 @@ class SettingsService:
             relative_availability_power=row.relative_availability_power,
             relative_availability_top_k=row.relative_availability_top_k,
             single_account_id=row.single_account_id,
+            manual_account_priority_ids=_parse_manual_account_priority_ids(row.manual_account_priority_ids_json),
             openai_cache_affinity_max_age_seconds=row.openai_cache_affinity_max_age_seconds,
             dashboard_session_ttl_seconds=row.dashboard_session_ttl_seconds,
             http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
@@ -135,6 +138,7 @@ class SettingsService:
             relative_availability_power=payload.relative_availability_power,
             relative_availability_top_k=payload.relative_availability_top_k,
             single_account_id=payload.single_account_id,
+            manual_account_priority_ids_json=_dump_manual_account_priority_ids(payload.manual_account_priority_ids),
             openai_cache_affinity_max_age_seconds=payload.openai_cache_affinity_max_age_seconds,
             dashboard_session_ttl_seconds=payload.dashboard_session_ttl_seconds,
             http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
@@ -170,6 +174,7 @@ class SettingsService:
             relative_availability_power=row.relative_availability_power,
             relative_availability_top_k=row.relative_availability_top_k,
             single_account_id=row.single_account_id,
+            manual_account_priority_ids=_parse_manual_account_priority_ids(row.manual_account_priority_ids_json),
             openai_cache_affinity_max_age_seconds=row.openai_cache_affinity_max_age_seconds,
             dashboard_session_ttl_seconds=row.dashboard_session_ttl_seconds,
             http_responses_session_bridge_prompt_cache_idle_ttl_seconds=(
@@ -239,3 +244,29 @@ def _dump_additional_quota_routing_policies(policies: dict[str, str]) -> str:
         if normalized_quota_key is not None and normalized_policy in _ROUTING_POLICIES:
             normalized[normalized_quota_key] = normalized_policy
     return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+
+
+def _parse_manual_account_priority_ids(raw: str | None) -> tuple[str, ...]:
+    if not raw:
+        return ()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(parsed, list):
+        return ()
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw_account_id in parsed:
+        if not isinstance(raw_account_id, str):
+            continue
+        account_id = raw_account_id.strip()
+        if not account_id or account_id in seen:
+            continue
+        seen.add(account_id)
+        ordered.append(account_id)
+    return tuple(ordered)
+
+
+def _dump_manual_account_priority_ids(account_ids: tuple[str, ...]) -> str:
+    return json.dumps(list(account_ids), separators=(",", ":"))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthGate } from "@/features/auth/components/auth-gate";
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
 import { AccountsPage } from "@/features/accounts/components/accounts-page";
 import { ApisPage } from "@/features/apis/components/apis-page";
+import { ProvidersPage } from "@/features/agent-providers/components/providers-page";
 import { DashboardPage } from "@/features/dashboard/components/dashboard-page";
 import { ReportsPage } from "@/features/reports/components/reports-page";
 import { SettingsPage } from "@/features/settings/components/settings-page";
@@ -44,6 +45,7 @@ export default function App() {
             <Route path="/" element={<Navigate to="/dashboard" replace />} />
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/reports" element={<ReportsPage />} />
+            <Route path="/providers" element={<ProvidersPage />} />
             <Route path="/accounts" element={<AccountsPage />} />
             <Route path="/apis" element={<ApisPage />} />
             <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 const NAV_ITEMS = [
   { to: "/dashboard", label: "Dashboard" },
   { to: "/reports", label: "Reports" },
+  { to: "/providers", label: "Providers" },
   { to: "/accounts", label: "Accounts" },
   { to: "/apis", label: "APIs" },
   { to: "/settings", label: "Settings" },

--- a/frontend/src/components/layout/status-bar.tsx
+++ b/frontend/src/components/layout/status-bar.tsx
@@ -17,6 +17,7 @@ type RoutingStrategy =
   | "relative_availability"
   | "fill_first"
   | "single_account"
+  | "ordered_fallback"
   | "sequential_drain"
   | "reset_drain";
 
@@ -47,6 +48,9 @@ function getRoutingLabel(
   }
   if (strategy === "single_account") {
     return "Single account";
+  }
+  if (strategy === "ordered_fallback") {
+    return sticky ? "Ordered fallback + Sticky threads" : "Ordered fallback";
   }
   if (strategy === "sequential_drain") {
     return sticky ? "Sequential drain + Sticky threads" : "Sequential drain";

--- a/frontend/src/features/agent-providers/accounts-schemas.test.ts
+++ b/frontend/src/features/agent-providers/accounts-schemas.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AgentProviderAccountsSchema,
+  AgentProviderAccountUpdateSchema,
+  AntigravityProviderAccountCreateSchema,
+} from "@/features/agent-providers/accounts-schemas";
+
+describe("AgentProviderAccountsSchema", () => {
+  it("parses provider-scoped account metadata without secret material", () => {
+    const parsed = AgentProviderAccountsSchema.parse({
+      accounts: [
+        {
+          accountId: "acct_1",
+          providerId: "gemini",
+          displayName: "Gemini dev key",
+          status: "active",
+          authMode: "api_key",
+          apiKeySet: true,
+          credentialFingerprint: "abc123",
+          projectId: "dev-project",
+          location: "global",
+          createdAt: "2026-06-09T00:00:00Z",
+          updatedAt: "2026-06-09T00:00:00Z",
+        },
+        {
+          accountId: "agy_1",
+          providerId: "antigravity",
+          externalAccountId: "default",
+          displayName: "Antigravity default",
+          status: "configured",
+          authMode: "cli_keyring",
+          apiKeySet: false,
+          credentialFingerprint: "fingerprint",
+          projectId: "workspace-a",
+          location: "agy",
+          createdAt: "2026-06-09T00:00:00Z",
+          updatedAt: "2026-06-09T00:00:00Z",
+        },
+      ],
+    });
+
+    expect(parsed.accounts[0].providerId).toBe("gemini");
+    expect("apiKey" in parsed.accounts[0]).toBe(false);
+    expect(parsed.accounts[1].providerId).toBe("antigravity");
+    expect(parsed.accounts[1].apiKeySet).toBe(false);
+  });
+
+  it("parses provider account lifecycle update payloads", () => {
+    const parsed = AgentProviderAccountUpdateSchema.parse({
+      displayName: "Gemini prod",
+      status: "paused",
+      apiKey: "new-key",
+      projectId: "prod-project",
+      location: "global",
+    });
+
+    expect(parsed.status).toBe("paused");
+    expect(parsed.apiKey).toBe("new-key");
+  });
+
+  it("parses Antigravity API-key account creation payloads", () => {
+    const parsed = AntigravityProviderAccountCreateSchema.parse({
+      displayName: "Antigravity managed",
+      authMode: "api_key",
+      apiKey: "AIza-secret",
+      projectId: "agent-project",
+    });
+
+    expect(parsed.authMode).toBe("api_key");
+    expect(parsed.apiKey).toBe("AIza-secret");
+  });
+});

--- a/frontend/src/features/agent-providers/accounts-schemas.ts
+++ b/frontend/src/features/agent-providers/accounts-schemas.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+export const AgentProviderAccountSchema = z.object({
+  accountId: z.string(),
+  providerId: z.enum(["codex", "gemini", "antigravity"]),
+  externalAccountId: z.string().nullable().optional(),
+  displayName: z.string(),
+  status: z.string(),
+  authMode: z.string(),
+  apiKeySet: z.boolean(),
+  credentialFingerprint: z.string().nullable().optional(),
+  projectId: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const AgentProviderAccountsSchema = z.object({
+  accounts: z.array(AgentProviderAccountSchema),
+});
+
+export const GeminiProviderAccountCreateSchema = z.object({
+  displayName: z.string().min(1),
+  apiKey: z.string().min(1),
+  externalAccountId: z.string().nullable().optional(),
+  projectId: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+});
+
+export const AntigravityProviderAccountCreateSchema = z.object({
+  displayName: z.string().min(1),
+  authMode: z.enum(["api_key", "cli_keyring"]).optional(),
+  apiKey: z.string().min(1).optional(),
+  externalAccountId: z.string().nullable().optional(),
+  projectId: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+});
+
+export const AgentProviderAccountUpdateSchema = z.object({
+  displayName: z.string().min(1).optional(),
+  status: z.enum(["active", "paused"]).optional(),
+  apiKey: z.string().min(1).optional(),
+  externalAccountId: z.string().nullable().optional(),
+  projectId: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+});
+
+export type AgentProviderAccount = z.infer<typeof AgentProviderAccountSchema>;
+export type AgentProviderAccounts = z.infer<typeof AgentProviderAccountsSchema>;
+export type GeminiProviderAccountCreate = z.infer<typeof GeminiProviderAccountCreateSchema>;
+export type AntigravityProviderAccountCreate = z.infer<typeof AntigravityProviderAccountCreateSchema>;
+export type AgentProviderAccountUpdate = z.infer<typeof AgentProviderAccountUpdateSchema>;

--- a/frontend/src/features/agent-providers/api.ts
+++ b/frontend/src/features/agent-providers/api.ts
@@ -1,0 +1,124 @@
+import { get, patch, post, put } from "@/lib/api-client";
+
+import {
+  AgentProviderAccountSchema,
+  AgentProviderAccountUpdateSchema,
+  AgentProviderAccountsSchema,
+  AntigravityProviderAccountCreateSchema,
+  type AgentProviderAccountUpdate,
+  type AntigravityProviderAccountCreate,
+  type GeminiProviderAccountCreate,
+} from "@/features/agent-providers/accounts-schemas";
+import {
+  AgentProviderPreflightSchema,
+  AgentProviderQuotaWindowSchema,
+  AgentProviderQuotaWindowUpsertSchema,
+  AgentProviderRoutingSettingsSchema,
+  AgentProviderRoutingSettingsUpdateSchema,
+  type AgentProviderQuotaWindowUpsert,
+  type AgentProviderRoutingSettingsUpdate,
+} from "@/features/agent-providers/routing-schemas";
+import {
+  AntigravityHarnessPrintRequestSchema,
+  AntigravityHarnessPrintResponseSchema,
+  AntigravityManagedInteractionRunRequestSchema,
+  AntigravityManagedInteractionRunResponseSchema,
+  type AntigravityHarnessPrintRequest,
+  type AntigravityManagedInteractionRunRequest,
+} from "@/features/agent-providers/harness-schemas";
+import {
+  AgentProviderListSchema,
+  AgentProviderOverviewSchema,
+  type ProviderOverviewTimeframe,
+} from "@/features/agent-providers/schemas";
+
+const AGENT_PROVIDERS_PATH = "/api/agent-providers";
+export type AgentProviderId = "codex" | "gemini" | "antigravity";
+
+export function getAgentProviders() {
+  return get(AGENT_PROVIDERS_PATH, AgentProviderListSchema);
+}
+
+export function getAgentProviderOverview(timeframe: ProviderOverviewTimeframe = "7d") {
+  return get(
+    `${AGENT_PROVIDERS_PATH}/overview?timeframe=${encodeURIComponent(timeframe)}`,
+    AgentProviderOverviewSchema,
+  );
+}
+
+export function getAgentProviderAccounts(providerId: AgentProviderId) {
+  return get(`${AGENT_PROVIDERS_PATH}/${providerId}/accounts`, AgentProviderAccountsSchema);
+}
+
+export async function createGeminiProviderAccount(payload: GeminiProviderAccountCreate) {
+  return post(`${AGENT_PROVIDERS_PATH}/gemini/accounts`, AgentProviderAccountSchema, {
+    body: payload,
+  });
+}
+
+export function createAntigravityProviderAccount(payload: AntigravityProviderAccountCreate) {
+  return post(`${AGENT_PROVIDERS_PATH}/antigravity/accounts`, AgentProviderAccountSchema, {
+    body: AntigravityProviderAccountCreateSchema.parse(payload),
+  });
+}
+
+export function updateAgentProviderAccount(
+  providerId: AgentProviderId,
+  accountId: string,
+  payload: AgentProviderAccountUpdate,
+) {
+  const validated = AgentProviderAccountUpdateSchema.parse(payload);
+  return patch(
+    `${AGENT_PROVIDERS_PATH}/${providerId}/accounts/${encodeURIComponent(accountId)}`,
+    AgentProviderAccountSchema,
+    { body: validated },
+  );
+}
+
+export function getAgentProviderRoutingSettings(providerId: AgentProviderId) {
+  return get(`${AGENT_PROVIDERS_PATH}/${providerId}/routing/settings`, AgentProviderRoutingSettingsSchema);
+}
+
+export function updateAgentProviderRoutingSettings(
+  providerId: AgentProviderId,
+  payload: AgentProviderRoutingSettingsUpdate,
+) {
+  const validated = AgentProviderRoutingSettingsUpdateSchema.parse(payload);
+  return patch(`${AGENT_PROVIDERS_PATH}/${providerId}/routing/settings`, AgentProviderRoutingSettingsSchema, {
+    body: validated,
+  });
+}
+
+export function upsertAgentProviderQuotaWindow(
+  providerId: AgentProviderId,
+  accountId: string,
+  dimension: string,
+  payload: AgentProviderQuotaWindowUpsert,
+) {
+  const validated = AgentProviderQuotaWindowUpsertSchema.parse(payload);
+  return put(
+    `${AGENT_PROVIDERS_PATH}/${providerId}/accounts/${encodeURIComponent(accountId)}/quota-windows/${encodeURIComponent(dimension)}`,
+    AgentProviderQuotaWindowSchema,
+    { body: validated },
+  );
+}
+
+export function preflightAgentProviderRouting(providerId: AgentProviderId) {
+  return post(`${AGENT_PROVIDERS_PATH}/${providerId}/routing/preflight`, AgentProviderPreflightSchema);
+}
+
+export function runAntigravityHarnessPrint(payload: AntigravityHarnessPrintRequest) {
+  return post(`${AGENT_PROVIDERS_PATH}/antigravity/harness/print`, AntigravityHarnessPrintResponseSchema, {
+    body: AntigravityHarnessPrintRequestSchema.parse(payload),
+  });
+}
+
+export function runAntigravityManagedInteraction(payload: AntigravityManagedInteractionRunRequest) {
+  return post(
+    `${AGENT_PROVIDERS_PATH}/antigravity/interactions/run`,
+    AntigravityManagedInteractionRunResponseSchema,
+    {
+      body: AntigravityManagedInteractionRunRequestSchema.parse(payload),
+    },
+  );
+}

--- a/frontend/src/features/agent-providers/components/providers-page.tsx
+++ b/frontend/src/features/agent-providers/components/providers-page.tsx
@@ -1,0 +1,1418 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Activity,
+  ArrowDown,
+  ArrowUp,
+  Bot,
+  Gauge,
+  KeyRound,
+  Pause,
+  Play,
+  Plus,
+  RefreshCw,
+  Route,
+  Settings2,
+  Terminal,
+  Trash2,
+} from "lucide-react";
+
+import { AlertMessage } from "@/components/alert-message";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { listAccounts } from "@/features/accounts/api";
+import type { AccountSummary } from "@/features/accounts/schemas";
+import {
+  useAgentProviderAccounts,
+  useAgentProviderOverview,
+  useAgentProviderRegistry,
+  useAntigravityHarnessPrint,
+  useAntigravityManagedInteraction,
+  useAgentProviderRouting,
+  useCreateAntigravityProviderAccount,
+  useCreateGeminiProviderAccount,
+  useUpdateAgentProviderAccount,
+} from "@/features/agent-providers/hooks/use-agent-providers";
+import type {
+  AgentProviderAccount,
+  AgentProviderAccountUpdate,
+} from "@/features/agent-providers/accounts-schemas";
+import type {
+  AgentProviderPreflight,
+  AgentProviderQuotaWindowUpsert,
+  AgentProviderRoutingSettings,
+  AgentProviderRoutingSettingsUpdate,
+  AgentProviderRoutingStrategy,
+} from "@/features/agent-providers/routing-schemas";
+import type {
+  AntigravityHarnessPrintResponse,
+  AntigravityManagedInteractionRunResponse,
+} from "@/features/agent-providers/harness-schemas";
+import type { AgentProviderCapability, AgentProviderOverview } from "@/features/agent-providers/schemas";
+import { useSettings } from "@/features/settings/hooks/use-settings";
+import { buildSettingsUpdateRequest } from "@/features/settings/payload";
+import type { DashboardSettings, SettingsUpdateRequest } from "@/features/settings/schemas";
+import { getErrorMessageOrNull } from "@/utils/errors";
+
+const STRATEGY_LABELS: Record<AgentProviderRoutingStrategy, string> = {
+  capacity_weighted: "Capacity weighted",
+  round_robin: "Round robin",
+  sequential_drain: "Sequential drain",
+  reset_drain: "Reset drain",
+  single_account: "Single account",
+  ordered_fallback: "Ordered fallback",
+};
+
+const STRATEGIES = Object.keys(STRATEGY_LABELS) as AgentProviderRoutingStrategy[];
+type CodexRoutingStrategy = DashboardSettings["routingStrategy"];
+const CODEX_STRATEGY_LABELS: Record<CodexRoutingStrategy, string> = {
+  usage_weighted: "Usage weighted",
+  round_robin: "Round robin",
+  capacity_weighted: "Capacity weighted",
+  relative_availability: "Relative availability",
+  fill_first: "Fill first",
+  sequential_drain: "Sequential drain",
+  reset_drain: "Reset drain",
+  single_account: "Single account",
+  ordered_fallback: "Ordered fallback",
+};
+const CODEX_STRATEGIES = Object.keys(CODEX_STRATEGY_LABELS) as CodexRoutingStrategy[];
+const COUNT_FORMATTER = new Intl.NumberFormat();
+
+function normalizeProviderAccountOrder(accountIds: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const rawAccountId of accountIds) {
+    const accountId = rawAccountId.trim();
+    if (!accountId || seen.has(accountId)) {
+      continue;
+    }
+    seen.add(accountId);
+    ordered.push(accountId);
+  }
+  return ordered;
+}
+
+function moveProviderAccountOrder(accountIds: readonly string[], index: number, direction: -1 | 1): string[] {
+  const next = [...accountIds];
+  const targetIndex = index + direction;
+  if (targetIndex < 0 || targetIndex >= next.length) {
+    return next;
+  }
+  [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+  return next;
+}
+
+export function ProvidersPage() {
+  const providerQuery = useAgentProviderRegistry();
+  const overviewQuery = useAgentProviderOverview("7d");
+  const codexAccountsQuery = useQuery({
+    queryKey: ["accounts", "list", "providers-page"],
+    queryFn: listAccounts,
+    select: (data) => data.accounts,
+  });
+  const geminiAccountsQuery = useAgentProviderAccounts("gemini");
+  const antigravityAccountsQuery = useAgentProviderAccounts("antigravity");
+  const geminiRouting = useAgentProviderRouting("gemini");
+  const antigravityRouting = useAgentProviderRouting("antigravity");
+  const codexSettings = useSettings();
+  const createGeminiAccount = useCreateGeminiProviderAccount();
+  const createAntigravityAccount = useCreateAntigravityProviderAccount();
+  const updateGeminiAccount = useUpdateAgentProviderAccount("gemini");
+  const updateAntigravityAccount = useUpdateAgentProviderAccount("antigravity");
+  const antigravityInteraction = useAntigravityManagedInteraction();
+  const antigravityHarness = useAntigravityHarnessPrint();
+
+  const providers = providerQuery.data?.providers ?? [];
+  const codexProvider = providers.find((provider) => provider.providerId === "codex");
+  const geminiProvider = providers.find((provider) => provider.providerId === "gemini");
+  const antigravityProvider = providers.find((provider) => provider.providerId === "antigravity");
+  const codexAccounts = codexAccountsQuery.data ?? [];
+  const geminiAccounts = geminiAccountsQuery.data?.accounts ?? [];
+  const antigravityAccounts = antigravityAccountsQuery.data?.accounts ?? [];
+  const geminiPreflight = geminiRouting.preflightQuery.data;
+  const antigravityPreflight = antigravityRouting.preflightQuery.data;
+
+  const error =
+    getErrorMessageOrNull(providerQuery.error) ||
+    getErrorMessageOrNull(overviewQuery.error) ||
+    getErrorMessageOrNull(codexAccountsQuery.error) ||
+    getErrorMessageOrNull(geminiAccountsQuery.error) ||
+    getErrorMessageOrNull(antigravityAccountsQuery.error) ||
+    getErrorMessageOrNull(codexSettings.settingsQuery.error) ||
+    getErrorMessageOrNull(geminiRouting.settingsQuery.error) ||
+    getErrorMessageOrNull(geminiRouting.preflightQuery.error) ||
+    getErrorMessageOrNull(antigravityRouting.settingsQuery.error) ||
+    getErrorMessageOrNull(antigravityRouting.preflightQuery.error) ||
+    getErrorMessageOrNull(createGeminiAccount.error) ||
+    getErrorMessageOrNull(createAntigravityAccount.error) ||
+    getErrorMessageOrNull(updateGeminiAccount.error) ||
+    getErrorMessageOrNull(updateAntigravityAccount.error) ||
+    getErrorMessageOrNull(codexSettings.updateSettingsMutation.error) ||
+    getErrorMessageOrNull(antigravityInteraction.error) ||
+    getErrorMessageOrNull(antigravityHarness.error);
+
+  const refresh = () => {
+    void providerQuery.refetch();
+    void overviewQuery.refetch();
+    void codexAccountsQuery.refetch();
+    void geminiAccountsQuery.refetch();
+    void antigravityAccountsQuery.refetch();
+    void codexSettings.settingsQuery.refetch();
+    void geminiRouting.settingsQuery.refetch();
+    void geminiRouting.preflightQuery.refetch();
+    void antigravityRouting.settingsQuery.refetch();
+    void antigravityRouting.preflightQuery.refetch();
+  };
+
+  const busy =
+    providerQuery.isFetching ||
+    overviewQuery.isFetching ||
+    codexAccountsQuery.isFetching ||
+    geminiAccountsQuery.isFetching ||
+    antigravityAccountsQuery.isFetching ||
+    codexSettings.settingsQuery.isFetching ||
+    geminiRouting.settingsQuery.isFetching ||
+    geminiRouting.preflightQuery.isFetching ||
+    antigravityRouting.settingsQuery.isFetching ||
+    antigravityRouting.preflightQuery.isFetching;
+
+  return (
+    <div className="animate-fade-in-up space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+            <Bot className="h-5 w-5 text-primary" />
+            Providers
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">Combined provider health and provider-scoped routing.</p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={refresh} disabled={busy}>
+          <RefreshCw className={`h-4 w-4${busy ? " animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {error ? <AlertMessage variant="error">{error}</AlertMessage> : null}
+
+      <CombinedOverview overview={overviewQuery.data} />
+
+      <Tabs defaultValue="gemini" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="gemini">Gemini</TabsTrigger>
+          <TabsTrigger value="antigravity">Antigravity</TabsTrigger>
+          <TabsTrigger value="codex">Codex</TabsTrigger>
+        </TabsList>
+        <TabsContent value="gemini" className="space-y-4">
+          <ProviderHeader
+            name={geminiProvider?.displayName ?? "Gemini"}
+            status={geminiProvider?.status ?? "foundation"}
+            authModes={geminiProvider?.authModes ?? ["api_key"]}
+            capabilities={geminiProvider?.capabilities ?? []}
+          />
+          <GeminiAccountCreateForm
+            busy={createGeminiAccount.isPending}
+            onSubmit={(payload) => createGeminiAccount.mutateAsync(payload)}
+          />
+          <ProviderAccountLifecyclePanel
+            title="Gemini account lifecycle"
+            emptyLabel="No Gemini accounts."
+            providerId="gemini"
+            accounts={geminiAccounts}
+            busy={updateGeminiAccount.isPending}
+            onUpdate={(accountId, payload) => updateGeminiAccount.mutateAsync({ accountId, payload })}
+          />
+          <ProviderRoutingPanel
+            title="Gemini routing"
+            emptyLabel="No Gemini accounts."
+            defaultQuotaDimension="requests_per_day"
+            accounts={geminiAccounts}
+            settings={geminiRouting.settingsQuery.data}
+            preflight={geminiPreflight}
+            busy={geminiRouting.updateSettingsMutation.isPending || geminiRouting.upsertQuotaWindowMutation.isPending}
+            onSaveSettings={(payload) => geminiRouting.updateSettingsMutation.mutateAsync(payload)}
+            onSaveQuota={(accountId, dimension, payload) =>
+              geminiRouting.upsertQuotaWindowMutation.mutateAsync({ accountId, dimension, payload })
+            }
+          />
+        </TabsContent>
+        <TabsContent value="antigravity" className="space-y-4">
+          <ProviderHeader
+            name={antigravityProvider?.displayName ?? "Antigravity"}
+            status={antigravityProvider?.status ?? "foundation"}
+            authModes={antigravityProvider?.authModes ?? ["cli_keyring"]}
+            capabilities={antigravityProvider?.capabilities ?? []}
+          />
+          <AntigravityProfileCreateForm
+            busy={createAntigravityAccount.isPending}
+            onSubmit={(payload) => createAntigravityAccount.mutateAsync(payload)}
+          />
+          <ProviderAccountLifecyclePanel
+            title="Antigravity profile lifecycle"
+            emptyLabel="No Antigravity profiles."
+            providerId="antigravity"
+            accounts={antigravityAccounts}
+            busy={updateAntigravityAccount.isPending}
+            onUpdate={(accountId, payload) => updateAntigravityAccount.mutateAsync({ accountId, payload })}
+          />
+          <ProviderRoutingPanel
+            title="Antigravity routing"
+            emptyLabel="No Antigravity profiles."
+            defaultQuotaDimension="requests"
+            accounts={antigravityAccounts}
+            settings={antigravityRouting.settingsQuery.data}
+            preflight={antigravityPreflight}
+            busy={
+              antigravityRouting.updateSettingsMutation.isPending ||
+              antigravityRouting.upsertQuotaWindowMutation.isPending
+            }
+            onSaveSettings={(payload) => antigravityRouting.updateSettingsMutation.mutateAsync(payload)}
+            onSaveQuota={(accountId, dimension, payload) =>
+              antigravityRouting.upsertQuotaWindowMutation.mutateAsync({ accountId, dimension, payload })
+            }
+          />
+          <AntigravityManagedInteractionPanel
+            accounts={antigravityAccounts}
+            busy={antigravityInteraction.isPending}
+            result={antigravityInteraction.data}
+            onSubmit={(payload) => antigravityInteraction.mutateAsync(payload)}
+          />
+          <AntigravityHarnessPanel
+            accounts={antigravityAccounts}
+            busy={antigravityHarness.isPending}
+            result={antigravityHarness.data}
+            onSubmit={(payload) => antigravityHarness.mutateAsync(payload)}
+          />
+        </TabsContent>
+        <TabsContent value="codex" className="space-y-4">
+          <ProviderHeader
+            name={codexProvider?.displayName ?? "Codex"}
+            status={codexProvider?.status ?? "ready"}
+            authModes={codexProvider?.authModes ?? ["chatgpt_oauth"]}
+            capabilities={codexProvider?.capabilities ?? []}
+          />
+          <CodexPanel
+            accounts={codexAccounts}
+            settings={codexSettings.settingsQuery.data}
+            busy={codexSettings.updateSettingsMutation.isPending}
+            onSave={(patch) => {
+              const settings = codexSettings.settingsQuery.data;
+              if (!settings) {
+                return Promise.resolve();
+              }
+              return codexSettings.updateSettingsMutation.mutateAsync(buildSettingsUpdateRequest(settings, patch));
+            }}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function CombinedOverview({ overview }: { overview?: AgentProviderOverview }) {
+  const totals = overview?.totals;
+  const items = [
+    { label: "Providers", value: totals?.providerCount ?? 0, icon: Bot },
+    { label: "Accounts", value: totals?.accountCount ?? 0, icon: KeyRound },
+    { label: "Active accounts", value: totals?.activeAccountCount ?? 0, icon: Activity },
+    { label: "Quota windows", value: totals?.quotaWindowCount ?? 0, icon: Gauge },
+    { label: "Requests", value: totals?.requestCount ?? 0, icon: Route },
+    { label: "Errors", value: totals?.errorCount ?? 0, icon: Activity },
+  ];
+  return (
+    <section className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
+        {items.map((item) => (
+          <div key={item.label} className="rounded-lg border bg-card p-4">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm text-muted-foreground">{item.label}</span>
+              <item.icon className="h-4 w-4 text-muted-foreground" />
+            </div>
+            <div className="mt-3 text-2xl font-semibold tabular-nums">{formatCount(item.value)}</div>
+          </div>
+        ))}
+      </div>
+      {overview?.providers.length ? (
+        <div className="overflow-x-auto rounded-lg border bg-card">
+          <div className="grid min-w-[42rem] grid-cols-[1.2fr_repeat(5,minmax(4.5rem,1fr))] gap-3 border-b px-4 py-2 text-xs font-medium text-muted-foreground">
+            <span>Provider</span>
+            <span className="text-right">Accounts</span>
+            <span className="text-right">Active</span>
+            <span className="text-right">Quota</span>
+            <span className="text-right">Requests</span>
+            <span className="text-right">Errors</span>
+          </div>
+          {overview.providers.map((provider) => (
+            <div
+              key={provider.providerId}
+              className="grid min-w-[42rem] grid-cols-[1.2fr_repeat(5,minmax(4.5rem,1fr))] gap-3 border-b px-4 py-3 text-sm last:border-b-0"
+            >
+              <span className="font-medium">{provider.displayName}</span>
+              <span className="text-right tabular-nums">{formatCount(provider.accountCount)}</span>
+              <span className="text-right tabular-nums">{formatCount(provider.activeAccountCount)}</span>
+              <span className="text-right tabular-nums">{formatCount(provider.quotaWindowCount)}</span>
+              <span className="text-right tabular-nums">{formatCount(provider.requestCount)}</span>
+              <span className="text-right tabular-nums">{formatCount(provider.errorCount)}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function formatCount(value: number): string {
+  return COUNT_FORMATTER.format(value);
+}
+
+function ProviderHeader({
+  name,
+  status,
+  authModes,
+  capabilities,
+}: {
+  name: string;
+  status: string;
+  authModes: string[];
+  capabilities: AgentProviderCapability[];
+}) {
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-base font-semibold">{name}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{authModes.join(" / ")}</p>
+        </div>
+        <Badge variant={status === "ready" ? "default" : "secondary"}>{status}</Badge>
+      </div>
+      {capabilities.length ? (
+        <div className="mt-4 grid gap-3 lg:grid-cols-3">
+          {capabilities.map((capability) => (
+            <div key={capability.protocol} className="rounded-lg border p-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium">{capability.protocol}</span>
+                <Badge variant={capability.status === "ready" ? "default" : "secondary"}>
+                  {capability.status}
+                </Badge>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                <Badge variant={capability.proxyable ? "outline" : "secondary"}>
+                  {capability.proxyable ? "Proxy" : "Harness"}
+                </Badge>
+                <Badge variant={capability.streaming ? "outline" : "secondary"}>
+                  {capability.streaming ? "Streaming" : "Session"}
+                </Badge>
+                {capability.availableUntil ? <Badge variant="secondary">until {capability.availableUntil}</Badge> : null}
+              </div>
+              <p className="mt-3 text-xs text-muted-foreground">{capability.lifecycleNotes}</p>
+              <p className="mt-2 text-xs font-medium">{capability.operatorAction}</p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function GeminiAccountCreateForm({
+  busy,
+  onSubmit,
+}: {
+  busy: boolean;
+  onSubmit: (payload: { displayName: string; apiKey: string; projectId?: string; location?: string }) => Promise<unknown>;
+}) {
+  const [displayName, setDisplayName] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [projectId, setProjectId] = useState("");
+  const [location, setLocation] = useState("");
+
+  return (
+    <form
+      className="rounded-lg border bg-card p-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void onSubmit({
+          displayName,
+          apiKey,
+          projectId: projectId || undefined,
+          location: location || undefined,
+        }).then(() => {
+          setDisplayName("");
+          setApiKey("");
+          setProjectId("");
+          setLocation("");
+        });
+      }}
+    >
+      <div className="mb-4 flex items-center gap-2">
+        <KeyRound className="h-4 w-4 text-primary" />
+        <h3 className="text-sm font-semibold">Gemini accounts</h3>
+      </div>
+      <div className="grid gap-3 lg:grid-cols-[minmax(12rem,1fr)_minmax(16rem,1.3fr)_minmax(10rem,1fr)_minmax(9rem,0.8fr)_auto]">
+        <Input value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Display name" required />
+        <Input value={apiKey} onChange={(event) => setApiKey(event.target.value)} placeholder="API key" type="password" required />
+        <Input value={projectId} onChange={(event) => setProjectId(event.target.value)} placeholder="Project" />
+        <Input value={location} onChange={(event) => setLocation(event.target.value)} placeholder="Location" />
+        <Button type="submit" disabled={busy}>
+          Add
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function AntigravityProfileCreateForm({
+  busy,
+  onSubmit,
+}: {
+  busy: boolean;
+  onSubmit: (payload: {
+    displayName: string;
+    authMode?: "api_key" | "cli_keyring";
+    apiKey?: string;
+    externalAccountId?: string;
+    projectId?: string;
+    location?: string;
+  }) => Promise<unknown>;
+}) {
+  const [displayName, setDisplayName] = useState("");
+  const [authMode, setAuthMode] = useState<"api_key" | "cli_keyring">("api_key");
+  const [apiKey, setApiKey] = useState("");
+  const [externalAccountId, setExternalAccountId] = useState("");
+  const [projectId, setProjectId] = useState("");
+  const [location, setLocation] = useState("");
+
+  return (
+    <form
+      className="rounded-lg border bg-card p-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void onSubmit({
+          displayName,
+          authMode,
+          apiKey: authMode === "api_key" ? apiKey : undefined,
+          externalAccountId: externalAccountId || undefined,
+          projectId: projectId || undefined,
+          location: location || undefined,
+        }).then(() => {
+          setDisplayName("");
+          setApiKey("");
+          setExternalAccountId("");
+          setProjectId("");
+          setLocation("");
+        });
+      }}
+    >
+      <div className="mb-4 flex items-center gap-2">
+        <Bot className="h-4 w-4 text-primary" />
+        <h3 className="text-sm font-semibold">Antigravity profiles</h3>
+      </div>
+      <div className="grid gap-3 lg:grid-cols-[minmax(12rem,1fr)_minmax(10rem,0.8fr)_minmax(14rem,1.2fr)_minmax(10rem,1fr)_minmax(9rem,0.8fr)_auto]">
+        <Input value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Display name" required />
+        <Select value={authMode} onValueChange={(value) => setAuthMode(value as "api_key" | "cli_keyring")}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="api_key">API key</SelectItem>
+            <SelectItem value="cli_keyring">CLI profile</SelectItem>
+          </SelectContent>
+        </Select>
+        {authMode === "api_key" ? (
+          <Input
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+            placeholder="Gemini API key"
+            type="password"
+            required
+          />
+        ) : (
+          <Input
+            value={externalAccountId}
+            onChange={(event) => setExternalAccountId(event.target.value)}
+            placeholder="agy profile id"
+            required
+          />
+        )}
+        <Input value={projectId} onChange={(event) => setProjectId(event.target.value)} placeholder="Workspace" />
+        <Input value={location} onChange={(event) => setLocation(event.target.value)} placeholder="Harness" />
+        <Button type="submit" disabled={busy}>
+          Add
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function ProviderAccountLifecyclePanel({
+  title,
+  emptyLabel,
+  providerId,
+  accounts,
+  busy,
+  onUpdate,
+}: {
+  title: string;
+  emptyLabel: string;
+  providerId: "gemini" | "antigravity";
+  accounts: AgentProviderAccount[];
+  busy: boolean;
+  onUpdate: (accountId: string, payload: AgentProviderAccountUpdate) => Promise<unknown>;
+}) {
+  if (accounts.length === 0) {
+    return <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">{emptyLabel}</p>;
+  }
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="mb-4 flex items-center gap-2">
+        <Route className="h-4 w-4 text-primary" aria-hidden="true" />
+        <h3 className="text-sm font-semibold">{title}</h3>
+      </div>
+      <div className="divide-y rounded-lg border">
+        {accounts.map((account) => (
+          <ProviderAccountLifecycleRow
+            key={account.accountId}
+            providerId={providerId}
+            account={account}
+            busy={busy}
+            onUpdate={onUpdate}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ProviderAccountLifecycleRow({
+  providerId,
+  account,
+  busy,
+  onUpdate,
+}: {
+  providerId: "gemini" | "antigravity";
+  account: AgentProviderAccount;
+  busy: boolean;
+  onUpdate: (accountId: string, payload: AgentProviderAccountUpdate) => Promise<unknown>;
+}) {
+  const [displayName, setDisplayName] = useState(account.displayName);
+  const [externalAccountId, setExternalAccountId] = useState(account.externalAccountId ?? "");
+  const [projectId, setProjectId] = useState(account.projectId ?? "");
+  const [location, setLocation] = useState(account.location ?? "");
+  const [apiKey, setApiKey] = useState("");
+  const nextStatus = account.status === "paused" ? "active" : "paused";
+  const canEditExternalId = providerId === "antigravity";
+  const canRotateApiKey = providerId === "gemini" || account.authMode === "api_key";
+
+  return (
+    <div className="grid gap-3 p-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="truncate text-sm font-medium">{account.displayName}</span>
+            <Badge variant={account.status === "active" ? "default" : "secondary"}>{account.status}</Badge>
+            {account.apiKeySet ? <Badge variant="outline">key set</Badge> : null}
+          </div>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {account.externalAccountId ?? account.credentialFingerprint ?? account.accountId}
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={busy}
+          onClick={() => void onUpdate(account.accountId, { status: nextStatus })}
+        >
+          {nextStatus === "active" ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+          {nextStatus === "active" ? "Resume" : "Pause"}
+        </Button>
+      </div>
+
+      <form
+        className="grid gap-3 lg:grid-cols-[minmax(11rem,1fr)_minmax(10rem,1fr)_minmax(10rem,1fr)_minmax(9rem,0.8fr)_auto]"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void onUpdate(account.accountId, {
+            displayName,
+            externalAccountId: canEditExternalId ? externalAccountId : undefined,
+            projectId: projectId || null,
+            location: location || null,
+          });
+        }}
+      >
+        <Input value={displayName} onChange={(event) => setDisplayName(event.target.value)} required />
+        {canEditExternalId ? (
+          <Input
+            value={externalAccountId}
+            onChange={(event) => setExternalAccountId(event.target.value)}
+            placeholder={account.authMode === "api_key" ? "Agent id" : "Profile id"}
+            required={account.authMode === "cli_keyring"}
+          />
+        ) : (
+          null
+        )}
+        <Input value={projectId} onChange={(event) => setProjectId(event.target.value)} placeholder="Project" />
+        <Input
+          value={location}
+          onChange={(event) => setLocation(event.target.value)}
+          placeholder={canEditExternalId ? "Harness" : "Location"}
+        />
+        <Button type="submit" variant="outline" disabled={busy}>
+          <Settings2 className="h-4 w-4" />
+          Save
+        </Button>
+      </form>
+
+      {canRotateApiKey ? (
+        <form
+          className="grid gap-3 sm:grid-cols-[minmax(14rem,1fr)_auto]"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void onUpdate(account.accountId, { apiKey }).then(() => setApiKey(""));
+          }}
+        >
+          <Input
+            value={apiKey}
+            onChange={(event) => setApiKey(event.target.value)}
+            placeholder="New API key"
+            type="password"
+            required
+          />
+          <Button type="submit" variant="outline" disabled={busy || !apiKey}>
+            <RefreshCw className="h-4 w-4" />
+            Rotate
+          </Button>
+        </form>
+      ) : null}
+    </div>
+  );
+}
+
+function AntigravityManagedInteractionPanel({
+  accounts,
+  busy,
+  result,
+  onSubmit,
+}: {
+  accounts: AgentProviderAccount[];
+  busy: boolean;
+  result?: AntigravityManagedInteractionRunResponse;
+  onSubmit: (payload: { agent?: string; input: string; environment?: string }) => Promise<unknown>;
+}) {
+  const [agent, setAgent] = useState("antigravity-preview-05-2026");
+  const [input, setInput] = useState("");
+  const [environment, setEnvironment] = useState("remote");
+  const apiAccounts = accounts.filter((account) => account.authMode === "api_key");
+  const disabled = busy || apiAccounts.length === 0;
+
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="mb-4 flex items-center gap-2">
+        <Bot className="h-4 w-4 text-primary" />
+        <h3 className="text-sm font-semibold">Antigravity managed agent</h3>
+      </div>
+      <form
+        className="grid gap-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void onSubmit({ agent, input, environment });
+        }}
+      >
+        <div className="grid gap-3 lg:grid-cols-[minmax(14rem,1fr)_minmax(9rem,0.55fr)_auto]">
+          <Input value={agent} onChange={(event) => setAgent(event.target.value)} required />
+          <Input value={environment} onChange={(event) => setEnvironment(event.target.value)} required />
+          <Button type="submit" disabled={disabled || !input}>
+            <Play className="h-4 w-4" />
+            Run
+          </Button>
+        </div>
+        <textarea
+          className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder="Input"
+          required
+        />
+        <span className="text-sm text-muted-foreground">
+          {apiAccounts.length
+            ? `${apiAccounts.length} API key account${apiAccounts.length === 1 ? "" : "s"} available`
+            : "No API key accounts"}
+        </span>
+      </form>
+      {result ? (
+        <div className="mt-4 overflow-hidden rounded-lg border">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b bg-muted/40 px-3 py-2 text-xs">
+            <span className="font-medium">{result.agent}</span>
+            <span className="text-muted-foreground">Interactions API</span>
+          </div>
+          <pre className="max-h-80 overflow-auto whitespace-pre-wrap p-3 text-xs">
+            {result.outputText || JSON.stringify(result.response, null, 2)}
+          </pre>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function AntigravityHarnessPanel({
+  accounts,
+  busy,
+  result,
+  onSubmit,
+}: {
+  accounts: AgentProviderAccount[];
+  busy: boolean;
+  result?: AntigravityHarnessPrintResponse;
+  onSubmit: (payload: {
+    prompt: string;
+    workspacePath: string;
+    timeoutSeconds: number;
+    continueConversation?: boolean;
+  }) => Promise<unknown>;
+}) {
+  const [prompt, setPrompt] = useState("");
+  const [workspacePath, setWorkspacePath] = useState("");
+  const [timeoutSeconds, setTimeoutSeconds] = useState("300");
+  const [continueConversation, setContinueConversation] = useState(false);
+  const disabled = busy || accounts.length === 0;
+
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="mb-4 flex items-center gap-2">
+        <Terminal className="h-4 w-4 text-primary" />
+        <h3 className="text-sm font-semibold">Antigravity harness</h3>
+      </div>
+      <form
+        className="grid gap-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void onSubmit({
+            prompt,
+            workspacePath,
+            timeoutSeconds: Number(timeoutSeconds),
+            continueConversation,
+          });
+        }}
+      >
+        <div className="grid gap-3 lg:grid-cols-[minmax(16rem,1fr)_7rem_auto]">
+          <Input
+            value={workspacePath}
+            onChange={(event) => setWorkspacePath(event.target.value)}
+            placeholder="Workspace path"
+            required
+          />
+          <Input
+            value={timeoutSeconds}
+            onChange={(event) => setTimeoutSeconds(event.target.value)}
+            type="number"
+            min={1}
+            max={1800}
+          />
+          <label className="flex h-10 items-center gap-2 rounded-md border px-3 text-sm">
+            <input
+              type="checkbox"
+              checked={continueConversation}
+              onChange={(event) => setContinueConversation(event.target.checked)}
+            />
+            Continue
+          </label>
+        </div>
+        <textarea
+          className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          placeholder="Prompt"
+          required
+        />
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-sm text-muted-foreground">
+            {accounts.length ? `${accounts.length} profile${accounts.length === 1 ? "" : "s"} available` : "No profiles"}
+          </span>
+          <Button type="submit" disabled={disabled}>
+            <Play className="h-4 w-4" />
+            Run
+          </Button>
+        </div>
+      </form>
+      {result ? (
+        <div className="mt-4 overflow-hidden rounded-lg border">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b bg-muted/40 px-3 py-2 text-xs">
+            <span className="font-medium">{result.externalAccountId ?? result.accountId}</span>
+            <span className="text-muted-foreground">
+              exit {result.exitCode} / {result.durationMs}ms
+            </span>
+          </div>
+          <pre className="max-h-80 overflow-auto whitespace-pre-wrap p-3 text-xs">{result.stdout || result.stderr}</pre>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ProviderRoutingPanel({
+  title,
+  emptyLabel,
+  defaultQuotaDimension,
+  accounts,
+  settings,
+  preflight,
+  busy,
+  onSaveSettings,
+  onSaveQuota,
+}: {
+  title: string;
+  emptyLabel: string;
+  defaultQuotaDimension: string;
+  accounts: AgentProviderAccount[];
+  settings?: AgentProviderRoutingSettings;
+  preflight?: AgentProviderPreflight;
+  busy: boolean;
+  onSaveSettings: (payload: AgentProviderRoutingSettingsUpdate) => Promise<unknown>;
+  onSaveQuota: (accountId: string, dimension: string, payload: AgentProviderQuotaWindowUpsert) => Promise<unknown>;
+}) {
+  const [strategyDraft, setStrategyDraft] = useState<AgentProviderRoutingStrategy | null>(null);
+  const [singleAccountDraft, setSingleAccountDraft] = useState<string | null>(null);
+  const [orderedAccountDraft, setOrderedAccountDraft] = useState<string[] | null>(null);
+  const [thresholdDraft, setThresholdDraft] = useState<string | null>(null);
+  const [quotaAccountDraft, setQuotaAccountDraft] = useState("");
+  const [dimension, setDimension] = useState(defaultQuotaDimension);
+  const [used, setUsed] = useState("0");
+  const [limit, setLimit] = useState("100");
+  const strategy = strategyDraft ?? settings?.strategy ?? "capacity_weighted";
+  const singleAccountId = singleAccountDraft ?? settings?.singleAccountId ?? "";
+  const orderedAccountIds = orderedAccountDraft ?? normalizeProviderAccountOrder(settings?.orderedAccountIds ?? []);
+  const orderedAccountIdSet = new Set(orderedAccountIds);
+  const nextOrderedAccountId = accounts.find((account) => !orderedAccountIdSet.has(account.accountId))?.accountId;
+  const threshold = thresholdDraft ?? String(settings?.quotaThresholdPct ?? 100);
+  const quotaAccountId = quotaAccountDraft || accounts[0]?.accountId || "";
+
+  return (
+    <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,0.7fr)]">
+      <div className="space-y-4 rounded-lg border bg-card p-4">
+        <div className="flex items-center gap-2">
+          <Settings2 className="h-4 w-4 text-primary" />
+          <h3 className="text-sm font-semibold">{title}</h3>
+        </div>
+        <form
+          className="grid gap-3 md:grid-cols-[minmax(12rem,1fr)_minmax(12rem,1fr)_8rem_auto]"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void onSaveSettings({
+              strategy,
+              singleAccountId: singleAccountId || null,
+              orderedAccountIds:
+                strategy === "ordered_fallback" && orderedAccountIds.length === 0 && accounts[0]
+                  ? [accounts[0].accountId]
+                  : orderedAccountIds,
+              quotaThresholdPct: Number(threshold),
+            });
+          }}
+        >
+          <Select
+            value={strategy}
+            onValueChange={(value) => {
+              const nextStrategy = value as AgentProviderRoutingStrategy;
+              setStrategyDraft(nextStrategy);
+              if (nextStrategy === "ordered_fallback" && orderedAccountIds.length === 0 && accounts[0]) {
+                setOrderedAccountDraft([accounts[0].accountId]);
+              }
+            }}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {STRATEGIES.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {STRATEGY_LABELS[option]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={singleAccountId || "none"} onValueChange={(value) => setSingleAccountDraft(value === "none" ? "" : value)}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">No single account</SelectItem>
+              {accounts.map((account) => (
+                <SelectItem key={account.accountId} value={account.accountId}>
+                  {account.displayName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input value={threshold} onChange={(event) => setThresholdDraft(event.target.value)} type="number" min={0} max={100} />
+          <Button type="submit" disabled={busy || (strategy === "ordered_fallback" && orderedAccountIds.length === 0)}>
+            Save
+          </Button>
+        </form>
+
+        {strategy === "ordered_fallback" ? (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-xs font-medium text-muted-foreground">Account priority</p>
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                className="h-8 w-8"
+                disabled={busy || !nextOrderedAccountId}
+                aria-label="Add provider account priority"
+                onClick={() =>
+                  nextOrderedAccountId ? setOrderedAccountDraft([...orderedAccountIds, nextOrderedAccountId]) : undefined
+                }
+              >
+                <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+              </Button>
+            </div>
+            {orderedAccountIds.map((accountId, index) => {
+              const account = accounts.find((item) => item.accountId === accountId);
+              const availableAccounts = accounts.filter(
+                (item) => item.accountId === accountId || !orderedAccountIdSet.has(item.accountId),
+              );
+              return (
+                <div key={accountId + "-" + index} className="flex items-center gap-2">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-muted/20 text-xs text-muted-foreground">
+                    {index + 1}
+                  </div>
+                  <Select
+                    value={accountId}
+                    onValueChange={(value) => {
+                      const next = [...orderedAccountIds];
+                      next[index] = value;
+                      setOrderedAccountDraft(normalizeProviderAccountOrder(next));
+                    }}
+                  >
+                    <SelectTrigger className="h-8 min-w-0 flex-1 text-xs" disabled={busy}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableAccounts.map((item) => (
+                        <SelectItem key={item.accountId} value={item.accountId}>
+                          {item.displayName}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    disabled={busy || index === 0}
+                    aria-label={"Move " + (account?.displayName ?? accountId) + " up"}
+                    onClick={() => setOrderedAccountDraft(moveProviderAccountOrder(orderedAccountIds, index, -1))}
+                  >
+                    <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    disabled={busy || index === orderedAccountIds.length - 1}
+                    aria-label={"Move " + (account?.displayName ?? accountId) + " down"}
+                    onClick={() => setOrderedAccountDraft(moveProviderAccountOrder(orderedAccountIds, index, 1))}
+                  >
+                    <ArrowDown className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    disabled={busy || orderedAccountIds.length <= 1}
+                    aria-label={"Remove " + (account?.displayName ?? accountId)}
+                    onClick={() =>
+                      setOrderedAccountDraft(orderedAccountIds.filter((_, itemIndex) => itemIndex !== index))
+                    }
+                  >
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        ) : null}
+
+        <form
+          className="grid gap-3 md:grid-cols-[minmax(12rem,1fr)_minmax(10rem,1fr)_7rem_7rem_auto]"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!quotaAccountId) return;
+            void onSaveQuota(quotaAccountId, dimension, {
+              dimension,
+              used: Number(used),
+              limit: limit ? Number(limit) : null,
+            });
+          }}
+        >
+          <Select value={quotaAccountId || "none"} onValueChange={(value) => setQuotaAccountDraft(value === "none" ? "" : value)}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">No account</SelectItem>
+              {accounts.map((account) => (
+                <SelectItem key={account.accountId} value={account.accountId}>
+                  {account.displayName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input value={dimension} onChange={(event) => setDimension(event.target.value)} />
+          <Input value={used} onChange={(event) => setUsed(event.target.value)} type="number" min={0} />
+          <Input value={limit} onChange={(event) => setLimit(event.target.value)} type="number" min={0} />
+          <Button type="submit" variant="outline" disabled={busy || !quotaAccountId}>
+            Set quota
+          </Button>
+        </form>
+
+        <ProviderAccountTable accounts={preflight?.accounts ?? []} emptyLabel={emptyLabel} />
+      </div>
+
+      <div className="rounded-lg border bg-card p-4">
+        <div className="flex items-center gap-2">
+          <Route className="h-4 w-4 text-primary" />
+          <h3 className="text-sm font-semibold">Preflight</h3>
+        </div>
+        <dl className="mt-4 space-y-3 text-sm">
+          <MetricRow label="Selected" value={preflight?.selectedAccountId ?? "None"} />
+          <MetricRow label="Denied" value={preflight?.deniedReason ?? "None"} />
+          <MetricRow label="Candidates" value={String(preflight?.candidateAccountIds.length ?? 0)} />
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+function ProviderAccountTable({
+  accounts,
+  emptyLabel,
+}: {
+  accounts: AgentProviderPreflight["accounts"];
+  emptyLabel: string;
+}) {
+  if (accounts.length === 0) {
+    return <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">{emptyLabel}</p>;
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full min-w-[34rem] text-sm">
+        <thead className="bg-muted/40 text-left text-xs text-muted-foreground">
+          <tr>
+            <th className="px-3 py-2 font-medium">Account</th>
+            <th className="px-3 py-2 font-medium">Status</th>
+            <th className="px-3 py-2 font-medium">Quota</th>
+          </tr>
+        </thead>
+        <tbody>
+          {accounts.map((account) => (
+            <tr key={account.accountId} className="border-t">
+              <td className="px-3 py-2 font-medium">{account.displayName}</td>
+              <td className="px-3 py-2">{account.status}</td>
+              <td className="px-3 py-2 text-muted-foreground">
+                {account.quotaWindows.length
+                  ? account.quotaWindows.map((window) => `${window.dimension}: ${window.used}/${window.limit ?? "open"}`).join(", ")
+                  : "No windows"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CodexPanel({
+  accounts,
+  settings,
+  busy,
+  onSave,
+}: {
+  accounts: AccountSummary[];
+  settings?: DashboardSettings;
+  busy: boolean;
+  onSave: (patch: Partial<SettingsUpdateRequest>) => Promise<unknown>;
+}) {
+  const active = accounts.filter((account) => account.status === "active").length;
+  const limited = accounts.length - active;
+  return (
+    <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(18rem,0.55fr)]">
+      <div className="rounded-lg border bg-card p-4">
+        <div className="mb-4 flex items-center gap-2">
+          <KeyRound className="h-4 w-4 text-primary" />
+          <h3 className="text-sm font-semibold">Codex accounts</h3>
+        </div>
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full min-w-[34rem] text-sm">
+            <thead className="bg-muted/40 text-left text-xs text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 font-medium">Account</th>
+                <th className="px-3 py-2 font-medium">Plan</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 font-medium">Primary</th>
+              </tr>
+            </thead>
+            <tbody>
+              {accounts.map((account) => (
+                <tr key={account.accountId} className="border-t">
+                  <td className="px-3 py-2 font-medium">{account.displayName || account.email}</td>
+                  <td className="px-3 py-2">{account.planType}</td>
+                  <td className="px-3 py-2">{account.status}</td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {account.usage?.primaryRemainingPercent == null
+                      ? "Unknown"
+                      : `${account.usage.primaryRemainingPercent.toFixed(1)}% remaining`}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div className="rounded-lg border bg-card p-4">
+        <div className="flex items-center gap-2">
+          <Gauge className="h-4 w-4 text-primary" />
+          <h3 className="text-sm font-semibold">Codex routing</h3>
+        </div>
+        <dl className="mt-4 space-y-3 text-sm">
+          <MetricRow label="Total" value={String(accounts.length)} />
+          <MetricRow label="Active" value={String(active)} />
+          <MetricRow label="Limited" value={String(limited)} />
+          <MetricRow label="Strategy" value={settings ? CODEX_STRATEGY_LABELS[settings.routingStrategy] : "Loading"} />
+          <MetricRow
+            label="Primary gate"
+            value={
+              settings?.stickyReallocationPrimaryBudgetThresholdPct == null
+                ? "Unset"
+                : `${settings.stickyReallocationPrimaryBudgetThresholdPct}%`
+            }
+          />
+        </dl>
+      </div>
+      <CodexRoutingPanel accounts={accounts} settings={settings} busy={busy} onSave={onSave} />
+    </section>
+  );
+}
+
+function CodexRoutingPanel({
+  accounts,
+  settings,
+  busy,
+  onSave,
+}: {
+  accounts: AccountSummary[];
+  settings?: DashboardSettings;
+  busy: boolean;
+  onSave: (patch: Partial<SettingsUpdateRequest>) => Promise<unknown>;
+}) {
+  const [thresholdDraft, setThresholdDraft] = useState("");
+  const selectableAccounts = accounts.filter((account) =>
+    ["active", "rate_limited", "quota_exceeded"].includes(account.status),
+  );
+  const firstAccountId = selectableAccounts[0]?.accountId;
+  const manualAccountIds = normalizeProviderAccountOrder(settings?.manualAccountPriorityIds ?? []);
+  const manualAccountIdSet = new Set(manualAccountIds);
+  const nextManualAccountId = selectableAccounts.find((account) => !manualAccountIdSet.has(account.accountId))?.accountId;
+  const thresholdValue =
+    thresholdDraft ||
+    (settings?.stickyReallocationPrimaryBudgetThresholdPct == null
+      ? ""
+      : String(settings.stickyReallocationPrimaryBudgetThresholdPct));
+
+  if (!settings) {
+    return <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">Codex settings loading.</p>;
+  }
+
+  const saveStrategy = (strategy: CodexRoutingStrategy) => {
+    if (strategy === "single_account") {
+      const selectedAccountId = settings.singleAccountId ?? firstAccountId;
+      if (!selectedAccountId) return;
+      void onSave({ routingStrategy: strategy, singleAccountId: selectedAccountId });
+      return;
+    }
+    if (strategy === "ordered_fallback") {
+      const orderedIds = manualAccountIds.length > 0 ? manualAccountIds : firstAccountId ? [firstAccountId] : [];
+      if (orderedIds.length === 0) return;
+      void onSave({ routingStrategy: strategy, manualAccountPriorityIds: orderedIds });
+      return;
+    }
+    void onSave({ routingStrategy: strategy });
+  };
+
+  const saveManualAccountIds = (accountIds: string[]) => {
+    void onSave({ manualAccountPriorityIds: normalizeProviderAccountOrder(accountIds) });
+  };
+
+  return (
+    <div className="rounded-lg border bg-card p-4 xl:col-span-2">
+      <div className="mb-4 flex items-center gap-2">
+        <Settings2 className="h-4 w-4 text-primary" />
+        <h3 className="text-sm font-semibold">Codex settings</h3>
+      </div>
+      <div className="grid gap-3 md:grid-cols-[minmax(12rem,1fr)_minmax(12rem,1fr)_8rem_auto]">
+        <Select value={settings.routingStrategy} onValueChange={(value) => saveStrategy(value as CodexRoutingStrategy)}>
+          <SelectTrigger className="w-full" disabled={busy}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {CODEX_STRATEGIES.map((option) => (
+              <SelectItem
+                key={option}
+                value={option}
+                disabled={
+                  (option === "single_account" && !settings.singleAccountId && !firstAccountId) ||
+                  (option === "ordered_fallback" && manualAccountIds.length === 0 && !firstAccountId)
+                }
+              >
+                {CODEX_STRATEGY_LABELS[option]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={settings.singleAccountId ?? "none"}
+          onValueChange={(value) => void onSave({ singleAccountId: value === "none" ? null : value })}
+        >
+          <SelectTrigger className="w-full" disabled={busy || selectableAccounts.length === 0}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">No single account</SelectItem>
+            {selectableAccounts.map((account) => (
+              <SelectItem key={account.accountId} value={account.accountId}>
+                {accountLabel(account)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          value={thresholdValue}
+          onChange={(event) => setThresholdDraft(event.target.value)}
+          type="number"
+          min={0}
+          max={100}
+          disabled={busy}
+          aria-label="Codex primary threshold"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          disabled={busy || thresholdValue === ""}
+          onClick={() => {
+            const threshold = Number(thresholdValue);
+            void onSave({
+              stickyReallocationPrimaryBudgetThresholdPct: threshold,
+              stickyReallocationSecondaryBudgetThresholdPct:
+                settings.stickyReallocationSecondaryBudgetThresholdPct ?? 100,
+            }).then(() => setThresholdDraft(""));
+          }}
+        >
+          Save
+        </Button>
+      </div>
+
+      {settings.routingStrategy === "ordered_fallback" ? (
+        <div className="mt-4 space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-xs font-medium text-muted-foreground">Account priority</p>
+            <Button
+              type="button"
+              size="icon"
+              variant="outline"
+              className="h-8 w-8"
+              disabled={busy || !nextManualAccountId}
+              aria-label="Add Codex account priority"
+              onClick={() => (nextManualAccountId ? saveManualAccountIds([...manualAccountIds, nextManualAccountId]) : undefined)}
+            >
+              <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          </div>
+          {manualAccountIds.map((accountId, index) => {
+            const account = accounts.find((item) => item.accountId === accountId);
+            const availableAccounts = selectableAccounts.filter(
+              (item) => item.accountId === accountId || !manualAccountIdSet.has(item.accountId),
+            );
+            return (
+              <div key={`${accountId}-${index}`} className="flex items-center gap-2">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-muted/20 text-xs text-muted-foreground">
+                  {index + 1}
+                </div>
+                <Select
+                  value={accountId}
+                  onValueChange={(value) => {
+                    const next = [...manualAccountIds];
+                    next[index] = value;
+                    saveManualAccountIds(next);
+                  }}
+                >
+                  <SelectTrigger className="h-8 min-w-0 flex-1 text-xs" disabled={busy}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableAccounts.map((item) => (
+                      <SelectItem key={item.accountId} value={item.accountId}>
+                        {accountLabel(item)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8"
+                  disabled={busy || index === 0}
+                  aria-label={"Move " + (account?.displayName ?? accountId) + " up"}
+                  onClick={() => saveManualAccountIds(moveProviderAccountOrder(manualAccountIds, index, -1))}
+                >
+                  <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8"
+                  disabled={busy || index === manualAccountIds.length - 1}
+                  aria-label={"Move " + (account?.displayName ?? accountId) + " down"}
+                  onClick={() => saveManualAccountIds(moveProviderAccountOrder(manualAccountIds, index, 1))}
+                >
+                  <ArrowDown className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8"
+                  disabled={busy || manualAccountIds.length <= 1}
+                  aria-label={"Remove " + (account?.displayName ?? accountId)}
+                  onClick={() => saveManualAccountIds(manualAccountIds.filter((_, itemIndex) => itemIndex !== index))}
+                >
+                  <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function accountLabel(account: AccountSummary): string {
+  return account.displayName || account.email || account.accountId;
+}
+
+function MetricRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="max-w-[12rem] truncate font-medium tabular-nums">{value}</dd>
+    </div>
+  );
+}

--- a/frontend/src/features/agent-providers/harness-schemas.test.ts
+++ b/frontend/src/features/agent-providers/harness-schemas.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AntigravityHarnessPrintResponseSchema,
+  AntigravityManagedInteractionRunResponseSchema,
+} from "@/features/agent-providers/harness-schemas";
+
+describe("AntigravityHarnessPrintResponseSchema", () => {
+  it("parses redacted agy harness output", () => {
+    const parsed = AntigravityHarnessPrintResponseSchema.parse({
+      providerId: "antigravity",
+      accountId: "agy_1",
+      externalAccountId: "default",
+      command: ["agy", "--print", "--prompt", "<redacted>"],
+      cwd: "C:\\repo",
+      exitCode: 0,
+      stdout: "done",
+      stderr: "",
+      durationMs: 42,
+    });
+
+    expect(parsed.command).toContain("<redacted>");
+    expect(parsed.stdout).toBe("done");
+  });
+
+  it("parses managed Interactions API run output", () => {
+    const parsed = AntigravityManagedInteractionRunResponseSchema.parse({
+      providerId: "antigravity",
+      agent: "antigravity-preview-05-2026",
+      outputText: "done",
+      response: { id: "interaction_1", output_text: "done" },
+    });
+
+    expect(parsed.agent).toBe("antigravity-preview-05-2026");
+    expect(parsed.outputText).toBe("done");
+  });
+});

--- a/frontend/src/features/agent-providers/harness-schemas.ts
+++ b/frontend/src/features/agent-providers/harness-schemas.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+export const AntigravityHarnessPrintRequestSchema = z.object({
+  prompt: z.string().min(1),
+  workspacePath: z.string().min(1),
+  timeoutSeconds: z.number().min(1).max(1800).optional(),
+  addDirs: z.array(z.string().min(1)).optional(),
+  conversationId: z.string().nullable().optional(),
+  continueConversation: z.boolean().optional(),
+  sandbox: z.string().nullable().optional(),
+});
+
+export const AntigravityHarnessPrintResponseSchema = z.object({
+  providerId: z.literal("antigravity"),
+  accountId: z.string(),
+  externalAccountId: z.string().nullable().optional(),
+  command: z.array(z.string()),
+  cwd: z.string(),
+  exitCode: z.number(),
+  stdout: z.string(),
+  stderr: z.string(),
+  durationMs: z.number(),
+});
+
+export const AntigravityManagedInteractionRunRequestSchema = z.object({
+  agent: z.string().min(1).optional(),
+  input: z.string().min(1),
+  environment: z.string().min(1).optional(),
+  tools: z.array(z.record(z.string(), z.unknown())).optional(),
+});
+
+export const AntigravityManagedInteractionRunResponseSchema = z.object({
+  providerId: z.literal("antigravity"),
+  agent: z.string(),
+  outputText: z.string(),
+  response: z.record(z.string(), z.unknown()),
+});
+
+export type AntigravityHarnessPrintRequest = z.infer<typeof AntigravityHarnessPrintRequestSchema>;
+export type AntigravityHarnessPrintResponse = z.infer<typeof AntigravityHarnessPrintResponseSchema>;
+export type AntigravityManagedInteractionRunRequest = z.infer<
+  typeof AntigravityManagedInteractionRunRequestSchema
+>;
+export type AntigravityManagedInteractionRunResponse = z.infer<
+  typeof AntigravityManagedInteractionRunResponseSchema
+>;

--- a/frontend/src/features/agent-providers/hooks/use-agent-providers.ts
+++ b/frontend/src/features/agent-providers/hooks/use-agent-providers.ts
@@ -1,0 +1,183 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import {
+  createAntigravityProviderAccount,
+  createGeminiProviderAccount,
+  getAgentProviderAccounts,
+  getAgentProviderOverview,
+  getAgentProviderRoutingSettings,
+  getAgentProviders,
+  preflightAgentProviderRouting,
+  runAntigravityHarnessPrint,
+  runAntigravityManagedInteraction,
+  updateAgentProviderAccount,
+  updateAgentProviderRoutingSettings,
+  upsertAgentProviderQuotaWindow,
+  type AgentProviderId,
+} from "@/features/agent-providers/api";
+import type {
+  AgentProviderAccountUpdate,
+  AntigravityProviderAccountCreate,
+  GeminiProviderAccountCreate,
+} from "@/features/agent-providers/accounts-schemas";
+import type {
+  AntigravityHarnessPrintRequest,
+  AntigravityManagedInteractionRunRequest,
+} from "@/features/agent-providers/harness-schemas";
+import type {
+  AgentProviderQuotaWindowUpsert,
+  AgentProviderRoutingSettingsUpdate,
+} from "@/features/agent-providers/routing-schemas";
+import type { ProviderOverviewTimeframe } from "@/features/agent-providers/schemas";
+
+export function useAgentProviderRegistry() {
+  return useQuery({
+    queryKey: ["agent-providers", "registry"],
+    queryFn: getAgentProviders,
+  });
+}
+
+export function useAgentProviderOverview(timeframe: ProviderOverviewTimeframe = "7d") {
+  return useQuery({
+    queryKey: ["agent-providers", "overview", timeframe],
+    queryFn: () => getAgentProviderOverview(timeframe),
+  });
+}
+
+export function useAgentProviderAccounts(providerId: AgentProviderId) {
+  return useQuery({
+    queryKey: ["agent-providers", providerId, "accounts"],
+    queryFn: () => getAgentProviderAccounts(providerId),
+  });
+}
+
+export function useAgentProviderRouting(providerId: AgentProviderId) {
+  const queryClient = useQueryClient();
+
+  const settingsQuery = useQuery({
+    queryKey: ["agent-providers", providerId, "routing", "settings"],
+    queryFn: () => getAgentProviderRoutingSettings(providerId),
+  });
+
+  const preflightQuery = useQuery({
+    queryKey: ["agent-providers", providerId, "routing", "preflight"],
+    queryFn: () => preflightAgentProviderRouting(providerId),
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: ["agent-providers", providerId] });
+    void queryClient.invalidateQueries({ queryKey: ["agent-providers", "overview"] });
+  };
+
+  const updateSettingsMutation = useMutation({
+    mutationFn: (payload: AgentProviderRoutingSettingsUpdate) =>
+      updateAgentProviderRoutingSettings(providerId, payload),
+    onSuccess: () => {
+      toast.success("Provider routing saved");
+      invalidate();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Provider routing update failed");
+    },
+  });
+
+  const upsertQuotaWindowMutation = useMutation({
+    mutationFn: ({
+      accountId,
+      dimension,
+      payload,
+    }: {
+      accountId: string;
+      dimension: string;
+      payload: AgentProviderQuotaWindowUpsert;
+    }) => upsertAgentProviderQuotaWindow(providerId, accountId, dimension, payload),
+    onSuccess: () => {
+      toast.success("Provider quota saved");
+      invalidate();
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Provider quota update failed");
+    },
+  });
+
+  return {
+    settingsQuery,
+    preflightQuery,
+    updateSettingsMutation,
+    upsertQuotaWindowMutation,
+  };
+}
+
+export function useCreateGeminiProviderAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: GeminiProviderAccountCreate) => createGeminiProviderAccount(payload),
+    onSuccess: () => {
+      toast.success("Gemini account added");
+      void queryClient.invalidateQueries({ queryKey: ["agent-providers", "gemini"] });
+      void queryClient.invalidateQueries({ queryKey: ["agent-providers", "overview"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Gemini account creation failed");
+    },
+  });
+}
+
+export function useCreateAntigravityProviderAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: AntigravityProviderAccountCreate) => createAntigravityProviderAccount(payload),
+    onSuccess: () => {
+      toast.success("Antigravity profile added");
+      void queryClient.invalidateQueries({ queryKey: ["agent-providers", "antigravity"] });
+      void queryClient.invalidateQueries({ queryKey: ["agent-providers", "overview"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Antigravity profile creation failed");
+    },
+  });
+}
+
+export function useUpdateAgentProviderAccount(providerId: AgentProviderId) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ accountId, payload }: { accountId: string; payload: AgentProviderAccountUpdate }) =>
+      updateAgentProviderAccount(providerId, accountId, payload),
+    onSuccess: () => {
+      toast.success("Provider account saved");
+      void queryClient.invalidateQueries({ queryKey: ["agent-providers", providerId] });
+      void queryClient.invalidateQueries({ queryKey: ["agent-providers", "overview"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Provider account update failed");
+    },
+  });
+}
+
+export function useAntigravityHarnessPrint() {
+  return useMutation({
+    mutationFn: (payload: AntigravityHarnessPrintRequest) => runAntigravityHarnessPrint(payload),
+    onSuccess: () => {
+      toast.success("Antigravity harness completed");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Antigravity harness failed");
+    },
+  });
+}
+
+export function useAntigravityManagedInteraction() {
+  return useMutation({
+    mutationFn: (payload: AntigravityManagedInteractionRunRequest) => runAntigravityManagedInteraction(payload),
+    onSuccess: () => {
+      toast.success("Antigravity interaction completed");
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Antigravity interaction failed");
+    },
+  });
+}

--- a/frontend/src/features/agent-providers/routing-schemas.test.ts
+++ b/frontend/src/features/agent-providers/routing-schemas.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AgentProviderPreflightSchema,
+  AgentProviderRoutingSettingsSchema,
+  AgentProviderRoutingSettingsUpdateSchema,
+} from "@/features/agent-providers/routing-schemas";
+
+describe("agent provider routing schemas", () => {
+  it("parses provider routing settings", () => {
+    const parsed = AgentProviderRoutingSettingsSchema.parse({
+      providerId: "gemini",
+      strategy: "ordered_fallback",
+      singleAccountId: null,
+      orderedAccountIds: ["gemini-2", "gemini-1"],
+      quotaThresholdPct: 95,
+      roundRobinCursor: null,
+      createdAt: "2026-06-09T00:00:00Z",
+      updatedAt: "2026-06-09T00:00:00Z",
+    });
+
+    expect(parsed.strategy).toBe("ordered_fallback");
+    expect(parsed.orderedAccountIds).toEqual(["gemini-2", "gemini-1"]);
+    expect(parsed.quotaThresholdPct).toBe(95);
+  });
+
+  it("parses preflight with account quota windows", () => {
+    const parsed = AgentProviderPreflightSchema.parse({
+      providerId: "gemini",
+      selectedAccountId: "acc_1",
+      deniedReason: null,
+      candidateAccountIds: ["acc_1"],
+      settings: {
+        providerId: "gemini",
+        strategy: "capacity_weighted",
+        singleAccountId: null,
+        orderedAccountIds: [],
+        quotaThresholdPct: 100,
+        roundRobinCursor: null,
+        createdAt: "2026-06-09T00:00:00Z",
+        updatedAt: "2026-06-09T00:00:00Z",
+      },
+      accounts: [
+        {
+          accountId: "acc_1",
+          displayName: "Gemini dev",
+          status: "active",
+          quotaWindows: [
+            {
+              dimension: "requests_per_day",
+              used: 20,
+              limit: 100,
+              resetAt: "2026-06-10T00:00:00Z",
+              recordedAt: "2026-06-09T00:00:00Z",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parsed.accounts[0]?.quotaWindows[0]?.dimension).toBe("requests_per_day");
+  });
+
+  it("parses ordered fallback updates", () => {
+    const parsed = AgentProviderRoutingSettingsUpdateSchema.parse({
+      strategy: "ordered_fallback",
+      orderedAccountIds: ["gemini-2", "gemini-1"],
+    });
+
+    expect(parsed.orderedAccountIds).toEqual(["gemini-2", "gemini-1"]);
+  });
+});

--- a/frontend/src/features/agent-providers/routing-schemas.ts
+++ b/frontend/src/features/agent-providers/routing-schemas.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+export const AgentProviderRoutingStrategySchema = z.enum([
+  "capacity_weighted",
+  "round_robin",
+  "sequential_drain",
+  "reset_drain",
+  "single_account",
+  "ordered_fallback",
+]);
+
+export const AgentProviderQuotaWindowSchema = z.object({
+  dimension: z.string(),
+  used: z.number(),
+  limit: z.number().nullable().optional(),
+  resetAt: z.string().nullable().optional(),
+  recordedAt: z.string(),
+});
+
+export const AgentProviderQuotaWindowUpsertSchema = z.object({
+  dimension: z.string().min(1),
+  used: z.number().min(0),
+  limit: z.number().min(0).nullable().optional(),
+  resetAt: z.string().nullable().optional(),
+});
+
+export const AgentProviderRoutingSettingsSchema = z.object({
+  providerId: z.enum(["codex", "gemini", "antigravity"]),
+  strategy: AgentProviderRoutingStrategySchema,
+  singleAccountId: z.string().nullable().optional(),
+  orderedAccountIds: z.array(z.string()).optional().default([]),
+  quotaThresholdPct: z.number(),
+  roundRobinCursor: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const AgentProviderRoutingSettingsUpdateSchema = z.object({
+  strategy: AgentProviderRoutingStrategySchema.optional(),
+  singleAccountId: z.string().nullable().optional(),
+  orderedAccountIds: z.array(z.string()).optional(),
+  quotaThresholdPct: z.number().min(0).max(100).optional(),
+  roundRobinCursor: z.string().nullable().optional(),
+});
+
+export const AgentProviderPreflightAccountStateSchema = z.object({
+  accountId: z.string(),
+  displayName: z.string(),
+  status: z.string(),
+  quotaWindows: z.array(AgentProviderQuotaWindowSchema),
+});
+
+export const AgentProviderPreflightSchema = z.object({
+  providerId: z.enum(["codex", "gemini", "antigravity"]),
+  selectedAccountId: z.string().nullable().optional(),
+  deniedReason: z.string().nullable().optional(),
+  candidateAccountIds: z.array(z.string()),
+  settings: AgentProviderRoutingSettingsSchema,
+  accounts: z.array(AgentProviderPreflightAccountStateSchema),
+});
+
+export type AgentProviderRoutingStrategy = z.infer<typeof AgentProviderRoutingStrategySchema>;
+export type AgentProviderQuotaWindow = z.infer<typeof AgentProviderQuotaWindowSchema>;
+export type AgentProviderQuotaWindowUpsert = z.infer<typeof AgentProviderQuotaWindowUpsertSchema>;
+export type AgentProviderRoutingSettings = z.infer<typeof AgentProviderRoutingSettingsSchema>;
+export type AgentProviderRoutingSettingsUpdate = z.infer<typeof AgentProviderRoutingSettingsUpdateSchema>;
+export type AgentProviderPreflight = z.infer<typeof AgentProviderPreflightSchema>;

--- a/frontend/src/features/agent-providers/schemas.test.ts
+++ b/frontend/src/features/agent-providers/schemas.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AgentProviderListSchema,
+  AgentProviderOverviewSchema,
+} from "@/features/agent-providers/schemas";
+
+describe("AgentProviderListSchema", () => {
+  it("parses the provider metadata contract", () => {
+    const parsed = AgentProviderListSchema.parse({
+      providers: [
+        {
+          providerId: "codex",
+          displayName: "Codex",
+          status: "ready",
+          authModes: ["chatgpt_oauth"],
+          quotaDimensions: ["primary", "secondary", "additional_quota"],
+          dashboardSections: ["accounts", "settings"],
+          capabilities: [
+            {
+              protocol: "codex_chatgpt",
+              status: "ready",
+              proxyable: true,
+              streaming: true,
+              lifecycleNotes: "Existing production surface.",
+              operatorAction: "Keep current settings.",
+              availableUntil: null,
+              notes: "Existing Codex routes.",
+            },
+          ],
+        },
+        {
+          providerId: "gemini",
+          displayName: "Gemini",
+          status: "foundation",
+          authModes: ["api_key", "google_cloud_adc", "cli_keyring"],
+          quotaDimensions: ["rpm", "tpm", "rpd"],
+          dashboardSections: ["accounts", "settings"],
+          capabilities: [
+            {
+              protocol: "gemini_api",
+              status: "foundation",
+              proxyable: true,
+              streaming: true,
+              lifecycleNotes: "Gemini API endpoints.",
+              operatorAction: "Add API-key accounts.",
+              availableUntil: null,
+              notes: "Gemini API foundation.",
+            },
+            {
+              protocol: "antigravity_cli",
+              status: "planned",
+              proxyable: false,
+              streaming: false,
+              lifecycleNotes: "Gemini CLI individual tier cutover.",
+              operatorAction: "Build agy harness connector.",
+              availableUntil: "2026-06-18",
+              notes: "Harness connector.",
+            },
+          ],
+        },
+        {
+          providerId: "antigravity",
+          displayName: "Antigravity",
+          status: "foundation",
+          authModes: ["api_key", "cli_keyring"],
+          quotaDimensions: ["requests", "sessions"],
+          dashboardSections: ["accounts", "settings"],
+          capabilities: [
+            {
+              protocol: "interactions_api",
+              status: "foundation",
+              proxyable: true,
+              streaming: false,
+              lifecycleNotes: "Managed agent.",
+              operatorAction: "Route antigravity-preview models.",
+              availableUntil: null,
+              notes: "Interactions API.",
+            },
+            {
+              protocol: "antigravity_cli",
+              status: "foundation",
+              proxyable: false,
+              streaming: false,
+              lifecycleNotes: "agy harness.",
+              operatorAction: "Run agy --print harness probes.",
+              availableUntil: null,
+              notes: "Harness connector.",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parsed.providers.map((provider) => provider.providerId)).toEqual(["codex", "gemini", "antigravity"]);
+  });
+});
+
+describe("AgentProviderOverviewSchema", () => {
+  it("parses the combined provider overview contract", () => {
+    const parsed = AgentProviderOverviewSchema.parse({
+      timeframe: "7d",
+      providers: [
+        {
+          providerId: "codex",
+          displayName: "Codex",
+          status: "ready",
+          accountCount: 2,
+          activeAccountCount: 1,
+          quotaWindowCount: 0,
+          requestCount: 3,
+          successCount: 2,
+          errorCount: 1,
+          inputTokens: 10,
+          outputTokens: 20,
+          cachedInputTokens: 4,
+        },
+      ],
+      totals: {
+        providerCount: 3,
+        accountCount: 2,
+        activeAccountCount: 1,
+        quotaWindowCount: 0,
+        requestCount: 3,
+        successCount: 2,
+        errorCount: 1,
+        inputTokens: 10,
+        outputTokens: 20,
+        cachedInputTokens: 4,
+      },
+    });
+
+    expect(parsed.totals.providerCount).toBe(3);
+    expect(parsed.providers[0].providerId).toBe("codex");
+  });
+});

--- a/frontend/src/features/agent-providers/schemas.ts
+++ b/frontend/src/features/agent-providers/schemas.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+export const AgentProviderCapabilitySchema = z.object({
+  protocol: z.enum(["codex_chatgpt", "gemini_api", "vertex_ai", "antigravity_cli", "interactions_api"]),
+  status: z.enum(["ready", "foundation", "planned"]),
+  proxyable: z.boolean(),
+  streaming: z.boolean(),
+  lifecycleNotes: z.string(),
+  operatorAction: z.string(),
+  availableUntil: z.string().nullable(),
+  notes: z.string(),
+});
+
+export const AgentProviderSummarySchema = z.object({
+  providerId: z.enum(["codex", "gemini", "antigravity"]),
+  displayName: z.string(),
+  status: z.enum(["ready", "foundation", "planned"]),
+  authModes: z.array(z.enum(["chatgpt_oauth", "api_key", "google_cloud_adc", "cli_keyring"])),
+  quotaDimensions: z.array(z.string()),
+  dashboardSections: z.array(z.string()),
+  capabilities: z.array(AgentProviderCapabilitySchema),
+});
+
+export const AgentProviderListSchema = z.object({
+  providers: z.array(AgentProviderSummarySchema),
+});
+
+export const ProviderOverviewTimeframeSchema = z.enum(["1d", "7d", "30d"]);
+
+export const AgentProviderOverviewItemSchema = z.object({
+  providerId: z.enum(["codex", "gemini", "antigravity"]),
+  displayName: z.string(),
+  status: z.enum(["ready", "foundation", "planned"]),
+  accountCount: z.number().int().nonnegative(),
+  activeAccountCount: z.number().int().nonnegative(),
+  quotaWindowCount: z.number().int().nonnegative(),
+  requestCount: z.number().int().nonnegative(),
+  successCount: z.number().int().nonnegative(),
+  errorCount: z.number().int().nonnegative(),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  cachedInputTokens: z.number().int().nonnegative(),
+});
+
+export const AgentProviderOverviewTotalsSchema = z.object({
+  providerCount: z.number().int().nonnegative(),
+  accountCount: z.number().int().nonnegative(),
+  activeAccountCount: z.number().int().nonnegative(),
+  quotaWindowCount: z.number().int().nonnegative(),
+  requestCount: z.number().int().nonnegative(),
+  successCount: z.number().int().nonnegative(),
+  errorCount: z.number().int().nonnegative(),
+  inputTokens: z.number().int().nonnegative(),
+  outputTokens: z.number().int().nonnegative(),
+  cachedInputTokens: z.number().int().nonnegative(),
+});
+
+export const AgentProviderOverviewSchema = z.object({
+  timeframe: ProviderOverviewTimeframeSchema,
+  providers: z.array(AgentProviderOverviewItemSchema),
+  totals: AgentProviderOverviewTotalsSchema,
+});
+
+export type AgentProviderCapability = z.infer<typeof AgentProviderCapabilitySchema>;
+export type AgentProviderSummary = z.infer<typeof AgentProviderSummarySchema>;
+export type AgentProviderList = z.infer<typeof AgentProviderListSchema>;
+export type ProviderOverviewTimeframe = z.infer<typeof ProviderOverviewTimeframeSchema>;
+export type AgentProviderOverviewItem = z.infer<typeof AgentProviderOverviewItemSchema>;
+export type AgentProviderOverview = z.infer<typeof AgentProviderOverviewSchema>;

--- a/frontend/src/features/settings/components/routing-settings.test.tsx
+++ b/frontend/src/features/settings/components/routing-settings.test.tsx
@@ -39,6 +39,7 @@ const BASE_SETTINGS: DashboardSettings = {
   relativeAvailabilityPower: 2,
   relativeAvailabilityTopK: 5,
   singleAccountId: null,
+  manualAccountPriorityIds: [],
   weeklyPaceWorkingDays: "0,1,2,3,4,5,6",
   openaiCacheAffinityMaxAgeSeconds: 300,
   dashboardSessionTtlSeconds: 43200,
@@ -447,6 +448,29 @@ describe("RoutingSettings", () => {
       apiKeyAuthEnabled: true,
       ...LIMIT_WARMUP_DEFAULTS,
     });
+  });
+
+  it("seeds account priority when ordered fallback routing is selected", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(
+      <RoutingSettings
+        settings={{ ...BASE_SETTINGS, routingStrategy: "capacity_weighted" }}
+        accounts={[createAccountSummary({ accountId: "acc-one", email: "one@example.com", displayName: "one@example.com" })]}
+        busy={false}
+        onSave={onSave}
+      />,
+    );
+
+    await user.click(screen.getAllByRole("combobox")[1]);
+    await user.click(await screen.findByRole("option", { name: "Ordered fallback" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routingStrategy: "ordered_fallback",
+        manualAccountPriorityIds: ["acc-one"],
+      }),
+    );
   });
 
   it("names limit warm-up controls for assistive technology", () => {

--- a/frontend/src/features/settings/components/routing-settings.tsx
+++ b/frontend/src/features/settings/components/routing-settings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Route, Zap } from "lucide-react";
+import { ArrowDown, ArrowUp, Plus, Route, Trash2, Zap } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -61,6 +61,30 @@ function accountLabel(account: AccountSummary): string {
   const name = account.alias?.trim() || account.displayName?.trim() || account.email?.trim() || account.accountId;
   const compactId = formatCompactAccountId(account.accountId, 6, 4);
   return `${name} (${compactId})`;
+}
+
+function normalizeAccountOrder(accountIds: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const rawAccountId of accountIds) {
+    const accountId = rawAccountId.trim();
+    if (!accountId || seen.has(accountId)) {
+      continue;
+    }
+    seen.add(accountId);
+    ordered.push(accountId);
+  }
+  return ordered;
+}
+
+function moveOrderedAccount(accountIds: readonly string[], index: number, direction: -1 | 1): string[] {
+  const next = [...accountIds];
+  const targetIndex = index + direction;
+  if (targetIndex < 0 || targetIndex >= next.length) {
+    return next;
+  }
+  [next[index], next[targetIndex]] = [next[targetIndex], next[index]];
+  return next;
 }
 
 export function RoutingSettings({
@@ -157,6 +181,11 @@ export function RoutingSettings({
   const blockedSelectedAccount =
     selectedAccount !== undefined && !isSingleAccountRoutingSelectable(selectedAccount.status) ? selectedAccount : null;
   const firstAccountId = selectableAccounts[0]?.accountId;
+  const manualPriorityIds = normalizeAccountOrder(settings.manualAccountPriorityIds ?? []);
+  const manualPriorityIdSet = new Set(manualPriorityIds);
+  const nextManualPriorityAccountId = selectableAccounts.find(
+    (account) => !manualPriorityIdSet.has(account.accountId),
+  )?.accountId;
   const additionalQuotaOverrides = settings.additionalQuotaRoutingPolicies ?? {};
   const knownAdditionalQuotaKeys = new Set((settings.additionalQuotaPolicies ?? []).map((policy) => policy.quotaKey));
   const additionalQuotaRows = [
@@ -294,6 +323,17 @@ export function RoutingSettings({
                   });
                   return;
                 }
+                if (routingStrategy === "ordered_fallback") {
+                  const orderedIds = manualPriorityIds.length > 0 ? manualPriorityIds : firstAccountId ? [firstAccountId] : [];
+                  if (orderedIds.length === 0) {
+                    return;
+                  }
+                  save({
+                    routingStrategy,
+                    manualAccountPriorityIds: orderedIds,
+                  });
+                  return;
+                }
                 save({
                   routingStrategy,
                 });
@@ -310,6 +350,9 @@ export function RoutingSettings({
                 <SelectItem value="reset_drain">Reset drain</SelectItem>
                 <SelectItem value="single_account" disabled={!settings.singleAccountId && !firstAccountId}>
                   Single account
+                </SelectItem>
+                <SelectItem value="ordered_fallback" disabled={manualPriorityIds.length === 0 && !firstAccountId}>
+                  Ordered fallback
                 </SelectItem>
                 <SelectItem value="usage_weighted">Usage weighted</SelectItem>
                 <SelectItem value="round_robin">Round robin</SelectItem>
@@ -516,6 +559,117 @@ export function RoutingSettings({
               </Select>
               {!accountsLoading && selectableAccounts.length === 0 ? (
                 <p className="text-xs text-muted-foreground">Import an account before enabling single-account routing.</p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {settings.routingStrategy === "ordered_fallback" ? (
+            <div className="space-y-3 p-3">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm font-medium">Account priority</p>
+                  <p className="text-xs text-muted-foreground">Try accounts in this order before denying the request.</p>
+                </div>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  className="h-8 w-8"
+                  disabled={busy || accountsLoading || !nextManualPriorityAccountId}
+                  aria-label="Add account priority"
+                  onClick={() =>
+                    nextManualPriorityAccountId
+                      ? save({
+                          manualAccountPriorityIds: [...manualPriorityIds, nextManualPriorityAccountId],
+                        })
+                      : undefined
+                  }
+                >
+                  <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+              </div>
+              <div className="space-y-2">
+                {manualPriorityIds.map((accountId, index) => {
+                  const account = accounts.find((item) => item.accountId === accountId);
+                  const availableAccounts = selectableAccounts.filter(
+                    (item) => item.accountId === accountId || !manualPriorityIdSet.has(item.accountId),
+                  );
+                  return (
+                    <div key={`${accountId}-${index}`} className="flex items-center gap-2">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-muted/20 text-xs text-muted-foreground">
+                        {index + 1}
+                      </div>
+                      <Select
+                        value={accountId}
+                        onValueChange={(value) => {
+                          const next = [...manualPriorityIds];
+                          next[index] = value;
+                          save({ manualAccountPriorityIds: normalizeAccountOrder(next) });
+                        }}
+                      >
+                        <SelectTrigger
+                          aria-label={`Priority account ${index + 1}`}
+                          className="h-8 min-w-0 flex-1 text-xs"
+                          disabled={busy || accountsLoading}
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent align="end">
+                          {account && !isSingleAccountRoutingSelectable(account.status) ? (
+                            <SelectItem value={account.accountId} disabled>
+                              {accountLabel(account)}
+                            </SelectItem>
+                          ) : null}
+                          {availableAccounts.map((item) => (
+                            <SelectItem key={item.accountId} value={item.accountId}>
+                              {accountLabel(item)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8"
+                        disabled={busy || index === 0}
+                        aria-label={`Move ${account?.alias ?? account?.displayName ?? accountId} up`}
+                        onClick={() => save({ manualAccountPriorityIds: moveOrderedAccount(manualPriorityIds, index, -1) })}
+                      >
+                        <ArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
+                      </Button>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8"
+                        disabled={busy || index === manualPriorityIds.length - 1}
+                        aria-label={`Move ${account?.alias ?? account?.displayName ?? accountId} down`}
+                        onClick={() => save({ manualAccountPriorityIds: moveOrderedAccount(manualPriorityIds, index, 1) })}
+                      >
+                        <ArrowDown className="h-3.5 w-3.5" aria-hidden="true" />
+                      </Button>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8"
+                        disabled={busy || manualPriorityIds.length <= 1}
+                        aria-label={`Remove ${account?.alias ?? account?.displayName ?? accountId}`}
+                        onClick={() =>
+                          save({
+                            manualAccountPriorityIds: manualPriorityIds.filter((_, itemIndex) => itemIndex !== index),
+                          })
+                        }
+                      >
+                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+              {!accountsLoading && selectableAccounts.length === 0 ? (
+                <p className="text-xs text-muted-foreground">Import an account before enabling ordered fallback.</p>
               ) : null}
             </div>
           ) : null}

--- a/frontend/src/features/settings/components/session-settings.test.tsx
+++ b/frontend/src/features/settings/components/session-settings.test.tsx
@@ -28,6 +28,7 @@ const baseSettings = {
   relativeAvailabilityPower: 2,
   relativeAvailabilityTopK: 5,
   singleAccountId: null,
+  manualAccountPriorityIds: [],
   weeklyPaceWorkingDays: "0,1,2,3,4,5,6",
   openaiCacheAffinityMaxAgeSeconds: 300,
   dashboardSessionTtlSeconds: 43200,

--- a/frontend/src/features/settings/components/totp-settings.test.tsx
+++ b/frontend/src/features/settings/components/totp-settings.test.tsx
@@ -41,6 +41,7 @@ const baseSettings = {
   relativeAvailabilityPower: 2,
   relativeAvailabilityTopK: 5,
   singleAccountId: null,
+  manualAccountPriorityIds: [],
   weeklyPaceWorkingDays: "0,1,2,3,4,5,6",
   openaiCacheAffinityMaxAgeSeconds: 300,
   dashboardSessionTtlSeconds: 43200,
@@ -141,6 +142,7 @@ describe("TotpSettings", () => {
     delete saveSettings.totpConfigured;
     delete saveSettings.upstreamProxyRoutingEnabled;
     delete saveSettings.upstreamProxyDefaultPoolId;
+    delete saveSettings.manualAccountPriorityIds;
 
     renderWithClient(<TotpSettings settings={baseSettings} onSave={onSave} />);
 

--- a/frontend/src/features/settings/payload.test.ts
+++ b/frontend/src/features/settings/payload.test.ts
@@ -120,4 +120,24 @@ describe("buildSettingsUpdateRequest", () => {
     expect(payload.stickyReallocationPrimaryBudgetThresholdPct).toBe(80);
     expect(payload.stickyReallocationSecondaryBudgetThresholdPct).toBe(100);
   });
+
+  it("preserves nonempty manual account priority when saving unrelated settings", () => {
+    const settings = DashboardSettingsSchema.parse({
+      stickyThreadsEnabled: true,
+      upstreamStreamTransport: "default",
+      preferEarlierResetAccounts: false,
+      routingStrategy: "ordered_fallback",
+      manualAccountPriorityIds: ["acc-two", "acc-one"],
+      openaiCacheAffinityMaxAgeSeconds: 300,
+      dashboardSessionTtlSeconds: 43200,
+      importWithoutOverwrite: true,
+      totpRequiredOnLogin: true,
+      totpConfigured: false,
+      apiKeyAuthEnabled: true,
+    });
+
+    const payload = buildSettingsUpdateRequest(settings, { dashboardSessionTtlSeconds: 7200 });
+
+    expect(payload.manualAccountPriorityIds).toEqual(["acc-two", "acc-one"]);
+  });
 });

--- a/frontend/src/features/settings/payload.ts
+++ b/frontend/src/features/settings/payload.ts
@@ -16,6 +16,7 @@ export function buildSettingsUpdateRequest(
     relativeAvailabilityPower: settings.relativeAvailabilityPower,
     relativeAvailabilityTopK: settings.relativeAvailabilityTopK,
     singleAccountId: settings.singleAccountId,
+    manualAccountPriorityIds: settings.manualAccountPriorityIds,
     openaiCacheAffinityMaxAgeSeconds: settings.openaiCacheAffinityMaxAgeSeconds,
     dashboardSessionTtlSeconds: settings.dashboardSessionTtlSeconds,
     warmupModel: settings.warmupModel,
@@ -62,6 +63,12 @@ export function buildSettingsUpdateRequest(
     settings.__stickyReallocationBudgetThresholdPctProvided !== false
   ) {
     payload.stickyReallocationBudgetThresholdPct = patch.stickyReallocationPrimaryBudgetThresholdPct;
+  }
+  if (
+    !("manualAccountPriorityIds" in patch) &&
+    settings.manualAccountPriorityIds.length === 0
+  ) {
+    delete payload.manualAccountPriorityIds;
   }
   return payload;
 }

--- a/frontend/src/features/settings/schemas.test.ts
+++ b/frontend/src/features/settings/schemas.test.ts
@@ -19,6 +19,7 @@ describe("DashboardSettingsSchema", () => {
       relativeAvailabilityPower: 2,
       relativeAvailabilityTopK: 5,
       singleAccountId: "acc-1",
+      manualAccountPriorityIds: ["acc-2", "acc-1"],
       weeklyPaceWorkingDays: "0,1,2,3,4",
       openaiCacheAffinityMaxAgeSeconds: 300,
       dashboardSessionTtlSeconds: 43200,
@@ -47,6 +48,7 @@ describe("DashboardSettingsSchema", () => {
     expect(parsed.relativeAvailabilityPower).toBe(2);
     expect(parsed.relativeAvailabilityTopK).toBe(5);
     expect(parsed.singleAccountId).toBe("acc-1");
+    expect(parsed.manualAccountPriorityIds).toEqual(["acc-2", "acc-1"]);
     expect(parsed.weeklyPaceWorkingDays).toBe("0,1,2,3,4");
     expect(parsed.openaiCacheAffinityMaxAgeSeconds).toBe(300);
     expect(parsed.dashboardSessionTtlSeconds).toBe(43200);
@@ -75,6 +77,7 @@ describe("DashboardSettingsSchema", () => {
     expect(parsed.upstreamProxyDefaultPoolId).toBeNull();
     expect(parsed.routingStrategy).toBe("usage_weighted");
     expect(parsed.singleAccountId).toBeNull();
+    expect(parsed.manualAccountPriorityIds).toEqual([]);
     expect(parsed.openaiCacheAffinityMaxAgeSeconds).toBe(300);
     expect(parsed.limitWarmupEnabled).toBe(false);
     expect(parsed.limitWarmupWindows).toBe("both");
@@ -139,6 +142,7 @@ describe("SettingsUpdateRequestSchema", () => {
       relativeAvailabilityPower: 1.5,
       relativeAvailabilityTopK: 7,
       singleAccountId: "acc-1",
+      manualAccountPriorityIds: ["acc-2", "acc-1"],
       weeklyPaceWorkingDays: "0,1,2,3,4",
       openaiCacheAffinityMaxAgeSeconds: 120,
       dashboardSessionTtlSeconds: 7200,
@@ -171,6 +175,7 @@ describe("SettingsUpdateRequestSchema", () => {
     expect(parsed.relativeAvailabilityPower).toBe(1.5);
     expect(parsed.relativeAvailabilityTopK).toBe(7);
     expect(parsed.singleAccountId).toBe("acc-1");
+    expect(parsed.manualAccountPriorityIds).toEqual(["acc-2", "acc-1"]);
     expect(parsed.weeklyPaceWorkingDays).toBe("0,1,2,3,4");
     expect(parsed.totpRequiredOnLogin).toBe(true);
     expect(parsed.apiKeyAuthEnabled).toBe(false);
@@ -226,6 +231,18 @@ describe("SettingsUpdateRequestSchema", () => {
     });
 
     expect(parsed.routingStrategy).toBe("fill_first");
+  });
+
+  it("accepts ordered_fallback as a valid routing strategy", () => {
+    const parsed = SettingsUpdateRequestSchema.parse({
+      stickyThreadsEnabled: false,
+      preferEarlierResetAccounts: true,
+      routingStrategy: "ordered_fallback",
+      manualAccountPriorityIds: ["acc-2", "acc-1"],
+    });
+
+    expect(parsed.routingStrategy).toBe("ordered_fallback");
+    expect(parsed.manualAccountPriorityIds).toEqual(["acc-2", "acc-1"]);
   });
 
   it("rejects unknown routing strategies", () => {

--- a/frontend/src/features/settings/schemas.ts
+++ b/frontend/src/features/settings/schemas.ts
@@ -7,6 +7,7 @@ export const RoutingStrategySchema = z.enum([
   "sequential_drain",
   "reset_drain",
   "single_account",
+  "ordered_fallback",
   "relative_availability",
   "fill_first",
 ]);
@@ -57,6 +58,7 @@ export const DashboardSettingsSchema = z
       .optional()
       .default(5),
     singleAccountId: z.string().nullable().optional().default(null),
+    manualAccountPriorityIds: z.array(z.string()).optional().default([]),
     openaiCacheAffinityMaxAgeSeconds: z
       .number()
       .int()
@@ -128,6 +130,7 @@ export const SettingsUpdateRequestSchema = z.object({
   relativeAvailabilityPower: z.number().positive().optional(),
   relativeAvailabilityTopK: z.number().int().min(1).max(20).optional(),
   singleAccountId: z.string().nullable().optional(),
+  manualAccountPriorityIds: z.array(z.string()).optional(),
   openaiCacheAffinityMaxAgeSeconds: z.number().int().positive().optional(),
   dashboardSessionTtlSeconds: z.number().int().min(3600).optional(),
   stickyReallocationBudgetThresholdPct: z.number().min(0).max(100).optional(),

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -114,11 +114,13 @@ const SettingsPayloadSchema = z
         "sequential_drain",
         "reset_drain",
         "single_account",
+        "ordered_fallback",
       ])
       .optional(),
     relativeAvailabilityPower: z.number().positive().optional(),
     relativeAvailabilityTopK: z.number().int().min(1).max(20).optional(),
     singleAccountId: z.string().nullable().optional(),
+    manualAccountPriorityIds: z.array(z.string()).optional(),
     openaiCacheAffinityMaxAgeSeconds: z.number().int().positive().optional(),
     stickyReallocationBudgetThresholdPct: z.number().min(0).max(100).optional(),
     stickyReallocationPrimaryBudgetThresholdPct: z

--- a/openspec/changes/add-multi-agent-providers/design.md
+++ b/openspec/changes/add-multi-agent-providers/design.md
@@ -1,0 +1,77 @@
+## Provider Model
+
+Agent Load Balancer will treat each agent backend as an `agent_provider`.
+Provider-owned code should hold protocol/auth specifics while shared routing
+logic consumes typed provider metadata. The central proxy should dispatch by
+provider and request surface, not infer behavior from model-name strings alone.
+
+Initial provider ids:
+
+- `codex`: existing ChatGPT/Codex account pool and current proxy routes.
+- `gemini`: Google Gemini API and Vertex-compatible Gemini traffic.
+- `antigravity`: Google Antigravity CLI harness profiles and future `agy`
+  execution sessions.
+
+Initial protocol surfaces:
+
+- `codex_chatgpt`: existing Codex/ChatGPT upstream behavior.
+- `gemini_api`: Gemini Developer API over API key.
+- `vertex_ai`: Vertex AI Gemini surface, planned after Developer API.
+- `antigravity_cli`: Google Antigravity CLI harness connector. This is not
+  OpenAI-proxy-ready in V1 because it has CLI/keyring/session behavior rather
+  than a simple load-balanced HTTP endpoint.
+
+Current Google guidance says individual-tier Gemini CLI traffic stops being
+served on 2026-06-18 and Antigravity CLI (`agy`) is the migration target.
+Antigravity CLI stores settings under `~/.gemini/antigravity-cli/`, uses shared
+Antigravity harness/session behavior, and relies on local auth/keyring
+semantics. ALB therefore treats it as a harness connector, not as a drop-in HTTP
+proxy backend. The dashboard can register Antigravity CLI profiles as provider
+accounts with `cli_keyring` auth mode and run a dashboard-authenticated
+noninteractive `agy --print` probe through provider routing.
+
+## Dashboard Shape
+
+The dashboard should eventually show:
+
+- A combined overview across providers.
+- A Codex section preserving current accounts, quotas, routing settings, usage,
+  reports, and logs.
+- A Gemini section with separate accounts/API keys, rate-limit/quota drains,
+  provider-specific model catalog, usage, reports, and settings.
+- An Antigravity section with separate CLI harness profiles, provider routing
+  settings, quota windows, preflight state, and harness execution.
+
+The first implementation slice exposes read-only provider metadata so frontend
+work can render separate sections without hardcoding provider availability.
+
+Gemini Developer API traffic is exposed both through the provider-specific
+`/v1/gemini/chat/completions` route and through the normal OpenAI-compatible
+`/v1/chat/completions` route when the effective model starts with `gemini-`.
+Codex models continue through the existing proxy path.
+
+OpenAI-compatible `/v1/models` includes provider-owned Gemini Developer API
+text-output models alongside Codex registry models. Gemini entries carry
+provider/protocol/lifecycle metadata, token limits, multimodal input
+capabilities, streaming support, and obey the same API-key allowed/enforced
+model filters as Codex entries. Dashboard `/api/models` also includes these
+Gemini entries so provider-aware UI surfaces can discover Codex and Gemini
+models from one catalog.
+
+Antigravity profiles use the provider-account table without storing API-key
+material. The external account id is the local `agy` profile/session identity.
+Profiles are active routing candidates for the harness, but raw `/v1` proxy
+requests are not routed to Antigravity CLI. Antigravity uses the shared
+provider-routing settings and quota-window APIs so dashboard controls stay
+provider-scoped instead of sharing Gemini state.
+Provider metadata marks Antigravity as a foundation harness surface once the
+dashboard-authenticated agy --print adapter is available, while keeping
+proxyable=false so clients do not mistake it for an HTTP model endpoint.
+
+## Review Trapdoors Applied
+
+- OpenSpec comes first for provider/API/dashboard/operator-contract changes.
+- Provider settings must be persisted before routing code reads them.
+- Preflight must mirror real routing once Gemini selection exists.
+- Quota drain policies must stay behind budget-safety gates.
+- Provider credentials and quotas must not bleed across Codex and Gemini.

--- a/openspec/changes/add-multi-agent-providers/proposal.md
+++ b/openspec/changes/add-multi-agent-providers/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`codex-lb` is currently centered on Codex/ChatGPT account routing. Agent Load
+Balancer needs a provider model that can keep Codex behavior intact while adding
+Gemini API routing and a later Google Antigravity CLI connector without mixing
+credentials, quota policy, or dashboard state across providers.
+
+## What Changes
+
+- Introduce an agent-provider registry with explicit provider identifiers,
+  protocol surfaces, auth modes, quota dimensions, and dashboard sections.
+- Expose a read-only provider metadata API for the dashboard and future
+  provider-specific settings pages.
+- Preserve existing Codex account selection and proxy paths as the only
+  production-ready runtime until Gemini account persistence and routing are
+  implemented.
+- Define Gemini API as the first new proxyable provider surface, with
+  Antigravity CLI tracked as a separate harness connector instead of pretending
+  it is a raw HTTP model endpoint.
+- Record provider capability lifecycle notes and operator actions so the
+  dashboard can show Gemini API setup separately from the 2026-06-18 Gemini CLI
+  to Antigravity CLI transition.
+
+## Impact
+
+- Existing Codex users keep current routes, settings, quotas, and dashboard
+  behavior unchanged.
+- Gemini work gains a typed contract before credentials, migrations, or routing
+  are introduced.
+- Operators get an explicit Antigravity cutover note without ALB claiming that
+  `agy` is proxy-ready.
+- Review risk is reduced by making provider scope explicit and preventing
+  accidental cross-provider quota/dashboard coupling.

--- a/openspec/changes/add-multi-agent-providers/specs/agent-provider-routing/spec.md
+++ b/openspec/changes/add-multi-agent-providers/specs/agent-provider-routing/spec.md
@@ -1,0 +1,245 @@
+## ADDED Requirements
+
+### Requirement: Agent provider registry
+The system SHALL expose a typed agent-provider registry that distinguishes
+Codex and Gemini provider state. Provider metadata SHALL include provider id,
+display name, lifecycle status, protocol surfaces, auth modes, quota dimensions,
+dashboard sections, lifecycle notes, operator action, and optional availability
+cutover date.
+
+#### Scenario: Codex provider remains production-ready
+- **WHEN** provider metadata is requested
+- **THEN** the Codex provider is reported as `ready`
+- **AND** its protocol surfaces include the existing Codex/ChatGPT route surface
+
+#### Scenario: Gemini provider is visible before routing is enabled
+- **WHEN** provider metadata is requested
+- **THEN** the Gemini provider is reported separately from Codex
+- **AND** the response identifies Gemini API as proxyable foundation work
+- **AND** the response does not claim Gemini request routing is production-ready
+- **AND** the response includes operator guidance for creating Gemini API-key accounts
+
+### Requirement: Provider-scoped dashboard contract
+The dashboard SHALL consume provider metadata from the backend instead of
+hardcoding provider availability. Provider-specific settings and account views
+MUST remain scoped to their provider, and the combined overview MUST aggregate
+provider summaries without sharing credentials or quota state across providers.
+
+#### Scenario: Provider metadata API is dashboard authenticated
+- **GIVEN** a remote unauthenticated client
+- **WHEN** it requests provider metadata
+- **THEN** the API rejects the request with the dashboard authentication error
+
+#### Scenario: Combined overview is backend aggregated
+- **WHEN** the dashboard requests the provider overview for a supported timeframe
+- **THEN** the API returns Codex, Gemini, and Antigravity provider rows
+- **AND** totals include provider count, account count, active account count, quota-window count, request count, success count, error count, input tokens, output tokens, and cached input tokens
+- **AND** request-log aggregation maps Gemini and Antigravity source logs to their provider ids while treating existing Codex logs as Codex
+- **AND** warmup requests and soft-deleted request logs are excluded from provider overview request totals
+
+#### Scenario: Codex provider tab exposes routing controls
+- **WHEN** an operator opens the Codex provider section
+- **THEN** the dashboard shows Codex account health, the active Codex routing strategy, and budget threshold state
+- **AND** the operator can update Codex routing strategy, selected single account, ordered-fallback account priority, and primary budget threshold from the provider dashboard
+- **AND** those controls reuse the existing Codex settings contract instead of storing Codex routing in Gemini or Antigravity provider rows
+
+### Requirement: Gemini account credentials are provider-scoped
+Gemini API credentials SHALL be stored in provider-scoped account rows instead
+of Codex account rows. The API MUST encrypt Gemini API keys at rest, MUST expose
+only non-secret account metadata, and MUST support listing Gemini accounts
+separately from Codex accounts.
+
+#### Scenario: Gemini account creation stores no plaintext key
+- **WHEN** an operator creates a Gemini provider account with an API key
+- **THEN** the API response includes provider id, account id, display name,
+  auth mode, fingerprint, and non-secret metadata
+- **AND** the API response does not include the plaintext API key
+- **AND** the persisted credential material is encrypted
+
+#### Scenario: Gemini account update rotates encrypted credentials
+- **WHEN** an operator updates a Gemini provider account with a replacement API key
+- **THEN** the API stores the replacement as encrypted credential material
+- **AND** the account fingerprint changes
+- **AND** the API response does not include the plaintext API key
+- **AND** display name, status, project, and location remain provider-scoped metadata
+
+### Requirement: Gemini native request adapter
+Gemini runtime code SHALL translate OpenAI-style chat request metadata into
+Gemini native `generateContent` and `streamGenerateContent` request payloads
+inside provider-owned code. The adapter MUST keep Codex proxy request
+translation unchanged and MUST expose streaming output as OpenAI-compatible chat
+completion chunks before it is wired into shared routing.
+
+#### Scenario: Chat messages map to Gemini contents
+- **WHEN** a Gemini chat request includes system, user, and assistant messages
+- **THEN** system/developer text is mapped to Gemini `systemInstruction`
+- **AND** user messages are mapped to Gemini `role = user`
+- **AND** assistant messages are mapped to Gemini `role = model`
+
+#### Scenario: Gemini SSE maps to chat chunks
+- **WHEN** Gemini streaming SSE emits a JSON `data:` event with text parts
+- **THEN** the adapter returns an OpenAI-compatible chat completion chunk
+- **AND** the finish reason is normalized to the OpenAI chat finish reason set
+
+#### Scenario: Gemini function calls map to OpenAI tool calls
+- **WHEN** Gemini returns a `functionCall` part for a function declaration
+- **THEN** the adapter returns an OpenAI-compatible assistant `tool_calls` payload
+- **AND** the function name and JSON arguments are preserved for the client agent loop
+
+#### Scenario: Gemini stream cleanup handles cancellation and split UTF-8
+- **WHEN** Gemini streaming bytes split a UTF-8 code point across network chunks
+- **THEN** the stream decoder preserves the character and continues parsing SSE events
+- **AND** if the downstream client cancels a Gemini stream with an API-key reservation
+- **THEN** the reservation is released and the cancellation is logged before propagating cancellation
+
+#### Scenario: Standard chat completions dispatches Gemini models
+- **WHEN** a client calls `/v1/chat/completions` with an effective model id that starts with `gemini-`
+- **THEN** the request is routed through the Gemini provider runtime
+- **AND** Codex model ids continue through the existing Codex proxy path
+- **AND** provider-scoped Gemini quota settlement and request logging are applied
+
+#### Scenario: Model discovery includes Gemini provider models
+- **WHEN** a client calls `/v1/models`
+- **THEN** Gemini Developer API chat models are listed with provider, protocol, lifecycle, token-limit, and capability metadata
+- **AND** Codex registry models remain listed with the existing Codex metadata contract
+- **AND** API-key allowed/enforced model settings filter Gemini models before returning the catalog
+
+#### Scenario: Model discovery includes Antigravity managed-agent model
+- **WHEN** a client calls `/v1/models`
+- **THEN** the Antigravity managed-agent model `antigravity-preview-05-2026` is listed with provider, protocol, lifecycle, token-limit, and capability metadata
+- **AND** API-key allowed/enforced model settings can include or filter the Antigravity model id
+
+#### Scenario: Dashboard model catalog includes provider models
+- **WHEN** the dashboard requests `/api/models`
+- **THEN** the response includes public Codex models, Gemini Developer API models, and Antigravity managed-agent models
+- **AND** provider entries identify their provider, protocol, and lifecycle
+
+### Requirement: Provider-scoped routing preflight
+Gemini routing state SHALL persist provider-owned routing settings before
+selection logic reads them. Preflight SHALL use the same account status,
+single-account scope, quota windows, budget threshold, and drain strategy
+inputs as the future Gemini request router, and MUST NOT fallback to another
+account when single-account scope or quota budget denies the selected account.
+
+#### Scenario: Drain strategy is budget gated
+- **GIVEN** one Gemini account is over the quota threshold and another remains
+  inside budget
+- **WHEN** reset-drain preflight runs
+- **THEN** the over-budget account is excluded before drain ordering
+- **AND** the selected account is one of the budget-safe candidates
+
+#### Scenario: Single-account preflight does not opportunistically fallback
+- **GIVEN** Gemini routing settings select one account
+- **AND** that account is unavailable or over budget
+- **WHEN** preflight runs
+- **THEN** the request is denied with a provider routing reason
+- **AND** no other Gemini account is selected
+
+#### Scenario: Ordered fallback preflight honors manual priority
+- **GIVEN** provider routing settings use `ordered_fallback`
+- **AND** the configured ordered account list contains one over-budget account followed by one budget-safe account
+- **WHEN** preflight runs
+- **THEN** the budget-safe configured account is selected
+- **AND** unconfigured budget-safe accounts are not used as fallback when no configured account is eligible
+
+#### Scenario: Round-robin runtime selection advances cursor
+- **GIVEN** provider routing settings use `round_robin`
+- **WHEN** runtime routing selects an account for a provider request
+- **THEN** the selected account id is persisted as the provider round-robin cursor
+- **AND** the next round-robin selection can advance from that cursor
+
+#### Scenario: Provider quota settlement is atomic
+- **WHEN** concurrent provider requests settle usage for the same quota window
+- **THEN** quota usage is incremented through an atomic database update
+- **AND** one settlement cannot overwrite another settlement read from a stale ORM object
+
+#### Scenario: Paused provider accounts are excluded from preflight
+- **GIVEN** a provider account is paused from the provider dashboard
+- **WHEN** provider routing preflight runs
+- **THEN** the paused account is excluded from candidate selection
+- **AND** the account can be resumed without changing its credential material
+
+### Requirement: Codex manual account priority
+Codex dashboard routing settings SHALL support an `ordered_fallback` strategy
+that stores a deduplicated manual account priority list. The selector MUST try
+eligible accounts in that order after normal availability and budget filters,
+and MUST deny the request instead of falling back to an unlisted account when
+the configured ordered accounts are exhausted or unavailable.
+
+#### Scenario: Codex ordered fallback uses configured account order
+- **GIVEN** multiple Codex accounts are active
+- **AND** manual priority is configured as account B before account A
+- **WHEN** Codex account selection runs with `ordered_fallback`
+- **THEN** account B is selected before account A even if account A has lower usage
+
+#### Scenario: Codex ordered fallback requires known accounts
+- **WHEN** dashboard settings are updated to `ordered_fallback`
+- **THEN** the API rejects an empty priority list
+- **AND** the API rejects priority entries that are not known Codex account ids
+
+### Requirement: Antigravity is modeled as a harness connector
+Google Antigravity CLI support SHALL be tracked as a separate harness connector
+surface unless an official HTTP-compatible model endpoint is configured. The
+system MUST NOT route raw proxy requests to Antigravity CLI by pretending it is
+equivalent to Gemini API.
+
+#### Scenario: Antigravity is not marked proxy-ready in V1
+- **WHEN** provider metadata is requested
+- **THEN** Antigravity CLI appears as a foundation harness surface
+- **AND** it is not marked proxyable for raw /v1 traffic
+- **AND** the Gemini provider remains marked as not production-ready for routing
+- **AND** its metadata identifies the 2026-06-18 Gemini CLI individual-tier cutover
+- **AND** its operator action describes an `agy` harness connector rather than HTTP proxy routing
+
+#### Scenario: Antigravity provider profile is registered without secret material
+- **WHEN** an operator creates an Antigravity provider account with a display name and local `agy` profile id
+- **THEN** the account is stored under provider id `antigravity`
+- **AND** the auth mode is `cli_keyring`
+- **AND** no API key material is stored or returned
+- **AND** the dashboard lists the profile in the Antigravity section
+
+#### Scenario: Antigravity managed-agent account stores encrypted API key
+- **WHEN** an operator creates an Antigravity provider account with auth mode `api_key`
+- **THEN** the API stores encrypted Gemini API-key credential material under provider id `antigravity`
+- **AND** the API response exposes only non-secret metadata and fingerprint state
+- **AND** the account can be selected by Antigravity managed-agent routing without being selected by the local CLI harness
+
+#### Scenario: Antigravity profile update keeps CLI credentials local
+- **WHEN** an operator updates an Antigravity profile display name, status, profile id, project, or harness location
+- **THEN** the API updates only provider-scoped account metadata
+- **AND** no API key material is accepted or stored for the Antigravity account
+- **AND** changing the profile id updates the non-secret account fingerprint
+
+#### Scenario: Antigravity Interactions API uses provider routing
+- **GIVEN** an active Antigravity API-key provider account exists
+- **AND** provider routing selects that account
+- **WHEN** a proxy-authenticated client submits `/v1/antigravity/interactions`
+- **THEN** the system calls the Gemini Interactions API with `Api-Revision: 2026-05-20`
+- **AND** the selected provider account credential is used without exposing plaintext key material
+- **AND** successful execution settles provider request usage and writes Antigravity request logs
+
+#### Scenario: Dashboard can run Antigravity managed-agent probe
+- **GIVEN** an active Antigravity API-key provider account exists
+- **WHEN** an operator submits a dashboard-authenticated managed-agent run
+- **THEN** the system uses Antigravity provider routing and calls the Gemini Interactions API
+- **AND** the dashboard response includes the agent id, extracted output text, and raw non-secret response payload
+
+#### Scenario: Standard chat completions dispatches Antigravity models
+- **WHEN** a client calls `/v1/chat/completions` with model `antigravity-preview-05-2026`
+- **THEN** the request is routed through Antigravity managed-agent provider runtime
+- **AND** Codex and Gemini model ids continue through their existing provider-specific paths
+
+#### Scenario: Antigravity harness print uses provider routing
+- **GIVEN** an active Antigravity CLI profile account exists
+- **AND** provider routing selects that profile
+- **WHEN** an operator submits a dashboard-authenticated harness print request
+- **THEN** the system runs `agy --print` noninteractively in the requested workspace
+- **AND** the prompt is redacted from the returned command preview
+- **AND** the dangerous permission-bypass flag is not used
+- **AND** successful execution settles provider request usage for the selected profile
+
+#### Scenario: Antigravity routing is visible in the dashboard
+- **WHEN** an operator opens the Antigravity provider section
+- **THEN** the dashboard shows Antigravity routing settings, quota-window controls, and preflight state
+- **AND** the controls use Antigravity provider accounts rather than Gemini or Codex accounts
+- **AND** the combined provider overview includes Antigravity quota windows in its provider quota total

--- a/openspec/changes/add-multi-agent-providers/tasks.md
+++ b/openspec/changes/add-multi-agent-providers/tasks.md
@@ -1,0 +1,38 @@
+## 1. Provider Foundation
+
+- [x] 1.1 Add OpenSpec proposal, design, tasks, and provider-routing delta spec.
+- [x] 1.2 Add a typed backend provider registry for Codex and Gemini surfaces.
+- [x] 1.3 Expose a dashboard-authenticated read-only provider metadata API.
+- [x] 1.4 Add frontend schemas/API client for the provider metadata contract.
+- [x] 1.5 Add lifecycle/operator metadata for Gemini API and Antigravity CLI cutover state.
+- [x] 1.6 Add a backend combined provider overview API for account, quota, and request-log totals.
+
+## 2. Gemini Runtime
+
+- [x] 2.1 Add provider-scoped credential/account persistence for Gemini without changing Codex account rows.
+- [x] 2.2 Add Gemini API request/stream adapters using provider-owned code.
+- [x] 2.3 Add provider-scoped load-balancer state, quota windows, drain strategies, and preflight.
+- [x] 2.4 Add Gemini dashboard accounts/settings/usage views and a backend-backed combined overview.
+- [x] 2.5 Dispatch `gemini-*` models from `/v1/chat/completions` to the Gemini provider runtime.
+- [x] 2.6 Expose Gemini Developer API models in `/v1/models` with provider metadata and API-key filtering.
+- [x] 2.7 Add first-class Antigravity provider metadata, CLI profile accounts, and dashboard profile tab.
+- [x] 2.8 Add dashboard-authenticated Antigravity `agy --print` harness execution with provider routing selection.
+- [x] 2.9 Add Antigravity dashboard routing settings, quota windows, and preflight parity.
+- [x] 2.10 Add manual ordered-fallback routing for Codex settings and provider-scoped routing.
+- [x] 2.11 Add provider account lifecycle updates for Gemini key rotation and Antigravity profile edits.
+- [x] 2.12 Add Antigravity managed-agent API-key accounts and Interactions API routing.
+- [x] 2.13 Add dashboard Antigravity managed-agent run controls.
+- [x] 2.14 Surface Codex routing settings in the provider dashboard alongside Gemini and Antigravity.
+
+## 3. Verification
+
+- [x] 3.1 Add unit tests for provider registry metadata.
+- [x] 3.2 Add integration tests for provider metadata API auth and response shape.
+- [x] 3.3 Add frontend schema tests.
+- [x] 3.4 Run focused backend/frontend checks.
+- [x] 3.5 Add mocked Antigravity harness unit and integration tests that do not launch real `agy`.
+- [x] 3.6 Add integration coverage for backend provider overview aggregation.
+- [x] 3.7 Add ordered-fallback unit, API, and frontend schema coverage.
+- [x] 3.8 Address Codex review findings for Gemini tool calls, streaming cancellation, UTF-8 stream decoding, atomic quota settlement, and provider round-robin cursor persistence.
+- [ ] 3.9 Run OpenSpec validation when the CLI is available.
+  - `openspec` is not on PATH and `npx --yes openspec validate --specs` cannot determine an executable.

--- a/tests/integration/test_agent_provider_accounts_api.py
+++ b/tests/integration/test_agent_provider_accounts_api.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.db.models import AgentProviderAccount
+from app.db.session import SessionLocal
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_gemini_provider_account(async_client) -> None:
+    response = await async_client.post(
+        "/api/agent-providers/gemini/accounts",
+        json={
+            "displayName": "Gemini dev key",
+            "apiKey": "AIza-test-secret",
+            "projectId": "dev-project",
+            "location": "global",
+        },
+    )
+
+    assert response.status_code == 200
+    created = response.json()
+    assert created["providerId"] == "gemini"
+    assert created["displayName"] == "Gemini dev key"
+    assert created["authMode"] == "api_key"
+    assert created["apiKeySet"] is True
+    assert "apiKey" not in created
+
+    async with SessionLocal() as session:
+        stored = await session.get(AgentProviderAccount, created["accountId"])
+        assert stored is not None
+        assert stored.api_key_encrypted != b"AIza-test-secret"
+        assert stored.credential_fingerprint == created["credentialFingerprint"]
+
+    listed_response = await async_client.get("/api/agent-providers/gemini/accounts")
+
+    assert listed_response.status_code == 200
+    listed = listed_response.json()
+    assert [account["accountId"] for account in listed["accounts"]] == [created["accountId"]]
+    assert "apiKey" not in listed["accounts"][0]
+
+
+@pytest.mark.asyncio
+async def test_update_gemini_provider_account_rotates_key_without_returning_secret(async_client) -> None:
+    response = await async_client.post(
+        "/api/agent-providers/gemini/accounts",
+        json={"displayName": "Gemini old", "apiKey": "old-secret"},
+    )
+    assert response.status_code == 200
+    created = response.json()
+
+    update_response = await async_client.patch(
+        f"/api/agent-providers/gemini/accounts/{created['accountId']}",
+        json={
+            "displayName": "Gemini prod",
+            "status": "paused",
+            "apiKey": "new-secret",
+            "projectId": "prod-project",
+            "location": "global",
+        },
+    )
+
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["displayName"] == "Gemini prod"
+    assert updated["status"] == "paused"
+    assert updated["apiKeySet"] is True
+    assert updated["projectId"] == "prod-project"
+    assert updated["location"] == "global"
+    assert updated["credentialFingerprint"] != created["credentialFingerprint"]
+    assert "apiKey" not in updated
+
+    async with SessionLocal() as session:
+        stored = await session.get(AgentProviderAccount, created["accountId"])
+        assert stored is not None
+        assert stored.api_key_encrypted != b"new-secret"
+        assert stored.credential_fingerprint == updated["credentialFingerprint"]
+
+
+@pytest.mark.asyncio
+async def test_update_provider_account_clears_nullable_metadata(async_client) -> None:
+    response = await async_client.post(
+        "/api/agent-providers/gemini/accounts",
+        json={
+            "displayName": "Gemini metadata",
+            "apiKey": "secret",
+            "projectId": "project",
+            "location": "global",
+        },
+    )
+    assert response.status_code == 200
+    created = response.json()
+
+    update_response = await async_client.patch(
+        f"/api/agent-providers/gemini/accounts/{created['accountId']}",
+        json={"projectId": None, "location": None},
+    )
+
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["projectId"] is None
+    assert updated["location"] is None
+    async with SessionLocal() as session:
+        stored = await session.get(AgentProviderAccount, created["accountId"])
+        assert stored is not None
+        assert stored.project_id is None
+        assert stored.location is None
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_antigravity_provider_account(async_client) -> None:
+    response = await async_client.post(
+        "/api/agent-providers/antigravity/accounts",
+        json={
+            "displayName": "Antigravity default",
+            "externalAccountId": "default",
+            "projectId": "workspace-a",
+            "location": "agy",
+        },
+    )
+
+    assert response.status_code == 200
+    created = response.json()
+    assert created["providerId"] == "antigravity"
+    assert created["displayName"] == "Antigravity default"
+    assert created["externalAccountId"] == "default"
+    assert created["authMode"] == "cli_keyring"
+    assert created["apiKeySet"] is False
+    assert "apiKey" not in created
+
+    async with SessionLocal() as session:
+        stored = await session.get(AgentProviderAccount, created["accountId"])
+        assert stored is not None
+        assert stored.api_key_encrypted is None
+        assert stored.credential_fingerprint == created["credentialFingerprint"]
+
+    listed_response = await async_client.get("/api/agent-providers/antigravity/accounts")
+
+    assert listed_response.status_code == 200
+    listed = listed_response.json()
+    assert [account["accountId"] for account in listed["accounts"]] == [created["accountId"]]
+
+
+@pytest.mark.asyncio
+async def test_create_antigravity_api_key_provider_account_encrypts_key(async_client) -> None:
+    response = await async_client.post(
+        "/api/agent-providers/antigravity/accounts",
+        json={
+            "displayName": "Antigravity managed",
+            "authMode": "api_key",
+            "apiKey": "AIza-antigravity-secret",
+            "projectId": "agent-project",
+        },
+    )
+
+    assert response.status_code == 200
+    created = response.json()
+    assert created["providerId"] == "antigravity"
+    assert created["displayName"] == "Antigravity managed"
+    assert created["authMode"] == "api_key"
+    assert created["apiKeySet"] is True
+    assert created["projectId"] == "agent-project"
+    assert "apiKey" not in created
+
+    async with SessionLocal() as session:
+        stored = await session.get(AgentProviderAccount, created["accountId"])
+        assert stored is not None
+        assert stored.api_key_encrypted != b"AIza-antigravity-secret"
+        assert stored.credential_fingerprint == created["credentialFingerprint"]
+
+
+@pytest.mark.asyncio
+async def test_update_antigravity_provider_account_and_duplicate_conflict(async_client) -> None:
+    first_response = await async_client.post(
+        "/api/agent-providers/antigravity/accounts",
+        json={"displayName": "Antigravity default", "externalAccountId": "default"},
+    )
+    second_response = await async_client.post(
+        "/api/agent-providers/antigravity/accounts",
+        json={"displayName": "Antigravity other", "externalAccountId": "other"},
+    )
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    first = first_response.json()
+    second = second_response.json()
+
+    update_response = await async_client.patch(
+        f"/api/agent-providers/antigravity/accounts/{first['accountId']}",
+        json={
+            "displayName": "Antigravity workspace",
+            "status": "paused",
+            "externalAccountId": "workspace-a",
+            "location": "agy",
+        },
+    )
+
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["displayName"] == "Antigravity workspace"
+    assert updated["status"] == "paused"
+    assert updated["externalAccountId"] == "workspace-a"
+    assert updated["location"] == "agy"
+    assert updated["credentialFingerprint"] != first["credentialFingerprint"]
+
+    duplicate_response = await async_client.patch(
+        f"/api/agent-providers/antigravity/accounts/{second['accountId']}",
+        json={"externalAccountId": "workspace-a"},
+    )
+
+    assert duplicate_response.status_code == 409
+    assert duplicate_response.json()["error"]["code"] == "duplicate_agent_provider_account"
+
+
+@pytest.mark.asyncio
+async def test_update_provider_account_missing_account_returns_404(async_client) -> None:
+    response = await async_client.patch(
+        "/api/agent-providers/gemini/accounts/missing",
+        json={"status": "active"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "agent_provider_account_not_found"
+
+
+@pytest.mark.asyncio
+async def test_provider_accounts_endpoint_rejects_unknown_provider(async_client) -> None:
+    response = await async_client.get("/api/agent-providers/unknown/accounts")
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "unsupported_agent_provider"
+
+
+@pytest.mark.asyncio
+async def test_provider_accounts_endpoint_requires_dashboard_auth_for_remote_clients(app_instance) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("203.0.113.11", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
+            response = await remote_client.get("/api/agent-providers/gemini/accounts")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "bootstrap_required"

--- a/tests/integration/test_agent_provider_routing_api.py
+++ b/tests/integration/test_agent_provider_routing_api.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.integration
+
+
+async def _create_gemini_account(async_client, name: str) -> str:
+    response = await async_client.post(
+        "/api/agent-providers/gemini/accounts",
+        json={"displayName": name, "apiKey": f"AIza-{name}-secret"},
+    )
+    assert response.status_code == 200
+    return response.json()["accountId"]
+
+
+@pytest.mark.asyncio
+async def test_provider_routing_settings_are_persisted_before_preflight(async_client) -> None:
+    account_id = await _create_gemini_account(async_client, "Gemini single")
+
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={
+            "strategy": "single_account",
+            "singleAccountId": account_id,
+            "quotaThresholdPct": 95.0,
+        },
+    )
+
+    assert settings_response.status_code == 200
+    assert settings_response.json()["strategy"] == "single_account"
+
+    preflight_response = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+
+    assert preflight_response.status_code == 200
+    preflight = preflight_response.json()
+    assert preflight["settings"]["strategy"] == "single_account"
+    assert preflight["selectedAccountId"] == account_id
+    assert preflight["candidateAccountIds"] == [account_id]
+
+
+@pytest.mark.asyncio
+async def test_single_account_partial_settings_update_preserves_account(async_client) -> None:
+    account_id = await _create_gemini_account(async_client, "Gemini partial settings")
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={"strategy": "single_account", "singleAccountId": account_id},
+    )
+    assert settings_response.status_code == 200
+
+    update_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={"quotaThresholdPct": 80.0},
+    )
+
+    assert update_response.status_code == 200
+    payload = update_response.json()
+    assert payload["strategy"] == "single_account"
+    assert payload["singleAccountId"] == account_id
+    assert payload["quotaThresholdPct"] == 80.0
+    preflight_response = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+    assert preflight_response.status_code == 200
+    assert preflight_response.json()["selectedAccountId"] == account_id
+
+
+@pytest.mark.asyncio
+async def test_provider_preflight_honors_quota_budget_before_reset_drain(async_client) -> None:
+    blocked_id = await _create_gemini_account(async_client, "Gemini blocked")
+    safe_id = await _create_gemini_account(async_client, "Gemini safe")
+    now = datetime.now(timezone.utc)
+
+    blocked_quota = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{blocked_id}/quota-windows/requests_per_day",
+        json={
+            "dimension": "requests_per_day",
+            "used": 99,
+            "limit": 100,
+            "resetAt": (now + timedelta(minutes=5)).isoformat(),
+        },
+    )
+    safe_quota = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{safe_id}/quota-windows/requests_per_day",
+        json={
+            "dimension": "requests_per_day",
+            "used": 20,
+            "limit": 100,
+            "resetAt": (now + timedelta(days=2)).isoformat(),
+        },
+    )
+    assert blocked_quota.status_code == 200
+    assert safe_quota.status_code == 200
+
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={"strategy": "reset_drain", "quotaThresholdPct": 95.0},
+    )
+    assert settings_response.status_code == 200
+
+    preflight_response = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+
+    assert preflight_response.status_code == 200
+    preflight = preflight_response.json()
+    assert preflight["selectedAccountId"] == safe_id
+    assert preflight["candidateAccountIds"] == [safe_id]
+    assert {account["accountId"] for account in preflight["accounts"]} == {blocked_id, safe_id}
+
+
+@pytest.mark.asyncio
+async def test_provider_ordered_fallback_settings_drive_preflight(async_client) -> None:
+    blocked_id = await _create_gemini_account(async_client, "Gemini ordered blocked")
+    safe_id = await _create_gemini_account(async_client, "Gemini ordered safe")
+    now = datetime.now(timezone.utc)
+
+    blocked_quota = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{blocked_id}/quota-windows/requests_per_day",
+        json={
+            "dimension": "requests_per_day",
+            "used": 99,
+            "limit": 100,
+            "resetAt": (now + timedelta(days=1)).isoformat(),
+        },
+    )
+    safe_quota = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{safe_id}/quota-windows/requests_per_day",
+        json={
+            "dimension": "requests_per_day",
+            "used": 10,
+            "limit": 100,
+            "resetAt": (now + timedelta(days=1)).isoformat(),
+        },
+    )
+    assert blocked_quota.status_code == 200
+    assert safe_quota.status_code == 200
+
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={
+            "strategy": "ordered_fallback",
+            "orderedAccountIds": [blocked_id, safe_id, blocked_id],
+            "quotaThresholdPct": 95.0,
+        },
+    )
+    assert settings_response.status_code == 200
+    assert settings_response.json()["orderedAccountIds"] == [blocked_id, safe_id]
+
+    preflight_response = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+
+    assert preflight_response.status_code == 200
+    preflight = preflight_response.json()
+    assert preflight["settings"]["strategy"] == "ordered_fallback"
+    assert preflight["selectedAccountId"] == safe_id
+    assert preflight["candidateAccountIds"] == [safe_id]
+
+
+@pytest.mark.asyncio
+async def test_provider_preflight_excludes_paused_accounts(async_client) -> None:
+    paused_id = await _create_gemini_account(async_client, "Gemini paused")
+    active_id = await _create_gemini_account(async_client, "Gemini active")
+
+    pause_response = await async_client.patch(
+        f"/api/agent-providers/gemini/accounts/{paused_id}",
+        json={"status": "paused"},
+    )
+    assert pause_response.status_code == 200
+
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={
+            "strategy": "ordered_fallback",
+            "orderedAccountIds": [paused_id, active_id],
+            "quotaThresholdPct": 95.0,
+        },
+    )
+    assert settings_response.status_code == 200
+
+    preflight_response = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+
+    assert preflight_response.status_code == 200
+    preflight = preflight_response.json()
+    assert preflight["selectedAccountId"] == active_id
+    assert preflight["candidateAccountIds"] == [active_id]
+
+
+@pytest.mark.asyncio
+async def test_provider_ordered_fallback_rejects_missing_order(async_client) -> None:
+    response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={"strategy": "ordered_fallback", "orderedAccountIds": []},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_agent_provider_routing"
+
+
+@pytest.mark.asyncio
+async def test_provider_routing_endpoint_requires_dashboard_auth_for_remote_clients(app_instance) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("203.0.113.21", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
+            response = await remote_client.post("/api/agent-providers/gemini/routing/preflight")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "bootstrap_required"

--- a/tests/integration/test_agent_provider_runtime_api.py
+++ b/tests/integration/test_agent_provider_runtime_api.py
@@ -1,0 +1,739 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+import app.modules.agent_provider_runtime.service as runtime_service_module
+from app.modules.agent_provider_runtime.antigravity import AntigravityProcessResult
+
+pytestmark = pytest.mark.integration
+
+
+class _Response:
+    def __init__(
+        self,
+        payload: dict[str, Any] | None = None,
+        *,
+        chunks: list[bytes] | None = None,
+        status: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status = status
+        self.headers = headers or {}
+        self._payload = payload or {}
+        self.content = _Content(chunks or [])
+
+    async def __aenter__(self) -> _Response:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+    async def text(self) -> str:
+        return "upstream-error"
+
+
+class _Content:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def iter_any(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _Session:
+    def __init__(self, responses: list[_Response]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, url: str, **kwargs: Any) -> _Response:
+        self.calls.append({"url": url, **kwargs})
+        return self._responses.pop(0)
+
+
+async def _create_proxy_key(async_client, payload: dict[str, object] | None = None) -> str:
+    settings = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert settings.status_code == 200
+    body = {"name": "gemini-proxy", **(payload or {})}
+    response = await async_client.post("/api/api-keys/", json=body)
+    assert response.status_code == 200
+    return response.json()["key"]
+
+
+async def _create_gemini_account(
+    async_client,
+    *,
+    display_name: str = "Gemini API",
+    api_key: str = "AIza-test-secret",
+) -> str:
+    response = await async_client.post(
+        "/api/agent-providers/gemini/accounts",
+        json={"displayName": display_name, "apiKey": api_key},
+    )
+    assert response.status_code == 200
+    return response.json()["accountId"]
+
+
+async def _create_antigravity_account(async_client) -> str:
+    response = await async_client.post(
+        "/api/agent-providers/antigravity/accounts",
+        json={"displayName": "Antigravity default", "externalAccountId": "default"},
+    )
+    assert response.status_code == 200
+    return response.json()["accountId"]
+
+
+async def _create_antigravity_api_key_account(async_client) -> str:
+    response = await async_client.post(
+        "/api/agent-providers/antigravity/accounts",
+        json={"displayName": "Antigravity API", "authMode": "api_key", "apiKey": "AIza-antigravity-secret"},
+    )
+    assert response.status_code == 200
+    return response.json()["accountId"]
+
+
+@pytest.mark.asyncio
+async def test_gemini_chat_completion_route_uses_provider_account_and_proxy_auth(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(
+        async_client,
+        {"limits": [{"limitType": "total_tokens", "limitWindow": "daily", "maxValue": 20000}]},
+    )
+    account_id = await _create_gemini_account(async_client)
+    request_quota = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{account_id}/quota-windows/requests_per_day",
+        json={"dimension": "requests_per_day", "used": 0, "limit": 10},
+    )
+    prompt_quota = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{account_id}/quota-windows/prompt_tokens",
+        json={"dimension": "prompt_tokens", "used": 10, "limit": 100},
+    )
+    assert request_quota.status_code == 200
+    assert prompt_quota.status_code == 200
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={"strategy": "single_account", "singleAccountId": account_id},
+    )
+    assert settings_response.status_code == 200
+
+    session = _Session(
+        [
+            _Response(
+                {
+                    "responseId": "resp_api",
+                    "candidates": [{"content": {"parts": [{"text": "Pong"}]}, "finishReason": "STOP"}],
+                    "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 1, "totalTokenCount": 3},
+                }
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/v1/gemini/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Ping"}]},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "chat.completion"
+    assert payload["choices"][0]["message"]["content"] == "Pong"
+    assert session.calls[0]["headers"]["x-goog-api-key"] == "AIza-test-secret"
+    assert session.calls[0]["json"] == {"contents": [{"role": "user", "parts": [{"text": "Ping"}]}]}
+    preflight = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+    assert preflight.status_code == 200
+    windows = {
+        window["dimension"]: window["used"]
+        for account in preflight.json()["accounts"]
+        if account["accountId"] == account_id
+        for window in account["quotaWindows"]
+    }
+    assert windows["requests_per_day"] == 1
+    assert windows["prompt_tokens"] == 12
+    api_keys = await async_client.get("/api/api-keys/")
+    assert api_keys.status_code == 200
+    api_key_row = api_keys.json()[0]
+    assert api_key_row["usageSummary"]["requestCount"] == 1
+    assert api_key_row["usageSummary"]["totalTokens"] == 3
+    assert api_key_row["limits"][0]["currentValue"] == 3
+    request_logs = await async_client.get("/api/request-logs")
+    assert request_logs.status_code == 200
+    log = request_logs.json()["requests"][0]
+    assert log["source"] == "gemini"
+    assert log["transport"] == "gemini_native"
+    assert log["apiKeyId"] == api_key_row["id"]
+    assert log["inputTokens"] == 2
+    assert log["outputTokens"] == 1
+
+
+@pytest.mark.asyncio
+async def test_gemini_stream_route_reports_startup_errors_before_200(async_client) -> None:
+    key = await _create_proxy_key(async_client)
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Ping"}], "stream": True},
+    )
+
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_direct_gemini_stream_route_reports_startup_errors_before_200(async_client) -> None:
+    key = await _create_proxy_key(async_client)
+
+    response = await async_client.post(
+        "/v1/gemini/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Ping"}], "stream": True},
+    )
+
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_gemini_expired_quota_window_advances_reset_after_settlement(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(async_client)
+    account_id = await _create_gemini_account(async_client)
+    expired_reset = datetime.now(timezone.utc) - timedelta(minutes=5)
+    quota_response = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{account_id}/quota-windows/requests_per_day",
+        json={"dimension": "requests_per_day", "used": 99, "limit": 100, "resetAt": expired_reset.isoformat()},
+    )
+    assert quota_response.status_code == 200
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={"strategy": "single_account", "singleAccountId": account_id},
+    )
+    assert settings_response.status_code == 200
+    session = _Session(
+        [
+            _Response(
+                {
+                    "responseId": "resp_reset",
+                    "candidates": [{"content": {"parts": [{"text": "Pong"}]}, "finishReason": "STOP"}],
+                    "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 1, "totalTokenCount": 3},
+                }
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Ping"}]},
+    )
+
+    assert response.status_code == 200
+    preflight = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+    assert preflight.status_code == 200
+    window = next(
+        window
+        for account in preflight.json()["accounts"]
+        if account["accountId"] == account_id
+        for window in account["quotaWindows"]
+        if window["dimension"] == "requests_per_day"
+    )
+    assert window["used"] == 1
+    assert datetime.fromisoformat(window["resetAt"]) > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_standard_chat_completion_route_dispatches_gemini_models(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(async_client, {"allowedModels": []})
+    account_id = await _create_gemini_account(async_client)
+    request_quota = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{account_id}/quota-windows/requests_per_day",
+        json={"dimension": "requests_per_day", "used": 0, "limit": 10},
+    )
+    prompt_quota = await async_client.put(
+        f"/api/agent-providers/gemini/accounts/{account_id}/quota-windows/prompt_tokens",
+        json={"dimension": "prompt_tokens", "used": 0, "limit": 100},
+    )
+    assert request_quota.status_code == 200
+    assert prompt_quota.status_code == 200
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={"strategy": "single_account", "singleAccountId": account_id},
+    )
+    assert settings_response.status_code == 200
+    session = _Session(
+        [
+            _Response(
+                {
+                    "responseId": "resp_standard",
+                    "candidates": [{"content": {"parts": [{"text": "Standard route"}]}, "finishReason": "STOP"}],
+                    "usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 2, "totalTokenCount": 5},
+                }
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Ping"}]},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["choices"][0]["message"]["content"] == "Standard route"
+    assert session.calls[0]["url"].endswith("/models/gemini-2.5-flash:generateContent")
+    preflight = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+    assert preflight.status_code == 200
+    windows = {
+        window["dimension"]: window["used"]
+        for account in preflight.json()["accounts"]
+        if account["accountId"] == account_id
+        for window in account["quotaWindows"]
+    }
+    assert windows["requests_per_day"] == 1
+    assert windows["prompt_tokens"] == 3
+
+
+@pytest.mark.asyncio
+async def test_gemini_runtime_round_robin_persists_selected_cursor(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(async_client)
+    first_id = await _create_gemini_account(
+        async_client,
+        display_name="Gemini round robin A",
+        api_key="AIza-round-robin-a",
+    )
+    second_id = await _create_gemini_account(
+        async_client,
+        display_name="Gemini round robin B",
+        api_key="AIza-round-robin-b",
+    )
+    settings_response = await async_client.patch(
+        "/api/agent-providers/gemini/routing/settings",
+        json={"strategy": "round_robin", "quotaThresholdPct": 100.0},
+    )
+    assert settings_response.status_code == 200
+
+    preflight = await async_client.post("/api/agent-providers/gemini/routing/preflight")
+    assert preflight.status_code == 200
+    selected_id = preflight.json()["selectedAccountId"]
+    assert selected_id in {first_id, second_id}
+
+    session = _Session(
+        [
+            _Response(
+                {
+                    "responseId": "resp_round_robin",
+                    "candidates": [{"content": {"parts": [{"text": "Cursor saved"}]}, "finishReason": "STOP"}],
+                    "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+                }
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Ping"}]},
+    )
+
+    assert response.status_code == 200
+    settings_after = await async_client.get("/api/agent-providers/gemini/routing/settings")
+    assert settings_after.status_code == 200
+    assert settings_after.json()["roundRobinCursor"] == selected_id
+
+
+@pytest.mark.asyncio
+async def test_gemini_chat_completion_route_enforces_api_key_model_policy(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(
+        async_client,
+        {
+            "allowedModels": ["gemini-2.5-flash"],
+            "enforcedModel": "gemini-2.5-flash",
+        },
+    )
+    await _create_gemini_account(async_client)
+    session = _Session(
+        [
+            _Response(
+                {
+                    "responseId": "resp_enforced",
+                    "candidates": [{"content": {"parts": [{"text": "Policy ok"}]}, "finishReason": "STOP"}],
+                }
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/v1/gemini/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "ignored-request-model", "messages": [{"role": "user", "content": "Ping"}]},
+    )
+
+    assert response.status_code == 200
+    assert session.calls[0]["url"].endswith("/models/gemini-2.5-flash:generateContent")
+
+
+@pytest.mark.asyncio
+async def test_gemini_chat_completion_route_rejects_api_key_disallowed_model(async_client) -> None:
+    key = await _create_proxy_key(async_client, {"allowedModels": ["gemini-2.5-flash"]})
+    await _create_gemini_account(async_client)
+
+    response = await async_client.post(
+        "/v1/gemini/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-pro", "messages": [{"role": "user", "content": "Ping"}]},
+    )
+
+    assert response.status_code == 403
+    payload = response.json()
+    assert payload["error"]["type"] == "permission_error"
+    assert payload["error"]["code"] == "model_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_gemini_chat_completion_route_streams_openai_sse(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(async_client)
+    await _create_gemini_account(async_client)
+    session = _Session(
+        [
+            _Response(
+                chunks=[
+                    (
+                        b'data: {"responseId":"resp_stream","candidates":'
+                        b'[{"content":{"parts":[{"text":"Hi"}]},"finishReason":"STOP"}]}\n\n'
+                    ),
+                ]
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    async with async_client.stream(
+        "POST",
+        "/v1/gemini/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-flash", "stream": True, "messages": [{"role": "user", "content": "Ping"}]},
+    ) as response:
+        text = await response.aread()
+
+    assert response.status_code == 200
+    body = text.decode("utf-8")
+    assert '"object":"chat.completion.chunk"' in body
+    assert '"content":"Hi"' in body
+    assert "data: [DONE]" in body
+
+
+@pytest.mark.asyncio
+async def test_gemini_chat_completion_route_preserves_upstream_retry_after(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(async_client)
+    await _create_gemini_account(async_client)
+    session = _Session(
+        [
+            _Response(
+                {"error": {"message": "Gemini quota exhausted"}},
+                status=429,
+                headers={"Retry-After": "60"},
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/v1/gemini/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Ping"}]},
+    )
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "60"
+    payload = response.json()
+    assert payload["error"]["type"] == "rate_limit_error"
+    assert payload["error"]["message"] == "Gemini quota exhausted"
+
+
+@pytest.mark.asyncio
+async def test_gemini_chat_completion_route_rejects_invalid_payload_with_openai_error(async_client) -> None:
+    key = await _create_proxy_key(async_client)
+
+    response = await async_client.post(
+        "/v1/gemini/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"messages": [{"role": "user", "content": "Ping"}]},
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["error"]["type"] == "invalid_request_error"
+    assert payload["error"]["message"] == "model is required"
+
+
+@pytest.mark.asyncio
+async def test_antigravity_harness_print_route_uses_selected_cli_profile(async_client, monkeypatch, tmp_path) -> None:
+    account_id = await _create_antigravity_account(async_client)
+    settings_response = await async_client.patch(
+        "/api/agent-providers/antigravity/routing/settings",
+        json={"strategy": "single_account", "singleAccountId": account_id},
+    )
+    assert settings_response.status_code == 200
+    quota_response = await async_client.put(
+        f"/api/agent-providers/antigravity/accounts/{account_id}/quota-windows/requests",
+        json={"dimension": "requests", "used": 0, "limit": 10},
+    )
+    assert quota_response.status_code == 200
+    calls = []
+
+    async def _run(self, command, *, env):
+        calls.append((command, env))
+        return AntigravityProcessResult(exit_code=0, stdout="hello from agy", stderr="", duration_ms=9)
+
+    monkeypatch.setattr(runtime_service_module.AntigravitySubprocessRunner, "run", _run)
+
+    response = await async_client.post(
+        "/api/agent-providers/antigravity/harness/print",
+        json={"prompt": "Say hello", "workspacePath": str(tmp_path), "timeoutSeconds": 5},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["providerId"] == "antigravity"
+    assert payload["accountId"] == account_id
+    assert payload["externalAccountId"] == "default"
+    assert payload["stdout"] == "hello from agy"
+    assert payload["command"][:6] == ["agy", "--print", "--print-timeout", "5s", "--prompt", "<redacted>"]
+    assert "--dangerously-skip-permissions" not in calls[0][0].args
+    assert calls[0][1]["AGY_CLI_DISABLE_AUTO_UPDATE"] == "true"
+    assert calls[0][1]["AGY_CLI_PROFILE"] == "default"
+    assert calls[0][1]["ANTIGRAVITY_CLI_PROFILE"] == "default"
+    preflight = await async_client.post("/api/agent-providers/antigravity/routing/preflight")
+    assert preflight.status_code == 200
+    windows = {
+        window["dimension"]: window["used"]
+        for account in preflight.json()["accounts"]
+        if account["accountId"] == account_id
+        for window in account["quotaWindows"]
+    }
+    assert windows.get("requests") == 1
+
+
+@pytest.mark.asyncio
+async def test_antigravity_interactions_route_uses_api_key_account(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(async_client)
+    account_id = await _create_antigravity_api_key_account(async_client)
+    settings_response = await async_client.patch(
+        "/api/agent-providers/antigravity/routing/settings",
+        json={"strategy": "single_account", "singleAccountId": account_id},
+    )
+    assert settings_response.status_code == 200
+    session = _Session(
+        [
+            _Response(
+                {
+                    "id": "interaction_1",
+                    "output_text": "done",
+                    "usageMetadata": {"promptTokenCount": 4, "candidatesTokenCount": 2, "totalTokenCount": 6},
+                }
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/v1/antigravity/interactions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"agent": "antigravity-preview-05-2026", "input": "Do work", "environment": "remote"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["output_text"] == "done"
+    call = session.calls[0]
+    assert call["url"].endswith("/v1beta/interactions")
+    assert call["headers"]["x-goog-api-key"] == "AIza-antigravity-secret"
+    assert call["headers"]["Api-Revision"] == "2026-05-20"
+    assert call["json"]["agent"] == "antigravity-preview-05-2026"
+    preflight = await async_client.post("/api/agent-providers/antigravity/routing/preflight")
+    assert preflight.status_code == 200
+    windows = {
+        window["dimension"]: window["used"]
+        for account in preflight.json()["accounts"]
+        if account["accountId"] == account_id
+        for window in account["quotaWindows"]
+    }
+    assert windows == {}
+
+
+@pytest.mark.asyncio
+async def test_antigravity_dashboard_interaction_run_uses_api_key_account(async_client, monkeypatch) -> None:
+    account_id = await _create_antigravity_api_key_account(async_client)
+    settings_response = await async_client.patch(
+        "/api/agent-providers/antigravity/routing/settings",
+        json={"strategy": "single_account", "singleAccountId": account_id},
+    )
+    assert settings_response.status_code == 200
+    session = _Session(
+        [
+            _Response(
+                {
+                    "id": "interaction_dashboard",
+                    "steps": [{"type": "model_output", "content": [{"type": "text", "text": "dashboard done"}]}],
+                }
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/api/agent-providers/antigravity/interactions/run",
+        json={
+            "agent": "antigravity-preview-05-2026",
+            "input": "Summarize this repo",
+            "environment": "remote",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["providerId"] == "antigravity"
+    assert payload["agent"] == "antigravity-preview-05-2026"
+    assert payload["outputText"] == "dashboard done"
+    assert payload["response"]["id"] == "interaction_dashboard"
+    assert session.calls[0]["headers"]["x-goog-api-key"] == "AIza-antigravity-secret"
+    assert session.calls[0]["headers"]["Api-Revision"] == "2026-05-20"
+
+
+@pytest.mark.asyncio
+async def test_antigravity_interactions_route_enforces_api_key_model_policy(async_client) -> None:
+    key = await _create_proxy_key(async_client, {"allowedModels": ["gemini-2.5-flash"]})
+    await _create_antigravity_api_key_account(async_client)
+
+    response = await async_client.post(
+        "/v1/antigravity/interactions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"agent": "antigravity-preview-05-2026", "input": "Do work", "environment": "remote"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "model_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_standard_chat_completion_route_dispatches_antigravity_models(async_client, monkeypatch) -> None:
+    key = await _create_proxy_key(async_client, {"allowedModels": []})
+    account_id = await _create_antigravity_api_key_account(async_client)
+    settings_response = await async_client.patch(
+        "/api/agent-providers/antigravity/routing/settings",
+        json={"strategy": "single_account", "singleAccountId": account_id},
+    )
+    assert settings_response.status_code == 200
+    session = _Session(
+        [
+            _Response(
+                {
+                    "id": "interaction_chat",
+                    "steps": [{"type": "model_output", "content": [{"type": "text", "text": "Agent result"}]}],
+                }
+            )
+        ]
+    )
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={
+            "model": "antigravity-preview-05-2026",
+            "messages": [{"role": "user", "content": "Plan and run"}],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["model"] == "antigravity-preview-05-2026"
+    assert payload["choices"][0]["message"]["content"] == "Agent result"
+    assert session.calls[0]["json"] == {
+        "agent": "antigravity-preview-05-2026",
+        "input": "user: Plan and run",
+        "environment": "remote",
+    }
+
+
+@pytest.mark.asyncio
+async def test_v1_models_includes_antigravity_managed_agent(async_client) -> None:
+    key = await _create_proxy_key(async_client, {"allowedModels": ["antigravity-preview-05-2026"]})
+
+    response = await async_client.get("/v1/models", headers={"Authorization": f"Bearer {key}"})
+
+    assert response.status_code == 200
+    models = response.json()["data"]
+    assert [model["id"] for model in models] == ["antigravity-preview-05-2026"]
+    assert models[0]["provider"] == "antigravity"
+    assert models[0]["protocol"] == "interactions_api"

--- a/tests/integration/test_agent_providers_api.py
+++ b/tests/integration/test_agent_providers_api.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus, RequestKind
+from app.db.session import SessionLocal
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.request_logs.repository import RequestLogsRepository
+
+pytestmark = pytest.mark.integration
+
+
+def _make_codex_account(account_id: str, email: str, status: AccountStatus = AccountStatus.ACTIVE) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        email=email,
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=status,
+        deactivation_reason=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_providers_endpoint_returns_camel_case_contract(async_client) -> None:
+    response = await async_client.get("/api/agent-providers")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [provider["providerId"] for provider in body["providers"]] == ["codex", "gemini", "antigravity"]
+    assert body["providers"][0]["status"] == "ready"
+    assert body["providers"][1]["status"] == "foundation"
+    assert body["providers"][1]["capabilities"][0]["protocol"] == "gemini_api"
+    assert body["providers"][1]["capabilities"][0]["operatorAction"].startswith("Add Gemini API-key")
+    assert body["providers"][1]["capabilities"][2]["availableUntil"] == "2026-06-18"
+    assert body["providers"][2]["status"] == "foundation"
+    assert body["providers"][2]["authModes"] == ["api_key", "cli_keyring"]
+    assert body["providers"][2]["capabilities"][0]["protocol"] == "interactions_api"
+    assert body["providers"][2]["capabilities"][0]["status"] == "foundation"
+    assert body["providers"][2]["capabilities"][0]["proxyable"] is True
+    assert body["providers"][2]["capabilities"][1]["protocol"] == "antigravity_cli"
+    assert "agy --print" in body["providers"][2]["capabilities"][1]["operatorAction"]
+
+
+@pytest.mark.asyncio
+async def test_agent_providers_endpoint_requires_dashboard_auth_for_remote_clients(app_instance) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("203.0.113.11", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
+            response = await remote_client.get("/api/agent-providers")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "bootstrap_required"
+
+
+@pytest.mark.asyncio
+async def test_agent_provider_overview_combines_accounts_quotas_and_requests(async_client, db_setup) -> None:
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_codex_account("codex-active", "active@example.com"))
+        await accounts_repo.upsert(_make_codex_account("codex-paused", "paused@example.com", AccountStatus.PAUSED))
+
+        now = utcnow()
+        await logs_repo.add_log(
+            account_id="codex-active",
+            request_id="req_codex_success",
+            model="gpt-5.1",
+            input_tokens=10,
+            output_tokens=20,
+            cached_input_tokens=2,
+            latency_ms=100,
+            status="success",
+            error_code=None,
+            requested_at=now - timedelta(minutes=5),
+        )
+        await logs_repo.add_log(
+            account_id="codex-active",
+            request_id="req_codex_error",
+            model="gpt-5.1",
+            input_tokens=1,
+            output_tokens=0,
+            cached_input_tokens=0,
+            latency_ms=50,
+            status="error",
+            error_code="rate_limited",
+            requested_at=now - timedelta(minutes=4),
+        )
+        await logs_repo.add_log(
+            account_id=None,
+            request_id="req_gemini_success",
+            model="gemini-2.5-pro",
+            input_tokens=5,
+            output_tokens=7,
+            cached_input_tokens=1,
+            latency_ms=80,
+            status="success",
+            error_code=None,
+            requested_at=now - timedelta(minutes=3),
+            source="gemini",
+        )
+        await logs_repo.add_log(
+            account_id=None,
+            request_id="req_antigravity_error",
+            model="agy",
+            input_tokens=3,
+            output_tokens=0,
+            cached_input_tokens=0,
+            latency_ms=120,
+            status="error",
+            error_code="harness_failed",
+            requested_at=now - timedelta(minutes=2),
+            source="antigravity",
+        )
+        await logs_repo.add_log(
+            account_id="codex-active",
+            request_id="req_warmup_excluded",
+            model="gpt-5.1",
+            input_tokens=99,
+            output_tokens=99,
+            latency_ms=1,
+            status="success",
+            error_code=None,
+            requested_at=now - timedelta(minutes=1),
+            request_kind=RequestKind.WARMUP.value,
+        )
+        await logs_repo.add_log(
+            account_id=None,
+            request_id="req_old_excluded",
+            model="gemini-2.5-pro",
+            input_tokens=99,
+            output_tokens=99,
+            latency_ms=1,
+            status="success",
+            error_code=None,
+            requested_at=now - timedelta(days=2),
+            source="gemini",
+        )
+
+    gemini_response = await async_client.post(
+        "/api/agent-providers/gemini/accounts",
+        json={"displayName": "Gemini API", "apiKey": "AIza-test-secret"},
+    )
+    assert gemini_response.status_code == 200
+    gemini_id = gemini_response.json()["accountId"]
+    antigravity_response = await async_client.post(
+        "/api/agent-providers/antigravity/accounts",
+        json={"displayName": "Antigravity default", "externalAccountId": "default"},
+    )
+    assert antigravity_response.status_code == 200
+    antigravity_id = antigravity_response.json()["accountId"]
+
+    for dimension in ("requests_per_day", "prompt_tokens"):
+        response = await async_client.put(
+            f"/api/agent-providers/gemini/accounts/{gemini_id}/quota-windows/{dimension}",
+            json={"dimension": dimension, "used": 1, "limit": 10},
+        )
+        assert response.status_code == 200
+    antigravity_quota = await async_client.put(
+        f"/api/agent-providers/antigravity/accounts/{antigravity_id}/quota-windows/requests",
+        json={"dimension": "requests", "used": 0, "limit": 5},
+    )
+    assert antigravity_quota.status_code == 200
+
+    response = await async_client.get("/api/agent-providers/overview?timeframe=1d")
+
+    assert response.status_code == 200
+    body = response.json()
+    providers = {provider["providerId"]: provider for provider in body["providers"]}
+    assert body["timeframe"] == "1d"
+    assert body["totals"] == {
+        "providerCount": 3,
+        "accountCount": 4,
+        "activeAccountCount": 3,
+        "quotaWindowCount": 3,
+        "requestCount": 4,
+        "successCount": 2,
+        "errorCount": 2,
+        "inputTokens": 19,
+        "outputTokens": 27,
+        "cachedInputTokens": 3,
+    }
+    assert providers["codex"]["accountCount"] == 2
+    assert providers["codex"]["activeAccountCount"] == 1
+    assert providers["codex"]["requestCount"] == 2
+    assert providers["gemini"]["accountCount"] == 1
+    assert providers["gemini"]["quotaWindowCount"] == 2
+    assert providers["gemini"]["successCount"] == 1
+    assert providers["antigravity"]["accountCount"] == 1
+    assert providers["antigravity"]["quotaWindowCount"] == 1
+    assert providers["antigravity"]["errorCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_provider_overview_requires_dashboard_auth_for_remote_clients(app_instance) -> None:
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("203.0.113.11", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
+            response = await remote_client.get("/api/agent-providers/overview")
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "bootstrap_required"

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -506,6 +506,7 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
             assert "limit_warmup_cooldown_seconds" in dashboard_columns
             assert "limit_warmup_min_available_percent" in dashboard_columns
             assert "single_account_id" in dashboard_columns
+            assert "manual_account_priority_ids_json" in dashboard_columns
             if "routing_strategy" in dashboard_columns:
                 routing_strategy = (
                     await session.execute(text("SELECT routing_strategy FROM dashboard_settings WHERE id=1"))

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -54,6 +54,7 @@ async def test_settings_api_get_and_update(async_client):
     assert payload["relativeAvailabilityPower"] == 2.0
     assert payload["relativeAvailabilityTopK"] == 5
     assert payload["singleAccountId"] is None
+    assert payload["manualAccountPriorityIds"] == []
     assert payload["openaiCacheAffinityMaxAgeSeconds"] == 1800
     assert payload["dashboardSessionTtlSeconds"] == 43200
     assert payload["httpResponsesSessionBridgePromptCacheIdleTtlSeconds"] == 3600
@@ -87,6 +88,7 @@ async def test_settings_api_get_and_update(async_client):
             "relativeAvailabilityTopK": 7,
             "preferEarlierResetWindow": "secondary",
             "singleAccountId": None,
+            "manualAccountPriorityIds": [],
             "openaiCacheAffinityMaxAgeSeconds": 180,
             "dashboardSessionTtlSeconds": 31536000,
             "httpResponsesSessionBridgePromptCacheIdleTtlSeconds": 1800,
@@ -119,6 +121,7 @@ async def test_settings_api_get_and_update(async_client):
     assert updated["relativeAvailabilityTopK"] == 7
     assert updated["preferEarlierResetWindow"] == "secondary"
     assert updated["singleAccountId"] is None
+    assert updated["manualAccountPriorityIds"] == []
     assert updated["openaiCacheAffinityMaxAgeSeconds"] == 180
     assert updated["dashboardSessionTtlSeconds"] == 31536000
     assert updated["httpResponsesSessionBridgePromptCacheIdleTtlSeconds"] == 1800
@@ -152,6 +155,7 @@ async def test_settings_api_get_and_update(async_client):
     assert payload["relativeAvailabilityTopK"] == 7
     assert payload["preferEarlierResetWindow"] == "secondary"
     assert payload["singleAccountId"] is None
+    assert payload["manualAccountPriorityIds"] == []
     assert payload["openaiCacheAffinityMaxAgeSeconds"] == 180
     assert payload["dashboardSessionTtlSeconds"] == 31536000
     assert payload["httpResponsesSessionBridgePromptCacheIdleTtlSeconds"] == 1800
@@ -189,6 +193,60 @@ async def test_settings_api_accepts_fill_first_routing_strategy(async_client):
     response = await async_client.get("/api/settings")
     assert response.status_code == 200
     assert response.json()["routingStrategy"] == "fill_first"
+
+
+@pytest.mark.asyncio
+async def test_settings_api_persists_ordered_fallback_manual_priority(async_client):
+    first_id = await _import_account(async_client, "chatgpt-priority-1", "priority1@example.com")
+    second_id = await _import_account(async_client, "chatgpt-priority-2", "priority2@example.com")
+
+    response = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": True,
+            "preferEarlierResetAccounts": True,
+            "routingStrategy": "ordered_fallback",
+            "manualAccountPriorityIds": [second_id, first_id, second_id],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["routingStrategy"] == "ordered_fallback"
+    assert payload["manualAccountPriorityIds"] == [second_id, first_id]
+
+    response = await async_client.get("/api/settings")
+    assert response.status_code == 200
+    assert response.json()["manualAccountPriorityIds"] == [second_id, first_id]
+
+
+@pytest.mark.asyncio
+async def test_settings_api_rejects_ordered_fallback_without_known_priority(async_client):
+    response = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": True,
+            "preferEarlierResetAccounts": True,
+            "routingStrategy": "ordered_fallback",
+            "manualAccountPriorityIds": [],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "manual_account_priority_required"
+
+    response = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": True,
+            "preferEarlierResetAccounts": True,
+            "routingStrategy": "ordered_fallback",
+            "manualAccountPriorityIds": ["missing-account"],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "manual_account_priority_unknown_account"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -100,8 +100,39 @@ async def test_v1_models_list(async_client):
     ids = {item["id"] for item in data}
     assert "gpt-5.2" in ids
     assert "gpt-5.3-codex" in ids
+    assert "gemini-3.5-flash" in ids
+    gemini = next(item for item in data if item["id"] == "gemini-3.5-flash")
+    assert gemini["owned_by"] == "agent-lb"
+    assert gemini["provider"] == "gemini"
+    assert gemini["protocol"] == "gemini_api"
+    assert gemini["context_length"] == 1_048_576
+    assert gemini["max_output_tokens"] == 65_536
+    assert gemini["capabilities"]["supports_streaming"] is True
+    assert gemini["capabilities"]["input_modalities"] == ["text"]
+    assert gemini["capabilities"]["output_modalities"] == ["text"]
+    assert gemini["capabilities"]["supportsImages"] is False
+    assert gemini["capabilities"]["supports_images"] is False
+    assert gemini["capabilities"]["supports_vision"] is False
+    assert gemini["supportsImages"] is False
+    assert gemini["supports_images"] is False
+    assert gemini["supportsVision"] is False
+    assert gemini["supports_vision"] is False
+    antigravity = next(item for item in data if item["id"] == "antigravity-preview-05-2026")
+    assert antigravity["provider"] == "antigravity"
+    assert antigravity["capabilities"]["input_modalities"] == ["text"]
+    assert antigravity["capabilities"]["supports_tool_use"] is False
+    assert antigravity["capabilities"]["supportsImages"] is False
+    assert antigravity["capabilities"]["supports_images"] is False
+    assert antigravity["capabilities"]["supports_vision"] is False
+    assert antigravity["supportsImages"] is False
+    assert antigravity["supports_images"] is False
+    assert antigravity["supportsVision"] is False
+    assert antigravity["supports_vision"] is False
     for item in data:
         assert item["object"] == "model"
+        if item.get("provider") in {"gemini", "antigravity"}:
+            assert item["owned_by"] == "agent-lb"
+            continue
         assert item["owned_by"] == "codex-lb"
         assert "metadata" in item
         assert item["api_types"] == ["chat_completions"]
@@ -128,7 +159,8 @@ async def test_v1_models_uses_bootstrap_models_when_registry_not_populated(async
     payload = resp.json()
     assert payload["object"] == "list"
     ids = {item["id"] for item in payload["data"]}
-    assert ids == BOOTSTRAP_MODEL_SLUGS
+    assert BOOTSTRAP_MODEL_SLUGS.issubset(ids)
+    assert "gemini-3.5-flash" in ids
     assert "gpt-5.5-pro" not in ids
 
 
@@ -473,6 +505,40 @@ async def test_model_catalogs_canonicalize_enforced_model_alias(async_client):
 
 
 @pytest.mark.asyncio
+async def test_v1_models_filters_to_allowed_gemini_model(async_client):
+    await _populate_test_registry()
+    enable = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert enable.status_code == 200
+
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "gemini-model-catalog",
+            "allowedModels": ["gemini-3.5-flash"],
+            "enforcedModel": "gemini-3.5-flash",
+        },
+    )
+    assert created.status_code == 200
+    key = created.json()["key"]
+
+    resp = await async_client.get("/v1/models", headers={"Authorization": f"Bearer {key}"})
+
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert [entry["id"] for entry in data] == ["gemini-3.5-flash"]
+    assert data[0]["provider"] == "gemini"
+    assert data[0]["metadata"]["max_output_tokens"] == 65_536
+
+
+@pytest.mark.asyncio
 async def test_backend_codex_models_preserves_original_flow_without_allowlist(async_client):
     registry = get_model_registry()
     models = [
@@ -573,7 +639,12 @@ async def test_model_sets_are_consistent_across_api_endpoints(async_client):
     dashboard_ids = {item["id"] for item in dashboard.json()["models"]}
     v1_ids = {item["id"] for item in v1.json()["data"]}
     codex_slugs = {item["slug"] for item in codex.json()["models"]}
-    assert dashboard_ids == v1_ids == codex_slugs
+    assert codex_slugs.issubset(dashboard_ids)
+    assert codex_slugs.issubset(v1_ids)
+    assert dashboard_ids == v1_ids
+    assert "gemini-3.5-flash" in dashboard_ids
+    gemini = next(item for item in dashboard.json()["models"] if item["id"] == "gemini-3.5-flash")
+    assert gemini["provider"] == "gemini"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_agent_provider_accounts.py
+++ b/tests/unit/test_agent_provider_accounts.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent_provider_accounts.service import (
+    AgentProviderAccountNotFoundError,
+    AgentProviderAccountsService,
+    AgentProviderAccountUpdateData,
+    AgentProviderAccountValidationError,
+    AntigravityProviderAccountCreateData,
+    GeminiProviderAccountCreateData,
+)
+
+
+class _RepositoryStub:
+    def __init__(self) -> None:
+        self.created = []
+        self.rows = {}
+        self.saved = []
+
+    async def list_by_provider(self, provider_id: str):
+        return []
+
+    async def get_for_provider(self, provider_id: str, account_id: str):
+        row = self.rows.get(account_id)
+        if row is None or row.provider_id != provider_id:
+            return None
+        return row
+
+    async def create(self, row):
+        self.created.append(row)
+        self.rows[row.id] = row
+        return row
+
+    async def save(self, row):
+        self.saved.append(row)
+        self.rows[row.id] = row
+        return row
+
+
+class _EncryptorStub:
+    def encrypt(self, token: str) -> bytes:
+        return f"encrypted:{token}".encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_create_gemini_account_encrypts_api_key_and_fingerprints_secret() -> None:
+    repository = _RepositoryStub()
+    service = AgentProviderAccountsService(repository, encryptor=_EncryptorStub())
+
+    row = await service.create_gemini_account(
+        GeminiProviderAccountCreateData(display_name=" Gemini ", api_key=" secret ", project_id=" project ")
+    )
+
+    assert row.provider_id == "gemini"
+    assert row.display_name == "Gemini"
+    assert row.api_key_encrypted == b"encrypted:secret"
+    assert row.credential_fingerprint is not None
+    assert row.project_id == "project"
+    assert repository.created == [row]
+
+
+@pytest.mark.asyncio
+async def test_create_antigravity_account_stores_cli_profile_without_secret() -> None:
+    repository = _RepositoryStub()
+    service = AgentProviderAccountsService(repository, encryptor=_EncryptorStub())
+
+    row = await service.create_antigravity_account(
+        AntigravityProviderAccountCreateData(
+            display_name=" Antigravity ",
+            external_account_id=" default ",
+            location=" agy ",
+        )
+    )
+
+    assert row.provider_id == "antigravity"
+    assert row.display_name == "Antigravity"
+    assert row.external_account_id == "default"
+    assert row.auth_mode == "cli_keyring"
+    assert row.status == "active"
+    assert row.api_key_encrypted is None
+    assert row.credential_fingerprint is not None
+    assert row.location == "agy"
+    assert repository.created == [row]
+
+
+@pytest.mark.asyncio
+async def test_create_antigravity_cli_account_rejects_api_key() -> None:
+    service = AgentProviderAccountsService(_RepositoryStub(), encryptor=_EncryptorStub())
+
+    with pytest.raises(AgentProviderAccountValidationError, match="api_key is not allowed"):
+        await service.create_antigravity_account(
+            AntigravityProviderAccountCreateData(
+                display_name="Antigravity local",
+                auth_mode="cli_keyring",
+                external_account_id="default",
+                api_key="should-not-store",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_antigravity_api_key_account_encrypts_secret() -> None:
+    repository = _RepositoryStub()
+    service = AgentProviderAccountsService(repository, encryptor=_EncryptorStub())
+
+    row = await service.create_antigravity_account(
+        AntigravityProviderAccountCreateData(
+            display_name=" Antigravity managed ",
+            auth_mode="api_key",
+            api_key=" ag-key ",
+            project_id=" project ",
+        )
+    )
+
+    assert row.provider_id == "antigravity"
+    assert row.display_name == "Antigravity managed"
+    assert row.auth_mode == "api_key"
+    assert row.api_key_encrypted == b"encrypted:ag-key"
+    assert row.credential_fingerprint is not None
+    assert row.external_account_id is None
+    assert row.project_id == "project"
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_rejects_unknown_provider() -> None:
+    service = AgentProviderAccountsService(_RepositoryStub(), encryptor=_EncryptorStub())
+
+    with pytest.raises(AgentProviderAccountValidationError):
+        await service.list_accounts("unknown")
+
+
+@pytest.mark.asyncio
+async def test_update_gemini_account_rotates_key_and_pauses_account() -> None:
+    repository = _RepositoryStub()
+    service = AgentProviderAccountsService(repository, encryptor=_EncryptorStub())
+    row = await service.create_gemini_account(
+        GeminiProviderAccountCreateData(display_name="Old", api_key="old-key", project_id="old-project")
+    )
+    old_fingerprint = row.credential_fingerprint
+
+    updated = await service.update_account(
+        "gemini",
+        row.id,
+        AgentProviderAccountUpdateData(
+            display_name=" New name ",
+            status=" paused ",
+            api_key=" new-key ",
+            project_id=" new-project ",
+            location=" global ",
+        ),
+    )
+
+    assert updated is row
+    assert row.display_name == "New name"
+    assert row.status == "paused"
+    assert row.api_key_encrypted == b"encrypted:new-key"
+    assert row.credential_fingerprint != old_fingerprint
+    assert row.project_id == "new-project"
+    assert row.location == "global"
+    assert repository.saved == [row]
+
+
+@pytest.mark.asyncio
+async def test_update_antigravity_cli_account_changes_external_id_fingerprint_and_rejects_blank() -> None:
+    repository = _RepositoryStub()
+    service = AgentProviderAccountsService(repository, encryptor=_EncryptorStub())
+    row = await service.create_antigravity_account(
+        AntigravityProviderAccountCreateData(display_name="Agy", external_account_id="default")
+    )
+    old_fingerprint = row.credential_fingerprint
+
+    updated = await service.update_account(
+        "antigravity",
+        row.id,
+        AgentProviderAccountUpdateData(external_account_id=" workspace-b ", status="active", location=" harness "),
+    )
+
+    assert updated.external_account_id == "workspace-b"
+    assert updated.location == "harness"
+    assert updated.credential_fingerprint != old_fingerprint
+
+    with pytest.raises(AgentProviderAccountValidationError):
+        await service.update_account("antigravity", row.id, AgentProviderAccountUpdateData(external_account_id=" "))
+
+
+@pytest.mark.asyncio
+async def test_update_account_rejects_wrong_provider_or_missing_account() -> None:
+    repository = _RepositoryStub()
+    service = AgentProviderAccountsService(repository, encryptor=_EncryptorStub())
+
+    with pytest.raises(AgentProviderAccountValidationError):
+        await service.update_account("unknown", "missing", AgentProviderAccountUpdateData(status="active"))
+
+    with pytest.raises(AgentProviderAccountNotFoundError):
+        await service.update_account("gemini", "missing", AgentProviderAccountUpdateData(status="active"))
+
+
+@pytest.mark.asyncio
+async def test_update_antigravity_account_rejects_api_key_rotation() -> None:
+    repository = _RepositoryStub()
+    service = AgentProviderAccountsService(repository, encryptor=_EncryptorStub())
+    row = await service.create_antigravity_account(
+        AntigravityProviderAccountCreateData(display_name="Agy", external_account_id="default")
+    )
+
+    with pytest.raises(AgentProviderAccountValidationError):
+        await service.update_account("antigravity", row.id, AgentProviderAccountUpdateData(api_key="secret"))
+
+
+@pytest.mark.asyncio
+async def test_update_antigravity_api_key_account_rotates_key() -> None:
+    repository = _RepositoryStub()
+    service = AgentProviderAccountsService(repository, encryptor=_EncryptorStub())
+    row = await service.create_antigravity_account(
+        AntigravityProviderAccountCreateData(display_name="Agy API", auth_mode="api_key", api_key="old")
+    )
+    old_fingerprint = row.credential_fingerprint
+
+    updated = await service.update_account("antigravity", row.id, AgentProviderAccountUpdateData(api_key="new"))
+
+    assert updated.api_key_encrypted == b"encrypted:new"
+    assert updated.credential_fingerprint != old_fingerprint

--- a/tests/unit/test_agent_provider_routing.py
+++ b/tests/unit/test_agent_provider_routing.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import AgentProviderAccount, AgentProviderRoutingSettings
+from app.modules.agent_provider_routing.logic import (
+    ProviderAccountRoutingState,
+    ProviderQuotaWindow,
+    ProviderRoutingSettings,
+    select_provider_account,
+)
+from app.modules.agent_provider_routing.repository import AgentProviderRoutingRepository
+from app.modules.agent_provider_routing.service import (
+    AgentProviderRoutingService,
+    AgentProviderRoutingSettingsUpdateData,
+    AgentProviderRoutingValidationError,
+)
+
+
+def _state(
+    account_id: str,
+    *,
+    used: int = 0,
+    limit: int | None = 100,
+    reset_at: datetime | None = None,
+    status: str = "active",
+) -> ProviderAccountRoutingState:
+    return ProviderAccountRoutingState(
+        account_id=account_id,
+        status=status,
+        quota_windows=(
+            ProviderQuotaWindow(
+                dimension="requests_per_day",
+                used=used,
+                limit=limit,
+                reset_at=reset_at,
+            ),
+        ),
+    )
+
+
+def test_capacity_weighted_selects_account_with_remaining_budget() -> None:
+    result = select_provider_account(
+        [_state("low", used=90), _state("high", used=10)],
+        ProviderRoutingSettings(strategy="capacity_weighted", quota_threshold_pct=95.0),
+    )
+
+    assert result.account_id == "high"
+    assert result.denied_reason is None
+    assert result.candidate_account_ids == ("low", "high")
+
+
+def test_budget_filter_blocks_drain_strategy_before_selection() -> None:
+    now = datetime(2026, 6, 9, tzinfo=timezone.utc)
+    result = select_provider_account(
+        [
+            _state("near-reset-over-budget", used=99, reset_at=now + timedelta(minutes=1)),
+            _state("later-safe", used=40, reset_at=now + timedelta(days=2)),
+        ],
+        ProviderRoutingSettings(strategy="reset_drain", quota_threshold_pct=95.0),
+        now=now,
+    )
+
+    assert result.account_id == "later-safe"
+    assert result.candidate_account_ids == ("later-safe",)
+
+
+def test_preflight_denies_when_all_candidates_exceed_budget() -> None:
+    result = select_provider_account(
+        [_state("a", used=95), _state("b", used=100)],
+        ProviderRoutingSettings(strategy="sequential_drain", quota_threshold_pct=95.0),
+    )
+
+    assert result.account_id is None
+    assert result.denied_reason == "provider_quota_budget_exhausted"
+    assert result.candidate_account_ids == ("a", "b")
+
+
+def test_expired_quota_window_is_budget_safe_again() -> None:
+    now = datetime(2026, 6, 9, tzinfo=timezone.utc)
+    result = select_provider_account(
+        [_state("expired", used=100, reset_at=now - timedelta(minutes=1))],
+        ProviderRoutingSettings(strategy="capacity_weighted", quota_threshold_pct=95.0),
+        now=now,
+    )
+
+    assert result.account_id == "expired"
+    assert result.denied_reason is None
+    assert result.candidate_account_ids == ("expired",)
+
+
+def test_single_account_scope_does_not_fallback_to_other_accounts() -> None:
+    result = select_provider_account(
+        [_state("chosen", used=100), _state("other", used=0)],
+        ProviderRoutingSettings(strategy="single_account", single_account_id="chosen", quota_threshold_pct=95.0),
+    )
+
+    assert result.account_id is None
+    assert result.denied_reason == "provider_quota_budget_exhausted"
+    assert result.candidate_account_ids == ("chosen",)
+
+
+def test_ordered_fallback_selects_first_budget_safe_ordered_account() -> None:
+    result = select_provider_account(
+        [_state("first", used=99), _state("second", used=10), _state("third", used=0)],
+        ProviderRoutingSettings(
+            strategy="ordered_fallback",
+            ordered_account_ids=("first", "second", "third"),
+            quota_threshold_pct=95.0,
+        ),
+    )
+
+    assert result.account_id == "second"
+    assert result.denied_reason is None
+    assert result.candidate_account_ids == ("second", "third")
+
+
+def test_ordered_fallback_denies_when_ordered_accounts_are_not_budget_safe() -> None:
+    result = select_provider_account(
+        [_state("first", used=99), _state("unordered", used=10)],
+        ProviderRoutingSettings(
+            strategy="ordered_fallback",
+            ordered_account_ids=("first",),
+            quota_threshold_pct=95.0,
+        ),
+    )
+
+    assert result.account_id is None
+    assert result.denied_reason == "ordered_fallback_unavailable"
+    assert result.candidate_account_ids == ("unordered",)
+
+
+class _SettingsInsertRaceSession:
+    def __init__(self) -> None:
+        self.added: AgentProviderRoutingSettings | None = None
+        self.existing: AgentProviderRoutingSettings | None = None
+        self.rolled_back = False
+
+    async def get(
+        self, _model: type[AgentProviderRoutingSettings], provider_id: str
+    ) -> AgentProviderRoutingSettings | None:
+        if self.existing is not None:
+            return self.existing
+        return None
+
+    def add(self, row: AgentProviderRoutingSettings) -> None:
+        self.added = row
+
+    async def commit(self) -> None:
+        assert self.added is not None
+        self.existing = AgentProviderRoutingSettings(provider_id=self.added.provider_id)
+        raise IntegrityError("insert", {}, Exception("unique"))
+
+    async def rollback(self) -> None:
+        self.rolled_back = True
+
+    async def refresh(self, _row: AgentProviderRoutingSettings) -> None:
+        raise AssertionError("race recovery should return the reloaded row")
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_settings_recovers_from_concurrent_insert() -> None:
+    session = _SettingsInsertRaceSession()
+    repository = AgentProviderRoutingRepository(cast(AsyncSession, session))
+
+    row = await repository.get_or_create_settings("gemini")
+
+    assert row.provider_id == "gemini"
+    assert session.rolled_back is True
+
+
+class _SettingsRepository:
+    def __init__(self, row: AgentProviderRoutingSettings) -> None:
+        self.row = row
+        self.saved = False
+
+    async def get_or_create_settings(self, _provider_id: str) -> AgentProviderRoutingSettings:
+        return self.row
+
+    async def save_settings(self, row: AgentProviderRoutingSettings) -> AgentProviderRoutingSettings:
+        self.saved = True
+        self.row = row
+        return row
+
+    async def get_account_for_provider(self, _provider_id: str, _account_id: str) -> Any:
+        raise AssertionError("explicitly cleared single-account selection should fail before account lookup")
+
+
+@pytest.mark.asyncio
+async def test_update_settings_rejects_clearing_active_single_account() -> None:
+    repository = _SettingsRepository(
+        AgentProviderRoutingSettings(
+            provider_id="gemini",
+            strategy="single_account",
+            single_account_id="account-1",
+        )
+    )
+    service = AgentProviderRoutingService(cast(Any, repository))
+
+    with pytest.raises(AgentProviderRoutingValidationError, match="single_account_id is required"):
+        await service.update_settings(
+            "gemini",
+            AgentProviderRoutingSettingsUpdateData(single_account_id=None, single_account_id_set=True),
+        )
+
+    assert repository.saved is False
+
+
+class _RoundRobinRepository:
+    def __init__(self) -> None:
+        self.settings = AgentProviderRoutingSettings(
+            provider_id="gemini",
+            strategy="round_robin",
+            round_robin_cursor=None,
+        )
+        self.accounts = [
+            AgentProviderAccount(
+                id="account-a",
+                provider_id="gemini",
+                display_name="A",
+                auth_mode="api_key",
+                status="active",
+            ),
+            AgentProviderAccount(
+                id="account-b",
+                provider_id="gemini",
+                display_name="B",
+                auth_mode="api_key",
+                status="active",
+            ),
+        ]
+        self.advance_calls: list[tuple[str | None, str]] = []
+
+    async def get_or_create_settings(self, _provider_id: str) -> AgentProviderRoutingSettings:
+        return self.settings
+
+    async def list_accounts_with_quota_windows(self, _provider_id: str) -> list[AgentProviderAccount]:
+        return self.accounts
+
+    async def advance_round_robin_cursor(
+        self,
+        _provider_id: str,
+        *,
+        expected_cursor: str | None,
+        selected_account_id: str,
+    ) -> bool:
+        self.advance_calls.append((expected_cursor, selected_account_id))
+        if len(self.advance_calls) == 1:
+            self.settings.round_robin_cursor = selected_account_id
+            return False
+        if self.settings.round_robin_cursor != expected_cursor:
+            return False
+        self.settings.round_robin_cursor = selected_account_id
+        return True
+
+
+@pytest.mark.asyncio
+async def test_select_account_retries_round_robin_cursor_conflict() -> None:
+    repository = _RoundRobinRepository()
+    service = AgentProviderRoutingService(cast(Any, repository))
+
+    selected = await service.select_account("gemini")
+
+    assert selected.account.id == "account-b"
+    assert repository.advance_calls == [(None, "account-a"), ("account-a", "account-b")]
+    assert repository.settings.round_robin_cursor == "account-b"

--- a/tests/unit/test_agent_provider_runtime_service.py
+++ b/tests/unit/test_agent_provider_runtime_service.py
@@ -1,0 +1,673 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+import app.modules.agent_provider_runtime.service as runtime_service_module
+from app.db.models import AgentProviderAccount
+from app.modules.agent_provider_routing.settlement import AgentProviderUsageSettlementData
+from app.modules.agent_provider_runtime.antigravity import (
+    AntigravityHarnessRequest,
+    AntigravityProcessResult,
+    antigravity_harness_env,
+    build_antigravity_command,
+    command_preview,
+)
+from app.modules.agent_provider_runtime.service import (
+    AntigravityHarnessService,
+    AntigravityManagedAgentService,
+    AntigravityRuntimeRequestContext,
+    GeminiRuntimeRequestContext,
+    GeminiRuntimeService,
+    GeminiRuntimeValidationError,
+    parse_chat_completion_request,
+)
+from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
+
+
+@dataclass(slots=True)
+class _Selected:
+    account: AgentProviderAccount
+
+
+class _RoutingService:
+    def __init__(self, account: AgentProviderAccount) -> None:
+        self.account = account
+        self.provider_ids: list[str] = []
+        self.auth_modes: list[str | None] = []
+        self.settlements: list[tuple[str, str, AgentProviderUsageSettlementData]] = []
+
+    async def select_account(self, provider_id: str, *, auth_mode: str | None = None) -> _Selected:
+        self.provider_ids.append(provider_id)
+        self.auth_modes.append(auth_mode)
+        return _Selected(account=self.account)
+
+    async def settle_usage(
+        self,
+        provider_id: str,
+        account_id: str,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None:
+        self.settlements.append((provider_id, account_id, usage))
+
+
+class _FailingSettlementRoutingService(_RoutingService):
+    async def settle_usage(
+        self,
+        provider_id: str,
+        account_id: str,
+        usage: AgentProviderUsageSettlementData,
+    ) -> None:
+        del provider_id, account_id, usage
+        raise RuntimeError("database unavailable")
+
+
+class _Decryptor:
+    def decrypt(self, encrypted: bytes) -> str:
+        assert encrypted == b"encrypted-key"
+        return "AIza-test-key"
+
+
+class _Response:
+    def __init__(
+        self,
+        payload: dict[str, Any] | None = None,
+        *,
+        status: int = 200,
+        headers: dict[str, str] | None = None,
+        chunks: list[bytes] | None = None,
+    ) -> None:
+        self.status = status
+        self.headers = headers or {}
+        self._payload = payload or {}
+        self.content = _Content(chunks or [])
+
+    async def __aenter__(self) -> _Response:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+    async def text(self) -> str:
+        return "upstream-error"
+
+
+class _Content:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def iter_any(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _CancelledContent:
+    async def iter_any(self) -> AsyncIterator[bytes]:
+        raise asyncio.CancelledError
+        yield b""
+
+
+class _FailingAfterChunkContent:
+    async def iter_any(self) -> AsyncIterator[bytes]:
+        yield (
+            b'data: {"responseId":"resp_partial","candidates":[{"content":{"parts":[{"text":"Hi"}]}}],'
+            b'"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":1,"totalTokenCount":3}}\n\n'
+        )
+        raise RuntimeError("stream failed")
+
+
+class _CancelledResponse(_Response):
+    def __init__(self) -> None:
+        super().__init__(chunks=[])
+        self.content = _CancelledContent()
+
+
+class _FailingAfterChunkResponse(_Response):
+    def __init__(self) -> None:
+        super().__init__(chunks=[])
+        self.content = _FailingAfterChunkContent()
+
+
+class _Session:
+    def __init__(self, response: _Response) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, url: str, **kwargs: Any) -> _Response:
+        self.calls.append({"url": url, **kwargs})
+        return self.response
+
+
+class _ApiKeyUsageService:
+    def __init__(self) -> None:
+        self.released: list[str] = []
+        self.finalized: list[tuple[str, int, int]] = []
+
+    async def enforce_limits_for_request(
+        self,
+        key_id: str,
+        *,
+        request_model: str | None,
+        request_service_tier: str | None = None,
+        request_usage_budget: object | None = None,
+    ) -> ApiKeyUsageReservationData:
+        del request_service_tier, request_usage_budget
+        return ApiKeyUsageReservationData(
+            reservation_id=f"reservation-{request_model}",
+            key_id=key_id,
+            model=request_model or "",
+        )
+
+    async def finalize_usage_reservation(
+        self,
+        reservation_id: str,
+        *,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cached_input_tokens: int = 0,
+        service_tier: str | None = None,
+    ) -> None:
+        del model, cached_input_tokens, service_tier
+        self.finalized.append((reservation_id, input_tokens, output_tokens))
+
+    async def release_usage_reservation(self, reservation_id: str) -> None:
+        self.released.append(reservation_id)
+
+
+def _account(
+    *,
+    account_id: str = "gemini-account",
+    provider_id: str = "gemini",
+    display_name: str = "Gemini",
+    auth_mode: str = "api_key",
+    api_key_encrypted: bytes | None = b"encrypted-key",
+    external_account_id: str | None = None,
+) -> AgentProviderAccount:
+    return AgentProviderAccount(
+        id=account_id,
+        provider_id=provider_id,
+        external_account_id=external_account_id,
+        display_name=display_name,
+        auth_mode=auth_mode,
+        api_key_encrypted=api_key_encrypted,
+        status="active",
+    )
+
+
+class _AntigravityRunner:
+    def __init__(self, result: AntigravityProcessResult | None = None) -> None:
+        self.result = result or AntigravityProcessResult(
+            exit_code=0,
+            stdout="agy-result",
+            stderr="",
+            duration_ms=12,
+        )
+        self.commands = []
+        self.envs: list[dict[str, str]] = []
+
+    async def run(self, command, *, env):
+        self.commands.append(command)
+        self.envs.append(dict(env))
+        return self.result
+
+
+def test_build_antigravity_command_redacts_prompt_and_disables_dangerous_flags(tmp_path) -> None:
+    extra_dir = tmp_path / "extra"
+    extra_dir.mkdir()
+
+    command = build_antigravity_command(
+        AntigravityHarnessRequest(
+            prompt="Inspect this",
+            workspace_path=str(tmp_path),
+            timeout_seconds=30,
+            add_dirs=("extra",),
+            sandbox="read-only",
+        )
+    )
+
+    assert command.cwd == tmp_path.resolve()
+    assert command.args[:5] == ("--print", "--print-timeout", "30s", "--prompt", "Inspect this")
+    assert "--dangerously-skip-permissions" not in command.args
+    assert command_preview(command)[:5] == ("agy", "--print", "--print-timeout", "30s", "--prompt")
+    assert command_preview(command)[5] == "<redacted>"
+    assert antigravity_harness_env({})["AGY_CLI_DISABLE_AUTO_UPDATE"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_antigravity_harness_selects_profile_and_settles_request(tmp_path) -> None:
+    account = _account(
+        account_id="agy-account",
+        provider_id="antigravity",
+        display_name="Antigravity",
+        auth_mode="cli_keyring",
+        api_key_encrypted=None,
+        external_account_id="default",
+    )
+    routing = _RoutingService(account)
+    runner = _AntigravityRunner()
+    service = AntigravityHarnessService(routing, runner=runner)
+
+    result = await service.print_prompt(
+        AntigravityHarnessRequest(prompt="Say hi", workspace_path=str(tmp_path), timeout_seconds=5)
+    )
+
+    assert result.account.id == "agy-account"
+    assert routing.provider_ids == ["antigravity"]
+    assert routing.settlements == [("antigravity", "agy-account", AgentProviderUsageSettlementData(requests=1))]
+    assert runner.commands[0].args[:5] == ("--print", "--print-timeout", "5s", "--prompt", "Say hi")
+    assert "--dangerously-skip-permissions" not in runner.commands[0].args
+    assert runner.envs[0]["AGY_CLI_DISABLE_AUTO_UPDATE"] == "true"
+    assert runner.envs[0]["AGY_CLI_PROFILE"] == "default"
+    assert runner.envs[0]["ANTIGRAVITY_CLI_PROFILE"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_antigravity_harness_does_not_settle_failed_cli_run(tmp_path) -> None:
+    account = _account(
+        account_id="agy-account",
+        provider_id="antigravity",
+        display_name="Antigravity",
+        auth_mode="cli_keyring",
+        api_key_encrypted=None,
+    )
+    routing = _RoutingService(account)
+    runner = _AntigravityRunner(AntigravityProcessResult(exit_code=2, stdout="", stderr="failed", duration_ms=7))
+    service = AntigravityHarnessService(routing, runner=runner)
+
+    result = await service.print_prompt(
+        AntigravityHarnessRequest(prompt="Say hi", workspace_path=str(tmp_path), timeout_seconds=5)
+    )
+
+    assert result.process.exit_code == 2
+    assert routing.settlements == []
+
+
+@pytest.mark.asyncio
+async def test_antigravity_interaction_maps_steps_text_and_usage(monkeypatch) -> None:
+    upstream = _Response(
+        {
+            "id": "interaction_1",
+            "agent": "antigravity-preview-05-2026",
+            "steps": [
+                {
+                    "type": "model_output",
+                    "content": [
+                        {"type": "text", "text": "Official "},
+                        {"type": "text", "text": "shape"},
+                    ],
+                }
+            ],
+            "usage": {"total_input_tokens": 4, "total_output_tokens": 2, "total_tokens": 6},
+        }
+    )
+    session = _Session(upstream)
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+    routing = _RoutingService(_account(account_id="agy-account", provider_id="antigravity"))
+    service = AntigravityManagedAgentService(routing, decryptor=_Decryptor())
+
+    response = await service.complete_chat(
+        {"model": "antigravity-preview-05-2026", "messages": [{"role": "user", "content": "Do work"}]}
+    )
+
+    choices = cast(list[dict[str, Any]], response["choices"])
+    message = cast(dict[str, Any], choices[0]["message"])
+    assert message["content"] == "Official shape"
+    assert session.calls[0]["headers"]["Api-Revision"] == "2026-05-20"
+    assert routing.settlements == [
+        (
+            "antigravity",
+            "agy-account",
+            AgentProviderUsageSettlementData(requests=1, prompt_tokens=4, completion_tokens=2, total_tokens=6),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_antigravity_interaction_finalizes_api_key_when_provider_settlement_fails(monkeypatch) -> None:
+    upstream = _Response(
+        {
+            "id": "interaction_1",
+            "output_text": "done",
+            "usage": {"total_input_tokens": 4, "total_output_tokens": 2, "total_tokens": 6},
+        }
+    )
+    session = _Session(upstream)
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+    api_key_usage = _ApiKeyUsageService()
+    service = AntigravityManagedAgentService(
+        _FailingSettlementRoutingService(_account(account_id="agy-account", provider_id="antigravity")),
+        decryptor=_Decryptor(),
+        api_key_service=api_key_usage,
+    )
+    context = AntigravityRuntimeRequestContext(
+        api_key=ApiKeyData(
+            id="key-1",
+            name="Key",
+            key_prefix="sk",
+            allowed_models=None,
+            enforced_model=None,
+            enforced_reasoning_effort=None,
+            enforced_service_tier=None,
+            expires_at=None,
+            is_active=True,
+            created_at=datetime.now(timezone.utc),
+            last_used_at=None,
+        )
+    )
+
+    response = await service.create_interaction(
+        {"agent": "antigravity-preview-05-2026", "input": "Do work", "environment": "remote"},
+        context,
+    )
+
+    assert response["output_text"] == "done"
+    assert api_key_usage.finalized == [("reservation-antigravity-preview-05-2026", 4, 2)]
+    assert api_key_usage.released == []
+
+
+def test_parse_chat_completion_request_validates_shape() -> None:
+    with pytest.raises(GeminiRuntimeValidationError, match="model is required"):
+        parse_chat_completion_request({"messages": [{"role": "user", "content": "Hi"}]})
+
+    request = parse_chat_completion_request(
+        {
+            "model": "gemini-2.5-flash",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": True,
+            "temperature": 0.2,
+            "max_tokens": 8,
+        }
+    )
+
+    assert request.model == "gemini-2.5-flash"
+    assert request.stream is True
+    assert request.temperature == 0.2
+    assert request.max_tokens == 8
+
+
+def test_parse_chat_completion_request_uses_max_completion_tokens_fallback() -> None:
+    request = parse_chat_completion_request(
+        {
+            "model": "gemini-2.5-flash",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_completion_tokens": 32,
+        }
+    )
+
+    assert request.max_tokens == 32
+
+
+def test_parse_chat_completion_request_prefers_max_tokens_over_max_completion_tokens() -> None:
+    request = parse_chat_completion_request(
+        {
+            "model": "gemini-2.5-flash",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 8,
+            "max_completion_tokens": 32,
+        }
+    )
+
+    assert request.max_tokens == 8
+
+
+@pytest.mark.asyncio
+async def test_complete_chat_selects_gemini_account_and_calls_native_endpoint(monkeypatch) -> None:
+    upstream = _Response(
+        {
+            "responseId": "resp_1",
+            "candidates": [{"content": {"parts": [{"text": "Hello"}]}, "finishReason": "STOP"}],
+            "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 1, "totalTokenCount": 3},
+        }
+    )
+    session = _Session(upstream)
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+    routing = _RoutingService(_account())
+    service = GeminiRuntimeService(routing, decryptor=_Decryptor())
+
+    response = await service.complete_chat(
+        {"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Hi"}]}
+    )
+
+    assert routing.provider_ids == ["gemini"]
+    assert routing.settlements == [
+        (
+            "gemini",
+            "gemini-account",
+            AgentProviderUsageSettlementData(requests=1, prompt_tokens=2, completion_tokens=1, total_tokens=3),
+        )
+    ]
+    choices = cast(list[dict[str, Any]], response["choices"])
+    message = cast(dict[str, Any], choices[0]["message"])
+    assert message["content"] == "Hello"
+    assert session.calls[0]["url"].endswith("/models/gemini-2.5-flash:generateContent")
+    assert session.calls[0]["headers"]["x-goog-api-key"] == "AIza-test-key"
+    assert session.calls[0]["json"] == {"contents": [{"role": "user", "parts": [{"text": "Hi"}]}]}
+
+
+@pytest.mark.asyncio
+async def test_complete_chat_finalizes_api_key_when_provider_settlement_fails(monkeypatch) -> None:
+    upstream = _Response(
+        {
+            "responseId": "resp_1",
+            "candidates": [{"content": {"parts": [{"text": "Hello"}]}, "finishReason": "STOP"}],
+            "usageMetadata": {"promptTokenCount": 2, "candidatesTokenCount": 1, "totalTokenCount": 3},
+        }
+    )
+    session = _Session(upstream)
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+    api_key_usage = _ApiKeyUsageService()
+    service = GeminiRuntimeService(
+        _FailingSettlementRoutingService(_account()),
+        decryptor=_Decryptor(),
+        api_key_service=api_key_usage,
+    )
+    context = GeminiRuntimeRequestContext(
+        api_key=ApiKeyData(
+            id="key-1",
+            name="Key",
+            key_prefix="sk",
+            allowed_models=None,
+            enforced_model=None,
+            enforced_reasoning_effort=None,
+            enforced_service_tier=None,
+            expires_at=None,
+            is_active=True,
+            created_at=datetime.now(timezone.utc),
+            last_used_at=None,
+        )
+    )
+
+    response = await service.complete_chat(
+        {"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Hi"}]},
+        context,
+    )
+
+    choices = cast(list[dict[str, Any]], response["choices"])
+    message = cast(dict[str, Any], choices[0]["message"])
+    assert message["content"] == "Hello"
+    assert api_key_usage.finalized == [("reservation-gemini-2.5-flash", 2, 1)]
+    assert api_key_usage.released == []
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_translates_gemini_sse_to_openai_sse(monkeypatch) -> None:
+    upstream = _Response(
+        chunks=[
+            b'data: {"responseId":"resp_2","candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}\r\n\r\n',
+            (
+                b'data: {"responseId":"resp_2","candidates":'
+                b'[{"content":{"parts":[{"text":"lo"}]},"finishReason":"STOP"}]}\n\n'
+            ),
+        ]
+    )
+    session = _Session(upstream)
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+    routing = _RoutingService(_account())
+    service = GeminiRuntimeService(routing, decryptor=_Decryptor())
+
+    body = await service.stream_chat(
+        {"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "Hi"}], "stream": True}
+    )
+    chunks = [chunk async for chunk in body]
+
+    assert session.calls[0]["url"].endswith("/models/gemini-2.5-flash:streamGenerateContent?alt=sse")
+    assert '"object":"chat.completion.chunk"' in chunks[0]
+    assert '"content":"Hel"' in chunks[0]
+    assert '"content":"lo"' in chunks[1]
+    assert chunks[-1] == "data: [DONE]\n\n"
+    assert routing.settlements == [
+        ("gemini", "gemini-account", AgentProviderUsageSettlementData(requests=1)),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_decodes_utf8_split_across_chunks(monkeypatch) -> None:
+    text = "H" + chr(233)
+    event = (
+        'data: {"responseId":"resp_utf8","candidates":[{"content":{"parts":[{"text":"'
+        + text
+        + '"}]},"finishReason":"STOP"}]}\n\n'
+    ).encode("utf-8")
+    split_at = event.index(chr(233).encode("utf-8")) + 1
+    upstream = _Response(chunks=[event[:split_at], event[split_at:]])
+    session = _Session(upstream)
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+    service = GeminiRuntimeService(_RoutingService(_account()), decryptor=_Decryptor())
+
+    body = await service.stream_chat(
+        {"model": "gemini-3.5-flash", "messages": [{"role": "user", "content": "Hi"}], "stream": True}
+    )
+    chunks = [chunk async for chunk in body]
+
+    assert "H\\u00e9" in chunks[0]
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_settles_request_when_cancelled_after_account_selection(monkeypatch) -> None:
+    session = _Session(_CancelledResponse())
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+    api_key_usage = _ApiKeyUsageService()
+    routing = _RoutingService(_account())
+    service = GeminiRuntimeService(routing, decryptor=_Decryptor(), api_key_service=api_key_usage)
+    context = GeminiRuntimeRequestContext(
+        api_key=ApiKeyData(
+            id="key-1",
+            name="Key",
+            key_prefix="sk",
+            allowed_models=None,
+            enforced_model=None,
+            enforced_reasoning_effort=None,
+            enforced_service_tier=None,
+            expires_at=None,
+            is_active=True,
+            created_at=datetime.now(timezone.utc),
+            last_used_at=None,
+        )
+    )
+
+    body = await service.stream_chat(
+        {"model": "gemini-3.5-flash", "messages": [{"role": "user", "content": "Hi"}], "stream": True},
+        context,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        async for _chunk in body:
+            pass
+
+    assert api_key_usage.released == ["reservation-gemini-3.5-flash"]
+    assert api_key_usage.finalized == []
+    assert routing.settlements == []
+
+
+@pytest.mark.asyncio
+async def test_stream_chat_settles_partial_usage_when_stream_fails_after_chunks(monkeypatch) -> None:
+    session = _Session(_FailingAfterChunkResponse())
+
+    @asynccontextmanager
+    async def _lease() -> AsyncIterator[_Session]:
+        yield session
+
+    monkeypatch.setattr(runtime_service_module, "lease_http_session", _lease)
+    api_key_usage = _ApiKeyUsageService()
+    routing = _RoutingService(_account())
+    service = GeminiRuntimeService(routing, decryptor=_Decryptor(), api_key_service=api_key_usage)
+    context = GeminiRuntimeRequestContext(
+        api_key=ApiKeyData(
+            id="key-1",
+            name="Key",
+            key_prefix="sk",
+            allowed_models=None,
+            enforced_model=None,
+            enforced_reasoning_effort=None,
+            enforced_service_tier=None,
+            expires_at=None,
+            is_active=True,
+            created_at=datetime.now(timezone.utc),
+            last_used_at=None,
+        )
+    )
+    body = await service.stream_chat(
+        {"model": "gemini-3.5-flash", "messages": [{"role": "user", "content": "Hi"}], "stream": True},
+        context,
+    )
+
+    chunks: list[str] = []
+    with pytest.raises(RuntimeError, match="stream failed"):
+        async for chunk in body:
+            chunks.append(chunk)
+
+    assert chunks
+    assert api_key_usage.released == []
+    assert api_key_usage.finalized == [("reservation-gemini-3.5-flash", 2, 1)]
+    assert routing.settlements == [
+        (
+            "gemini",
+            "gemini-account",
+            AgentProviderUsageSettlementData(requests=1, prompt_tokens=2, completion_tokens=1, total_tokens=3),
+        )
+    ]

--- a/tests/unit/test_agent_providers.py
+++ b/tests/unit/test_agent_providers.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from app.modules.agent_providers.service import list_agent_providers
+
+
+def test_agent_provider_registry_keeps_codex_ready_and_gemini_foundation() -> None:
+    response = list_agent_providers()
+    providers = {provider.provider_id: provider for provider in response.providers}
+
+    assert providers["codex"].status == "ready"
+    assert providers["codex"].capabilities[0].protocol == "codex_chatgpt"
+    assert providers["codex"].capabilities[0].proxyable is True
+
+    gemini = providers["gemini"]
+    assert gemini.status == "foundation"
+    assert "api_key" in gemini.auth_modes
+    assert any(capability.protocol == "gemini_api" and capability.proxyable for capability in gemini.capabilities)
+    antigravity = next(capability for capability in gemini.capabilities if capability.protocol == "antigravity_cli")
+    assert antigravity.proxyable is False
+    assert antigravity.available_until == "2026-06-18"
+    assert "agy harness" in antigravity.operator_action
+
+    antigravity_provider = providers["antigravity"]
+    assert antigravity_provider.status == "foundation"
+    assert antigravity_provider.auth_modes == ["api_key", "cli_keyring"]
+    managed = next(
+        capability for capability in antigravity_provider.capabilities if capability.protocol == "interactions_api"
+    )
+    cli = next(
+        capability for capability in antigravity_provider.capabilities if capability.protocol == "antigravity_cli"
+    )
+    assert managed.proxyable is True
+    assert managed.status == "foundation"
+    assert "antigravity-preview" in managed.operator_action
+    assert cli.proxyable is False
+    assert cli.status == "foundation"
+    assert "agy --print" in cli.operator_action

--- a/tests/unit/test_gemini_adapter.py
+++ b/tests/unit/test_gemini_adapter.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent_provider_runtime.gemini import (
+    GeminiAdapterError,
+    GeminiChatRequest,
+    build_generate_content_payload,
+    build_generate_content_url,
+    generate_content_to_chat_completion,
+    generate_content_to_chat_completion_chunk,
+    parse_gemini_sse_data_lines,
+)
+
+
+def test_build_generate_content_payload_maps_chat_messages_and_config() -> None:
+    payload = build_generate_content_payload(
+        GeminiChatRequest(
+            model="gemini-2.5-flash",
+            messages=[
+                {"role": "system", "content": "Be concise."},
+                {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
+                {"role": "assistant", "content": "Hi"},
+            ],
+            temperature=0.2,
+            top_p=0.9,
+            max_tokens=64,
+            stop=["END"],
+            response_format={"type": "json_object"},
+        )
+    )
+
+    assert payload == {
+        "contents": [
+            {"role": "user", "parts": [{"text": "Hello"}]},
+            {"role": "model", "parts": [{"text": "Hi"}]},
+        ],
+        "systemInstruction": {"parts": [{"text": "Be concise."}]},
+        "generationConfig": {
+            "temperature": 0.2,
+            "topP": 0.9,
+            "maxOutputTokens": 64,
+            "stopSequences": ["END"],
+            "responseMimeType": "application/json",
+        },
+    }
+
+
+def test_build_generate_content_payload_maps_function_tools() -> None:
+    payload = build_generate_content_payload(
+        GeminiChatRequest(
+            model="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "Weather?"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Gets weather.",
+                        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                    },
+                }
+            ],
+        )
+    )
+
+    assert payload["tools"] == [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "get_weather",
+                    "description": "Gets weather.",
+                    "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                }
+            ]
+        }
+    ]
+
+
+def test_build_generate_content_payload_maps_tool_call_history() -> None:
+    payload = build_generate_content_payload(
+        GeminiChatRequest(
+            model="gemini-2.5-flash",
+            messages=[
+                {"role": "user", "content": "Weather?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_weather",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_weather", "content": '{"temperature":21}'},
+            ],
+        )
+    )
+
+    assert payload["contents"] == [
+        {"role": "user", "parts": [{"text": "Weather?"}]},
+        {
+            "role": "model",
+            "parts": [{"functionCall": {"name": "get_weather", "args": {"city": "Paris"}, "id": "call_weather"}}],
+        },
+        {
+            "role": "user",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": "get_weather",
+                        "response": {"temperature": 21},
+                        "id": "call_weather",
+                    }
+                }
+            ],
+        },
+    ]
+
+
+def test_build_generate_content_payload_preserves_tool_call_thought_signature() -> None:
+    payload = build_generate_content_payload(
+        GeminiChatRequest(
+            model="gemini-2.5-flash",
+            messages=[
+                {"role": "user", "content": "Weather?"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_weather",
+                            "type": "function",
+                            "gemini_thought_signature": "sig-abc",
+                            "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
+                        }
+                    ],
+                },
+            ],
+        )
+    )
+
+    assert payload["contents"] == [
+        {"role": "user", "parts": [{"text": "Weather?"}]},
+        {
+            "role": "model",
+            "parts": [
+                {
+                    "functionCall": {"name": "get_weather", "args": {"city": "Paris"}, "id": "call_weather"},
+                    "thoughtSignature": "sig-abc",
+                }
+            ],
+        },
+    ]
+
+
+def test_build_generate_content_url_uses_native_endpoints() -> None:
+    assert (
+        build_generate_content_url("gemini-2.5-flash")
+        == "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent"
+    )
+    assert build_generate_content_url("gemini 2.5 flash", stream=True).endswith(
+        "/models/gemini%202.5%20flash:streamGenerateContent?alt=sse"
+    )
+
+
+def test_generate_content_to_chat_completion_maps_text_finish_and_usage() -> None:
+    response = generate_content_to_chat_completion(
+        {
+            "responseId": "resp_1",
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "Hel"}, {"text": "lo"}]},
+                    "finishReason": "STOP",
+                }
+            ],
+            "usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 2, "totalTokenCount": 5},
+        },
+        model="gemini-2.5-flash",
+        created=123,
+    )
+
+    assert response["choices"][0]["message"]["content"] == "Hello"
+    assert response["choices"][0]["finish_reason"] == "stop"
+    assert response.get("usage") == {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5}
+
+
+def test_generate_content_to_chat_completion_preserves_function_calls() -> None:
+    response = generate_content_to_chat_completion(
+        {
+            "responseId": "resp_tool",
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "functionCall": {
+                                    "name": "get_weather",
+                                    "args": {"city": "Paris", "unit": "c"},
+                                }
+                            }
+                        ]
+                    },
+                    "finishReason": "STOP",
+                }
+            ],
+        },
+        model="gemini-3.5-flash",
+        created=123,
+    )
+
+    choice = response["choices"][0]
+    assert choice["finish_reason"] == "tool_calls"
+    assert choice["message"]["content"] is None
+    assert choice["message"]["tool_calls"] == [
+        {
+            "id": "call_0_get_weather",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city":"Paris","unit":"c"}'},
+        }
+    ]
+
+
+def test_generate_content_to_chat_completion_preserves_function_call_thought_signature() -> None:
+    response = generate_content_to_chat_completion(
+        {
+            "responseId": "resp_tool",
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "functionCall": {"name": "get_weather", "args": {"city": "Paris"}},
+                                "thoughtSignature": "sig-xyz",
+                            }
+                        ]
+                    },
+                }
+            ],
+        },
+        model="gemini-3.5-flash",
+        created=123,
+    )
+
+    tool_calls = response["choices"][0]["message"]["tool_calls"]
+    assert tool_calls[0]["gemini_thought_signature"] == "sig-xyz"
+
+
+def test_parse_gemini_sse_data_lines_and_chunk_mapping() -> None:
+    events = parse_gemini_sse_data_lines(
+        [
+            "event: message",
+            'data: {"responseId":"resp_2","candidates":[{"content":{"parts":[{"text":"Hi"}]},"finishReason":"STOP"}]}',
+            "data: [DONE]",
+        ]
+    )
+
+    assert len(events) == 1
+    chunk = generate_content_to_chat_completion_chunk(events[0], model="gemini-2.5-flash", created=456)
+    assert chunk["object"] == "chat.completion.chunk"
+    assert chunk["choices"][0]["delta"]["content"] == "Hi"
+    assert chunk["choices"][0]["finish_reason"] == "stop"
+
+
+def test_adapter_rejects_non_text_content_for_now() -> None:
+    with pytest.raises(GeminiAdapterError):
+        build_generate_content_payload(
+            GeminiChatRequest(
+                model="gemini-2.5-flash",
+                messages=[{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://x"}}]}],
+            )
+        )

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -3943,6 +3943,56 @@ def test_select_account_fill_first_treats_none_used_percent_as_zero():
     assert result.account.account_id == "a"
 
 
+def test_select_account_ordered_fallback_uses_manual_priority_order():
+    states = [
+        AccountState("low-usage", AccountStatus.ACTIVE, used_percent=1.0),
+        AccountState("preferred", AccountStatus.ACTIVE, used_percent=80.0),
+        AccountState("backup", AccountStatus.ACTIVE, used_percent=20.0),
+    ]
+
+    result = select_account(
+        states,
+        routing_strategy="ordered_fallback",
+        ordered_account_ids=("preferred", "backup", "low-usage"),
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "preferred"
+
+
+def test_select_account_ordered_fallback_skips_exhausted_and_unlisted_accounts():
+    states = [
+        AccountState("exhausted", AccountStatus.ACTIVE, used_percent=100.0),
+        AccountState("backup", AccountStatus.ACTIVE, used_percent=20.0),
+        AccountState("unlisted", AccountStatus.ACTIVE, used_percent=1.0),
+    ]
+
+    result = select_account(
+        states,
+        routing_strategy="ordered_fallback",
+        ordered_account_ids=("exhausted", "backup"),
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "backup"
+
+
+def test_select_account_ordered_fallback_denies_when_no_ordered_account_available():
+    states = [
+        AccountState("exhausted", AccountStatus.ACTIVE, used_percent=100.0),
+        AccountState("unlisted", AccountStatus.ACTIVE, used_percent=1.0),
+    ]
+
+    result = select_account(
+        states,
+        routing_strategy="ordered_fallback",
+        ordered_account_ids=("exhausted", "missing"),
+    )
+
+    assert result.account is None
+    assert result.error_message == "No ordered fallback accounts are available"
+
+
 def test_select_account_fill_first_is_deterministic_across_calls():
     now = 1_700_000_000.0
     states = [


### PR DESCRIPTION
﻿## Summary

This is a draft Agent Load Balancer foundation slice. It keeps the existing Codex routes intact and adds provider-scoped infrastructure for Gemini and Antigravity:

- typed provider registry for Codex, Gemini, and Antigravity
- provider-scoped Gemini/Antigravity account storage, routing settings, quota windows, and preflight
- native Gemini Developer API chat completion + stream adapter
- /v1/chat/completions dispatch for gemini-* models while preserving Codex routing
- provider-aware /v1/models and /api/models Gemini model catalog entries
- dashboard /providers page with combined overview plus separate Codex/Gemini/Antigravity sections
- Antigravity gy --print dashboard harness probe routed through provider selection, without pretending gy is OpenAI-compatible HTTP
- OpenSpec change docs for provider routing/runtime/dashboard/operator contracts

## Review audit carried forward

Checked the prior Codex review threads around #863/#716 before opening this draft.

- #863 finding: missing OpenSpec for dashboard/operator routing changes. This draft adds openspec/changes/add-multi-agent-providers/ with proposal, design, tasks, and delta spec.
- #863 finding: single-account routing could transiently outage traffic without an account. Provider routing persists settings and tests no-fallback denial behavior instead of opportunistic fallback.
- #863 finding: reset-drain should bucket by reset window before exact timestamp. Provider routing uses budget filtering before drain ordering and reset bucket before exact reset timestamp.
- #716 was merged; remaining broader manual ordered fallback request is still tracked separately in #428 and is not claimed as closed by this draft.

## Verification

- python -m pytest tests/unit/test_agent_providers.py tests/unit/test_agent_provider_accounts.py tests/unit/test_agent_provider_routing.py tests/unit/test_agent_provider_runtime_service.py tests/unit/test_gemini_adapter.py tests/integration/test_agent_providers_api.py tests/integration/test_agent_provider_accounts_api.py tests/integration/test_agent_provider_routing_api.py tests/integration/test_agent_provider_runtime_api.py tests/integration/test_v1_models.py -> 57 passed
- frontend provider schema tests -> 5 passed
- backend uff check . -> passed
- backend uff format --check . -> passed
- backend 	y check -> passed
- frontend 
pm run typecheck -> passed
- frontend 
pm run lint -> passed
- frontend 
pm run build -> passed, existing large chunk warning only
- fresh SQLite migration gate: codex-lb-db --db-url <temp sqlite> upgrade head + check -> migration_policy=ok, schema_drift=none
- python -m compileall app -> passed
- mocked Playwright smoke for Antigravity routing + harness panel -> passed
- GitHub lightweight checks on latest head -> green
- live local codexlb repo remained clean/untouched during this work

## Known gaps / draft status

- OpenSpec CLI validation could not run locally: openspec is not on PATH and 
px --yes openspec validate add-multi-agent-providers --strict cannot determine an executable.
- Real gy --print was not executed; Antigravity tests and UI smoke use a mocked process runner to avoid mutating local sessions/workspaces or consuming account quota.
- This is a foundation PR, not the final full ALB product cutover.
