### PR TITLE
fix(proxy): preserve bridge restart continuity anchors

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -156,11 +156,12 @@ class Settings(BaseSettings):
     upstream_base_url: str = "https://chatgpt.com/backend-api"
     upstream_stream_transport: Literal["http", "websocket", "auto"] = "auto"
     upstream_connect_timeout_seconds: float = 8.0
-    upstream_compact_timeout_seconds: float | None = None
+    upstream_compact_timeout_seconds: float | None = 30.0
     upstream_websocket_trust_env: bool = Field(default_factory=_default_upstream_websocket_trust_env)
     proxy_request_budget_seconds: float = Field(default=600.0, gt=0)
     http_responses_stream_request_budget_seconds: float = Field(default=7200.0, gt=0)
     compact_request_budget_seconds: float = Field(default=180.0, gt=0)
+    compact_failure_cooldown_seconds: float = Field(default=60.0, ge=0)
     stream_idle_timeout_seconds: float = 600.0
     sse_keepalive_interval_seconds: float = Field(default=10.0, ge=0)
     proxy_downstream_websocket_idle_timeout_seconds: float = Field(default=120.0, gt=0)

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -162,6 +162,8 @@ class Settings(BaseSettings):
     http_responses_stream_request_budget_seconds: float = Field(default=7200.0, gt=0)
     compact_request_budget_seconds: float = Field(default=180.0, gt=0)
     compact_failure_cooldown_seconds: float = Field(default=60.0, ge=0)
