### PR TITLE
feat(dashboard-ui): Multiple dashboard changes

### DIFF
--- a/app/modules/dashboard/builders.py
+++ b/app/modules/dashboard/builders.py
@@ -6,6 +6,7 @@ from app.core import usage as usage_core
 from app.core.usage.types import UsageWindowRow
 from app.db.models import Account
 from app.modules.dashboard.schemas import (
+    DashboardMetricsComparison,
     DashboardOverviewSummary,
     DashboardOverviewTimeframe,
     DashboardOverviewTimeframeKey,
@@ -73,6 +74,7 @@ def build_dashboard_overview_summary(
     secondary_rows: list[UsageWindowRow],
     activity_cost: ActivityCostSummary,
     activity_metrics: ActivityMetricsSummary,
+    comparison: DashboardMetricsComparison | None = None,
 ) -> DashboardOverviewSummary:
     account_map = {account.id: account for account in accounts}
     primary_summary = usage_core.summarize_usage_window(primary_rows, account_map, "primary")
@@ -98,4 +100,5 @@ def build_dashboard_overview_summary(
                 "top_error": activity_metrics.top_error,
             }
         ),
+        comparison=comparison,
     )

--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -68,8 +68,21 @@ class DashboardRepository:
     async def aggregate_activity_since(self, since: datetime) -> RequestActivityAggregate:
         return await self._logs_repo.aggregate_activity_since(since)
 
+    async def aggregate_activity_between(
+        self,
+        since: datetime,
+        until: datetime,
+    ) -> RequestActivityAggregate:
+        return await self._logs_repo.aggregate_activity_between(since, until)
+
     async def top_error_since(self, since: datetime) -> str | None:
         return await self._logs_repo.top_error_since(since)
+
+    async def top_error_between(self, since: datetime, until: datetime) -> str | None:
+        return await self._logs_repo.top_error_between(since, until)
+
+    async def earliest_activity_at(self) -> datetime | None:
+        return await self._logs_repo.earliest_activity_at()
 
     async def list_additional_quota_keys(
         self,

--- a/app/modules/dashboard/schemas.py
+++ b/app/modules/dashboard/schemas.py
@@ -33,11 +33,23 @@ class DashboardUsageMetrics(DashboardModel):
     top_error: str | None = None
 
 
+class DashboardMetricsComparisonPrevious(DashboardModel):
+    requests: int
+    tokens: int
+    cost_usd: float = Field(alias="costUsd")
+
+
+class DashboardMetricsComparison(DashboardModel):
+    can_compare: bool = Field(alias="canCompare")
+    previous: DashboardMetricsComparisonPrevious
+
+
 class DashboardOverviewSummary(DashboardModel):
     primary_window: UsageWindow
     secondary_window: UsageWindow | None = None
     cost: DashboardUsageCost
     metrics: DashboardUsageMetrics | None = None
+    comparison: DashboardMetricsComparison | None = None
 
 
 class DashboardUsageWindows(DashboardModel):

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -16,6 +16,8 @@ from app.modules.dashboard.builders import (
 )
 from app.modules.dashboard.repository import DashboardRepository
 from app.modules.dashboard.schemas import (
+    DashboardMetricsComparison,
+    DashboardMetricsComparisonPrevious,
     DashboardOverviewResponse,
     DashboardOverviewTimeframeKey,
     DashboardProjectionsResponse,
@@ -104,11 +106,23 @@ class DashboardService:
             bucket_seconds=overview_timeframe.bucket_seconds,
             bucket_count=overview_timeframe.bucket_count,
         )
-        activity_aggregate = await self._repo.aggregate_activity_since(bucket_since)
-        top_error = await self._repo.top_error_since(bucket_since)
+        previous_window_start = bucket_since - timedelta(minutes=overview_timeframe.window_minutes)
+        activity_aggregate = await self._repo.aggregate_activity_between(bucket_since, now)
+        previous_activity_aggregate = await self._repo.aggregate_activity_between(previous_window_start, bucket_since)
+        top_error = await self._repo.top_error_between(bucket_since, now)
+        earliest_activity_at = await self._repo.earliest_activity_at()
         activity_metrics, activity_cost = build_activity_summaries(
             activity_aggregate,
             top_error=top_error,
+        )
+        previous_metrics, previous_cost = build_activity_summaries(previous_activity_aggregate)
+        comparison = DashboardMetricsComparison(
+            canCompare=earliest_activity_at is not None and earliest_activity_at <= previous_window_start,
+            previous=DashboardMetricsComparisonPrevious(
+                requests=previous_metrics.requests or 0,
+                tokens=previous_metrics.tokens or 0,
+                costUsd=previous_cost.total_usd,
+            ),
         )
 
         summary = build_dashboard_overview_summary(
@@ -117,6 +131,7 @@ class DashboardService:
             secondary_rows=secondary_rows,
             activity_metrics=activity_metrics,
             activity_cost=activity_cost,
+            comparison=comparison,
         )
 
         secondary_minutes = usage_core.resolve_window_minutes("secondary", secondary_rows)

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -133,6 +133,32 @@ class RequestLogsRepository:
         ]
 
     async def aggregate_activity_since(self, since: datetime) -> RequestActivityAggregate:
