### PR TITLE
fix(report): Multiple fixes and enhances on report

### DIFF
--- a/app/modules/reports/api.py
+++ b/app/modules/reports/api.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
 from app.dependencies import ReportsContext, get_reports_context
-from app.modules.reports.repository import MAX_DAILY_REPORT_DAYS, DailyReportRangeTooLargeError
+from app.modules.reports.repository import DailyReportRangeTooLargeError
 from app.modules.reports.schemas import ReportsResponse
 
 router = APIRouter(
@@ -26,13 +26,6 @@ async def get_reports(
     account_id: Annotated[list[str] | None, Query()] = None,
     model: Annotated[str | None, Query()] = None,
 ) -> ReportsResponse:
-    if start_date is not None and end_date is not None:
-        window_days = (end_date - start_date).days + 1
-        if window_days > MAX_DAILY_REPORT_DAYS:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"report date range must be {MAX_DAILY_REPORT_DAYS} days or less",
-            )
     try:
         return await context.service.get_reports(
             start_date=start_date,

--- a/app/modules/reports/api.py
+++ b/app/modules/reports/api.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from datetime import date
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
 from app.dependencies import ReportsContext, get_reports_context
+from app.modules.reports.repository import MAX_DAILY_REPORT_DAYS, DailyReportRangeTooLargeError
 from app.modules.reports.schemas import ReportsResponse
 
 router = APIRouter(
@@ -25,10 +26,20 @@ async def get_reports(
     account_id: Annotated[list[str] | None, Query()] = None,
     model: Annotated[str | None, Query()] = None,
 ) -> ReportsResponse:
-    return await context.service.get_reports(
-        start_date=start_date,
-        end_date=end_date,
-        report_timezone=report_timezone,
-        account_ids=account_id,
-        model=model,
-    )
+    if start_date is not None and end_date is not None:
+        window_days = (end_date - start_date).days + 1
+        if window_days > MAX_DAILY_REPORT_DAYS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"report date range must be {MAX_DAILY_REPORT_DAYS} days or less",
+            )
+    try:
+        return await context.service.get_reports(
+            start_date=start_date,
+            end_date=end_date,
+            report_timezone=report_timezone,
+            account_ids=account_id,
+            model=model,
+        )
+    except DailyReportRangeTooLargeError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/app/modules/reports/api.py
+++ b/app/modules/reports/api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import date
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
@@ -21,14 +21,14 @@ async def get_reports(
     context: ReportsContext = Depends(get_reports_context),
     start_date: Annotated[date | None, Query()] = None,
     end_date: Annotated[date | None, Query()] = None,
+    report_timezone: Annotated[str | None, Query(alias="timezone")] = None,
     account_id: Annotated[list[str] | None, Query()] = None,
     model: Annotated[str | None, Query()] = None,
 ) -> ReportsResponse:
-    start = datetime.combine(start_date, datetime.min.time(), tzinfo=timezone.utc) if start_date else None
-    end = datetime.combine(end_date + timedelta(days=1), datetime.min.time(), tzinfo=timezone.utc) if end_date else None
     return await context.service.get_reports(
-        start_date=start,
-        end_date=end,
+        start_date=start_date,
+        end_date=end_date,
+        report_timezone=report_timezone,
         account_ids=account_id,
         model=model,
     )

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -220,9 +220,7 @@ class ReportsRepository:
         if model:
             conditions.append(RequestLog.model == model)
 
-        result = await self._session.execute(
-            select(func.min(RequestLog.requested_at)).where(and_(*conditions))
-        )
+        result = await self._session.execute(select(func.min(RequestLog.requested_at)).where(and_(*conditions)))
         value = result.scalar_one_or_none()
         return value if isinstance(value, datetime) else None
 

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
+from itertools import batched
 from zoneinfo import ZoneInfo
 
 from sqlalchemy import and_, case, func, literal, or_, select, union_all
@@ -11,6 +12,7 @@ from app.db.models import Account, RequestLog
 
 _INTERNAL_LIMIT_WARMUP_SOURCE = "limit_warmup"
 _INTERNAL_WARMUP_REQUEST_KINDS = ("warmup", "limit_warmup")
+_SQLITE_COMPOUND_SELECT_LIMIT = 500
 
 
 @dataclass(frozen=True)
@@ -66,59 +68,26 @@ class ReportsRepository:
         if not day_ranges:
             return []
 
-        day_range_rows = [
-            select(
-                literal(report_date).label("report_date"),
-                literal(day_start).label("day_start"),
-                literal(day_end).label("day_end"),
-            )
-            for report_date, day_start, day_end in day_ranges
-        ]
-        day_ranges_query = day_range_rows[0] if len(day_range_rows) == 1 else union_all(*day_range_rows)
-        day_ranges_cte = day_ranges_query.cte("report_days")
-        stmt = (
-            select(
-                day_ranges_cte.c.report_date,
-                func.count(RequestLog.id).label("requests"),
-                func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
-                func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
-                func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
-                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
-                func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
-                func.coalesce(
-                    func.sum(case((RequestLog.status != "success", 1), else_=0)),
-                    0,
-                ).label("error_count"),
-            )
-            .select_from(
-                day_ranges_cte.join(
-                    RequestLog,
-                    and_(
-                        RequestLog.requested_at >= day_ranges_cte.c.day_start,
-                        RequestLog.requested_at < day_ranges_cte.c.day_end,
-                        _normal_traffic_clause(),
-                        *([RequestLog.account_id.in_(account_ids)] if account_ids else []),
-                        *([RequestLog.model == model] if model else []),
-                    ),
+        rows: list[DailyReportAggregateRow] = []
+        # SQLite caps compound SELECTs at 500 terms, so long report ranges are
+        # executed in chunks instead of building a single oversized UNION ALL.
+        for day_ranges_batch in batched(day_ranges, _SQLITE_COMPOUND_SELECT_LIMIT):
+            stmt = _daily_rows_stmt(list(day_ranges_batch), account_ids, model)
+            result = await self._session.execute(stmt)
+            rows.extend(
+                DailyReportAggregateRow(
+                    date=row.report_date,
+                    requests=int(row.requests or 0),
+                    input_tokens=int(row.input_tokens or 0),
+                    output_tokens=int(row.output_tokens or 0),
+                    cached_input_tokens=int(row.cached_input_tokens or 0),
+                    cost_usd=float(row.cost_usd or 0.0),
+                    active_accounts=int(row.active_accounts or 0),
+                    error_count=int(row.error_count or 0),
                 )
+                for row in result.all()
             )
-            .group_by(day_ranges_cte.c.report_date)
-            .order_by(day_ranges_cte.c.report_date)
-        )
-        result = await self._session.execute(stmt)
-        return [
-            DailyReportAggregateRow(
-                date=row.report_date,
-                requests=int(row.requests or 0),
-                input_tokens=int(row.input_tokens or 0),
-                output_tokens=int(row.output_tokens or 0),
-                cached_input_tokens=int(row.cached_input_tokens or 0),
-                cost_usd=float(row.cost_usd or 0.0),
-                active_accounts=int(row.active_accounts or 0),
-                error_count=int(row.error_count or 0),
-            )
-            for row in result.all()
-        ]
+        return rows
 
     async def aggregate_summary(
         self,
@@ -282,6 +251,52 @@ def _normal_traffic_clause():
             RequestLog.request_kind.is_(None),
             RequestLog.request_kind.not_in(_INTERNAL_WARMUP_REQUEST_KINDS),
         ),
+    )
+
+
+def _daily_rows_stmt(
+    day_ranges: list[tuple[str, datetime, datetime]],
+    account_ids: list[str] | None,
+    model: str | None,
+):
+    day_range_rows = [
+        select(
+            literal(report_date).label("report_date"),
+            literal(day_start).label("day_start"),
+            literal(day_end).label("day_end"),
+        )
+        for report_date, day_start, day_end in day_ranges
+    ]
+    day_ranges_query = day_range_rows[0] if len(day_range_rows) == 1 else union_all(*day_range_rows)
+    day_ranges_cte = day_ranges_query.cte("report_days")
+    return (
+        select(
+            day_ranges_cte.c.report_date,
+            func.count(RequestLog.id).label("requests"),
+            func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
+            func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
+            func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
+            func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
+            func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
+            func.coalesce(
+                func.sum(case((RequestLog.status != "success", 1), else_=0)),
+                0,
+            ).label("error_count"),
+        )
+        .select_from(
+            day_ranges_cte.join(
+                RequestLog,
+                and_(
+                    RequestLog.requested_at >= day_ranges_cte.c.day_start,
+                    RequestLog.requested_at < day_ranges_cte.c.day_end,
+                    _normal_traffic_clause(),
+                    *([RequestLog.account_id.in_(account_ids)] if account_ids else []),
+                    *([RequestLog.model == model] if model else []),
+                ),
+            )
+        )
+        .group_by(day_ranges_cte.c.report_date)
+        .order_by(day_ranges_cte.c.report_date)
     )
 
 

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -71,9 +71,7 @@ class ReportsRepository:
     ) -> list[DailyReportAggregateRow]:
         window_days = (end_date - start_date).days + 1
         if window_days > MAX_DAILY_REPORT_DAYS:
-            raise DailyReportRangeTooLargeError(
-                f"report date range must be {MAX_DAILY_REPORT_DAYS} days or less"
-            )
+            raise DailyReportRangeTooLargeError(f"report date range must be {MAX_DAILY_REPORT_DAYS} days or less")
         day_ranges = list(_daily_bucket_ranges(start_date, end_date, timezone_info))
         if not day_ranges:
             return []

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -96,9 +96,9 @@ class ReportsRepository:
                     and_(
                         RequestLog.requested_at >= day_ranges_cte.c.day_start,
                         RequestLog.requested_at < day_ranges_cte.c.day_end,
-                    _normal_traffic_clause(),
-                    *([RequestLog.account_id.in_(account_ids)] if account_ids else []),
-                    *([RequestLog.model == model] if model else []),
+                        _normal_traffic_clause(),
+                        *([RequestLog.account_id.in_(account_ids)] if account_ids else []),
+                        *([RequestLog.model == model] if model else []),
                     ),
                 )
             )

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -13,6 +13,11 @@ from app.db.models import Account, RequestLog
 _INTERNAL_LIMIT_WARMUP_SOURCE = "limit_warmup"
 _INTERNAL_WARMUP_REQUEST_KINDS = ("warmup", "limit_warmup")
 _SQLITE_COMPOUND_SELECT_LIMIT = 500
+MAX_DAILY_REPORT_DAYS = 730
+
+
+class DailyReportRangeTooLargeError(ValueError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -64,6 +69,11 @@ class ReportsRepository:
         account_ids: list[str] | None = None,
         model: str | None = None,
     ) -> list[DailyReportAggregateRow]:
+        window_days = (end_date - start_date).days + 1
+        if window_days > MAX_DAILY_REPORT_DAYS:
+            raise DailyReportRangeTooLargeError(
+                f"report date range must be {MAX_DAILY_REPORT_DAYS} days or less"
+            )
         day_ranges = list(_daily_bucket_ranges(start_date, end_date, timezone_info))
         if not day_ranges:
             return []

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from sqlalchemy import Integer, and_, cast, func, literal_column, or_, select
+from sqlalchemy import and_, case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Account, RequestLog
@@ -13,14 +13,24 @@ _INTERNAL_WARMUP_REQUEST_KINDS = ("warmup", "limit_warmup")
 
 
 @dataclass(frozen=True)
-class DailyAggregateRow:
-    date: str
-    request_count: int
-    error_count: int
+class DailyReportLogRow:
+    requested_at: datetime
+    account_id: str | None
+    is_error: bool
     input_tokens: int
     output_tokens: int
     cached_input_tokens: int
     cost_usd: float
+
+
+@dataclass(frozen=True)
+class SummaryAggregateRow:
+    total_cost_usd: float
+    total_input_tokens: int
+    total_output_tokens: int
+    total_cached_tokens: int
+    total_requests: int
+    total_errors: int
     active_accounts: int
 
 