+    local_compact_fallback_enabled: bool = True
+    local_compact_fallback_max_estimated_tokens: int = Field(default=20_000, gt=0)
     stream_idle_timeout_seconds: float = 600.0
     sse_keepalive_interval_seconds: float = Field(default=10.0, ge=0)
     proxy_downstream_websocket_idle_timeout_seconds: float = Field(default=120.0, gt=0)

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -39,9 +39,9 @@ _INTERLEAVED_REASONING_PART_TYPES = frozenset({"reasoning", "reasoning_content",
 _ASSISTANT_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 _TOOL_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text", "refusal"})
 _COMPACT_STATE_TOOL_NAMES = frozenset({"create_goal", "get_goal", "update_goal", "update_plan"})
-_COMPACT_TOOL_CALL_ITEM_TYPES = frozenset({"function_call", "custom_tool_call", "apply_patch_call"})
+_COMPACT_TOOL_CALL_ITEM_TYPES = frozenset({"function_call", "custom_tool_call", "apply_patch_call", "tool_search_call"})
 _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
-    {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
+    {"function_call_output", "custom_tool_call_output", "apply_patch_call_output", "tool_search_output"}
 )
 _GOAL_CONTINUATION_CONTEXT_PREFIX = '<codex_internal_context source="goal">'
 _PLAN_MODE_CONTEXT_PREFIX = "<collaboration_mode># Plan Mode"

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -718,6 +718,7 @@ _POISONED_LOCAL_COMPACT_FALLBACK_TEXT = "Local compact fallback preserved the la
 _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS = 100_000
 _COMPACT_UPSTREAM_HEAD_ESTIMATED_TOKENS = 12_000
 _LOCAL_COMPACT_FALLBACK_DEFAULT_MAX_ESTIMATED_TOKENS = 20_000
+_LOCAL_COMPACT_FALLBACK_MAX_SINGLE_TAIL_ITEM_ESTIMATED_TOKENS = 8_000
 _ESTIMATED_CHARS_PER_TOKEN = 4
 
 
@@ -874,15 +875,20 @@ def build_local_compact_fallback_output(
     token_counts = [_estimated_json_tokens(item) for item in input_items]
     marker_tokens = _estimated_json_tokens(marker)
     selected_indices = _compact_state_anchor_indices(input_items)
-    if input_items:
-        selected_indices.add(len(input_items) - 1)
+    latest_semantic_index = _compact_latest_semantic_tail_index(
+        input_items,
+        token_counts,
+        max_estimated_tokens=max_estimated_tokens,
+    )
+    if latest_semantic_index is not None:
+        selected_indices.add(latest_semantic_index)
     selected_tokens = sum(token_counts[index] for index in selected_indices)
     suffix_budget = max(0, max_estimated_tokens - marker_tokens - selected_tokens)
     selected_indices.update(
-        _compact_trim_suffix_indices(
+        _compact_local_fallback_tail_indices(
+            input_items,
             token_counts,
             selected_indices=selected_indices,
-            start_index=0,
             token_budget=suffix_budget,
         )
     )
@@ -1037,6 +1043,55 @@ def _compact_item_texts(item: Mapping[str, JsonValue]) -> list[str]:
         if isinstance(text, str):
             texts.append(text)
     return texts
+
+
+def _compact_latest_semantic_tail_index(
+    input_items: list[JsonValue],
+    token_counts: list[int],
+    *,
+    max_estimated_tokens: int,
+) -> int | None:
+    item_budget = max(
+        1,
+        min(_LOCAL_COMPACT_FALLBACK_MAX_SINGLE_TAIL_ITEM_ESTIMATED_TOKENS, max_estimated_tokens),
+    )
+    for index in range(len(input_items) - 1, -1, -1):
+        item = input_items[index]
+        if _compact_item_is_trim_marker(item):
+            continue
+        if token_counts[index] > item_budget:
+            continue
+        return index
+    return None
+
+
+def _compact_local_fallback_tail_indices(
+    input_items: list[JsonValue],
+    token_counts: list[int],
+    *,
+    selected_indices: set[int],
+    token_budget: int,
+) -> set[int]:
+    used = 0
+    indices: set[int] = set()
+    for index in range(len(input_items) - 1, -1, -1):
+        if index in selected_indices or _compact_item_is_trim_marker(input_items[index]):
+            continue
+        token_count = token_counts[index]
+        if used + token_count > token_budget:
+            continue
+        used += token_count
+        indices.add(index)
+    return indices
+
+
+def _compact_item_is_trim_marker(item: JsonValue) -> bool:
+    if not is_json_mapping(item):
+        return False
+    for text in _compact_item_texts(item):
+        if text.lstrip().startswith("[compact trim]"):
+            return True
+    return False
 
 
 def _compact_trimmed_input_with_markers(

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -44,7 +44,6 @@ _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
     {"function_call_output", "custom_tool_call_output", "apply_patch_call_output", "tool_search_output"}
 )
 _GOAL_CONTINUATION_CONTEXT_PREFIX = '<codex_internal_context source="goal">'
-_PLAN_MODE_CONTEXT_PREFIX = "<collaboration_mode># Plan Mode"
 
 
 def _json_mapping_or_none(value: JsonValue) -> Mapping[str, JsonValue] | None:
@@ -844,7 +843,8 @@ def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:
     selected_tokens = sum(token_counts[index] for index in selected_indices)
     tail_budget = max(0, _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS - selected_tokens - marker_tokens)
     selected_indices.update(
-        _compact_trim_suffix_indices(
+        _compact_semantic_tail_indices(
+            input_value,
             token_counts,
             selected_indices=selected_indices,
             start_index=head_count,
@@ -1016,8 +1016,6 @@ def _compact_item_is_state_anchor(item: Mapping[str, JsonValue]) -> bool:
         stripped = text.lstrip()
         if stripped.startswith(_GOAL_CONTINUATION_CONTEXT_PREFIX):
             return True
-        if stripped.startswith(_PLAN_MODE_CONTEXT_PREFIX):
-            return True
     return False
 
 
@@ -1057,7 +1055,7 @@ def _compact_latest_semantic_tail_index(
     )
     for index in range(len(input_items) - 1, -1, -1):
         item = input_items[index]
-        if _compact_item_is_trim_marker(item):
+        if _compact_item_is_low_value_tail_context(item):
             continue
         if token_counts[index] > item_budget:
             continue
@@ -1075,7 +1073,7 @@ def _compact_local_fallback_tail_indices(
     used = 0
     indices: set[int] = set()
     for index in range(len(input_items) - 1, -1, -1):
-        if index in selected_indices or _compact_item_is_trim_marker(input_items[index]):
+        if index in selected_indices or _compact_item_is_low_value_tail_context(input_items[index]):
             continue
         token_count = token_counts[index]
         if used + token_count > token_budget:
@@ -1091,6 +1089,29 @@ def _compact_item_is_trim_marker(item: JsonValue) -> bool:
     for text in _compact_item_texts(item):
         if text.lstrip().startswith("[compact trim]"):
             return True
+    return False
+
+
+def _compact_item_is_low_value_tail_context(item: JsonValue) -> bool:
+    if _compact_item_is_trim_marker(item):
+        return True
+    if not is_json_mapping(item):
+        return False
+
+    role = item.get("role")
+    texts = [text.lstrip() for text in _compact_item_texts(item)]
+    if role == "developer":
+        return any(
+            text.startswith("<permissions instructions>")
+            or text.startswith("<collaboration_mode>")
+            or text.startswith("<skills_instructions>")
+            or text.startswith("<personality_spec>")
+            for text in texts
+        )
+    if role == "user":
+        has_agents = any(text.startswith("# AGENTS.md instructions for ") for text in texts)
+        has_environment = any(text.startswith("<environment_context>") for text in texts)
+        return has_agents and has_environment
     return False
 
 
@@ -1139,6 +1160,27 @@ def _compact_trim_suffix_indices(
             break
         if not indices and token_count > token_budget:
             break
+        used += token_count
+        indices.add(index)
+    return indices
+
+
+def _compact_semantic_tail_indices(
+    input_items: list[JsonValue],
+    token_counts: list[int],
+    *,
+    selected_indices: set[int],
+    start_index: int,
+    token_budget: int,
+) -> set[int]:
+    used = 0
+    indices: set[int] = set()
+    for index in range(len(token_counts) - 1, start_index - 1, -1):
+        if index in selected_indices or _compact_item_is_low_value_tail_context(input_items[index]):
+            continue
+        token_count = token_counts[index]
+        if used + token_count > token_budget:
+            continue
         used += token_count
         indices.add(index)
     return indices

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -38,6 +38,13 @@ _INTERLEAVED_REASONING_KEYS = frozenset({"reasoning_content", "reasoning_details
 _INTERLEAVED_REASONING_PART_TYPES = frozenset({"reasoning", "reasoning_content", "reasoning_details"})
 _ASSISTANT_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 _TOOL_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text", "refusal"})
+_COMPACT_STATE_TOOL_NAMES = frozenset({"create_goal", "get_goal", "update_goal", "update_plan"})
+_COMPACT_TOOL_CALL_ITEM_TYPES = frozenset({"function_call", "custom_tool_call", "apply_patch_call"})
+_COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
+    {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
+)
+_GOAL_CONTINUATION_CONTEXT_PREFIX = '<codex_internal_context source="goal">'
+_PLAN_MODE_CONTEXT_PREFIX = "<collaboration_mode># Plan Mode"
 
 
 def _json_mapping_or_none(value: JsonValue) -> Mapping[str, JsonValue] | None:
@@ -707,15 +714,67 @@ _UNSUPPORTED_UPSTREAM_FIELDS = {
     "user",
 }
 
+_POISONED_LOCAL_COMPACT_FALLBACK_TEXT = "Local compact fallback preserved the latest encrypted reasoning state."
+_MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS = 100_000
+_COMPACT_UPSTREAM_HEAD_ESTIMATED_TOKENS = 12_000
+_LOCAL_COMPACT_FALLBACK_DEFAULT_MAX_ESTIMATED_TOKENS = 20_000
+_ESTIMATED_CHARS_PER_TOKEN = 4
+
 
 def _strip_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:
     _normalize_openai_compatible_aliases(payload)
     _normalize_service_tier_aliases(payload)
     _sanitize_interleaved_reasoning_input(payload)
+    _strip_poisoned_local_compact_fallback_items(payload)
     _canonicalize_tools(payload)
     for key in _UNSUPPORTED_UPSTREAM_FIELDS:
         payload.pop(key, None)
     return payload
+
+
+def _strip_poisoned_local_compact_fallback_items(payload: MutableJsonObject) -> None:
+    input_value = payload.get("input")
+    if not is_json_list(input_value):
+        return
+
+    input_items = input_value
+    kept: list[JsonValue] = []
+    skip_next_poison_compaction = False
+    changed = False
+    for item in input_items:
+        if skip_next_poison_compaction and is_json_mapping(item) and item.get("type") == "compaction":
+            encrypted_content = item.get("encrypted_content")
+            if isinstance(encrypted_content, str) and encrypted_content:
+                skip_next_poison_compaction = False
+                changed = True
+                continue
+        skip_next_poison_compaction = False
+
+        if _is_poisoned_local_compact_fallback_message(item):
+            skip_next_poison_compaction = True
+            changed = True
+            continue
+
+        kept.append(item)
+
+    if changed:
+        payload["input"] = kept
+
+
+def _is_poisoned_local_compact_fallback_message(item: JsonValue) -> bool:
+    if not is_json_mapping(item):
+        return False
+    if item.get("type") != "message" or item.get("role") != "assistant":
+        return False
+    content = item.get("content")
+    if not is_json_list(content):
+        return False
+    for part in content:
+        if not is_json_mapping(part):
+            continue
+        if part.get("text") == _POISONED_LOCAL_COMPACT_FALLBACK_TEXT:
+            return True
+    return False
 
 
 def _canonicalize_tools(payload: MutableJsonObject) -> None:
@@ -755,11 +814,302 @@ def _sort_keys_recursive(value: JsonValue) -> JsonValue:
 
 def _strip_compact_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:
     payload = _strip_unsupported_fields(payload)
+    normalized_payload = _normalize_responses_input_instructions(payload)
+    if is_json_mapping(normalized_payload):
+        payload = dict(normalized_payload)
+    _trim_compact_input_for_upstream(payload)
     payload.pop("store", None)
+    payload.pop("text", None)
     payload.pop("tools", None)
     payload.pop("tool_choice", None)
     payload.pop("parallel_tool_calls", None)
     return payload
+
+
+def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:
+    input_value = payload.get("input")
+    if not is_json_list(input_value):
+        return
+    token_counts = [_estimated_json_tokens(item) for item in input_value]
+    total_tokens = sum(token_counts)
+    if total_tokens <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
+        return
+
+    head_count = _compact_trim_prefix_count(token_counts)
+    preserved_indices = _compact_state_anchor_indices(input_value)
+    selected_indices = set(preserved_indices)
+    selected_indices.update(range(head_count))
+    marker_tokens = _estimated_json_tokens(_compact_trim_marker(omitted_items=0, omitted_tokens=0))
+    selected_tokens = sum(token_counts[index] for index in selected_indices)
+    tail_budget = max(0, _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS - selected_tokens - marker_tokens)
+    selected_indices.update(
+        _compact_trim_suffix_indices(
+            token_counts,
+            selected_indices=selected_indices,
+            start_index=head_count,
+            token_budget=tail_budget,
+        )
+    )
+    selected_indices = _compact_reconciled_tool_call_indices(input_value, selected_indices)
+    if len(selected_indices) == len(input_value):
+        return
+    payload["input"] = _compact_trimmed_input_with_markers(input_value, token_counts, selected_indices)
+
+
+def build_local_compact_fallback_output(
+    input_value: JsonValue,
+    *,
+    reason: str,
+    max_estimated_tokens: int = _LOCAL_COMPACT_FALLBACK_DEFAULT_MAX_ESTIMATED_TOKENS,
+) -> list[JsonValue]:
+    marker = _local_compact_fallback_marker(reason=reason)
+    if max_estimated_tokens <= 0:
+        return [marker]
+    if isinstance(input_value, str):
+        return [marker, _local_compact_fallback_text_message(input_value, max_estimated_tokens=max_estimated_tokens)]
+    if not is_json_list(input_value):
+        return [marker]
+
+    input_items = input_value
+    token_counts = [_estimated_json_tokens(item) for item in input_items]
+    marker_tokens = _estimated_json_tokens(marker)
+    selected_indices = _compact_state_anchor_indices(input_items)
+    if input_items:
+        selected_indices.add(len(input_items) - 1)
+    selected_tokens = sum(token_counts[index] for index in selected_indices)
+    suffix_budget = max(0, max_estimated_tokens - marker_tokens - selected_tokens)
+    selected_indices.update(
+        _compact_trim_suffix_indices(
+            token_counts,
+            selected_indices=selected_indices,
+            start_index=0,
+            token_budget=suffix_budget,
+        )
+    )
+    selected_indices = _compact_reconciled_tool_call_indices(input_items, selected_indices)
+    output: list[JsonValue] = [marker]
+    if len(selected_indices) == len(input_items):
+        output.extend(input_items)
+        return output
+    output.extend(_compact_trimmed_input_with_markers(input_items, token_counts, selected_indices))
+    return output
+
+
+def _local_compact_fallback_marker(*, reason: str) -> JsonObject:
+    reason_suffix = f" Reason: {reason}" if reason else ""
+    return {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "[local compact fallback] Remote compaction was unavailable, so the proxy installed a "
+                    "bounded local compacted transcript instead of blocking continuation."
+                    f"{reason_suffix} Goal/plan/control anchors and the newest conversation items were preserved; "
+                    "older middle items may be represented by explicit compact trim markers."
+                ),
+            }
+        ],
+    }
+
+
+def _local_compact_fallback_text_message(text: str, *, max_estimated_tokens: int) -> JsonObject:
+    max_chars = max(0, max_estimated_tokens * _ESTIMATED_CHARS_PER_TOKEN)
+    omitted_chars = max(0, len(text) - max_chars)
+    if omitted_chars:
+        text = text[-max_chars:] if max_chars else ""
+    prefix = (
+        f"[compact trim] Omitted ~{(omitted_chars + _ESTIMATED_CHARS_PER_TOKEN - 1) // _ESTIMATED_CHARS_PER_TOKEN} "
+        "estimated tokens from the start of a plain-text compact input.\n"
+        if omitted_chars
+        else ""
+    )
+    return {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": f"{prefix}{text}"}],
+    }
+
+
+def _compact_state_anchor_indices(input_value: list[JsonValue]) -> set[int]:
+    preserved_indices: set[int] = set()
+    preserved_call_ids: set[str] = set()
+    for index, item in enumerate(input_value):
+        if not is_json_mapping(item):
+            continue
+        item_mapping = item
+        if _compact_item_is_state_anchor(item_mapping):
+            preserved_indices.add(index)
+            call_id = item_mapping.get("call_id")
+            if isinstance(call_id, str) and call_id:
+                preserved_call_ids.add(call_id)
+
+    if not preserved_call_ids:
+        return preserved_indices
+    for index, item in enumerate(input_value):
+        if index in preserved_indices or not is_json_mapping(item):
+            continue
+        item_mapping = item
+        if item_mapping.get("type") != "function_call_output":
+            continue
+        call_id = item_mapping.get("call_id")
+        if isinstance(call_id, str) and call_id in preserved_call_ids:
+            preserved_indices.add(index)
+    return preserved_indices
+
+
+def _compact_reconciled_tool_call_indices(input_value: list[JsonValue], selected_indices: set[int]) -> set[int]:
+    call_indices_by_id: dict[str, int] = {}
+    output_indices_by_id: dict[str, list[int]] = {}
+    for index, item in enumerate(input_value):
+        if not is_json_mapping(item):
+            continue
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        item_type = item.get("type")
+        if item_type in _COMPACT_TOOL_CALL_ITEM_TYPES:
+            call_indices_by_id.setdefault(call_id, index)
+        elif item_type in _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES:
+            output_indices_by_id.setdefault(call_id, []).append(index)
+
+    reconciled = set(selected_indices)
+    for call_id, output_indices in output_indices_by_id.items():
+        selected_outputs = [index for index in output_indices if index in reconciled]
+        if not selected_outputs:
+            continue
+        call_index = call_indices_by_id.get(call_id)
+        if call_index is None:
+            reconciled.difference_update(selected_outputs)
+        else:
+            reconciled.add(call_index)
+    for call_id, call_index in call_indices_by_id.items():
+        if call_index not in reconciled:
+            continue
+        output_indices = output_indices_by_id.get(call_id)
+        if output_indices:
+            reconciled.update(output_indices)
+        else:
+            reconciled.remove(call_index)
+    return reconciled
+
+
+def _compact_item_is_state_anchor(item: Mapping[str, JsonValue]) -> bool:
+    item_type = item.get("type")
+    if item_type == "function_call":
+        name = item.get("name")
+        if isinstance(name, str) and name in _COMPACT_STATE_TOOL_NAMES:
+            return True
+        function = item.get("function")
+        if is_json_mapping(function):
+            function_name = function.get("name")
+            if isinstance(function_name, str) and function_name in _COMPACT_STATE_TOOL_NAMES:
+                return True
+    for text in _compact_item_texts(item):
+        stripped = text.lstrip()
+        if stripped.startswith(_GOAL_CONTINUATION_CONTEXT_PREFIX):
+            return True
+        if stripped.startswith(_PLAN_MODE_CONTEXT_PREFIX):
+            return True
+    return False
+
+
+def _compact_item_texts(item: Mapping[str, JsonValue]) -> list[str]:
+    content = item.get("content")
+    if isinstance(content, str):
+        return [content]
+    if is_json_mapping(content):
+        content_parts: list[JsonValue] = [content]
+    elif is_json_list(content):
+        content_parts = content
+    else:
+        return []
+
+    texts: list[str] = []
+    for part in content_parts:
+        if isinstance(part, str):
+            texts.append(part)
+            continue
+        if not is_json_mapping(part):
+            continue
+        text = part.get("text")
+        if isinstance(text, str):
+            texts.append(text)
+    return texts
+
+
+def _compact_trimmed_input_with_markers(
+    input_value: list[JsonValue], token_counts: list[int], selected_indices: set[int]
+) -> list[JsonValue]:
+    trimmed: list[JsonValue] = []
+    omitted_items = 0
+    omitted_tokens = 0
+    for index, item in enumerate(input_value):
+        if index in selected_indices:
+            if omitted_items:
+                trimmed.append(_compact_trim_marker(omitted_items=omitted_items, omitted_tokens=omitted_tokens))
+                omitted_items = 0
+                omitted_tokens = 0
+            trimmed.append(item)
+        else:
+            omitted_items += 1
+            omitted_tokens += token_counts[index]
+    if omitted_items:
+        trimmed.append(_compact_trim_marker(omitted_items=omitted_items, omitted_tokens=omitted_tokens))
+    return trimmed
+
+
+def _compact_trim_prefix_count(token_counts: list[int]) -> int:
+    used = 0
+    count = 0
+    for token_count in token_counts:
+        if used + token_count > _COMPACT_UPSTREAM_HEAD_ESTIMATED_TOKENS:
+            break
+        used += token_count
+        count += 1
+    return count
+
+
+def _compact_trim_suffix_indices(
+    token_counts: list[int], *, selected_indices: set[int], start_index: int, token_budget: int
+) -> set[int]:
+    used = 0
+    indices: set[int] = set()
+    for index in range(len(token_counts) - 1, start_index - 1, -1):
+        if index in selected_indices:
+            continue
+        token_count = token_counts[index]
+        if indices and used + token_count > token_budget:
+            break
+        if not indices and token_count > token_budget:
+            break
+        used += token_count
+        indices.add(index)
+    return indices
+
+
+def _compact_trim_marker(*, omitted_items: int, omitted_tokens: int) -> JsonObject:
+    return {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "[compact trim] Omitted "
+                    f"{omitted_items} input items (~{omitted_tokens} estimated tokens) "
+                    "before forwarding this oversized compact request upstream. The initial "
+                    "context, most recent context, and compact state anchors were preserved."
+                ),
+            }
+        ],
+    }
+
+
+def _estimated_json_tokens(value: JsonValue) -> int:
+    serialized = json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return max(1, (len(serialized) + _ESTIMATED_CHARS_PER_TOKEN - 1) // _ESTIMATED_CHARS_PER_TOKEN)
 
 
 def _sanitize_interleaved_reasoning_input(payload: MutableJsonObject) -> None:

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -23,7 +23,7 @@ from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.errors import openai_error
 from app.core.openai.models import CompactResponsePayload
-from app.core.openai.requests import ResponsesCompactRequest
+from app.core.openai.requests import ResponsesCompactRequest, build_local_compact_fallback_output
 from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id, get_request_id
@@ -217,6 +217,35 @@ def _record_compact_failure_cooldown(
     if cooldown_key is None or cooldown_seconds <= 0:
         return
     _COMPACT_FAILURE_COOLDOWNS[cooldown_key] = now + cooldown_seconds
+
+
+def _local_compact_fallback_response(
+    payload: ResponsesCompactRequest,
+    *,
+    reason: str,
+    max_estimated_tokens: int,
+) -> CompactResponsePayload:
+    return CompactResponsePayload.model_validate(
+        {
+            "object": "response.compaction",
+            "output": build_local_compact_fallback_output(
+                payload.input,
+                reason=reason,
+                max_estimated_tokens=max_estimated_tokens,
+            ),
+        }
+    )
+
+
+def _local_compact_fallback_enabled(settings: object) -> bool:
+    return bool(getattr(settings, "local_compact_fallback_enabled", True))
+
+
+def _local_compact_fallback_token_limit(settings: object) -> int:
+    raw_limit = getattr(settings, "local_compact_fallback_max_estimated_tokens", 20_000)
+    if isinstance(raw_limit, int) and raw_limit > 0:
+        return raw_limit
+    return 20_000
 
 
 def _raise_proxy_budget_exhausted() -> NoReturn:
@@ -473,6 +502,17 @@ class _CompactMixin:
                 affinity.kind.value if affinity.kind is not None else None,
                 cooldown_remaining,
             )
+            if _local_compact_fallback_enabled(settings):
+                logger.warning(
+                    "Returning local compact fallback during upstream cooldown request_id=%s sticky_kind=%s",
+                    request_id,
+                    affinity.kind.value if affinity.kind is not None else None,
+                )
+                return _local_compact_fallback_response(
+                    payload,
+                    reason="compact upstream cooldown active after repeated upstream timeouts",
+                    max_estimated_tokens=_local_compact_fallback_token_limit(settings),
+                )
             raise ProxyResponseError(
                 503,
                 openai_error(
@@ -969,6 +1009,28 @@ class _CompactMixin:
                                 now=_service_time().monotonic(),
                                 cooldown_seconds=getattr(base_settings, "compact_failure_cooldown_seconds", 60.0),
                             )
+                            if _local_compact_fallback_enabled(settings):
+                                response = _local_compact_fallback_response(
+                                    payload,
+                                    reason="all compact upstream account attempts timed out",
+                                    max_estimated_tokens=_local_compact_fallback_token_limit(settings),
+                                )
+                                logger.warning(
+                                    "Returning local compact fallback after upstream timeouts "
+                                    "request_id=%s account_id=%s",
+                                    request_id,
+                                    account.id,
+                                )
+                                await proxy._settle_compact_api_key_usage(
+                                    api_key=api_key,
+                                    api_key_reservation=api_key_reservation,
+                                    response=response,
+                                    request_service_tier=request_service_tier,
+                                )
+                                log_status = "success"
+                                log_error_code = None
+                                log_error_message = None
+                                return response
                             await proxy._settle_compact_api_key_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,
@@ -1013,6 +1075,41 @@ class _CompactMixin:
                         raise
                 if transient_exhausted:
                     continue  # outer loop: try different account
+            if last_exc is not None:
+                if _proxy_response_error_code(
+                    last_exc
+                ) == "upstream_request_timeout" and _local_compact_fallback_enabled(settings):
+                    _record_compact_failure_cooldown(
+                        cooldown_key,
+                        now=_service_time().monotonic(),
+                        cooldown_seconds=getattr(base_settings, "compact_failure_cooldown_seconds", 60.0),
+                    )
+                    response = _local_compact_fallback_response(
+                        payload,
+                        reason="compact upstream attempts exhausted before a healthy account completed",
+                        max_estimated_tokens=_local_compact_fallback_token_limit(settings),
+                    )
+                    logger.warning(
+                        "Returning local compact fallback after compact attempts exhausted request_id=%s",
+                        request_id,
+                    )
+                    await proxy._settle_compact_api_key_usage(
+                        api_key=api_key,
+                        api_key_reservation=api_key_reservation,
+                        response=response,
+                        request_service_tier=request_service_tier,
+                    )
+                    log_status = "success"
+                    log_error_code = None
+                    log_error_message = None
+                    return response
+                await proxy._settle_compact_api_key_usage(
+                    api_key=api_key,
+                    api_key_reservation=api_key_reservation,
+                    response=None,
+                    request_service_tier=request_service_tier,
+                )
+                raise last_exc
             # All account attempts exhausted — raise last error
             await proxy._settle_compact_api_key_usage(
                 api_key=api_key,
@@ -1020,8 +1117,6 @@ class _CompactMixin:
                 response=None,
                 request_service_tier=request_service_tier,
             )
-            if last_exc is not None:
-                raise last_exc
             raise ProxyResponseError(
                 502,
                 openai_error("upstream_unavailable", "All account attempts exhausted"),

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -52,6 +52,7 @@ logger = logging.getLogger("app.modules.proxy.service")
 T = TypeVar("T")
 
 _REQUEST_TRANSPORT_HTTP = "http"
+_COMPACT_FAILURE_COOLDOWNS: dict[str, float] = {}
 _CompactResponses = Callable[
     [ResponsesCompactRequest, Mapping[str, str], str, str | None],
     Awaitable[CompactResponsePayload],
@@ -184,6 +185,36 @@ def _compact_attempt_timeout_seconds(
     if configured_timeout_seconds is not None:
         return min(configured_timeout_seconds, remaining_budget)
     return remaining_budget
+
+
+def _compact_cooldown_key(affinity: _AffinityPolicy) -> str | None:
+    if affinity.key is None or affinity.kind is None:
+        return None
+    return f"{affinity.kind.value}:{affinity.key}"
+
+
+def _compact_cooldown_remaining_seconds(cooldown_key: str | None, *, now: float) -> float:
+    if cooldown_key is None:
+        return 0.0
+    expires_at = _COMPACT_FAILURE_COOLDOWNS.get(cooldown_key)
+    if expires_at is None:
+        return 0.0
+    remaining = expires_at - now
+    if remaining <= 0:
+        _COMPACT_FAILURE_COOLDOWNS.pop(cooldown_key, None)
+        return 0.0
+    return remaining
+
+
+def _record_compact_failure_cooldown(
+    cooldown_key: str | None,
+    *,
+    now: float,
+    cooldown_seconds: float,
+) -> None:
+    if cooldown_key is None or cooldown_seconds <= 0:
+        return
+    _COMPACT_FAILURE_COOLDOWNS[cooldown_key] = now + cooldown_seconds
 
 
 def _raise_proxy_budget_exhausted() -> NoReturn:
@@ -431,6 +462,23 @@ class _CompactMixin:
             sticky_threads_enabled=settings.sticky_threads_enabled,
             api_key=api_key,
         )
+        cooldown_key = _compact_cooldown_key(affinity)
+        cooldown_remaining = _compact_cooldown_remaining_seconds(cooldown_key, now=start)
+        if cooldown_remaining > 0:
+            logger.warning(
+                "Compact upstream cooldown active request_id=%s sticky_kind=%s cooldown_remaining_seconds=%.2f",
+                request_id,
+                affinity.kind.value if affinity.kind is not None else None,
+                cooldown_remaining,
+            )
+            raise ProxyResponseError(
+                503,
+                openai_error(
+                    "compact_upstream_unavailable",
+                    "Compact upstream is cooling down after repeated timeouts; retry shortly.",
+                    error_type="server_error",
+                ),
+            )
         sticky_key_source = "none"
         if affinity.kind == StickySessionKind.CODEX_SESSION:
             sticky_key_source = "session_header"
@@ -914,6 +962,11 @@ class _CompactMixin:
                                 excluded_account_ids.add(account.id)
                                 transient_exhausted = True
                                 break
+                            _record_compact_failure_cooldown(
+                                cooldown_key,
+                                now=_service_time().monotonic(),
+                                cooldown_seconds=getattr(base_settings, "compact_failure_cooldown_seconds", 60.0),
+                            )
                             await proxy._settle_compact_api_key_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -169,6 +169,21 @@ def _remaining_budget_seconds(deadline: float) -> float:
     return cast(Callable[[float], float], _service_global("_remaining_budget_seconds"))(deadline)
 
 
+def _compact_attempt_timeout_seconds(
+    remaining_budget: float,
+    configured_timeout_seconds: float | None = None,
+    *,
+    account_attempts_remaining: int = 1,
+) -> float:
+    if remaining_budget <= 0:
+        return 0.0
+    if account_attempts_remaining > 1:
+        remaining_budget = remaining_budget / account_attempts_remaining
+    if configured_timeout_seconds is not None:
+        return min(configured_timeout_seconds, remaining_budget)
+    return remaining_budget
+
+
 def _raise_proxy_budget_exhausted() -> NoReturn:
     cast(Callable[[], NoReturn], _service_global("_raise_proxy_budget_exhausted"))()
 
@@ -479,6 +494,8 @@ class _CompactMixin:
             async def _call_compact(
                 target: Account,
                 account_response_create_lease: AccountLease | None = None,
+                *,
+                account_attempts_remaining: int = 1,
             ) -> CompactResponsePayload:
                 nonlocal route_fallback_used, route_mode, route_pool_id, route_endpoint_id
                 access_token = proxy._encryptor.decrypt(target.access_token_encrypted)
@@ -491,15 +508,15 @@ class _CompactMixin:
                         target.id,
                     )
                     _raise_proxy_budget_exhausted()
-                if base_settings.upstream_compact_timeout_seconds is None:
-                    timeout_tokens = _service_push_compact_timeout_overrides(
-                        connect_timeout_seconds=remaining_budget,
-                    )
-                else:
-                    timeout_tokens = _service_push_compact_timeout_overrides(
-                        connect_timeout_seconds=remaining_budget,
-                        total_timeout_seconds=remaining_budget,
-                    )
+                attempt_timeout = _compact_attempt_timeout_seconds(
+                    remaining_budget,
+                    getattr(base_settings, "upstream_compact_timeout_seconds", None),
+                    account_attempts_remaining=account_attempts_remaining,
+                )
+                timeout_tokens = _service_push_compact_timeout_overrides(
+                    connect_timeout_seconds=attempt_timeout,
+                    total_timeout_seconds=attempt_timeout,
+                )
                 create_lease: AdmissionLease | None = None
                 try:
                     if account_response_create_lease is None:
@@ -663,7 +680,11 @@ class _CompactMixin:
                     try:
                         account_response_create_lease = selected_account_response_create_lease
                         selected_account_response_create_lease = None
-                        response = await _call_compact(account, account_response_create_lease)
+                        response = await _call_compact(
+                            account,
+                            account_response_create_lease,
+                            account_attempts_remaining=_compact_max_account_attempts() - _account_attempt,
+                        )
                         actual_service_tier = _service_tier_from_response(response)
                         await proxy._load_balancer.record_success(account)
                         await proxy._settle_compact_api_key_usage(
@@ -834,6 +855,63 @@ class _CompactMixin:
                             transient_exhausted = True
                             break
                         if _is_account_neutral_error_code(code):
+                            await proxy._settle_compact_api_key_usage(
+                                api_key=api_key,
+                                api_key_reservation=api_key_reservation,
+                                response=None,
+                                request_service_tier=request_service_tier,
+                            )
+                            raise
+                        if code == "upstream_request_timeout":
+                            classified = await proxy._handle_stream_error(
+                                account,
+                                _upstream_error_from_openai(error),
+                                code,
+                                http_status=exc.status_code,
+                            )
+                            if affinity.key is not None and affinity.kind is not None:
+                                try:
+                                    async with proxy._repo_factory() as repos:
+                                        await repos.sticky_sessions.delete(affinity.key, kind=affinity.kind)
+                                    logger.info(
+                                        "Compact sticky mapping cleared after upstream timeout request_id=%s "
+                                        "sticky_kind=%s",
+                                        request_id,
+                                        affinity.kind.value,
+                                    )
+                                except Exception:
+                                    logger.warning(
+                                        "Failed to clear compact sticky mapping after upstream timeout "
+                                        "request_id=%s sticky_kind=%s",
+                                        request_id,
+                                        affinity.kind.value,
+                                        exc_info=True,
+                                    )
+                            if (
+                                getattr(base_settings, "deterministic_failover_enabled", True)
+                                and file_preferred_account_id is None
+                            ):
+                                action = failover_decision(
+                                    failure_class=classified["failure_class"],
+                                    downstream_visible=False,
+                                    candidates_remaining=_compact_max_account_attempts() - _account_attempt - 1,
+                                )
+                            else:
+                                action = "surface"
+                            logger.info(
+                                "Failover decision request_id=%s transport=compact account_id=%s "
+                                "attempt=%d failure_class=%s action=%s",
+                                request_id,
+                                account.id,
+                                _account_attempt + 1,
+                                classified["failure_class"],
+                                action,
+                            )
+                            if action == "failover_next":
+                                last_exc = exc
+                                excluded_account_ids.add(account.id)
+                                transient_exhausted = True
+                                break
                             await proxy._settle_compact_api_key_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -45,6 +45,7 @@ from app.modules.proxy.affinity import (
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.helpers import _header_account_id, _normalize_error_code, _parse_openai_error
 from app.modules.proxy.load_balancer import AccountLease, AccountSelection
+from app.modules.proxy.repo_bundle import ProxyRepoFactory
 from app.modules.proxy.work_admission import AdmissionLease, WorkAdmissionController
 
 logger = logging.getLogger("app.modules.proxy.service")
@@ -60,6 +61,7 @@ _CompactResponses = Callable[
 class _CompactServiceProtocol(Protocol):
     _encryptor: Any
     _load_balancer: Any
+    _repo_factory: ProxyRepoFactory
 
     def _get_work_admission(self) -> WorkAdmissionController: ...
 

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -52,6 +52,7 @@ logger = logging.getLogger("app.modules.proxy.service")
 T = TypeVar("T")
 
 _REQUEST_TRANSPORT_HTTP = "http"
+_DEFAULT_COMPACT_UPSTREAM_TIMEOUT_SECONDS = 30.0
 _COMPACT_FAILURE_COOLDOWNS: dict[str, float] = {}
 _CompactResponses = Callable[
     [ResponsesCompactRequest, Mapping[str, str], str, str | None],
@@ -182,9 +183,10 @@ def _compact_attempt_timeout_seconds(
         return 0.0
     if account_attempts_remaining > 1:
         remaining_budget = remaining_budget / account_attempts_remaining
-    if configured_timeout_seconds is not None:
-        return min(configured_timeout_seconds, remaining_budget)
-    return remaining_budget
+    timeout = configured_timeout_seconds
+    if timeout is None:
+        timeout = _DEFAULT_COMPACT_UPSTREAM_TIMEOUT_SECONDS
+    return min(timeout, remaining_budget)
 
 
 def _compact_cooldown_key(affinity: _AffinityPolicy) -> str | None:

--- a/app/modules/proxy/_service/http_bridge/owner_forwarding.py
+++ b/app/modules/proxy/_service/http_bridge/owner_forwarding.py
@@ -60,6 +60,7 @@ from app.modules.proxy._service.compact import (
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _durable_bridge_lookup_active_owner,
+    _http_bridge_endpoint_matches_current_instance,
     _http_bridge_previous_response_alias_key,
     _http_bridge_session_allows_api_key,
     _http_bridge_session_retiring_with_visible_requests,
@@ -264,7 +265,9 @@ class _HTTPBridgeOwnerForwardingMixin:
         except Exception:
             logger.debug("Failed to resolve HTTP bridge owner endpoint during anchor injection decision", exc_info=True)
             return False
-        return owner_endpoint is not None
+        if owner_endpoint is None:
+            return False
+        return not _http_bridge_endpoint_matches_current_instance(owner_endpoint, _service_get_settings())
 
     async def _forward_http_bridge_request_to_owner(
         self: Any,

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -214,7 +214,6 @@ class DurableBridgeRepository:
                 HttpBridgeSessionState.DRAINING,
                 HttpBridgeSessionState.CLOSED,
             }
-            previous_state = existing.state
             account_changed = existing.account_id != account_id
             owner_changed = existing.owner_instance_id != instance_id
             if owner_changed:
@@ -243,9 +242,9 @@ class DurableBridgeRepository:
                     existing.latest_input_item_count = None
                     existing.latest_input_full_fingerprint = None
                 elif owner_changed:
-                    if latest_turn_state is not None or previous_state == HttpBridgeSessionState.CLOSED:
+                    if latest_turn_state is not None:
                         existing.latest_turn_state = latest_turn_state
-                    if latest_response_id is not None or previous_state == HttpBridgeSessionState.CLOSED:
+                    if latest_response_id is not None:
                         existing.latest_response_id = latest_response_id
                         existing.latest_input_item_count = None
                         existing.latest_input_full_fingerprint = None

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -809,6 +809,34 @@ compact client before exhausting eligible accounts.
 - **THEN** the service-level auth refresh/failover path handles it
 - **AND** the low-level compact transport does not mark it as a generic same-contract transport retry
 
+### Requirement: Compact upstream timeouts fail over before surfacing
+
+The proxy MUST treat a compact upstream timeout before any valid compact result
+as a pre-visible retryable transient account failure. The proxy MUST clear the
+stale compact affinity mapping for that request, exclude the timed-out account,
+and try another eligible account within the same compact request when one is
+available. Per-account compact upstream timeouts MUST share the remaining
+request budget across remaining eligible account attempts so the first timed-out
+account cannot consume the full retry window. The proxy MUST preserve
+account-pinned compact routing, such as file-scoped routing, and fail closed
+instead of crossing account boundaries when the request requires a specific
+account.
+
+#### Scenario: compact upstream timeout uses another account
+
+- **GIVEN** at least two accounts are eligible for a compact request
+- **AND** the selected account times out before returning a valid compact result
+- **WHEN** another eligible account can complete the compact request
+- **THEN** the downstream compact response succeeds from the second account
+- **AND** the compact affinity mapping for the timed-out account is cleared
+- **AND** the selected account is excluded from further attempts for that compact request
+
+#### Scenario: compact upstream timeout keeps retry budget for later accounts
+
+- **GIVEN** a compact request has multiple eligible account attempts remaining
+- **WHEN** calculating the upstream timeout for the current account attempt
+- **THEN** the proxy divides the remaining compact budget across the remaining account attempts
+
 ### Requirement: Pre-visible proxy auth failures fail over after forced refresh
 
 The proxy MUST treat repeated account-local authentication failures as

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -563,6 +563,13 @@ When serving HTTP `/v1/responses` or HTTP `/backend-api/codex/responses`, the se
 - **THEN** the service MUST fail the request with a generic 5xx bridge-forward error
 - **AND** it MUST NOT attempt another owner handoff
 
+#### Scenario: local restart orphan is recovered by the replacement instance
+- **WHEN** a single local bridge instance is replaced while durable hard-continuity ownership still references the old instance id
+- **AND** the old owner has no distinct active forwarding endpoint from the current replacement instance
+- **THEN** the replacement instance MUST treat the row as restart-orphaned and may claim durable ownership locally
+- **AND** same-account takeover MUST preserve the latest persisted response anchor until a replacement response id is recorded
+- **AND** normal client retries MUST NOT be stranded waiting for the old instance lease to expire
+
 ### Requirement: Responses account selection accounts for in-flight pressure
 
 For Responses API requests, usage-based routing MUST include immediate in-process account pressure in addition to persisted usage. Account selection MUST account for in-flight response-create work, active streams, leased token/cost estimates, recent selection pressure, account health, and configured account-local caps. Selection and lease acquisition MUST be atomic with respect to other in-process selections, and the critical section MUST NOT perform database calls, network calls, sleeps, or other blocking I/O.

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -380,6 +380,49 @@ async def test_durable_bridge_takeover_clears_stale_recovery_anchor_for_fresh_se
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_same_account_closed_takeover_preserves_restart_anchor(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-restart",
+        api_key_id=None,
+        instance_id="instance-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_old",
+        latest_response_id="resp_old",
+        allow_takeover=True,
+    )
+    await coordinator.release_live_session(
+        session_id=claimed.session_id,
+        instance_id="instance-a",
+        owner_epoch=claimed.owner_epoch,
+        draining=False,
+    )
+
+    reclaimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-restart",
+        api_key_id=None,
+        instance_id="instance-b",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+
+    assert reclaimed.owner_instance_id == "instance-b"
+    assert reclaimed.latest_turn_state == "http_turn_old"
+    assert reclaimed.latest_response_id == "resp_old"
+
+
+@pytest.mark.asyncio
 async def test_durable_bridge_takeover_preserves_existing_anchor_when_replacement_has_none(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -867,6 +867,47 @@ def test_local_compact_fallback_preserves_state_anchors_tool_pairs_and_tail():
     )
 
 
+def test_local_compact_fallback_scans_past_large_tail_blockers_and_trim_markers():
+    task_item: JsonValue = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "actual task: create the Chinese translation PR"}],
+    }
+    giant_technical_item: JsonValue = {
+        "type": "function_call_output",
+        "call_id": "call_big",
+        "output": "bootstrap/log noise " * 20_000,
+    }
+    trim_marker: JsonValue = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "[compact trim] Omitted 2 input items (~14552 estimated tokens) before forwarding this "
+                    "oversized compact request upstream."
+                ),
+            }
+        ],
+    }
+    input_items: JsonValue = [task_item, giant_technical_item, trim_marker]
+
+    output = build_local_compact_fallback_output(
+        input_items,
+        reason="upstream timeout",
+        max_estimated_tokens=80,
+    )
+
+    assert task_item in output
+    assert giant_technical_item not in output
+    assert trim_marker not in output
+    assert any(
+        isinstance(item, dict) and item.get("type") == "message" and "[compact trim]" in str(item.get("content"))
+        for item in output
+    )
+
+
 def test_responses_normalizes_assistant_input_text_to_output_text():
     payload = {
         "model": "gpt-5.1",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -804,6 +804,13 @@ def test_local_compact_fallback_preserves_state_anchors_tool_pairs_and_tail():
         {"type": "function_call_output", "call_id": "call_plan", "output": "plan updated"},
         {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "x" * 2000}]},
         {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "status": "completed",
+            "execution": "server",
+            "arguments": {"query": "codex-lb"},
+        },
+        {
             "type": "message",
             "role": "user",
             "content": [
@@ -816,13 +823,27 @@ def test_local_compact_fallback_preserves_state_anchors_tool_pairs_and_tail():
             ],
         },
         {"type": "function_call_output", "call_id": "call_orphan", "output": "must be dropped without its call"},
+        {
+            "type": "tool_search_call",
+            "call_id": "call_orphan_search",
+            "status": "completed",
+            "execution": "server",
+            "arguments": {"query": "must be dropped without output"},
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "status": "completed",
+            "execution": "server",
+            "tools": [],
+        },
         {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "latest retry"}]},
     ]
 
     output = build_local_compact_fallback_output(
         input_items,
         reason="test outage",
-        max_estimated_tokens=120,
+        max_estimated_tokens=240,
     )
 
     marker = cast(Mapping[str, object], output[0])
@@ -835,8 +856,11 @@ def test_local_compact_fallback_preserves_state_anchors_tool_pairs_and_tail():
     assert input_items[1] in output
     assert input_items[2] in output
     assert input_items[4] in output
+    assert input_items[5] in output
     assert input_items[-1] in output
-    assert input_items[5] not in output
+    assert input_items[6] not in output
+    assert input_items[7] not in output
+    assert input_items[8] in output
     assert any(
         isinstance(item, dict) and item.get("type") == "message" and "[compact trim]" in str(item.get("content"))
         for item in output

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -908,6 +908,62 @@ def test_local_compact_fallback_scans_past_large_tail_blockers_and_trim_markers(
     )
 
 
+def test_compact_trim_prefers_semantic_tail_over_current_turn_bootstrap():
+    task_item: JsonValue = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "actual task: plan cherry picks and create zh PR"}],
+    }
+    progress_item: JsonValue = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "I found the PR destinations and am checking comments."}],
+    }
+    developer_bootstrap: JsonValue = {
+        "type": "message",
+        "role": "developer",
+        "content": [
+            {
+                "type": "input_text",
+                "text": "<permissions instructions>\nnever ask approval\n</permissions instructions>",
+            },
+            {"type": "input_text", "text": "<collaboration_mode># Plan Mode\n" + "plan mode rules\n" * 2000},
+            {"type": "input_text", "text": "<skills_instructions>\n" + "skill docs\n" * 4000},
+        ],
+    }
+    workspace_bootstrap: JsonValue = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {"type": "input_text", "text": "# AGENTS.md instructions for /workspace\n" + "workspace rules\n" * 4000},
+            {"type": "input_text", "text": "<environment_context>\n  <cwd>/workspace</cwd>\n</environment_context>"},
+        ],
+    }
+    payload = {
+        "model": "gpt-5.5",
+        "input": [
+            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "old " * 200_000}]},
+            task_item,
+            progress_item,
+            developer_bootstrap,
+            workspace_bootstrap,
+        ],
+    }
+
+    dumped = ResponsesCompactRequest.model_validate(payload).to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert task_item in dumped_input
+    assert progress_item in dumped_input
+    assert developer_bootstrap not in dumped_input
+    assert workspace_bootstrap not in dumped_input
+    assert any(
+        isinstance(item, dict) and item.get("type") == "message" and "[compact trim]" in str(item.get("content"))
+        for item in dumped_input
+    )
+
+
 def test_responses_normalizes_assistant_input_text_to_output_text():
     payload = {
         "model": "gpt-5.1",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -10,6 +10,7 @@ from app.core.openai.requests import (
     ResponsesCompactRequest,
     ResponsesRequest,
     _input_image_file_reference,
+    build_local_compact_fallback_output,
     extract_input_file_ids,
     extract_input_image_file_references,
 )
@@ -789,6 +790,57 @@ def test_v1_compact_store_true_is_coerced_to_false():
     request = V1ResponsesCompactRequest.model_validate(payload)
     compact = request.to_compact_request()
     assert compact.store is False
+
+
+def test_local_compact_fallback_preserves_state_anchors_tool_pairs_and_tail():
+    input_items: JsonValue = [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "old request"}]},
+        {
+            "type": "function_call",
+            "name": "update_plan",
+            "call_id": "call_plan",
+            "arguments": '{"plan":[]}',
+        },
+        {"type": "function_call_output", "call_id": "call_plan", "output": "plan updated"},
+        {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "x" * 2000}]},
+        {
+            "type": "message",
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": (
+                        '<codex_internal_context source="goal">keep fixing restart recovery</codex_internal_context>'
+                    ),
+                }
+            ],
+        },
+        {"type": "function_call_output", "call_id": "call_orphan", "output": "must be dropped without its call"},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "latest retry"}]},
+    ]
+
+    output = build_local_compact_fallback_output(
+        input_items,
+        reason="test outage",
+        max_estimated_tokens=120,
+    )
+
+    marker = cast(Mapping[str, object], output[0])
+    assert marker["type"] == "message"
+    marker_content = cast(list[Mapping[str, str]], marker["content"])
+    assert marker_content[0]["text"].startswith("[local compact fallback]")
+    assert "Remote compaction was unavailable" in marker_content[0]["text"]
+    assert "test outage" in marker_content[0]["text"]
+    assert "codex-lb" not in marker_content[0]["text"]
+    assert input_items[1] in output
+    assert input_items[2] in output
+    assert input_items[4] in output
+    assert input_items[-1] in output
+    assert input_items[5] not in output
+    assert any(
+        isinstance(item, dict) and item.get("type") == "message" and "[compact trim]" in str(item.get("content"))
+        for item in output
+    )
 
 
 def test_responses_normalizes_assistant_input_text_to_output_text():

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -3528,6 +3528,44 @@ async def test_stream_via_http_bridge_clears_injected_anchor_after_owner_unavail
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_forwardable_owner_excludes_current_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: Settings(
+            http_responses_session_bridge_instance_id="instance-a",
+            http_responses_session_bridge_advertise_base_url="http://127.0.0.1:2455",
+        ),
+    )
+    service._ring_membership = cast(
+        Any,
+        SimpleNamespace(resolve_endpoint=AsyncMock(return_value="http://127.0.0.1:2455/")),
+    )
+
+    forwardable = await service._http_bridge_can_forward_to_active_owner(
+        proxy_service.DurableBridgeLookup(
+            session_id="durable-1",
+            canonical_kind="session_header",
+            canonical_key="sid-restart",
+            api_key_scope="__anonymous__",
+            account_id="acc-1",
+            owner_instance_id="instance-old",
+            owner_epoch=2,
+            lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+            state=HttpBridgeSessionState.ACTIVE,
+            latest_turn_state="http_turn_old",
+            latest_response_id="resp_old",
+        )
+    )
+
+    assert forwardable is False
+    service._ring_membership.resolve_endpoint.assert_awaited_once_with("instance-old")
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_anchor_for_derived_prompt_cache_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -44,6 +44,7 @@ from app.modules.proxy import affinity as proxy_affinity
 from app.modules.proxy import api as proxy_api
 from app.modules.proxy import request_policy as proxy_request_policy
 from app.modules.proxy import service as proxy_service
