### PR TITLE
fix(dashboard): link archive rows to request logs

### DIFF
--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -241,6 +241,9 @@ class ArchivingResponsesWebSocket:
 
     async def receive(self) -> UpstreamWebSocketMessage:
         message = await self._wrapped.receive()
+        return message
+
+    def archive_received(self, message: UpstreamWebSocketMessage) -> None:
         if message.kind == "text" and message.text is not None:
             archive_text(
                 direction="server_to_codex",
@@ -277,7 +280,6 @@ class ArchivingResponsesWebSocket:
                 headers=self._headers,
                 extra={"frame_type": message.kind, "close_code": message.close_code},
             )
-        return message
 
     async def close(self) -> None:
         await self._wrapped.close()

--- a/app/db/alembic/versions/20260611_000000_add_request_log_archive_request_id.py
+++ b/app/db/alembic/versions/20260611_000000_add_request_log_archive_request_id.py
@@ -1,0 +1,47 @@
+"""add request log archive request id
+
+Revision ID: 20260611_000000_add_request_log_archive_request_id
+Revises: 20260607_000000_merge_weekly_monthly_useragent_heads
+Create Date: 2026-06-11 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260611_000000_add_request_log_archive_request_id"
+down_revision = "20260607_000000_merge_weekly_monthly_useragent_heads"
+branch_labels = None
+depends_on = None
+
+_REQUEST_LOGS_TABLE = "request_logs"
+_ARCHIVE_REQUEST_ID_COLUMN = "archive_request_id"
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return set()
+    return {str(column["name"]) for column in inspector.get_columns(table_name) if column.get("name") is not None}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind, _REQUEST_LOGS_TABLE)
+    if not columns or _ARCHIVE_REQUEST_ID_COLUMN in columns:
+        return
+
+    with op.batch_alter_table(_REQUEST_LOGS_TABLE) as batch_op:
+        batch_op.add_column(sa.Column(_ARCHIVE_REQUEST_ID_COLUMN, sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind, _REQUEST_LOGS_TABLE)
+    if not columns or _ARCHIVE_REQUEST_ID_COLUMN not in columns:
+        return
+
+    with op.batch_alter_table(_REQUEST_LOGS_TABLE) as batch_op:
+        batch_op.drop_column(_ARCHIVE_REQUEST_ID_COLUMN)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -178,6 +178,7 @@ class RequestLog(Base):
     api_key_id: Mapped[str | None] = mapped_column(String, nullable=True)
     session_id: Mapped[str | None] = mapped_column(String, nullable=True)
     request_id: Mapped[str] = mapped_column(String, nullable=False)
+    archive_request_id: Mapped[str | None] = mapped_column(String, nullable=True)
     request_kind: Mapped[str] = mapped_column(
         String,
         default=RequestKind.NORMAL.value,

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -248,9 +248,11 @@ class _HTTPBridgeRequestSubmitMixin:
             if input_item_count > 0:
                 input_full_fingerprint = _fingerprint_input_items(payload_input_list)
 
+        resolved_request_id = request_id or f"ws_{uuid4().hex}"
         request_state = _WebSocketRequestState(
-            request_id=request_id or f"ws_{uuid4().hex}",
+            request_id=resolved_request_id,
             request_log_id=request_log_id,
+            archive_request_id=get_request_id() or resolved_request_id,
             model=payload.model,
             service_tier=forwarded_service_tier,
             reasoning_effort=payload.reasoning.effort if payload.reasoning else None,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -26,7 +26,9 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
 from app.core.clients.proxy import codex_control_request as core_codex_control_request  # noqa: F401
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
+from app.core.clients.proxy_websocket import UpstreamWebSocketMessage
 from app.core.openai.parsing import parse_sse_event
+from app.core.utils.request_id import reset_request_id, set_request_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 from app.modules.proxy._service.api_key_usage import (
     _API_KEY_RESERVATION_HEARTBEAT_SECONDS as _API_KEY_RESERVATION_HEARTBEAT_SECONDS,
@@ -167,6 +169,37 @@ _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS = 5.0
 _HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD = 100
 
 
+def _archive_http_bridge_upstream_text(
+    session: "_HTTPBridgeSession",
+    text: str,
+    request_state: "_WebSocketRequestState | None",
+) -> None:
+    _archive_http_bridge_upstream_message(
+        session,
+        UpstreamWebSocketMessage(kind="text", text=text),
+        request_state,
+    )
+
+
+def _archive_http_bridge_upstream_message(
+    session: "_HTTPBridgeSession",
+    message: UpstreamWebSocketMessage,
+    request_state: "_WebSocketRequestState | None",
+) -> None:
+    if request_state is None or request_state.archive_request_id is None:
+        archive_request_id = None
+    else:
+        archive_request_id = request_state.archive_request_id
+    archive_received = getattr(session.upstream, "archive_received", None)
+    if not callable(archive_received):
+        return
+    token = set_request_id(archive_request_id)
+    try:
+        archive_received(message)
+    finally:
+        reset_request_id(token)
+
+
 class _HTTPBridgeUpstreamEventsMixin:
     async def _relay_http_bridge_upstream_messages(
         self: Any,
@@ -226,6 +259,9 @@ class _HTTPBridgeUpstreamEventsMixin:
                         break
                     continue
 
+                async with session.pending_lock:
+                    archive_request_state = session.pending_requests[0] if len(session.pending_requests) == 1 else None
+                _archive_http_bridge_upstream_message(session, message, archive_request_state)
                 session.last_upstream_close_code = message.close_code
                 retried = await self._retry_http_bridge_precreated_request(session)
                 if retried:
@@ -288,6 +324,7 @@ class _HTTPBridgeUpstreamEventsMixin:
         session: "_HTTPBridgeSession",
         text: str,
     ) -> None:
+        original_text = text
         event_block = f"data: {text}\n\n"
         payload = parse_sse_data_json(event_block)
         event = parse_sse_event(event_block)
@@ -352,6 +389,8 @@ class _HTTPBridgeUpstreamEventsMixin:
                 release_create_gate = False
             else:
                 release_create_gate = False
+
+            _archive_http_bridge_upstream_text(session, original_text, matched_request_state)
 
             if matched_request_state is not None:
                 actual_service_tier = _service_tier_from_event_payload(payload)

--- a/app/modules/proxy/_service/request_log.py
+++ b/app/modules/proxy/_service/request_log.py
@@ -109,12 +109,14 @@ class _RequestLogMixin:
         upstream_proxy_fail_closed_reason: str | None = None,
         useragent: str | None = None,
         useragent_group: str | None = None,
+        archive_request_id: str | None = None,
     ) -> None:
         task = asyncio.create_task(
             self._persist_request_log(
                 account_id=account_id,
                 api_key_id=api_key.id if api_key else None,
                 request_id=request_id,
+                archive_request_id=archive_request_id,
                 model=model,
                 latency_ms=latency_ms,
                 status=status,
@@ -190,6 +192,7 @@ class _RequestLogMixin:
         account_id: str | None,
         api_key_id: str | None,
         request_id: str,
+        archive_request_id: str | None,
         model: str | None,
         latency_ms: int,
         status: str,
@@ -229,6 +232,7 @@ class _RequestLogMixin:
                     api_key_id=api_key_id,
                     session_id=_normalize_session_id(session_id),
                     request_id=request_id,
+                    archive_request_id=archive_request_id,
                     model=model or "",
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -1000,6 +1000,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                 account_id=account_id_value,
                 api_key=api_key,
                 request_id=response_id,
+                archive_request_id=request_id,
                 model=model,
                 latency_ms=int((time.monotonic() - start) * 1000),
                 status=status,

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -144,6 +144,7 @@ class _WebSocketRequestState:
     started_at: float
     latency_first_token_ms: int | None = None
     request_log_id: str | None = None
+    archive_request_id: str | None = None
     requested_service_tier: str | None = None
     actual_service_tier: str | None = None
     response_id: str | None = None

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -5,7 +5,8 @@ import json
 import sys
 import time
 from collections import deque
-from typing import Any, Mapping, NoReturn, cast
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, NoReturn, cast
 
 import aiohttp
 import anyio
@@ -63,7 +64,7 @@ from app.core.openai.requests import (
 from app.core.resilience.overload import is_local_overload_error_code
 from app.core.types import JsonValue
 from app.core.upstream_proxy import UpstreamProxyRouteError
-from app.core.utils.request_id import get_request_id
+from app.core.utils.request_id import get_request_id, reset_request_id, set_request_id
 from app.core.utils.sse import CODEX_KEEPALIVE_FRAME as CODEX_KEEPALIVE_FRAME  # noqa: F401
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 from app.core.utils.time import utcnow as utcnow
@@ -433,6 +434,112 @@ from app.modules.proxy.tool_call_dedupe import (
 
 def _facade() -> Any:
     return sys.modules["app.modules.proxy.service"]
+
+
+@contextmanager
+def _websocket_archive_request_context(request_id: str | None) -> Iterator[None]:
+    if not request_id:
+        yield
+        return
+    token = set_request_id(request_id)
+    try:
+        yield
+    finally:
+        reset_request_id(token)
+
+
+def _archive_received_websocket_message(
+    upstream: UpstreamResponsesWebSocket,
+    message: Any,
+    *,
+    archive_request_id: str | None,
+) -> None:
+    archive_received = getattr(upstream, "archive_received", None)
+    if not callable(archive_received):
+        return
+    with _websocket_archive_request_context(archive_request_id):
+        archive_received(message)
+
+
+def _websocket_archive_request_state_for_payload(
+    pending_requests: deque[_WebSocketRequestState],
+    *,
+    event: OpenAIEvent | None,
+    payload: dict[str, JsonValue] | None,
+    event_type: str | None,
+) -> _WebSocketRequestState | None:
+    response_id = _websocket_response_id(event, payload)
+    if event_type == "response.created":
+        if response_id is not None:
+            existing = _find_websocket_request_state_by_response_id(pending_requests, response_id)
+            if existing is not None:
+                return existing
+        for request_state in pending_requests:
+            if request_state.response_id is None and _http_bridge_request_counts_against_queue(request_state):
+                return request_state
+        for request_state in pending_requests:
+            if request_state.response_id is None and request_state.draining_until_terminal:
+                return request_state
+        for request_state in pending_requests:
+            if request_state.response_id is None:
+                return request_state
+        return None
+    if response_id is not None:
+        return _find_websocket_request_state_by_response_id(pending_requests, response_id)
+    error_message = _websocket_event_error_message(event_type, payload)
+    is_previous_response_not_found_event = _facade()._is_previous_response_not_found_error(
+        code=_normalize_error_code(
+            _websocket_event_error_code(event_type, payload),
+            _websocket_event_error_type(event_type, payload),
+        ),
+        param=_websocket_event_error_param(event_type, payload),
+        message=error_message,
+    )
+    is_missing_tool_output_event = _facade()._is_missing_tool_output_error(
+        code=_normalize_error_code(
+            _websocket_event_error_code(event_type, payload),
+            _websocket_event_error_type(event_type, payload),
+        ),
+        param=_websocket_event_error_param(event_type, payload),
+        message=error_message,
+    )
+    return _match_websocket_request_state_for_anonymous_event(
+        pending_requests,
+        prefer_previous_response_not_found=is_previous_response_not_found_event or is_missing_tool_output_event,
+        previous_response_id_hint=_facade()._previous_response_id_from_not_found_message(error_message),
+        error_message=error_message,
+        allow_unanchored_previous_response_error=is_previous_response_not_found_event,
+    )
+
+
+async def _websocket_archive_request_id_for_message(
+    message: Any,
+    *,
+    pending_requests: deque[_WebSocketRequestState],
+    pending_lock: anyio.Lock,
+) -> str | None:
+    if message.kind != "text" or message.text is None:
+        return None
+    event_block = f"data: {message.text}\n\n"
+    payload = parse_sse_data_json(event_block)
+    if payload is None:
+        try:
+            raw_payload = json.loads(message.text)
+        except json.JSONDecodeError:
+            raw_payload = None
+        if isinstance(raw_payload, dict):
+            payload = cast(dict[str, JsonValue], raw_payload)
+            event_block = format_sse_event(payload)
+    event = parse_sse_event(event_block)
+    event_type = _event_type_from_payload(event, payload)
+    async with pending_lock:
+        request_state = _websocket_archive_request_state_for_payload(
+            pending_requests,
+            event=event,
+            payload=payload,
+            event_type=event_type,
+        )
+        return None if request_state is None else request_state.archive_request_id
 
 
 def _raise_proxy_budget_exhausted() -> NoReturn:
@@ -986,9 +1093,13 @@ class _WebSocketMixin:
                         )
                         request_state.account_response_create_release = proxy._load_balancer.release_account_lease
                     if text_data is not None:
-                        await upstream.send_text(text_data)
+                        archive_request_id = None if request_state is None else request_state.archive_request_id
+                        with _websocket_archive_request_context(archive_request_id):
+                            await upstream.send_text(text_data)
                     elif bytes_data is not None:
-                        await upstream.send_bytes(bytes_data)
+                        archive_request_id = None if request_state is None else request_state.archive_request_id
+                        with _websocket_archive_request_context(archive_request_id):
+                            await upstream.send_bytes(bytes_data)
                 except ProxyResponseError as exc:
                     error = _parse_openai_error(exc.payload)
                     error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
@@ -2261,6 +2372,16 @@ class _WebSocketMixin:
                             upstream.receive(),
                             timeout=wait_timeout,
                         )
+                        archive_request_id = await _websocket_archive_request_id_for_message(
+                            message,
+                            pending_requests=pending_requests,
+                            pending_lock=pending_lock,
+                        )
+                        _archive_received_websocket_message(
+                            upstream,
+                            message,
+                            archive_request_id=archive_request_id,
+                        )
                         break
                 except asyncio.TimeoutError:
                     if receive_deadline is None or time.monotonic() < receive_deadline:
@@ -3247,6 +3368,7 @@ class _WebSocketMixin:
                 account_id=account_id_value,
                 api_key=api_key,
                 request_id=request_log_response_id,
+                archive_request_id=request_state.archive_request_id,
                 model=request_state.model or "",
                 latency_ms=latency_ms,
                 status=status,
@@ -3291,6 +3413,7 @@ class _WebSocketMixin:
             account_id=account_id,
             api_key=api_key,
             request_id=request_state.request_log_id or request_state.request_id,
+            archive_request_id=request_state.archive_request_id,
             model=request_state.model or "",
             latency_ms=int((time.monotonic() - request_state.started_at) * 1000),
             status="error",
@@ -3491,6 +3614,7 @@ class _WebSocketMixin:
                 account_id=account_id_value,
                 api_key=api_key,
                 request_id=request_state.response_id or request_state.request_log_id or request_state.request_id,
+                archive_request_id=request_state.archive_request_id,
                 model=request_state.model or "",
                 latency_ms=latency_ms,
                 status=status,

--- a/app/modules/request_logs/mappers.py
+++ b/app/modules/request_logs/mappers.py
@@ -40,6 +40,7 @@ def to_request_log_entry(log: RequestLog, *, api_key_name: str | None = None) ->
         api_key_id=log.api_key_id,
         api_key_name=api_key_name,
         request_id=log.request_id,
+        archive_request_id=log.archive_request_id,
         request_kind=log.request_kind,
         model=log.model,
         source=log.source,

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -250,9 +250,11 @@ class RequestLogsRepository:
         upstream_proxy_endpoint_id: str | None = None,
         upstream_proxy_fallback_used: bool | None = None,
         upstream_proxy_fail_closed_reason: str | None = None,
+        archive_request_id: str | None = None,
     ) -> RequestLog:
         async with sqlite_writer_section():
             resolved_request_id = ensure_request_id(request_id)
+            resolved_archive_request_id = (archive_request_id or "").strip() or resolved_request_id
             resolved_plan_type = plan_type
             if resolved_plan_type is None and account_id:
                 resolved_plan_type = await self._resolve_account_plan_type(account_id)
@@ -265,6 +267,7 @@ class RequestLogsRepository:
                 api_key_id=api_key_id,
                 session_id=session_id,
                 request_id=resolved_request_id,
+                archive_request_id=resolved_archive_request_id,
                 model=model,
                 plan_type=resolved_plan_type,
                 transport=transport,

--- a/app/modules/request_logs/schemas.py
+++ b/app/modules/request_logs/schemas.py
@@ -21,6 +21,7 @@ class RequestLogEntry(DashboardModel):
     api_key_id: str | None = None
     api_key_name: str | None = None
     request_id: str
+    archive_request_id: str | None = None
     request_kind: str = "normal"
     model: str
     source: str | None = None

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -102,6 +102,7 @@ describe("RecentRequestsTable", () => {
             apiKeyName: "Key Alpha",
             apiKeyId: "key-alpha",
             requestId: "req-1",
+            archiveRequestId: "archive-req-1",
             requestKind: "normal",
             model: "gpt-5.1",
             source: null,
@@ -145,7 +146,7 @@ describe("RecentRequestsTable", () => {
     expect(dialog).toBeInTheDocument();
     expect(within(dialog).getByText("Request Details")).toBeInTheDocument();
     expect(within(dialog).getByText("req-1")).toBeInTheDocument();
-    expect(within(dialog).getByTestId("request-archive-panel")).toHaveTextContent("Archive for req-1");
+    expect(within(dialog).getByTestId("request-archive-panel")).toHaveTextContent("Archive for archive-req-1");
     expect(within(dialog).getByText("rate_limit_exceeded")).toBeInTheDocument();
     expect(dialog.textContent).toContain("Rate limit reached while processing this request");
 

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -363,7 +363,10 @@ export function RecentRequestsTable({
               />
             </div>
 
-            <RequestArchivePanel requestId={selectedRequest?.requestId} requestedAt={selectedRequest?.requestedAt} />
+            <RequestArchivePanel
+              requestId={selectedRequest?.archiveRequestId ?? selectedRequest?.requestId}
+              requestedAt={selectedRequest?.requestedAt}
+            />
 
             {selectedRequestCostSummary ? (
               <div className="space-y-2">

--- a/frontend/src/features/dashboard/schemas.test.ts
+++ b/frontend/src/features/dashboard/schemas.test.ts
@@ -187,6 +187,7 @@ describe("RequestLogsResponseSchema", () => {
           apiKeyName: "Key A",
           apiKeyId: "key-1",
           requestId: "req-1",
+          archiveRequestId: "archive-req-1",
           model: "gpt-5.1",
           transport: "websocket",
           useragent: "Mozilla/5.0",
@@ -221,6 +222,7 @@ describe("RequestLogsResponseSchema", () => {
 
     expect(parsed.requests[0]?.apiKeyName).toBe("Key A");
     expect(parsed.requests[0]?.apiKeyId).toBe("key-1");
+    expect(parsed.requests[0]?.archiveRequestId).toBe("archive-req-1");
     expect(parsed.requests[0]?.requestKind).toBe("normal");
     expect(parsed.requests[0]?.planType).toBe("plus");
     expect(parsed.requests[0]?.transport).toBe("websocket");
@@ -235,6 +237,31 @@ describe("RequestLogsResponseSchema", () => {
     expect(parsed.requests[0]?.inputTokens).toBe(8);
     expect(parsed.requests[0]?.outputTokens).toBe(2);
     expect(parsed.requests[0]?.costBreakdown?.totalUsd).toBe(0.001);
+  });
+
+  it("keeps archiveRequestId optional for older request-log responses", () => {
+    const parsed = RequestLogsResponseSchema.parse({
+      requests: [
+        {
+          requestedAt: ISO,
+          accountId: "acc-1",
+          requestId: "req-1",
+          model: "gpt-5.1",
+          status: "ok",
+          errorCode: null,
+          errorMessage: null,
+          tokens: 10,
+          cachedInputTokens: null,
+          reasoningEffort: null,
+          costUsd: null,
+          latencyMs: 42,
+        },
+      ],
+      total: 1,
+      hasMore: false,
+    });
+
+    expect(parsed.requests[0]?.archiveRequestId).toBeUndefined();
   });
 
   it("accepts legacy limit warmup request kind rows", () => {

--- a/frontend/src/features/dashboard/schemas.ts
+++ b/frontend/src/features/dashboard/schemas.ts
@@ -159,6 +159,7 @@ export const RequestLogSchema = z.object({
   apiKeyName: z.string().nullable().optional().default(null),
   apiKeyId: z.string().nullable().optional().default(null),
   requestId: z.string(),
+  archiveRequestId: z.string().nullable().optional(),
   requestKind: z.enum(["normal", "warmup", "limit_warmup"]).optional().default("normal"),
   model: z.string(),
   source: z.string().nullable().optional().default(null),

--- a/openspec/changes/fix-request-log-archive-lookup/proposal.md
+++ b/openspec/changes/fix-request-log-archive-lookup/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+Conversation archive records are keyed by the request context id, but successful Responses/WebSocket request-log rows can store the downstream response id in `request_id` for continuity lookup. The dashboard archive panel currently queries by the request-log `requestId`, so archived payloads can exist while the request detail view reports that none were found.
+
+## What Changes
+
+- Add nullable `request_logs.archive_request_id` as the archive lookup key for request-log rows.
+- Expose `archiveRequestId` in the request-log API response.
+- Preserve `requestId` semantics for response-id continuity lookup.
+- Make the dashboard archive panel use `archiveRequestId` when present and fall back to `requestId` for older rows.
+
+## Impact
+
+- Existing request-log rows remain readable; older rows without `archive_request_id` continue to use `requestId`.
+- The schema migration is additive and nullable.

--- a/openspec/changes/fix-request-log-archive-lookup/specs/database-migrations/spec.md
+++ b/openspec/changes/fix-request-log-archive-lookup/specs/database-migrations/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+
+### Requirement: Request-log archive lookup schema
+The database schema SHALL preserve a nullable archive lookup id on request logs so dashboard archive lookups can remain distinct from response-id continuity lookup.
+
+#### Scenario: Request-log archive lookup column exists after migration
+- **WHEN** migrations run to head
+- **THEN** `request_logs` contains a nullable `archive_request_id` column
+- **AND** existing request-log rows without the column value remain valid

--- a/openspec/changes/fix-request-log-archive-lookup/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-request-log-archive-lookup/specs/frontend-architecture/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard request-log archive lookup
+The dashboard request-log detail dialog SHALL use each row's `archiveRequestId` for conversation archive lookup when that field is present. For older API responses that omit `archiveRequestId`, it SHALL fall back to the row's `requestId`.
+
+#### Scenario: Detail dialog uses archive lookup id
+- **WHEN** a request-log row has `requestId: "resp_123"` and `archiveRequestId: "req_123"`
+- **AND** the operator opens the request detail dialog
+- **THEN** the archive panel queries archive records for `req_123`
+
+#### Scenario: Detail dialog remains backward compatible
+- **WHEN** a request-log row does not include `archiveRequestId`
+- **AND** the operator opens the request detail dialog
+- **THEN** the archive panel queries archive records for the row's `requestId`

--- a/openspec/changes/fix-request-log-archive-lookup/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/fix-request-log-archive-lookup/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Full upstream conversation archive
+The proxy MUST provide an opt-in durable archive of Codex-to-upstream conversation traffic. When enabled, the archive MUST write gzip-compressed newline-delimited JSON records for upstream request payloads, streamed Responses events, compact response payloads, and websocket text or binary frames without performing gzip file I/O in the request event loop during normal operation. The archive writer queue MUST be bounded and MUST apply synchronous write backpressure instead of growing without limit when the background writer is saturated. Archive records MUST include request id, timestamp, direction, traffic kind, transport, account id when known, upstream target metadata, redacted headers, and the full payload or frame body. Credential-bearing headers such as authorization, cookies, proxy authorization, token headers, and API key headers MUST be redacted before persistence. JSON records MUST preserve non-ASCII payload text as UTF-8 rather than Unicode escape sequences. When disabled, no archive file MUST be created by the archive writer. Request-log API rows MUST expose an `archiveRequestId` lookup key when the persisted log id can differ from the archive record request id.
+
+#### Scenario: operator enables archive for audit
+- **WHEN** `CODEX_LB_CONVERSATION_ARCHIVE_ENABLED=true`
+- **AND** a Codex Responses request is proxied upstream
+- **THEN** the archive records both the outbound upstream payload and inbound upstream events or response body as gzip JSONL
+- **AND** credential-bearing headers are stored as redacted values
+
+#### Scenario: archive remains disabled by default
+- **WHEN** the archive setting is not enabled
+- **THEN** the archive writer does not create conversation archive files
+
+#### Scenario: operator views archived traffic
+- **GIVEN** conversation archive files exist as `.jsonl.gz` or legacy `.jsonl`
+- **WHEN** an authenticated dashboard operator opens an existing request log detail
+- **THEN** the dashboard can find matching archive records by request id across archive files and display payload plus metadata for that request
+
+#### Scenario: response-id request logs keep archive lookup
+- **WHEN** a successful proxied request stores a downstream response id in the request-log `requestId`
+- **AND** the conversation archive stored records under the original request context id
+- **THEN** the request-log API response includes `archiveRequestId` with the original archive lookup id
+- **AND** the persisted `requestId` remains available for response-id continuity lookup

--- a/openspec/changes/fix-request-log-archive-lookup/tasks.md
+++ b/openspec/changes/fix-request-log-archive-lookup/tasks.md
@@ -1,0 +1,7 @@
+## Implementation
+
+- [x] Add nullable request-log archive lookup column and migration.
+- [x] Persist the original request context id alongside downstream response ids.
+- [x] Expose `archiveRequestId` from the request-log API.
+- [x] Use `archiveRequestId ?? requestId` in the dashboard archive panel.
+- [x] Cover repository, API, HTTP stream, WebSocket, migration, schema, and UI fallback behavior with tests.

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -494,6 +494,7 @@ async def test_run_startup_migrations_drops_accounts_email_unique_with_non_casca
             assert "transport" in request_log_columns
             assert "plan_type" in request_log_columns
             assert "source" in request_log_columns
+            assert "archive_request_id" in request_log_columns
             assert "limit_warmup_enabled" in account_columns
             legacy_plan_type = (
                 await session.execute(text("SELECT plan_type FROM request_logs WHERE id=1"))

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -1385,6 +1385,7 @@ async def test_proxy_responses_streams_upstream(async_client, monkeypatch):
         log = result.scalars().first()
         assert log is not None
         assert log.request_id == "resp_1"
+        assert log.archive_request_id == request_id
         assert log.transport == "http"
 
 

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -12,6 +12,7 @@ from starlette.websockets import WebSocketDisconnect
 
 import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
+from app.core.utils.request_id import get_request_id
 
 pytestmark = pytest.mark.integration
 
@@ -50,20 +51,33 @@ class _FakeUpstreamMessage:
 class _FakeUpstreamWebSocket:
     def __init__(self, messages: list[_FakeUpstreamMessage]) -> None:
         self.sent_text: list[str] = []
+        self.sent_text_request_ids: list[str | None] = []
         self.sent_bytes: list[bytes] = []
+        self.sent_bytes_request_ids: list[str | None] = []
+        self.receive_request_ids: list[str | None] = []
+        self.archived_receive_request_ids: list[str | None] = []
+        self.archived_receive_texts: list[str] = []
         self.closed = False
         self._messages: asyncio.Queue[_FakeUpstreamMessage] = asyncio.Queue()
         for message in messages:
             self._messages.put_nowait(message)
 
     async def send_text(self, text: str) -> None:
+        self.sent_text_request_ids.append(get_request_id())
         self.sent_text.append(text)
 
     async def send_bytes(self, data: bytes) -> None:
+        self.sent_bytes_request_ids.append(get_request_id())
         self.sent_bytes.append(data)
 
     async def receive(self) -> _FakeUpstreamMessage:
+        self.receive_request_ids.append(get_request_id())
         return await self._messages.get()
+
+    def archive_received(self, message: _FakeUpstreamMessage) -> None:
+        self.archived_receive_request_ids.append(get_request_id())
+        if message.text is not None:
+            self.archived_receive_texts.append(message.text)
 
     async def close(self) -> None:
         self.closed = True
@@ -692,6 +706,9 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     log = log_calls[0]
     assert log["account_id"] == "acct_ws_proxy"
     assert log["request_id"] == "resp_ws_1"
+    assert log["archive_request_id"] == seen["request_id"]
+    assert fake_upstream.sent_text_request_ids == [log["archive_request_id"]]
+    assert fake_upstream.archived_receive_request_ids[0] == log["archive_request_id"]
     assert log["model"] == "gpt-5.4"
     assert log["service_tier"] == "priority"
     assert log["transport"] == "websocket"
@@ -1345,6 +1362,159 @@ def test_v1_responses_websocket_reuses_upstream_for_sequential_requests(app_inst
             "type": "response.create",
         },
     ]
+
+
+def test_v1_responses_websocket_archives_multiplexed_upstream_frames_by_response_id(app_instance, monkeypatch):
+    fake_upstream = _SequencedUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": "resp_ws_first", "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+        ],
+        deferred_message_batches=[
+            [],
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {"type": "response.created", "response": {"id": "resp_ws_second", "status": "in_progress"}},
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_ws_second",
+                                "status": "completed",
+                                "usage": {"input_tokens": 2, "output_tokens": 1, "total_tokens": 3},
+                            },
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp_ws_first",
+                                "status": "completed",
+                                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                            },
+                        },
+                        separators=(",", ":"),
+                    ),
+                ),
+            ],
+        ],
+    )
+    log_calls: list[dict[str, object]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        prefer_earlier_reset_window,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            prefer_earlier_reset_window,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return SimpleNamespace(id="acct_ws_proxy"), fake_upstream
+
+    async def fake_write_request_log(self, **kwargs):
+        del self
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    first_request = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "input": "first",
+        "promptCacheKey": "thread_a",
+        "stream": True,
+    }
+    second_request = {
+        "type": "response.create",
+        "model": "gpt-5.5",
+        "input": "second",
+        "promptCacheKey": "thread_b",
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/v1/responses") as websocket:
+            websocket.send_text(json.dumps(first_request))
+            first_created = json.loads(websocket.receive_text())
+            websocket.send_text(json.dumps(second_request))
+            second_created = json.loads(websocket.receive_text())
+            second_completed = json.loads(websocket.receive_text())
+            first_completed = json.loads(websocket.receive_text())
+
+    assert first_created["response"]["id"] == "resp_ws_first"
+    assert second_created["response"]["id"] == "resp_ws_second"
+    assert second_completed["response"]["id"] == "resp_ws_second"
+    assert first_completed["response"]["id"] == "resp_ws_first"
+
+    first_archive_request_id, second_archive_request_id = fake_upstream.sent_text_request_ids
+    assert first_archive_request_id is not None
+    assert second_archive_request_id is not None
+    assert fake_upstream.archived_receive_request_ids == [
+        first_archive_request_id,
+        second_archive_request_id,
+        second_archive_request_id,
+        first_archive_request_id,
+    ]
+
+    logs_by_request_id = {cast(str, log["request_id"]): log for log in log_calls}
+    assert logs_by_request_id["resp_ws_first"]["archive_request_id"] == first_archive_request_id
+    assert logs_by_request_id["resp_ws_second"]["archive_request_id"] == second_archive_request_id
 
 
 def test_v1_responses_websocket_accepts_and_reuses_generated_turn_state(app_instance, monkeypatch):

--- a/tests/integration/test_request_logs_api.py
+++ b/tests/integration/test_request_logs_api.py
@@ -61,6 +61,7 @@ async def test_request_logs_api_returns_recent(async_client, db_setup):
         await logs_repo.add_log(
             account_id="acc_logs",
             request_id="req_logs_2",
+            archive_request_id="archive_req_logs_2",
             model="legacy-model",
             input_tokens=50,
             output_tokens=0,
@@ -92,6 +93,8 @@ async def test_request_logs_api_returns_recent(async_client, db_setup):
     assert latest["apiKeyId"] == "key_logs_1"
     assert latest["apiKeyName"] == "Debug Key"
     assert latest["errorCode"] == "rate_limit_exceeded"
+    assert latest["requestId"] == "req_logs_2"
+    assert latest["archiveRequestId"] == "archive_req_logs_2"
     assert latest["errorMessage"] == "Rate limit reached"
     assert latest["failurePhase"] == "owner_forward_status"
     assert latest["failureDetail"] == "owner_forward_non_200"
@@ -110,6 +113,8 @@ async def test_request_logs_api_returns_recent(async_client, db_setup):
 
     older = payload[1]
     assert older["status"] == "ok"
+    assert older["requestId"] == "req_logs_1"
+    assert older["archiveRequestId"] == "req_logs_1"
     assert older["apiKeyId"] is None
     assert older["apiKeyName"] is None
     assert older["tokens"] == 300

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -20,6 +20,7 @@ from fastapi import WebSocket
 from app.core.clients.proxy import ProxyResponseError
 from app.core.clients.proxy_websocket import UpstreamResponsesWebSocket, UpstreamWebSocketMessage
 from app.core.config.settings import Settings
+from app.core.utils.request_id import get_request_id
 from app.db.models import AccountStatus, HttpBridgeSessionState
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy.http_bridge_forwarding import OwnerForwardRelayFailure
@@ -201,6 +202,104 @@ async def test_http_bridge_precreated_completed_terminal_falls_back_to_unresolve
     assert not session.pending_requests
     register_previous.assert_awaited_once()
     finalize.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_upstream_text_archives_with_request_archive_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    archived: list[tuple[str | None, str]] = []
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-bridge-archive",
+        model="gpt-5.2",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        archive_request_id="archive-bridge-archive",
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = _make_bridge_session(
+        key_value="bridge-archive",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    def archive_received(message: UpstreamWebSocketMessage) -> None:
+        archived.append((get_request_id(), message.text or ""))
+
+    session.upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(close=AsyncMock(), archive_received=archive_received),
+    )
+    monkeypatch.setattr(service, "_register_http_bridge_previous_response_id", AsyncMock())
+
+    upstream_text = json.dumps(
+        {
+            "type": "response.created",
+            "response": {"id": "resp_bridge_archive", "status": "in_progress"},
+        },
+        separators=(",", ":"),
+    )
+
+    await service._process_http_bridge_upstream_text(session, upstream_text)
+
+    assert archived == [("archive-bridge-archive", upstream_text)]
+    assert request_state.response_id == "resp_bridge_archive"
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_upstream_non_text_archives_with_request_archive_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    archived: list[tuple[str | None, str, int | None]] = []
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-bridge-close-archive",
+        model="gpt-5.2",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        archive_request_id="archive-bridge-close",
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    close_message = UpstreamWebSocketMessage(kind="close", close_code=1000)
+    session = _make_bridge_session(
+        key_value="bridge-close-archive",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    def archive_received(message: UpstreamWebSocketMessage) -> None:
+        archived.append((get_request_id(), message.kind, message.close_code))
+
+    session.upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=close_message),
+            close=AsyncMock(),
+            archive_received=archive_received,
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", AsyncMock())
+    monkeypatch.setattr(service, "_retire_stale_pending_http_bridge_session", AsyncMock())
+
+    await service._relay_http_bridge_upstream_messages(session)
+
+    assert archived == [("archive-bridge-close", "close", 1000)]
+    assert session.last_upstream_close_code == 1000
 
 
 def test_pop_terminal_websocket_request_state_precreated_completed_does_not_guess_with_ambiguous_pending() -> None:

--- a/tests/unit/test_request_logs_repository.py
+++ b/tests/unit/test_request_logs_repository.py
@@ -66,6 +66,44 @@ async def test_add_log_persists_request_kind(db_setup) -> None:
 
 
 @pytest.mark.asyncio
+async def test_add_log_persists_archive_request_id(db_setup) -> None:
+    del db_setup
+    async with SessionLocal() as session:
+        repo = RequestLogsRepository(session)
+
+        explicit = await repo.add_log(
+            account_id=None,
+            request_id="resp_downstream",
+            archive_request_id="req_archive_origin",
+            model="gpt-5.2",
+            input_tokens=10,
+            output_tokens=5,
+            latency_ms=1,
+            status="success",
+            error_code=None,
+        )
+        fallback = await repo.add_log(
+            account_id=None,
+            request_id="req_archive_same",
+            model="gpt-5.2",
+            input_tokens=10,
+            output_tokens=5,
+            latency_ms=1,
+            status="success",
+            error_code=None,
+        )
+
+        explicit_persisted = await session.scalar(select(RequestLog).where(RequestLog.id == explicit.id))
+        fallback_persisted = await session.scalar(select(RequestLog).where(RequestLog.id == fallback.id))
+
+    assert explicit_persisted is not None
+    assert explicit_persisted.request_id == "resp_downstream"
+    assert explicit_persisted.archive_request_id == "req_archive_origin"
+    assert fallback_persisted is not None
+    assert fallback_persisted.archive_request_id == "req_archive_same"
+
+
+@pytest.mark.asyncio
 async def test_find_latest_account_id_for_response_id_prefers_session_then_falls_back_to_api_key_scope() -> None:
     session = AsyncMock()
     repo = RequestLogsRepository(session)


### PR DESCRIPTION
## Summary
- fix request-log detail archive lookups when the visible `requestId` is a downstream response id instead of the archived request context id
- add nullable `request_logs.archive_request_id` and expose it as `archiveRequestId` in the dashboard request-log API
- keep response-id `requestId` semantics intact for continuity lookup, while the archive panel uses `archiveRequestId ?? requestId`
- add OpenSpec coverage for the request-log archive lookup contract

Fixes #962

## Tests
- `uv run pytest tests/unit/test_request_logs_repository.py tests/integration/test_request_logs_api.py tests/integration/test_proxy_responses.py -k 'archive_request_id or returns_recent or proxies_streaming_response' -q`
- `uv run pytest tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_proxies_upstream_and_persists_log -q`
- `uv run pytest tests/integration/test_proxy_responses.py::test_proxy_responses_streams_upstream -q`
- `uv run pytest tests/integration/test_migrations.py -q`
- `uv run ruff check app/db/models.py app/modules/request_logs app/modules/proxy/_service/request_log.py app/modules/proxy/_service/streaming/mixin.py app/modules/proxy/_service/websocket/mixin.py tests/unit/test_request_logs_repository.py tests/integration/test_request_logs_api.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_websocket_responses.py`
- `uv run ruff format --check app/db/models.py app/modules/request_logs app/modules/proxy/_service/request_log.py app/modules/proxy/_service/streaming/mixin.py app/modules/proxy/_service/websocket/mixin.py tests/unit/test_request_logs_repository.py tests/integration/test_request_logs_api.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_websocket_responses.py`
- `uv run ty check app/db/models.py app/modules/request_logs app/modules/proxy/_service/request_log.py app/modules/proxy/_service/streaming/mixin.py app/modules/proxy/_service/websocket/mixin.py tests/unit/test_request_logs_repository.py tests/integration/test_request_logs_api.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_websocket_responses.py`
- `bun run test src/features/dashboard/schemas.test.ts src/features/dashboard/components/recent-requests-table.test.tsx`
- `bun run typecheck`
- `bun run lint`
- `uv run codex-lb-db --db-url sqlite+aiosqlite:////tmp/codex-lb-issue962-migrate.db upgrade head`
- `openspec validate fix-request-log-archive-lookup --strict`
- `openspec validate --specs`