@@ -42,63 +52,75 @@ class ReportsRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def aggregate_daily(
+    async def list_daily_report_logs(
         self,
         start_date: datetime,
         end_date: datetime,
         account_ids: list[str] | None = None,
         model: str | None = None,
-    ) -> list[DailyAggregateRow]:
-        bind = self._session.get_bind()
-        dialect = bind.dialect.name if bind else "sqlite"
-        if dialect == "postgresql":
-            date_expr = func.date(RequestLog.requested_at)
-        else:
-            date_expr = func.strftime("%Y-%m-%d", RequestLog.requested_at)
-        date_col = date_expr.label("date")
-
-        conditions = [
-            RequestLog.requested_at >= start_date,
-            RequestLog.requested_at < end_date,
-            _normal_traffic_clause(),
-        ]
-        if account_ids:
-            conditions.append(RequestLog.account_id.in_(account_ids))
-        if model:
-            conditions.append(RequestLog.model == model)
+    ) -> list[DailyReportLogRow]:
+        conditions = _report_conditions(start_date, end_date, account_ids, model)
 
         stmt = (
             select(
-                date_col,
-                func.count().label("request_count"),
-                func.coalesce(
-                    func.sum(cast(RequestLog.status != literal_column("'success'"), Integer)),
-                    0,
-                ).label("error_count"),
-                func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
-                func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
-                func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
-                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
-                func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
+                RequestLog.requested_at,
+                RequestLog.account_id,
+                RequestLog.status,
+                RequestLog.input_tokens,
+                RequestLog.output_tokens,
+                RequestLog.cached_input_tokens,
+                RequestLog.cost_usd,
             )
             .where(and_(*conditions))
-            .group_by(date_col)
-            .order_by(date_col)
+            .order_by(RequestLog.requested_at, RequestLog.request_id)
         )
         result = await self._session.execute(stmt)
         return [
-            DailyAggregateRow(
-                date=str(row.date),
-                request_count=int(row.request_count),
-                error_count=int(row.error_count),
-                input_tokens=int(row.input_tokens),
-                output_tokens=int(row.output_tokens),
-                cached_input_tokens=int(row.cached_input_tokens),
-                cost_usd=float(row.cost_usd),
-                active_accounts=int(row.active_accounts),
+            DailyReportLogRow(
+                requested_at=row.requested_at,
+                account_id=row.account_id,
+                is_error=row.status != "success",
+                input_tokens=int(row.input_tokens or 0),
+                output_tokens=int(row.output_tokens or 0),
+                cached_input_tokens=int(row.cached_input_tokens or 0),
+                cost_usd=float(row.cost_usd or 0.0),
             )
             for row in result.all()
         ]
+
+    async def aggregate_summary(
+        self,
+        start_date: datetime,
+        end_date: datetime,
+        account_ids: list[str] | None = None,
+        model: str | None = None,
+    ) -> SummaryAggregateRow:
+        conditions = _report_conditions(start_date, end_date, account_ids, model)
+
+        result = await self._session.execute(
+            select(
+                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
+                func.coalesce(func.sum(RequestLog.input_tokens), 0).label("total_input_tokens"),
+                func.coalesce(func.sum(RequestLog.output_tokens), 0).label("total_output_tokens"),
+                func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("total_cached_tokens"),
+                func.count().label("total_requests"),
+                func.coalesce(
+                    func.sum(case((RequestLog.status != "success", 1), else_=0)),
+                    0,
+                ).label("total_errors"),
+                func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
+            ).where(and_(*conditions))
+        )
+        row = result.one()
+        return SummaryAggregateRow(
+            total_cost_usd=float(row.total_cost_usd),
+            total_input_tokens=int(row.total_input_tokens),
+            total_output_tokens=int(row.total_output_tokens),
+            total_cached_tokens=int(row.total_cached_tokens),
+            total_requests=int(row.total_requests),
+            total_errors=int(row.total_errors),
+            active_accounts=int(row.active_accounts),
+        )
 
     async def aggregate_by_model(
         self,
@@ -108,15 +130,9 @@ class ReportsRepository:
         model: str | None = None,
     ) -> list[ModelAggregateRow]:
         conditions = [
-            RequestLog.requested_at >= start_date,
-            RequestLog.requested_at < end_date,
-            _normal_traffic_clause(),
+            *_report_conditions(start_date, end_date, account_ids, model),
             RequestLog.model.is_not(None),
         ]
-        if account_ids:
-            conditions.append(RequestLog.account_id.in_(account_ids))
-        if model:
-            conditions.append(RequestLog.model == model)
 
         stmt = (
             select(
@@ -143,15 +159,7 @@ class ReportsRepository:
         account_ids: list[str] | None = None,
         model: str | None = None,
     ) -> list[AccountAggregateRow]:
-        conditions = [
-            RequestLog.requested_at >= start_date,
-            RequestLog.requested_at < end_date,
-            _normal_traffic_clause(),
-        ]
-        if account_ids:
-            conditions.append(RequestLog.account_id.in_(account_ids))
-        if model:
-            conditions.append(RequestLog.model == model)
+        conditions = _report_conditions(start_date, end_date, account_ids, model)
 
         stmt = (
             select(
@@ -192,20 +200,49 @@ class ReportsRepository:
         model: str | None = None,
     ) -> int:
         conditions = [
-            RequestLog.requested_at >= start_date,
-            RequestLog.requested_at < end_date,
-            _normal_traffic_clause(),
+            *_report_conditions(start_date, end_date, account_ids, model),
             RequestLog.account_id.is_not(None),
         ]
+
+        result = await self._session.execute(
+            select(func.count(func.distinct(RequestLog.account_id))).where(and_(*conditions))
+        )
+        return int(result.scalar_one() or 0)
+
+    async def earliest_report_activity_at(
+        self,
+        account_ids: list[str] | None = None,
+        model: str | None = None,
+    ) -> datetime | None:
+        conditions = [_normal_traffic_clause()]
         if account_ids:
             conditions.append(RequestLog.account_id.in_(account_ids))
         if model:
             conditions.append(RequestLog.model == model)
 
         result = await self._session.execute(
-            select(func.count(func.distinct(RequestLog.account_id))).where(and_(*conditions))
+            select(func.min(RequestLog.requested_at)).where(and_(*conditions))
         )
-        return int(result.scalar_one() or 0)
+        value = result.scalar_one_or_none()
+        return value if isinstance(value, datetime) else None
+
+
+def _report_conditions(
+    start_date: datetime,
+    end_date: datetime,
+    account_ids: list[str] | None,
+    model: str | None,
+) -> list:
+    conditions = [
+        RequestLog.requested_at >= start_date,
+        RequestLog.requested_at < end_date,
+        _normal_traffic_clause(),
+    ]
+    if account_ids:
+        conditions.append(RequestLog.account_id.in_(account_ids))
+    if model:
+        conditions.append(RequestLog.model == model)
+    return conditions
 
 
 def _normal_traffic_clause():

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
-from sqlalchemy import and_, case, func, or_, select
+from sqlalchemy import and_, case, func, literal, or_, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Account, RequestLog
@@ -13,14 +14,15 @@ _INTERNAL_WARMUP_REQUEST_KINDS = ("warmup", "limit_warmup")
 
 
 @dataclass(frozen=True)
-class DailyReportLogRow:
-    requested_at: datetime
-    account_id: str | None
-    is_error: bool
+class DailyReportAggregateRow:
+    date: str
+    requests: int
     input_tokens: int
     output_tokens: int
     cached_input_tokens: int
     cost_usd: float
+    active_accounts: int
+    error_count: int
 
 
 @dataclass(frozen=True)
@@ -52,38 +54,68 @@ class ReportsRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def list_daily_report_logs(
+    async def aggregate_daily_rows(
         self,
-        start_date: datetime,
-        end_date: datetime,
+        start_date: date,
+        end_date: date,
+        timezone_info: ZoneInfo | timezone,
         account_ids: list[str] | None = None,
         model: str | None = None,
-    ) -> list[DailyReportLogRow]:
-        conditions = _report_conditions(start_date, end_date, account_ids, model)
+    ) -> list[DailyReportAggregateRow]:
+        day_ranges = list(_daily_bucket_ranges(start_date, end_date, timezone_info))
+        if not day_ranges:
+            return []
 
+        day_range_rows = [
+            select(
+                literal(report_date).label("report_date"),
+                literal(day_start).label("day_start"),
+                literal(day_end).label("day_end"),
+            )
+            for report_date, day_start, day_end in day_ranges
+        ]
+        day_ranges_query = day_range_rows[0] if len(day_range_rows) == 1 else union_all(*day_range_rows)
+        day_ranges_cte = day_ranges_query.cte("report_days")
         stmt = (
             select(
-                RequestLog.requested_at,
-                RequestLog.account_id,
-                RequestLog.status,
-                RequestLog.input_tokens,
-                RequestLog.output_tokens,
-                RequestLog.cached_input_tokens,
-                RequestLog.cost_usd,
+                day_ranges_cte.c.report_date,
+                func.count(RequestLog.id).label("requests"),
+                func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
+                func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
+                func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
+                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
+                func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
+                func.coalesce(
+                    func.sum(case((RequestLog.status != "success", 1), else_=0)),
+                    0,
+                ).label("error_count"),
             )
-            .where(and_(*conditions))
-            .order_by(RequestLog.requested_at, RequestLog.request_id)
+            .select_from(
+                day_ranges_cte.join(
+                    RequestLog,
+                    and_(
+                        RequestLog.requested_at >= day_ranges_cte.c.day_start,
+                        RequestLog.requested_at < day_ranges_cte.c.day_end,
+                    _normal_traffic_clause(),
+                    *([RequestLog.account_id.in_(account_ids)] if account_ids else []),
+                    *([RequestLog.model == model] if model else []),
+                    ),
+                )
+            )
+            .group_by(day_ranges_cte.c.report_date)
+            .order_by(day_ranges_cte.c.report_date)
         )
         result = await self._session.execute(stmt)
         return [
-            DailyReportLogRow(
-                requested_at=row.requested_at,
-                account_id=row.account_id,
-                is_error=row.status != "success",
+            DailyReportAggregateRow(
+                date=row.report_date,
+                requests=int(row.requests or 0),
                 input_tokens=int(row.input_tokens or 0),
                 output_tokens=int(row.output_tokens or 0),
                 cached_input_tokens=int(row.cached_input_tokens or 0),
                 cost_usd=float(row.cost_usd or 0.0),
+                active_accounts=int(row.active_accounts or 0),
+                error_count=int(row.error_count or 0),
             )
             for row in result.all()
         ]
@@ -251,3 +283,24 @@ def _normal_traffic_clause():
             RequestLog.request_kind.not_in(_INTERNAL_WARMUP_REQUEST_KINDS),
         ),
     )
+
+
+def _daily_bucket_ranges(
+    start_date: date,
+    end_date: date,
+    timezone_info: ZoneInfo | timezone,
+) -> list[tuple[str, datetime, datetime]]:
+    ranges: list[tuple[str, datetime, datetime]] = []
+    current_date = start_date
+    while current_date <= end_date:
+        day_start = datetime.combine(current_date, datetime.min.time(), tzinfo=timezone_info)
+        next_day_start = datetime.combine(current_date + timedelta(days=1), datetime.min.time(), tzinfo=timezone_info)
+        ranges.append(
+            (
+                current_date.isoformat(),
+                day_start.astimezone(timezone.utc).replace(tzinfo=None),
+                next_day_start.astimezone(timezone.utc).replace(tzinfo=None),
+            )
+        )
+        current_date += timedelta(days=1)
+    return ranges

--- a/app/modules/reports/schemas.py
+++ b/app/modules/reports/schemas.py
@@ -41,8 +41,20 @@ class ReportSummary(DashboardModel):
     avg_requests_per_day: float = 0.0
 
 
+class ReportComparisonPrevious(DashboardModel):
+    total_cost_usd: float
+    total_tokens: int
+    total_requests: int
+
+
+class ReportComparison(DashboardModel):
+    can_compare: bool
+    previous: ReportComparisonPrevious
+
+
 class ReportsResponse(DashboardModel):
     summary: ReportSummary
+    comparison: ReportComparison
     daily: list[DailyReportRow] = Field(default_factory=list)
     by_model: list[ModelCostEntry] = Field(default_factory=list)
     by_account: list[AccountCostEntry] = Field(default_factory=list)

--- a/app/modules/reports/service.py
+++ b/app/modules/reports/service.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.core.utils.time import to_utc_naive, utcnow
-from app.modules.reports.repository import ReportsRepository
+from app.modules.reports.repository import MAX_DAILY_REPORT_DAYS, DailyReportRangeTooLargeError, ReportsRepository
 from app.modules.reports.schemas import (
     AccountCostEntry,
     DailyReportRow,
@@ -34,10 +34,13 @@ class ReportsService:
             end_date = now.date()
         if start_date is None:
             start_date = end_date - timedelta(days=6)
+        window_days = (end_date - start_date).days + 1
+        if window_days > MAX_DAILY_REPORT_DAYS:
+            raise DailyReportRangeTooLargeError(f"report date range must be {MAX_DAILY_REPORT_DAYS} days or less")
 
         start_at = _local_midnight_to_utc_naive(start_date, timezone_info)
         end_at = _local_midnight_to_utc_naive(end_date + timedelta(days=1), timezone_info)
-        window_days = max((end_date - start_date).days + 1, 1)
+        window_days = max(window_days, 1)
         previous_end_date = start_date - timedelta(days=1)
         previous_start_date = previous_end_date - timedelta(days=window_days - 1)
         previous_start_at = _local_midnight_to_utc_naive(previous_start_date, timezone_info)

--- a/app/modules/reports/service.py
+++ b/app/modules/reports/service.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from collections import OrderedDict
 from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.core.utils.time import to_utc_naive, utcnow
-from app.modules.reports.repository import DailyReportLogRow, ReportsRepository
+from app.modules.reports.repository import ReportsRepository
 from app.modules.reports.schemas import (
     AccountCostEntry,
     DailyReportRow,
@@ -52,8 +51,26 @@ class ReportsService:
             model,
         )
         earliest_activity_at = await self._repository.earliest_report_activity_at(account_ids, model)
-        daily_logs = await self._repository.list_daily_report_logs(start_at, end_at, account_ids, model)
-        daily = _bucket_daily_rows(daily_logs, timezone_info)
+        daily_rows = await self._repository.aggregate_daily_rows(
+            start_date,
+            end_date,
+            timezone_info,
+            account_ids,
+            model,
+        )
+        daily = [
+            DailyReportRow(
+                date=row.date,
+                requests=row.requests,
+                input_tokens=row.input_tokens,
+                output_tokens=row.output_tokens,
+                cached_input_tokens=row.cached_input_tokens,
+                cost_usd=round(row.cost_usd, 4),
+                active_accounts=row.active_accounts,
+                error_count=row.error_count,
+            )
+            for row in daily_rows
+        ]
         by_model = await self._repository.aggregate_by_model(start_at, end_at, account_ids, model)
         by_account = await self._repository.aggregate_by_account(start_at, end_at, account_ids, model)
 
@@ -114,43 +131,3 @@ def _resolve_timezone(timezone_name: str | None) -> ZoneInfo | timezone:
 
 def _local_midnight_to_utc_naive(value: date, timezone_info: ZoneInfo | timezone) -> datetime:
     return to_utc_naive(datetime.combine(value, datetime.min.time(), tzinfo=timezone_info))
-
-
-def _bucket_daily_rows(
-    daily_logs: list[DailyReportLogRow],
-    timezone_info: ZoneInfo | timezone,
-) -> list[DailyReportRow]:
-    buckets: OrderedDict[str, DailyReportRow] = OrderedDict()
-    bucket_accounts: dict[str, set[str]] = {}
-
-    for log in daily_logs:
-        local_date = log.requested_at.replace(tzinfo=timezone.utc).astimezone(timezone_info).date().isoformat()
-        row = buckets.get(local_date)
-        if row is None:
-            row = DailyReportRow(
-                date=local_date,
-                requests=0,
-                input_tokens=0,
-                output_tokens=0,
-                cached_input_tokens=0,
-                cost_usd=0.0,
-                active_accounts=0,
-                error_count=0,
-            )
-            buckets[local_date] = row
-            bucket_accounts[local_date] = set()
-
-        row.requests += 1
-        row.input_tokens += log.input_tokens
-        row.output_tokens += log.output_tokens
-        row.cached_input_tokens += log.cached_input_tokens
-        row.cost_usd += log.cost_usd
-        row.error_count += int(log.is_error)
-        if log.account_id is not None:
-            bucket_accounts[local_date].add(log.account_id)
-            row.active_accounts = len(bucket_accounts[local_date])
-
-    for row in buckets.values():
-        row.cost_usd = round(row.cost_usd, 4)
-
-    return list(buckets.values())

--- a/app/modules/reports/service.py
+++ b/app/modules/reports/service.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from collections import OrderedDict
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.core.utils.time import to_utc_naive, utcnow
-from app.modules.reports.repository import ReportsRepository
+from app.modules.reports.repository import DailyReportLogRow, ReportsRepository
 from app.modules.reports.schemas import (
     AccountCostEntry,
     DailyReportRow,
     ModelCostEntry,
+    ReportComparison,
+    ReportComparisonPrevious,
     ReportsResponse,
     ReportSummary,
 )
@@ -19,59 +23,66 @@ class ReportsService:
 
     async def get_reports(
         self,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        report_timezone: str | None = None,
         account_ids: list[str] | None = None,
         model: str | None = None,
     ) -> ReportsResponse:
-        now = utcnow()
+        timezone_info = _resolve_timezone(report_timezone)
+        now = utcnow().replace(tzinfo=timezone.utc).astimezone(timezone_info)
         if end_date is None:
-            end_date = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+            end_date = now.date()
         if start_date is None:
-            start_date = (end_date - timedelta(days=7)).replace(hour=0, minute=0, second=0, microsecond=0)
-        start_date = to_utc_naive(start_date)
-        end_date = to_utc_naive(end_date)
+            start_date = end_date - timedelta(days=6)
 
-        daily = await self._repository.aggregate_daily(start_date, end_date, account_ids, model)
-        by_model = await self._repository.aggregate_by_model(start_date, end_date, account_ids, model)
-        by_account = await self._repository.aggregate_by_account(start_date, end_date, account_ids, model)
-        active_accounts = await self._repository.count_active_accounts(start_date, end_date, account_ids, model)
+        start_at = _local_midnight_to_utc_naive(start_date, timezone_info)
+        end_at = _local_midnight_to_utc_naive(end_date + timedelta(days=1), timezone_info)
+        window_days = max((end_date - start_date).days + 1, 1)
+        previous_end_date = start_date - timedelta(days=1)
+        previous_start_date = previous_end_date - timedelta(days=window_days - 1)
+        previous_start_at = _local_midnight_to_utc_naive(previous_start_date, timezone_info)
+        previous_end_at = _local_midnight_to_utc_naive(previous_end_date + timedelta(days=1), timezone_info)
 
-        total_cost = sum(d.cost_usd for d in daily)
-        total_input = sum(d.input_tokens for d in daily)
-        total_output = sum(d.output_tokens for d in daily)
-        total_cached = sum(d.cached_input_tokens for d in daily)
-        total_requests = sum(d.request_count for d in daily)
-        total_errors = sum(d.error_count for d in daily)
-        day_count = max((end_date.date() - start_date.date()).days, 1)
+        summary = await self._repository.aggregate_summary(start_at, end_at, account_ids, model)
+        previous_summary = await self._repository.aggregate_summary(
+            previous_start_at,
+            previous_end_at,
+            account_ids,
+            model,
+        )
+        earliest_activity_at = await self._repository.earliest_report_activity_at(account_ids, model)
+        daily_logs = await self._repository.list_daily_report_logs(start_at, end_at, account_ids, model)
+        daily = _bucket_daily_rows(daily_logs, timezone_info)
+        by_model = await self._repository.aggregate_by_model(start_at, end_at, account_ids, model)
+        by_account = await self._repository.aggregate_by_account(start_at, end_at, account_ids, model)
+
+        day_count = max((end_at.date() - start_at.date()).days, 1)
 
         model_total = sum(m.cost_usd for m in by_model)
+        comparison = ReportComparison(
+            can_compare=earliest_activity_at is not None and earliest_activity_at <= previous_start_at,
+            previous=ReportComparisonPrevious(
+                total_cost_usd=round(previous_summary.total_cost_usd, 4),
+                total_tokens=previous_summary.total_input_tokens + previous_summary.total_output_tokens,
+                total_requests=previous_summary.total_requests,
+            ),
+        )
 
         return ReportsResponse(
             summary=ReportSummary(
-                total_cost_usd=round(total_cost, 4),
-                total_input_tokens=total_input,
-                total_output_tokens=total_output,
-                total_cached_tokens=total_cached,
-                total_requests=total_requests,
-                total_errors=total_errors,
-                active_accounts=active_accounts,
-                avg_cost_per_day=round(total_cost / day_count, 4),
-                avg_requests_per_day=round(total_requests / day_count, 2),
+                total_cost_usd=round(summary.total_cost_usd, 4),
+                total_input_tokens=summary.total_input_tokens,
+                total_output_tokens=summary.total_output_tokens,
+                total_cached_tokens=summary.total_cached_tokens,
+                total_requests=summary.total_requests,
+                total_errors=summary.total_errors,
+                active_accounts=summary.active_accounts,
+                avg_cost_per_day=round(summary.total_cost_usd / day_count, 4),
+                avg_requests_per_day=round(summary.total_requests / day_count, 2),
             ),
-            daily=[
-                DailyReportRow(
-                    date=d.date,
-                    requests=d.request_count,
-                    input_tokens=d.input_tokens,
-                    output_tokens=d.output_tokens,
-                    cached_input_tokens=d.cached_input_tokens,
-                    cost_usd=round(d.cost_usd, 4),
-                    active_accounts=d.active_accounts,
-                    error_count=d.error_count,
-                )
-                for d in daily
-            ],
+            comparison=comparison,
+            daily=daily,
             by_model=[
                 ModelCostEntry(
                     model=m.model,
@@ -90,3 +101,56 @@ class ReportsService:
                 for a in by_account
             ],
         )
+
+
+def _resolve_timezone(timezone_name: str | None) -> ZoneInfo | timezone:
+    if not timezone_name:
+        return timezone.utc
+    try:
+        return ZoneInfo(timezone_name)
+    except (ValueError, ZoneInfoNotFoundError):
+        return timezone.utc
+
+
+def _local_midnight_to_utc_naive(value: date, timezone_info: ZoneInfo | timezone) -> datetime:
+    return to_utc_naive(datetime.combine(value, datetime.min.time(), tzinfo=timezone_info))
+
+
+def _bucket_daily_rows(
+    daily_logs: list[DailyReportLogRow],
+    timezone_info: ZoneInfo | timezone,
+) -> list[DailyReportRow]:
+    buckets: OrderedDict[str, DailyReportRow] = OrderedDict()
+    bucket_accounts: dict[str, set[str]] = {}
+
+    for log in daily_logs:
+        local_date = log.requested_at.replace(tzinfo=timezone.utc).astimezone(timezone_info).date().isoformat()
+        row = buckets.get(local_date)
+        if row is None:
+            row = DailyReportRow(
+                date=local_date,
+                requests=0,
+                input_tokens=0,
+                output_tokens=0,
+                cached_input_tokens=0,
+                cost_usd=0.0,
+                active_accounts=0,
+                error_count=0,
+            )
+            buckets[local_date] = row
+            bucket_accounts[local_date] = set()
+
+        row.requests += 1
+        row.input_tokens += log.input_tokens
+        row.output_tokens += log.output_tokens
+        row.cached_input_tokens += log.cached_input_tokens
+        row.cost_usd += log.cost_usd
+        row.error_count += int(log.is_error)
+        if log.account_id is not None:
+            bucket_accounts[local_date].add(log.account_id)
+            row.active_accounts = len(bucket_accounts[local_date])
+
+    for row in buckets.values():
+        row.cost_usd = round(row.cost_usd, 4)
+
+    return list(buckets.values())

--- a/frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
@@ -310,6 +310,7 @@ const LIMIT_TYPE_SHORT: Record<LimitType, string> = {
 };
 
 function formatTokenCount(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);

--- a/frontend/src/features/apis/components/api-trend-chart.tsx
+++ b/frontend/src/features/apis/components/api-trend-chart.tsx
@@ -52,6 +52,7 @@ function formatCostTick(value: number): string {
 
 function formatTokenTick(value: number): string {
   if (value === 0) return "0";
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(0)}B`;
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(0)}M`;
   if (value >= 1_000) return `${(value / 1_000).toFixed(0)}K`;
   return String(value);

--- a/frontend/src/features/reports/api.ts
+++ b/frontend/src/features/reports/api.ts
@@ -6,6 +6,7 @@ export type ReportsParams = {
   endDate?: string;
   accountId?: string[];
   model?: string;
+  timezone?: string;
 };
 
 export function getReports(params: ReportsParams = {}) {
@@ -13,6 +14,7 @@ export function getReports(params: ReportsParams = {}) {
   if (params.startDate) query.set("start_date", params.startDate);
   if (params.endDate) query.set("end_date", params.endDate);
   if (params.model) query.set("model", params.model);
+  if (params.timezone) query.set("timezone", params.timezone);
   if (params.accountId) {
     for (const id of params.accountId) {
       query.append("account_id", id);

--- a/frontend/src/features/reports/components/cost-per-day-chart.test.tsx
+++ b/frontend/src/features/reports/components/cost-per-day-chart.test.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CostPerDayChart } from "./cost-per-day-chart";
+
+let capturedProps: { margin?: unknown } | null = null;
+
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    AreaChart: (props: { children: ReactNode; margin?: unknown }) => {
+      capturedProps = props;
+      return <div data-testid="cost-area-chart" />;
+    },
+    Area: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+  };
+});
+
+describe("CostPerDayChart", () => {
+  beforeEach(() => {
+    capturedProps = null;
+  });
+
+  it("uses equal left and right chart margins", () => {
+    render(
+      <CostPerDayChart
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 150,
+            inputTokens: 5_400_000,
+            outputTokens: 59_000,
+            cachedInputTokens: 0,
+            costUsd: 3.77,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    expect(capturedProps?.margin).toEqual({ top: 5, right: 10, left: 10, bottom: 0 });
+  });
+});

--- a/frontend/src/features/reports/components/cost-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/cost-per-day-chart.tsx
@@ -35,12 +35,12 @@ export function CostPerDayChart({ data }: CostPerDayChartProps) {
             <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+              tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
               axisLine={false}
               tickLine={false}
             />
             <YAxis
-              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+              tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
               axisLine={false}
               tickLine={false}
               tickFormatter={(v: number) => `$${v}`}

--- a/frontend/src/features/reports/components/cost-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/cost-per-day-chart.tsx
@@ -25,7 +25,7 @@ export function CostPerDayChart({ data }: CostPerDayChartProps) {
       <div className="text-sm font-semibold text-foreground">Cost by Day</div>
       <div className="mt-4 h-[200px]">
         <ResponsiveContainer width="100%" height="100%">
-          <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
+          <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
             <defs>
               <linearGradient id="costGrad" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.3} />

--- a/frontend/src/features/reports/components/daily-detail-table.test.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.test.tsx
@@ -44,4 +44,30 @@ describe("DailyDetailTable", () => {
       "overflow-y-auto",
     );
   });
+
+  it("renders existing rows when a date bound is cleared", () => {
+    render(
+      <DailyDetailTable
+        startDate=""
+        endDate="2026-06-12"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 150,
+            inputTokens: 5_400_000,
+            outputTokens: 59_000,
+            cachedInputTokens: 0,
+            costUsd: 3.77,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("daily-breakdown-row-2026-06-05")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("daily-breakdown-row-2026-06-06"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/reports/components/daily-detail-table.test.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DailyDetailTable } from "./daily-detail-table";
+
+describe("DailyDetailTable", () => {
+  it("fills missing days with zero rows and keeps the body scrollable", () => {
+    render(
+      <DailyDetailTable
+        startDate="2026-06-05"
+        endDate="2026-06-12"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 150,
+            inputTokens: 5_400_000,
+            outputTokens: 59_000,
+            cachedInputTokens: 0,
+            costUsd: 3.77,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-07",
+            requests: 179,
+            inputTokens: 6_800_000,
+            outputTokens: 73_000,
+            cachedInputTokens: 0,
+            costUsd: 4.54,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    const filledRow = screen.getByTestId("daily-breakdown-row-2026-06-05");
+    const zeroRow = screen.getByTestId("daily-breakdown-row-2026-06-06");
+
+    expect(within(zeroRow).getByText("2026-06-06")).toBeInTheDocument();
+    expect(within(zeroRow).getByText("$0.00")).toBeInTheDocument();
+    expect(zeroRow.className).toBe(filledRow.className);
+    expect(screen.getByTestId("daily-breakdown-scroll-body")).toHaveClass(
+      "overflow-y-auto",
+    );
+  });
+});

--- a/frontend/src/features/reports/components/daily-detail-table.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.tsx
@@ -111,6 +111,10 @@ function buildContinuousRows(
   endDate: string,
   rows: DailyReportRow[],
 ): DailyReportRow[] {
+  if (!isISODate(startDate) || !isISODate(endDate) || startDate > endDate) {
+    return rows;
+  }
+
   const rowsByDate = new Map(rows.map((row) => [row.date, row]));
   const continuousRows: DailyReportRow[] = [];
 
@@ -125,6 +129,15 @@ function nextISODate(date: string): string {
   const nextDate = new Date(`${date}T00:00:00Z`);
   nextDate.setUTCDate(nextDate.getUTCDate() + 1);
   return nextDate.toISOString().slice(0, 10);
+}
+
+function isISODate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
 }
 
 function createZeroRow(date: string): DailyReportRow {

--- a/frontend/src/features/reports/components/daily-detail-table.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.tsx
@@ -12,6 +12,7 @@ export type DailyDetailTableProps = {
 const DAILY_BREAKDOWN_SCROLL_HEIGHT_CLASS = "max-h-[17.5rem]";
 
 function formatTokens(v: number): string {
+  if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
   if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
   if (v >= 1_000) return `${(v / 1_000).toFixed(0)}K`;
   return String(v);

--- a/frontend/src/features/reports/components/daily-detail-table.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.tsx
@@ -4,8 +4,12 @@ import type { DailyReportRow } from "../schemas";
 import { formatReportBucketDate } from "../date";
 
 export type DailyDetailTableProps = {
+  startDate: string;
+  endDate: string;
   data: DailyReportRow[];
 };
+
+const DAILY_BREAKDOWN_SCROLL_HEIGHT_CLASS = "max-h-[17.5rem]";
 
 function formatTokens(v: number): string {
   if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
@@ -13,18 +17,26 @@ function formatTokens(v: number): string {
   return String(v);
 }
 
-export function DailyDetailTable({ data }: DailyDetailTableProps) {
+export function DailyDetailTable({ startDate, endDate, data }: DailyDetailTableProps) {
+  const rows = buildContinuousRows(startDate, endDate, data);
+
   return (
     <div className="rounded-xl border bg-card p-5">
       <div className="mb-3 flex items-center justify-between">
         <div className="text-sm font-semibold text-foreground">Daily Breakdown</div>
-        <Button variant="outline" size="sm" className="h-7 gap-1 text-xs" onClick={() => exportCSV(data)}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1 text-xs"
+          onClick={() => exportCSV(rows)}
+        >
           <Download className="h-3 w-3" />
           CSV
         </Button>
       </div>
       <div className="overflow-x-auto">
-        <table className="w-full text-xs">
+        <table className="w-full table-fixed text-xs">
+          <ColumnGroup />
           <thead>
             <tr className="border-b text-left text-muted-foreground">
               <th className="pb-2 pr-4 font-medium">Day</th>
@@ -35,38 +47,97 @@ export function DailyDetailTable({ data }: DailyDetailTableProps) {
               <th className="pb-2 text-right font-medium">Accounts</th>
             </tr>
           </thead>
-          <tbody>
-            {data.map((row) => (
-              <tr key={row.date} className="border-b border-border/50 last:border-0">
-                <td className="py-2.5 pr-4 font-medium text-foreground">
-                  {formatDate(row.date)}
-                </td>
-                <td className="py-2.5 pr-4 text-right text-foreground">
-                  {row.requests}
-                </td>
-                <td className="py-2.5 pr-4 text-right text-foreground">
-                  {formatTokens(row.inputTokens)}
-                </td>
-                <td className="py-2.5 pr-4 text-right text-foreground">
-                  {formatTokens(row.outputTokens)}
-                </td>
-                <td className="py-2.5 pr-4 text-right font-medium text-emerald-600 dark:text-emerald-400">
-                  ${row.costUsd.toFixed(2)}
-                </td>
-                <td className="py-2.5 text-right text-muted-foreground">
-                  {row.activeAccounts}
-                </td>
-              </tr>
-            ))}
-          </tbody>
         </table>
+        <div
+          data-testid="daily-breakdown-scroll-body"
+          className={`${DAILY_BREAKDOWN_SCROLL_HEIGHT_CLASS} overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden`}
+        >
+          <table className="w-full table-fixed text-xs">
+            <ColumnGroup />
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  key={row.date}
+                  data-testid={`daily-breakdown-row-${row.date}`}
+                  className="border-b border-border/50 last:border-0"
+                >
+                  <td className="py-2.5 pr-4 font-medium text-foreground">
+                    {formatDate(row.date)}
+                  </td>
+                  <td className="py-2.5 pr-4 text-right text-foreground">
+                    {row.requests}
+                  </td>
+                  <td className="py-2.5 pr-4 text-right text-foreground">
+                    {formatTokens(row.inputTokens)}
+                  </td>
+                  <td className="py-2.5 pr-4 text-right text-foreground">
+                    {formatTokens(row.outputTokens)}
+                  </td>
+                  <td className="py-2.5 pr-4 text-right font-medium text-emerald-600 dark:text-emerald-400">
+                    ${row.costUsd.toFixed(2)}
+                  </td>
+                  <td className="py-2.5 text-right text-muted-foreground">
+                    {row.activeAccounts}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );
 }
 
+function ColumnGroup() {
+  return (
+    <colgroup>
+      <col style={{ width: "18%" }} />
+      <col style={{ width: "14%" }} />
+      <col style={{ width: "20%" }} />
+      <col style={{ width: "20%" }} />
+      <col style={{ width: "14%" }} />
+      <col style={{ width: "14%" }} />
+    </colgroup>
+  );
+}
+
 function formatDate(iso: string): string {
   return formatReportBucketDate(iso);
+}
+
+function buildContinuousRows(
+  startDate: string,
+  endDate: string,
+  rows: DailyReportRow[],
+): DailyReportRow[] {
+  const rowsByDate = new Map(rows.map((row) => [row.date, row]));
+  const continuousRows: DailyReportRow[] = [];
+
+  for (let current = startDate; current <= endDate; current = nextISODate(current)) {
+    continuousRows.push(rowsByDate.get(current) ?? createZeroRow(current));
+  }
+
+  return continuousRows;
+}
+
+function nextISODate(date: string): string {
+  const nextDate = new Date(`${date}T00:00:00Z`);
+  nextDate.setUTCDate(nextDate.getUTCDate() + 1);
+  return nextDate.toISOString().slice(0, 10);
+}
+
+function createZeroRow(date: string): DailyReportRow {
+  return {
+    date,
+    requests: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedInputTokens: 0,
+    costUsd: 0,
+    activeAccounts: 0,
+    errorCount: 0,
+  };
 }
 
 function exportCSV(rows: DailyReportRow[]) {

--- a/frontend/src/features/reports/components/model-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.test.tsx
@@ -13,9 +13,19 @@ vi.mock("recharts", async (importOriginal) => {
       <div data-testid="responsive-container">{children}</div>
     ),
     PieChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-    Pie: ({ data, dataKey, onMouseEnter, onMouseLeave }: any) => (
+    Pie: ({
+      data,
+      dataKey,
+      onMouseEnter,
+      onMouseLeave,
+    }: {
+      data: Array<{ model: string }>;
+      dataKey: string;
+      onMouseEnter?: (entry: { model: string }, index: number) => void;
+      onMouseLeave?: (entry: { model: string }, index: number) => void;
+    }) => (
       <div data-testid="model-distribution-pie" data-key={dataKey}>
-        {data.map((entry: { model: string }, index: number) => (
+        {data.map((entry, index) => (
           <button
             key={entry.model}
             type="button"
@@ -37,7 +47,7 @@ vi.mock("recharts", async (importOriginal) => {
       return cloneElement(content, {
         active: true,
         payload: [{ dataKey: "costUsd", name: "costUsd", value: 42.02, color: "#3b82f6" }],
-      } as any);
+      } as Record<string, unknown>);
     },
   };
 });

--- a/frontend/src/features/reports/components/model-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.test.tsx
@@ -1,0 +1,65 @@
+import { cloneElement, isValidElement, type ReactNode } from "react";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ModelDistributionDonut } from "./model-distribution-donut";
+
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+      <div data-testid="responsive-container">{children}</div>
+    ),
+    PieChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Pie: ({ data, dataKey, onMouseEnter, onMouseLeave }: any) => (
+      <div data-testid="model-distribution-pie" data-key={dataKey}>
+        {data.map((entry: { model: string }, index: number) => (
+          <button
+            key={entry.model}
+            type="button"
+            data-testid={`model-slice-${index}`}
+            onMouseEnter={() => onMouseEnter?.(entry, index)}
+            onMouseLeave={() => onMouseLeave?.(entry, index)}
+          >
+            {entry.model}
+          </button>
+        ))}
+      </div>
+    ),
+    Cell: () => null,
+    Tooltip: ({ content }: { content: ReactNode }) => {
+      if (!isValidElement(content)) {
+        return null;
+      }
+
+      return cloneElement(content, {
+        active: true,
+        payload: [{ dataKey: "costUsd", name: "costUsd", value: 42.02, color: "#3b82f6" }],
+      } as any);
+    },
+  };
+});
+
+describe("ModelDistributionDonut", () => {
+  it("does not render a center cost value", () => {
+    render(
+      <ModelDistributionDonut
+        data={[
+          { model: "gpt-5", costUsd: 42.02, percentage: 70 },
+          { model: "o3", costUsd: 18.03, percentage: 30 },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId("model-distribution-center-cost")).not.toBeInTheDocument();
+    const tooltipRow = screen.getByText("Cost").parentElement;
+
+    expect(tooltipRow).not.toBeNull();
+    expect(within(tooltipRow as HTMLElement).getByText("Cost")).toBeInTheDocument();
+    expect(within(tooltipRow as HTMLElement).getByText("$42.02")).toBeInTheDocument();
+    expect(screen.getByText("$18.03")).toBeInTheDocument();
+    expect(screen.getByTestId("model-distribution-pie")).toHaveAttribute("data-key", "costUsd");
+  });
+});

--- a/frontend/src/features/reports/components/model-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.tsx
@@ -13,7 +13,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
     <div className="rounded-xl border bg-card p-5">
       <div className="text-sm font-semibold text-foreground">Distribution by Model</div>
       <div className="mt-4 flex items-center gap-4">
-        <div className="h-[140px] w-[140px] shrink-0">
+        <div className="relative h-[140px] w-[140px] shrink-0">
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie

--- a/frontend/src/features/reports/components/reports-filters.test.tsx
+++ b/frontend/src/features/reports/components/reports-filters.test.tsx
@@ -16,36 +16,16 @@ describe("ReportsFilters", () => {
     vi.useRealTimers();
   });
 
-  it("keeps preset ranges inclusive of the selected day count", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 5, 7, 12, 0, 0));
-    const onFiltersChange = vi.fn();
-    render(
-      <ReportsFilters
-        filters={FILTERS}
-        accountOptions={[]}
-        modelOptions={[]}
-        onFiltersChange={onFiltersChange}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "7d" }));
-
-    expect(onFiltersChange).toHaveBeenCalledWith({
-      ...FILTERS,
-      startDate: "2026-06-01",
-      endDate: "2026-06-07",
-    });
-  });
-
   it("updates account filters from the account selector", async () => {
     const user = userEvent.setup();
     const onFiltersChange = vi.fn();
     render(
       <ReportsFilters
         filters={FILTERS}
+        selectedPresetDays={7}
         accountOptions={[{ value: "acc_one", label: "Primary account", isEmail: false }]}
         modelOptions={[]}
+        onPresetSelect={vi.fn()}
         onFiltersChange={onFiltersChange}
       />,
     );
@@ -62,11 +42,13 @@ describe("ReportsFilters", () => {
     render(
       <ReportsFilters
         filters={{ ...FILTERS, model: "gpt-5.1" }}
+        selectedPresetDays={7}
         accountOptions={[]}
         modelOptions={[
           { value: "gpt-5.1", label: "gpt-5.1" },
           { value: "gpt-5.2", label: "gpt-5.2" },
         ]}
+        onPresetSelect={vi.fn()}
         onFiltersChange={onFiltersChange}
       />,
     );
@@ -78,5 +60,54 @@ describe("ReportsFilters", () => {
       ...FILTERS,
       model: "gpt-5.2",
     });
+  });
+
+  it("renders the selected preset as pressed and forwards preset clicks", () => {
+    const onFiltersChange = vi.fn();
+    const onPresetSelect = vi.fn();
+
+    render(
+      <ReportsFilters
+        filters={FILTERS}
+        selectedPresetDays={30}
+        accountOptions={[]}
+        modelOptions={[]}
+        onPresetSelect={onPresetSelect}
+        onFiltersChange={onFiltersChange}
+      />,
+    );
+
+    const button7d = screen.getByRole("button", { name: "7d" });
+    const button30d = screen.getByRole("button", { name: "30d" });
+
+    expect(button7d).toHaveAttribute("aria-pressed", "false");
+    expect(button7d).toHaveAttribute("data-variant", "outline");
+    expect(button30d).toHaveAttribute("aria-pressed", "true");
+    expect(button30d).toHaveAttribute("data-variant", "default");
+
+    fireEvent.click(screen.getByRole("button", { name: "90d" }));
+
+    expect(onPresetSelect).toHaveBeenCalledWith(90);
+  });
+
+  it("limits both date inputs to the current browser-local day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-12T12:00:00"));
+
+    const { container } = render(
+      <ReportsFilters
+        filters={FILTERS}
+        selectedPresetDays={30}
+        accountOptions={[]}
+        modelOptions={[]}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    const dateInputs = container.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    expect(dateInputs).toHaveLength(2);
+    expect(dateInputs[0]).toHaveAttribute("max", "2026-06-12");
+    expect(dateInputs[1]).toHaveAttribute("max", "2026-06-12");
   });
 });

--- a/frontend/src/features/reports/components/reports-filters.tsx
+++ b/frontend/src/features/reports/components/reports-filters.tsx
@@ -3,7 +3,7 @@ import {
   MultiSelectFilter,
   type MultiSelectOption,
 } from "@/features/dashboard/components/filters/multi-select-filter";
-import { daysAgoLocalISO, localDateISO } from "../date";
+import { localDateISO } from "../date";
 
 export type ReportsFiltersState = {
   startDate: string;
@@ -14,8 +14,10 @@ export type ReportsFiltersState = {
 
 export type ReportsFiltersProps = {
   filters: ReportsFiltersState;
+  selectedPresetDays: number | null;
   accountOptions: MultiSelectOption[];
   modelOptions: MultiSelectOption[];
+  onPresetSelect: (days: number) => void;
   onFiltersChange: (filters: ReportsFiltersState) => void;
 };
 
@@ -27,28 +29,31 @@ const PRESETS = [
 
 export function ReportsFilters({
   filters,
+  selectedPresetDays,
   accountOptions,
   modelOptions,
+  onPresetSelect,
   onFiltersChange,
 }: ReportsFiltersProps) {
+  const maxDate = localDateISO();
+
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-xl border bg-card p-3">
-      {PRESETS.map((preset) => (
-        <Button
-          key={preset.days}
-          variant="outline"
-          size="sm"
-          onClick={() =>
-            onFiltersChange({
-              ...filters,
-              startDate: daysAgoLocalISO(preset.days - 1),
-              endDate: localDateISO(),
-            })
-          }
-        >
-          {preset.label}
-        </Button>
-      ))}
+      {PRESETS.map((preset) => {
+        const isSelected = selectedPresetDays === preset.days;
+
+        return (
+          <Button
+            key={preset.days}
+            variant={isSelected ? "default" : "outline"}
+            size="sm"
+            aria-pressed={isSelected}
+            onClick={() => onPresetSelect(preset.days)}
+          >
+            {preset.label}
+          </Button>
+        );
+      })}
 
       <MultiSelectFilter
         label="Accounts"
@@ -68,6 +73,7 @@ export function ReportsFilters({
       <div className="ml-auto flex items-center gap-2">
         <input
           type="date"
+          max={maxDate}
           value={filters.startDate}
           onChange={(e) => onFiltersChange({ ...filters, startDate: e.target.value })}
           className="h-8 rounded-md border bg-transparent px-2 text-xs text-foreground"
@@ -75,6 +81,7 @@ export function ReportsFilters({
         <span className="text-xs text-muted-foreground">—</span>
         <input
           type="date"
+          max={maxDate}
           value={filters.endDate}
           onChange={(e) => onFiltersChange({ ...filters, endDate: e.target.value })}
           className="h-8 rounded-md border bg-transparent px-2 text-xs text-foreground"

--- a/frontend/src/features/reports/components/reports-page.test.tsx
+++ b/frontend/src/features/reports/components/reports-page.test.tsx
@@ -1,10 +1,12 @@
-import { screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 
 import { renderWithProviders } from "@/test/utils";
 import type { ReportsResponse } from "@/features/reports/schemas";
 import { listAccounts } from "@/features/accounts/api";
+import { getBrowserReportsTimeZone } from "@/features/reports/date";
 import { useReports } from "@/features/reports/hooks/use-reports";
 import { ReportsPage } from "./reports-page";
 
@@ -15,6 +17,26 @@ vi.mock("@/features/accounts/api", () => ({
 vi.mock("@/features/reports/hooks/use-reports", () => ({
   useReports: vi.fn(),
 }));
+
+vi.mock("@/features/reports/date", async () => {
+  const actual = await vi.importActual<typeof import("@/features/reports/date")>(
+    "@/features/reports/date",
+  );
+  return {
+    ...actual,
+    getBrowserReportsTimeZone: vi.fn(),
+  };
+});
+
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+      <div style={{ width: 400, height: 200 }}>{children}</div>
+    ),
+  };
+});
 
 const EMPTY_REPORT: ReportsResponse = {
   summary: {
@@ -28,6 +50,14 @@ const EMPTY_REPORT: ReportsResponse = {
     avgCostPerDay: 0,
     avgRequestsPerDay: 0,
   },
+  comparison: {
+    canCompare: false,
+    previous: {
+      totalCostUsd: 0,
+      totalTokens: 0,
+      totalRequests: 0,
+    },
+  },
   daily: [],
   byModel: [],
   byAccount: [],
@@ -35,7 +65,9 @@ const EMPTY_REPORT: ReportsResponse = {
 
 const useReportsMock = vi.mocked(useReports);
 const listAccountsMock = vi.mocked(listAccounts);
+const getBrowserReportsTimeZoneMock = vi.mocked(getBrowserReportsTimeZone);
 type UseReportsMockResult = ReturnType<typeof useReports>;
+const REPORTS_TIMEZONE_STORAGE_KEY = "codex-lb-reports-timezone";
 
 const asUseReportsResult = (
   value: Partial<UseReportsMockResult>,
@@ -45,11 +77,15 @@ describe("ReportsPage", () => {
   beforeEach(() => {
     useReportsMock.mockReset();
     listAccountsMock.mockReset();
+    getBrowserReportsTimeZoneMock.mockReset();
+    window.localStorage.clear();
     listAccountsMock.mockResolvedValue({ accounts: [] });
+    getBrowserReportsTimeZoneMock.mockReturnValue("America/Los_Angeles");
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    window.localStorage.clear();
   });
 
   it("initializes default dates when the reports page mounts", () => {
@@ -70,6 +106,198 @@ describe("ReportsPage", () => {
       startDate: "2030-01-09",
       endDate: "2030-01-15",
     });
+  });
+
+  it("passes the page-managed timezone state into both reports queries", () => {
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(<ReportsPage />);
+
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        startDate: expect.any(String),
+        endDate: expect.any(String),
+      }),
+      "America/Los_Angeles",
+    );
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        startDate: expect.any(String),
+        endDate: expect.any(String),
+        model: "",
+      }),
+      "America/Los_Angeles",
+    );
+  });
+
+  it("uses the live valid timezone for reports queries even when a cached value exists", async () => {
+    window.localStorage.setItem(REPORTS_TIMEZONE_STORAGE_KEY, "UTC");
+    getBrowserReportsTimeZoneMock.mockReset();
+    const actualDate = await vi.importActual<typeof import("@/features/reports/date")>(
+      "@/features/reports/date",
+    );
+    getBrowserReportsTimeZoneMock.mockImplementation(actualDate.getBrowserReportsTimeZone);
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: "America/Los_Angeles",
+    });
+
+    renderWithProviders(<ReportsPage />);
+
+    expect(useReportsMock).toHaveBeenNthCalledWith(1, expect.any(Object), "America/Los_Angeles");
+    expect(useReportsMock).toHaveBeenNthCalledWith(2, expect.any(Object), "America/Los_Angeles");
+  });
+
+  it("uses the cached valid timezone for reports queries when live detection is unavailable", async () => {
+    window.localStorage.setItem(REPORTS_TIMEZONE_STORAGE_KEY, "Europe/Paris");
+    getBrowserReportsTimeZoneMock.mockReset();
+    const actualDate = await vi.importActual<typeof import("@/features/reports/date")>(
+      "@/features/reports/date",
+    );
+    getBrowserReportsTimeZoneMock.mockImplementation(actualDate.getBrowserReportsTimeZone);
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: undefined as unknown as string,
+    });
+
+    renderWithProviders(<ReportsPage />);
+
+    expect(useReportsMock).toHaveBeenNthCalledWith(1, expect.any(Object), "Europe/Paris");
+    expect(useReportsMock).toHaveBeenNthCalledWith(2, expect.any(Object), "Europe/Paris");
+  });
+
+  it("omits timezone for reports queries only when live and cached timezones are both invalid", async () => {
+    window.localStorage.setItem(REPORTS_TIMEZONE_STORAGE_KEY, "Moon/BaseAlpha");
+    getBrowserReportsTimeZoneMock.mockReset();
+    const actualDate = await vi.importActual<typeof import("@/features/reports/date")>(
+      "@/features/reports/date",
+    );
+    getBrowserReportsTimeZoneMock.mockImplementation(actualDate.getBrowserReportsTimeZone);
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: "Mars/Olympus",
+    });
+
+    renderWithProviders(<ReportsPage />);
+
+    expect(useReportsMock).toHaveBeenNthCalledWith(1, expect.any(Object), undefined);
+    expect(useReportsMock).toHaveBeenNthCalledWith(2, expect.any(Object), undefined);
+  });
+
+  it("refreshes timezone state on focus, visibility changes, and interval ticks", async () => {
+    vi.useFakeTimers();
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+    getBrowserReportsTimeZoneMock.mockReturnValueOnce("America/Los_Angeles");
+
+    renderWithProviders(<ReportsPage />);
+
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Object),
+      "America/Los_Angeles",
+    );
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Object),
+      "America/Los_Angeles",
+    );
+
+    getBrowserReportsTimeZoneMock.mockReturnValue("America/New_York");
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      3,
+      expect.any(Object),
+      "America/New_York",
+    );
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      4,
+      expect.any(Object),
+      "America/New_York",
+    );
+
+    getBrowserReportsTimeZoneMock.mockReturnValue(undefined);
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      5,
+      expect.any(Object),
+      undefined,
+    );
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      6,
+      expect.any(Object),
+      undefined,
+    );
+
+    getBrowserReportsTimeZoneMock.mockReturnValue("America/Chicago");
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      7,
+      expect.any(Object),
+      "America/Chicago",
+    );
+    expect(useReportsMock).toHaveBeenNthCalledWith(
+      8,
+      expect.any(Object),
+      "America/Chicago",
+    );
   });
 
   it("keeps model options from the unfiltered model catalog", async () => {
@@ -96,6 +324,51 @@ describe("ReportsPage", () => {
     expect(
       await screen.findByRole("menuitemcheckbox", { name: /gpt-5.2/i }),
     ).toBeInTheDocument();
+  });
+
+  it("clears the last clicked preset highlight after manual date edits", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-15T12:00:00Z"));
+
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    const { container } = renderWithProviders(<ReportsPage />);
+
+    const button7d = screen.getByRole("button", { name: "7d" });
+    const button30d = screen.getByRole("button", { name: "30d" });
+
+    expect(button7d).toHaveAttribute("aria-pressed", "true");
+    expect(button30d).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(button30d);
+
+    expect(button30d).toHaveAttribute("aria-pressed", "true");
+    expect(useReportsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startDate: "2029-12-17",
+        endDate: "2030-01-15",
+      }),
+      "America/Los_Angeles",
+    );
+
+    const [startDateInput] = container.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    fireEvent.change(startDateInput, { target: { value: "2030-01-01" } });
+
+    expect(button30d).toHaveAttribute("aria-pressed", "false");
+    expect(useReportsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        startDate: "2030-01-01",
+        endDate: "2030-01-15",
+      }),
+      "America/Los_Angeles",
+    );
   });
 
   it("shows an error when report loading fails", async () => {

--- a/frontend/src/features/reports/components/reports-page.tsx
+++ b/frontend/src/features/reports/components/reports-page.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { AlertMessage } from "@/components/alert-message";
@@ -12,7 +12,10 @@ import { CostPerDayChart } from "./cost-per-day-chart";
 import { TokensPerDayChart } from "./tokens-per-day-chart";
 import { ModelDistributionDonut } from "./model-distribution-donut";
 import { DailyDetailTable } from "./daily-detail-table";
-import { daysAgoLocalISO, localDateISO } from "../date";
+import { daysAgoLocalISO, getBrowserReportsTimeZone, localDateISO } from "../date";
+
+const REPORTS_TIMEZONE_REFRESH_INTERVAL_MS = 60_000;
+const DEFAULT_PRESET_DAYS = 7;
 
 const createDefaultFilters = (): ReportsFiltersState => ({
   startDate: daysAgoLocalISO(6),
@@ -30,12 +33,42 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
     ...createDefaultFilters(),
     ...initialFilters,
   }));
-  const reportsQuery = useReports(filters);
+  const [selectedPresetDays, setSelectedPresetDays] = useState<number | null>(
+    DEFAULT_PRESET_DAYS,
+  );
+  const [reportsTimeZone, setReportsTimeZone] = useState<string | undefined>(() =>
+    getBrowserReportsTimeZone(),
+  );
+
+  useEffect(() => {
+    const refreshReportsTimeZone = () => {
+      setReportsTimeZone((currentTimeZone) => {
+        const nextTimeZone = getBrowserReportsTimeZone();
+        return currentTimeZone === nextTimeZone ? currentTimeZone : nextTimeZone;
+      });
+    };
+
+    const intervalId = window.setInterval(
+      refreshReportsTimeZone,
+      REPORTS_TIMEZONE_REFRESH_INTERVAL_MS,
+    );
+
+    window.addEventListener("focus", refreshReportsTimeZone);
+    document.addEventListener("visibilitychange", refreshReportsTimeZone);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshReportsTimeZone);
+      document.removeEventListener("visibilitychange", refreshReportsTimeZone);
+    };
+  }, []);
+
+  const reportsQuery = useReports(filters, reportsTimeZone);
   const modelCatalogFilters = useMemo(
     () => ({ ...filters, model: "" }),
     [filters],
   );
-  const modelCatalogQuery = useReports(modelCatalogFilters);
+  const modelCatalogQuery = useReports(modelCatalogFilters, reportsTimeZone);
   const accountsQuery = useQuery({
     queryKey: ["accounts", "reports-filter"],
     queryFn: listAccounts,
@@ -80,6 +113,25 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
     ]);
   };
 
