### PR TITLE
fix(accounts): scope identity merge by workspace label

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -706,6 +706,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "KakatkarAkshay",
+      "name": "Akshay Kakatkar",
+      "avatar_url": "https://avatars.githubusercontent.com/u/49910222?v=4",
+      "profile": "https://github.com/KakatkarAkshay",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/core/auth/__init__.py
+++ b/app/core/auth/__init__.py
@@ -171,8 +171,9 @@ def generate_unique_account_id(
     account_id: str | None,
     email: str | None,
     workspace_id: str | None = None,
+    workspace_label: str | None = None,
 ) -> str:
-    workspace_key = clean_account_identity_part(workspace_id)
+    workspace_key = clean_account_identity_part(workspace_id) or clean_account_identity_part(workspace_label)
     if account_id and workspace_key:
         workspace_hash = hashlib.sha256(workspace_key.encode()).hexdigest()[:8]
         return f"{account_id}_{workspace_hash}"

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -222,6 +222,7 @@ def _account_to_summary(
     )
     return AccountSummary(
         account_id=account.id,
+        chatgpt_account_id=account.chatgpt_account_id,
         email=account.email,
         alias=account.alias,
         display_name=account.alias or account.email,

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -59,7 +59,7 @@ def build_account_summaries(
 
 
 def _duplicate_detection_keys_appearing_more_than_once(accounts: list[Account]) -> set[tuple[str, str, str | None]]:
-    """Return duplicate (email, ChatGPT account id, workspace id) keys in this list.
+    """Return duplicate (email, ChatGPT account id, workspace slot key) keys in this list.
 
     Emails are compared case-sensitively to match the storage normalization
     already performed at OAuth-import time. Blank/None emails, the legacy
@@ -81,7 +81,7 @@ def _duplicate_detection_key(account: Account) -> tuple[str, str, str | None] | 
     chatgpt_account_id = account.chatgpt_account_id
     if not _is_duplicate_detection_email(email) or not chatgpt_account_id:
         return None
-    return email, chatgpt_account_id, account.workspace_id
+    return email, chatgpt_account_id, account.workspace_id or account.workspace_label
 
 
 def _is_duplicate_detection_email(email: str | None) -> bool:

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -281,7 +281,11 @@ class AccountsRepository:
                 return existing_by_id
             account.id = await self._next_available_account_id(account.id)
         elif not preserve_unknown_workspace_duplicates:
-            existing_by_email = await self._single_account_by_email(account.email)
+            existing_by_email = (
+                await self._single_unknown_workspace_account_by_email(account.email)
+                if _workspace_slot_key(account)
+                else await self._single_account_by_email(account.email)
+            )
             if existing_by_email and not _can_reuse_email_fallback(existing_by_email, account):
                 existing_by_email = None
             if existing_by_email:

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -317,8 +317,6 @@ class AccountsRepository:
         """
 
         stmt = select(Account).where(Account.chatgpt_account_id == chatgpt_account_id)
-        if email:
-            stmt = stmt.where(Account.email == email)
         order_by: list[Any] = [Account.created_at.asc(), Account.id.asc()]
         if workspace_id:
             stmt = stmt.where(or_(Account.workspace_id == workspace_id, Account.workspace_id.is_(None)))

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -280,7 +280,7 @@ class AccountsRepository:
                 await self._session.refresh(existing_by_id)
                 return existing_by_id
             account.id = await self._next_available_account_id(account.id)
-        elif not preserve_unknown_workspace_duplicates and _workspace_slot_key(account) is None:
+        elif not preserve_unknown_workspace_duplicates:
             existing_by_email = await self._single_account_by_email(account.email)
             if existing_by_email and not _can_reuse_email_fallback(existing_by_email, account):
                 existing_by_email = None

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -202,6 +202,7 @@ class AccountsRepository:
             canonical = await self._account_by_chatgpt_identity(
                 account.chatgpt_account_id,
                 workspace_id=account.workspace_id,
+                email=account.email,
             )
             if canonical is not None:
                 _apply_account_updates(canonical, account)
@@ -209,6 +210,7 @@ class AccountsRepository:
                     canonical=canonical,
                     chatgpt_account_id=account.chatgpt_account_id,
                     workspace_id=account.workspace_id,
+                    email=account.email,
                 )
                 await self._session.commit()
                 await self._session.refresh(canonical)
@@ -241,8 +243,6 @@ class AccountsRepository:
         return account
 
     async def upsert_reauthorized(self, account: Account) -> Account:
-        if account.chatgpt_account_id:
-            return await self.upsert(account, merge_by_email=False, merge_by_chatgpt_identity=True)
         return await self.upsert_account_slot(account, preserve_unknown_workspace_duplicates=False)
 
     async def upsert_account_slot(
@@ -306,6 +306,7 @@ class AccountsRepository:
         chatgpt_account_id: str,
         *,
         workspace_id: str | None,
+        email: str | None,
     ) -> Account | None:
         """Return the canonical local account row for a ChatGPT identity.
 
@@ -318,6 +319,8 @@ class AccountsRepository:
         """
 
         stmt = select(Account).where(Account.chatgpt_account_id == chatgpt_account_id)
+        if email:
+            stmt = stmt.where(Account.email == email)
         order_by: list[Any] = [Account.created_at.asc(), Account.id.asc()]
         if workspace_id:
             stmt = stmt.where(or_(Account.workspace_id == workspace_id, Account.workspace_id.is_(None)))
@@ -333,11 +336,14 @@ class AccountsRepository:
         canonical: Account,
         chatgpt_account_id: str,
         workspace_id: str | None,
+        email: str | None,
     ) -> None:
         duplicate_stmt = select(Account.id).where(
             Account.chatgpt_account_id == chatgpt_account_id,
             Account.id != canonical.id,
         )
+        if email:
+            duplicate_stmt = duplicate_stmt.where(Account.email == email)
         if workspace_id is None:
             duplicate_stmt = duplicate_stmt.where(Account.workspace_id.is_(None))
         else:
@@ -653,11 +659,11 @@ class AccountsRepository:
         return matches[0]
 
     async def _account_by_slot_identity(self, account: Account) -> Account | None:
-        if account.chatgpt_account_id and account.workspace_id:
+        if account.chatgpt_account_id and account.email:
             result = await self._session.execute(
                 select(Account)
                 .where(Account.chatgpt_account_id == account.chatgpt_account_id)
-                .where(Account.workspace_id == account.workspace_id)
+                .where(Account.email == account.email)
                 .order_by(Account.created_at.asc(), Account.id.asc())
                 .limit(1)
             )
@@ -733,8 +739,8 @@ def _slot_lock_key(account: Account, *, preserve_unknown_workspace_duplicates: b
 
 def _slot_lock_keys(account: Account, *, preserve_unknown_workspace_duplicates: bool = True) -> tuple[str, ...]:
     keys: list[str] = []
-    if account.chatgpt_account_id and account.workspace_id:
-        keys.append(f"slot:{account.chatgpt_account_id}:{account.workspace_id}")
+    if account.chatgpt_account_id and account.email:
+        keys.append(f"slot:{account.chatgpt_account_id}:{account.email}")
     if account.email and account.workspace_id:
         keys.append(f"slot-email:{account.email}:{account.workspace_id}")
         if not preserve_unknown_workspace_duplicates:

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -683,6 +683,18 @@ class AccountsRepository:
             )
             if matched := result.scalar_one_or_none():
                 return matched
+        if account.chatgpt_account_id and account.email and account.workspace_id and account.workspace_label:
+            result = await self._session.execute(
+                select(Account)
+                .where(Account.chatgpt_account_id == account.chatgpt_account_id)
+                .where(Account.email == account.email)
+                .where(Account.workspace_id.is_(None))
+                .where(Account.workspace_label == account.workspace_label)
+                .order_by(Account.created_at.asc(), Account.id.asc())
+                .limit(1)
+            )
+            if matched := result.scalar_one_or_none():
+                return matched
         if workspace_slot and account.email:
             column, value = workspace_slot
             result = await self._session.execute(

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -796,6 +796,10 @@ def _is_workspace_less_reauth_for_known_slot(
 
 
 def _can_reuse_email_fallback(existing: Account, incoming: Account) -> bool:
+    existing_workspace_key = _workspace_slot_key(existing)
+    incoming_workspace_key = _workspace_slot_key(incoming)
+    if existing_workspace_key and incoming_workspace_key and existing_workspace_key != incoming_workspace_key:
+        return False
     return (
         not incoming.chatgpt_account_id
         or not existing.chatgpt_account_id

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -644,6 +644,7 @@ class AccountsRepository:
             select(Account)
             .where(Account.email == email)
             .where(Account.workspace_id.is_(None))
+            .where(Account.workspace_label.is_(None))
             .order_by(Account.created_at.asc(), Account.id.asc())
             .limit(2)
         )

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -202,6 +202,7 @@ class AccountsRepository:
             canonical = await self._account_by_chatgpt_identity(
                 account.chatgpt_account_id,
                 workspace_id=account.workspace_id,
+                workspace_label=account.workspace_label,
                 email=account.email,
             )
             if canonical is not None:
@@ -210,6 +211,7 @@ class AccountsRepository:
                     canonical=canonical,
                     chatgpt_account_id=account.chatgpt_account_id,
                     workspace_id=account.workspace_id,
+                    workspace_label=account.workspace_label,
                     email=account.email,
                 )
                 await self._session.commit()
@@ -306,6 +308,7 @@ class AccountsRepository:
         chatgpt_account_id: str,
         *,
         workspace_id: str | None,
+        workspace_label: str | None,
         email: str | None,
     ) -> Account | None:
         """Return the canonical local account row for a ChatGPT identity.
@@ -321,10 +324,19 @@ class AccountsRepository:
         stmt = select(Account).where(Account.chatgpt_account_id == chatgpt_account_id)
         order_by: list[Any] = [Account.created_at.asc(), Account.id.asc()]
         if workspace_id:
-            stmt = stmt.where(or_(Account.workspace_id == workspace_id, Account.workspace_id.is_(None)))
+            unknown_workspace = Account.workspace_id.is_(None)
+            if workspace_label:
+                unknown_workspace = unknown_workspace & (Account.workspace_label == workspace_label)
+            else:
+                unknown_workspace = unknown_workspace & Account.workspace_label.is_(None)
+            stmt = stmt.where(or_(Account.workspace_id == workspace_id, unknown_workspace))
             order_by.insert(0, Account.workspace_id.is_(None).asc())
         else:
             stmt = stmt.where(Account.workspace_id.is_(None))
+            if workspace_label:
+                stmt = stmt.where(Account.workspace_label == workspace_label)
+            else:
+                stmt = stmt.where(Account.workspace_label.is_(None))
 
         result = await self._session.execute(stmt.order_by(*order_by))
         candidates = list(result.scalars().all())
@@ -346,6 +358,7 @@ class AccountsRepository:
         canonical: Account,
         chatgpt_account_id: str,
         workspace_id: str | None,
+        workspace_label: str | None,
         email: str | None,
     ) -> None:
         duplicate_stmt = select(Account.id).where(
@@ -356,6 +369,10 @@ class AccountsRepository:
             duplicate_stmt = duplicate_stmt.where(Account.email == email)
         if workspace_id is None:
             duplicate_stmt = duplicate_stmt.where(Account.workspace_id.is_(None))
+            if workspace_label:
+                duplicate_stmt = duplicate_stmt.where(Account.workspace_label == workspace_label)
+            else:
+                duplicate_stmt = duplicate_stmt.where(Account.workspace_label.is_(None))
         else:
             duplicate_stmt = duplicate_stmt.where(Account.workspace_id == workspace_id)
         duplicate_accounts = (await self._session.execute(duplicate_stmt)).scalars().all()

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -281,11 +281,12 @@ class AccountsRepository:
                 return existing_by_id
             account.id = await self._next_available_account_id(account.id)
         elif not preserve_unknown_workspace_duplicates:
-            existing_by_email = (
-                await self._single_unknown_workspace_account_by_email(account.email)
-                if _workspace_slot_key(account)
-                else await self._single_account_by_email(account.email)
-            )
+            if _workspace_slot_key(account):
+                existing_by_email = await self._single_unknown_workspace_account_by_email(account.email)
+            elif account.chatgpt_account_id:
+                existing_by_email = None
+            else:
+                existing_by_email = await self._single_account_by_email(account.email)
             if existing_by_email and not _can_reuse_email_fallback(existing_by_email, account):
                 existing_by_email = None
             if existing_by_email:

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -280,14 +280,11 @@ class AccountsRepository:
                 await self._session.refresh(existing_by_id)
                 return existing_by_id
             account.id = await self._next_available_account_id(account.id)
-        elif not preserve_unknown_workspace_duplicates:
-            existing_by_email = (
-                await self._single_unknown_workspace_account_by_email(account.email)
-                if account.workspace_id
-                else await self._single_account_by_email(account.email)
-                if not account.workspace_id
-                else None
-            )
+        elif (
+            not preserve_unknown_workspace_duplicates
+            and _workspace_slot_key(account) is None
+        ):
+            existing_by_email = await self._single_account_by_email(account.email)
             if existing_by_email and not _can_reuse_email_fallback(existing_by_email, account):
                 existing_by_email = None
             if existing_by_email:
@@ -667,16 +664,6 @@ class AccountsRepository:
                 .where(Account.chatgpt_account_id == account.chatgpt_account_id)
                 .where(Account.email == account.email)
                 .where(column == value)
-                .order_by(Account.created_at.asc(), Account.id.asc())
-                .limit(1)
-            )
-            if matched := result.scalar_one_or_none():
-                return matched
-        if account.chatgpt_account_id and account.email and not workspace_slot:
-            result = await self._session.execute(
-                select(Account)
-                .where(Account.chatgpt_account_id == account.chatgpt_account_id)
-                .where(Account.email == account.email)
                 .order_by(Account.created_at.asc(), Account.id.asc())
                 .limit(1)
             )

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -280,10 +280,7 @@ class AccountsRepository:
                 await self._session.refresh(existing_by_id)
                 return existing_by_id
             account.id = await self._next_available_account_id(account.id)
-        elif (
-            not preserve_unknown_workspace_duplicates
-            and _workspace_slot_key(account) is None
-        ):
+        elif not preserve_unknown_workspace_duplicates and _workspace_slot_key(account) is None:
             existing_by_email = await self._single_account_by_email(account.email)
             if existing_by_email and not _can_reuse_email_fallback(existing_by_email, account):
                 existing_by_email = None

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -659,7 +659,20 @@ class AccountsRepository:
         return matches[0]
 
     async def _account_by_slot_identity(self, account: Account) -> Account | None:
-        if account.chatgpt_account_id and account.email:
+        workspace_slot = _workspace_slot_identity(account)
+        if account.chatgpt_account_id and account.email and workspace_slot:
+            column, value = workspace_slot
+            result = await self._session.execute(
+                select(Account)
+                .where(Account.chatgpt_account_id == account.chatgpt_account_id)
+                .where(Account.email == account.email)
+                .where(column == value)
+                .order_by(Account.created_at.asc(), Account.id.asc())
+                .limit(1)
+            )
+            if matched := result.scalar_one_or_none():
+                return matched
+        if account.chatgpt_account_id and account.email and not workspace_slot:
             result = await self._session.execute(
                 select(Account)
                 .where(Account.chatgpt_account_id == account.chatgpt_account_id)
@@ -669,11 +682,12 @@ class AccountsRepository:
             )
             if matched := result.scalar_one_or_none():
                 return matched
-        if account.workspace_id and account.email:
+        if workspace_slot and account.email:
+            column, value = workspace_slot
             result = await self._session.execute(
                 select(Account)
                 .where(Account.email == account.email)
-                .where(Account.workspace_id == account.workspace_id)
+                .where(column == value)
                 .order_by(Account.created_at.asc(), Account.id.asc())
                 .limit(1)
             )
@@ -739,10 +753,14 @@ def _slot_lock_key(account: Account, *, preserve_unknown_workspace_duplicates: b
 
 def _slot_lock_keys(account: Account, *, preserve_unknown_workspace_duplicates: bool = True) -> tuple[str, ...]:
     keys: list[str] = []
-    if account.chatgpt_account_id and account.email:
-        keys.append(f"slot:{account.chatgpt_account_id}:{account.email}")
-    if account.email and account.workspace_id:
-        keys.append(f"slot-email:{account.email}:{account.workspace_id}")
+    workspace_key = _workspace_slot_key(account)
+    if account.chatgpt_account_id:
+        if workspace_key:
+            keys.append(f"slot:{account.chatgpt_account_id}:{workspace_key}")
+        elif account.email:
+            keys.append(f"slot:{account.chatgpt_account_id}:{account.email}")
+    if account.email and workspace_key:
+        keys.append(f"slot-email:{account.email}:{workspace_key}")
         if not preserve_unknown_workspace_duplicates:
             keys.append(f"slot-email-unknown:{account.email}")
     if keys:
@@ -754,11 +772,27 @@ def _slot_lock_keys(account: Account, *, preserve_unknown_workspace_duplicates: 
 
 def _same_unknown_workspace_identity(existing: Account, incoming: Account) -> bool:
     return (
-        not existing.workspace_id
-        and not incoming.workspace_id
+        _workspace_slot_key(existing) is None
+        and _workspace_slot_key(incoming) is None
         and existing.chatgpt_account_id == incoming.chatgpt_account_id
         and existing.email == incoming.email
     )
+
+
+def _workspace_slot_identity(account: Account) -> tuple[Any, str] | None:
+    if account.workspace_id:
+        return Account.workspace_id, account.workspace_id
+    if account.workspace_label:
+        return Account.workspace_label, account.workspace_label
+    return None
+
+
+def _workspace_slot_key(account: Account) -> str | None:
+    if account.workspace_id:
+        return account.workspace_id
+    if account.workspace_label:
+        return account.workspace_label
+    return None
 
 
 def _is_workspace_less_reauth_for_known_slot(

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -310,12 +310,12 @@ class AccountsRepository:
     ) -> Account | None:
         """Return the canonical local account row for a ChatGPT identity.
 
-        Order of preference, so that reauth reuses the row that already
-        carries the historical usage and audit trail:
+        Order of preference, so that reauth targets the matching real-email
+        slot when one exists, while still allowing an upstream email change
+        to reuse a single unambiguous identity row:
 
-        1. The oldest row by ``created_at`` (deterministic tie-break on
-           ``id``) — this is almost always the original row, before any
-           ``__copyN`` rows were created.
+        1. The oldest row with the incoming email.
+        2. The only identity row when no email match exists.
         """
 
         stmt = select(Account).where(Account.chatgpt_account_id == chatgpt_account_id)
@@ -326,8 +326,20 @@ class AccountsRepository:
         else:
             stmt = stmt.where(Account.workspace_id.is_(None))
 
-        result = await self._session.execute(stmt.order_by(*order_by).limit(1))
-        return result.scalar_one_or_none()
+        result = await self._session.execute(stmt.order_by(*order_by))
+        candidates = list(result.scalars().all())
+        if not candidates:
+            return None
+        if not email:
+            return candidates[0]
+
+        for candidate in candidates:
+            if candidate.email == email:
+                return candidate
+
+        if len(candidates) == 1:
+            return candidates[0]
+        return None
 
     async def _reconcile_chatgpt_identity_duplicates(
         self,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -250,6 +250,7 @@ class AccountsRepository:
         account: Account,
         *,
         preserve_unknown_workspace_duplicates: bool | None = None,
+        preserve_identity_slots: bool = False,
     ) -> Account:
         if preserve_unknown_workspace_duplicates is None:
             preserve_unknown_workspace_duplicates = not await self._merge_by_email_enabled()
@@ -283,7 +284,7 @@ class AccountsRepository:
         elif not preserve_unknown_workspace_duplicates:
             if _workspace_slot_key(account):
                 existing_by_email = await self._single_unknown_workspace_account_by_email(account.email)
-            elif account.chatgpt_account_id:
+            elif preserve_identity_slots and account.chatgpt_account_id:
                 existing_by_email = None
             else:
                 existing_by_email = await self._single_account_by_email(account.email)

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -72,6 +72,7 @@ class AccountAdditionalQuota(DashboardModel):
 
 class AccountSummary(DashboardModel):
     account_id: str
+    chatgpt_account_id: str | None = None
     email: str
     alias: str | None = None
     display_name: str

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -281,7 +281,7 @@ class AccountsService:
 
         email = claims.email or DEFAULT_EMAIL
         raw_account_id = claims.account_id
-        account_id = generate_unique_account_id(raw_account_id, email, claims.workspace_id)
+        account_id = generate_unique_account_id(raw_account_id, email, claims.workspace_id, claims.workspace_label)
         plan_type = coerce_account_plan_type(claims.plan_type, DEFAULT_PLAN)
         last_refresh = to_utc_naive(auth.last_refresh_at) if auth.last_refresh_at else utcnow()
 

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -596,19 +596,9 @@ class OauthService:
         )
         if self._repo_factory:
             async with self._repo_factory() as repo:
-                if raw_account_id and workspace_id is None:
-                    await repo.upsert(account, merge_by_email=False, merge_by_chatgpt_identity=True)
-                else:
-                    await repo.upsert_account_slot(account, preserve_unknown_workspace_duplicates=False)
+                await repo.upsert_account_slot(account, preserve_unknown_workspace_duplicates=False)
         else:
-            if raw_account_id and workspace_id is None:
-                await self._accounts_repo.upsert(
-                    account,
-                    merge_by_email=False,
-                    merge_by_chatgpt_identity=True,
-                )
-            else:
-                await self._accounts_repo.upsert_account_slot(account, preserve_unknown_workspace_duplicates=False)
+            await self._accounts_repo.upsert_account_slot(account, preserve_unknown_workspace_duplicates=False)
 
         await self._invalidate_account_routing_caches()
 

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -596,7 +596,12 @@ class OauthService:
         )
         if self._repo_factory:
             async with self._repo_factory() as repo:
-                if account.chatgpt_account_id:
+                if account.workspace_id or account.workspace_label:
+                    await repo.upsert_account_slot(
+                        account,
+                        preserve_unknown_workspace_duplicates=False,
+                    )
+                elif account.chatgpt_account_id:
                     await repo.upsert(
                         account,
                         merge_by_email=False,
@@ -608,7 +613,12 @@ class OauthService:
                         preserve_unknown_workspace_duplicates=False,
                     )
         else:
-            if account.chatgpt_account_id:
+            if account.workspace_id or account.workspace_label:
+                await self._accounts_repo.upsert_account_slot(
+                    account,
+                    preserve_unknown_workspace_duplicates=False,
+                )
+            elif account.chatgpt_account_id:
                 await self._accounts_repo.upsert(
                     account,
                     merge_by_email=False,

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -596,39 +596,15 @@ class OauthService:
         )
         if self._repo_factory:
             async with self._repo_factory() as repo:
-                if account.workspace_id or account.workspace_label:
-                    await repo.upsert_account_slot(
-                        account,
-                        preserve_unknown_workspace_duplicates=False,
-                    )
-                elif account.chatgpt_account_id:
-                    await repo.upsert(
-                        account,
-                        merge_by_email=False,
-                        merge_by_chatgpt_identity=True,
-                    )
-                else:
-                    await repo.upsert_account_slot(
-                        account,
-                        preserve_unknown_workspace_duplicates=False,
-                    )
+                await repo.upsert_account_slot(
+                    account,
+                    preserve_unknown_workspace_duplicates=False,
+                )
         else:
-            if account.workspace_id or account.workspace_label:
-                await self._accounts_repo.upsert_account_slot(
-                    account,
-                    preserve_unknown_workspace_duplicates=False,
-                )
-            elif account.chatgpt_account_id:
-                await self._accounts_repo.upsert(
-                    account,
-                    merge_by_email=False,
-                    merge_by_chatgpt_identity=True,
-                )
-            else:
-                await self._accounts_repo.upsert_account_slot(
-                    account,
-                    preserve_unknown_workspace_duplicates=False,
-                )
+            await self._accounts_repo.upsert_account_slot(
+                account,
+                preserve_unknown_workspace_duplicates=False,
+            )
 
         await self._invalidate_account_routing_caches()
 

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -596,9 +596,29 @@ class OauthService:
         )
         if self._repo_factory:
             async with self._repo_factory() as repo:
