### PR TITLE
fix(proxy): bridge codex compaction triggers

### DIFF
--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -79,6 +79,15 @@ class _CompactServiceProtocol(Protocol):
 
     async def _select_account_with_budget_compatible(self, deadline: float, **kwargs: object) -> AccountSelection: ...
 
+    async def _resolve_websocket_previous_response_owner(
+        self,
+        *,
+        previous_response_id: str | None,
+        api_key: ApiKeyData | None,
+        session_id: str | None = None,
+        surface: str,
+    ) -> str | None: ...
+
     async def _ensure_fresh_with_budget(
         self, account: Account, *, force: bool = False, timeout_seconds: float | None = None
     ) -> Account: ...
@@ -419,12 +428,46 @@ class _CompactMixin:
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)
+        previous_response_preferred_account_id: str | None = None
+        previous_response_lookup_session_id: str | None = None
+        if payload.previous_response_id is not None:
+            previous_response_lookup_session_id = _owner_lookup_session_id_from_headers(headers)
+            previous_response_preferred_account_id = await proxy._resolve_websocket_previous_response_owner(
+                previous_response_id=payload.previous_response_id,
+                api_key=api_key,
+                session_id=previous_response_lookup_session_id,
+                surface="compact",
+            )
+            if previous_response_preferred_account_id is None:
+                selection_inputs = await proxy._load_balancer._load_selection_inputs(
+                    model=payload.model,
+                    additional_limit_name=None,
+                    account_ids=None,
+                )
+                if len(selection_inputs.accounts) != 1:
+                    message = "Previous response owner account is unavailable; retry later."
+                    _record_continuity_fail_closed(
+                        surface="compact",
+                        reason="owner_account_unavailable",
+                        previous_response_id=payload.previous_response_id,
+                        session_id=previous_response_lookup_session_id,
+                        upstream_error_code="owner_lookup_miss",
+                    )
+                    raise ProxyResponseError(
+                        502,
+                        openai_error(
+                            "previous_response_owner_unavailable",
+                            message,
+                            error_type="server_error",
+                        ),
+                    )
+
         # ``input_file.file_id`` references must land on the account that
         # registered the upload (chatgpt-account-id-scoped). The helper
         # returns ``None`` when stronger affinity signals are present
         # (prompt_cache_key / session header / turn_state header /
         # previous_response_id), so existing routing wins.
-        file_preferred_account_id = rewritten_file_account_id
+        file_preferred_account_id = previous_response_preferred_account_id or rewritten_file_account_id
         if file_preferred_account_id is None:
             file_preferred_account_id = await proxy._resolve_file_account_for_responses(payload, headers)
         try:

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -444,7 +444,9 @@ class _CompactMixin:
                 selection_inputs = await proxy._load_balancer._load_selection_inputs(
                     model=payload.model,
                     additional_limit_name=None,
-                    account_ids=None,
+                    account_ids=api_key.assigned_account_ids
+                    if api_key is not None and api_key.account_assignment_scope_enabled
+                    else None,
                 )
                 if len(selection_inputs.accounts) != 1:
                     message = "Previous response owner account is unavailable; retry later."

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -428,12 +428,14 @@ class _CompactMixin:
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)
+        previous_response_id = getattr(payload, "previous_response_id", None)
         previous_response_preferred_account_id: str | None = None
         previous_response_lookup_session_id: str | None = None