+  const handlePresetSelect = (days: number) => {
+    setSelectedPresetDays(days);
+    setFilters((current) => ({
+      ...current,
+      startDate: daysAgoLocalISO(days - 1),
+      endDate: localDateISO(),
+    }));
+  };
+
+  const handleFiltersChange = (nextFilters: ReportsFiltersState) => {
+    if (
+      nextFilters.startDate !== filters.startDate ||
+      nextFilters.endDate !== filters.endDate
+    ) {
+      setSelectedPresetDays(null);
+    }
+    setFilters(nextFilters);
+  };
+
   return (
     <div className="mx-auto w-full max-w-[1500px] flex-1 space-y-6 px-4 py-8 sm:px-6">
       <div>
@@ -93,9 +145,11 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
 
       <ReportsFilters
         filters={filters}
+        selectedPresetDays={selectedPresetDays}
         accountOptions={accountOptions}
         modelOptions={modelOptions}
-        onFiltersChange={setFilters}
+        onPresetSelect={handlePresetSelect}
+        onFiltersChange={handleFiltersChange}
       />
 
       {mainReportsError ? (
@@ -120,7 +174,10 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
         </div>
       ) : reportsQuery.data ? (
         <>
-          <ReportsSummaryCards summary={reportsQuery.data.summary} />
+          <ReportsSummaryCards
+            summary={reportsQuery.data.summary}
+            comparison={reportsQuery.data.comparison}
+          />
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <CostPerDayChart data={reportsQuery.data.daily} />
             <TokensPerDayChart data={reportsQuery.data.daily} />
@@ -130,7 +187,11 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
               <ModelDistributionDonut data={reportsQuery.data.byModel} />
             </div>
             <div className="lg:col-span-2">
-              <DailyDetailTable data={reportsQuery.data.daily} />
+              <DailyDetailTable
+                startDate={filters.startDate}
+                endDate={filters.endDate}
+                data={reportsQuery.data.daily}
+              />
             </div>
           </div>
         </>

--- a/frontend/src/features/reports/components/reports-summary-cards.test.tsx
+++ b/frontend/src/features/reports/components/reports-summary-cards.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ReportsSummaryCards } from "./reports-summary-cards";
+
+describe("ReportsSummaryCards", () => {
+  it("renders inline comparison badges for cost, tokens, and requests", () => {
+    render(
+      <ReportsSummaryCards
+        summary={{
+          totalCostUsd: 15,
+          totalInputTokens: 300,
+          totalOutputTokens: 150,
+          totalCachedTokens: 0,
+          totalRequests: 1500,
+          totalErrors: 0,
+          activeAccounts: 3,
+          avgCostPerDay: 5,
+          avgRequestsPerDay: 500,
+        }}
+        comparison={{
+          canCompare: true,
+          previous: {
+            totalCostUsd: 10,
+            totalTokens: 900,
+            totalRequests: 1000,
+          },
+        }}
+      />,
+    );
+
+    const costCard = screen.getByTestId("report-summary-card-Total Cost");
+    expect(within(costCard).getByText("▲ 50%")).toHaveClass(
+      "text-emerald-600",
+      "dark:text-emerald-400",
+    );
+
+    const tokensCard = screen.getByTestId("report-summary-card-Tokens");
+    expect(within(tokensCard).getByText("▼ 50%")).toHaveClass(
+      "text-red-600",
+      "dark:text-red-400",
+    );
+
+    const requestsCard = screen.getByTestId("report-summary-card-Requests");
+    expect(within(requestsCard).getByText("▲ 50%")).toHaveClass(
+      "text-emerald-600",
+      "dark:text-emerald-400",
+    );
+
+    expect(within(tokensCard).getByText("Input 300 · Output 150")).toBeInTheDocument();
+    expect(within(requestsCard).getByText("avg 500/day · 3 accounts")).toBeInTheDocument();
+  });
+
+  it("hides comparison badges when unavailable or previous totals are zero", () => {
+    const { rerender } = render(
+      <ReportsSummaryCards
+        summary={{
+          totalCostUsd: 15,
+          totalInputTokens: 300,
+          totalOutputTokens: 150,
+          totalCachedTokens: 0,
+          totalRequests: 1500,
+          totalErrors: 0,
+          activeAccounts: 3,
+          avgCostPerDay: 5,
+          avgRequestsPerDay: 500,
+        }}
+        comparison={{
+          canCompare: false,
+          previous: {
+            totalCostUsd: 10,
+            totalTokens: 900,
+            totalRequests: 1000,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText(/^[▲▼] \d+%$/)).not.toBeInTheDocument();
+
+    rerender(
+      <ReportsSummaryCards
+        summary={{
+          totalCostUsd: 15,
+          totalInputTokens: 300,
+          totalOutputTokens: 150,
+          totalCachedTokens: 0,
+          totalRequests: 1500,
+          totalErrors: 0,
+          activeAccounts: 3,
+          avgCostPerDay: 5,
+          avgRequestsPerDay: 500,
+        }}
+        comparison={{
+          canCompare: true,
+          previous: {
+            totalCostUsd: 0,
+            totalTokens: 0,
+            totalRequests: 1000,
+          },
+        }}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId("report-summary-card-Total Cost")).queryByText(/^[▲▼] \d+%$/),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("report-summary-card-Tokens")).queryByText(/^[▲▼] \d+%$/),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("report-summary-card-Requests")).getByText("▲ 50%"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides comparison badges when canCompare is true but all previous totals are zero", () => {
+    render(
+      <ReportsSummaryCards
+        summary={{
+          totalCostUsd: 15,
+          totalInputTokens: 300,
+          totalOutputTokens: 150,
+          totalCachedTokens: 0,
+          totalRequests: 1500,
+          totalErrors: 0,
+          activeAccounts: 3,
+          avgCostPerDay: 5,
+          avgRequestsPerDay: 500,
+        }}
+        comparison={{
+          canCompare: true,
+          previous: {
+            totalCostUsd: 0,
+            totalTokens: 0,
+            totalRequests: 0,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText(/^[▲▼] \d+%$/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/reports/components/reports-summary-cards.tsx
+++ b/frontend/src/features/reports/components/reports-summary-cards.tsx
@@ -1,37 +1,63 @@
-import type { ReportSummary } from "../schemas";
+import { cn } from "@/lib/utils";
+
+import type { ReportComparison, ReportSummary } from "../schemas";
+
+const COMPARISON_STYLES = {
+  positive: "text-emerald-600 dark:text-emerald-400",
+  negative: "text-red-600 dark:text-red-400",
+} as const;
 
 export type ReportsSummaryCardsProps = {
   summary: ReportSummary;
+  comparison: ReportComparison;
 };
 
-export function ReportsSummaryCards({ summary }: ReportsSummaryCardsProps) {
+export function ReportsSummaryCards({ summary, comparison }: ReportsSummaryCardsProps) {
   const cards = [
     {
       label: "Total Cost",
       value: `$${summary.totalCostUsd.toFixed(2)}`,
       sub: `avg $${summary.avgCostPerDay.toFixed(2)}/day`,
+      comparison: buildComparison(summary.totalCostUsd, comparison.previous.totalCostUsd, comparison.canCompare),
     },
     {
       label: "Tokens",
       value: formatNumber(summary.totalInputTokens + summary.totalOutputTokens),
       sub: `Input ${formatNumber(summary.totalInputTokens)} · Output ${formatNumber(summary.totalOutputTokens)}`,
+      comparison: buildComparison(
+        summary.totalInputTokens + summary.totalOutputTokens,
+        comparison.previous.totalTokens,
+        comparison.canCompare,
+      ),
     },
     {
       label: "Requests",
       value: formatNumber(summary.totalRequests),
       sub: `avg ${summary.avgRequestsPerDay.toFixed(0)}/day · ${summary.activeAccounts} accounts`,
+      comparison: buildComparison(summary.totalRequests, comparison.previous.totalRequests, comparison.canCompare),
     },
   ];
 
   return (
     <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
       {cards.map((card) => (
-        <div key={card.label} className="rounded-xl border bg-card p-4">
+        <div
+          key={card.label}
+          data-testid={`report-summary-card-${card.label}`}
+          className="rounded-xl border bg-card p-4"
+        >
           <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
             {card.label}
           </div>
-          <div className="mt-1 text-[1.625rem] font-semibold tracking-[-0.02em] text-foreground">
-            {card.value}
+          <div className="mt-1 flex items-baseline gap-2">
+            <div className="text-[1.625rem] font-semibold tracking-[-0.02em] text-foreground">
+              {card.value}
+            </div>
+            {card.comparison ? (
+              <div className={cn("text-xs font-medium", COMPARISON_STYLES[card.comparison.tone])}>
+                {card.comparison.text}
+              </div>
+            ) : null}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">{card.sub}</div>
         </div>
@@ -44,4 +70,26 @@ function formatNumber(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
+}
+
+function buildComparison(
+  current: number,
+  previous: number,
+  canCompare: boolean,
+): { text: string; tone: keyof typeof COMPARISON_STYLES } | undefined {
+  if (!canCompare || previous <= 0) {
+    return undefined;
+  }
+
+  const deltaPercent = ((current - previous) / previous) * 100;
+  const roundedPercent = Math.round(Math.abs(deltaPercent));
+
+  if (roundedPercent === 0) {
+    return undefined;
+  }
+  if (deltaPercent > 0) {
+    return { text: `▲ ${roundedPercent}%`, tone: "positive" };
+  }
+
+  return { text: `▼ ${roundedPercent}%`, tone: "negative" };
 }

--- a/frontend/src/features/reports/components/reports-summary-cards.tsx
+++ b/frontend/src/features/reports/components/reports-summary-cards.tsx
@@ -67,6 +67,7 @@ export function ReportsSummaryCards({ summary, comparison }: ReportsSummaryCards
 }
 
 function formatNumber(n: number): string {
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);

--- a/frontend/src/features/reports/components/tokens-per-day-chart.test.tsx
+++ b/frontend/src/features/reports/components/tokens-per-day-chart.test.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TokensPerDayChart } from "./tokens-per-day-chart";
+
+let capturedProps: { margin?: unknown } | null = null;
+
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    AreaChart: (props: { children: ReactNode; margin?: unknown }) => {
+      capturedProps = props;
+      return <div data-testid="tokens-area-chart" />;
+    },
+    Area: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+  };
+});
+
+describe("TokensPerDayChart", () => {
+  beforeEach(() => {
+    capturedProps = null;
+  });
+
+  it("uses equal left and right chart margins", () => {
+    render(
+      <TokensPerDayChart
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 150,
+            inputTokens: 5_400_000,
+            outputTokens: 59_000,
+            cachedInputTokens: 0,
+            costUsd: 3.77,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    expect(capturedProps?.margin).toEqual({ top: 5, right: 10, left: 10, bottom: 0 });
+  });
+});

--- a/frontend/src/features/reports/components/tokens-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/tokens-per-day-chart.tsx
@@ -46,12 +46,12 @@ export function TokensPerDayChart({ data }: TokensPerDayChartProps) {
             <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+              tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
               axisLine={false}
               tickLine={false}
             />
             <YAxis
-              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+              tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
               axisLine={false}
               tickLine={false}
               tickFormatter={formatTokens}

--- a/frontend/src/features/reports/components/tokens-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/tokens-per-day-chart.tsx
@@ -32,7 +32,7 @@ export function TokensPerDayChart({ data }: TokensPerDayChartProps) {
       <div className="text-sm font-semibold text-foreground">Tokens by Day</div>
       <div className="mt-4 h-[200px]">
         <ResponsiveContainer width="100%" height="100%">
-          <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 0 }}>
+          <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 10, bottom: 0 }}>
             <defs>
               <linearGradient id="inputGrad" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor="#8b5cf6" stopOpacity={0.3} />

--- a/frontend/src/features/reports/components/tokens-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/tokens-per-day-chart.tsx
@@ -15,6 +15,7 @@ export type TokensPerDayChartProps = {
 };
 
 function formatTokens(v: number): string {
+  if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
   if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
   if (v >= 1_000) return `${(v / 1_000).toFixed(0)}K`;
   return String(v);

--- a/frontend/src/features/reports/date.test.ts
+++ b/frontend/src/features/reports/date.test.ts
@@ -1,15 +1,180 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { formatReportBucketDate, localDateISO } from "./date";
+import {
+  daysAgoLocalISO,
+  formatReportBucketDate,
+  getBrowserReportsTimeZone,
+  localDateISO,
+} from "./date";
+
+const REPORTS_TIMEZONE_STORAGE_KEY = "codex-lb-reports-timezone";
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
 
 describe("reports date helpers", () => {
-  it("formats local calendar dates without UTC day shifts", () => {
-    const eveningBehindUtc = new Date(2026, 5, 1, 20, 30, 0);
+  beforeEach(() => {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(window, "localStorage", originalLocalStorageDescriptor);
+    }
+    window.localStorage.clear();
+  });
 
-    expect(localDateISO(eveningBehindUtc)).toBe("2026-06-01");
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(window, "localStorage", originalLocalStorageDescriptor);
+      window.localStorage.clear();
+    }
+  });
+
+  function createBlockedLocalStorage(): Storage {
+    return {
+      get length() {
+        return 0;
+      },
+      clear() {},
+      getItem() {
+        return null;
+      },
+      key() {
+        return null;
+      },
+      removeItem() {},
+      setItem() {
+        throw new DOMException("blocked", "SecurityError");
+      },
+    };
+  }
+
+  function createReadBlockedLocalStorage(): Storage {
+    return {
+      get length() {
+        return 0;
+      },
+      clear() {},
+      getItem() {
+        throw new DOMException("blocked", "SecurityError");
+      },
+      key() {
+        return null;
+      },
+      removeItem() {},
+      setItem() {},
+    };
+  }
+
+  it("formats a local calendar date without shifting it to the UTC day", () => {
+    const localLateEvening = new Date("2026-06-02T02:30:00.000Z");
+    vi.spyOn(localLateEvening, "getTimezoneOffset").mockReturnValue(300);
+
+    expect(localDateISO(localLateEvening)).toBe("2026-06-01");
+  });
+
+  it("shifts the local calendar date back by the requested number of days", () => {
+    const localNoon = new Date(2026, 5, 2, 12, 0, 0);
+
+    expect(daysAgoLocalISO(1, localNoon)).toBe("2026-06-01");
   });
 
   it("formats report bucket strings without parsing them as UTC instants", () => {
-    expect(formatReportBucketDate("2026-06-01")).toBe("01/06");
+    expect(formatReportBucketDate("2026-06-01")).toBe("2026-06-01");
   });
+
+  it("returns the live browser timezone and refreshes the cached value", () => {
+    window.localStorage.setItem(REPORTS_TIMEZONE_STORAGE_KEY, "UTC");
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: "America/Los_Angeles",
+    });
+
+    expect(getBrowserReportsTimeZone()).toBe("America/Los_Angeles");
+    expect(window.localStorage.getItem(REPORTS_TIMEZONE_STORAGE_KEY)).toBe(
+      "America/Los_Angeles",
+    );
+  });
+
+  it("returns the live browser timezone when localStorage writes are blocked", () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: "America/Los_Angeles",
+    });
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createBlockedLocalStorage(),
+    });
+
+    expect(getBrowserReportsTimeZone()).toBe("America/Los_Angeles");
+    expect(window.localStorage.getItem(REPORTS_TIMEZONE_STORAGE_KEY)).toBeNull();
+  });
+
+  it("reuses the cached timezone when the live browser timezone is invalid", () => {
+    window.localStorage.setItem(REPORTS_TIMEZONE_STORAGE_KEY, "Europe/Paris");
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: "Mars/Olympus",
+    });
+
+    expect(getBrowserReportsTimeZone()).toBe("Europe/Paris");
+    expect(window.localStorage.getItem(REPORTS_TIMEZONE_STORAGE_KEY)).toBe("Europe/Paris");
+  });
+
+  it("reuses the cached timezone when live browser detection is unavailable", () => {
+    window.localStorage.setItem(REPORTS_TIMEZONE_STORAGE_KEY, "Europe/Paris");
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: undefined as unknown as string,
+    });
+
+    expect(getBrowserReportsTimeZone()).toBe("Europe/Paris");
+    expect(window.localStorage.getItem(REPORTS_TIMEZONE_STORAGE_KEY)).toBe("Europe/Paris");
+  });
+
+  it("returns undefined when neither the live nor cached timezone is valid", () => {
+    window.localStorage.setItem(REPORTS_TIMEZONE_STORAGE_KEY, "Moon/BaseAlpha");
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: "Mars/Olympus",
+    });
+
+    expect(getBrowserReportsTimeZone()).toBeUndefined();
+  });
+
+  it("returns undefined when the live timezone is invalid and no cached timezone exists", () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: "Mars/Olympus",
+    });
+
+    expect(getBrowserReportsTimeZone()).toBeUndefined();
+    expect(window.localStorage.getItem(REPORTS_TIMEZONE_STORAGE_KEY)).toBeNull();
+  });
+
+  it.each(["Mars/Olympus", undefined])(
+    "returns undefined when cached timezone reads are blocked and live detection is %s",
+    (timeZone) => {
+      vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+        locale: "en-US",
+        calendar: "gregory",
+        numberingSystem: "latn",
+        timeZone: timeZone as unknown as string,
+      });
+      Object.defineProperty(window, "localStorage", {
+        configurable: true,
+        value: createReadBlockedLocalStorage(),
+      });
+
+      expect(getBrowserReportsTimeZone()).toBeUndefined();
+    },
+  );
 });

