### PR TITLE
fix(proxy): replay owner quota full resends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /app
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade \
-        libc-bin libc6 libcap2 libsystemd0 libudev1 sed \
+        libc-bin libc6 libcap2 libssl3t64 libsystemd0 libudev1 openssl openssl-provider-legacy sed \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip uninstall -y pip setuptools wheel || true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,9 @@ WORKDIR /app
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade \
-        libc-bin libc6 libcap2 libssl3t64 libsystemd0 libudev1 openssl openssl-provider-legacy sed \
+        libc-bin libc6 libcap2 libssl3t64 libsystemd0 libudev1 openssl sed \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip uninstall -y pip setuptools wheel || true \

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -644,6 +644,42 @@ def _websocket_auth_request_can_switch_account(request_state: _WebSocketRequestS
     )
 
 
+def _websocket_owner_unavailable_request_can_replay_fresh(request_state: _WebSocketRequestState) -> bool:
+    if request_state.previous_response_id is None or request_state.preferred_account_id is None:
+        return False
+    if request_state.file_required_preferred_account:
+        return False
+    if request_state.replay_count > 0:
+        return False
+    if request_state.response_id is not None:
+        return False
+    if request_state.response_event_count > 0:
+        return False
+    return bool(request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text)
+
+
+def _prepare_websocket_request_state_for_owner_unavailable_replay(
+    request_state: _WebSocketRequestState,
+) -> str | None:
+    if not _websocket_owner_unavailable_request_can_replay_fresh(request_state):
+        return None
+    request_state.request_text = request_state.fresh_upstream_request_text
+    request_state.previous_response_id = None
+    request_state.preferred_account_id = None
+    request_state.proxy_injected_previous_response_id = False
+    request_state.fresh_upstream_request_is_retry_safe = False
+    request_text = request_state.request_text
+    if not isinstance(request_text, str):
+        return None
+    request_state.replay_count += 1
+    request_state.awaiting_response_created = True
+    request_state.response_id = None
+    request_state.response_event_count = 0
+    _clear_websocket_request_error_overrides(request_state)
+    _refresh_websocket_request_input_fingerprint_from_text(request_state)
+    return request_text
+
+
 def _prepare_websocket_request_state_for_auth_replay(
     request_state: _WebSocketRequestState,
 ) -> str | None:

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -50,6 +50,7 @@ from app.core.openai.models import OpenAIEvent
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import (
     ResponsesRequest,
+    extract_input_file_ids,
 )
 from app.core.types import JsonValue
 from app.core.utils.sse import CODEX_KEEPALIVE_FRAME as CODEX_KEEPALIVE_FRAME  # noqa: F401
