### PR TITLE
fix(proxy): settle timed-out startup probe tasks

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2624,6 +2624,23 @@ async def _read_first_stream_item(stream: AsyncIterator[str]) -> str:
     return await anext(stream)
 
 
+def _consume_first_stream_task_exception(first_task: asyncio.Task[str]) -> None:
+    if first_task.cancelled():
+        return
+    try:
+        first_task.exception()
+    except asyncio.CancelledError:
+        return
+
+
+async def _await_first_stream_item_probe(first_task: asyncio.Task[str], timeout_seconds: float) -> str:
+    done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
+    if not done:
+        first_task.add_done_callback(_consume_first_stream_task_exception)
+        raise TimeoutError
+    return await first_task
+
+
 async def _probe_stream_startup_error(
     stream: AsyncIterator[str],
     *,
@@ -2634,10 +2651,7 @@ async def _probe_stream_startup_error(
         timeout_seconds = _STREAM_STARTUP_ERROR_PROBE_SECONDS
     first_task = asyncio.create_task(_read_first_stream_item(stream))
     try:
-        first = await asyncio.wait_for(
-            asyncio.shield(first_task),
-            timeout=timeout_seconds,
-        )
+        first = await _await_first_stream_item_probe(first_task, timeout_seconds)
     except TimeoutError:
         return _prepend_first_task(first_task, stream), None
     except StopAsyncIteration:
@@ -2946,10 +2960,7 @@ async def _probe_chat_stream_startup_error(
     for _ in range(max_startup_events):
         first_task = asyncio.create_task(_read_first_stream_item(stream))
         try:
-            first = await asyncio.wait_for(
-                asyncio.shield(first_task),
-                timeout=timeout_seconds,
-            )
+            first = await _await_first_stream_item_probe(first_task, timeout_seconds)
         except TimeoutError:
             return _prepend_items(buffered, _prepend_first_task(first_task, stream)), None
         except StopAsyncIteration:

--- a/openspec/changes/fix-startup-probe-task-exceptions/proposal.md
+++ b/openspec/changes/fix-startup-probe-task-exceptions/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Startup error probes for Responses and chat-completions streams keep reading the
+first upstream item in a shielded task after the probe timeout expires. If the
+owning request path abandons the returned stream before consuming that task, an
+upstream `ProxyResponseError` can surface later as an unhandled asyncio task
+exception.
+
+## What Changes
+
+- Ensure timed-out startup probe tasks have their eventual exception consumed if
+  the returned stream is abandoned.
+- Preserve the existing behavior for callers that do consume the returned stream:
+  the first item, `StopAsyncIteration`, or `ProxyResponseError` is still observed
+  through iteration.
+- Add regression coverage for abandoned startup probe streams.
+
+## Impact
+
+- Removes noisy and misleading asyncio diagnostics for upstream first-item
+  failures.
+- Keeps client-visible startup error and streaming behavior unchanged.

--- a/openspec/changes/fix-startup-probe-task-exceptions/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-startup-probe-task-exceptions/specs/responses-api-compat/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Timed-out startup probes MUST settle first-item task exceptions
+
+The proxy MUST retrieve eventual first-item task exceptions when a Responses or
+chat-completions startup error probe times out while its first-item task is
+still running and the returned stream is abandoned before iteration resumes.
+This MUST prevent unhandled asyncio task diagnostics such as `Task exception was
+never retrieved` or shielded-future exception logs for upstream
+`ProxyResponseError` failures that arrive after the probe timeout.
+
+If the returned stream is consumed later, the task result or exception MUST
+remain observable through normal stream iteration.
+
+#### Scenario: Abandoned timed-out probe consumes first-item exception
+
+- **GIVEN** a startup probe times out before the first upstream stream item is available
+- **AND** the first-item task later raises `ProxyResponseError`
+- **WHEN** the request path abandons the returned stream before consuming that task
+- **THEN** the event loop does not emit an unhandled task-exception diagnostic
+- **AND** task ownership is settled without changing the client-visible result
+
+#### Scenario: Consumed timed-out probe preserves stream behavior
+
+- **GIVEN** a startup probe times out before the first upstream stream item is available
+- **WHEN** the caller later iterates the returned stream
+- **THEN** the first task's result or exception is still yielded or raised through the returned stream

--- a/openspec/changes/fix-startup-probe-task-exceptions/tasks.md
+++ b/openspec/changes/fix-startup-probe-task-exceptions/tasks.md
@@ -1,0 +1,4 @@
+- [x] Add a Responses API compatibility requirement for startup probe task ownership.
+- [x] Consume first-item task exceptions when a timed-out startup probe stream is abandoned.
+- [x] Add unit regression coverage for Responses and chat-completions startup probes.
+- [x] Run targeted tests and OpenSpec validation.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
 import logging
 import ssl
 import time
 from collections import deque
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from types import SimpleNamespace
 from typing import Any, Iterator, Protocol, Self, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -185,6 +186,65 @@ async def test_account_selection_recovery_sleep_refuses_exhausted_budget(monkeyp
 
     assert waited is False
     sleep.assert_not_awaited()
+
+
+async def _raise_proxy_response_error_after_timeout() -> AsyncIterator[str]:
+    await asyncio.sleep(0.02)
+    raise proxy_module.ProxyResponseError(429, openai_error("rate_limit_exceeded", "upstream quota reached"))
+    yield ""
+
+
+async def _collect_unhandled_loop_exceptions() -> tuple[
+    asyncio.AbstractEventLoop,
+    list[dict[str, Any]],
+    Callable[[asyncio.AbstractEventLoop, dict[str, Any]], object] | None,
+]:
+    loop = asyncio.get_running_loop()
+    captured: list[dict[str, Any]] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: captured.append(context))
+    return loop, captured, previous_handler
+
+
+async def _finish_unobserved_task_cleanup() -> None:
+    for _ in range(5):
+        gc.collect()
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.asyncio
+async def test_responses_startup_probe_timeout_consumes_abandoned_first_task_exception():
+    loop, captured, previous_handler = await _collect_unhandled_loop_exceptions()
+    try:
+        stream, startup_error = await proxy_api._probe_stream_startup_error(
+            _raise_proxy_response_error_after_timeout(),
+            timeout_seconds=0.001,
+        )
+        assert startup_error is None
+        del stream
+        await _finish_unobserved_task_cleanup()
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_chat_startup_probe_timeout_consumes_abandoned_first_task_exception():
+    loop, captured, previous_handler = await _collect_unhandled_loop_exceptions()
+    try:
+        stream, startup_error = await proxy_api._probe_chat_stream_startup_error(
+            _raise_proxy_response_error_after_timeout(),
+            timeout_seconds=0.001,
+            max_startup_events=1,
+        )
+        assert startup_error is None
+        del stream
+        await _finish_unobserved_task_cleanup()
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert captured == []
 
 
 def test_relative_availability_settings_default_when_stored_values_are_null():


### PR DESCRIPTION
## Summary

Settle timed-out startup probe first-item tasks so an abandoned stream cannot later emit an unhandled asyncio task exception when upstream raises `ProxyResponseError`.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Fixes #976

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-startup-probe-task-exceptions/`

## Changes

- Replace `wait_for(shield(first_task))` startup probing with an `asyncio.wait()` helper so probe timeout does not create an extra shield future that can report the later task exception.
- Add a done callback for timed-out first-item tasks so abandoned returned streams still retrieve eventual task exceptions.
- Add unit regressions for both Responses and chat-completions startup probes.
- Add an OpenSpec requirement for timed-out startup probe task ownership.

## Test plan

```
uv run pytest tests/unit/test_proxy_utils.py -k 'startup_probe_timeout_consumes_abandoned_first_task_exception' -q
uv run pytest tests/unit/test_proxy_utils.py -k 'startup_probe or stream_startup or raw_error_when_sdk_contract_disabled or response_create_admission_session_gate_timeout' -q
uv run ruff check app/modules/proxy/api.py tests/unit/test_proxy_utils.py
uv run ruff format --check app/modules/proxy/api.py tests/unit/test_proxy_utils.py
uv run ty check app/modules/proxy/api.py tests/unit/test_proxy_utils.py
openspec validate fix-startup-probe-task-exceptions --strict
openspec validate --specs
git diff --check
```

Result: all commands above passed locally.

## Screenshots / output (optional)

N/A.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