-                await repo.upsert_account_slot(account, preserve_unknown_workspace_duplicates=False)
+                if account.chatgpt_account_id:
+                    await repo.upsert(
+                        account,
+                        merge_by_email=False,
+                        merge_by_chatgpt_identity=True,
+                    )
+                else:
+                    await repo.upsert_account_slot(
+                        account,
+                        preserve_unknown_workspace_duplicates=False,
+                    )
         else:
-            await self._accounts_repo.upsert_account_slot(account, preserve_unknown_workspace_duplicates=False)
+            if account.chatgpt_account_id:
+                await self._accounts_repo.upsert(
+                    account,
+                    merge_by_email=False,
+                    merge_by_chatgpt_identity=True,
+                )
+            else:
+                await self._accounts_repo.upsert_account_slot(
+                    account,
+                    preserve_unknown_workspace_duplicates=False,
+                )
 
         await self._invalidate_account_routing_caches()
 

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -573,7 +573,7 @@ class OauthService:
         workspace_id = clean_account_identity_part(auth_claims.workspace_id or claims.workspace_id)
         workspace_label = clean_account_identity_part(auth_claims.workspace_label or claims.workspace_label)
         seat_type = normalize_seat_type(auth_claims.seat_type or claims.seat_type)
-        account_id = generate_unique_account_id(raw_account_id, email, workspace_id)
+        account_id = generate_unique_account_id(raw_account_id, email, workspace_id, workspace_label)
         plan_type = coerce_account_plan_type(
             auth_claims.chatgpt_plan_type or claims.chatgpt_plan_type,
             DEFAULT_PLAN,

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -599,11 +599,13 @@ class OauthService:
                 await repo.upsert_account_slot(
                     account,
                     preserve_unknown_workspace_duplicates=False,
+                    preserve_identity_slots=True,
                 )
         else:
             await self._accounts_repo.upsert_account_slot(
                 account,
                 preserve_unknown_workspace_duplicates=False,
+                preserve_identity_slots=True,
             )
 
         await self._invalidate_account_routing_caches()

--- a/frontend/src/features/accounts/components/account-detail.tsx
+++ b/frontend/src/features/accounts/components/account-detail.tsx
@@ -85,7 +85,7 @@ export function AccountDetail({
       ? account.email
       : null;
   const idSuffix = showAccountId ? ` (${compactId})` : "";
-  const workspaceLabel = account.workspaceLabel || account.workspaceId || "Personal / unknown workspace";
+  const workspaceLabel = account.chatgptAccountId || account.workspaceLabel || account.workspaceId || "Personal / unknown workspace";
   const seatLabel = account.seatType ? ` | ${formatSlug(account.seatType)}` : "";
 
   return (

--- a/frontend/src/features/accounts/components/account-list-item.test.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.test.tsx
@@ -196,6 +196,7 @@ describe("AccountListItem", () => {
       displayName: "Work seat",
       email: "work@example.com",
       planType: "team",
+      chatgptAccountId: null,
       workspaceLabel: "Design Workspace",
       seatType: "member",
     });
@@ -206,5 +207,20 @@ describe("AccountListItem", () => {
     expect(
       screen.getByText((_, element) => element?.textContent === "work@example.com | Team | Design Workspace | Member"),
     ).toBeInTheDocument();
+  });
+
+  it("uses ChatGPT account id before workspace metadata or unknown fallback", () => {
+    const account = createAccountSummary({
+      planType: "team",
+      workspaceId: "legacy-workspace-id",
+      workspaceLabel: "Legacy Workspace",
+      chatgptAccountId: "chatgpt-workspace-123",
+    });
+
+    render(<AccountListItem account={account} selected={false} onSelect={vi.fn()} />);
+
+    expect(screen.getByText("Team | chatgpt-workspace-123")).toBeInTheDocument();
+    expect(screen.queryByText(/Legacy Workspace/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Personal \/ unknown workspace/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/accounts/components/account-list-item.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.tsx
@@ -41,7 +41,7 @@ export function AccountListItem({
   const emailSubtitle = account.displayName && account.displayName !== account.email
     ? account.email
     : null;
-  const workspaceLabel = account.workspaceLabel || account.workspaceId || "Personal / unknown workspace";
+  const workspaceLabel = account.chatgptAccountId || account.workspaceLabel || account.workspaceId || "Personal / unknown workspace";
   const seatLabel = account.seatType ? ` | ${formatSlug(account.seatType)}` : "";
   const slotSubtitle = `${formatSlug(account.planType)} | ${workspaceLabel}${seatLabel}`;
   const idSuffix = showAccountId ? ` | ID ${formatCompactAccountId(account.accountId)}` : "";

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -64,6 +64,7 @@ export const AccountAdditionalQuotaSchema = z.object({
 
 export const AccountSummarySchema = z.object({
   accountId: z.string(),
+  chatgptAccountId: z.string().nullable().optional(),
   email: z.string(),
   alias: z.string().nullable().optional(),
   displayName: z.string(),

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -92,6 +92,7 @@ export function createAccountSummary(
 ): AccountSummary {
 	return AccountSummarySchema.parse({
 		accountId: "acc_primary",
+		chatgptAccountId: "chatgpt_acc_primary",
 		email: "primary@example.com",
 		alias: null,
 		displayName: "primary@example.com",

--- a/openspec/changes/fix-account-workspace-identity/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-account-workspace-identity/specs/frontend-architecture/spec.md
@@ -10,6 +10,12 @@ The Accounts page SHALL display a two-column layout: left panel with searchable 
 - **AND** at least one account has workspace metadata
 - **THEN** the list and detail views show workspace identity or compact account id context sufficient to distinguish the credential slots
 
+#### Scenario: Same-login workspace slots are preserved
+
+- **WHEN** multiple imported or OAuth-completed credentials share the same ChatGPT account identity
+- **AND** they carry distinct workspace ids or workspace labels
+- **THEN** each workspace credential is preserved as a separate local account slot
+
 #### Scenario: Import copy reflects credential slots
 
 - **WHEN** a user views import settings

--- a/openspec/changes/fix-shared-workspace-account-slots/proposal.md
+++ b/openspec/changes/fix-shared-workspace-account-slots/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+Some OpenAI workspace tokens expose the same `chatgpt_account_id` for multiple
+human login emails in the same workspace. When codex-lb treats that upstream
+workspace identifier as a unique account identity, adding or reauthorizing one
+workspace member can overwrite another member's stored tokens.
+
+## What Changes
+
+- Preserve separate local account slots for different emails that share the
+  same upstream `chatgpt_account_id`, with or without a reported workspace id.
+- Keep re-import/reauth of the same email on the same slot updating that slot.
+- Display the upstream ChatGPT account id as the primary workspace/account-slot
+  context because OpenAI does not reliably provide a selected workspace name.
+- Add regression coverage for shared workspace account identities.
+
+## Impact
+
+Operators can add multiple accounts from the same OpenAI workspace without the
+latest OAuth/import replacing a sibling account's email and tokens.

--- a/openspec/changes/fix-shared-workspace-account-slots/specs/account-identity/spec.md
+++ b/openspec/changes/fix-shared-workspace-account-slots/specs/account-identity/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Shared upstream workspace identities preserve account slots
+
+The account import and OAuth add-account flows MUST preserve separate local account slots for different real email addresses even when the upstream token reports the same ChatGPT account id, with or without a workspace id.
+
+Dashboard account summaries MUST expose and render the upstream ChatGPT account id as the primary workspace/account-slot context before falling back to optional workspace metadata or a generic unknown-workspace label.
+
+#### Scenario: Shared workspace account ids preserve separate emails
+- **GIVEN** two account credentials have different real email addresses
+- **AND** both credentials report the same upstream ChatGPT account id
+- **WHEN** the operator imports or adds both accounts through OAuth
+- **THEN** the system persists separate local account slots for each email
+- **AND** the second account does not overwrite the first account's stored email or tokens
+
+#### Scenario: Workspace context uses ChatGPT account id
+- **GIVEN** an account has a ChatGPT account id
+- **WHEN** the dashboard renders the account workspace context
+- **THEN** it displays the ChatGPT account id
+- **AND** it does not display the generic unknown-workspace label

--- a/openspec/changes/fix-shared-workspace-account-slots/tasks.md
+++ b/openspec/changes/fix-shared-workspace-account-slots/tasks.md
@@ -1,0 +1,15 @@
+## 1. Account Identity
+
+- [x] 1.1 Scope ChatGPT identity reconciliation by email as well as workspace identity.
+- [x] 1.2 Persist workspace-less OAuth logins through the account-slot path so different emails do not merge.
+
+## 2. Tests
+
+- [x] 2.1 Add regression coverage for two emails sharing the same `chatgpt_account_id` and `workspace_id`.
+- [x] 2.2 Add regression coverage for two workspace-less emails sharing the same `chatgpt_account_id`.
+- [x] 2.3 Add regression coverage for ChatGPT account id workspace display fallback.
+
+## 3. Validation
+
+- [ ] 3.1 Run focused account repository/API tests.
+- [ ] 3.2 Run OpenSpec validation.

--- a/tests/integration/test_accounts_repository.py
+++ b/tests/integration/test_accounts_repository.py
@@ -219,3 +219,42 @@ async def test_upsert_account_slot_preserves_same_chatgpt_id_across_workspace_la
         ("mavos_workspace", "Mavos"),
         ("triton_workspace", "Triton"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_upsert_account_slot_adds_third_label_only_workspace_for_same_email(db_setup):
+    del db_setup
+    first = _account(
+        "mavos_workspace",
+        chatgpt_account_id="chatgpt_label_slots",
+        email="operator@example.com",
+        workspace_label="Mavos",
+    )
+    second = _account(
+        "triton_workspace",
+        chatgpt_account_id="chatgpt_label_slots",
+        email="operator@example.com",
+        workspace_label="Triton",
+    )
+    third = _account(
+        "atlas_workspace",
+        chatgpt_account_id="chatgpt_label_slots",
+        email="operator@example.com",
+        workspace_label="Atlas",
+    )
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        saved_first = await repo.upsert_account_slot(first, preserve_unknown_workspace_duplicates=False)
+        saved_second = await repo.upsert_account_slot(second, preserve_unknown_workspace_duplicates=False)
+        saved_third = await repo.upsert_account_slot(third, preserve_unknown_workspace_duplicates=False)
+        accounts = await repo.list_accounts()
+
+    assert saved_first.id == "mavos_workspace"
+    assert saved_second.id == "triton_workspace"
+    assert saved_third.id == "atlas_workspace"
+    assert [(account.id, account.workspace_label) for account in accounts] == [
+        ("mavos_workspace", "Mavos"),
+        ("triton_workspace", "Triton"),
+        ("atlas_workspace", "Atlas"),
+    ]

--- a/tests/integration/test_accounts_repository.py
+++ b/tests/integration/test_accounts_repository.py
@@ -8,11 +8,18 @@ from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 
 
-def _account(account_id: str = "acc_refresh") -> Account:
+def _account(
+    account_id: str = "acc_refresh",
+    *,
+    chatgpt_account_id: str = "chatgpt_refresh",
+    email: str | None = None,
+    workspace_id: str | None = None,
+) -> Account:
     return Account(
         id=account_id,
-        chatgpt_account_id="chatgpt_refresh",
-        email=f"{account_id}@example.com",
+        chatgpt_account_id=chatgpt_account_id,
+        email=email or f"{account_id}@example.com",
+        workspace_id=workspace_id,
         plan_type="plus",
         access_token_encrypted=b"access",
         refresh_token_encrypted=b"refresh",
@@ -48,3 +55,66 @@ async def test_list_accounts_refresh_existing_reloads_identity_map(db_setup):
         refreshed = (await reader_repo.list_accounts(refresh_existing=True))[0]
         assert refreshed is loaded
         assert refreshed.limit_warmup_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_upsert_account_slot_preserves_emails_sharing_workspace_identity(db_setup):
+    del db_setup
+    shared_chatgpt_id = "chatgpt_workspace_shared"
+    shared_workspace_id = "workspace_shared"
+    first = _account(
+        "first_slot",
+        chatgpt_account_id=shared_chatgpt_id,
+        email="first@example.com",
+        workspace_id=shared_workspace_id,
+    )
+    second = _account(
+        "second_slot",
+        chatgpt_account_id=shared_chatgpt_id,
+        email="second@example.com",
+        workspace_id=shared_workspace_id,
+    )
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        saved_first = await repo.upsert_account_slot(first, preserve_unknown_workspace_duplicates=False)
+        saved_second = await repo.upsert_account_slot(second, preserve_unknown_workspace_duplicates=False)
+
+        assert saved_first.id == "first_slot"
+        assert saved_second.id == "second_slot"
+        accounts = await repo.list_accounts()
+
+    assert [(account.id, account.email) for account in accounts] == [
+        ("first_slot", "first@example.com"),
+        ("second_slot", "second@example.com"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upsert_account_slot_preserves_emails_sharing_workspace_less_identity(db_setup):
+    del db_setup
+    shared_chatgpt_id = "chatgpt_workspace_less_shared"
+    first = _account(
+        "workspace_less_first",
+        chatgpt_account_id=shared_chatgpt_id,
+        email="first@example.com",
+    )
+    second = _account(
+        "workspace_less_second",
+        chatgpt_account_id=shared_chatgpt_id,
+        email="second@example.com",
+    )
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        saved_first = await repo.upsert_account_slot(first, preserve_unknown_workspace_duplicates=False)
+        saved_second = await repo.upsert_account_slot(second, preserve_unknown_workspace_duplicates=False)
+
+        assert saved_first.id == "workspace_less_first"
+        assert saved_second.id == "workspace_less_second"
+        accounts = await repo.list_accounts()
+
+    assert [(account.id, account.email) for account in accounts] == [
+        ("workspace_less_first", "first@example.com"),
+        ("workspace_less_second", "second@example.com"),
+    ]

--- a/tests/integration/test_accounts_repository.py
+++ b/tests/integration/test_accounts_repository.py
@@ -153,6 +153,45 @@ async def test_upsert_account_slot_preserves_same_chatgpt_id_across_workspace_id
 
 
 @pytest.mark.asyncio
+async def test_upsert_account_slot_adds_third_workspace_slot_for_same_email(db_setup):
+    del db_setup
+    first = _account(
+        "mavos_primary",
+        chatgpt_account_id="chatgpt_mavos_primary",
+        email="operator@example.com",
+        workspace_id="ws_mavos_primary",
+    )
+    second = _account(
+        "mavos_secondary",
+        chatgpt_account_id="chatgpt_mavos_secondary",
+        email="operator@example.com",
+        workspace_id="ws_mavos_secondary",
+    )
+    third = _account(
+        "mavos_tertiary",
+        chatgpt_account_id="chatgpt_mavos_tertiary",
+        email="operator@example.com",
+        workspace_id="ws_mavos_tertiary",
+    )
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        saved_first = await repo.upsert_account_slot(first, preserve_unknown_workspace_duplicates=False)
+        saved_second = await repo.upsert_account_slot(second, preserve_unknown_workspace_duplicates=False)
+        saved_third = await repo.upsert_account_slot(third, preserve_unknown_workspace_duplicates=False)
+        accounts = await repo.list_accounts()
+
+    assert saved_first.id == "mavos_primary"
+    assert saved_second.id == "mavos_secondary"
+    assert saved_third.id == "mavos_tertiary"
+    assert [(account.id, account.workspace_id) for account in accounts] == [
+        ("mavos_primary", "ws_mavos_primary"),
+        ("mavos_secondary", "ws_mavos_secondary"),
+        ("mavos_tertiary", "ws_mavos_tertiary"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_upsert_account_slot_preserves_same_chatgpt_id_across_workspace_labels(db_setup):
     del db_setup
     first = _account(

--- a/tests/integration/test_accounts_repository.py
+++ b/tests/integration/test_accounts_repository.py
@@ -14,12 +14,14 @@ def _account(
     chatgpt_account_id: str = "chatgpt_refresh",
     email: str | None = None,
     workspace_id: str | None = None,
+    workspace_label: str | None = None,
 ) -> Account:
     return Account(
         id=account_id,
         chatgpt_account_id=chatgpt_account_id,
         email=email or f"{account_id}@example.com",
         workspace_id=workspace_id,
+        workspace_label=workspace_label,
         plan_type="plus",
         access_token_encrypted=b"access",
         refresh_token_encrypted=b"refresh",
@@ -117,4 +119,64 @@ async def test_upsert_account_slot_preserves_emails_sharing_workspace_less_ident
     assert [(account.id, account.email) for account in accounts] == [
         ("workspace_less_first", "first@example.com"),
         ("workspace_less_second", "second@example.com"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upsert_account_slot_preserves_same_chatgpt_id_across_workspace_ids(db_setup):
+    del db_setup
+    first = _account(
+        "mavos_primary",
+        chatgpt_account_id="chatgpt_mavos_shared",
+        email="operator@example.com",
+        workspace_id="ws_mavos_primary",
+    )
+    second = _account(
+        "mavos_secondary",
+        chatgpt_account_id="chatgpt_mavos_shared",
+        email="operator@example.com",
+        workspace_id="ws_mavos_secondary",
+    )
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        saved_first = await repo.upsert_account_slot(first, preserve_unknown_workspace_duplicates=False)
+        saved_second = await repo.upsert_account_slot(second, preserve_unknown_workspace_duplicates=False)
+        accounts = await repo.list_accounts()
+
+    assert saved_first.id == "mavos_primary"
+    assert saved_second.id == "mavos_secondary"
+    assert [(account.id, account.workspace_id) for account in accounts] == [
+        ("mavos_primary", "ws_mavos_primary"),
+        ("mavos_secondary", "ws_mavos_secondary"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_upsert_account_slot_preserves_same_chatgpt_id_across_workspace_labels(db_setup):
+    del db_setup
+    first = _account(
+        "mavos_workspace",
+        chatgpt_account_id="chatgpt_mavos_shared_label",
+        email="operator@example.com",
+        workspace_label="Mavos",
+    )
+    second = _account(
+        "triton_workspace",
+        chatgpt_account_id="chatgpt_mavos_shared_label",
+        email="operator@example.com",
+        workspace_label="Triton",
+    )
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        saved_first = await repo.upsert_account_slot(first, preserve_unknown_workspace_duplicates=False)
+        saved_second = await repo.upsert_account_slot(second, preserve_unknown_workspace_duplicates=False)
+        accounts = await repo.list_accounts()
+
+    assert saved_first.id == "mavos_workspace"
+    assert saved_second.id == "triton_workspace"
+    assert [(account.id, account.workspace_label) for account in accounts] == [
+        ("mavos_workspace", "Mavos"),
+        ("triton_workspace", "Triton"),
     ]

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -487,12 +487,9 @@ async def test_oauth_persist_tokens_invalidates_routing_caches_after_identity_me
         )
     )
 
-    repo.upsert.assert_awaited_once()
-    _, upsert_kwargs = repo.upsert.await_args
-    assert upsert_kwargs == {
-        "merge_by_email": False,
-        "merge_by_chatgpt_identity": True,
-    }
+    repo.upsert.assert_not_awaited()
+    repo.upsert_account_slot.assert_awaited_once()
+    assert repo.upsert_account_slot.await_args.kwargs == {"preserve_unknown_workspace_duplicates": False}
     assert account_cache.invalidated is True
     assert api_key_cache.cleared is True
     assert poller.bumped == ["api_key"]

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -499,6 +499,43 @@ async def test_oauth_persist_tokens_invalidates_routing_caches_after_identity_me
 
 
 @pytest.mark.asyncio
+async def test_oauth_persist_tokens_uses_slot_upsert_for_label_only_workspace(monkeypatch):
+    repo = AsyncMock()
+    service = oauth_module.OauthService(repo)
+    monkeypatch.setattr(
+        oauth_module,
+        "get_account_selection_cache",
+        lambda: SimpleNamespace(invalidate=lambda: None),
+        raising=False,
+    )
+    monkeypatch.setattr(oauth_module, "get_api_key_cache", lambda: SimpleNamespace(clear=lambda: None), raising=False)
+    monkeypatch.setattr(oauth_module, "get_cache_invalidation_poller", lambda: None, raising=False)
+
+    payload = {
+        "email": "label-workspace@example.com",
+        "chatgpt_account_id": "acc_label_workspace",
+        "https://api.openai.com/auth": {
+            "workspace_label": "Label Only Workspace",
+            "chatgpt_plan_type": "plus",
+        },
+    }
+
+    await service._persist_tokens(
+        OAuthTokens(
+            access_token="access-token",
+            refresh_token="refresh-token",
+            id_token=_encode_jwt(payload),
+        )
+    )
+
+    repo.upsert.assert_not_awaited()
+    repo.upsert_account_slot.assert_awaited_once()
+    saved_account = repo.upsert_account_slot.await_args.args[0]
+    assert saved_account.workspace_label == "Label Only Workspace"
+    assert repo.upsert_account_slot.await_args.kwargs == {"preserve_unknown_workspace_duplicates": False}
+
+
+@pytest.mark.asyncio
 async def test_device_oauth_flow_keeps_same_email_distinct_upstream_identities_in_overwrite_mode(
     async_client,
     monkeypatch,

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -487,7 +487,12 @@ async def test_oauth_persist_tokens_invalidates_routing_caches_after_identity_me
         )
     )
 
-    repo.upsert_account_slot.assert_awaited_once()
+    repo.upsert.assert_awaited_once()
+    _, upsert_kwargs = repo.upsert.await_args
+    assert upsert_kwargs == {
+        "merge_by_email": False,
+        "merge_by_chatgpt_identity": True,
+    }
     assert account_cache.invalidated is True
     assert api_key_cache.cleared is True
     assert poller.bumped == ["api_key"]

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -489,7 +489,10 @@ async def test_oauth_persist_tokens_invalidates_routing_caches_after_identity_me
 
     repo.upsert.assert_not_awaited()
     repo.upsert_account_slot.assert_awaited_once()
-    assert repo.upsert_account_slot.await_args.kwargs == {"preserve_unknown_workspace_duplicates": False}
+    assert repo.upsert_account_slot.await_args.kwargs == {
+        "preserve_unknown_workspace_duplicates": False,
+        "preserve_identity_slots": True,
+    }
     assert account_cache.invalidated is True
     assert api_key_cache.cleared is True
     assert poller.bumped == ["api_key"]
@@ -529,7 +532,10 @@ async def test_oauth_persist_tokens_uses_slot_upsert_for_label_only_workspace(mo
     repo.upsert_account_slot.assert_awaited_once()
     saved_account = repo.upsert_account_slot.await_args.args[0]
     assert saved_account.workspace_label == "Label Only Workspace"
-    assert repo.upsert_account_slot.await_args.kwargs == {"preserve_unknown_workspace_duplicates": False}
+    assert repo.upsert_account_slot.await_args.kwargs == {
+        "preserve_unknown_workspace_duplicates": False,
+        "preserve_identity_slots": True,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -487,7 +487,7 @@ async def test_oauth_persist_tokens_invalidates_routing_caches_after_identity_me
         )
     )
 
-    repo.upsert.assert_awaited_once()
+    repo.upsert_account_slot.assert_awaited_once()
     assert account_cache.invalidated is True
     assert api_key_cache.cleared is True
     assert poller.bumped == ["api_key"]

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -274,6 +274,33 @@ async def test_account_slot_upgrades_single_legacy_unknown_workspace_row(db_setu
 
 
 @pytest.mark.asyncio
+async def test_account_slot_upgrades_label_only_workspace_when_id_arrives(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        label_only = _make_account("acc_label_only_workspace", "label-only-workspace@example.com")
+        label_only.chatgpt_account_id = "raw_label_only_workspace"
+        label_only.workspace_label = "Legacy Team"
+        stored_label_only = await repo.upsert_account_slot(label_only, preserve_unknown_workspace_duplicates=False)
+
+        upgraded = _make_account("acc_workspace_id", "label-only-workspace@example.com")
+        upgraded.chatgpt_account_id = "raw_label_only_workspace"
+        upgraded.workspace_id = "ws_legacy_team"
+        upgraded.workspace_label = "Legacy Team"
+        upgraded.plan_type = "team"
+
+        stored = await repo.upsert_account_slot(upgraded, preserve_unknown_workspace_duplicates=False)
+
+        assert stored.id == stored_label_only.id
+        assert stored.workspace_id == "ws_legacy_team"
+        assert stored.workspace_label == "Legacy Team"
+        assert stored.plan_type == "team"
+
+        accounts = list((await session.execute(select(Account))).scalars().all())
+        assert [account.id for account in accounts] == [stored_label_only.id]
+
+
+@pytest.mark.asyncio
 async def test_workspace_slot_taken_ignores_same_email_workspace_when_chatgpt_identity_differs(db_setup):
     async with SessionLocal() as session:
         repo = AccountsRepository(session)

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -429,6 +429,30 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reuses_deactivated_row(
 
 
 @pytest.mark.asyncio
+async def test_accounts_upsert_merge_by_chatgpt_identity_reuses_row_when_email_changes(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        original = _make_account_with_chatgpt_id("acc_email_change", "old-email@example.com", "chatgpt_email_change")
+        await repo.upsert(original, merge_by_email=False)
+
+        reauth = _make_account_with_chatgpt_id("acc_email_change", "new-email@example.com", "chatgpt_email_change")
+        reauth.plan_type = "team"
+        saved = await repo.upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        assert saved.id == "acc_email_change"
+        assert saved.email == "new-email@example.com"
+        assert saved.plan_type == "team"
+        rows = list(
+            (await session.execute(select(Account).where(Account.chatgpt_account_id == "chatgpt_email_change")))
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].id == "acc_email_change"
+
+
+@pytest.mark.asyncio
 async def test_accounts_upsert_merge_by_chatgpt_identity_picks_oldest_canonical(db_setup):
     async with SessionLocal() as session:
         repo = AccountsRepository(session)

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -522,6 +522,55 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_matches_email_row_among
 
 
 @pytest.mark.asyncio
+async def test_accounts_upsert_merge_by_chatgpt_identity_matches_label_only_workspace_slot(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        mavos = _make_account_with_chatgpt_id(
+            "acc_mavos",
+            "shared-label@example.com",
+            "chatgpt_label_collision",
+        )
+        mavos.workspace_label = "Mavos"
+        await repo.upsert(mavos, merge_by_email=False)
+
+        triton = _make_account_with_chatgpt_id(
+            "acc_triton",
+            "shared-label@example.com",
+            "chatgpt_label_collision",
+        )
+        triton.workspace_label = "Triton"
+        await repo.upsert(triton, merge_by_email=False)
+
+        reauth = _make_account_with_chatgpt_id(
+            "acc_triton",
+            "shared-label@example.com",
+            "chatgpt_label_collision",
+        )
+        reauth.workspace_label = "Triton"
+        reauth.plan_type = "team"
+        saved = await repo.upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        assert saved.id == "acc_triton"
+        assert saved.workspace_label == "Triton"
+        assert saved.plan_type == "team"
+
+        rows = list(
+            (
+                await session.execute(
+                    select(Account).where(Account.chatgpt_account_id == "chatgpt_label_collision")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert {(row.id, row.workspace_label, row.plan_type) for row in rows} == {
+            ("acc_mavos", "Mavos", "plus"),
+            ("acc_triton", "Triton", "team"),
+        }
+
+
+@pytest.mark.asyncio
 async def test_accounts_upsert_merge_by_chatgpt_identity_picks_oldest_canonical(db_setup):
     async with SessionLocal() as session:
         repo = AccountsRepository(session)

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -453,6 +453,48 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reuses_row_when_email_c
 
 
 @pytest.mark.asyncio
+async def test_accounts_upsert_merge_by_chatgpt_identity_matches_email_row_among_collisions(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+
+        original_other_email = _make_account_with_chatgpt_id(
+            "acc_other_email",
+            "other@example.com",
+            "chatgpt_email_collision",
+        )
+        await repo.upsert(original_other_email, merge_by_email=False)
+
+        canonical_email = _make_account_with_chatgpt_id(
+            "acc_matching_email",
+            "current@example.com",
+            "chatgpt_email_collision",
+        )
+        await repo.upsert(canonical_email, merge_by_email=False)
+
+        reauth = _make_account_with_chatgpt_id(
+            "acc_reauth",
+            "current@example.com",
+            "chatgpt_email_collision",
+        )
+        reauth.plan_type = "team"
+        saved = await repo.upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
+
+        assert saved.id == "acc_matching_email"
+        assert saved.email == "current@example.com"
+        assert saved.plan_type == "team"
+
+        rows = list(
+            (await session.execute(select(Account).where(Account.chatgpt_account_id == "chatgpt_email_collision")))
+            .scalars()
+            .all()
+        )
+        assert {(row.id, row.email) for row in rows} == {
+            ("acc_other_email", "other@example.com"),
+            ("acc_matching_email", "current@example.com"),
+        }
+
+
+@pytest.mark.asyncio
 async def test_accounts_upsert_merge_by_chatgpt_identity_picks_oldest_canonical(db_setup):
     async with SessionLocal() as session:
         repo = AccountsRepository(session)

--- a/tests/unit/test_accounts_repository_locks.py
+++ b/tests/unit/test_accounts_repository_locks.py
@@ -55,8 +55,14 @@ def _make_postgres_repo(monkeypatch: pytest.MonkeyPatch) -> tuple[AccountsReposi
     async def fake_merge_by_email_enabled() -> bool:  # only used when merge_by_email is None
         return True
 
-    async def fake_account_by_chatgpt_identity(_chatgpt_id: str, *, workspace_id: str | None):
+    async def fake_account_by_chatgpt_identity(
+        _chatgpt_id: str,
+        *,
+        workspace_id: str | None,
+        email: str | None,
+    ):
         del workspace_id
+        del email
         return None
 
     async def fake_single_account_by_email(_email: str):

--- a/tests/unit/test_accounts_repository_locks.py
+++ b/tests/unit/test_accounts_repository_locks.py
@@ -59,9 +59,11 @@ def _make_postgres_repo(monkeypatch: pytest.MonkeyPatch) -> tuple[AccountsReposi
         _chatgpt_id: str,
         *,
         workspace_id: str | None,
+        workspace_label: str | None,
         email: str | None,
     ):
         del workspace_id
+        del workspace_label
         del email
         return None
 


### PR DESCRIPTION
Follow-up for #974 after the source fork rejected maintainer pushes (`maintainerCanModify=false`).

This keeps the shared-workspace account-slot fix moving without losing the original contributor context. It addresses the current Codex finding on #974: same-email label-only workspace slots (for example Mavos/Triton) must not collapse through the `merge_by_chatgpt_identity` reauth path.

Changes:
- pass `workspace_label` into ChatGPT-identity canonical lookup and duplicate reconciliation
- constrain unknown-workspace fallbacks by label when the label is the only workspace identity
- add a regression proving one label-only workspace reauth does not overwrite/delete a sibling label-only slot

Validation:
- `uv run pytest tests/integration/test_repositories.py tests/integration/test_accounts_repository.py tests/integration/test_oauth_flow.py tests/unit/test_accounts_repository_locks.py -q`
- `uv run ruff check app/modules/accounts/repository.py tests/integration/test_repositories.py tests/unit/test_accounts_repository_locks.py`
- `git diff --check`

Refs #974.