-        if payload.previous_response_id is not None:
+        if isinstance(previous_response_id, str) and previous_response_id.strip():
+            previous_response_id = previous_response_id.strip()
             previous_response_lookup_session_id = _owner_lookup_session_id_from_headers(headers)
             previous_response_preferred_account_id = await proxy._resolve_websocket_previous_response_owner(
-                previous_response_id=payload.previous_response_id,
+                previous_response_id=previous_response_id,
                 api_key=api_key,
                 session_id=previous_response_lookup_session_id,
                 surface="compact",
@@ -449,7 +451,7 @@ class _CompactMixin:
                     _record_continuity_fail_closed(
                         surface="compact",
                         reason="owner_account_unavailable",
-                        previous_response_id=payload.previous_response_id,
+                        previous_response_id=previous_response_id,
                         session_id=previous_response_lookup_session_id,
                         upstream_error_code="owner_lookup_miss",
                     )

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2141,6 +2141,8 @@ async def _stream_responses(
         compact_payload_data["input"] = compact_trigger_input
         if payload.previous_response_id is not None:
             compact_payload_data["previous_response_id"] = payload.previous_response_id
+        if payload.conversation is not None:
+            compact_payload_data["conversation"] = payload.conversation
         compact_payload = ResponsesCompactRequest.model_validate(compact_payload_data)
         try:
             try:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -7,7 +7,8 @@ import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping
 from datetime import datetime, timezone
 from json import JSONDecodeError
-from typing import Final, Literal, cast
+from typing import Any, Final, Literal, cast
+from uuid import uuid4
 
 from fastapi import (
     APIRouter,
@@ -62,6 +63,7 @@ from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.images import V1ImageResponse, V1ImagesEditsForm, V1ImagesGenerationsRequest
 from app.core.openai.model_registry import UpstreamModel, get_model_registry, is_public_model
 from app.core.openai.models import (
+    CompactResponsePayload,
     CompactResponseResult,
     OpenAIError,
     OpenAIResponsePayload,
@@ -115,6 +117,7 @@ from app.modules.proxy.request_policy import (
     openai_client_payload_error,
     openai_validation_error,
     resolve_model_alias,
+    strip_terminal_compaction_trigger_input,
     validate_model_access,
 )
 from app.modules.proxy.schemas import (
@@ -2088,6 +2091,13 @@ async def _stream_responses(
     admission_denial = await _opportunistic_admission_denial(request, context, api_key, model=payload.model)
     if admission_denial is not None:
         return admission_denial
+    compact_trigger_input: list[JsonValue] | None = None
+    if codex_session_affinity:
+        try:
+            compact_trigger_input = strip_terminal_compaction_trigger_input(payload)
+        except ClientPayloadError as exc:
+            error = openai_client_payload_error(exc)
+            return _logged_error_json_response(request, 400, error)
     owns_reservation = api_key_reservation_override is None
     reservation = (
         api_key_reservation_override
@@ -2115,6 +2125,73 @@ async def _stream_responses(
         if downstream_turn_state is not None
         else {}
     )
+    if compact_trigger_input is not None:
+        compact_payload = ResponsesCompactRequest(
+            model=payload.model,
+            instructions=payload.instructions,
+            input=compact_trigger_input,
+            reasoning=payload.reasoning,
+            store=payload.store,
+            service_tier=payload.service_tier,
+            prompt_cache_key=payload.prompt_cache_key,
+        )
+        try:
+            try:
+                compact_result = await context.service.compact_responses(
+                    compact_payload,
+                    effective_headers,
+                    codex_session_affinity=codex_session_affinity,
+                    openai_cache_affinity=openai_cache_affinity,
+                    api_key=api_key,
+                    api_key_reservation=reservation,
+                )
+            except NotImplementedError:
+                error = OpenAIErrorEnvelopeModel(
+                    error=OpenAIError(
+                        message="responses/compact is not implemented",
+                        type="server_error",
+                        code="not_implemented",
+                    )
+                )
+                return _logged_error_json_response(
+                    request,
+                    501,
+                    error.model_dump(mode="json", exclude_none=True),
+                    headers=rate_limit_headers,
+                )
+            except ProxyResponseError as exc:
+                return _stream_startup_error_response(
+                    request,
+                    exc,
+                    headers=rate_limit_headers,
+                )
+            compact_item = _compact_response_output_item(compact_result)
+            if compact_item is None:
+                error = openai_error(
+                    "upstream_error",
+                    "Compact response did not include a compaction output item",
+                    error_type="server_error",
+                )
+                return _logged_error_json_response(request, 502, error, headers=rate_limit_headers)
+            response_id = _compact_response_id(compact_result)
+            stream = _synthetic_compaction_response_stream(
+                compact_item,
+                response_id=response_id,
+                usage=compact_result.usage,
+            )
+            return StreamingResponse(
+                stream,
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache, no-transform",
+                    "X-Accel-Buffering": "no",
+                    **turn_state_headers,
+                    **rate_limit_headers,
+                },
+            )
+        finally:
+            if owns_reservation:
+                await _release_reservation(reservation)
     payload.stream = True
     if prefer_http_bridge:
         stream = context.service.stream_http_responses(
@@ -2387,6 +2464,88 @@ async def _compact_responses(
         content=result.model_dump(mode="json", exclude_none=True),
         headers=rate_limit_headers,
     )
+
+
+def _compact_response_output_item(payload: CompactResponsePayload) -> dict[str, JsonValue] | None:
+    extra = payload.model_extra or {}
+    output = getattr(payload, "output", None)
+    if output is None:
+        output = extra.get("output")
+    if isinstance(output, list):
+        for raw_item in output:
+            item = _json_mapping_from_model_or_mapping(raw_item)
+            if item is None:
+                continue
+            item_type = item.get("type")
+            encrypted_content = item.get("encrypted_content")
+            if isinstance(item_type, str) and item_type in {"compaction", "compaction_summary"}:
+                if isinstance(encrypted_content, str):
+                    return {
+                        "type": "compaction",
+                        "encrypted_content": encrypted_content,
+                    }
+    summary = getattr(payload, "compaction_summary", None)
+    if summary is None:
+        summary = extra.get("compaction_summary")
+    summary_mapping = _json_mapping_from_model_or_mapping(summary)
+    if summary_mapping is not None:
+        encrypted_content = summary_mapping.get("encrypted_content")
+        if isinstance(encrypted_content, str):
+            return {
+                "type": "compaction",
+                "encrypted_content": encrypted_content,
+            }
+    return None
+
+
+def _json_mapping_from_model_or_mapping(value: object) -> Mapping[str, JsonValue] | None:
+    if is_json_mapping(value):
+        return value
+    if hasattr(value, "model_dump"):
+        dumped = cast(Any, value).model_dump(mode="json", exclude_none=True)
+        if is_json_mapping(dumped):
+            return dumped
+    return None
+
+
+def _compact_response_id(payload: CompactResponsePayload) -> str:
+    if payload.id:
+        return payload.id
+    request_id = get_request_id()
+    if request_id:
+        return f"resp_{request_id}"
+    return f"resp_{uuid4().hex}"
+
+
+async def _synthetic_compaction_response_stream(
+    compact_item: Mapping[str, JsonValue],
+    *,
+    response_id: str,
+    usage: object | None,
+) -> AsyncIterator[str]:
+    completed_response: dict[str, JsonValue] = {
+        "id": response_id,
+        "object": "response",
+        "status": "completed",
+        "output": [dict(compact_item)],
+    }
+    usage_mapping = _json_mapping_from_model_or_mapping(usage)
+    if usage_mapping is not None:
+        completed_response["usage"] = dict(usage_mapping)
+    yield format_sse_event(
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": dict(compact_item),
+        }
+    )
+    yield format_sse_event(
+        {
+            "type": "response.completed",
+            "response": completed_response,
+        }
+    )
+    yield "data: [DONE]\n\n"
 
 
 async def _transcribe_request(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2126,8 +2126,21 @@ async def _stream_responses(
         else {}
     )
     if compact_trigger_input is not None:
-        compact_payload_data = payload.model_dump(mode="json", exclude_none=True)
+        compact_payload_data = payload.model_dump(
+            mode="json",
+            include={
+                "model",
+                "instructions",
+                "reasoning",
+                "store",
+                "service_tier",
+                "prompt_cache_key",
+            },
+            exclude_none=True,
+        )
         compact_payload_data["input"] = compact_trigger_input
+        if payload.previous_response_id is not None:
+            compact_payload_data["previous_response_id"] = payload.previous_response_id
         compact_payload = ResponsesCompactRequest.model_validate(compact_payload_data)
         try:
             try:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2138,6 +2138,10 @@ async def _stream_responses(
             },
             exclude_none=True,
         )
+        if isinstance(payload.model_extra, dict):
+            prompt_cache_key_alias = payload.model_extra.get("promptCacheKey")
+            if isinstance(prompt_cache_key_alias, str) and "prompt_cache_key" not in compact_payload_data:
+                compact_payload_data["prompt_cache_key"] = prompt_cache_key_alias
         compact_payload_data["input"] = compact_trigger_input
         if payload.previous_response_id is not None:
             compact_payload_data["previous_response_id"] = payload.previous_response_id

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2126,15 +2126,9 @@ async def _stream_responses(
         else {}
     )
     if compact_trigger_input is not None:
-        compact_payload = ResponsesCompactRequest(
-            model=payload.model,
-            instructions=payload.instructions,
-            input=compact_trigger_input,
-            reasoning=payload.reasoning,
-            store=payload.store,
-            service_tier=payload.service_tier,
-            prompt_cache_key=payload.prompt_cache_key,
-        )
+        compact_payload_data = payload.model_dump(mode="json", exclude_none=True)
+        compact_payload_data["input"] = compact_trigger_input
+        compact_payload = ResponsesCompactRequest.model_validate(compact_payload_data)
         try:
             try:
                 compact_result = await context.service.compact_responses(

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -15,6 +15,7 @@ from app.core.openai.strict_schema import (
 )
 from app.core.openai.v1_requests import V1ResponsesRequest
 from app.core.types import JsonValue
+from app.core.utils.json_guards import is_json_list, is_json_mapping
 from app.core.utils.request_id import get_request_id
 from app.modules.api_keys.service import ApiKeyData
 
@@ -360,6 +361,34 @@ def normalize_responses_request_payload(
     enforce_strict_text_format(responses)
     enforce_strict_function_tools_format(responses.tools)
     return responses
+
+
+def strip_terminal_compaction_trigger_input(payload: ResponsesRequest) -> list[JsonValue] | None:
+    input_value = payload.input
+    if not is_json_list(input_value):
+        return None
+
+    stripped_input: list[JsonValue] = []
+    trigger_seen = False
+    last_index = len(input_value) - 1
+
+    for index, item in enumerate(input_value):
+        if not (is_json_mapping(item) and item.get("type") == "compaction_trigger"):
+            stripped_input.append(item)
+            continue
+
+        if trigger_seen or index != last_index:
+            raise ClientPayloadError(
+                "compaction_trigger must appear exactly once as the final top-level input item",
+                param="input",
+                code="invalid_request_error",
+                error_type="invalid_request_error",
+            )
+        trigger_seen = True
+
+    if not trigger_seen:
+        return None
+    return stripped_input
 
 
 def enforce_strict_text_format(request: ResponsesRequest) -> None:

--- a/openspec/changes/bridge-codex-compaction-trigger/.openspec.yaml
+++ b/openspec/changes/bridge-codex-compaction-trigger/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/bridge-codex-compaction-trigger/design.md
+++ b/openspec/changes/bridge-codex-compaction-trigger/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Codex remote compaction v2 now appends a terminal `compaction_trigger` item to a normal `POST /backend-api/codex/responses` turn. The current proxy forwards that item as ordinary Responses input, which leaves the downstream compact collector with no `response.output_item.done` compaction item and causes the client-side remote compaction loop to fail.
+
+The repo already has a working `/responses/compact` path that can fetch the compact summary from upstream and already has request normalization, OpenAI error envelopes, and SSE helpers. The missing piece is a Codex-route bridge that recognizes the trigger and emits the raw SSE shape the client expects.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect a terminal top-level `compaction_trigger` on `/backend-api/codex/responses`.
+- Fail closed when a present trigger is duplicated or not final.
+- Reuse the existing compact service path instead of building a second compaction implementation.
+- Emit a raw SSE sequence that contains exactly one compaction output item and a terminal completion event.
+- Leave `/responses/compact` and public `/v1/responses` behavior unchanged.
+
+**Non-Goals:**
+- Redesign the Codex compaction protocol.
+- Change dashboard state, account routing, or compact persistence.
+- Add new upstream dependencies.
+- Alter the public OpenAI SSE contract for `/v1/responses`.
+
+## Decisions
+
+1. Add a small request-policy helper that strips a terminal top-level `compaction_trigger` from a `ResponsesRequest` input list and raises an OpenAI-shaped client payload error when placement is invalid.
+   - Rationale: request normalization already lives in the request-policy layer, and this keeps validation close to the existing payload rules.
+   - Alternative considered: detect the trigger inline in the route handler. Rejected because it would duplicate validation logic and make the request contract harder to test in isolation.
+
+2. Special-case the Codex stream path inside `_stream_responses` only when `codex_session_affinity` is enabled.
+   - Rationale: the behavior is specific to backend Codex turns, not public `/v1/responses`.
+   - Alternative considered: add a separate route or move the branch into the service layer. Rejected because the route already owns the stream shaping and header plumbing.
+
+3. Call the existing compact service and then synthesize a short SSE stream from the compact result.
+   - Rationale: the compact service already handles account selection, retries, and direct upstream compact transport. The bridge only needs to translate the compact result into the Codex stream shape.
+   - The synthetic stream should emit one `response.output_item.done` event containing a `compaction` item, then a `response.completed` event whose `response.output` contains the same single item, then `[DONE]`.
+   - The synthetic response id should reuse the compact result id when present and otherwise fall back to the current request id.
+   - Alternative considered: forward the trigger to upstream `/responses` and hope the model emits the right item. Rejected because the current failure shows that path returns no compaction output item.
+
+4. Normalize the compact result into a single compaction item by preferring an explicit `output` item when present and otherwise deriving one from `compaction_summary.encrypted_content`.
+   - Rationale: upstream compact payloads have varied slightly, but the Codex client only needs one canonical `compaction` item.
+   - Alternative considered: accept any upstream shape and forward it as-is. Rejected because the downstream collector requires a single compaction output item.
+
+5. Keep the bridge narrow.
+   - `/responses/compact` remains unchanged.
+   - `/v1/responses` remains unchanged.
+   - The raw Codex route continues to bypass the public OpenAI SDK stream normalizer.
+
+## Risks / Trade-offs
+
+- [Risk] The compact result shape may drift and stop exposing either `output` or `compaction_summary`.
+  - Mitigation: derive the stream item from both sources, prefer the canonical compact item shape, and add regression tests around the current result payload shape.
+
+- [Risk] A synthetic response id derived from the request id is not the same as a true upstream response id.
+  - Mitigation: only use the synthetic id when the compact result does not already provide one, and keep the raw Codex route behavior isolated from the public SDK contract.
+
+- [Risk] Rejecting malformed trigger placement could surface new 400s for future client variants.
+  - Mitigation: keep the validator narrow and targeted to top-level `compaction_trigger` placement, which is the only shape currently exercised by the Codex client.
+
+## Migration Plan
+
+No schema or data migration is required. Ship the validator and bridge together, verify the Codex stream regression tests, and roll back by reverting the route and request-policy changes if the synthetic compaction stream proves incompatible.
+
+## Open Questions
+
+- Should the synthetic Codex compaction stream ever include `response.output_item.added`, or is `response.output_item.done` plus `response.completed` sufficient for every current client?
+- If upstream compact payloads begin returning additional output items, should the bridge preserve them or continue to enforce a single compaction item?

--- a/openspec/changes/bridge-codex-compaction-trigger/proposal.md
+++ b/openspec/changes/bridge-codex-compaction-trigger/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Codex clients now send a terminal `compaction_trigger` item on normal `/backend-api/codex/responses` turns when they want remote compaction. codex-lb currently forwards that item as ordinary Responses input, which leaves the downstream compact flow with no compaction output item and can trap the client in a failed retry loop.
+
+## What Changes
+
+- Detect a terminal top-level `compaction_trigger` item on `/backend-api/codex/responses`.
+- Strip the trigger before calling upstream compact handling, then synthesize the raw SSE response Codex expects: one compaction output item followed by terminal completion.
+- When a request includes `compaction_trigger`, reject malformed placement where it is duplicated or not the final top-level input item with a 400 OpenAI error.
+- Keep the existing `/responses/compact` endpoint unchanged for direct compact callers.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `responses-api-compat`: Codex responses turns gain explicit compaction-trigger handling and fail-closed validation for malformed trigger placement.
+
+## Impact
+
+- `app/modules/proxy/api.py`
+- `app/modules/proxy/request_policy.py`
+- streaming regression tests for Codex responses
+- OpenSpec spec and task artifacts for `responses-api-compat`

--- a/openspec/changes/bridge-codex-compaction-trigger/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bridge-codex-compaction-trigger/specs/responses-api-compat/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Codex compaction triggers are bridged into compact output
+
+When `POST /backend-api/codex/responses` receives a request whose top-level `input` array contains exactly one `{"type":"compaction_trigger"}` item as its final element, the proxy SHALL remove that trigger before calling upstream compaction handling and SHALL emit a raw SSE stream that contains exactly one compaction output item.
+
+The stream MUST include a `response.output_item.done` event whose `item` is a `compaction` record, and the terminal `response.completed` event MUST carry the same single compaction item in `response.output`.
+
+The standalone `/responses/compact` endpoint is unchanged by this requirement.
+
+#### Scenario: terminal trigger is converted into a compact stream
+- **WHEN** a `POST /backend-api/codex/responses` request ends with exactly one top-level `compaction_trigger`
+- **THEN** the proxy strips the trigger, invokes compact handling, and streams one `response.output_item.done` event containing a `compaction` item
+- **AND** the terminal `response.completed` event carries that same item in `response.output`
+
+#### Scenario: malformed trigger placement is rejected
+- **WHEN** a `POST /backend-api/codex/responses` request contains a duplicated or non-terminal top-level `compaction_trigger` item
+- **THEN** the proxy returns HTTP 400 with `invalid_request_error`
+- **AND** it does not attempt upstream compaction handling

--- a/openspec/changes/bridge-codex-compaction-trigger/tasks.md
+++ b/openspec/changes/bridge-codex-compaction-trigger/tasks.md
@@ -1,0 +1,13 @@
+## 1. Bridge the trigger
+
+- [x] 1.1 Add a request-policy helper that strips a terminal top-level `compaction_trigger` from a `ResponsesRequest` input list and rejects malformed placement with an OpenAI-shaped 400.
+- [x] 1.2 Teach `/backend-api/codex/responses` to detect that helper result, call the existing compact service instead of the normal streaming path, and synthesize the raw SSE compaction stream from the compact result.
+
+## 2. Cover the regressions
+
+- [x] 2.1 Add a streaming integration test that verifies a valid terminal `compaction_trigger` yields exactly one `response.output_item.done` compaction item and a terminal `response.completed` event with the same item in `output`.
+- [x] 2.2 Add a 400 regression test for malformed trigger placement, including duplicated and non-terminal trigger items.
+
+## 3. Validate the change
+
+- [x] 3.1 Run the focused OpenSpec validation and targeted proxy tests for the new bridge path.

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -13,6 +13,7 @@ import app.core.clients.proxy as proxy_client_module
 import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
 from app.core.config.settings import Settings
+from app.core.openai.models import CompactResponsePayload
 from app.db.models import Account, DashboardSettings, RequestLog
 from app.db.session import SessionLocal
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -216,6 +217,102 @@ async def test_proxy_responses_repeated_401_after_refresh_fails_over(async_clien
     assert event["response"]["id"] == "resp_stream_failover"
     assert captured_account_ids[0] == invalidated_account_id
     assert captured_account_ids[1] != invalidated_account_id
+
+
+@pytest.mark.asyncio
+async def test_proxy_responses_compaction_trigger_streams_single_compaction_item(async_client, monkeypatch):
+    email = "compact-trigger@example.com"
+    raw_account_id = "acc_compact_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_compact(payload, headers, access_token, account_id, **kwargs):
+        del headers, access_token, account_id, kwargs
+        seen_payload["input"] = payload.input
+        seen_payload["model"] = payload.model
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "compaction_summary": {
+                    "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
+                    "summary_text": "condensed thread state",
+                },
+                "usage": {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15},
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "compact this turn",
+        "input": [
+            {"role": "user", "content": "hello"},
+            {"type": "compaction_trigger"},
+        ],
+        "stream": True,
+    }
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = list(_iter_sse_events(lines))
+    assert [event["type"] for event in events] == ["response.output_item.done", "response.completed"]
+    assert seen_payload["model"] == "gpt-5.1"
+    assert seen_payload["input"] == [{"role": "user", "content": "hello"}]
+    assert events[0]["item"] == {
+        "type": "compaction",
+        "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
+    }
+    assert events[1]["response"]["output"] == [
+        {
+            "type": "compaction",
+            "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
+        }
+    ]
+    assert events[1]["response"]["usage"] == {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15}
+    assert lines[-1] == "data: [DONE]"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "input_items",
+    [
+        [{"type": "compaction_trigger"}, {"role": "user", "content": "hello"}],
+        [{"role": "user", "content": "hello"}, {"type": "compaction_trigger"}, {"type": "compaction_trigger"}],
+    ],
+)
+async def test_proxy_responses_rejects_malformed_compaction_trigger(async_client, monkeypatch, input_items):
+    email = "compact-trigger-invalid@example.com"
+    raw_account_id = "acc_compact_trigger_invalid"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_compact(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("compact should not be called for malformed compaction_trigger placement")
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "compact this turn",
+        "input": input_items,
+        "stream": True,
+    }
+    response = await async_client.post("/backend-api/codex/responses", json=payload)
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["code"] == "invalid_request_error"
+    assert body["error"]["param"] == "input"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -228,13 +228,48 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
     response = await async_client.post("/api/accounts/import", files=files)
     assert response.status_code == 200
 
+    other_email = "compact-trigger-other@example.com"
+    other_raw_account_id = "acc_compact_trigger_other"
+    other_auth_json = _make_auth_json(other_raw_account_id, other_email)
+    other_files = {"auth_json": ("auth.json", json.dumps(other_auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=other_files)
+    assert response.status_code == 200
+
+    async with SessionLocal() as session:
+        accounts = {
+            account.chatgpt_account_id: account
+            for account in (await session.execute(select(Account))).scalars().all()
+            if account.chatgpt_account_id in {raw_account_id, other_raw_account_id}
+        }
+        owner_account = accounts[raw_account_id]
+        session.add(
+            RequestLog(
+                account_id=owner_account.id,
+                session_id="sid_compact_trigger",
+                request_id="resp_compact_anchor",
+                request_kind="response_create",
+                model="gpt-5.1",
+                status="success",
+            )
+        )
+        await session.commit()
+
     seen_payload: dict[str, object] = {}
+    selection_preferred_ids: list[str | None] = []
+
+    async def fake_select_account(self, deadline: float, **kwargs):
+        del self, deadline
+        preferred_account_id = cast(str | None, kwargs.get("preferred_account_id"))
+        selection_preferred_ids.append(preferred_account_id)
+        assert preferred_account_id == owner_account.id
+        return proxy_module.AccountSelection(account=owner_account, error_message=None, error_code=None)
 
     async def fake_compact(payload, headers, access_token, account_id, **kwargs):
-        del headers, access_token, account_id, kwargs
+        del headers, access_token, kwargs
         seen_payload["input"] = payload.input
         seen_payload["model"] = payload.model
         seen_payload["previous_response_id"] = getattr(payload, "previous_response_id", None)
+        seen_payload["account_id"] = account_id
         return CompactResponsePayload.model_validate(
             {
                 "object": "response.compaction",
@@ -246,6 +281,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
             }
         )
 
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget_compatible", fake_select_account)
     monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
 
     payload = {
@@ -258,15 +294,22 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
         "previous_response_id": "resp_compact_anchor",
         "stream": True,
     }
-    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"session_id": "sid_compact_trigger"},
+    ) as resp:
         assert resp.status_code == 200
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = list(_iter_sse_events(lines))
     assert [event["type"] for event in events] == ["response.output_item.done", "response.completed"]
+    assert selection_preferred_ids == [owner_account.id]
     assert seen_payload["model"] == "gpt-5.1"
     assert seen_payload["input"] == [{"role": "user", "content": "hello"}]
     assert seen_payload["previous_response_id"] == "resp_compact_anchor"
+    assert seen_payload["account_id"] == raw_account_id
     assert events[0]["item"] == {
         "type": "compaction",
         "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -271,6 +271,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
         seen_payload["input"] = payload.input
         seen_payload["model"] = payload.model
         seen_payload["previous_response_id"] = getattr(payload, "previous_response_id", None)
+        seen_payload["conversation"] = getattr(payload, "conversation", None)
         seen_payload["account_id"] = account_id
         return CompactResponsePayload.model_validate(
             {
@@ -328,6 +329,73 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
     ]
     assert events[1]["response"]["usage"] == {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15}
     assert lines[-1] == "data: [DONE]"
+
+
+@pytest.mark.asyncio
+async def test_proxy_responses_compaction_trigger_preserves_conversation(async_client, monkeypatch):
+    email = "compact-trigger-conversation@example.com"
+    raw_account_id = "acc_compact_trigger_conversation"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async with SessionLocal() as session:
+        owner_account = (
+            await session.execute(select(Account).where(Account.chatgpt_account_id == raw_account_id))
+        ).scalar_one()
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_select_account(self, deadline: float, **kwargs):
+        del self, deadline, kwargs
+        return proxy_module.AccountSelection(account=owner_account, error_message=None, error_code=None)
+
+    async def fake_compact(payload, headers, access_token, account_id, **kwargs):
+        del headers, access_token, kwargs
+        seen_payload["payload"] = payload.model_dump(mode="json", exclude_none=True)
+        seen_payload["conversation"] = getattr(payload, "conversation", None)
+        seen_payload["account_id"] = account_id
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "compaction_summary": {
+                    "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
+                    "summary_text": "condensed thread state",
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget_compatible", fake_select_account)
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {
+        "model": "gpt-5.1",
+        "input": [
+            {"role": "user", "content": "hello"},
+            {"type": "compaction_trigger"},
+        ],
+        "conversation": "conv_compact_anchor",
+        "include": [],
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers={"session_id": "sid_compact_trigger_conversation"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = list(_iter_sse_events(lines))
+    assert [event["type"] for event in events] == ["response.output_item.done", "response.completed"]
+    assert seen_payload["conversation"] == "conv_compact_anchor"
+    assert seen_payload["account_id"] == raw_account_id
+    compact_payload = cast(Mapping[str, object], seen_payload["payload"])
+    assert compact_payload["conversation"] == "conv_compact_anchor"
+    assert "include" not in compact_payload
+    assert "stream" not in compact_payload
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -234,6 +234,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
         del headers, access_token, account_id, kwargs
         seen_payload["input"] = payload.input
         seen_payload["model"] = payload.model
+        seen_payload["previous_response_id"] = getattr(payload, "previous_response_id", None)
         return CompactResponsePayload.model_validate(
             {
                 "object": "response.compaction",
@@ -254,6 +255,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
             {"role": "user", "content": "hello"},
             {"type": "compaction_trigger"},
         ],
+        "previous_response_id": "resp_compact_anchor",
         "stream": True,
     }
     async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
@@ -264,6 +266,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
     assert [event["type"] for event in events] == ["response.output_item.done", "response.completed"]
     assert seen_payload["model"] == "gpt-5.1"
     assert seen_payload["input"] == [{"role": "user", "content": "hello"}]
+    assert seen_payload["previous_response_id"] == "resp_compact_anchor"
     assert events[0]["item"] == {
         "type": "compaction",
         "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -295,6 +295,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
             {"type": "compaction_trigger"},
         ],
         "previous_response_id": "resp_compact_anchor",
+        "promptCacheKey": "compact-cache-affinity",
         "include": [],
         "stream": True,
     }
@@ -315,6 +316,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
     assert seen_payload["previous_response_id"] == "resp_compact_anchor"
     assert seen_payload["account_id"] == raw_account_id
     compact_payload = cast(Mapping[str, object], seen_payload["payload"])
+    assert compact_payload["prompt_cache_key"] == "compact-cache-affinity"
     assert "include" not in compact_payload
     assert "stream" not in compact_payload
     assert events[0]["item"] == {

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import cast
 
@@ -266,6 +267,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
 
     async def fake_compact(payload, headers, access_token, account_id, **kwargs):
         del headers, access_token, kwargs
+        seen_payload["payload"] = payload.model_dump(mode="json", exclude_none=True)
         seen_payload["input"] = payload.input
         seen_payload["model"] = payload.model
         seen_payload["previous_response_id"] = getattr(payload, "previous_response_id", None)
@@ -292,6 +294,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
             {"type": "compaction_trigger"},
         ],
         "previous_response_id": "resp_compact_anchor",
+        "include": [],
         "stream": True,
     }
     async with async_client.stream(
@@ -310,6 +313,9 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
     assert seen_payload["input"] == [{"role": "user", "content": "hello"}]
     assert seen_payload["previous_response_id"] == "resp_compact_anchor"
     assert seen_payload["account_id"] == raw_account_id
+    compact_payload = cast(Mapping[str, object], seen_payload["payload"])
+    assert "include" not in compact_payload
+    assert "stream" not in compact_payload
     assert events[0]["item"] == {
         "type": "compaction",
         "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 import pytest
 
 import app.modules.proxy.api as proxy_api_module
+from app.core.openai.models import CompactResponsePayload
+from app.core.types import JsonValue
 
 pytestmark = pytest.mark.unit
 
@@ -13,6 +15,58 @@ pytestmark = pytest.mark.unit
 async def _iter_blocks(*blocks: str) -> AsyncIterator[str]:
     for block in blocks:
         yield block
+
+
+def test_compact_response_output_item_accepts_modeled_output_field() -> None:
+    class ModeledCompactPayload(CompactResponsePayload):
+        output: list[dict[str, JsonValue]] | None = None
+
+    payload = ModeledCompactPayload.model_validate(
+        {
+            "object": "response.compaction",
+            "output": [
+                {
+                    "type": "compaction",
+                    "encrypted_content": "MODELED_CONTEXT",
+                }
+            ],
+        }
+    )
+
+    assert proxy_api_module._compact_response_output_item(payload) == {
+        "type": "compaction",
+        "encrypted_content": "MODELED_CONTEXT",
+    }
+
+
+def test_compact_response_id_generates_unique_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(proxy_api_module, "get_request_id", lambda: None)
+    payload = CompactResponsePayload.model_validate({"object": "response.compaction"})
+
+    first = proxy_api_module._compact_response_id(payload)
+    second = proxy_api_module._compact_response_id(payload)
+
+    assert first.startswith("resp_")
+    assert second.startswith("resp_")
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_synthetic_compaction_stream_preserves_mapping_usage() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._synthetic_compaction_response_stream(
+            {"type": "compaction", "encrypted_content": "SUMMARY"},
+            response_id="resp_mapping_usage",
+            usage={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+        )
+    ]
+
+    completed = proxy_api_module._parse_sse_payload(blocks[1])
+    assert completed is not None
+    response = completed["response"]
+    assert isinstance(response, dict)
+    assert response["usage"] == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6098,6 +6098,69 @@ async def test_compact_responses_does_not_infer_previous_response_id_from_sessio
 
 
 @pytest.mark.asyncio
+async def test_compact_owner_miss_uses_api_key_scope_before_fail_closed(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_scoped_owner_miss")
+    seen_account_ids: list[list[str] | None] = []
+
+    api_key = ApiKeyData(
+        id="key_compact_scope",
+        name="compact scoped",
+        key_prefix="sk-clb-scope",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+        account_assignment_scope_enabled=True,
+        assigned_account_ids=[account.id],
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=None))
+
+    async def fake_load_selection_inputs(**kwargs):
+        seen_account_ids.append(kwargs.get("account_ids"))
+        return SimpleNamespace(accounts=[account])
+
+    monkeypatch.setattr(service._load_balancer, "_load_selection_inputs", fake_load_selection_inputs)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "summarize",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
+            "previous_response_id": "resp_missing_owner_scoped",
+        }
+    )
+
+    result = await service.compact_responses(payload, {"session_id": "turn_compact_scope"}, api_key=api_key)
+
+    assert result.object == "response.compaction"
+    assert result.model_extra == {"output": []}
+    assert seen_account_ids == [[account.id]]
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_propagates_selection_error_code(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()


### PR DESCRIPTION
## Summary
- Add an OpenSpec change for Codex compaction trigger handling.
- Detect a terminal top-level `compaction_trigger` on `/backend-api/codex/responses`, strip it before compact handling, and synthesize a raw SSE stream with exactly one `compaction` output item.
- Reject duplicated or non-terminal compaction triggers with an OpenAI-shaped 400, and settle API-key reservations via `finally` on the bridge path.

## Why
The Codex app can send remote compaction through `/backend-api/codex/responses` with a trailing `compaction_trigger`. Without bridging that request into the compact service and returning a canonical single compaction output item, the client can fail with:

`Fatal error: remote compaction v2 expected exactly one compaction output item, got 0 from 0 output items`

That leaves the app stuck retrying compaction instead of receiving the compacted context.

## Validation
- `uv run ruff check app/modules/proxy/api.py app/modules/proxy/request_policy.py tests/integration/test_proxy_responses.py`
- `.venv/bin/python -m py_compile app/modules/proxy/api.py app/modules/proxy/request_policy.py tests/integration/test_proxy_responses.py`
- `openspec validate --specs`
- `uv run pytest tests/integration/test_proxy_responses.py -k "compaction_trigger or no_accounts or additional_quota_data_unavailable"`
- `uv run pytest tests/integration/test_proxy_compact.py -k "success_preserves_compaction_payload"`
- `git diff --check`