@@ -655,7 +656,18 @@ def _websocket_owner_unavailable_request_can_replay_fresh(request_state: _WebSoc
         return False
     if request_state.response_event_count > 0:
         return False
-    return bool(request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text)
+    if not (request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text):
+        return False
+    try:
+        fresh_payload = json.loads(request_state.fresh_upstream_request_text)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(fresh_payload, dict):
+        return False
+    input_value = fresh_payload.get("input")
+    if input_value is not None and extract_input_file_ids(cast(JsonValue, input_value)):
+        return False
+    return True
 
 
 def _prepare_websocket_request_state_for_owner_unavailable_replay(

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -1287,8 +1287,9 @@ def _pop_matching_websocket_request_states(
 
 async def _release_websocket_response_create_gate(
     request_state: _WebSocketRequestState,
-    response_create_gate: asyncio.Semaphore,
+    response_create_gate: asyncio.Semaphore | None = None,
 ) -> None:
+    response_create_gate = response_create_gate or request_state.response_create_gate
     account_response_create_lease = request_state.account_response_create_lease
     account_response_create_release = request_state.account_response_create_release
     request_state.account_response_create_lease = None
@@ -1303,7 +1304,8 @@ async def _release_websocket_response_create_gate(
     if not request_state.response_create_gate_acquired:
         return
     request_state.response_create_gate_acquired = False
-    response_create_gate.release()
+    if response_create_gate is not None:
+        response_create_gate.release()
 
 
 def _pop_terminal_websocket_request_state(

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -948,6 +948,9 @@ class _WebSocketMixin:
                         continue
                     account_lease = request_state.websocket_stream_lease
                     request_state.websocket_stream_lease = None
+                    if text_data is not None and request_state.request_text != text_data:
+                        text_data = request_state.request_text
+                        payload = _parse_websocket_payload(text_data) if text_data is not None else None
                     upstream_turn_state = _facade()._upstream_turn_state_from_socket(upstream) or upstream_turn_state
                     upstream_control = _WebSocketUpstreamControl()
                     upstream_reader = asyncio.create_task(
@@ -1472,6 +1475,7 @@ class _WebSocketMixin:
                     last_failover_account = account
                     excluded_account_ids.add(account.id)
                     if can_replay_owner_unavailable:
+                        await _release_websocket_response_create_gate(request_state)
                         _prepare_websocket_request_state_for_owner_unavailable_replay(request_state)
                     continue
                 error = _parse_openai_error(exc.payload)
@@ -2852,7 +2856,11 @@ class _WebSocketMixin:
                 {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
                 retry_error_code,
             )
-            if _prepare_websocket_request_state_for_owner_unavailable_replay(request_state) is not None:
+            replay_text = None
+            if _websocket_owner_unavailable_request_can_replay_fresh(request_state):
+                await _release_websocket_response_create_gate(request_state)
+                replay_text = _prepare_websocket_request_state_for_owner_unavailable_replay(request_state)
+            if replay_text is not None:
                 upstream_control.reconnect_requested = True
                 upstream_control.suppress_downstream_event = True
                 upstream_control.replay_request_state = request_state

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -358,6 +358,7 @@ from app.modules.proxy._service.websocket.helpers import (
     _pop_replayable_precreated_websocket_request_state,
     _pop_terminal_websocket_request_state,
     _prepare_websocket_request_state_for_auth_replay,
+    _prepare_websocket_request_state_for_owner_unavailable_replay,
     _record_websocket_continuity_completion,
     _release_websocket_response_create_gate,
     _rewrite_websocket_continuity_corruption_event,
@@ -382,6 +383,7 @@ from app.modules.proxy._service.websocket.helpers import (
     _websocket_event_error_param,
     _websocket_event_error_type,
     _websocket_full_resend_conflicts_with_visible_pending,
+    _websocket_owner_unavailable_request_can_replay_fresh,
     _websocket_precreated_auth_error_code,
     _websocket_precreated_retry_error_code,
     _websocket_receive_timeout_for_pending_requests,
@@ -1382,8 +1384,11 @@ class _WebSocketMixin:
             is_retry = attempt > 0
             forced_refresh_account_id = request_state.force_refresh_account_id
             preferred_account_id = forced_refresh_account_id or request_state.preferred_account_id
+            can_replay_owner_unavailable = _websocket_owner_unavailable_request_can_replay_fresh(request_state)
             require_preferred_account = (
-                request_state.previous_response_id is not None and request_state.preferred_account_id is not None
+                request_state.previous_response_id is not None
+                and request_state.preferred_account_id is not None
+                and not can_replay_owner_unavailable
             ) or request_state.file_required_preferred_account
             try:
                 account = await proxy._select_websocket_connect_account(
@@ -1432,6 +1437,14 @@ class _WebSocketMixin:
                 request_state.force_refresh_account_id = None
                 if request_state.preferred_account_id == forced_refresh_account_id:
                     request_state.preferred_account_id = None
+            if (
+                can_replay_owner_unavailable
+                and request_state.preferred_account_id is not None
+                and account.id != request_state.preferred_account_id
+                and _prepare_websocket_request_state_for_owner_unavailable_replay(request_state) is None
+            ):
+                await proxy._load_balancer.release_account_lease(selected_stream_lease)
+                return None, None
 
             try:
                 connect_result = await proxy._try_open_websocket_connect_attempt(
@@ -1458,6 +1471,8 @@ class _WebSocketMixin:
                     last_failover_exc = exc
                     last_failover_account = account
                     excluded_account_ids.add(account.id)
+                    if can_replay_owner_unavailable:
+                        _prepare_websocket_request_state_for_owner_unavailable_replay(request_state)
                     continue
                 error = _parse_openai_error(exc.payload)
                 error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
@@ -2837,10 +2852,21 @@ class _WebSocketMixin:
                 {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
                 retry_error_code,
             )
-            event, payload, event_type, downstream_text = _rewrite_websocket_previous_response_owner_unavailable_event(
-                request_state=request_state,
-            )
-            retry_error_code = None
+            if _prepare_websocket_request_state_for_owner_unavailable_replay(request_state) is not None:
+                upstream_control.reconnect_requested = True
+                upstream_control.suppress_downstream_event = True
+                upstream_control.replay_request_state = request_state
+                return downstream_text
+            else:
+                (
+                    event,
+                    payload,
+                    event_type,
+                    downstream_text,
+                ) = _rewrite_websocket_previous_response_owner_unavailable_event(
+                    request_state=request_state,
+                )
+                retry_error_code = None
         if retry_error_code is not None:
             if retry_is_previous_response_not_found:
                 if not (

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1475,7 +1475,7 @@ class _WebSocketMixin:
                     last_failover_account = account
                     excluded_account_ids.add(account.id)
                     if can_replay_owner_unavailable:
-                        await _release_websocket_response_create_gate(request_state)
+                        await proxy._release_request_state_account_response_create_lease(request_state)
                         _prepare_websocket_request_state_for_owner_unavailable_replay(request_state)
                     continue
                 error = _parse_openai_error(exc.payload)
@@ -2858,7 +2858,7 @@ class _WebSocketMixin:
             )
             replay_text = None
             if _websocket_owner_unavailable_request_can_replay_fresh(request_state):
-                await _release_websocket_response_create_gate(request_state)
+                await proxy._release_request_state_account_response_create_lease(request_state)
                 replay_text = _prepare_websocket_request_state_for_owner_unavailable_replay(request_state)
             if replay_text is not None:
                 upstream_control.reconnect_requested = True

--- a/app/modules/proxy/_service/websocket/protocol.py
+++ b/app/modules/proxy/_service/websocket/protocol.py
@@ -38,6 +38,7 @@ class _WebSocketServiceProtocol(Protocol):
     _relay_upstream_websocket_messages: Any
     _release_websocket_request_state_reservation: Any
     _release_websocket_reservation: Any
+    _release_request_state_account_response_create_lease: Any
     _remember_websocket_previous_response_owner: Any
     _remember_websocket_previous_response_owner_miss: Any
     _repo_factory: Any

--- a/openspec/changes/fix-owner-quota-full-resend-replay/proposal.md
+++ b/openspec/changes/fix-owner-quota-full-resend-replay/proposal.md
@@ -1,0 +1,25 @@
+# Fix owner quota full-resend replay
+
+## Why
+
+Codex-native Responses WebSocket follow-ups can include both a
+`previous_response_id` anchor and a retry-safe full resend body. When the owner
+account for that anchor hits `usage_limit_reached`, codex-lb currently rewrites
+the failure into `previous_response_owner_unavailable` and stops. That preserves
+account ownership, but it also blocks a safe migration path that does not depend
+on the exhausted owner's anchor.
+
+## What Changes
+
+- Allow owner-pinned WebSocket quota failures to replay on another account only
+  when the proxy has a retry-safe fresh request body.
+- Strip `previous_response_id` and clear the preferred account before replaying
+  that safe full resend.
+- Keep the existing fail-closed behavior for anchor-only continuations, file-id
+  pinned requests, and requests that already emitted visible upstream output.
+
+## Impact
+
+- **Spec**: `responses-api-compat`
+- **Behavior**: Codex-native full-resend follow-ups can migrate away from a
+  spend-capped owner account without leaking the raw quota event downstream.

--- a/openspec/changes/fix-owner-quota-full-resend-replay/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-owner-quota-full-resend-replay/specs/responses-api-compat/spec.md
@@ -35,3 +35,14 @@ The proxy SHALL replay a Codex-native direct Responses WebSocket request pinned 
 - **WHEN** that owner returns an account-recovery quota failure
 - **THEN** the proxy preserves the file-owner routing contract
 - **AND** it does not replay the request on another account
+
+#### Scenario: owner replay releases the failed create lease first
+
+- **GIVEN** a direct Responses WebSocket request has already acquired a
+  response-create lease for `account_a`
+- **AND** the proxy has captured a retry-safe fresh full-resend body
+- **WHEN** `account_a` returns an account-recovery quota failure before
+  `response.created`
+- **THEN** the proxy releases `account_a`'s response-create lease before
+  requeueing the request
+- **AND** the replay must acquire admission for the next selected account

--- a/openspec/changes/fix-owner-quota-full-resend-replay/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-owner-quota-full-resend-replay/specs/responses-api-compat/spec.md
@@ -26,10 +26,12 @@ The proxy SHALL replay a Codex-native direct Responses WebSocket request pinned 
   failure
 - **AND** it does not replay the anchor-only continuation on another account
 
-#### Scenario: file-pinned owner quota failures do not migrate
+#### Scenario: file-bearing full-resend owner quota failures do not migrate
 
-- **GIVEN** a direct Responses WebSocket request is pinned to an owner account by
-  a live file-id routing requirement
+- **GIVEN** a direct Responses WebSocket request includes `previous_response_id`
+  for `account_a`
+- **AND** the proxy has captured a retry-safe fresh full-resend body
+- **AND** that fresh body contains an `input_file.file_id` reference
 - **WHEN** that owner returns an account-recovery quota failure
 - **THEN** the proxy preserves the file-owner routing contract
 - **AND** it does not replay the request on another account

--- a/openspec/changes/fix-owner-quota-full-resend-replay/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-owner-quota-full-resend-replay/specs/responses-api-compat/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Retry-safe owner quota failures may replay as fresh WebSocket requests
+
+The proxy SHALL replay a Codex-native direct Responses WebSocket request pinned by `previous_response_id` to an owner account on another eligible account only when the owner returns a retryable account-recovery quota failure before any upstream response is created or visible output is emitted and the proxy already has a retry-safe fresh full-resend request body for the same client turn. The replay MUST remove `previous_response_id`, clear the preferred owner account, suppress the failed upstream event from downstream, and mark the failed owner through the normal stream-error health path.
+
+#### Scenario: safe full resend migrates from a quota-exhausted owner
+
+- **GIVEN** a direct Responses WebSocket request includes `previous_response_id`
+  for `account_a`
+- **AND** the proxy has captured a retry-safe fresh full-resend body for the
+  same turn
+- **WHEN** `account_a` returns `usage_limit_reached` before `response.created`
+  or any visible output
+- **THEN** the proxy strips `previous_response_id` from the replay body
+- **AND** it may reconnect and replay the fresh body on `account_b`
+- **AND** it does not emit the owner quota failure downstream
+
+#### Scenario: unsafe owner continuation still fails closed
+
+- **GIVEN** a direct Responses WebSocket request includes `previous_response_id`
+  for `account_a`
+- **AND** the proxy does not have a retry-safe fresh full-resend body
+- **WHEN** `account_a` returns `usage_limit_reached`
+- **THEN** the proxy emits the stable previous-response owner unavailable
+  failure
+- **AND** it does not replay the anchor-only continuation on another account
+
+#### Scenario: file-pinned owner quota failures do not migrate
+
+- **GIVEN** a direct Responses WebSocket request is pinned to an owner account by
+  a live file-id routing requirement
+- **WHEN** that owner returns an account-recovery quota failure
+- **THEN** the proxy preserves the file-owner routing contract
+- **AND** it does not replay the request on another account

--- a/openspec/changes/fix-owner-quota-full-resend-replay/tasks.md
+++ b/openspec/changes/fix-owner-quota-full-resend-replay/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spec Delta
+
+- [x] 1.1 Document retry-safe owner quota migration for direct Responses
+  WebSocket follow-ups.
+- [x] 1.2 Preserve fail-closed behavior for unsafe owner-bound continuations.
+
+## 2. Implementation
+
+- [x] 2.1 Add a strict helper for stripping `previous_response_id` only when a
+  fresh full-resend request body is already marked retry-safe.
+- [x] 2.2 Use the helper for owner quota failures during WebSocket connect and
+  pre-created upstream error handling.
+
+## 3. Verification
+
+- [x] 3.1 Run focused WebSocket owner quota unit tests.
+- [x] 3.2 Validate the OpenSpec change.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8442,6 +8442,85 @@ async def test_connect_proxy_websocket_previous_response_owner_usage_limit_fails
 
 
 @pytest.mark.asyncio
+async def test_connect_proxy_websocket_previous_response_owner_usage_limit_replays_safe_full_resend(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_owner = _make_account("acc_ws_prev_owner_replay")
+    account_other = _make_account("acc_ws_other_replay")
+    upstream = SimpleNamespace()
+    seen_excluded_account_ids: list[set[str]] = []
+
+    async def select_account(deadline: float, **kwargs: object) -> AccountSelection:
+        del deadline
+        excluded_account_ids = kwargs.get("exclude_account_ids")
+        seen_excluded_account_ids.append(set(cast(set[str], excluded_account_ids)))
+        if len(seen_excluded_account_ids) == 1:
+            return AccountSelection(account=account_owner, error_message=None)
+        return AccountSelection(account=account_other, error_message=None)
+
+    mark_rate_limit = AsyncMock()
+    first_handshake_error = proxy_module.ProxyResponseError(
+        429,
+        openai_error("usage_limit_reached", "usage limit reached"),
+    )
+    fresh_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
+    }
+
+    monkeypatch.setattr(service, "_select_account_with_budget", select_account)
+    monkeypatch.setattr(service._load_balancer, "mark_rate_limit", mark_rate_limit)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_owner, account_other]))
+    monkeypatch.setattr(service, "_open_upstream_websocket", AsyncMock(side_effect=[first_handshake_error, upstream]))
+    monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_owner_handshake_429_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_prev_anchor",
+        preferred_account_id=account_owner.id,
+        request_text=json.dumps(
+            {**fresh_payload, "previous_response_id": "resp_prev_anchor"},
+            separators=(",", ":"),
+        ),
+        fresh_upstream_request_text=json.dumps(fresh_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=True,
+    )
+
+    websocket_send = AsyncMock()
+    websocket = cast(WebSocket, SimpleNamespace(send_text=websocket_send))
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        prefer_earlier_reset_window="secondary",
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=websocket,
+    )
+
+    assert selected_account == account_other
+    assert selected_upstream is upstream
+    assert seen_excluded_account_ids == [set(), {account_owner.id}]
+    mark_rate_limit.assert_awaited_once()
+    assert request_state.previous_response_id is None
+    assert request_state.preferred_account_id is None
+    assert request_state.replay_count == 1
+    assert "previous_response_id" not in cast(str, request_state.request_text)
+    websocket_send.assert_not_awaited()
+    assert request_logs.calls == []
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_surfaces_local_connect_overload_without_penalizing_account(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.proxy_upstream_websocket_connect_limit = 1
@@ -12291,6 +12370,81 @@ async def test_process_upstream_websocket_text_maps_previous_response_usage_limi
     assert upstream_control.suppress_downstream_event is False
     assert upstream_control.replay_request_state is None
     assert pending_request.replay_count == 0
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_replays_owner_pinned_usage_limit_when_retry_safe(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_prev_quota_owner_replay")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    fresh_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
+    }
+    request_payload = {**fresh_payload, "previous_response_id": "resp_anchor"}
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_quota_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(request_payload, separators=(",", ":")),
+        previous_response_id="resp_anchor",
+        preferred_account_id=account.id,
+        fresh_upstream_request_text=json.dumps(fresh_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=True,
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_payload = {
+        "type": "error",
+        "status": 429,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+        },
+    }
+    upstream_text = json.dumps(upstream_payload, separators=(",", ":"))
+
+    downstream_text = await service._process_upstream_websocket_text(
+        upstream_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert downstream_text == upstream_text
+    handle_stream_error.assert_awaited_once()
+    handle_call = handle_stream_error.await_args
+    assert handle_call is not None
+    assert handle_call.args[0] == account
+    assert handle_call.args[2] == "usage_limit_reached"
+    finalize_request_state.assert_not_awaited()
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.replay_request_state is pending_request
+    assert pending_request.previous_response_id is None
+    assert pending_request.preferred_account_id is None
+    assert pending_request.replay_count == 1
+    assert "previous_response_id" not in cast(str, pending_request.request_text)
     assert list(pending_requests) == []
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12407,6 +12407,19 @@ async def test_process_upstream_websocket_text_replays_owner_pinned_usage_limit_
         fresh_upstream_request_text=json.dumps(fresh_payload, separators=(",", ":")),
         fresh_upstream_request_is_retry_safe=True,
     )
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+    response_create_lease = AccountLease(
+        lease_id="lease_prev_quota_replay",
+        account_id=account.id,
+        kind="response_create",
+        acquired_at=0.0,
+    )
+    release_account_lease = AsyncMock()
+    pending_request.response_create_gate = response_create_gate
+    pending_request.response_create_gate_acquired = True
+    pending_request.account_response_create_lease = response_create_lease
+    pending_request.account_response_create_release = release_account_lease
     pending_requests = deque([pending_request])
     upstream_control = proxy_service._WebSocketUpstreamControl()
     upstream_payload = {
@@ -12428,10 +12441,11 @@ async def test_process_upstream_websocket_text_replays_owner_pinned_usage_limit_
         pending_lock=anyio.Lock(),
         api_key=None,
         upstream_control=upstream_control,
-        response_create_gate=asyncio.Semaphore(1),
+        response_create_gate=response_create_gate,
     )
 
     assert downstream_text == upstream_text
+    release_account_lease.assert_awaited_once_with(response_create_lease)
     handle_stream_error.assert_awaited_once()
     handle_call = handle_stream_error.await_args
     assert handle_call is not None
@@ -12444,6 +12458,10 @@ async def test_process_upstream_websocket_text_replays_owner_pinned_usage_limit_
     assert pending_request.previous_response_id is None
     assert pending_request.preferred_account_id is None
     assert pending_request.replay_count == 1
+    assert pending_request.awaiting_response_created is True
+    assert pending_request.response_create_gate_acquired is False
+    assert pending_request.account_response_create_lease is None
+    assert pending_request.account_response_create_release is None
     assert "previous_response_id" not in cast(str, pending_request.request_text)
     assert list(pending_requests) == []
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8474,6 +8474,8 @@ async def test_connect_proxy_websocket_previous_response_owner_usage_limit_repla
     monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_owner, account_other]))
     monkeypatch.setattr(service, "_open_upstream_websocket", AsyncMock(side_effect=[first_handshake_error, upstream]))
     monkeypatch.setattr(service, "_release_websocket_reservation", AsyncMock())
+    release_account_lease = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
 
     request_state = proxy_service._WebSocketRequestState(
         request_id="ws_req_prev_owner_handshake_429_replay",
@@ -8491,6 +8493,18 @@ async def test_connect_proxy_websocket_previous_response_owner_usage_limit_repla
         fresh_upstream_request_text=json.dumps(fresh_payload, separators=(",", ":")),
         fresh_upstream_request_is_retry_safe=True,
     )
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+    response_create_lease = AccountLease(
+        lease_id="lease_prev_owner_handshake_replay",
+        account_id=account_owner.id,
+        kind="response_create",
+        acquired_at=0.0,
+    )
+    request_state.response_create_gate = response_create_gate
+    request_state.response_create_gate_acquired = True
+    request_state.account_response_create_lease = response_create_lease
+    request_state.account_response_create_release = release_account_lease
 
     websocket_send = AsyncMock()
     websocket = cast(WebSocket, SimpleNamespace(send_text=websocket_send))
@@ -8512,9 +8526,15 @@ async def test_connect_proxy_websocket_previous_response_owner_usage_limit_repla
     assert selected_upstream is upstream
     assert seen_excluded_account_ids == [set(), {account_owner.id}]
     mark_rate_limit.assert_awaited_once()
+    release_account_lease.assert_any_await(response_create_lease)
     assert request_state.previous_response_id is None
     assert request_state.preferred_account_id is None
     assert request_state.replay_count == 1
+    assert request_state.response_create_gate_acquired is True
+    assert request_state.response_create_gate is response_create_gate
+    assert response_create_gate.locked() is True
+    assert request_state.account_response_create_lease is None
+    assert request_state.account_response_create_release is None
     assert "previous_response_id" not in cast(str, request_state.request_text)
     websocket_send.assert_not_awaited()
     assert request_logs.calls == []
@@ -12385,6 +12405,8 @@ async def test_process_upstream_websocket_text_replays_owner_pinned_usage_limit_
 
     monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    release_account_lease = AsyncMock()
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
 
     fresh_payload = {
         "type": "response.create",
@@ -12415,7 +12437,6 @@ async def test_process_upstream_websocket_text_replays_owner_pinned_usage_limit_
         kind="response_create",
         acquired_at=0.0,
     )
-    release_account_lease = AsyncMock()
     pending_request.response_create_gate = response_create_gate
     pending_request.response_create_gate_acquired = True
     pending_request.account_response_create_lease = response_create_lease
@@ -12459,7 +12480,9 @@ async def test_process_upstream_websocket_text_replays_owner_pinned_usage_limit_
     assert pending_request.preferred_account_id is None
     assert pending_request.replay_count == 1
     assert pending_request.awaiting_response_created is True
-    assert pending_request.response_create_gate_acquired is False
+    assert pending_request.response_create_gate_acquired is True
+    assert pending_request.response_create_gate is response_create_gate
+    assert response_create_gate.locked() is True
     assert pending_request.account_response_create_lease is None
     assert pending_request.account_response_create_release is None
     assert "previous_response_id" not in cast(str, pending_request.request_text)

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12449,6 +12449,82 @@ async def test_process_upstream_websocket_text_replays_owner_pinned_usage_limit_
 
 
 @pytest.mark.asyncio
+async def test_process_upstream_websocket_text_keeps_owner_pin_for_file_full_resend(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_prev_quota_owner_file")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    fresh_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "instructions": "",
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "continue"},
+                    {"type": "input_file", "file_id": "file_pinned"},
+                ],
+            }
+        ],
+    }
+    request_payload = {**fresh_payload, "previous_response_id": "resp_anchor"}
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_quota_file_no_replay",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(request_payload, separators=(",", ":")),
+        previous_response_id="resp_anchor",
+        preferred_account_id=account.id,
+        fresh_upstream_request_text=json.dumps(fresh_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=True,
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_payload = {
+        "type": "error",
+        "status": 429,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "usage_limit_reached",
+            "message": "The usage limit has been reached",
+        },
+    }
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(upstream_payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"code":"upstream_unavailable"' in downstream_text
+    handle_stream_error.assert_awaited_once()
+    finalize_request_state.assert_awaited_once()
+    assert upstream_control.reconnect_requested is False
+    assert upstream_control.suppress_downstream_event is False
+    assert upstream_control.replay_request_state is None
+    assert pending_request.previous_response_id == "resp_anchor"
+    assert pending_request.preferred_account_id == account.id
+    assert pending_request.replay_count == 0
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_websocket_transparent_replay_preserves_sticky_thread_affinity(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- allow direct Responses WebSocket owner-pinned quota failures to replay on another account only when a retry-safe fresh full-resend body is available
- keep anchor-only, file-pinned, and already-visible owner-bound continuations fail-closed
- add an OpenSpec delta and unit coverage for handshake and pre-created upstream quota replay

## Type
- Bug fix

## Linked issue
- None

## OpenSpec
- openspec/changes/fix-owner-quota-full-resend-replay

## Existing PR search
- Checked open/adjacent work including #892 and #875; neither implements quota-based previous_response owner migration. The closest quota behavior was already merged in #634 and only masks owner-pinned quota failures.

## Test plan
- uv run pytest tests/unit/test_proxy_utils.py -q -k 'previous_response_owner_usage_limit or owner_pinned_usage_limit or maps_previous_response_usage_limit'
- uv run pytest tests/unit/test_proxy_utils.py -q -k 'websocket and (usage_limit or previous_response_owner)'
- uv run pytest tests/unit/test_proxy_utils.py -q
- uv run ruff check app/modules/proxy/_service/websocket/helpers.py app/modules/proxy/_service/websocket/mixin.py tests/unit/test_proxy_utils.py
- uv run openspec validate fix-owner-quota-full-resend-replay --strict
- uv run openspec validate --specs

## Checklist
- [x] Tests updated
- [x] OpenSpec updated
- [x] Focused validation passed