+from app.modules.proxy._service import compact as proxy_compact_service
 from app.modules.proxy.load_balancer import AccountLease, AccountSelection, RuntimeState, SelectionInputs
 from app.modules.proxy.repo_bundle import ProxyRepositories
 from app.modules.proxy.sticky_repository import StickySessionsRepository
@@ -58,6 +59,19 @@ def test_relative_availability_settings_default_when_stored_values_are_null():
 
     assert proxy_service._relative_availability_power(settings) == 2.0
     assert proxy_service._relative_availability_top_k(settings) == 5
+
+
+def test_compact_attempt_timeout_splits_remaining_budget_across_account_attempts():
+    assert proxy_compact_service._compact_attempt_timeout_seconds(600.0) == pytest.approx(600.0)
+    assert proxy_compact_service._compact_attempt_timeout_seconds(600.0, account_attempts_remaining=2) == pytest.approx(
+        300.0
+    )
+    assert proxy_compact_service._compact_attempt_timeout_seconds(180.0, account_attempts_remaining=2) == pytest.approx(
+        90.0
+    )
+    assert proxy_compact_service._compact_attempt_timeout_seconds(
+        600.0, 120.0, account_attempts_remaining=2
+    ) == pytest.approx(120.0)
 
 
 def test_websocket_precreated_retry_error_code_does_not_replay_missing_tool_output():