--- a/frontend/src/features/reports/date.ts
+++ b/frontend/src/features/reports/date.ts
@@ -1,3 +1,41 @@
+const REPORTS_TIMEZONE_STORAGE_KEY = "codex-lb-reports-timezone";
+
+function isValidTimeZone(timeZone: string | undefined): timeZone is string {
+  if (!timeZone) {
+    return false;
+  }
+
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getBrowserReportsTimeZone(): string | undefined {
+  const detectedTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (isValidTimeZone(detectedTimeZone)) {
+    try {
+      window.localStorage.setItem(REPORTS_TIMEZONE_STORAGE_KEY, detectedTimeZone);
+    } catch {
+      // Some browser contexts block storage access; detection still succeeded.
+    }
+    return detectedTimeZone;
+  }
+
+  try {
+    const cachedTimeZone = window.localStorage.getItem(REPORTS_TIMEZONE_STORAGE_KEY) ?? undefined;
+    if (isValidTimeZone(cachedTimeZone)) {
+      return cachedTimeZone;
+    }
+  } catch {
+    // Some browser contexts block storage access; fall through and omit timezone.
+  }
+
+  return undefined;
+}
+
 export function localDateISO(date: Date = new Date()): string {
   const localTime = date.getTime() - date.getTimezoneOffset() * 60_000;
   return new Date(localTime).toISOString().slice(0, 10);
@@ -14,5 +52,5 @@ export function formatReportBucketDate(date: string): string {
   if (!year || !month || !day) {
     return date;
   }
-  return `${day}/${month}`;
+  return `${year}-${month}-${day}`;
 }

--- a/frontend/src/features/reports/hooks/use-reports.test.tsx
+++ b/frontend/src/features/reports/hooks/use-reports.test.tsx
@@ -1,0 +1,192 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { get } from "@/lib/api-client";
+import { useReports } from "./use-reports";
+
+vi.mock("@/lib/api-client", () => ({
+  get: vi.fn().mockResolvedValue({
+    summary: {
+      totalCostUsd: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCachedTokens: 0,
+      totalRequests: 0,
+      totalErrors: 0,
+      activeAccounts: 0,
+      avgCostPerDay: 0,
+      avgRequestsPerDay: 0,
+    },
+    comparison: {
+      canCompare: false,
+      previous: {
+        totalCostUsd: 0,
+        totalTokens: 0,
+        totalRequests: 0,
+      },
+    },
+    daily: [],
+    byModel: [],
+    byAccount: [],
+  }),
+}));
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+const getMock = vi.mocked(get);
+
+function getRequestedSearchParams(): URLSearchParams {
+  const [url] = getMock.mock.calls[0] ?? [];
+  expect(typeof url).toBe("string");
+  return new URL(url, "http://localhost").searchParams;
+}
+
+describe("useReports", () => {
+  beforeEach(() => {
+    getMock.mockClear();
+  });
+
+  it("includes the provided timezone in reports requests when available", async () => {
+    const queryClient = createTestQueryClient();
+
+    const { result } = renderHook(
+      () =>
+        useReports(
+          {
+            startDate: "2030-01-09",
+            endDate: "2030-01-15",
+            accountId: ["acct_123"],
+            model: "gpt-5.1",
+          },
+          "America/Los_Angeles",
+        ),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    const searchParams = getRequestedSearchParams();
+    expect(searchParams.get("start_date")).toBe("2030-01-09");
+    expect(searchParams.get("end_date")).toBe("2030-01-15");
+    expect(searchParams.get("model")).toBe("gpt-5.1");
+    expect(searchParams.getAll("account_id")).toEqual(["acct_123"]);
+    expect(searchParams.get("timezone")).toBe("America/Los_Angeles");
+  });
+
+  it("keeps query key and request timezone aligned across rerenders", async () => {
+    const queryClient = createTestQueryClient();
+    const filters = {
+      startDate: "2030-01-09",
+      endDate: "2030-01-15",
+      accountId: ["acct_123"],
+      model: "gpt-5.1",
+    };
+
+    const { result, rerender } = renderHook(
+      ({ timeZone }) => useReports(filters, timeZone),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { timeZone: "America/Los_Angeles" as string | undefined },
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    rerender({ timeZone: "America/New_York" });
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+
+    const [firstUrl] = getMock.mock.calls[0] ?? [];
+    const [secondUrl] = getMock.mock.calls[1] ?? [];
+    expect(
+      new URL(String(firstUrl), "http://localhost").searchParams.get(
+        "timezone",
+      ),
+    ).toBe("America/Los_Angeles");
+    expect(
+      new URL(String(secondUrl), "http://localhost").searchParams.get(
+        "timezone",
+      ),
+    ).toBe("America/New_York");
+  });
+
+  it("reuses the same cache entry when refetching with the same timezone", async () => {
+    const queryClient = createTestQueryClient();
+
+    const filters = {
+      startDate: "2030-01-09",
+      endDate: "2030-01-15",
+      accountId: ["acct_123"],
+      model: "gpt-5.1",
+    };
+
+    const { result } = renderHook(() => useReports(filters, "America/Los_Angeles"), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    await result.current.refetch();
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+
+    const [firstUrl] = getMock.mock.calls[0] ?? [];
+    const [secondUrl] = getMock.mock.calls[1] ?? [];
+    expect(
+      new URL(String(firstUrl), "http://localhost").searchParams.get(
+        "timezone",
+      ),
+    ).toBe("America/Los_Angeles");
+    expect(
+      new URL(String(secondUrl), "http://localhost").searchParams.get(
+        "timezone",
+      ),
+    ).toBe("America/Los_Angeles");
+  });
+
+  it("omits the timezone query parameter when the provided timezone is unavailable", async () => {
+    const queryClient = createTestQueryClient();
+
+    const { result } = renderHook(
+      () =>
+        useReports({
+          startDate: "2030-01-09",
+            endDate: "2030-01-15",
+            accountId: ["acct_123"],
+            model: "gpt-5.1",
+          },
+          undefined,
+        ),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    const searchParams = getRequestedSearchParams();
+    expect(searchParams.get("start_date")).toBe("2030-01-09");
+    expect(searchParams.get("end_date")).toBe("2030-01-15");
+    expect(searchParams.get("model")).toBe("gpt-5.1");
+    expect(searchParams.getAll("account_id")).toEqual(["acct_123"]);
+    expect(searchParams.has("timezone")).toBe(false);
+  });
+});

--- a/frontend/src/features/reports/hooks/use-reports.ts
+++ b/frontend/src/features/reports/hooks/use-reports.ts
@@ -8,15 +8,19 @@ type ReportsFilterState = {
   model: string | undefined;
 };
 
-export function useReports(filters: ReportsFilterState) {
+export function useReports(
+  filters: ReportsFilterState,
+  timeZone: string | undefined,
+) {
   return useQuery({
-    queryKey: ["reports", filters],
+    queryKey: ["reports", filters, timeZone],
     queryFn: () =>
       getReports({
         startDate: filters.startDate,
         endDate: filters.endDate,
         accountId: filters.accountId.length > 0 ? filters.accountId : undefined,
         model: filters.model || undefined,
+        timezone: timeZone,
       }),
     refetchInterval: 60_000,
     refetchIntervalInBackground: false,

--- a/frontend/src/features/reports/schemas.test.ts
+++ b/frontend/src/features/reports/schemas.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { ReportsResponseSchema } from "./schemas";
+
+describe("ReportsResponseSchema", () => {
+  it("parses the required comparison block", () => {
+    const parsed = ReportsResponseSchema.parse({
+      summary: {
+        totalCostUsd: 12.5,
+        totalInputTokens: 300,
+        totalOutputTokens: 200,
+        totalCachedTokens: 0,
+        totalRequests: 25,
+        totalErrors: 1,
+        activeAccounts: 3,
+        avgCostPerDay: 4.17,
+        avgRequestsPerDay: 8.33,
+      },
+      comparison: {
+        canCompare: true,
+        previous: {
+          totalCostUsd: 10,
+          totalTokens: 400,
+          totalRequests: 20,
+        },
+      },
+      daily: [],
+      byModel: [],
+      byAccount: [],
+    });
+
+    expect(parsed.comparison.canCompare).toBe(true);
+    expect(parsed.comparison.previous.totalCostUsd).toBe(10);
+    expect(parsed.comparison.previous.totalTokens).toBe(400);
+    expect(parsed.comparison.previous.totalRequests).toBe(20);
+  });
+
+  it("rejects payloads without the comparison block", () => {
+    expect(() =>
+      ReportsResponseSchema.parse({
+        summary: {
+          totalCostUsd: 12.5,
+          totalInputTokens: 300,
+          totalOutputTokens: 200,
+          totalCachedTokens: 0,
+          totalRequests: 25,
+          totalErrors: 1,
+          activeAccounts: 3,
+          avgCostPerDay: 4.17,
+          avgRequestsPerDay: 8.33,
+        },
+        daily: [],
+        byModel: [],
+        byAccount: [],
+      }),
+    ).toThrow(/comparison/i);
+  });
+
+  it("rejects comparison blocks without previous totals", () => {
+    expect(() =>
+      ReportsResponseSchema.parse({
+        summary: {
+          totalCostUsd: 12.5,
+          totalInputTokens: 300,
+          totalOutputTokens: 200,
+          totalCachedTokens: 0,
+          totalRequests: 25,
+          totalErrors: 1,
+          activeAccounts: 3,
+          avgCostPerDay: 4.17,
+          avgRequestsPerDay: 8.33,
+        },
+        comparison: {
+          canCompare: false,
+        },
+        daily: [],
+        byModel: [],
+        byAccount: [],
+      }),
+    ).toThrow(/previous/i);
+  });
+});

--- a/frontend/src/features/reports/schemas.ts
+++ b/frontend/src/features/reports/schemas.ts
@@ -36,8 +36,20 @@ export const ReportSummarySchema = z.object({
   avgRequestsPerDay: z.number(),
 });
 
+export const ReportComparisonPreviousSchema = z.object({
+  totalCostUsd: z.number(),
+  totalTokens: z.number(),
+  totalRequests: z.number(),
+});
+
+export const ReportComparisonSchema = z.object({
+  canCompare: z.boolean(),
+  previous: ReportComparisonPreviousSchema,
+});
+
 export const ReportsResponseSchema = z.object({
   summary: ReportSummarySchema,
+  comparison: ReportComparisonSchema,
   daily: z.array(DailyReportRowSchema),
   byModel: z.array(ModelCostEntrySchema),
   byAccount: z.array(AccountCostEntrySchema),
@@ -47,4 +59,5 @@ export type DailyReportRow = z.infer<typeof DailyReportRowSchema>;
 export type ModelCostEntry = z.infer<typeof ModelCostEntrySchema>;
 export type AccountCostEntry = z.infer<typeof AccountCostEntrySchema>;
 export type ReportSummary = z.infer<typeof ReportSummarySchema>;
+export type ReportComparison = z.infer<typeof ReportComparisonSchema>;
 export type ReportsResponse = z.infer<typeof ReportsResponseSchema>;

--- a/openspec/changes/fix-reports-range-guard/proposal.md
+++ b/openspec/changes/fix-reports-range-guard/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+`GET /api/reports` currently expands every requested calendar day into a bucket
+list before querying daily aggregates. Because the endpoint accepts arbitrary
+past dates, a caller can request an extremely large span and force excessive
+memory use plus a large number of chunked UNION queries.
+
+## What Changes
+
+- Reject report requests whose inclusive date span is larger than the supported
+  daily reporting window.
+- Return a 400-class dashboard error before the backend expands per-day report
+  buckets for oversized ranges.
+- Add regression coverage for the oversized-range path.
+
+## Impact
+
+- Prevents resource exhaustion from pathologically large report requests.
+- Keeps `/api/reports` behavior explicit instead of silently attempting to
+  process unbounded daily windows.
+- Adds an OpenSpec-backed contract for the supported report range.

--- a/openspec/changes/fix-reports-range-guard/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-reports-range-guard/specs/frontend-architecture/spec.md
@@ -3,11 +3,19 @@
 ### Requirement: Reports API SHALL reject oversized daily ranges
 
 `GET /api/reports` SHALL reject requests whose inclusive `start_date` to
-`end_date` span exceeds 730 calendar days.
+`end_date` span exceeds 730 calendar days after applying endpoint defaults for
+any omitted bound.
 
 #### Scenario: Oversized report range is rejected
 
 - **WHEN** an authenticated operator requests `/api/reports` with a date span
   longer than 730 days
+- **THEN** the API returns a 400-class response
+- **AND** the backend does not expand the request into per-day report buckets
+
+#### Scenario: Single-bound report range is validated after defaults
+
+- **WHEN** an authenticated operator requests `/api/reports` with only
+  `start_date` set to a date more than 730 days before the effective end date
 - **THEN** the API returns a 400-class response
 - **AND** the backend does not expand the request into per-day report buckets

--- a/openspec/changes/fix-reports-range-guard/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-reports-range-guard/specs/frontend-architecture/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Reports API SHALL reject oversized daily ranges
+
+`GET /api/reports` SHALL reject requests whose inclusive `start_date` to
+`end_date` span exceeds 730 calendar days.
+
+#### Scenario: Oversized report range is rejected
+
+- **WHEN** an authenticated operator requests `/api/reports` with a date span
+  longer than 730 days
+- **THEN** the API returns a 400-class response
+- **AND** the backend does not expand the request into per-day report buckets

--- a/openspec/changes/fix-reports-range-guard/tasks.md
+++ b/openspec/changes/fix-reports-range-guard/tasks.md
@@ -1,0 +1,6 @@
+- [x] Add an OpenSpec requirement for the maximum supported `/api/reports`
+  date span and the oversized-range rejection behavior.
+- [x] Reject oversized report date ranges before daily bucket expansion in the
+  reports API path.
+- [x] Add regression coverage for the oversized-range response.
+- [ ] Run focused report tests and OpenSpec validation.

--- a/openspec/changes/polish-reports-visualization/design.md
+++ b/openspec/changes/polish-reports-visualization/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The current reports surface already has the right component boundaries for this work: `ReportsPage` owns the filter state and request wiring, `ReportsFilters` renders the controls, `ReportsSummaryCards` renders the top-level metrics, `DailyDetailTable` renders the tabular daily output, and the charts stay isolated in small presentational components. The consolidation is therefore a behavior and contract cleanup inside the existing reports stack rather than a new architecture.
+
+Two earlier OpenSpec changes captured narrower parts of this behavior and one of them now contradicts the implemented reports UI by keeping the last-clicked preset highlighted after manual date edits. This consolidated change replaces those fragments with one coherent `/reports` contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make this change the single surviving OpenSpec record for the covered reports work.
+- Keep report date filters aligned with the browser's local calendar and prevent future-date input.
+- Send browser-local timezone context on reports requests and make the endpoint interpret ranges and daily buckets in that timezone.
+- Show previous-window summary-card comparison only when the immediately preceding window is fully covered.
+- Show a continuous daily breakdown window by filling missing calendar days with zero-valued rows.
+- Keep daily breakdown dates in ISO `yyyy-mm-dd` format.
+- Keep the daily breakdown header fixed while only the body scrolls, with a default height of seven rows.
+- Clear quick-preset highlighting as soon as the operator manually edits the date range.
+- Keep the model donut driven by cost data without rendering a center value.
+- Balance the left and right chart padding for the two daily reports charts.
+- Keep the change local to the existing reports frontend/backend contracts and tests.
+
+**Non-Goals:**
+
+- Adding a persisted user-configurable reporting timezone.
+- Recomputing whether a custom range should automatically reselect `7d`, `30d`, or `90d`.
+- Changing CSV export columns.
+- Redesigning the overall reports layout.
+
+## Decisions
+
+### 1. Keep preset state in `ReportsPage`, but clear it on manual date edits
+
+`ReportsPage` already owns the canonical filter state, so it will continue to own `selectedPresetDays`. Preset button clicks will set both the date range and the selected preset. Manual changes to `startDate` or `endDate` will set `selectedPresetDays` to `null` before updating the filters.
+
+The date inputs also use the browser-local current day as their `max` value so operators cannot pick a future report date from the native control.
+
+### 2. Send browser-local timezone on each reports request
+
+The reports page will detect the browser's current IANA timezone, cache the latest valid value locally for convenience, and include a valid timezone on `GET /api/reports` whenever one is available. The fallback order is: use the browser's live detected timezone when it is valid, otherwise reuse the cached valid timezone, otherwise omit the `timezone` query parameter entirely. The backend will interpret `start_date` and `end_date` as local-midnight boundaries in the supplied timezone, convert those boundaries to UTC for filtering, and bucket `daily` rows by that same local calendar day. Missing or invalid request timezones fall back to UTC.
+
+### 3. Expose previous-window comparison conservatively
+
+The reports response includes a `comparison` block with `canCompare` plus previous-window totals for cost, tokens, and requests. The backend only sets `canCompare` when the earliest eligible report activity proves the immediately preceding window is fully covered. The summary cards render percentage deltas only when `canCompare` is true and the relevant previous total is greater than zero.
+
+### 4. Fill missing daily rows inside `DailyDetailTable`
+
+The daily table will build a contiguous calendar window from the active start and end dates, map API rows by date, and synthesize zero-valued rows for any missing day.
+
+### 5. Split the daily table into a fixed header and scrollable body
+
+The table rendering will be structured so the header remains visible and only the body scrolls. The body height will be capped to approximately seven row heights.
+
+### 6. Keep the donut legend cost-based without center text
+
+`ModelDistributionDonut` continues to size slices from `costUsd` and show cost in the legend and tooltip, but it does not render a center label or hover-driven center text.
+
+### 7. Normalize chart margins locally in each chart component
+
+`CostPerDayChart` and `TokensPerDayChart` will each update their chart margin config so `left` and `right` are equal.
+
+## Verification
+
+- Validate that manual date edits clear preset highlighting and that report date inputs reject future dates.
+- Add or keep coverage for timezone detection, cached timezone reuse, invalid-live-detection fallback, and `timezone` request wiring.
+- Validate reports summary-card comparison rendering for available and suppressed previous-window cases.
+- Add backend coverage for timezone-aware range interpretation, local-day daily bucketing, and UTC fallback.
+- Add daily table coverage for zero-filled missing days and the seven-row scroll container.
+- Validate the donut stays cost-based without a center value.
+- Verify the two daily chart components use equal left and right margins.
+- Run `uv run openspec validate --specs`.

--- a/openspec/changes/polish-reports-visualization/proposal.md
+++ b/openspec/changes/polish-reports-visualization/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The reports surface had drifted across several small follow-up changes and no longer had one coherent OpenSpec source of truth. Operators need `/reports` to use the browser's local calendar consistently, keep the active date range visually honest, prevent invalid future-date inputs, show continuous day-by-day reporting even when some days have no data, and expose previous-window comparison only when the backend can prove the baseline window is fully covered.
+
+## What Changes
+
+- Consolidate the reports visualization work into one surviving OpenSpec change.
+- Keep the visible `/reports` controls for presets, dates, account, and model, but clear the active preset highlight after manual date edits.
+- Disallow future dates in the report start and end inputs.
+- Send the browser's current IANA timezone on reports requests when available, and define the reports endpoint's timezone-aware date-range and daily-bucketing behavior.
+- Fill missing calendar days in the daily breakdown with zero-valued rows for the selected date window, keep ISO calendar dates, and keep only the body scrollable with a seven-row viewport.
+- Define the previous-window comparison contract for report summary cards and require comparison to stay hidden unless the immediately preceding window is fully covered.
+- Keep the model distribution donut cost-based while omitting any center value.
+- Use equal left and right horizontal padding in the `Cost by Day` and `Tokens by Day` chart plots.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: refine `/reports` filter, request, summary-card, table, donut, chart, and endpoint requirements for the consolidated behavior.
+
+## Impact
+
+- Frontend: `frontend/src/features/reports/components/{reports-page,reports-filters,reports-summary-cards,daily-detail-table,model-distribution-donut,cost-per-day-chart,tokens-per-day-chart}.tsx`
+- Frontend utilities/hooks: `frontend/src/features/reports/{date,hooks,use-reports.ts,api.ts}`
+- Backend: `app/modules/reports/{api,service,repository,schemas}.py`
+- Frontend and backend tests covering reports filters, summary comparison, timezone requests, and timezone-aware daily bucketing
+- OpenSpec: `openspec/specs/frontend-architecture/spec.md`

--- a/openspec/changes/polish-reports-visualization/specs/frontend-architecture/spec.md
+++ b/openspec/changes/polish-reports-visualization/specs/frontend-architecture/spec.md
@@ -1,0 +1,132 @@
+## MODIFIED Requirements
+
+### Requirement: Reports page exposes visible filter controls
+
+The `/reports` page SHALL expose visible filter controls for `7d`, `30d`, and `90d` quick presets, start date, end date, account, and model. When an authenticated operator clicks one of the quick presets, the page SHALL visibly highlight that preset. When the operator manually edits the start date or end date afterward, the page SHALL clear the quick-preset highlight until another quick preset is clicked. The start and end date inputs SHALL disallow selecting dates later than the browser's current local calendar date.
+
+#### Scenario: Reports page shows report filter controls
+
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the page exposes visible filter controls for `7d`, `30d`, and `90d` quick presets, start date, end date, account, and model
+
+#### Scenario: Quick preset highlight follows the selected preset
+
+- **WHEN** an authenticated operator clicks the `30d` quick preset on `/reports`
+- **THEN** the page visibly highlights the `30d` preset
+- **AND** the page updates the start and end dates to the `30d` preset range
+
+#### Scenario: Quick preset highlight clears after manual date edits
+
+- **WHEN** an authenticated operator clicks a quick preset on `/reports`
+- **AND** then manually edits the start date or end date
+- **THEN** the page clears the quick-preset highlight
+- **AND** the page keeps the edited date range values
+
+#### Scenario: Report date inputs disallow future dates
+
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the start date and end date inputs prevent selecting a date later than the browser's current local calendar date
+
+### Requirement: Reports page sends browser-local timezone context
+
+The `/reports` page SHALL detect the browser's current IANA timezone, cache the latest detected valid value locally for convenience, and include a valid timezone in `GET /api/reports` requests whenever one is available. The page SHALL prefer the browser's current valid timezone over any cached value, SHALL reuse the cached valid timezone when live detection is unavailable or invalid, and SHALL omit the `timezone` query parameter only when neither the live nor cached value is valid.
+
+#### Scenario: Reports page includes browser timezone on requests
+
+- **WHEN** an authenticated operator opens `/reports` or changes a report filter
+- **THEN** the request to `GET /api/reports` includes the browser's current IANA timezone in the `timezone` query parameter when detection succeeds
+
+#### Scenario: Reports page reuses cached timezone when live detection fails
+
+- **WHEN** the browser cannot provide a valid IANA timezone name
+- **AND** the page has a cached valid timezone from an earlier successful detection
+- **THEN** the reports page still requests `GET /api/reports`
+- **AND** the request uses the cached valid timezone in the `timezone` query parameter
+
+#### Scenario: Reports page omits timezone only when no valid timezone is available
+
+- **WHEN** the browser cannot provide a valid IANA timezone name
+- **AND** the page does not have a cached valid timezone
+- **THEN** the reports page still requests `GET /api/reports`
+- **AND** the request omits the `timezone` query parameter
+
+### Requirement: Reports endpoint applies timezone-aware ranges and daily bucketing
+
+`GET /api/reports` SHALL interpret `start_date` and `end_date` as calendar dates in the supplied IANA timezone, convert those local-midnight boundaries to UTC for filtering, and group `daily` rows by calendar day in that same timezone. When the timezone is missing or invalid, the endpoint MUST fall back to UTC.
+
+#### Scenario: Reports endpoint uses local-day buckets before UTC midnight
+
+- **WHEN** `/api/reports` receives `start_date`, `end_date`, and `timezone=America/Los_Angeles`
+- **AND** a request log row falls on `2026-06-02T01:30:00Z`
+- **THEN** the row is included in the `2026-06-01` daily bucket for that response
+
+#### Scenario: Reports endpoint falls back to UTC for invalid timezone
+
+- **WHEN** `/api/reports` receives an invalid `timezone` value
+- **THEN** the endpoint still returns a successful response
+- **AND** it interprets the report range and daily buckets in UTC
+
+### Requirement: Reports summary cards show previous-window deltas conservatively
+
+`GET /api/reports` SHALL expose a `comparison` block for the `Total Cost`, `Tokens`, and `Requests` summary cards that includes `canCompare` plus the previous-window totals for cost, tokens, and requests. The current window and previous window SHALL use equal calendar-window lengths derived from the selected report date range. The endpoint SHALL set `canCompare` to `true` only when eligible report history fully covers the immediately preceding window. When `canCompare` is `false`, the `/reports` summary cards SHALL hide the previous-window percentage indicators. Even when `canCompare` is `true`, an individual summary card SHALL hide its own percentage indicator when that card's previous-window total is zero.
+
+#### Scenario: Reports summary cards show previous-window increase
+
+- **WHEN** `GET /api/reports` returns current summary totals plus `comparison.canCompare: true`
+- **AND** a previous-window total for `Total Cost`, `Tokens`, or `Requests` is lower than the current total for that same card
+- **THEN** the matching summary card renders a visible percentage-change increase indicator
+
+#### Scenario: Incomplete previous window suppresses comparison
+
+- **WHEN** the earliest eligible report activity is later than the start of the immediately preceding report window
+- **THEN** `GET /api/reports` returns `comparison.canCompare: false`
+- **AND** the `/reports` summary cards do not render previous-window percentage indicators
+
+#### Scenario: Zero previous total suppresses the matching card indicator
+
+- **WHEN** `GET /api/reports` returns `comparison.canCompare: true`
+- **AND** the previous-window total for one of `Total Cost`, `Tokens`, or `Requests` is `0`
+- **THEN** that summary card does not render a previous-window percentage indicator
+- **AND** the other summary cards may still render percentage indicators when their own previous-window totals are greater than `0`
+
+### Requirement: Reports daily breakdown renders a continuous calendar window
+
+The `/reports` daily breakdown table SHALL render one row per calendar day in the selected date range. Each row SHALL display its date as an ISO `yyyy-mm-dd` calendar date string. If the reports API omits one or more days inside that range, the table SHALL synthesize zero-valued rows for those days using the same row styling as API-backed rows. The table SHALL keep the header visible while only the data rows scroll, with a default visible body height of seven row heights.
+
+#### Scenario: Daily breakdown fills missing days with zero-valued rows
+
+- **WHEN** the selected reports window spans `2026-06-05` through `2026-06-12`
+- **AND** the reports API returns daily rows for every day except `2026-06-06`
+- **THEN** the daily breakdown renders a row for `2026-06-06`
+- **AND** that row shows zero requests, zero input tokens, zero output tokens, zero cost, and zero accounts
+- **AND** that row uses the same row styling as neighboring rows
+
+#### Scenario: Daily breakdown header stays visible while rows scroll
+
+- **WHEN** the daily breakdown contains more than seven rows
+- **THEN** the table header remains visible
+- **AND** only the table body scrolls vertically through the remaining rows
+
+#### Scenario: Daily breakdown preserves ISO bucket dates
+
+- **WHEN** the reports API returns a daily bucket row with `date` set to `2026-06-01`
+- **THEN** the daily breakdown table renders that row label as `2026-06-01`
+
+### Requirement: Reports model distribution donut remains cost-based without center text
+
+The `/reports` model distribution donut SHALL size each slice from cost data and SHALL continue to show cost values in the donut legend and tooltip. The donut SHALL NOT render a center value while idle or on hover.
+
+#### Scenario: Donut shows cost without center label
+
+- **WHEN** an authenticated operator opens `/reports` with model distribution data
+- **THEN** the donut uses cost-based slices and cost-valued legend entries
+- **AND** the donut does not render center text
+
+### Requirement: Reports daily charts use symmetric horizontal padding
+
+The `/reports` `Cost by Day` and `Tokens by Day` charts SHALL use equal left and right horizontal plot padding within their chart cards.
+
+#### Scenario: Daily charts render with balanced left and right inset
+
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the `Cost by Day` and `Tokens by Day` charts render with equal left and right horizontal padding around the plotted area

--- a/openspec/changes/polish-reports-visualization/tasks.md
+++ b/openspec/changes/polish-reports-visualization/tasks.md
@@ -1,0 +1,31 @@
+## 1. OpenSpec Consolidation
+
+- [x] 1.1 Rewrite `polish-reports-visualization` proposal, design, tasks, and the `frontend-architecture` delta so they describe the final consolidated reports behavior.
+- [x] 1.2 Absorb the selected scope from `polish-report-filter-presets` and `respect-browser-reports-timezone`, then delete those change folders.
+
+## 2. Reports Filters And Requests
+
+- [x] 2.1 Keep visible `/reports` controls for presets, start date, end date, account, and model.
+- [x] 2.2 Clear `selectedPresetDays` after manual start/end edits while preset clicks still set the active range.
+- [x] 2.3 Prevent future dates in the report start and end inputs.
+- [x] 2.4 Detect the browser's IANA timezone, cache the latest valid value locally, and include it on reports requests when available.
+
+## 3. Reports Backend And Summary Cards
+
+- [x] 3.1 Make `GET /api/reports` interpret `start_date` and `end_date` as local-midnight boundaries in the requested timezone, falling back to UTC when the timezone is missing or invalid.
+- [x] 3.2 Bucket `daily` report rows by calendar day in the requested timezone.
+- [x] 3.3 Expose a previous-window comparison block for report summary cards and gate `canCompare` on full previous-window coverage.
+- [x] 3.4 Render report summary-card percentage deltas only for `Total Cost`, `Tokens`, and `Requests` when comparison is available.
+
+## 4. Reports Visualization
+
+- [x] 4.1 Render the daily breakdown as a continuous ISO calendar window with zero-filled missing days.
+- [x] 4.2 Keep the daily breakdown header visible while only the body scrolls through a seven-row viewport.
+- [x] 4.3 Keep the model distribution donut cost-based while omitting any center value.
+- [x] 4.4 Use equal left and right plot padding in the `Cost by Day` and `Tokens by Day` charts.
+
+## 5. Verification
+
+- [x] 5.1 Keep or add focused frontend coverage for preset clearing, future-date inputs, timezone request wiring, summary-card comparison rendering, daily zero-fill behavior, donut rendering, and chart padding.
+- [x] 5.2 Keep or add focused backend coverage for timezone-aware report ranges, local-day daily bucketing, previous-window comparison gating, and UTC fallback.
+- [x] 5.3 Run `uv run openspec validate --specs`.

--- a/tests/integration/test_reports_api.py
+++ b/tests/integration/test_reports_api.py
@@ -112,6 +112,17 @@ async def test_reports_api_rejects_oversized_date_ranges(async_client, db_setup)
     assert response.json()["error"]["message"] == "report date range must be 730 days or less"
 
 
+async def test_reports_api_rejects_oversized_date_ranges_with_default_end_date(async_client, db_setup):
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2020-01-01",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "report date range must be 730 days or less"
+
+
 async def test_reports_api_includes_preserved_deleted_account_history(async_client, db_setup):
     start_at = _naive_utc(datetime(2026, 6, 1, 11, 0, 0, tzinfo=timezone.utc))
     deleted_at = _naive_utc(datetime(2026, 6, 2, 9, 0, 0, tzinfo=timezone.utc))

--- a/tests/integration/test_reports_api.py
+++ b/tests/integration/test_reports_api.py
@@ -100,6 +100,18 @@ async def test_reports_api_returns_null_account_bucket(async_client, db_setup):
     ]
 
 
+async def test_reports_api_rejects_oversized_date_ranges(async_client, db_setup):
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2024-01-01",
+            "end_date": "2026-01-01",
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "report date range must be 730 days or less"
+
+
 async def test_reports_api_includes_preserved_deleted_account_history(async_client, db_setup):
     start_at = _naive_utc(datetime(2026, 6, 1, 11, 0, 0, tzinfo=timezone.utc))
     deleted_at = _naive_utc(datetime(2026, 6, 2, 9, 0, 0, tzinfo=timezone.utc))

--- a/tests/integration/test_reports_api.py
+++ b/tests/integration/test_reports_api.py
@@ -202,6 +202,191 @@ async def test_reports_api_includes_end_date_until_next_midnight(async_client, d
     assert payload["daily"][0]["date"] == "2026-06-01"
 
 
+async def test_reports_api_interprets_dates_in_requested_timezone(async_client, db_setup):
+    before_local_day = _naive_utc(datetime(2026, 6, 1, 6, 59, 59, tzinfo=timezone.utc))
+    local_day_start = _naive_utc(datetime(2026, 6, 1, 7, 0, 0, tzinfo=timezone.utc))
+    local_day_end = _naive_utc(datetime(2026, 6, 2, 6, 59, 59, tzinfo=timezone.utc))
+    after_local_day = _naive_utc(datetime(2026, 6, 2, 7, 0, 0, tzinfo=timezone.utc))
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_tz", "reports-tz@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_tz",
+                    request_id="report-tz-before",
+                    requested_at=before_local_day,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=1,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.1,
+                ),
+                RequestLog(
+                    account_id="acc_reports_tz",
+                    request_id="report-tz-start",
+                    requested_at=local_day_start,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=2,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.2,
+                ),
+                RequestLog(
+                    account_id="acc_reports_tz",
+                    request_id="report-tz-end",
+                    requested_at=local_day_end,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=3,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.3,
+                ),
+                RequestLog(
+                    account_id="acc_reports_tz",
+                    request_id="report-tz-after",
+                    requested_at=after_local_day,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=4,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.4,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-01",
+            "timezone": "America/Los_Angeles",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["totalRequests"] == 2
+    assert payload["summary"]["totalInputTokens"] == 5
+    assert payload["summary"]["totalCostUsd"] == 0.5
+    assert payload["daily"] == [
+        {
+            "activeAccounts": 1,
+            "costUsd": 0.5,
+            "cachedInputTokens": 0,
+            "date": "2026-06-01",
+            "errorCount": 0,
+            "requests": 2,
+            "inputTokens": 5,
+            "outputTokens": 2,
+        }
+    ]
+
+
+async def test_reports_api_falls_back_to_utc_for_invalid_timezone(async_client, db_setup):
+    utc_day_end = _naive_utc(datetime(2026, 6, 1, 23, 59, 59, tzinfo=timezone.utc))
+    next_utc_midnight = _naive_utc(datetime(2026, 6, 2, 0, 0, 0, tzinfo=timezone.utc))
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_bad_tz", "reports-bad-tz@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_bad_tz",
+                    request_id="report-bad-tz-included",
+                    requested_at=utc_day_end,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=7,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.7,
+                ),
+                RequestLog(
+                    account_id="acc_reports_bad_tz",
+                    request_id="report-bad-tz-excluded",
+                    requested_at=next_utc_midnight,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=8,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.8,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-01",
+            "timezone": "Mars/Olympus_Mons",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["totalRequests"] == 1
+    assert payload["summary"]["totalInputTokens"] == 7
+    assert payload["summary"]["totalCostUsd"] == 0.7
+    assert payload["daily"][0]["date"] == "2026-06-01"
+
+
+async def test_reports_api_falls_back_to_utc_for_malformed_timezone(async_client, db_setup):
+    utc_day_end = _naive_utc(datetime(2026, 6, 1, 23, 59, 59, tzinfo=timezone.utc))
+    next_utc_midnight = _naive_utc(datetime(2026, 6, 2, 0, 0, 0, tzinfo=timezone.utc))
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_malformed_tz", "reports-malformed-tz@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_malformed_tz",
+                    request_id="report-malformed-tz-included",
+                    requested_at=utc_day_end,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=7,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.7,
+                ),
+                RequestLog(
+                    account_id="acc_reports_malformed_tz",
+                    request_id="report-malformed-tz-excluded",
+                    requested_at=next_utc_midnight,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=8,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.8,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-01",
+            "timezone": "../etc/passwd",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["totalRequests"] == 1
+    assert payload["summary"]["totalInputTokens"] == 7
+    assert payload["summary"]["totalCostUsd"] == 0.7
+    assert payload["daily"][0]["date"] == "2026-06-01"
+
+
 async def test_reports_api_default_range_uses_last_seven_calendar_days(async_client, db_setup, monkeypatch):
     fixed_now = datetime(2026, 6, 8, 10, 0, 0, tzinfo=timezone.utc)
     monkeypatch.setattr("app.modules.reports.service.utcnow", lambda: fixed_now)
@@ -265,6 +450,485 @@ async def test_reports_api_default_range_uses_last_seven_calendar_days(async_cli
     assert payload["summary"]["avgRequestsPerDay"] == 0.29
     assert payload["daily"][0]["date"] == "2026-06-02"
     assert payload["daily"][1]["date"] == "2026-06-08"
+
+
+async def test_reports_api_default_range_uses_last_seven_calendar_days_in_requested_timezone(
+    async_client, db_setup, monkeypatch
+):
+    fixed_now = datetime(2026, 6, 8, 1, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("app.modules.reports.service.utcnow", lambda: fixed_now)
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_default_tz", "reports-default-tz@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_default_tz",
+                    request_id="report-default-tz-old",
+                    requested_at=_naive_utc(datetime(2026, 6, 1, 6, 59, 59, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=99,
+                    output_tokens=99,
+                    cached_input_tokens=0,
+                    cost_usd=9.9,
+                ),
+                RequestLog(
+                    account_id="acc_reports_default_tz",
+                    request_id="report-default-tz-start",
+                    requested_at=_naive_utc(datetime(2026, 6, 1, 7, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=5,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.7,
+                ),
+                RequestLog(
+                    account_id="acc_reports_default_tz",
+                    request_id="report-default-tz-end",
+                    requested_at=_naive_utc(datetime(2026, 6, 8, 6, 59, 59, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=5,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=1.4,
+                ),
+                RequestLog(
+                    account_id="acc_reports_default_tz",
+                    request_id="report-default-tz-future",
+                    requested_at=_naive_utc(datetime(2026, 6, 8, 7, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=99,
+                    output_tokens=99,
+                    cached_input_tokens=0,
+                    cost_usd=9.9,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={"timezone": "America/Los_Angeles"},
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["totalRequests"] == 2
+    assert payload["summary"]["avgRequestsPerDay"] == 0.29
+    assert payload["summary"]["totalCostUsd"] == 2.1
+    assert payload["daily"] == [
+        {
+            "activeAccounts": 1,
+            "costUsd": 0.7,
+            "cachedInputTokens": 0,
+            "date": "2026-06-01",
+            "errorCount": 0,
+            "requests": 1,
+            "inputTokens": 5,
+            "outputTokens": 1,
+        },
+        {
+            "activeAccounts": 1,
+            "costUsd": 1.4,
+            "cachedInputTokens": 0,
+            "date": "2026-06-07",
+            "errorCount": 0,
+            "requests": 1,
+            "inputTokens": 5,
+            "outputTokens": 1,
+        },
+    ]
+
+
+async def test_reports_api_uses_dst_aware_boundaries_for_requested_timezone(async_client, db_setup):
+    before_local_day = _naive_utc(datetime(2026, 3, 8, 4, 59, 59, tzinfo=timezone.utc))
+    local_day_start = _naive_utc(datetime(2026, 3, 8, 5, 0, 0, tzinfo=timezone.utc))
+    local_day_end = _naive_utc(datetime(2026, 3, 9, 3, 59, 59, tzinfo=timezone.utc))
+    after_local_day = _naive_utc(datetime(2026, 3, 9, 4, 0, 0, tzinfo=timezone.utc))
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_dst", "reports-dst@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_dst",
+                    request_id="report-dst-before",
+                    requested_at=before_local_day,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=1,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.1,
+                ),
+                RequestLog(
+                    account_id="acc_reports_dst",
+                    request_id="report-dst-start",
+                    requested_at=local_day_start,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=2,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.2,
+                ),
+                RequestLog(
+                    account_id="acc_reports_dst",
+                    request_id="report-dst-end",
+                    requested_at=local_day_end,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=3,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.3,
+                ),
+                RequestLog(
+                    account_id="acc_reports_dst",
+                    request_id="report-dst-after",
+                    requested_at=after_local_day,
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=4,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.4,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-03-08",
+            "end_date": "2026-03-08",
+            "timezone": "America/New_York",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["totalRequests"] == 2
+    assert payload["summary"]["totalInputTokens"] == 5
+    assert payload["summary"]["totalCostUsd"] == 0.5
+    assert payload["daily"] == [
+        {
+            "activeAccounts": 1,
+            "costUsd": 0.5,
+            "cachedInputTokens": 0,
+            "date": "2026-03-08",
+            "errorCount": 0,
+            "requests": 2,
+            "inputTokens": 5,
+            "outputTokens": 2,
+        }
+    ]
+
+
+async def test_reports_api_returns_previous_window_comparison_for_complete_history(async_client, db_setup):
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_compare", "reports-compare@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_compare",
+                    request_id="report-compare-prev-1",
+                    requested_at=_naive_utc(datetime(2026, 5, 28, 0, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=10,
+                    output_tokens=2,
+                    cached_input_tokens=0,
+                    cost_usd=0.4,
+                ),
+                RequestLog(
+                    account_id="acc_reports_compare",
+                    request_id="report-compare-current-1",
+                    requested_at=_naive_utc(datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=20,
+                    output_tokens=4,
+                    cached_input_tokens=0,
+                    cost_usd=0.8,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-05",
+            "end_date": "2026-06-12",
+            "timezone": "UTC",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["comparison"] == {
+        "canCompare": True,
+        "previous": {
+            "totalCostUsd": 0.4,
+            "totalTokens": 12,
+            "totalRequests": 1,
+        },
+    }
+
+
+async def test_reports_api_suppresses_comparison_when_previous_window_is_incomplete(async_client, db_setup):
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_incomplete", "reports-incomplete@example.com"))
+        session.add(
+            RequestLog(
+                account_id="acc_reports_incomplete",
+                request_id="report-incomplete-prev-1",
+                requested_at=_naive_utc(datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=7,
+                output_tokens=2,
+                cached_input_tokens=0,
+                cost_usd=0.3,
+            )
+        )
+        session.add(
+            RequestLog(
+                account_id="acc_reports_incomplete",
+                request_id="report-incomplete-current-1",
+                requested_at=_naive_utc(datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=9,
+                output_tokens=3,
+                cached_input_tokens=0,
+                cost_usd=0.6,
+            )
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-05",
+            "end_date": "2026-06-12",
+            "timezone": "UTC",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["comparison"] == {
+        "canCompare": False,
+        "previous": {
+            "totalCostUsd": 0.3,
+            "totalTokens": 9,
+            "totalRequests": 1,
+        },
+    }
+
+
+async def test_reports_api_comparison_uses_requested_timezone_boundaries(async_client, db_setup):
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_compare_tz", "reports-compare-tz@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_compare_tz",
+                    request_id="report-compare-tz-prev",
+                    requested_at=_naive_utc(datetime(2026, 5, 27, 16, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=5,
+                    output_tokens=5,
+                    cached_input_tokens=0,
+                    cost_usd=0.25,
+                ),
+                RequestLog(
+                    account_id="acc_reports_compare_tz",
+                    request_id="report-compare-tz-current",
+                    requested_at=_naive_utc(datetime(2026, 6, 5, 16, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=8,
+                    output_tokens=4,
+                    cached_input_tokens=0,
+                    cost_usd=0.5,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-05",
+            "end_date": "2026-06-12",
+            "timezone": "Asia/Hong_Kong",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["comparison"] == {
+        "canCompare": True,
+        "previous": {
+            "totalCostUsd": 0.25,
+            "totalTokens": 10,
+            "totalRequests": 1,
+        },
+    }
+
+
+async def test_reports_api_comparison_completeness_honors_active_filters(async_client, db_setup):
+    async with SessionLocal() as session:
+        session.add_all(
+            [
+                _make_account("acc_reports_compare_filters", "reports-compare-filters@example.com"),
+                _make_account("acc_reports_compare_other", "reports-compare-other@example.com"),
+            ]
+        )
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_compare_other",
+                    request_id="report-compare-filter-other-account-prev",
+                    requested_at=_naive_utc(datetime(2026, 5, 28, 0, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=10,
+                    output_tokens=2,
+                    cached_input_tokens=0,
+                    cost_usd=0.4,
+                ),
+                RequestLog(
+                    account_id="acc_reports_compare_filters",
+                    request_id="report-compare-filter-wrong-model-prev",
+                    requested_at=_naive_utc(datetime(2026, 5, 28, 0, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.2",
+                    status="success",
+                    input_tokens=9,
+                    output_tokens=3,
+                    cached_input_tokens=0,
+                    cost_usd=0.3,
+                ),
+                RequestLog(
+                    account_id="acc_reports_compare_filters",
+                    request_id="report-compare-filter-selected-prev",
+                    requested_at=_naive_utc(datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=7,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.2,
+                ),
+                RequestLog(
+                    account_id="acc_reports_compare_filters",
+                    request_id="report-compare-filter-selected-current",
+                    requested_at=_naive_utc(datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=11,
+                    output_tokens=2,
+                    cached_input_tokens=0,
+                    cost_usd=0.6,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-05",
+            "end_date": "2026-06-12",
+            "timezone": "UTC",
+            "account_id": "acc_reports_compare_filters",
+            "model": "gpt-5.1",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["comparison"] == {
+        "canCompare": False,
+        "previous": {
+            "totalCostUsd": 0.2,
+            "totalTokens": 8,
+            "totalRequests": 1,
+        },
+    }
+
+
+async def test_reports_api_comparison_ignores_warmup_traffic_for_coverage(async_client, db_setup):
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_compare_warmup", "reports-compare-warmup@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_compare_warmup",
+                    request_id="report-compare-warmup-prev",
+                    requested_at=_naive_utc(datetime(2026, 5, 28, 0, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=50,
+                    output_tokens=10,
+                    cached_input_tokens=0,
+                    cost_usd=5.0,
+                    source="limit_warmup",
+                ),
+                RequestLog(
+                    account_id="acc_reports_compare_warmup",
+                    request_id="report-compare-normal-prev",
+                    requested_at=_naive_utc(datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=6,
+                    output_tokens=2,
+                    cached_input_tokens=0,
+                    cost_usd=0.3,
+                ),
+                RequestLog(
+                    account_id="acc_reports_compare_warmup",
+                    request_id="report-compare-normal-current",
+                    requested_at=_naive_utc(datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=12,
+                    output_tokens=3,
+                    cached_input_tokens=0,
+                    cost_usd=0.7,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-05",
+            "end_date": "2026-06-12",
+            "timezone": "UTC",
+            "account_id": "acc_reports_compare_warmup",
+            "model": "gpt-5.1",
+        },
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["comparison"] == {
+        "canCompare": False,
+        "previous": {
+            "totalCostUsd": 0.3,
+            "totalTokens": 8,
+            "totalRequests": 1,
+        },
+    }
 
 
 async def test_reports_api_excludes_warmup_logs(async_client, db_setup):
@@ -521,3 +1185,88 @@ async def test_reports_api_summary_counts_range_accounts_and_calendar_days(async
     assert payload["summary"]["activeAccounts"] == 2
     assert payload["summary"]["avgCostPerDay"] == 0.5
     assert payload["summary"]["avgRequestsPerDay"] == 0.67
+
+
+async def test_reports_api_summary_uses_sql_range_totals_not_rounded_daily_rows(async_client, db_setup):
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_summary_sql", "reports-summary-sql@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_summary_sql",
+                    request_id="report-summary-sql-1",
+                    requested_at=_naive_utc(datetime(2026, 6, 1, 10, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=1,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.00004,
+                ),
+                RequestLog(
+                    account_id="acc_reports_summary_sql",
+                    request_id="report-summary-sql-2",
+                    requested_at=_naive_utc(datetime(2026, 6, 2, 10, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=1,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.00004,
+                ),
+                RequestLog(
+                    account_id="acc_reports_summary_sql",
+                    request_id="report-summary-sql-3",
+                    requested_at=_naive_utc(datetime(2026, 6, 3, 10, 0, 0, tzinfo=timezone.utc)),
+                    model="gpt-5.1",
+                    status="success",
+                    input_tokens=1,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.00004,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={"start_date": "2026-06-01", "end_date": "2026-06-03"},
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["summary"]["totalCostUsd"] == 0.0001
+    assert payload["summary"]["avgCostPerDay"] == 0.0
+    assert payload["daily"] == [
+        {
+            "activeAccounts": 1,
+            "costUsd": 0.0,
+            "cachedInputTokens": 0,
+            "date": "2026-06-01",
+            "errorCount": 0,
+            "requests": 1,
+            "inputTokens": 1,
+            "outputTokens": 1,
+        },
+        {
+            "activeAccounts": 1,
+            "costUsd": 0.0,
+            "cachedInputTokens": 0,
+            "date": "2026-06-02",
+            "errorCount": 0,
+            "requests": 1,
+            "inputTokens": 1,
+            "outputTokens": 1,
+        },
+        {
+            "activeAccounts": 1,
+            "costUsd": 0.0,
+            "cachedInputTokens": 0,
+            "date": "2026-06-03",
+            "errorCount": 0,
+            "requests": 1,
+            "inputTokens": 1,
+            "outputTokens": 1,
+        },
+    ]

--- a/tests/unit/test_reports_repository.py
+++ b/tests/unit/test_reports_repository.py
@@ -101,3 +101,50 @@ async def test_aggregate_daily_rows_groups_in_sql_and_returns_only_buckets_with_
     assert rows[1].cost_usd == 0.1
     assert rows[1].active_accounts == 0
     assert rows[1].error_count == 1
+
+
+@pytest.mark.asyncio
+async def test_aggregate_daily_rows_supports_ranges_longer_than_sqlite_compound_limit(
+    async_session: AsyncSession,
+) -> None:
+    repo = ReportsRepository(async_session)
+    timezone_info = timezone.utc
+    start_date = date(2024, 1, 1)
+    end_date = start_date + timedelta(days=500)
+
+    async_session.add(_make_account("acc_reports_long_range", "reports-long-range@example.com"))
+    async_session.add_all(
+        [
+            RequestLog(
+                account_id="acc_reports_long_range",
+                request_id="report-long-range-1",
+                requested_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=10,
+                output_tokens=4,
+                cached_input_tokens=2,
+                cost_usd=0.25,
+            ),
+            RequestLog(
+                account_id="acc_reports_long_range",
+                request_id="report-long-range-2",
+                requested_at=datetime(2025, 5, 15, 12, 0, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.1",
+                status="error",
+                input_tokens=5,
+                output_tokens=1,
+                cached_input_tokens=0,
+                cost_usd=0.1,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    rows = await repo.aggregate_daily_rows(start_date, end_date, timezone_info)
+
+    assert [row.date for row in rows] == ["2024-01-01", "2025-05-15"]
+    assert rows[0].requests == 1
+    assert rows[0].cost_usd == 0.25
+    assert rows[1].requests == 1
+    assert rows[1].cost_usd == 0.1

--- a/tests/unit/test_reports_repository.py
+++ b/tests/unit/test_reports_repository.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from app.core.crypto import TokenEncryptor
 from app.db.models import Account, AccountStatus, Base, RequestLog
-from app.modules.reports.repository import ReportsRepository
+from app.modules.reports.repository import DailyReportRangeTooLargeError, ReportsRepository
 
 pytestmark = pytest.mark.unit
 
@@ -148,3 +148,17 @@ async def test_aggregate_daily_rows_supports_ranges_longer_than_sqlite_compound_
     assert rows[0].cost_usd == 0.25
     assert rows[1].requests == 1
     assert rows[1].cost_usd == 0.1
+
+
+@pytest.mark.asyncio
+async def test_aggregate_daily_rows_rejects_ranges_over_supported_window(
+    async_session: AsyncSession,
+) -> None:
+    repo = ReportsRepository(async_session)
+
+    with pytest.raises(DailyReportRangeTooLargeError, match="730 days or less"):
+        await repo.aggregate_daily_rows(
+            date(2024, 1, 1),
+            date(2026, 1, 1),
+            timezone.utc,
+        )

--- a/tests/unit/test_reports_repository.py
+++ b/tests/unit/test_reports_repository.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import date, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.crypto import TokenEncryptor
+from app.db.models import Account, AccountStatus, Base, RequestLog
+from app.modules.reports.repository import ReportsRepository
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+async def async_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+def _make_account(account_id: str, email: str) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        email=email,
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=datetime.now(timezone.utc).replace(tzinfo=None),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregate_daily_rows_groups_in_sql_and_returns_only_buckets_with_data(
+    async_session: AsyncSession,
+) -> None:
+    repo = ReportsRepository(async_session)
+    timezone_info = timezone(timedelta(hours=8))
+
+    async_session.add(_make_account("acc_reports_daily", "reports-daily@example.com"))
+    async_session.add_all(
+        [
+            RequestLog(
+                account_id="acc_reports_daily",
+                request_id="report-daily-1",
+                requested_at=datetime(2026, 6, 1, 16, 30, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=10,
+                output_tokens=4,
+                cached_input_tokens=2,
+                cost_usd=0.25,
+            ),
+            RequestLog(
+                account_id=None,
+                request_id="report-daily-2",
+                requested_at=datetime(2026, 6, 3, 16, 30, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.1",
+                status="error",
+                input_tokens=5,
+                output_tokens=1,
+                cached_input_tokens=0,
+                cost_usd=0.1,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    rows = await repo.aggregate_daily_rows(
+        date(2026, 6, 2),
+        date(2026, 6, 4),
+        timezone_info,
+    )
+
+    assert [row.date for row in rows] == ["2026-06-02", "2026-06-04"]
+    assert rows[0].requests == 1
+    assert rows[0].input_tokens == 10
+    assert rows[0].output_tokens == 4
+    assert rows[0].cached_input_tokens == 2
+    assert rows[0].cost_usd == 0.25
+    assert rows[0].active_accounts == 1
+    assert rows[0].error_count == 0
+
+    assert rows[1].requests == 1
+    assert rows[1].input_tokens == 5
+    assert rows[1].output_tokens == 1
+    assert rows[1].cached_input_tokens == 0
+    assert rows[1].cost_usd == 0.1
+    assert rows[1].active_accounts == 0
+    assert rows[1].error_count == 1

--- a/tests/unit/test_reports_service.py
+++ b/tests/unit/test_reports_service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.modules.reports.repository import DailyReportRangeTooLargeError
+from app.modules.reports.service import ReportsService
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_get_reports_rejects_oversized_range_after_applying_default_end_date(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = SimpleNamespace(
+        aggregate_summary=AsyncMock(),
+        aggregate_daily_rows=AsyncMock(),
+        aggregate_by_model=AsyncMock(),
+        aggregate_by_account=AsyncMock(),
+        earliest_report_activity_at=AsyncMock(),
+    )
+    service = ReportsService(repo)
+    fixed_now = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("app.modules.reports.service.utcnow", lambda: fixed_now)
+
+    with pytest.raises(DailyReportRangeTooLargeError, match="730 days or less"):
+        await service.get_reports(start_date=date(2020, 1, 1))
+
+    repo.aggregate_summary.assert_not_awaited()
+    repo.aggregate_daily_rows.assert_not_awaited()
+    repo.aggregate_by_model.assert_not_awaited()
+    repo.aggregate_by_account.assert_not_awaited()
+    repo.earliest_report_activity_at.assert_not_awaited()

--- a/tests/unit/test_reports_service.py
+++ b/tests/unit/test_reports_service.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
 
 from app.modules.reports.repository import DailyReportRangeTooLargeError
+from app.modules.reports.repository import ReportsRepository
 from app.modules.reports.service import ReportsService
 
 pytestmark = pytest.mark.unit
@@ -23,7 +25,7 @@ async def test_get_reports_rejects_oversized_range_after_applying_default_end_da
         aggregate_by_account=AsyncMock(),
         earliest_report_activity_at=AsyncMock(),
     )
-    service = ReportsService(repo)
+    service = ReportsService(cast(ReportsRepository, repo))
     fixed_now = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
     monkeypatch.setattr("app.modules.reports.service.utcnow", lambda: fixed_now)
 

--- a/tests/unit/test_reports_service.py
+++ b/tests/unit/test_reports_service.py
@@ -7,8 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from app.modules.reports.repository import DailyReportRangeTooLargeError
-from app.modules.reports.repository import ReportsRepository
+from app.modules.reports.repository import DailyReportRangeTooLargeError, ReportsRepository
 from app.modules.reports.service import ReportsService
 
 pytestmark = pytest.mark.unit


### PR DESCRIPTION
## Summary

Consolidate reports visualization fixes into one coherent OpenSpec change: respect browser-local timezone for date ranges and daily bucketing, show previous-window comparison only when the baseline window is fully covered, fill missing calendar days with zero-valued rows, clear quick-preset highlighting after manual date edits, and polish chart/table rendering details.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability

Linked issue: N/A

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/polish-reports-visualization/`

## Changes

**Frontend — Reports page, filters, and timezone:**
- Clear quick-preset highlighting after manual date edits; preset clicks set both date range and `selectedPresetDays`
- Prevent future dates in the start/end date inputs via `max={localDateISO()}`
- Detect browser IANA timezone, cache the latest valid value in localStorage, and include `timezone` on `GET /api/reports` requests
- Fallback order: live detection → cached valid → omit parameter

**Frontend — Summary cards and comparison:**
- Render percentage-change deltas for Total Cost, Tokens, and Requests when `comparison.canCompare` is true and the relevant previous total > 0
- Green up-arrow for increases, red down-arrow for decreases; suppress at 0% delta or zero previous baseline

**Frontend — Daily detail table and charts:**
- Build a contiguous daily window from `startDate` to `endDate`, synthesizing zero-valued rows for missing days
- Split the table into a fixed header and scrollable body with a 7-row viewport (`max-h-[17.5rem]`)
- Preserve ISO `yyyy-mm-dd` date format everywhere (changed from `dd/mm`)
- Equal left/right chart margins in `CostPerDayChart` and `TokensPerDayChart`

**Backend — Reports API and service:**
- Interpret `start_date` and `end_date` as local-midnight boundaries in the supplied IANA timezone, convert to UTC for filtering, and bucket `daily` rows by that same local calendar day
- Fall back to UTC when timezone is missing, malformed, or not found in the zoneinfo database
- Split repository into `list_daily_report_logs` (raw log rows) + `aggregate_summary` (single summary query) + daily bucketing in the service layer using `ZoneInfo`
- Add `earliest_report_activity_at` to gate `canCompare` on full previous-window coverage
- Default date range respects the client timezone (not forced UTC)

**OpenSpec:**
- Delta spec at `openspec/changes/polish-reports-visualization/specs/frontend-architecture/spec.md` with 7 MODIFIED requirements covering all reports behavior

## Test plan

```
# Backend integration tests
uv run pytest tests/integration/test_reports_api.py -q

# Frontend unit tests
cd frontend && npx vitest run src/features/reports/

# OpenSpec validation
uv run openspec validate --specs
```

## Screenshots / output (optional)
<img width="1411" height="831" alt="螢幕截圖 2026-06-12 22 00 55" src="https://github.com/user-attachments/assets/ea60e5f3-10d5-418e-a72e-94c0627c78eb" />


## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.