+        stmt = self._aggregate_activity_stmt(since)
+        result = await self._session.execute(stmt)
+        row = result.one()
+        return RequestActivityAggregate(
+            request_count=int(row.request_count),
+            error_count=int(row.error_count),
+            input_tokens=int(row.input_tokens),
+            output_tokens=int(row.output_tokens),
+            cached_input_tokens=int(row.cached_input_tokens),
+            cost_usd=float(row.cost_usd or 0.0),
+        )
+
+    async def aggregate_activity_between(self, since: datetime, until: datetime) -> RequestActivityAggregate:
+        stmt = self._aggregate_activity_stmt(since, until)
+        result = await self._session.execute(stmt)
+        row = result.one()
+        return RequestActivityAggregate(
+            request_count=int(row.request_count),
+            error_count=int(row.error_count),
+            input_tokens=int(row.input_tokens),
+            output_tokens=int(row.output_tokens),
+            cached_input_tokens=int(row.cached_input_tokens),
+            cost_usd=float(row.cost_usd or 0.0),
+        )
+
+    def _aggregate_activity_stmt(self, since: datetime, until: datetime | None = None):
         stmt = select(
             func.count().label("request_count"),
             func.coalesce(
@@ -147,18 +173,23 @@ class RequestLogsRepository:
             RequestLog.requested_at >= since,
             self._exclude_warmup_clause(),
         )
-        result = await self._session.execute(stmt)
-        row = result.one()
-        return RequestActivityAggregate(
-            request_count=int(row.request_count),
-            error_count=int(row.error_count),
-            input_tokens=int(row.input_tokens),
-            output_tokens=int(row.output_tokens),
-            cached_input_tokens=int(row.cached_input_tokens),
-            cost_usd=float(row.cost_usd or 0.0),
-        )
+        if until is not None:
+            stmt = stmt.where(RequestLog.requested_at < until)
+        return stmt
 
     async def top_error_since(self, since: datetime) -> str | None:
+        stmt = self._top_error_stmt(since)
+        result = await self._session.execute(stmt)
+        row = result.first()
+        return str(row[0]) if row and row[0] else None
+
+    async def top_error_between(self, since: datetime, until: datetime) -> str | None:
+        stmt = self._top_error_stmt(since, until)
+        result = await self._session.execute(stmt)
+        row = result.first()
+        return str(row[0]) if row and row[0] else None
+
+    def _top_error_stmt(self, since: datetime, until: datetime | None = None):
         stmt = (
             select(RequestLog.error_code, func.count(RequestLog.id).label("error_count"))
             .where(
@@ -171,9 +202,15 @@ class RequestLogsRepository:
             .order_by(func.count(RequestLog.id).desc(), RequestLog.error_code.asc())
             .limit(1)
         )
+        if until is not None:
+            stmt = stmt.where(RequestLog.requested_at < until)
+        return stmt
+
+    async def earliest_activity_at(self) -> datetime | None:
+        stmt = select(func.min(RequestLog.requested_at)).where(self._exclude_warmup_clause())
         result = await self._session.execute(stmt)
-        row = result.first()
-        return str(row[0]) if row and row[0] else None
+        value = result.scalar_one_or_none()
+        return value if isinstance(value, datetime) else None
 
     async def add_log(
         self,

--- a/frontend/src/features/dashboard/components/account-summary-line.test.tsx
+++ b/frontend/src/features/dashboard/components/account-summary-line.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AccountSummaryLine } from "@/features/dashboard/components/account-summary-line";
+import { createAccountSummary } from "@/test/mocks/factories";
+
+describe("AccountSummaryLine", () => {
+  it("renders registered, active, and unavailable counts for mixed statuses", () => {
+    render(
+      <AccountSummaryLine
+        accounts={[
+          createAccountSummary({ accountId: "acc-1", status: "active" }),
+          createAccountSummary({ accountId: "acc-2", status: "paused" }),
+          createAccountSummary({ accountId: "acc-3", status: "rate_limited" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("dashboard-account-summary-line")).toHaveTextContent(
+      /3.*registered.*1.*active.*2.*unavailable/,
+    );
+  });
+
+  it("shows zero unavailable when all accounts are active", () => {
+    render(
+      <AccountSummaryLine
+        accounts={[
+          createAccountSummary({ accountId: "acc-1", status: "active" }),
+          createAccountSummary({ accountId: "acc-2", status: "active" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("dashboard-account-summary-line")).toHaveTextContent(
+      /2.*registered.*2.*active.*0.*unavailable/,
+    );
+  });
+
+  it("renders zero counts for an empty dashboard account list", () => {
+    render(<AccountSummaryLine accounts={[]} />);
+
+    expect(screen.getByTestId("dashboard-account-summary-line")).toHaveTextContent(
+      /0.*registered.*0.*active.*0.*unavailable/,
+    );
+  });
+});

--- a/frontend/src/features/dashboard/components/account-summary-line.tsx
+++ b/frontend/src/features/dashboard/components/account-summary-line.tsx
@@ -1,0 +1,28 @@
+import type { AccountSummary } from "@/features/dashboard/schemas";
+import { normalizeStatus } from "@/utils/account-status";
+
+type AccountSummaryLineProps = {
+  accounts: AccountSummary[];
+};
+
+export function AccountSummaryLine({ accounts }: AccountSummaryLineProps) {
+  const registeredCount = accounts.length;
+  const activeCount = accounts.filter((account) => normalizeStatus(account.status) === "active").length;
+  const unavailableCount = registeredCount - activeCount;
+
+  return (
+    <div
+      data-testid="dashboard-account-summary-line"
+      className="flex items-center gap-1.5 whitespace-nowrap text-xs"
+    >
+      <span className="font-semibold tabular-nums text-foreground">{registeredCount}</span>
+      <span className="text-muted-foreground">registered</span>
+      <span className="text-border">·</span>
+      <span className="font-semibold tabular-nums text-emerald-600 dark:text-emerald-400">{activeCount}</span>
+      <span className="text-muted-foreground">active</span>
+      <span className="text-border">·</span>
+      <span className="font-semibold tabular-nums text-red-600 dark:text-red-400">{unavailableCount}</span>
+      <span className="text-muted-foreground">unavailable</span>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/dashboard-page.test.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.test.tsx
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, within } from "@testing-library/react";
+
+import { renderWithProviders } from "@/test/utils";
+import { createDashboardOverview, createDashboardProjections } from "@/test/mocks/factories";
+import { useAccountMutations } from "@/features/accounts/hooks/use-accounts";
+import { useDashboard, useDashboardProjections } from "@/features/dashboard/hooks/use-dashboard";
+import { useRequestLogs } from "@/features/dashboard/hooks/use-request-logs";
+import { buildDashboardView } from "@/features/dashboard/utils";
+
+import { DashboardPage } from "./dashboard-page";
+
+const { accountSummaryLineSpy } = vi.hoisted(() => ({
+  accountSummaryLineSpy: vi.fn(),
+}));
+
+vi.mock("@/features/accounts/hooks/use-accounts", () => ({
+  useAccountMutations: vi.fn(),
+}));
+
+vi.mock("@/features/dashboard/hooks/use-dashboard", () => ({
+  useDashboard: vi.fn(),
+  useDashboardProjections: vi.fn(),
+}));
+
+vi.mock("@/features/dashboard/hooks/use-request-logs", () => ({
+  useRequestLogs: vi.fn(),
+}));
+
+vi.mock("@/features/dashboard/utils", () => ({
+  buildDashboardView: vi.fn(),
+}));
+
+vi.mock("@/features/dashboard/components/account-cards", () => ({
+  AccountCards: () => <div data-testid="account-cards" />,
+}));
+
+vi.mock("@/features/dashboard/components/account-summary-line", () => ({
+  AccountSummaryLine: ({ accounts }: { accounts: Array<{ accountId: string }> }) => {
+    accountSummaryLineSpy(accounts);
+    return <div data-testid="account-summary-line">Summary for {accounts.length} accounts</div>;
+  },
+}));
+
+vi.mock("@/features/dashboard/components/dashboard-skeleton", () => ({
+  DashboardSkeleton: () => <div data-testid="dashboard-skeleton" />,
+}));
+
+vi.mock("@/features/dashboard/components/filters/overview-timeframe-select", () => ({
+  OverviewTimeframeSelect: () => <div data-testid="overview-timeframe-select" />,
+}));
+
+vi.mock("@/features/dashboard/components/filters/request-filters", () => ({
+  RequestFilters: () => <div data-testid="request-filters" />,
+}));
+
+vi.mock("@/features/dashboard/components/recent-requests-table", () => ({
+  RecentRequestsTable: () => <div data-testid="recent-requests-table" />,
+}));
+
+vi.mock("@/features/dashboard/components/stats-grid", () => ({
+  StatsGrid: () => <div data-testid="stats-grid" />,
+}));
+
+vi.mock("@/features/dashboard/components/usage-donuts", () => ({
+  UsageDonuts: () => <div data-testid="usage-donuts" />,
+}));
+
+vi.mock("@/features/dashboard/components/weekly-credits-pace-card", () => ({
+  WeeklyCreditsPaceCard: () => <div data-testid="weekly-credits-pace-card" />,
+}));
+
+const useAccountMutationsMock = vi.mocked(useAccountMutations);
+const useDashboardMock = vi.mocked(useDashboard);
+const useDashboardProjectionsMock = vi.mocked(useDashboardProjections);
+const useRequestLogsMock = vi.mocked(useRequestLogs);
+const buildDashboardViewMock = vi.mocked(buildDashboardView);
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    accountSummaryLineSpy.mockReset();
+    useAccountMutationsMock.mockReset();
+    useDashboardMock.mockReset();
+    useDashboardProjectionsMock.mockReset();
+    useRequestLogsMock.mockReset();
+    buildDashboardViewMock.mockReset();
+  });
+
+  it("renders the account summary line in the Accounts header using overview accounts", () => {
+    const overview = createDashboardOverview();
+
+    useAccountMutationsMock.mockReturnValue({
+      resumeMutation: { mutateAsync: vi.fn() },
+      limitWarmupMutation: { mutateAsync: vi.fn() },
+    } as unknown as ReturnType<typeof useAccountMutations>);
+    useDashboardMock.mockReturnValue({
+      data: overview,
+      isFetching: false,
+      error: null,
+    } as ReturnType<typeof useDashboard>);
+    useDashboardProjectionsMock.mockReturnValue({
+      data: createDashboardProjections(),
+      isFetching: false,
+      error: null,
+    } as ReturnType<typeof useDashboardProjections>);
+    useRequestLogsMock.mockReturnValue({
+      filters: {
+        search: "",
+        timeframe: "all",
+        accountIds: [],
+        apiKeyIds: [],
+        modelOptions: [],
+        statuses: [],
+        limit: 25,
+        offset: 0,
+      },
+      listFilters: {
+        search: undefined,
+        limit: 25,
+        offset: 0,
+        accountIds: [],
+        apiKeyIds: [],
+        statuses: [],
+        modelOptions: [],
+        since: undefined,
+      },
+      facetFilters: {
+        since: undefined,
+        accountIds: [],
+        apiKeyIds: [],
+        modelOptions: [],
+      },
+      logsQuery: {
+        data: { requests: [], total: 0, hasMore: false },
+        isFetching: false,
+        error: null,
+      },
+      optionsQuery: {
+        data: { accountIds: [], apiKeys: [], modelOptions: [], statuses: [] },
+        error: null,
+      },
+      updateFilters: vi.fn(),
+    } as unknown as ReturnType<typeof useRequestLogs>);
+    buildDashboardViewMock.mockReturnValue({
+      stats: [],
+      weeklyCreditPace: null,
+      primaryUsageItems: [],
+      secondaryUsageItems: [],
+      primaryTotal: 0,
+      secondaryTotal: 0,
+      safeLinePrimary: null,
+      safeLineSecondary: null,
+      requestLogs: [],
+    } as ReturnType<typeof buildDashboardView>);
+
+    renderWithProviders(<DashboardPage />);
+
+    const accountsHeader = screen.getByRole("heading", { name: "Accounts" }).parentElement;
+
+    expect(accountsHeader).not.toBeNull();
+    expect(within(accountsHeader as HTMLElement).getByTestId("account-summary-line")).toHaveTextContent(
+      "Summary for 2 accounts",
+    );
+    expect(accountSummaryLineSpy).toHaveBeenCalledWith(overview.accounts);
+  });
+});

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -6,6 +6,7 @@ import { RefreshCw } from "lucide-react";
 import { AlertMessage } from "@/components/alert-message";
 import { useAccountMutations } from "@/features/accounts/hooks/use-accounts";
 import { AccountCards } from "@/features/dashboard/components/account-cards";
+import { AccountSummaryLine } from "@/features/dashboard/components/account-summary-line";
 import { DashboardSkeleton } from "@/features/dashboard/components/dashboard-skeleton";
 import { OverviewTimeframeSelect } from "@/features/dashboard/components/filters/overview-timeframe-select";
 import { RequestFilters } from "@/features/dashboard/components/filters/request-filters";
@@ -219,6 +220,7 @@ export function DashboardPage() {
           <section className="space-y-4">
             <div className="flex items-center gap-3">
               <h2 className="text-[13px] font-medium uppercase tracking-wider text-muted-foreground">Accounts</h2>
+              <AccountSummaryLine accounts={overview?.accounts ?? []} />
               <div className="h-px flex-1 bg-border" />
             </div>
             <AccountCards accounts={overview?.accounts ?? []} onAction={handleAccountAction} />

--- a/frontend/src/features/dashboard/components/stats-grid.test.tsx
+++ b/frontend/src/features/dashboard/components/stats-grid.test.tsx
@@ -13,8 +13,8 @@ describe("StatsGrid", () => {
     render(
       <StatsGrid
         stats={[
-          { label: "Requests (30d)", value: "228", icon: Activity, trend: SAMPLE_TREND, trendColor: "#3b82f6" },
-          { label: "Tokens (30d)", value: "45K", icon: Coins, trend: SAMPLE_TREND, trendColor: "#8b5cf6" },
+          { label: "Requests (30d)", value: "228", comparison: { text: "▲ 50%", tone: "positive" }, icon: Activity, trend: SAMPLE_TREND, trendColor: "#3b82f6" },
+          { label: "Tokens (30d)", value: "45K", comparison: { text: "▼ 50%", tone: "negative" }, icon: Coins, trend: SAMPLE_TREND, trendColor: "#8b5cf6" },
           { label: "Cost (30d)", value: "$1.82", meta: "Avg/day $0.06", icon: DollarSign, trend: SAMPLE_TREND, trendColor: "#10b981" },
           { label: "Account burn projection (5h/7d)", value: "0.7 / 0.8", meta: "Projected account-equivalents: 0.7/5h · 0.8/7d", icon: Flame, trend: SAMPLE_TREND, trendColor: "#ef4444" },
           { label: "Error rate (30d)", value: "2.8%", meta: "Top: rate_limit_exceeded", icon: AlertTriangle, trend: SAMPLE_TREND, trendColor: "#f59e0b" },
@@ -24,14 +24,28 @@ describe("StatsGrid", () => {
 
     expect(screen.getByText("Requests (30d)")).toBeInTheDocument();
     expect(screen.getByText("228")).toBeInTheDocument();
+    expect(screen.getByText("▲ 50%")).toBeInTheDocument();
     expect(screen.getByText("Tokens (30d)")).toBeInTheDocument();
     expect(screen.getByText("45K")).toBeInTheDocument();
+    expect(screen.getByText("▼ 50%")).toBeInTheDocument();
     expect(screen.getByText("Cost (30d)")).toBeInTheDocument();
     expect(screen.getByText("Avg/day $0.06")).toBeInTheDocument();
     expect(screen.getByText("Account burn projection (5h/7d)")).toBeInTheDocument();
     expect(screen.getByText("Projected account-equivalents: 0.7/5h · 0.8/7d")).toBeInTheDocument();
     expect(screen.getByText("Error rate (30d)")).toBeInTheDocument();
     expect(screen.getByText("Top: rate_limit_exceeded")).toBeInTheDocument();
+  });
+
+  it("does not render a comparison line when a stat has no comparison", () => {
+    render(
+      <StatsGrid
+        stats={[
+          { label: "Requests (30d)", value: "228", icon: Activity, trend: SAMPLE_TREND, trendColor: "#3b82f6" },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("▲ 50%")).not.toBeInTheDocument();
   });
 
   it("renders without sparklines when trend is empty", () => {

--- a/frontend/src/features/dashboard/components/stats-grid.test.tsx
+++ b/frontend/src/features/dashboard/components/stats-grid.test.tsx
@@ -36,6 +36,20 @@ describe("StatsGrid", () => {
     expect(screen.getByText("Top: rate_limit_exceeded")).toBeInTheDocument();
   });
 
+  it("renders the comparison indicator inline with the metric value", () => {
+    render(
+      <StatsGrid
+        stats={[
+          { label: "Requests (30d)", value: "228", comparison: { text: "▲ 50%", tone: "positive" }, icon: Activity, trend: SAMPLE_TREND, trendColor: "#3b82f6" },
+        ]}
+      />,
+    );
+
+    const valueRow = screen.getByTestId("stat-value-row");
+    expect(valueRow).toContainElement(screen.getByText("228"));
+    expect(valueRow).toContainElement(screen.getByText("▲ 50%"));
+  });
+
   it("does not render a comparison line when a stat has no comparison", () => {
     render(
       <StatsGrid

--- a/frontend/src/features/dashboard/components/stats-grid.tsx
+++ b/frontend/src/features/dashboard/components/stats-grid.tsx
@@ -41,12 +41,14 @@ export function StatsGrid({ stats }: StatsGridProps) {
               </div>
             </div>
             <div className="mt-1">
-              <p className="text-[1.625rem] font-semibold tracking-[-0.02em]">{stat.value}</p>
-              {stat.comparison ? (
-                <p className={cn("mt-1 text-xs font-medium", COMPARISON_STYLES[stat.comparison.tone])}>
-                  {stat.comparison.text}
-                </p>
-              ) : null}
+              <div data-testid="stat-value-row" className="flex items-baseline gap-2">
+                <p className="text-[1.625rem] font-semibold tracking-[-0.02em]">{stat.value}</p>
+                {stat.comparison ? (
+                  <p className={cn("text-xs font-medium", COMPARISON_STYLES[stat.comparison.tone])}>
+                    {stat.comparison.text}
+                  </p>
+                ) : null}
+              </div>
               {stat.meta ? (
                 <p className="mt-1 text-xs text-muted-foreground">{stat.meta}</p>
               ) : null}

--- a/frontend/src/features/dashboard/components/stats-grid.tsx
+++ b/frontend/src/features/dashboard/components/stats-grid.tsx
@@ -10,6 +10,12 @@ const ACCENT_STYLES = [
   "bg-slate-500/10 text-slate-600 dark:bg-neutral-500/15 dark:text-slate-400",
 ];
 
+const COMPARISON_STYLES = {
+  positive: "text-emerald-600 dark:text-emerald-400",
+  negative: "text-red-600 dark:text-red-400",
+  neutral: "text-muted-foreground",
+} as const;
+
 export type StatsGridProps = {
   stats: DashboardStat[];
 };
@@ -36,6 +42,11 @@ export function StatsGrid({ stats }: StatsGridProps) {
             </div>
             <div className="mt-1">
               <p className="text-[1.625rem] font-semibold tracking-[-0.02em]">{stat.value}</p>
+              {stat.comparison ? (
+                <p className={cn("mt-1 text-xs font-medium", COMPARISON_STYLES[stat.comparison.tone])}>
+                  {stat.comparison.text}
+                </p>
+              ) : null}
               {stat.meta ? (
                 <p className="mt-1 text-xs text-muted-foreground">{stat.meta}</p>
               ) : null}

--- a/frontend/src/features/dashboard/schemas.test.ts
+++ b/frontend/src/features/dashboard/schemas.test.ts
@@ -53,6 +53,14 @@ describe("DashboardOverviewSchema", () => {
           errorCount: 10,
           topError: null,
         },
+        comparison: {
+          canCompare: true,
+          previous: {
+            requests: 250,
+            tokens: 1000,
+            costUsd: 6.25,
+          },
+        },
       },
       windows: {
         primary: {
@@ -66,6 +74,7 @@ describe("DashboardOverviewSchema", () => {
     });
 
     expect(parsed.accounts).toHaveLength(0);
+    expect(parsed.summary.comparison?.previous.requests).toBe(250);
   });
 
   it("drops legacy request_logs field from parse result", () => {
@@ -106,6 +115,45 @@ describe("DashboardOverviewSchema", () => {
     });
 
     expect(parsed).not.toHaveProperty("request_logs");
+  });
+
+  it("accepts overview payloads without comparison block for backward compatibility", () => {
+    const parsed = DashboardOverviewSchema.parse({
+      lastSyncAt: ISO,
+      timeframe: {
+        key: "7d",
+        windowMinutes: 10080,
+        bucketSeconds: 21600,
+        bucketCount: 28,
+      },
+      accounts: [],
+      summary: {
+        primaryWindow: {
+          remainingPercent: 70,
+          capacityCredits: 100,
+          remainingCredits: 70,
+          resetAt: ISO,
+          windowMinutes: 300,
+        },
+        secondaryWindow: null,
+        cost: {
+          currency: "USD",
+          totalUsd: 0,
+        },
+        metrics: null,
+      },
+      windows: {
+        primary: {
+          windowKey: "primary",
+          windowMinutes: 300,
+          accounts: [],
+        },
+        secondary: null,
+      },
+      trends: EMPTY_TRENDS,
+    });
+
+    expect(parsed.summary.comparison).toBeUndefined();
   });
 });
 

--- a/frontend/src/features/dashboard/schemas.ts
+++ b/frontend/src/features/dashboard/schemas.ts
@@ -58,6 +58,17 @@ export const DashboardMetricsSchema = z.object({
   topError: z.string().nullable(),
 });
 
+export const DashboardMetricsComparisonPreviousSchema = z.object({
+  requests: z.number(),
+  tokens: z.number(),
+  costUsd: z.number(),
+});
+
+export const DashboardMetricsComparisonSchema = z.object({
+  canCompare: z.boolean(),
+  previous: DashboardMetricsComparisonPreviousSchema,
+});
+
 export const TrendPointSchema = z.object({
   t: z.string().datetime({ offset: true }),
   v: z.number(),
@@ -115,6 +126,7 @@ export const DashboardOverviewSchema = z.object({
     secondaryWindow: UsageSummaryWindowSchema.nullable(),
     cost: UsageCostSchema,
     metrics: DashboardMetricsSchema.nullable(),
+    comparison: DashboardMetricsComparisonSchema.optional(),
   }),
   windows: z.object({
     primary: UsageWindowSchema,
@@ -211,6 +223,7 @@ export const FilterStateSchema = z.object({
 });
 
 export type DashboardMetrics = z.infer<typeof DashboardMetricsSchema>;
+export type DashboardMetricsComparison = z.infer<typeof DashboardMetricsComparisonSchema>;
 export type DashboardOverview = z.infer<typeof DashboardOverviewSchema>;
 export type DashboardProjections = z.infer<typeof DashboardProjectionsSchema>;
 export type DashboardOverviewTimeframe = z.infer<typeof DashboardOverviewTimeframeSchema>;

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -1016,6 +1016,45 @@ describe("buildDashboardView", () => {
     expect(view.stats[view.stats.length - 1]?.comparison).toBeUndefined();
   });
 
+  it("hides comparison indicators for sub-percent deltas that would round to 0%", () => {
+    const overview = createDashboardOverview();
+
+    const view = buildDashboardView(
+      {
+        ...overview,
+        summary: {
+          ...overview.summary,
+          metrics: {
+            requests: 1001,
+            tokens: 999,
+            cachedInputTokens: 0,
+            errorRate: 0.028,
+            errorCount: 6,
+            topError: "rate_limit_exceeded",
+          },
+          cost: {
+            currency: "USD",
+            totalUsd: 10.04,
+          },
+          comparison: {
+            canCompare: true,
+            previous: {
+              requests: 1000,
+              tokens: 1000,
+              costUsd: 10,
+            },
+          },
+        },
+      },
+      createDefaultRequestLogs(),
+      false,
+    );
+
+    expect(view.stats[0]?.comparison).toBeUndefined();
+    expect(view.stats[1]?.comparison).toBeUndefined();
+    expect(view.stats[2]?.comparison).toBeUndefined();
+  });
+
   it("hides previous-window comparison indicators when comparison is unavailable or previous totals are zero", () => {
     const overview = createDashboardOverview();
 

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -975,4 +975,94 @@ describe("buildDashboardView", () => {
     expect(burn.value).toBe("0.0 / 1.0");
     expect(burn.meta).toBe("Projected account-equivalents: 0.0/5h · 1.0/7d");
   });
+
+  it("adds previous-window comparison indicators to requests tokens and cost cards", () => {
+    const overview = createDashboardOverview();
+
+    const view = buildDashboardView(
+      {
+        ...overview,
+        summary: {
+          ...overview.summary,
+          metrics: {
+            requests: 1500,
+            tokens: 450,
+            cachedInputTokens: 0,
+            errorRate: 0.028,
+            errorCount: 6,
+            topError: "rate_limit_exceeded",
+          },
+          cost: {
+            currency: "USD",
+            totalUsd: 15,
+          },
+          comparison: {
+            canCompare: true,
+            previous: {
+              requests: 1000,
+              tokens: 900,
+              costUsd: 10,
+            },
+          },
+        },
+      },
+      createDefaultRequestLogs(),
+      false,
+    );
+
+    expect(view.stats[0]?.comparison).toEqual({ text: "▲ 50%", tone: "positive" });
+    expect(view.stats[1]?.comparison).toEqual({ text: "▼ 50%", tone: "negative" });
+    expect(view.stats[2]?.comparison).toEqual({ text: "▲ 50%", tone: "positive" });
+    expect(view.stats[view.stats.length - 1]?.comparison).toBeUndefined();
+  });
+
+  it("hides previous-window comparison indicators when comparison is unavailable or previous totals are zero", () => {
+    const overview = createDashboardOverview();
+
+    const unavailableView = buildDashboardView(
+      {
+        ...overview,
+        summary: {
+          ...overview.summary,
+          comparison: {
+            canCompare: false,
+            previous: {
+              requests: 1000,
+              tokens: 1000,
+              costUsd: 10,
+            },
+          },
+        },
+      },
+      createDefaultRequestLogs(),
+      false,
+    );
+
+    expect(unavailableView.stats[0]?.comparison).toBeUndefined();
+    expect(unavailableView.stats[1]?.comparison).toBeUndefined();
+    expect(unavailableView.stats[2]?.comparison).toBeUndefined();
+
+    const zeroPreviousView = buildDashboardView(
+      {
+        ...overview,
+        summary: {
+          ...overview.summary,
+          comparison: {
+            canCompare: true,
+            previous: {
+              requests: 0,
+              tokens: 0,
+              costUsd: 0,
+            },
+          },
+        },
+      },
+      createDefaultRequestLogs(),
+      false,
+    );
+
+    expect(zeroPreviousView.stats[0]?.comparison).toBeUndefined();
+    expect(zeroPreviousView.stats[1]?.comparison).toBeUndefined();
+    expect(zeroPreviousView.stats[2]?.comparison).toBeUndefined();
+  });
 });

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -976,6 +976,87 @@ describe("buildDashboardView", () => {
     expect(burn.meta).toBe("Projected account-equivalents: 0.0/5h · 1.0/7d");
   });
 
+  it("shows only the averaged cost text on the estimated cost card", () => {
+    const weeklyView = buildDashboardView(
+      createDashboardOverview({
+        summary: {
+          primaryWindow: {
+            remainingPercent: 63.5,
+            capacityCredits: 225,
+            remainingCredits: 142.875,
+            resetAt: null,
+            windowMinutes: 300,
+          },
+          secondaryWindow: {
+            remainingPercent: 55.2,
+            capacityCredits: 7560,
+            remainingCredits: 4173.12,
+            resetAt: null,
+            windowMinutes: 10080,
+          },
+          cost: {
+            currency: "USD",
+            totalUsd: 56,
+          },
+          metrics: {
+            requests: 228,
+            tokens: 45000,
+            cachedInputTokens: 8200,
+            errorRate: 0.028,
+            errorCount: 6,
+            topError: "rate_limit_exceeded",
+          },
+        },
+      }),
+      createDefaultRequestLogs(),
+      false,
+    );
+
+    const dailyView = buildDashboardView(
+      createDashboardOverview({
+        timeframe: {
+          key: "1d",
+          windowMinutes: 1440,
+          bucketSeconds: 3600,
+          bucketCount: 24,
+        },
+        summary: {
+          primaryWindow: {
+            remainingPercent: 63.5,
+            capacityCredits: 225,
+            remainingCredits: 142.875,
+            resetAt: null,
+            windowMinutes: 300,
+          },
+          secondaryWindow: {
+            remainingPercent: 55.2,
+            capacityCredits: 7560,
+            remainingCredits: 4173.12,
+            resetAt: null,
+            windowMinutes: 10080,
+          },
+          cost: {
+            currency: "USD",
+            totalUsd: 24,
+          },
+          metrics: {
+            requests: 228,
+            tokens: 45000,
+            cachedInputTokens: 8200,
+            errorRate: 0.028,
+            errorCount: 6,
+            topError: "rate_limit_exceeded",
+          },
+        },
+      }),
+      createDefaultRequestLogs(),
+      false,
+    );
+
+    expect(weeklyView.stats[2]?.meta).toBe("Avg/day $8.00");
+    expect(dailyView.stats[2]?.meta).toBe("Avg/hr $1.00");
+  });
+
   it("adds previous-window comparison indicators to requests tokens and cost cards", () => {
     const overview = createDashboardOverview();
 

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -758,10 +758,7 @@ export function buildDashboardView(
     timeframeHours <= 24
       ? `Avg/hr ${formatCurrency(avgPerUnit(cost, timeframeHours))}`
       : `Avg/day ${formatCurrency(avgPerUnit(cost, timeframeDays))}`;
-  const costMeta =
-    metrics?.cachedInputTokens && metrics.cachedInputTokens > 0
-      ? `${costAverage} · API estimate, ${formatCompactNumber(metrics.cachedInputTokens)} cached`
-      : `${costAverage} · API estimate`;
+  const costMeta = costAverage;
   const trends = overview.trends;
   const primaryBurnLabel = formatBurnWindowLabel("primary", overview.summary.primaryWindow.windowMinutes);
   const secondaryBurnLabel = formatBurnWindowLabel("secondary", overview.summary.secondaryWindow?.windowMinutes);

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -246,13 +246,16 @@ function buildStatComparison(
 
   const deltaPercent = ((current - previous) / previous) * 100;
   const roundedPercent = Math.round(Math.abs(deltaPercent));
+  if (roundedPercent === 0) {
+    return undefined;
+  }
   if (deltaPercent > 0) {
     return { text: `▲ ${roundedPercent}%`, tone: "positive" };
   }
   if (deltaPercent < 0) {
     return { text: `▼ ${roundedPercent}%`, tone: "negative" };
   }
-  return { text: "0%", tone: "neutral" };
+  return undefined;
 }
 
 function windowUsedAccountEquivalents(

--- a/frontend/src/features/dashboard/utils.ts
+++ b/frontend/src/features/dashboard/utils.ts
@@ -35,9 +35,15 @@ export type DashboardStat = {
   label: string;
   value: string;
   meta?: string;
+  comparison?: DashboardStatComparison;
   icon: LucideIcon;
   trend: { value: number }[];
   trendColor: string;
+};
+
+export type DashboardStatComparison = {
+  text: string;
+  tone: "positive" | "negative" | "neutral";
 };
 
 export interface SafeLineView {
@@ -227,6 +233,26 @@ function isFiniteNumber(value: number | null | undefined): value is number {
 
 function clampPercent(value: number): number {
   return Math.min(100, Math.max(0, value));
+}
+
+function buildStatComparison(
+  current: number | null | undefined,
+  previous: number,
+  canCompare: boolean,
+): DashboardStatComparison | undefined {
+  if (!canCompare || !isFiniteNumber(current) || previous <= 0) {
+    return undefined;
+  }
+
+  const deltaPercent = ((current - previous) / previous) * 100;
+  const roundedPercent = Math.round(Math.abs(deltaPercent));
+  if (deltaPercent > 0) {
+    return { text: `▲ ${roundedPercent}%`, tone: "positive" };
+  }
+  if (deltaPercent < 0) {
+    return { text: `▼ ${roundedPercent}%`, tone: "negative" };
+  }
+  return { text: "0%", tone: "neutral" };
 }
 
 function windowUsedAccountEquivalents(
@@ -742,12 +768,15 @@ export function buildDashboardView(
     (primaryBurnEquivalent ?? 0) + (secondaryBurnEquivalent ?? 0) > 0
       ? (primaryBurnEquivalent ?? 0) + (secondaryBurnEquivalent ?? 0)
       : null;
+  const comparison = overview.summary.comparison;
+  const canCompare = comparison?.canCompare ?? false;
 
   const stats: DashboardStat[] = [
     {
       label: `Requests (${timeframeLabel})`,
       value: formatCompactNumber(metrics?.requests ?? 0),
       meta: requestMeta,
+      comparison: buildStatComparison(metrics?.requests, comparison?.previous.requests ?? 0, canCompare),
       icon: Activity,
       trend: trendPointsToValues(trends.requests),
       trendColor: TREND_COLORS[0],
@@ -756,6 +785,7 @@ export function buildDashboardView(
       label: `Tokens (${timeframeLabel})`,
       value: formatCompactNumber(metrics?.tokens ?? 0),
       meta: formatCachedTokensMeta(metrics?.tokens, metrics?.cachedInputTokens),
+      comparison: buildStatComparison(metrics?.tokens, comparison?.previous.tokens ?? 0, canCompare),
       icon: Coins,
       trend: trendPointsToValues(trends.tokens),
       trendColor: TREND_COLORS[1],
@@ -764,6 +794,7 @@ export function buildDashboardView(
       label: `Est. API Cost (${timeframeLabel})`,
       value: formatCurrency(cost),
       meta: costMeta,
+      comparison: buildStatComparison(cost, comparison?.previous.costUsd ?? 0, canCompare),
       icon: DollarSign,
       trend: trendPointsToValues(trends.cost),
       trendColor: TREND_COLORS[2],

--- a/openspec/changes/add-dashboard-account-summary-line/.openspec.yaml
+++ b/openspec/changes/add-dashboard-account-summary-line/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/add-dashboard-account-summary-line/design.md
+++ b/openspec/changes/add-dashboard-account-summary-line/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The dashboard already receives an `overview.accounts` collection from `GET /api/dashboard/overview` and renders it inside the `Accounts` section through `DashboardPage` and `AccountCards`. The requested summary is a dashboard-only presentation change, so the smallest correct implementation is to derive counts locally from that existing array.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a compact summary line that shows registered, active, and unavailable account counts.
+- Keep the change frontend-only with no API or schema additions.
+- Render the summary in the dashboard `Accounts` section header using existing theme color conventions.
+- Cover the behavior with focused component and page tests.
+
+**Non-Goals:**
+
+- Changing the Accounts page layout or account-card behavior.
+- Adding new dashboard API fields or backend aggregation logic.
+- Introducing new filtering, sorting, or account health semantics beyond existing status normalization.
+
+## Decisions
+
+### 1. Derive counts from `overview.accounts` in a small presentational component
+
+Add `AccountSummaryLine` under the dashboard components folder and pass `overview?.accounts ?? []` from `DashboardPage`.
+
+Rationale:
+
+- Keeps the change isolated to the dashboard UI.
+- Reuses the same account summaries the cards already render.
+- Makes the count logic easy to test independently from the full page.
+
+Alternative considered:
+
+- Compute counts inline inside `DashboardPage`: rejected because the count formatting would be harder to unit test and reuse.
+
+### 2. Treat only normalized `active` accounts as active
+
+Use `normalizeStatus(account.status)` so only normalized `active` contributes to the active count. Normalized `paused`, `limited`, `exceeded`, `reauth`, and `deactivated` all count as unavailable.
+
+Rationale:
+
+- Matches the existing dashboard account-status presentation rules.
+- Prevents duplicate status interpretation logic.
+
+### 3. Integrate the summary into the existing Accounts header row
+
+Render the summary at the trailing end of the existing `Accounts` header row in `DashboardPage`.
+
+Rationale:
+
+- Keeps the information close to the account cards it summarizes.
+- Avoids adding another dashboard section or card.
+
+### 4. Use focused tests at component and page level
+
+Add a component test for count derivation and a page integration test proving the summary renders in the Accounts header using dashboard overview data.
+
+Rationale:
+
+- Component tests cover the status-count logic directly.
+- The page test confirms placement and wiring without expanding unrelated dashboard coverage.
+
+## Risks / Trade-offs
+
+- The summary depends on the client-side overview payload already being loaded. This is acceptable because the dashboard account cards use the same data source.
+- A compact header treatment leaves little room for extra explanatory text. This is intentional because the goal is quick scanability, not a new detailed status surface.

--- a/openspec/changes/add-dashboard-account-summary-line/proposal.md
+++ b/openspec/changes/add-dashboard-account-summary-line/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Operators with many shared accounts cannot quickly tell how many accounts are registered and how many are currently usable from the dashboard without manually scanning the account cards.
+
+## What Changes
+
+- Add a compact account summary line to the dashboard `Accounts` section header.
+- Show total registered account count, active account count, and unavailable account count.
+- Keep the dedicated Accounts page and backend dashboard overview payload unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: The dashboard Accounts section requirements will define a compact availability summary derived from the existing overview accounts array.
+
+## Impact
+
+- Frontend dashboard components in `frontend/src/features/dashboard/components/`
+- Frontend dashboard page integration in `frontend/src/features/dashboard/components/dashboard-page.tsx`
+- Frontend dashboard tests in `frontend/src/features/dashboard/components/*.test.tsx`

--- a/openspec/changes/add-dashboard-account-summary-line/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-dashboard-account-summary-line/specs/frontend-architecture/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Dashboard accounts section shows account availability summary
+
+The dashboard `Accounts` section SHALL render a compact summary derived from the existing dashboard overview accounts collection. The summary SHALL show the total registered account count, the active account count, and the unavailable account count.
+
+An account SHALL count as active only when its dashboard status normalizes to `active`. Accounts whose normalized status is `paused`, `limited`, `exceeded`, `reauth`, or `deactivated` SHALL count as unavailable.
+
+The summary SHALL render in the `Accounts` section header row and SHALL use the project's existing foreground, muted, positive, and negative theme color conventions for light and dark mode.
+
+#### Scenario: Mixed account states show registered, active, and unavailable counts
+
+- **WHEN** `GET /api/dashboard/overview` returns three accounts with statuses `active`, `paused`, and `rate_limited`
+- **THEN** the dashboard `Accounts` section header shows `3 registered`
+- **AND** shows `1 active`
+- **AND** shows `2 unavailable`
+
+#### Scenario: Only normalized active accounts count as active
+
+- **WHEN** `GET /api/dashboard/overview` returns accounts with statuses `active`, `quota_exceeded`, `reauth_required`, and `deactivated`
+- **THEN** only the `active` account contributes to the active count
+- **AND** the other three accounts contribute to the unavailable count
+
+#### Scenario: Theme-aware colors match dashboard conventions
+
+- **WHEN** the dashboard renders in light mode or dark mode
+- **THEN** the registered count uses foreground styling
+- **AND** the labels use muted-foreground styling
+- **AND** the active count uses the dashboard positive green styling
+- **AND** the unavailable count uses the dashboard negative red styling

--- a/openspec/changes/add-dashboard-account-summary-line/tasks.md
+++ b/openspec/changes/add-dashboard-account-summary-line/tasks.md
@@ -1,0 +1,11 @@
+## 1. Dashboard account summary line
+
+- [x] 1.1 Add dashboard component tests covering registered, active, and unavailable counts.
+- [x] 1.2 Add a dashboard page integration test proving the summary line renders in the Accounts section header.
+- [x] 1.3 Implement the dashboard summary-line component and render it in the Accounts section header.
+
+## 2. Validation
+
+- [x] 2.1 Run the targeted dashboard component tests.
+- [x] 2.2 Run frontend lint and typecheck.
+- [x] 2.3 Validate the OpenSpec change with `openspec validate add-dashboard-account-summary-line --strict`.

--- a/openspec/changes/add-dashboard-summary-window-deltas/.openspec.yaml
+++ b/openspec/changes/add-dashboard-summary-window-deltas/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/add-dashboard-summary-window-deltas/design.md
+++ b/openspec/changes/add-dashboard-summary-window-deltas/design.md
@@ -1,0 +1,181 @@
+## Context
+
+The dashboard overview currently builds one current-window activity summary from `GET /api/dashboard/overview` and renders it through `frontend/src/features/dashboard/utils.ts` into the top stats grid. The selected overview timeframe already supports `1d`, `7d`, and `30d`, but the API only returns current-window totals and current-window trend buckets.
+
+This change spans backend aggregation, API schema, frontend parsing, and stat-card rendering. The user requirement is specifically about comparing the current window against the immediately preceding equivalent window for the existing `Requests`, `Tokens`, and `Est. API Cost` cards. The existing `Error rate` and `Account burn projection` cards stay unchanged.
+
+There is no persisted history-completeness marker in the current model. The only available proxy for whether the previous window fully exists is request-log coverage. Because the summary cards already exclude warmup rows, the comparison logic must use the same eligible request-log population.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Extend the dashboard overview response with enough data to compare current and previous windows for requests, tokens, and estimated API cost.
+- Make the previous-window comparison honor the selected dashboard timeframe: `1d`, `7d`, or `30d`.
+- Hide the comparison when the previous window is not fully covered by available eligible request-log history.
+- Render compact up/down percentage indicators on the existing three summary cards using the project's established `emerald` positive styling and `red` negative styling.
+- Keep the implementation local to the current dashboard overview path without adding a new endpoint.
+
+**Non-Goals:**
+
+- Changing the meaning, ordering, or visibility of the existing summary cards beyond the new comparison indicator.
+- Adding comparison indicators to `Error rate` or `Account burn projection`.
+- Reworking the dashboard trends payload or the sparkline charts.
+- Introducing a historical backfill marker, migration, or new persistence model.
+
+## Decisions
+
+### 1. Extend the existing overview response instead of adding a new API
+
+The comparison data will be added to the existing `summary` payload returned by `GET /api/dashboard/overview`.
+
+Proposed shape:
+
+```json
+{
+  "summary": {
+    "metrics": {
+      "requests": 1500,
+      "tokens": 420000,
+      "cachedInputTokens": 80000,
+      "errorRate": 0.02,
+      "errorCount": 30,
+      "topError": "rate_limit_exceeded"
+    },
+    "cost": {
+      "currency": "USD",
+      "totalUsd": 12.34
+    },
+    "comparison": {
+      "canCompare": true,
+      "previous": {
+        "requests": 1000,
+        "tokens": 300000,
+        "costUsd": 8.0
+      }
+    }
+  }
+}
+```
+
+Rationale:
+
+- The dashboard already requests all top-card data from one overview query.
+- A single payload keeps the comparison aligned with the same timeframe and refresh cycle as the current totals.
+- This is the smallest schema change that can support the frontend without inventing a second request path.
+
+Alternatives considered:
+
+- Compute comparison entirely in the frontend from existing trends: rejected because the current API only exposes current-window buckets, not the previous-window totals or completeness signal.
+- Add a new `/api/dashboard/comparison` endpoint: rejected because it adds request coordination and cache complexity for a narrow extension to the existing overview.
+
+### 2. Use a backend range-based activity aggregate for both current and previous windows
+
+The backend will introduce a range-based request-log aggregation helper that can summarize eligible rows inside `[since, until)` windows. `DashboardService.get_overview()` will compute:
+
+- current window: `[now - timeframe.window_minutes, now]`
+- previous window: `[now - 2 * timeframe.window_minutes, now - timeframe.window_minutes]`
+
+The current summary metrics and previous summary metrics will both come from the same aggregation primitive so the counts and token totals stay consistent.
+
+Rationale:
+
+- The current implementation uses `aggregate_activity_since(since)` for the current window only.
+- Previous-window comparison requires a bounded interval, not an open-ended lower bound.
+- Using one bounded aggregation style for both windows avoids off-by-one behavior between the displayed current total and the comparison baseline.
+
+Alternatives considered:
+
+- Keep `aggregate_activity_since()` for current and add a separate previous-window helper: possible, but it increases the chance of drifting query semantics.
+
+### 3. Determine comparison eligibility conservatively from earliest eligible request-log coverage
+
+The API will only set `canCompare: true` when the request-log history proves the previous window is fully covered. The conservative rule is:
+
+- find the earliest eligible request-log timestamp from the same population used by the summary cards
+- if that timestamp is at or before `previous_window_start`, the previous window is considered fully covered
+- otherwise, `canCompare` is false and the frontend renders no delta
+
+Rationale:
+
+- The user explicitly asked to suppress comparison when the previous window is shorter than the selected cycle, such as only 5 days of data for a 7-day window.
+- The current system does not store a better completeness marker.
+- A conservative rule avoids presenting a misleading percentage derived from partial history.
+
+Trade-off:
+
+- If the system had a full previous window but no requests during its early portion, this rule will still suppress the comparison because coverage cannot be proven from the available data. That is acceptable for this change because hiding the delta is safer than showing a potentially false one.
+
+### 4. Return previous totals, but calculate displayed percent in the frontend
+
+The backend will return previous raw totals and the `canCompare` flag. The frontend will calculate the displayed percentage for each of the three cards using a small helper in the dashboard feature.
+
+Display rule:
+
+- change percent = `((current - previous) / previous) * 100`
+- positive result renders `▲ <rounded>%`
+- negative result renders `▼ <rounded>%`
+- zero result renders a neutral `0%` indicator or an unsigned compact label, depending on what matches the existing card layout most cleanly during implementation
+- if `previous <= 0` or `canCompare` is false, render no indicator
+
+Rationale:
+
+- Raw previous totals are generally useful response data; arrow glyphs and display rounding are UI concerns.
+- Keeping the percent formatting in the frontend lets the stat-card renderer control compact presentation.
+- Hiding the indicator when `previous <= 0` avoids undefined or misleading percentage math.
+
+Alternatives considered:
+
+- Precompute percentage deltas in the backend: valid, but it couples API shape to card-specific presentation and still leaves the frontend deciding arrow, sign, and styling.
+
+### 5. Reuse established success/failure text styles for the delta indicator
+
+The delta indicator will use the same general semantic colors already present in the frontend:
+
+- positive: `text-emerald-600 dark:text-emerald-400`
+- negative: `text-red-600 dark:text-red-400`
+
+The indicator will live inside the existing stat-card metadata area so the card layout remains compact and stable.
+
+Rationale:
+
+- These classes are already used in dashboard and related account surfaces for positive/negative state.
+- Reusing them keeps the new indicator visually consistent with the rest of the product.
+
+Alternatives considered:
+
+- Introduce a custom comparison badge palette: rejected as unnecessary for a simple inline indicator.
+
+### 6. Keep `top_error` and current trend data based on the current window only
+
+Only the three top-card comparison metrics gain previous-window data. The existing `top_error` lookup and current-window sparkline trends remain unchanged.
+
+Rationale:
+
+- This preserves the current meaning of the non-comparison cards and avoids broadening the scope into comparative error analytics.
+- The user explicitly limited the change to the three existing summary cards.
+
+## Risks / Trade-offs
+
+- [Partial-history detection is conservative] -> Use earliest eligible request-log coverage as an explicit safety gate and document that the UI hides comparison when full coverage cannot be proven.
+- [Extra dashboard query work] -> Limit the backend change to two bounded aggregates plus one earliest-timestamp lookup, all against the same request-log dataset already queried for overview metrics.
+- [Schema drift between backend and frontend] -> Add backend schema tests and frontend zod/schema tests for the new optional `summary.comparison` contract.
+- [Percent display edge cases around zero] -> Treat `previous <= 0` as non-comparable and hide the indicator instead of inventing infinity or 100%-from-zero behavior.
+
+## Migration Plan
+
+No database migration is required.
+
+Rollout plan:
+
+1. Extend backend aggregation and response schemas with the optional comparison block.
+2. Add frontend parsing and rendering for the three existing summary cards.
+3. Verify that older states without comparison data degrade cleanly by rendering no indicator.
+
+Rollback plan:
+
+- Revert the comparison block population in the backend and the frontend indicator rendering. Because the new fields are additive and optional, rollback does not require data cleanup.
+
+## Open Questions
+
+None for the current scope. The design fixes the conservative completeness rule and the `previous <= 0` handling so implementation can proceed without another behavior decision.

--- a/openspec/changes/add-dashboard-summary-window-deltas/proposal.md
+++ b/openspec/changes/add-dashboard-summary-window-deltas/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The dashboard overview shows current-window totals for Requests, Tokens, and Est. API Cost, but operators cannot quickly tell whether usage is rising or falling relative to the immediately preceding equivalent window. Adding a previous-window percentage delta makes the existing summary cards more actionable while keeping the comparison aligned with the selected `1d`, `7d`, or `30d` timeframe.
+
+## What Changes
+
+- Extend the dashboard overview contract so the summary metrics include previous-window totals for requests, tokens, and estimated API cost.
+- Define when previous-window comparison is allowed: only when the preceding window is fully covered by available request-log history for the selected timeframe.
+- Update the dashboard summary cards to render percentage-change indicators for Requests, Tokens, and Est. API Cost, using the project's established positive/negative color semantics and hiding the indicator when comparison is unavailable.
+- Leave Error rate and Account burn projection unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: The dashboard overview requirements will expand to cover previous-window comparison data and rendering rules for the existing Requests, Tokens, and Est. API Cost cards.
+
+## Impact
+
+- Backend overview aggregation in `app/modules/dashboard/` and request-log aggregation in `app/modules/request_logs/`
+- Dashboard overview API response for `GET /api/dashboard/overview`
+- Frontend dashboard schemas, view-model building, and summary-card rendering in `frontend/src/features/dashboard/`
+- Backend and frontend tests covering previous-window completeness and delta rendering

--- a/openspec/changes/add-dashboard-summary-window-deltas/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-dashboard-summary-window-deltas/specs/frontend-architecture/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Dashboard overview summary cards show previous-window usage deltas
+
+The dashboard overview API SHALL expose previous-window comparison data for the existing `Requests`, `Tokens`, and `Est. API Cost` summary cards returned by `GET /api/dashboard/overview`. The comparison SHALL be tied to the selected overview timeframe so that `1d` compares the current 1-day window with the immediately preceding 1-day window, `7d` compares the current 7-day window with the immediately preceding 7-day window, and `30d` compares the current 30-day window with the immediately preceding 30-day window.
+
+The overview response SHALL include a comparison block that exposes whether previous-window comparison is allowed and the previous-window totals for requests, tokens, and estimated API cost. The dashboard SHALL use that block to render a compact percentage-change indicator on the existing `Requests`, `Tokens`, and `Est. API Cost` cards only. The dashboard MUST NOT add this indicator to `Error rate` or `Account burn projection`.
+
+If the immediately preceding window is not fully covered by eligible request-log history for the selected timeframe, the overview response SHALL mark the comparison as unavailable and the dashboard SHALL hide the percentage-change indicator for those cards.
+
+If previous-window comparison is available and the previous total for a card is greater than zero, the dashboard SHALL calculate the displayed change from the current total relative to the previous total, SHALL show increases with an upward indicator using the project's positive `emerald` styling, and SHALL show decreases with a downward indicator using the project's negative `red` styling.
+
+#### Scenario: Daily overview renders increase from previous window
+
+- **WHEN** `GET /api/dashboard/overview?timeframe=1d` returns current totals for requests, tokens, and estimated API cost plus comparison data with `canCompare: true`
+- **AND** the previous-window totals are lower than the current-window totals
+- **THEN** the dashboard renders percentage-change indicators on the `Requests`, `Tokens`, and `Est. API Cost` cards
+- **AND** each increase uses an upward indicator with positive `emerald` styling
+
+#### Scenario: Weekly overview renders decrease from previous window
+
+- **WHEN** `GET /api/dashboard/overview?timeframe=7d` returns comparison data with `canCompare: true`
+- **AND** at least one of the previous-window totals for requests, tokens, or estimated API cost is higher than the current-window total for that same card
+- **THEN** the dashboard renders a downward percentage-change indicator for that card
+- **AND** that decrease uses negative `red` styling
+
+#### Scenario: Partial previous window suppresses comparison
+
+- **WHEN** `GET /api/dashboard/overview?timeframe=7d` or `GET /api/dashboard/overview?timeframe=30d` cannot prove the immediately preceding same-length window is fully covered by eligible request-log history
+- **THEN** the overview response marks the comparison as unavailable
+- **AND** the dashboard does not render percentage-change indicators on the `Requests`, `Tokens`, or `Est. API Cost` cards
+
+#### Scenario: Non-comparison cards remain unchanged
+
+- **WHEN** the dashboard renders overview cards from `GET /api/dashboard/overview` with or without comparison data
+- **THEN** `Error rate` and `Account burn projection` do not render previous-window percentage-change indicators

--- a/openspec/changes/add-dashboard-summary-window-deltas/tasks.md
+++ b/openspec/changes/add-dashboard-summary-window-deltas/tasks.md
@@ -1,0 +1,23 @@
+## 1. Backend comparison aggregation
+
+- [x] 1.1 Add bounded request-log aggregation support for eligible dashboard summary rows so the service can compute current-window and previous-window totals with the same query semantics.
+- [x] 1.2 Add earliest eligible request-log coverage lookup so the dashboard service can determine whether the previous same-length window is fully covered.
+- [x] 1.3 Update `DashboardService.get_overview()` to compute previous-window requests, tokens, and estimated API cost totals for `1d`, `7d`, and `30d`, and suppress comparison when coverage is incomplete.
+
+## 2. Overview API and frontend schema wiring
+
+- [x] 2.1 Extend backend dashboard overview schemas to expose an optional comparison block with `canCompare` and previous totals for requests, tokens, and cost.
+- [x] 2.2 Extend frontend dashboard zod schemas and types to parse the new overview comparison block without breaking older responses that omit it.
+- [x] 2.3 Update dashboard view-model helpers to derive per-card comparison display data only for `Requests`, `Tokens`, and `Est. API Cost`.
+
+## 3. Dashboard summary card rendering
+
+- [x] 3.1 Extend the stats-grid card data model to carry an optional comparison indicator alongside existing value and meta text.
+- [x] 3.2 Render compact previous-window percentage indicators on the `Requests`, `Tokens`, and `Est. API Cost` cards using existing positive `emerald` and negative `red` semantics.
+- [x] 3.3 Keep `Error rate` and `Account burn projection` unchanged, and hide comparison indicators when `canCompare` is false or the previous total is zero or missing.
+
+## 4. Regression coverage and validation
+
+- [x] 4.1 Add backend tests covering previous-window totals, incomplete previous-window suppression, and zero-or-missing previous totals.
+- [x] 4.2 Add frontend tests covering schema parsing and stat-card rendering for increase, decrease, and hidden-comparison states.
+- [x] 4.3 Run targeted frontend and backend test commands plus `openspec validate add-dashboard-summary-window-deltas --strict` and record any follow-up fixes needed before implementation is considered complete.

--- a/openspec/changes/simplify-dashboard-cost-card-meta/.openspec.yaml
+++ b/openspec/changes/simplify-dashboard-cost-card-meta/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/simplify-dashboard-cost-card-meta/design.md
+++ b/openspec/changes/simplify-dashboard-cost-card-meta/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The dashboard top stats grid builds its card metadata in `frontend/src/features/dashboard/utils.ts`. For the `Est. API Cost` card, the current meta line starts with the average cost for the selected timeframe and then appends both `API estimate` and the cached-token count when cached input exists.
+
+The title already communicates that the metric is estimated, and cached-token volume is already represented on the Tokens card. This change is limited to the frontend display text for the existing cost card.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the `Est. API Cost` card meta line show only the averaged cost string.
+- Preserve the existing title, total value, timeframe behavior, and comparison indicator.
+- Keep the change frontend-only and covered by a focused regression test.
+
+**Non-Goals:**
+
+- Changing how total cost is calculated or sourced.
+- Changing the Tokens card cached-token metadata.
+- Adding new API fields, tooltips, or alternate labels.
+
+## Decisions
+
+### 1. Replace the cost-card meta formatter with the average-cost string directly
+
+The card will reuse the existing `costAverage` string as the full meta line, with no additional suffix.
+
+Rationale:
+
+- This is the smallest implementation change.
+- It removes both redundant phrases in one place.
+- It does not require backend schema or API updates.
+
+Alternative considered:
+
+- Keep `API estimate` while removing cached tokens: rejected because the title already carries the estimate qualifier.
+
+### 2. Keep cached-token context on the Tokens card only
+
+The Tokens card will continue to surface cached-token count and percentage through `formatCachedTokensMeta`.
+
+Rationale:
+
+- Cached-token volume is token-specific metadata, not cost-specific metadata in the current overview payload.
+- Restricting it to the Tokens card reduces duplication while keeping the information visible.
+
+### 3. Cover the behavior with an existing dashboard view-model test
+
+The regression test will stay in `frontend/src/features/dashboard/utils.test.ts`, where dashboard stat metadata is already asserted.
+
+Rationale:
+
+- The behavior is produced by the dashboard view-model builder, so that test file exercises the right level.
+- A focused assertion avoids unnecessary component-test churn.
+
+## Risks / Trade-offs
+
+- Removing `API estimate` makes the meta line less explicit about how the value is derived. → Mitigation: the card title remains `Est. API Cost`, so the estimate qualifier is still visible.
+- Future operators may want cost-specific cached-input detail. → Mitigation: add a dedicated cost field later if the backend starts exposing one; do not reuse token-count copy for that purpose.

--- a/openspec/changes/simplify-dashboard-cost-card-meta/proposal.md
+++ b/openspec/changes/simplify-dashboard-cost-card-meta/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The dashboard `Est. API Cost` card currently repeats two pieces of information in its meta line: the card title already says the value is estimated, and the cached-token count already appears on the Tokens card. That makes the cost card harder to scan without adding distinct cost-specific meaning.
+
+## What Changes
+
+- Update the dashboard overview `Est. API Cost` card meta text to show only the average cost for the selected timeframe.
+- Keep the existing card title, total value, and comparison indicator behavior unchanged.
+- Leave the Tokens card's cached-token metadata unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: The dashboard overview requirements will define the `Est. API Cost` card meta text as the averaged cost only, without repeating estimate wording or cached-token counts.
+
+## Impact
+
+- Frontend dashboard view-model formatting in `frontend/src/features/dashboard/utils.ts`
+- Frontend tests covering dashboard stat metadata in `frontend/src/features/dashboard/utils.test.ts`
+- Frontend architecture OpenSpec requirements for dashboard summary-card copy

--- a/openspec/changes/simplify-dashboard-cost-card-meta/specs/frontend-architecture/spec.md
+++ b/openspec/changes/simplify-dashboard-cost-card-meta/specs/frontend-architecture/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Dashboard estimated cost card meta avoids duplicate estimate and cache copy
+
+The dashboard overview `Est. API Cost` summary card SHALL render its meta text as only the averaged cost for the selected overview timeframe. The meta text MUST NOT append duplicate estimate wording or cached-token counts.
+
+#### Scenario: Weekly estimated cost card shows only average-per-day text
+
+- **WHEN** `GET /api/dashboard/overview?timeframe=7d` returns an `Est. API Cost` total and the summary metrics also include cached input tokens
+- **THEN** the dashboard renders the cost-card meta text as `Avg/day <currency value>`
+- **AND** the same meta text does not include `API estimate`
+- **AND** the same meta text does not include `cached`
+
+#### Scenario: Daily estimated cost card shows only average-per-hour text
+
+- **WHEN** `GET /api/dashboard/overview?timeframe=1d` returns an `Est. API Cost` total
+- **THEN** the dashboard renders the cost-card meta text as `Avg/hr <currency value>`
+- **AND** the same meta text does not include any extra suffix text

--- a/openspec/changes/simplify-dashboard-cost-card-meta/tasks.md
+++ b/openspec/changes/simplify-dashboard-cost-card-meta/tasks.md
@@ -1,0 +1,9 @@
+## 1. Dashboard cost-card meta copy
+
+- [x] 1.1 Add or update dashboard view-model tests to assert that the `Est. API Cost` card meta renders only the averaged cost text for daily and weekly timeframes.
+- [x] 1.2 Update `frontend/src/features/dashboard/utils.ts` so the cost-card meta reuses the existing average-cost string without appending `API estimate` or cached-token text.
+
+## 2. Validation
+
+- [x] 2.1 Run the targeted frontend dashboard tests.
+- [x] 2.2 Validate the OpenSpec change with `openspec validate simplify-dashboard-cost-card-meta --strict`.

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -714,3 +714,201 @@ async def test_dashboard_overview_summary_uses_exact_timeframe_even_when_trends_
     assert payload["summary"]["metrics"]["errorCount"] == 1
     assert payload["summary"]["metrics"]["topError"] == "rate_limit_exceeded"
     assert all(point["v"] == 0 for point in payload["trends"]["requests"])
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_includes_previous_window_summary_when_history_covers_full_cycle(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fixed_now = datetime(2026, 4, 3, 10, 37, 0)
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: fixed_now)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        logs_repo = RequestLogsRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_compare", "compare@example.com"))
+        await usage_repo.add_entry(
+            "acc_compare",
+            20.0,
+            window="primary",
+            recorded_at=fixed_now - timedelta(minutes=5),
+        )
+        await usage_repo.add_entry(
+            "acc_compare",
+            40.0,
+            window="secondary",
+            recorded_at=fixed_now - timedelta(minutes=2),
+        )
+        await logs_repo.add_log(
+            account_id="acc_compare",
+            request_id="req_compare_coverage",
+            model="gpt-5.1",
+            input_tokens=1,
+            output_tokens=0,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - timedelta(days=2, minutes=1),
+        )
+        await logs_repo.add_log(
+            account_id="acc_compare",
+            request_id="req_compare_previous",
+            model="gpt-5.1",
+            input_tokens=200,
+            output_tokens=100,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - timedelta(days=1, hours=1),
+        )
+        await logs_repo.add_log(
+            account_id="acc_compare",
+            request_id="req_compare_current",
+            model="gpt-5.1",
+            input_tokens=100,
+            output_tokens=50,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - timedelta(hours=2),
+        )
+
+    response = await async_client.get("/api/dashboard/overview?timeframe=1d")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["metrics"]["requests"] == 1
+    assert payload["summary"]["metrics"]["tokens"] == 150
+    assert payload["summary"]["comparison"] == {
+        "canCompare": True,
+        "previous": {
+            "requests": 1,
+            "tokens": 300,
+            "costUsd": pytest.approx(0.00125),
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_hides_previous_window_summary_when_history_does_not_cover_full_cycle(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fixed_now = datetime(2026, 4, 3, 10, 37, 0)
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: fixed_now)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        logs_repo = RequestLogsRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_partial_compare", "partial-compare@example.com"))
+        await usage_repo.add_entry(
+            "acc_partial_compare",
+            20.0,
+            window="primary",
+            recorded_at=fixed_now - timedelta(minutes=5),
+        )
+        await usage_repo.add_entry(
+            "acc_partial_compare",
+            40.0,
+            window="secondary",
+            recorded_at=fixed_now - timedelta(minutes=2),
+        )
+        await logs_repo.add_log(
+            account_id="acc_partial_compare",
+            request_id="req_partial_previous",
+            model="gpt-5.1",
+            input_tokens=200,
+            output_tokens=100,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - timedelta(days=1, hours=1),
+        )
+        await logs_repo.add_log(
+            account_id="acc_partial_compare",
+            request_id="req_partial_current",
+            model="gpt-5.1",
+            input_tokens=100,
+            output_tokens=50,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - timedelta(hours=2),
+        )
+
+    response = await async_client.get("/api/dashboard/overview?timeframe=1d")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["comparison"]["canCompare"] is False
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_exposes_zero_previous_window_totals_when_full_cycle_has_no_usage(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fixed_now = datetime(2026, 4, 3, 10, 37, 0)
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: fixed_now)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        logs_repo = RequestLogsRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_zero_compare", "zero-compare@example.com"))
+        await usage_repo.add_entry(
+            "acc_zero_compare",
+            20.0,
+            window="primary",
+            recorded_at=fixed_now - timedelta(minutes=5),
+        )
+        await usage_repo.add_entry(
+            "acc_zero_compare",
+            40.0,
+            window="secondary",
+            recorded_at=fixed_now - timedelta(minutes=2),
+        )
+        await logs_repo.add_log(
+            account_id="acc_zero_compare",
+            request_id="req_zero_coverage",
+            model="gpt-5.1",
+            input_tokens=1,
+            output_tokens=0,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - timedelta(days=2, minutes=1),
+        )
+        await logs_repo.add_log(
+            account_id="acc_zero_compare",
+            request_id="req_zero_current",
+            model="gpt-5.1",
+            input_tokens=100,
+            output_tokens=50,
+            latency_ms=50,
+            status="success",
+            error_code=None,
+            requested_at=fixed_now - timedelta(hours=2),
+        )
+
+    response = await async_client.get("/api/dashboard/overview?timeframe=1d")
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["comparison"] == {
+        "canCompare": True,
+        "previous": {
+            "requests": 0,
+            "tokens": 0,
+            "costUsd": 0.0,
+        },
+    }


### PR DESCRIPTION
## Summary

This PR makes the dashboard overview easier to scan by adding previous-window percentage deltas for Requests, Tokens, and Est. API Cost, and by adding a compact account availability summary to the Accounts header. It also simplifies the Est. API Cost card meta text so the card only shows the timeframe average instead of repeating estimate or cached-token details.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Part of it solves #958 

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/add-dashboard-summary-window-deltas/`, `openspec/changes/add-dashboard-account-summary-line/`, `openspec/changes/simplify-dashboard-cost-card-meta/`

## Changes

- Backend dashboard overview now returns optional previous-window comparison data for requests, tokens, and estimated cost, and only enables comparison when request-log history fully covers the prior equivalent window.
- Frontend dashboard summary cards now parse and render compact percentage deltas for Requests, Tokens, and Est. API Cost; Error rate and Account burn projection remain unchanged when comparison is unavailable.
- Added an `Accounts` header summary line showing registered, active, and unavailable counts, and simplified the Est. API Cost meta text to show only the average cost for the selected timeframe.
- Added and updated backend integration tests and frontend Vitest coverage for comparison eligibility, delta rendering, account summary counts, and cost-card meta formatting.

## Test plan

```
# bun run test src/features/dashboard/utils.test.ts src/features/dashboard/schemas.test.ts src/features/dashboard/components/stats-grid.test.tsx src/features/dashboard/components/account-summary-line.test.tsx src/features/dashboard/components/dashboard-page.test.tsx
# Test Files 5 passed (5); Tests 80 passed (80)

# bun run lint
# exit 0

# bun run typecheck
# exit 0

# make frontend-lint frontend-typecheck
# completed successfully

# uv run pytest tests/integration/test_dashboard_overview.py -q
# 19 passed in 2.45s

# openspec validate --specs
# Totals: 30 passed, 0 failed (30 items)

# openspec validate add-dashboard-summary-window-deltas --strict && openspec validate add-dashboard-account-summary-line --strict && openspec validate simplify-dashboard-cost-card-meta --strict
# Change 'add-dashboard-summary-window-deltas' is valid
# Change 'add-dashboard-account-summary-line' is valid
# Change 'simplify-dashboard-cost-card-meta' is valid
```

## Screenshots / output (optional)
<img width="1448" height="715" alt="螢幕截圖 2026-06-10 01 32 27" src="https://github.com/user-attachments/assets/bc3440d7-b986-4333-b151-7b12ac9370cc" />