@@ -16989,6 +17003,80 @@ async def test_compact_responses_records_transient_error_for_generic_upstream_fa
     assert _proxy_error_code(exc) == "upstream_unavailable"
     record_error.assert_awaited_once_with(account)
     record_success.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_fails_over_after_upstream_timeout(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    sticky_sessions = AsyncMock()
+
+    class _StickyRepoContext:
+        async def __aenter__(self) -> ProxyRepositories:
+            return ProxyRepositories(
+                accounts=cast(AccountsRepository, AsyncMock()),
+                usage=cast(UsageRepository, AsyncMock()),
+                request_logs=cast(RequestLogsRepository, request_logs),
+                sticky_sessions=cast(StickySessionsRepository, sticky_sessions),
+                api_keys=cast(ApiKeysRepository, AsyncMock()),
+                additional_usage=cast(AdditionalUsageRepository, AsyncMock()),
+            )
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    service = proxy_service.ProxyService(cast(proxy_service.ProxyRepoFactory, lambda: _StickyRepoContext()))
+    account_a = _make_account("acc_compact_silent_upstream_a")
+    account_b = _make_account("acc_compact_silent_upstream_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    upstream_accounts: list[str | None] = []
+    call_order: list[str] = []
+
+    async def handle_stream_error(*args, **kwargs):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "retryable_transient"}
+
+    async def settle_compact_api_key_usage(**kwargs):
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    record_errors = AsyncMock()
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        upstream_accounts.append(account_id)
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                502,
+                openai_error("upstream_request_timeout", "Compact upstream call timed out"),
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_a, account_b]))
+    handle_stream_error_mock = AsyncMock(side_effect=handle_stream_error)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error_mock)
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(service._load_balancer, "record_errors", record_errors)
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+
+    response = await service.compact_responses(payload, {"session_id": "sid-compact"}, codex_session_affinity=True)
+
+    assert response.model_extra == {"output": []}
+    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert upstream_accounts == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
+    handle_stream_error_mock.assert_awaited_once()
+    assert call_order[:2] == ["handle_stream_error", "settle_compact_api_key_usage"]
+    record_errors.assert_not_awaited()
+    sticky_sessions.delete.assert_awaited_once_with("sid-compact", kind=proxy_service.StickySessionKind.CODEX_SESSION)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account_b.id
+    assert request_logs.calls[0]["error_code"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -62,12 +62,12 @@ def test_relative_availability_settings_default_when_stored_values_are_null():
 
 
 def test_compact_attempt_timeout_splits_remaining_budget_across_account_attempts():
-    assert proxy_compact_service._compact_attempt_timeout_seconds(600.0) == pytest.approx(600.0)
+    assert proxy_compact_service._compact_attempt_timeout_seconds(600.0) == pytest.approx(30.0)
     assert proxy_compact_service._compact_attempt_timeout_seconds(600.0, account_attempts_remaining=2) == pytest.approx(
-        300.0
+        30.0
     )
     assert proxy_compact_service._compact_attempt_timeout_seconds(180.0, account_attempts_remaining=2) == pytest.approx(
-        90.0
+        30.0
     )
     assert proxy_compact_service._compact_attempt_timeout_seconds(
         600.0, 120.0, account_attempts_remaining=2

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5735,7 +5735,7 @@ def test_sticky_key_for_responses_request_derives_when_payload_key_is_whitespace
 
 
 @pytest.mark.asyncio
-async def test_service_compact_budget_does_not_override_unbounded_read_timeout(monkeypatch):
+async def test_service_compact_budget_bounds_timeout_per_remaining_account_attempt(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -5767,8 +5767,8 @@ async def test_service_compact_budget_does_not_override_unbounded_read_timeout(m
 
     result = await service.compact_responses(payload, {"session_id": "sid-compact"})
 
-    assert captured["connect_timeout"] == pytest.approx(3.0)
-    assert captured["total_timeout"] is None
+    assert captured["connect_timeout"] == pytest.approx(1.5)
+    assert captured["total_timeout"] == pytest.approx(1.5)
     assert result.model_extra == {"output": []}
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2189,6 +2189,8 @@ def _make_proxy_settings(*, log_proxy_service_tier_trace: bool) -> SimpleNamespa
         transcription_request_budget_seconds=120.0,
         upstream_compact_timeout_seconds=None,
         compact_failure_cooldown_seconds=60.0,
+        local_compact_fallback_enabled=True,
+        local_compact_fallback_max_estimated_tokens=20_000,
         http_responses_session_bridge_gateway_safe_mode=False,
         log_proxy_request_payload=False,
         log_proxy_request_shape=False,
@@ -17013,6 +17015,100 @@ async def test_compact_responses_records_transient_error_for_generic_upstream_fa
 
 
 @pytest.mark.asyncio
+async def test_compact_responses_returns_local_fallback_after_codex_compaction_timeout(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_timeout_fallback")
+    record_success = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(
+        service,
+        "_handle_stream_error",
+        AsyncMock(return_value={"failure_class": "retryable_transient"}),
+    )
+
+    async def failing_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_request_timeout", "Proxy request budget exhausted"),
+        )
+
+    monkeypatch.setattr(proxy_service, "core_compact_responses", failing_compact)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    headers = {"x-codex-turn-metadata": json.dumps({"request_kind": "compaction"})}
+
+    response = await service.compact_responses(payload, headers)
+
+    assert response.object == "response.compaction"
+    output = (response.model_extra or {})["output"]
+    assert isinstance(output, list)
+    assert output
+    marker = output[0]
+    assert isinstance(marker, dict)
+    assert marker["type"] == "message"
+    assert "local compact fallback" in str(marker["content"])
+    record_success.assert_not_awaited()
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["error_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_can_disable_local_fallback_after_compaction_timeout(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.local_compact_fallback_enabled = False
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_timeout_fallback_disabled")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(
+        service,
+        "_handle_stream_error",
+        AsyncMock(return_value={"failure_class": "retryable_transient"}),
+    )
+
+    async def failing_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_request_timeout", "Proxy request budget exhausted"),
+        )
+
+    monkeypatch.setattr(proxy_service, "core_compact_responses", failing_compact)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    headers = {"x-codex-turn-metadata": json.dumps({"request_kind": "compaction"})}
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(payload, headers)
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "upstream_request_timeout"
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["error_code"] == "upstream_request_timeout"
+
+
+@pytest.mark.asyncio
 async def test_compact_responses_fails_over_after_upstream_timeout(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
@@ -17137,21 +17233,22 @@ async def test_compact_responses_cools_down_after_all_upstream_timeouts(monkeypa
     payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
 
     try:
-        with pytest.raises(proxy_module.ProxyResponseError) as first_exc_info:
-            await service.compact_responses(payload, {"session_id": "sid-compact"}, codex_session_affinity=True)
+        first_response = await service.compact_responses(
+            payload, {"session_id": "sid-compact"}, codex_session_affinity=True
+        )
 
-        first_exc = _assert_proxy_response_error(first_exc_info.value)
-        assert first_exc.status_code == 502
-        assert _proxy_error_code(first_exc) == "upstream_request_timeout"
+        assert first_response.object == "response.compaction"
         assert seen_excluded_account_ids == [set(), {account_a.id}]
         assert upstream_accounts == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
 
-        with pytest.raises(proxy_module.ProxyResponseError) as second_exc_info:
-            await service.compact_responses(payload, {"session_id": "sid-compact"}, codex_session_affinity=True)
+        second_response = await service.compact_responses(
+            payload, {"session_id": "sid-compact"}, codex_session_affinity=True
+        )
 
-        second_exc = _assert_proxy_response_error(second_exc_info.value)
-        assert second_exc.status_code == 503
-        assert _proxy_error_code(second_exc) == "compact_upstream_unavailable"
+        assert second_response.object == "response.compaction"
+        second_output = (second_response.model_extra or {})["output"]
+        assert isinstance(second_output, list)
+        assert "local compact fallback" in str(second_output[0])
         assert seen_excluded_account_ids == [set(), {account_a.id}]
         assert upstream_accounts == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
     finally:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -74,6 +74,12 @@ def test_compact_attempt_timeout_splits_remaining_budget_across_account_attempts
     ) == pytest.approx(120.0)
 
 
+def test_runtime_settings_default_caps_compact_upstream_timeout():
+    settings = Settings()
+
+    assert settings.upstream_compact_timeout_seconds == pytest.approx(30.0)
+
+
 def test_websocket_precreated_retry_error_code_does_not_replay_missing_tool_output():
     request_state = proxy_service._WebSocketRequestState(
         request_id="req_missing_tool_precreated",
@@ -2182,6 +2188,7 @@ def _make_proxy_settings(*, log_proxy_service_tier_trace: bool) -> SimpleNamespa
         compact_request_budget_seconds=75.0,
         transcription_request_budget_seconds=120.0,
         upstream_compact_timeout_seconds=None,
+        compact_failure_cooldown_seconds=60.0,
         http_responses_session_bridge_gateway_safe_mode=False,
         log_proxy_request_payload=False,
         log_proxy_request_shape=False,
@@ -17077,6 +17084,78 @@ async def test_compact_responses_fails_over_after_upstream_timeout(monkeypatch):
     assert request_logs.calls[0]["status"] == "success"
     assert request_logs.calls[0]["account_id"] == account_b.id
     assert request_logs.calls[0]["error_code"] is None
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_cools_down_after_all_upstream_timeouts(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.compact_failure_cooldown_seconds = 30.0
+    request_logs = _RequestLogsRecorder()
+    sticky_sessions = AsyncMock()
+
+    class _StickyRepoContext:
+        async def __aenter__(self) -> ProxyRepositories:
+            return ProxyRepositories(
+                accounts=cast(AccountsRepository, AsyncMock()),
+                usage=cast(UsageRepository, AsyncMock()),
+                request_logs=cast(RequestLogsRepository, request_logs),
+                sticky_sessions=cast(StickySessionsRepository, sticky_sessions),
+                api_keys=cast(ApiKeysRepository, AsyncMock()),
+                additional_usage=cast(AdditionalUsageRepository, AsyncMock()),
+            )
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    service = proxy_service.ProxyService(cast(proxy_service.ProxyRepoFactory, lambda: _StickyRepoContext()))
+    account_a = _make_account("acc_compact_timeout_cooldown_a")
+    account_b = _make_account("acc_compact_timeout_cooldown_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    upstream_accounts: list[str | None] = []
+
+    async def handle_stream_error(*args, **kwargs):
+        del args, kwargs
+        return {"failure_class": "retryable_transient"}
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        upstream_accounts.append(account_id)
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_request_timeout", "Compact upstream call timed out"),
+        )
+
+    proxy_compact_service._COMPACT_FAILURE_COOLDOWNS.clear()
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock())
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+
+    try:
+        with pytest.raises(proxy_module.ProxyResponseError) as first_exc_info:
+            await service.compact_responses(payload, {"session_id": "sid-compact"}, codex_session_affinity=True)
+
+        first_exc = _assert_proxy_response_error(first_exc_info.value)
+        assert first_exc.status_code == 502
+        assert _proxy_error_code(first_exc) == "upstream_request_timeout"
+        assert seen_excluded_account_ids == [set(), {account_a.id}]
+        assert upstream_accounts == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
+
+        with pytest.raises(proxy_module.ProxyResponseError) as second_exc_info:
+            await service.compact_responses(payload, {"session_id": "sid-compact"}, codex_session_affinity=True)
+
+        second_exc = _assert_proxy_response_error(second_exc_info.value)
+        assert second_exc.status_code == 503
+        assert _proxy_error_code(second_exc) == "compact_upstream_unavailable"
+        assert seen_excluded_account_ids == [set(), {account_a.id}]
+        assert upstream_accounts == [account_a.chatgpt_account_id, account_b.chatgpt_account_id]
+    finally:
+        proxy_compact_service._COMPACT_FAILURE_COOLDOWNS.clear()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve durable HTTP bridge previous-response anchors when the replacement instance takes over a closed same-account session without a new response id yet
- avoid treating an owner endpoint that resolves to the current instance as forwardable, so local restart recovery and anchor injection can run
- document the local restart-orphan invariant in OpenSpec and cover it with regression tests

## Live deploy
- deployed locally as `codex-lb:live-stack-3d63876` from aggregate commit `3d638765f`
- previous rollback container: `codex-lb-before-live-stack-3d63876-20260613T114136Z`
- `/health` and `/health/ready` are OK; bridge ring settled to one live member

## Tests
- `uv run pytest tests/unit/test_durable_bridge_sessions.py tests/unit/test_proxy_http_bridge.py -q`
- `uv run ruff check app/modules/proxy/durable_bridge_repository.py app/modules/proxy/_service/http_bridge/owner_forwarding.py tests/unit/test_durable_bridge_sessions.py tests/unit/test_proxy_http_bridge.py`
- `openspec validate --specs`
- `git diff --check origin/main..HEAD`