### PR TITLE
Harden SQLite backups and account writes

### DIFF
--- a/app/db/backup.py
+++ b/app/db/backup.py
@@ -30,10 +30,12 @@ def list_sqlite_pre_migration_backups(source: Path) -> list[Path]:
 
 
 def _sqlite_backup(source: Path, backup_path: Path) -> None:
+    source_mode = source.stat().st_mode
     with sqlite3.connect(source) as source_conn:
         with sqlite3.connect(backup_path) as backup_conn:
             source_conn.backup(backup_conn)
             backup_conn.execute("PRAGMA journal_mode=DELETE")
+    backup_path.chmod(source_mode)
 
 
 def create_sqlite_pre_migration_backup(

--- a/app/db/backup.py
+++ b/app/db/backup.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import shutil
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -29,6 +29,13 @@ def list_sqlite_pre_migration_backups(source: Path) -> list[Path]:
     return sorted((path for path in source.parent.glob(pattern) if path.is_file()))
 
 
+def _sqlite_backup(source: Path, backup_path: Path) -> None:
+    with sqlite3.connect(source) as source_conn:
+        with sqlite3.connect(backup_path) as backup_conn:
+            source_conn.backup(backup_conn)
+            backup_conn.execute("PRAGMA journal_mode=DELETE")
+
+
 def create_sqlite_pre_migration_backup(
     source: Path,
     *,
@@ -43,7 +50,7 @@ def create_sqlite_pre_migration_backup(
     timestamp = now or datetime.now(timezone.utc)
     backup_path = _next_backup_path(source, timestamp)
 
-    shutil.copy2(source, backup_path)
+    _sqlite_backup(source, backup_path)
 
     backups = list_sqlite_pre_migration_backups(source)
     excess = len(backups) - max_files

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -23,6 +23,7 @@ from app.db.models import (
     StickySession,
     UsageHistory,
 )
+from app.db.session import sqlite_writer_section
 from app.modules.usage.additional_quota_keys import normalize_additional_quota_routing_policy_overrides
 
 _SETTINGS_ROW_ID = 1
@@ -151,6 +152,20 @@ class AccountsRepository:
         merge_by_email: bool | None = None,
         merge_by_chatgpt_identity: bool = False,
     ) -> Account:
+        async with sqlite_writer_section():
+            return await self._upsert_unlocked(
+                account,
+                merge_by_email=merge_by_email,
+                merge_by_chatgpt_identity=merge_by_chatgpt_identity,
+            )
+
+    async def _upsert_unlocked(
+        self,
+        account: Account,
+        *,
+        merge_by_email: bool | None = None,
+        merge_by_chatgpt_identity: bool = False,
+    ) -> Account:
         dialect_name = self._dialect_name()
         sqlite_lock_acquired = False
         if merge_by_email is None:
@@ -246,6 +261,20 @@ class AccountsRepository:
         return await self.upsert_account_slot(account, preserve_unknown_workspace_duplicates=False)
 
     async def upsert_account_slot(
+        self,
+        account: Account,
+        *,
+        preserve_unknown_workspace_duplicates: bool | None = None,
+        preserve_identity_slots: bool = False,
+    ) -> Account:
+        async with sqlite_writer_section():
+            return await self._upsert_account_slot_unlocked(
+                account,
+                preserve_unknown_workspace_duplicates=preserve_unknown_workspace_duplicates,
+                preserve_identity_slots=preserve_identity_slots,
+            )
+
+    async def _upsert_account_slot_unlocked(
         self,
         account: Account,
         *,
@@ -448,28 +477,30 @@ class AccountsRepository:
         reset_at: int | None = None,
         blocked_at: int | None | object = _UNSET,
     ) -> bool:
-        values: dict[str, object | None] = {
-            "status": status,
-            "deactivation_reason": deactivation_reason,
-            "reset_at": reset_at,
-        }
-        if blocked_at is not _UNSET:
-            values["blocked_at"] = blocked_at
-        result = await self._session.execute(
-            update(Account).where(Account.id == account_id).values(**values).returning(Account.id)
-        )
-        await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        async with sqlite_writer_section():
+            values: dict[str, object | None] = {
+                "status": status,
+                "deactivation_reason": deactivation_reason,
+                "reset_at": reset_at,
+            }
+            if blocked_at is not _UNSET:
+                values["blocked_at"] = blocked_at
+            result = await self._session.execute(
+                update(Account).where(Account.id == account_id).values(**values).returning(Account.id)
+            )
+            await self._session.commit()
+            return result.scalar_one_or_none() is not None
 
     async def update_security_work_authorized(self, account_id: str, enabled: bool) -> bool:
-        result = await self._session.execute(
-            update(Account)
-            .where(Account.id == account_id)
-            .values(security_work_authorized=enabled)
-            .returning(Account.id)
-        )
-        await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        async with sqlite_writer_section():
+            result = await self._session.execute(
+                update(Account)
+                .where(Account.id == account_id)
+                .values(security_work_authorized=enabled)
+                .returning(Account.id)
+            )
+            await self._session.commit()
+            return result.scalar_one_or_none() is not None
 
     async def update_status_if_current(
         self,
@@ -484,72 +515,83 @@ class AccountsRepository:
         expected_reset_at: int | None = None,
         expected_blocked_at: int | None | object = _UNSET,
     ) -> bool:
-        values: dict[str, object | None] = {
-            "status": status,
-            "deactivation_reason": deactivation_reason,
-            "reset_at": reset_at,
-        }
-        if blocked_at is not _UNSET:
-            values["blocked_at"] = blocked_at
-        stmt = (
-            update(Account)
-            .where(Account.id == account_id)
-            .where(Account.status == expected_status)
-            .values(**values)
-            .returning(Account.id)
-        )
-        if expected_deactivation_reason is None:
-            stmt = stmt.where(Account.deactivation_reason.is_(None))
-        else:
-            stmt = stmt.where(Account.deactivation_reason == expected_deactivation_reason)
-        if expected_reset_at is None:
-            stmt = stmt.where(Account.reset_at.is_(None))
-        else:
-            stmt = stmt.where(Account.reset_at == expected_reset_at)
-        if expected_blocked_at is not _UNSET:
-            if expected_blocked_at is None:
-                stmt = stmt.where(Account.blocked_at.is_(None))
+        async with sqlite_writer_section():
+            values: dict[str, object | None] = {
+                "status": status,
+                "deactivation_reason": deactivation_reason,
+                "reset_at": reset_at,
+            }
+            if blocked_at is not _UNSET:
+                values["blocked_at"] = blocked_at
+            stmt = (
+                update(Account)
+                .where(Account.id == account_id)
+                .where(Account.status == expected_status)
+                .values(**values)
+                .returning(Account.id)
+            )
+            if expected_deactivation_reason is None:
+                stmt = stmt.where(Account.deactivation_reason.is_(None))
             else:
-                stmt = stmt.where(Account.blocked_at == expected_blocked_at)
-        result = await self._session.execute(stmt)
-        await self._session.commit()
-        return result.scalar_one_or_none() is not None
+                stmt = stmt.where(Account.deactivation_reason == expected_deactivation_reason)
+            if expected_reset_at is None:
+                stmt = stmt.where(Account.reset_at.is_(None))
+            else:
+                stmt = stmt.where(Account.reset_at == expected_reset_at)
+            if expected_blocked_at is not _UNSET:
+                if expected_blocked_at is None:
+                    stmt = stmt.where(Account.blocked_at.is_(None))
+                else:
+                    stmt = stmt.where(Account.blocked_at == expected_blocked_at)
+            result = await self._session.execute(stmt)
+            await self._session.commit()
+            return result.scalar_one_or_none() is not None
 
     async def update_alias(self, account_id: str, alias: str | None) -> bool:
-        result = await self._session.execute(
-            update(Account).where(Account.id == account_id).values(alias=alias).returning(Account.id)
-        )
-        await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        async with sqlite_writer_section():
+            result = await self._session.execute(
+                update(Account).where(Account.id == account_id).values(alias=alias).returning(Account.id)
+            )
+            await self._session.commit()
+            return result.scalar_one_or_none() is not None
 
     async def update_limit_warmup_enabled(self, account_id: str, enabled: bool) -> bool:
-        result = await self._session.execute(
-            update(Account).where(Account.id == account_id).values(limit_warmup_enabled=enabled).returning(Account.id)
-        )
-        await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        async with sqlite_writer_section():
+            result = await self._session.execute(
+                update(Account)
+                .where(Account.id == account_id)
+                .values(limit_warmup_enabled=enabled)
+                .returning(Account.id)
+            )
+            await self._session.commit()
+            return result.scalar_one_or_none() is not None
 
     async def update_routing_policy(self, account_id: str, routing_policy: str) -> bool:
-        result = await self._session.execute(
-            update(Account).where(Account.id == account_id).values(routing_policy=routing_policy).returning(Account.id)
-        )
-        await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        async with sqlite_writer_section():
+            result = await self._session.execute(
+                update(Account)
+                .where(Account.id == account_id)
+                .values(routing_policy=routing_policy)
+                .returning(Account.id)
+            )
+            await self._session.commit()
+            return result.scalar_one_or_none() is not None
 
     async def delete(self, account_id: str, *, delete_history: bool = False) -> bool:
-        await self._session.execute(delete(UsageHistory).where(UsageHistory.account_id == account_id))
-        if delete_history:
-            await self._session.execute(delete(RequestLog).where(RequestLog.account_id == account_id))
-        else:
-            await self._session.execute(
-                update(RequestLog)
-                .where(RequestLog.account_id == account_id)
-                .values(account_id=None, deleted_at=utcnow()),
-            )
-        await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
-        result = await self._session.execute(delete(Account).where(Account.id == account_id).returning(Account.id))
-        await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        async with sqlite_writer_section():
+            await self._session.execute(delete(UsageHistory).where(UsageHistory.account_id == account_id))
+            if delete_history:
+                await self._session.execute(delete(RequestLog).where(RequestLog.account_id == account_id))
+            else:
+                await self._session.execute(
+                    update(RequestLog)
+                    .where(RequestLog.account_id == account_id)
+                    .values(account_id=None, deleted_at=utcnow()),
+                )
+            await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
+            result = await self._session.execute(delete(Account).where(Account.id == account_id).returning(Account.id))
+            await self._session.commit()
+            return result.scalar_one_or_none() is not None
 
     async def update_tokens(
         self,
@@ -565,29 +607,30 @@ class AccountsRepository:
         workspace_label: str | None = None,
         seat_type: str | None = None,
     ) -> bool:
-        values: dict[str, bytes | datetime | str] = {
-            "access_token_encrypted": access_token_encrypted,
-            "refresh_token_encrypted": refresh_token_encrypted,
-            "id_token_encrypted": id_token_encrypted,
-            "last_refresh": last_refresh,
-        }
-        if plan_type is not None:
-            values["plan_type"] = plan_type
-        if email is not None:
-            values["email"] = email
-        if chatgpt_account_id is not None:
-            values["chatgpt_account_id"] = chatgpt_account_id
-        if workspace_id is not None:
-            values["workspace_id"] = workspace_id
-        if workspace_label is not None:
-            values["workspace_label"] = workspace_label
-        if seat_type is not None:
-            values["seat_type"] = seat_type
-        result = await self._session.execute(
-            update(Account).where(Account.id == account_id).values(**values).returning(Account.id)
-        )
-        await self._session.commit()
-        return result.scalar_one_or_none() is not None
+        async with sqlite_writer_section():
+            values: dict[str, bytes | datetime | str] = {
+                "access_token_encrypted": access_token_encrypted,
+                "refresh_token_encrypted": refresh_token_encrypted,
+                "id_token_encrypted": id_token_encrypted,
+                "last_refresh": last_refresh,
+            }
+            if plan_type is not None:
+                values["plan_type"] = plan_type
+            if email is not None:
+                values["email"] = email
+            if chatgpt_account_id is not None:
+                values["chatgpt_account_id"] = chatgpt_account_id
+            if workspace_id is not None:
+                values["workspace_id"] = workspace_id
+            if workspace_label is not None:
+                values["workspace_label"] = workspace_label
+            if seat_type is not None:
+                values["seat_type"] = seat_type
+            result = await self._session.execute(
+                update(Account).where(Account.id == account_id).values(**values).returning(Account.id)
+            )
+            await self._session.commit()
+            return result.scalar_one_or_none() is not None
 
     async def workspace_slot_taken(
         self,

--- a/openspec/changes/harden-sqlite-backups-writes/proposal.md
+++ b/openspec/changes/harden-sqlite-backups-writes/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Local SQLite deployments can run with WAL enabled and multiple async database
+connections. Pre-migration backups that copy only the main database file can miss
+uncheckpointed WAL pages, and account writes that bypass the shared SQLite write
+section can contend with other writer paths during high account churn.
+
+## What Changes
+
+- Create SQLite pre-migration backups through SQLite's online backup API so WAL
+  content is included in the backup database.
+- Route account mutation methods through the shared SQLite writer section while
+  preserving PostgreSQL locking behavior.
+
+## Impact
+
+- **Database safety**: local SQLite backups are consistent snapshots, including
+  WAL-resident rows.
+- **Runtime behavior**: account import, reauth, token refresh, status updates,
+  account preferences, and account deletion serialize with other SQLite write
+  sections.

--- a/openspec/changes/harden-sqlite-backups-writes/specs/database-backends/spec.md
+++ b/openspec/changes/harden-sqlite-backups-writes/specs/database-backends/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: SQLite account writes share the local writer section
+
+SQLite account mutation paths SHALL enter the shared SQLite writer section
+before performing database writes. This includes account import/upsert,
+reauthentication upsert, token refresh persistence, status transitions,
+account-level dashboard preference writes, and account deletion.
+
+PostgreSQL account mutation paths SHALL preserve their existing transaction and
+advisory-lock behavior.
+
+#### Scenario: Account token persistence is serialized on SQLite
+
+- **GIVEN** the deployment uses a file-backed SQLite database
+- **WHEN** an account token refresh persists new encrypted token values
+- **THEN** the write executes inside the shared SQLite writer section
+
+#### Scenario: Account status persistence is serialized on SQLite
+
+- **GIVEN** the deployment uses a file-backed SQLite database
+- **WHEN** an account status transition is persisted
+- **THEN** the write executes inside the shared SQLite writer section

--- a/openspec/changes/harden-sqlite-backups-writes/specs/database-migrations/spec.md
+++ b/openspec/changes/harden-sqlite-backups-writes/specs/database-migrations/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: SQLite pre-migration backups use online snapshots
+
+When startup creates a pre-migration backup for a SQLite database, it SHALL use
+SQLite's online backup mechanism rather than copying only the main database
+file. The backup SHALL include committed rows that are currently resident in WAL
+state and SHALL produce a standalone SQLite database file without requiring a
+sidecar WAL file.
+
+#### Scenario: WAL-resident rows are present in the backup
+
+- **GIVEN** a file-backed SQLite database has WAL mode enabled
+- **AND** committed rows are still present in the source database WAL
+- **WHEN** the pre-migration backup is created
+- **THEN** those rows are queryable from the backup database
+- **AND** the backup passes SQLite integrity checking

--- a/openspec/changes/harden-sqlite-backups-writes/tasks.md
+++ b/openspec/changes/harden-sqlite-backups-writes/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Replace pre-migration database file copying with SQLite online backup.
+- [x] 1.2 Serialize account mutation methods with the shared SQLite writer section.
+
+## 2. Tests
+
+- [x] 2.1 Cover WAL-backed pre-migration backup snapshots.
+- [x] 2.2 Cover account status and token writes entering the SQLite writer section.
+
+## 3. Validation
+
+- [x] 3.1 Run focused unit tests.
+- [x] 3.2 Run lint/type checks relevant to the patch.
+- [ ] 3.3 Validate the OpenSpec change and specs.

--- a/tests/unit/test_accounts_repository_locks.py
+++ b/tests/unit/test_accounts_repository_locks.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import app.modules.accounts.repository as repository_module
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
@@ -80,6 +82,80 @@ def _make_postgres_repo(monkeypatch: pytest.MonkeyPatch) -> tuple[AccountsReposi
     monkeypatch.setattr(repo, "_next_available_account_id", fake_next_available_account_id)
 
     return repo, recorded
+
+
+def _make_result(value: str | None = "acc") -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    return result
+
+
+@pytest.mark.asyncio
+async def test_account_update_status_uses_sqlite_writer_section(monkeypatch):
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_make_result("acc"))
+    session.commit = AsyncMock()
+    repo = AccountsRepository(session)
+    order: list[str] = []
+
+    @asynccontextmanager
+    async def fake_writer_section():
+        order.append("lock-enter")
+        yield
+        order.append("lock-exit")
+
+    async def execute_with_order(*args, **kwargs):
+        del args, kwargs
+        order.append("execute")
+        return _make_result("acc")
+
+    async def commit_with_order():
+        order.append("commit")
+
+    monkeypatch.setattr(repository_module, "sqlite_writer_section", fake_writer_section)
+    session.execute.side_effect = execute_with_order
+    session.commit.side_effect = commit_with_order
+
+    assert await repo.update_status("acc", AccountStatus.RATE_LIMITED) is True
+
+    assert order == ["lock-enter", "execute", "commit", "lock-exit"]
+
+
+@pytest.mark.asyncio
+async def test_account_update_tokens_uses_sqlite_writer_section(monkeypatch):
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_make_result("acc"))
+    session.commit = AsyncMock()
+    repo = AccountsRepository(session)
+    order: list[str] = []
+
+    @asynccontextmanager
+    async def fake_writer_section():
+        order.append("lock-enter")
+        yield
+        order.append("lock-exit")
+
+    async def execute_with_order(*args, **kwargs):
+        del args, kwargs
+        order.append("execute")
+        return _make_result("acc")
+
+    async def commit_with_order():
+        order.append("commit")
+
+    monkeypatch.setattr(repository_module, "sqlite_writer_section", fake_writer_section)
+    session.execute.side_effect = execute_with_order
+    session.commit.side_effect = commit_with_order
+
+    assert await repo.update_tokens(
+        "acc",
+        b"access",
+        b"refresh",
+        b"id",
+        utcnow(),
+    )
+
+    assert order == ["lock-enter", "execute", "commit", "lock-exit"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -929,6 +929,21 @@ def test_create_sqlite_pre_migration_backup_consolidates_wal_rows(tmp_path: Path
     assert not Path(f"{backup}-wal").exists()
 
 
+def test_create_sqlite_pre_migration_backup_preserves_source_mode(tmp_path: Path) -> None:
+    db_path = tmp_path / "store.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+    db_path.chmod(0o600)
+
+    backup = create_sqlite_pre_migration_backup(
+        db_path,
+        max_files=2,
+        now=datetime(2026, 2, 13, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert backup.stat().st_mode & 0o777 == 0o600
+
+
 class _FakeStringType:
     def __init__(self, length: int | None) -> None:
         self.length = length

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -882,7 +883,9 @@ def test_check_migration_policy_reports_head_and_format_violations(monkeypatch, 
 
 def test_create_sqlite_pre_migration_backup_rotates_old_files(tmp_path: Path) -> None:
     db_path = tmp_path / "store.db"
-    db_path.write_bytes(b"sqlite-bytes")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+        conn.execute("INSERT INTO items (name) VALUES ('alpha')")
 
     created: list[Path] = []
     base_time = datetime(2026, 2, 13, 12, 0, 0, tzinfo=timezone.utc)
@@ -898,8 +901,32 @@ def test_create_sqlite_pre_migration_backup_rotates_old_files(tmp_path: Path) ->
     backups = list_sqlite_pre_migration_backups(db_path)
     assert len(backups) == 2
     assert backups == created[-2:]
-    assert backups[0].read_bytes() == b"sqlite-bytes"
-    assert backups[1].read_bytes() == b"sqlite-bytes"
+    for backup in backups:
+        with sqlite3.connect(backup) as conn:
+            assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+            assert conn.execute("SELECT name FROM items").fetchall() == [("alpha",)]
+        assert not Path(f"{backup}-wal").exists()
+
+
+def test_create_sqlite_pre_migration_backup_consolidates_wal_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "store.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+        conn.execute("INSERT INTO items (name) VALUES ('from-wal')")
+        conn.commit()
+        assert Path(f"{db_path}-wal").exists()
+
+        backup = create_sqlite_pre_migration_backup(
+            db_path,
+            max_files=2,
+            now=datetime(2026, 2, 13, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
+    with sqlite3.connect(backup) as conn:
+        assert conn.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+        assert conn.execute("SELECT name FROM items").fetchall() == [("from-wal",)]
+    assert not Path(f"{backup}-wal").exists()
 
 
 class _FakeStringType:


### PR DESCRIPTION
## Summary

- replace SQLite pre-migration file copies with SQLite online backup snapshots, including WAL-resident committed rows
- serialize account mutation paths with the shared SQLite writer section while preserving PostgreSQL advisory-lock behavior
- add OpenSpec deltas and regression tests for WAL backup snapshots and account status/token write locking

## Verification

- `uv run pytest tests/unit/test_db_migrate.py::test_create_sqlite_pre_migration_backup_rotates_old_files tests/unit/test_db_migrate.py::test_create_sqlite_pre_migration_backup_consolidates_wal_rows tests/unit/test_accounts_repository_locks.py tests/unit/test_db_session.py::test_sqlite_writer_section_serializes_file_sqlite_writers tests/unit/test_db_session.py::test_sqlite_writer_section_does_not_serialize_memory_sqlite`
- `uv run ruff check app/db/backup.py app/modules/accounts/repository.py tests/unit/test_db_migrate.py tests/unit/test_accounts_repository_locks.py`
- `uv run ty check app/db/backup.py app/modules/accounts/repository.py tests/unit/test_db_migrate.py tests/unit/test_accounts_repository_locks.py`
- `git diff --check`

## Notes

- OpenSpec validation could not be run locally because the `openspec` CLI is not installed in this environment.
- Full `uv run pytest tests/unit` reached `2631 passed, 39 skipped` but failed on existing `tests/unit/test_usage_updater.py::test_usage_refresh_uses_fresh_monthly_row_for_quota_freshness`, which reproduces by itself and is outside the files changed here.
