### PR TITLE
[codex] Add dashboard account list view

### DIFF
--- a/frontend/src/features/dashboard/components/account-card.tsx
+++ b/frontend/src/features/dashboard/components/account-card.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/utils/account-status";
 import { formatDateTimeInline, formatPercentNullable, formatQuotaResetLabel, formatSlug } from "@/utils/formatters";
 
-type AccountAction = "details" | "resume" | "reauth" | "warmup-toggle";
+export type AccountAction = "details" | "resume" | "reauth" | "warmup-toggle";
 
 export type AccountCardProps = {
   account: AccountSummary;

--- a/frontend/src/features/dashboard/components/account-list.test.tsx
+++ b/frontend/src/features/dashboard/components/account-list.test.tsx
@@ -142,4 +142,77 @@ describe("AccountList", () => {
 
     expect(rowNames()).toEqual(["Low Account", "Middle Account", "Healthy Account"]);
   });
+
+  it("sorts accounts with missing quota telemetry after real quota values", async () => {
+    const user = userEvent.setup();
+    render(
+      <AccountList
+        accounts={[
+          createAccountSummary({
+            accountId: "acc-unknown",
+            displayName: "Unknown Account",
+            usage: {
+              primaryRemainingPercent: null,
+              secondaryRemainingPercent: null,
+              monthlyRemainingPercent: null,
+            },
+          }),
+          createAccountSummary({
+            accountId: "acc-empty",
+            displayName: "Empty Account",
+            usage: { primaryRemainingPercent: 0, secondaryRemainingPercent: 0 },
+          }),
+          createAccountSummary({
+            accountId: "acc-low",
+            displayName: "Low Account",
+            usage: { primaryRemainingPercent: 18, secondaryRemainingPercent: 12 },
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Quota" }));
+
+    expect(rowNames()).toEqual(["Empty Account", "Low Account", "Unknown Account"]);
+
+    await user.click(screen.getByRole("button", { name: "Quota, sorted ascending" }));
+
+    expect(rowNames()).toEqual(["Low Account", "Empty Account", "Unknown Account"]);
+  });
+
+  it("sorts accounts with missing credit telemetry after real credit balances", async () => {
+    const user = userEvent.setup();
+    render(
+      <AccountList
+        accounts={[
+          createAccountSummary({
+            accountId: "acc-unknown",
+            displayName: "Unknown Account",
+            creditsBalance: null,
+            remainingCreditsPrimary: null,
+            remainingCreditsSecondary: null,
+            remainingCreditsMonthly: null,
+          }),
+          createAccountSummary({
+            accountId: "acc-empty",
+            displayName: "Empty Account",
+            creditsBalance: 0,
+          }),
+          createAccountSummary({
+            accountId: "acc-low",
+            displayName: "Low Account",
+            creditsBalance: 2.5,
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Credits" }));
+
+    expect(rowNames()).toEqual(["Empty Account", "Low Account", "Unknown Account"]);
+
+    await user.click(screen.getByRole("button", { name: "Credits, sorted ascending" }));
+
+    expect(rowNames()).toEqual(["Low Account", "Empty Account", "Unknown Account"]);
+  });
 });

--- a/frontend/src/features/dashboard/components/account-list.test.tsx
+++ b/frontend/src/features/dashboard/components/account-list.test.tsx
@@ -106,12 +106,12 @@ describe("AccountList", () => {
     await user.click(screen.getByRole("button", { name: "Account" }));
 
     expect(rowNames()).toEqual(["Alpha Account", "Beta Account", "Charlie Account"]);
-    expect(screen.getByRole("button", { name: "Account" })).toHaveAttribute("aria-sort", "ascending");
+    expect(screen.getByRole("button", { name: "Account, sorted ascending" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Account" }));
+    await user.click(screen.getByRole("button", { name: "Account, sorted ascending" }));
 
     expect(rowNames()).toEqual(["Charlie Account", "Beta Account", "Alpha Account"]);
-    expect(screen.getByRole("button", { name: "Account" })).toHaveAttribute("aria-sort", "descending");
+    expect(screen.getByRole("button", { name: "Account, sorted descending" })).toBeInTheDocument();
   });
 
   it("sorts quota by the lowest visible remaining quota percent", async () => {

--- a/frontend/src/features/dashboard/components/account-list.test.tsx
+++ b/frontend/src/features/dashboard/components/account-list.test.tsx
@@ -1,0 +1,145 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AccountList } from "@/features/dashboard/components/account-list";
+import { usePrivacyStore } from "@/hooks/use-privacy";
+import { createAccountSummary } from "@/test/mocks/factories";
+
+afterEach(() => {
+  act(() => {
+    usePrivacyStore.setState({ blurred: false });
+  });
+});
+
+describe("AccountList", () => {
+  function rowNames() {
+    return screen.getAllByTestId("account-list-row").map((row) => {
+      const paragraph = within(row).getAllByText(/Account$/)[0];
+      return paragraph.textContent;
+    });
+  }
+
+  it("renders a compact list with account status, quota, credits, and warm-up state", () => {
+    render(
+      <AccountList
+        accounts={[
+          createAccountSummary({
+            accountId: "acc-1",
+            displayName: "Primary Account",
+            email: "primary@example.com",
+            status: "active",
+            creditsBalance: 42.5,
+            limitWarmupEnabled: true,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("dashboard-account-list")).toBeInTheDocument();
+    expect(screen.getByText("Primary Account")).toBeInTheDocument();
+    expect(screen.getByText("primary@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("5h")).toBeInTheDocument();
+    expect(screen.getByText("Weekly")).toBeInTheDocument();
+    expect(screen.getAllByTestId("account-list-quota-meter")).toHaveLength(2);
+    expect(screen.getByText("42.50")).toBeInTheDocument();
+    expect(screen.getByText("On")).toBeInTheDocument();
+  });
+
+  it("exposes account actions from list rows", async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    const account = createAccountSummary({
+      accountId: "acc-paused",
+      displayName: "Paused Account",
+      status: "paused",
+      limitWarmupEnabled: false,
+    });
+
+    render(<AccountList accounts={[account]} onAction={onAction} />);
+
+    await user.click(screen.getByRole("button", { name: "View details for Paused Account" }));
+    await user.click(screen.getByRole("button", { name: "Enable limit warm-up for Paused Account" }));
+    await user.click(screen.getByRole("button", { name: "Resume Paused Account" }));
+
+    expect(onAction).toHaveBeenNthCalledWith(1, account, "details");
+    expect(onAction).toHaveBeenNthCalledWith(2, account, "warmup-toggle");
+    expect(onAction).toHaveBeenNthCalledWith(3, account, "resume");
+  });
+
+  it("blurs list identity text when privacy mode is enabled", () => {
+    act(() => {
+      usePrivacyStore.setState({ blurred: true });
+    });
+
+    const { container } = render(
+      <AccountList
+        accounts={[
+          createAccountSummary({
+            accountId: "acc-private",
+            displayName: "Private Account",
+            email: "private@example.com",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Private Account")).toBeInTheDocument();
+    expect(container.querySelector(".privacy-blur")).not.toBeNull();
+  });
+
+  it("sorts by account header and toggles direction", async () => {
+    const user = userEvent.setup();
+    render(
+      <AccountList
+        accounts={[
+          createAccountSummary({ accountId: "acc-b", displayName: "Beta Account" }),
+          createAccountSummary({ accountId: "acc-a", displayName: "Alpha Account" }),
+          createAccountSummary({ accountId: "acc-c", displayName: "Charlie Account" }),
+        ]}
+      />,
+    );
+
+    expect(rowNames()).toEqual(["Beta Account", "Alpha Account", "Charlie Account"]);
+
+    await user.click(screen.getByRole("button", { name: "Account" }));
+
+    expect(rowNames()).toEqual(["Alpha Account", "Beta Account", "Charlie Account"]);
+    expect(screen.getByRole("button", { name: "Account" })).toHaveAttribute("aria-sort", "ascending");
+
+    await user.click(screen.getByRole("button", { name: "Account" }));
+
+    expect(rowNames()).toEqual(["Charlie Account", "Beta Account", "Alpha Account"]);
+    expect(screen.getByRole("button", { name: "Account" })).toHaveAttribute("aria-sort", "descending");
+  });
+
+  it("sorts quota by the lowest visible remaining quota percent", async () => {
+    const user = userEvent.setup();
+    render(
+      <AccountList
+        accounts={[
+          createAccountSummary({
+            accountId: "acc-healthy",
+            displayName: "Healthy Account",
+            usage: { primaryRemainingPercent: 91, secondaryRemainingPercent: 88 },
+          }),
+          createAccountSummary({
+            accountId: "acc-low",
+            displayName: "Low Account",
+            usage: { primaryRemainingPercent: 62, secondaryRemainingPercent: 4 },
+          }),
+          createAccountSummary({
+            accountId: "acc-mid",
+            displayName: "Middle Account",
+            usage: { primaryRemainingPercent: 50, secondaryRemainingPercent: 40 },
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Quota" }));
+
+    expect(rowNames()).toEqual(["Low Account", "Middle Account", "Healthy Account"]);
+  });
+});

--- a/frontend/src/features/dashboard/components/account-list.tsx
+++ b/frontend/src/features/dashboard/components/account-list.tsx
@@ -1,0 +1,380 @@
+import { ArrowDown, ArrowUp, ArrowUpDown, Clock, ExternalLink, List, Play, RotateCcw, Zap } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { EmptyState } from "@/components/empty-state";
+import { StatusBadge } from "@/components/status-badge";
+import { Button } from "@/components/ui/button";
+import type { AccountAction } from "@/features/dashboard/components/account-card";
+import type { AccountSummary } from "@/features/dashboard/schemas";
+import { usePrivacyStore } from "@/hooks/use-privacy";
+import { cn } from "@/lib/utils";
+import { formatCompactAccountId } from "@/utils/account-identifiers";
+import { normalizeStatus, quotaBarColor, quotaBarTrack } from "@/utils/account-status";
+import { formatDateTimeInline, formatPercentNullable, formatQuotaResetLabel, formatSlug } from "@/utils/formatters";
+
+const ACCOUNT_LIST_VISIBLE_ROWS = 8;
+const ACCOUNT_LIST_ROW_HEIGHT_REM = 4.5;
+const ACCOUNT_LIST_COLUMNS = "minmax(13rem,1.3fr) 7.75rem 5rem minmax(14rem,1.2fr) 6rem minmax(8rem,0.8fr) 6.5rem";
+
+type AccountListProps = {
+  accounts: AccountSummary[];
+  onAction?: (account: AccountSummary, action: AccountAction) => void;
+};
+
+type AccountListSortKey = "account" | "status" | "plan" | "quota" | "credits" | "warmup";
+type SortDirection = "asc" | "desc";
+type AccountListSort = {
+  key: AccountListSortKey;
+  direction: SortDirection;
+} | null;
+
+const SORTABLE_HEADERS: Array<{ key: AccountListSortKey; label: string }> = [
+  { key: "account", label: "Account" },
+  { key: "status", label: "Status" },
+  { key: "plan", label: "Plan" },
+  { key: "quota", label: "Quota" },
+  { key: "credits", label: "Credits" },
+  { key: "warmup", label: "Warm-up" },
+];
+
+function quotaLabel(label: string, percent: number | null, resetAt: string | null | undefined) {
+  return {
+    label,
+    percent,
+    percentLabel: formatPercentNullable(percent),
+    resetLabel: formatQuotaResetLabel(resetAt ?? null),
+  };
+}
+
+function accountQuotaLabels(account: AccountSummary) {
+  const weeklyOnly = account.windowMinutesPrimary == null && account.windowMinutesSecondary != null;
+  const monthlyOnly =
+    account.windowMinutesMonthly != null &&
+    account.windowMinutesPrimary == null &&
+    account.windowMinutesSecondary == null;
+
+  if (monthlyOnly) {
+    return [
+      quotaLabel("Monthly", account.usage?.monthlyRemainingPercent ?? null, account.resetAtMonthly),
+    ];
+  }
+
+  if (weeklyOnly) {
+    return [
+      quotaLabel("Weekly", account.usage?.secondaryRemainingPercent ?? null, account.resetAtSecondary),
+    ];
+  }
+
+  return [
+    quotaLabel("5h", account.usage?.primaryRemainingPercent ?? null, account.resetAtPrimary),
+    quotaLabel("Weekly", account.usage?.secondaryRemainingPercent ?? null, account.resetAtSecondary),
+  ];
+}
+
+function accountTitle(account: AccountSummary): string {
+  return account.displayName || account.email || account.accountId;
+}
+
+function compareText(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { sensitivity: "base", numeric: true });
+}
+
+function accountQuotaSortValue(account: AccountSummary): number {
+  const values = accountQuotaLabels(account)
+    .map((quota) => quota.percent)
+    .filter((percent): percent is number => percent !== null);
+  if (values.length === 0) {
+    return -1;
+  }
+  return Math.min(...values);
+}
+
+function accountCreditsLabel(account: AccountSummary) {
+  const monthlyOnly =
+    account.windowMinutesMonthly != null &&
+    account.windowMinutesPrimary == null &&
+    account.windowMinutesSecondary == null;
+  const weeklyOnly = account.windowMinutesPrimary == null && account.windowMinutesSecondary != null;
+  const displayCredits = account.creditsBalance ?? (
+    monthlyOnly
+      ? account.remainingCreditsMonthly
+      : weeklyOnly
+        ? account.remainingCreditsSecondary
+        : (account.remainingCreditsSecondary ?? account.remainingCreditsPrimary)
+  );
+  if (account.creditsUnlimited) {
+    return "Unlimited";
+  }
+  return displayCredits === null || displayCredits === undefined ? "-" : displayCredits.toFixed(2);
+}
+
+function accountCreditsSortValue(account: AccountSummary): number {
+  if (account.creditsUnlimited) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const value = Number(accountCreditsLabel(account));
+  return Number.isFinite(value) ? value : -1;
+}
+
+function accountWarmupSortValue(account: AccountSummary): string {
+  const enabledPrefix = account.limitWarmupEnabled ? "0" : "1";
+  const attemptedAt = account.limitWarmup?.completedAt ?? account.limitWarmup?.attemptedAt ?? "";
+  return `${enabledPrefix}|${attemptedAt}|${account.accountId}`;
+}
+
+function compareAccountsBySort(a: AccountSummary, b: AccountSummary, sort: AccountListSort): number {
+  if (!sort) {
+    return 0;
+  }
+
+  let result = 0;
+  switch (sort.key) {
+    case "account":
+      result = compareText(accountTitle(a), accountTitle(b));
+      break;
+    case "status":
+      result = compareText(normalizeStatus(a.status), normalizeStatus(b.status));
+      break;
+    case "plan":
+      result = compareText(formatSlug(a.planType), formatSlug(b.planType));
+      break;
+    case "quota":
+      result = accountQuotaSortValue(a) - accountQuotaSortValue(b);
+      break;
+    case "credits":
+      result = accountCreditsSortValue(a) - accountCreditsSortValue(b);
+      break;
+    case "warmup":
+      result = compareText(accountWarmupSortValue(a), accountWarmupSortValue(b));
+      break;
+  }
+
+  if (result === 0) {
+    result = compareText(accountTitle(a), accountTitle(b));
+  }
+  return sort.direction === "asc" ? result : -result;
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  activeSort,
+  onSort,
+}: {
+  label: string;
+  sortKey: AccountListSortKey;
+  activeSort: AccountListSort;
+  onSort: (key: AccountListSortKey) => void;
+}) {
+  const active = activeSort?.key === sortKey;
+  const Icon = active ? (activeSort.direction === "asc" ? ArrowUp : ArrowDown) : ArrowUpDown;
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex min-w-0 items-center gap-1 text-left uppercase tracking-wider transition-colors hover:text-foreground",
+        active ? "text-foreground" : "text-muted-foreground",
+      )}
+      aria-sort={active ? (activeSort.direction === "asc" ? "ascending" : "descending") : "none"}
+      onClick={() => onSort(sortKey)}
+    >
+      <span className="truncate">{label}</span>
+      <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />
+    </button>
+  );
+}
+
+function AccountQuotaCells({ account }: { account: AccountSummary }) {
+  return (
+    <div className="grid gap-1.5 text-xs">
+      {accountQuotaLabels(account).map((quota) => (
+        <div key={quota.label} className="grid grid-cols-[2.75rem_minmax(3rem,auto)_minmax(2.75rem,0.45fr)_minmax(0,1fr)] items-center gap-2">
+          <span className="text-muted-foreground">{quota.label}</span>
+          <span className="font-medium tabular-nums text-foreground">{quota.percentLabel}</span>
+          <QuotaMeter percent={quota.percent} />
+          <span className="inline-flex min-w-0 items-center gap-1 text-[11px] text-muted-foreground">
+            <Clock className="h-3 w-3 shrink-0" aria-hidden="true" />
+            <span className="truncate">{quota.resetLabel}</span>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function QuotaMeter({ percent }: { percent: number | null }) {
+  const clamped = percent === null ? 0 : Math.max(0, Math.min(100, percent));
+  return (
+    <div
+      className={cn("h-1.5 overflow-hidden rounded-full", quotaBarTrack(clamped))}
+      aria-hidden="true"
+      data-testid="account-list-quota-meter"
+    >
+      <div
+        className={cn("h-full rounded-full transition-all duration-500 ease-out", quotaBarColor(clamped))}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}
+
+export function AccountList({ accounts, onAction }: AccountListProps) {
+  const blurred = usePrivacyStore((s) => s.blurred);
+  const [sort, setSort] = useState<AccountListSort>(null);
+  const sortedAccounts = useMemo(() => {
+    if (!sort) {
+      return accounts;
+    }
+    return accounts
+      .map((account, index) => ({ account, index }))
+      .sort((a, b) => compareAccountsBySort(a.account, b.account, sort) || a.index - b.index)
+      .map((entry) => entry.account);
+  }, [accounts, sort]);
+
+  const handleSort = (key: AccountListSortKey) => {
+    setSort((current) => {
+      if (current?.key !== key) {
+        return { key, direction: "asc" };
+      }
+      return { key, direction: current.direction === "asc" ? "desc" : "asc" };
+    });
+  };
+
+  if (accounts.length === 0) {
+    return (
+      <EmptyState
+        icon={List}
+        title="No accounts connected yet"
+        description="Import or authenticate an account to get started."
+      />
+    );
+  }
+
+  return (
+    <div
+      data-testid="dashboard-account-list"
+      className="overflow-x-auto rounded-lg border bg-card"
+    >
+      <div
+        className="min-w-[54rem] divide-y overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={{ maxHeight: `${ACCOUNT_LIST_VISIBLE_ROWS * ACCOUNT_LIST_ROW_HEIGHT_REM}rem` }}
+      >
+        <div
+          className="grid gap-3 bg-muted/35 px-3 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground"
+          style={{ gridTemplateColumns: ACCOUNT_LIST_COLUMNS }}
+        >
+          {SORTABLE_HEADERS.map((header) => (
+            <SortHeader
+              key={header.key}
+              label={header.label}
+              sortKey={header.key}
+              activeSort={sort}
+              onSort={handleSort}
+            />
+          ))}
+          <span className="text-right">Actions</span>
+        </div>
+        {sortedAccounts.map((account, index) => {
+          const status = normalizeStatus(account.status);
+          const title = accountTitle(account);
+          const emailSubtitle =
+            account.displayName && account.displayName !== account.email
+              ? account.email
+              : null;
+          const compactId = formatCompactAccountId(account.accountId);
+          const showAccountId = account.isEmailDuplicate === true;
+          const warmupDetail = account.limitWarmup
+            ? `${formatSlug(account.limitWarmup.status)} | ${account.limitWarmup.window === "primary" ? "5h" : "weekly"} | ${formatDateTimeInline(account.limitWarmup.completedAt ?? account.limitWarmup.attemptedAt)}`
+            : "No attempts";
+          return (
+            <div
+              key={account.accountId}
+              data-testid="account-list-row"
+              className="grid min-h-[4.5rem] items-center gap-3 px-3 py-2 text-sm"
+              style={{ animationDelay: `${index * 50}ms`, gridTemplateColumns: ACCOUNT_LIST_COLUMNS }}
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium leading-tight">
+                  <span className={blurred ? "privacy-blur" : undefined}>{title}</span>
+                </p>
+                <p className="mt-1 truncate text-xs text-muted-foreground">
+                  {emailSubtitle ? (
+                    <span className={blurred ? "privacy-blur" : undefined}>{emailSubtitle}</span>
+                  ) : (
+                    `ID ${compactId}`
+                  )}
+                  {showAccountId && emailSubtitle ? ` | ID ${compactId}` : ""}
+                </p>
+              </div>
+              <StatusBadge status={status} />
+              <span className="text-xs text-muted-foreground">{formatSlug(account.planType)}</span>
+              <AccountQuotaCells account={account} />
+              <span className="font-medium tabular-nums">{accountCreditsLabel(account)}</span>
+              <div className="min-w-0 text-xs">
+                <p className={cn("font-medium", account.limitWarmupEnabled ? "text-primary" : "text-muted-foreground")}>
+                  {account.limitWarmupEnabled ? "On" : "Off"}
+                </p>
+                <p className="truncate text-[11px] text-muted-foreground">{warmupDetail}</p>
+              </div>
+              <div className="flex justify-end gap-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 w-7 rounded-md p-0 text-muted-foreground hover:text-foreground"
+                  aria-label={`View details for ${title}`}
+                  title="Details"
+                  onClick={() => onAction?.(account, "details")}
+                >
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className={cn(
+                    "h-7 w-7 rounded-md p-0",
+                    account.limitWarmupEnabled
+                      ? "text-primary hover:bg-primary/10 hover:text-primary"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                  aria-label={`${account.limitWarmupEnabled ? "Disable" : "Enable"} limit warm-up for ${title}`}
+                  title="Limit warm-up"
+                  onClick={() => onAction?.(account, "warmup-toggle")}
+                >
+                  <Zap className="h-3.5 w-3.5" aria-hidden="true" />
+                </Button>
+                {status === "paused" ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 w-7 rounded-md p-0 text-emerald-600 hover:bg-emerald-500/10 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
+                    aria-label={`Resume ${title}`}
+                    title="Resume"
+                    onClick={() => onAction?.(account, "resume")}
+                  >
+                    <Play className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                ) : null}
+                {status === "reauth" || status === "deactivated" ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 w-7 rounded-md p-0 text-amber-600 hover:bg-amber-500/10 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300"
+                    aria-label={`Re-authenticate ${title}`}
+                    title="Re-authenticate"
+                    onClick={() => onAction?.(account, "reauth")}
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/account-list.tsx
+++ b/frontend/src/features/dashboard/components/account-list.tsx
@@ -168,6 +168,7 @@ function SortHeader({
 }) {
   const active = activeSort?.key === sortKey;
   const Icon = active ? (activeSort.direction === "asc" ? ArrowUp : ArrowDown) : ArrowUpDown;
+  const sortLabel = active ? `${label}, sorted ${activeSort.direction === "asc" ? "ascending" : "descending"}` : label;
   return (
     <button
       type="button"
@@ -175,7 +176,7 @@ function SortHeader({
         "inline-flex min-w-0 items-center gap-1 text-left uppercase tracking-wider transition-colors hover:text-foreground",
         active ? "text-foreground" : "text-muted-foreground",
       )}
-      aria-sort={active ? (activeSort.direction === "asc" ? "ascending" : "descending") : "none"}
+      aria-label={sortLabel}
       onClick={() => onSort(sortKey)}
     >
       <span className="truncate">{label}</span>

--- a/frontend/src/features/dashboard/components/account-list.tsx
+++ b/frontend/src/features/dashboard/components/account-list.tsx
@@ -79,12 +79,12 @@ function compareText(a: string, b: string): number {
   return a.localeCompare(b, undefined, { sensitivity: "base", numeric: true });
 }
 
-function accountQuotaSortValue(account: AccountSummary): number {
+function accountQuotaSortValue(account: AccountSummary): number | null {
   const values = accountQuotaLabels(account)
     .map((quota) => quota.percent)
     .filter((percent): percent is number => percent !== null);
   if (values.length === 0) {
-    return -1;
+    return null;
   }
   return Math.min(...values);
 }
@@ -108,12 +108,26 @@ function accountCreditsLabel(account: AccountSummary) {
   return displayCredits === null || displayCredits === undefined ? "-" : displayCredits.toFixed(2);
 }
 
-function accountCreditsSortValue(account: AccountSummary): number {
+function accountCreditsSortValue(account: AccountSummary): number | null {
   if (account.creditsUnlimited) {
     return Number.POSITIVE_INFINITY;
   }
   const value = Number(accountCreditsLabel(account));
-  return Number.isFinite(value) ? value : -1;
+  return Number.isFinite(value) ? value : null;
+}
+
+function compareNullableNumber(a: number | null, b: number | null, direction: SortDirection): number {
+  if (a === null || b === null) {
+    if (a === b) {
+      return 0;
+    }
+    return a === null ? 1 : -1;
+  }
+  if (a === b) {
+    return 0;
+  }
+  const result = a - b;
+  return direction === "asc" ? result : -result;
 }
 
 function accountWarmupSortValue(account: AccountSummary): string {
@@ -139,10 +153,10 @@ function compareAccountsBySort(a: AccountSummary, b: AccountSummary, sort: Accou
       result = compareText(formatSlug(a.planType), formatSlug(b.planType));
       break;
     case "quota":
-      result = accountQuotaSortValue(a) - accountQuotaSortValue(b);
+      result = compareNullableNumber(accountQuotaSortValue(a), accountQuotaSortValue(b), sort.direction);
       break;
     case "credits":
-      result = accountCreditsSortValue(a) - accountCreditsSortValue(b);
+      result = compareNullableNumber(accountCreditsSortValue(a), accountCreditsSortValue(b), sort.direction);
       break;
     case "warmup":
       result = compareText(accountWarmupSortValue(a), accountWarmupSortValue(b));
@@ -151,6 +165,10 @@ function compareAccountsBySort(a: AccountSummary, b: AccountSummary, sort: Accou
 
   if (result === 0) {
     result = compareText(accountTitle(a), accountTitle(b));
+    return sort.direction === "asc" ? result : -result;
+  }
+  if (sort.key === "quota" || sort.key === "credits") {
+    return result;
   }
   return sort.direction === "asc" ? result : -result;
 }

--- a/frontend/src/features/dashboard/components/account-view-mode-toggle.tsx
+++ b/frontend/src/features/dashboard/components/account-view-mode-toggle.tsx
@@ -1,0 +1,48 @@
+import { Grid2X2, List } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { DashboardAccountViewMode } from "@/hooks/use-dashboard-preferences";
+
+type AccountViewModeToggleProps = {
+  value: DashboardAccountViewMode;
+  onChange: (value: DashboardAccountViewMode) => void;
+};
+
+const OPTIONS: Array<{ value: DashboardAccountViewMode; label: string; icon: typeof Grid2X2 }> = [
+  { value: "cards", label: "View accounts as cards", icon: Grid2X2 },
+  { value: "list", label: "View accounts as list", icon: List },
+];
+
+export function AccountViewModeToggle({ value, onChange }: AccountViewModeToggleProps) {
+  return (
+    <div
+      className="inline-flex h-8 items-center rounded-md border bg-background p-0.5"
+      role="radiogroup"
+      aria-label="Account view mode"
+    >
+      {OPTIONS.map((option) => {
+        const Icon = option.icon;
+        const selected = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-label={option.label}
+            title={option.label}
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "inline-flex h-6 w-7 items-center justify-center rounded-[5px] text-muted-foreground transition-colors",
+              selected
+                ? "bg-accent text-accent-foreground shadow-sm"
+                : "hover:bg-accent/60 hover:text-accent-foreground",
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/dashboard-page.test.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders } from "@/test/utils";
 import { createDashboardOverview, createDashboardProjections } from "@/test/mocks/factories";
@@ -7,10 +8,13 @@ import { useAccountMutations } from "@/features/accounts/hooks/use-accounts";
 import { useDashboard, useDashboardProjections } from "@/features/dashboard/hooks/use-dashboard";
 import { useRequestLogs } from "@/features/dashboard/hooks/use-request-logs";
 import { buildDashboardView } from "@/features/dashboard/utils";
+import { useDashboardPreferencesStore } from "@/hooks/use-dashboard-preferences";
 
 import { DashboardPage } from "./dashboard-page";
 
-const { accountSummaryLineSpy } = vi.hoisted(() => ({
+const { accountCardsSpy, accountListSpy, accountSummaryLineSpy } = vi.hoisted(() => ({
+  accountCardsSpy: vi.fn(),
+  accountListSpy: vi.fn(),
   accountSummaryLineSpy: vi.fn(),
 }));
 
@@ -32,7 +36,17 @@ vi.mock("@/features/dashboard/utils", () => ({
 }));
 
 vi.mock("@/features/dashboard/components/account-cards", () => ({
-  AccountCards: () => <div data-testid="account-cards" />,
+  AccountCards: ({ accounts }: { accounts: Array<{ accountId: string }> }) => {
+    accountCardsSpy(accounts);
+    return <div data-testid="account-cards">Cards for {accounts.length} accounts</div>;
+  },
+}));
+
+vi.mock("@/features/dashboard/components/account-list", () => ({
+  AccountList: ({ accounts }: { accounts: Array<{ accountId: string }> }) => {
+    accountListSpy(accounts);
+    return <div data-testid="account-list">List for {accounts.length} accounts</div>;
+  },
 }));
 
 vi.mock("@/features/dashboard/components/account-summary-line", () => ({
@@ -78,15 +92,22 @@ const buildDashboardViewMock = vi.mocked(buildDashboardView);
 
 describe("DashboardPage", () => {
   beforeEach(() => {
+    accountCardsSpy.mockReset();
+    accountListSpy.mockReset();
     accountSummaryLineSpy.mockReset();
     useAccountMutationsMock.mockReset();
     useDashboardMock.mockReset();
     useDashboardProjectionsMock.mockReset();
     useRequestLogsMock.mockReset();
     buildDashboardViewMock.mockReset();
+    useDashboardPreferencesStore.setState({
+      accountBurnrateEnabled: true,
+      accountViewMode: "cards",
+      initialized: true,
+    });
   });
 
-  it("renders the account summary line in the Accounts header using overview accounts", () => {
+  function mockReadyDashboard() {
     const overview = createDashboardOverview();
 
     useAccountMutationsMock.mockReturnValue({
@@ -153,6 +174,12 @@ describe("DashboardPage", () => {
       requestLogs: [],
     } as ReturnType<typeof buildDashboardView>);
 
+    return overview;
+  }
+
+  it("renders the account summary line in the Accounts header using overview accounts", () => {
+    const overview = mockReadyDashboard();
+
     renderWithProviders(<DashboardPage />);
 
     const accountsHeader = screen.getByRole("heading", { name: "Accounts" }).parentElement;
@@ -162,5 +189,30 @@ describe("DashboardPage", () => {
       "Summary for 2 accounts",
     );
     expect(accountSummaryLineSpy).toHaveBeenCalledWith(overview.accounts);
+  });
+
+  it("defaults the Accounts section to card view", () => {
+    const overview = mockReadyDashboard();
+
+    renderWithProviders(<DashboardPage />);
+
+    expect(screen.getByTestId("account-cards")).toHaveTextContent("Cards for 2 accounts");
+    expect(screen.queryByTestId("account-list")).not.toBeInTheDocument();
+    expect(accountCardsSpy).toHaveBeenCalledWith(overview.accounts);
+    expect(screen.getByRole("radio", { name: "View accounts as cards" })).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("switches the Accounts section to list view", async () => {
+    const user = userEvent.setup();
+    const overview = mockReadyDashboard();
+
+    renderWithProviders(<DashboardPage />);
+
+    await user.click(screen.getByRole("radio", { name: "View accounts as list" }));
+
+    expect(screen.getByTestId("account-list")).toHaveTextContent("List for 2 accounts");
+    expect(screen.queryByTestId("account-cards")).not.toBeInTheDocument();
+    expect(accountListSpy).toHaveBeenCalledWith(overview.accounts);
+    expect(useDashboardPreferencesStore.getState().accountViewMode).toBe("list");
   });
 });

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -6,7 +6,9 @@ import { RefreshCw } from "lucide-react";
 import { AlertMessage } from "@/components/alert-message";
 import { useAccountMutations } from "@/features/accounts/hooks/use-accounts";
 import { AccountCards } from "@/features/dashboard/components/account-cards";
+import { AccountList } from "@/features/dashboard/components/account-list";
 import { AccountSummaryLine } from "@/features/dashboard/components/account-summary-line";
+import { AccountViewModeToggle } from "@/features/dashboard/components/account-view-mode-toggle";
 import { DashboardSkeleton } from "@/features/dashboard/components/dashboard-skeleton";
 import { OverviewTimeframeSelect } from "@/features/dashboard/components/filters/overview-timeframe-select";
 import { RequestFilters } from "@/features/dashboard/components/filters/request-filters";
@@ -36,6 +38,8 @@ export function DashboardPage() {
   const queryClient = useQueryClient();
   const isDark = useThemeStore((s) => s.theme === "dark");
   const showAccountBurnrate = useDashboardPreferencesStore((s) => s.accountBurnrateEnabled);
+  const accountViewMode = useDashboardPreferencesStore((s) => s.accountViewMode);
+  const setAccountViewMode = useDashboardPreferencesStore((s) => s.setAccountViewMode);
   const overviewTimeframe = useMemo(
     () => parseOverviewTimeframe(searchParams.get("overviewTimeframe")),
     [searchParams],
@@ -218,12 +222,19 @@ export function DashboardPage() {
           )}
 
           <section className="space-y-4">
-            <div className="flex items-center gap-3">
-              <h2 className="text-[13px] font-medium uppercase tracking-wider text-muted-foreground">Accounts</h2>
-              <AccountSummaryLine accounts={overview?.accounts ?? []} />
-              <div className="h-px flex-1 bg-border" />
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex min-w-0 items-center gap-3">
+                <h2 className="text-[13px] font-medium uppercase tracking-wider text-muted-foreground">Accounts</h2>
+                <AccountSummaryLine accounts={overview?.accounts ?? []} />
+              </div>
+              <div className="h-px min-w-8 flex-1 bg-border" />
+              <AccountViewModeToggle value={accountViewMode} onChange={setAccountViewMode} />
             </div>
-            <AccountCards accounts={overview?.accounts ?? []} onAction={handleAccountAction} />
+            {accountViewMode === "list" ? (
+              <AccountList accounts={overview?.accounts ?? []} onAction={handleAccountAction} />
+            ) : (
+              <AccountCards accounts={overview?.accounts ?? []} onAction={handleAccountAction} />
+            )}
           </section>
 
           <section className="space-y-4">

--- a/frontend/src/hooks/use-dashboard-preferences.test.ts
+++ b/frontend/src/hooks/use-dashboard-preferences.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function installLocalStorageMock() {
+  const storage = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      clear: () => {
+        storage.clear();
+      },
+    },
+  });
+}
+
+describe("useDashboardPreferencesStore", () => {
+  beforeEach(() => {
+    installLocalStorageMock();
+    vi.resetModules();
+  });
+
+  it("defaults account view mode to cards", async () => {
+    const { useDashboardPreferencesStore } = await import("@/hooks/use-dashboard-preferences");
+
+    useDashboardPreferencesStore.getState().initializePreferences();
+
+    expect(useDashboardPreferencesStore.getState().accountViewMode).toBe("cards");
+    expect(window.localStorage.getItem("codex-lb-dashboard-account-view-mode")).toBe("cards");
+  });
+
+  it("persists account view mode updates", async () => {
+    const { useDashboardPreferencesStore } = await import("@/hooks/use-dashboard-preferences");
+
+    useDashboardPreferencesStore.getState().setAccountViewMode("list");
+
+    expect(useDashboardPreferencesStore.getState().accountViewMode).toBe("list");
+    expect(window.localStorage.getItem("codex-lb-dashboard-account-view-mode")).toBe("list");
+  });
+});

--- a/frontend/src/hooks/use-dashboard-preferences.ts
+++ b/frontend/src/hooks/use-dashboard-preferences.ts
@@ -1,12 +1,17 @@
 import { create } from "zustand";
 
 const ACCOUNT_BURNRATE_STORAGE_KEY = "codex-lb-account-burnrate-enabled";
+const ACCOUNT_VIEW_MODE_STORAGE_KEY = "codex-lb-dashboard-account-view-mode";
+
+export type DashboardAccountViewMode = "cards" | "list";
 
 type DashboardPreferencesState = {
   accountBurnrateEnabled: boolean;
+  accountViewMode: DashboardAccountViewMode;
   initialized: boolean;
   initializePreferences: () => void;
   setAccountBurnrateEnabled: (enabled: boolean) => void;
+  setAccountViewMode: (mode: DashboardAccountViewMode) => void;
 };
 
 function readStoredAccountBurnrateEnabled(): boolean | null {
@@ -23,6 +28,14 @@ function readStoredAccountBurnrateEnabled(): boolean | null {
   return null;
 }
 
+function readStoredAccountViewMode(): DashboardAccountViewMode | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  const stored = window.localStorage.getItem(ACCOUNT_VIEW_MODE_STORAGE_KEY);
+  return stored === "cards" || stored === "list" ? stored : null;
+}
+
 function persistAccountBurnrateEnabled(enabled: boolean): void {
   if (typeof window === "undefined") {
     return;
@@ -30,16 +43,30 @@ function persistAccountBurnrateEnabled(enabled: boolean): void {
   window.localStorage.setItem(ACCOUNT_BURNRATE_STORAGE_KEY, String(enabled));
 }
 
+function persistAccountViewMode(mode: DashboardAccountViewMode): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(ACCOUNT_VIEW_MODE_STORAGE_KEY, mode);
+}
+
 export const useDashboardPreferencesStore = create<DashboardPreferencesState>((set) => ({
   accountBurnrateEnabled: true,
+  accountViewMode: "cards",
   initialized: false,
   initializePreferences: () => {
     const accountBurnrateEnabled = readStoredAccountBurnrateEnabled() ?? true;
+    const accountViewMode = readStoredAccountViewMode() ?? "cards";
     persistAccountBurnrateEnabled(accountBurnrateEnabled);
-    set({ accountBurnrateEnabled, initialized: true });
+    persistAccountViewMode(accountViewMode);
+    set({ accountBurnrateEnabled, accountViewMode, initialized: true });
   },
   setAccountBurnrateEnabled: (enabled) => {
     persistAccountBurnrateEnabled(enabled);
     set({ accountBurnrateEnabled: enabled, initialized: true });
+  },
+  setAccountViewMode: (mode) => {
+    persistAccountViewMode(mode);
+    set({ accountViewMode: mode, initialized: true });
   },
 }));

--- a/openspec/changes/add-dashboard-account-list-view/.openspec.yaml
+++ b/openspec/changes/add-dashboard-account-list-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/add-dashboard-account-list-view/proposal.md
+++ b/openspec/changes/add-dashboard-account-list-view/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Operators with many accounts need a denser way to scan account status, quota, credits, and actions from the dashboard. The existing account cards remain useful, but they take more vertical space when the account count grows.
+
+## What Changes
+
+- Add a dashboard Accounts section view-mode control with card and list options.
+- Keep the current card view as the default.
+- Persist the selected dashboard account view mode locally.
+- Add a compact list view that exposes the same dashboard account actions as the card view.
+- Render compact quota meters in the list view so remaining capacity is visually scannable.
+- Allow operators to sort the list by clicking account, status, plan, quota, credits, and warm-up headers.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: The dashboard Accounts section can render account summaries as cards or as a compact list, based on a local operator preference.
+
+## Impact
+
+- Dashboard account section components in `frontend/src/features/dashboard/components/`
+- Dashboard local preferences in `frontend/src/hooks/use-dashboard-preferences.ts`
+- Frontend dashboard component and preference tests

--- a/openspec/changes/add-dashboard-account-list-view/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-dashboard-account-list-view/specs/frontend-architecture/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Dashboard accounts section supports card and list views
+
+The Dashboard Accounts section SHALL allow operators to choose between the existing card layout and a compact list layout. The default mode SHALL remain cards. The selected account view mode SHALL persist locally and apply on later dashboard visits.
+
+The list layout SHALL use the same dashboard overview account collection as the card layout and SHALL expose account identity, status, plan, quota remaining, credits, limit warm-up state, and the same account actions available from the card layout. The list quota cells SHALL include compact visual meters for each rendered quota row while preserving numeric percent and reset timing text. The Account, Status, Plan, Quota, Credits, and Warm-up list headers SHALL be clickable sort controls.
+
+#### Scenario: Dashboard defaults to card view
+
+- **WHEN** the account view-mode preference is unset
+- **THEN** the Dashboard Accounts section renders account cards
+- **AND** the card/list control indicates card mode is selected
+
+#### Scenario: Operator switches to list view
+
+- **WHEN** an operator selects list mode in the Dashboard Accounts section
+- **THEN** the account cards are replaced by a compact list of the same accounts
+- **AND** the list exposes each account's status, quota, credits, warm-up state, and available actions
+- **AND** each quota row includes a compact visual remaining-capacity meter
+
+#### Scenario: Operator sorts account list columns
+
+- **WHEN** an operator clicks a sortable list header
+- **THEN** the account list sorts by that column in ascending order
+- **AND** clicking the same header again toggles the sort direction
+- **AND** the active sort header exposes its sort direction to assistive technology
+
+#### Scenario: Account view mode persists locally
+
+- **WHEN** an operator selects list mode
+- **AND** later returns to the dashboard in the same browser profile
+- **THEN** the Dashboard Accounts section renders in list mode without requiring another selection

--- a/openspec/changes/add-dashboard-account-list-view/tasks.md
+++ b/openspec/changes/add-dashboard-account-list-view/tasks.md
@@ -1,0 +1,15 @@
+## 1. Dashboard account view mode
+
+- [x] 1.1 Add a local dashboard preference for account view mode with `cards` as the default.
+- [x] 1.2 Add a compact Accounts section view-mode control.
+- [x] 1.3 Render the existing account cards when card mode is selected.
+- [x] 1.4 Render a compact list view with account identity, status, quota, credits, warm-up, and actions when list mode is selected.
+- [x] 1.5 Add compact visual quota meters to the list view.
+- [x] 1.6 Add clickable list headers for account, status, plan, quota, credits, and warm-up sorting.
+
+## 2. Validation
+
+- [x] 2.1 Add/update focused frontend tests for card/list mode and preference persistence.
+- [x] 2.2 Run targeted dashboard/preference tests.
+- [x] 2.3 Run frontend lint and typecheck.
+- [ ] 2.4 Validate the OpenSpec change with `openspec validate add-dashboard-account-list-view --strict` if the CLI is available.


### PR DESCRIPTION
## Summary

Adds an optional list view for the dashboard Accounts section while keeping the existing card view as the default. This is useful for operators with many accounts because the list is denser, sortable, and easier to scan across account status, plan, quota, credits, and warm-up state.

This does not add backend/API bloat or new persisted server data. The only preference is local browser state (`localStorage`) for choosing `cards` vs `list`.

## Details

- Adds a card/list toggle in the dashboard Accounts header.
- Persists the selected view mode locally in the browser.
- Adds a compact account list view with quota bars, credits, warm-up state, and existing account actions.
- Supports sorting list view by Account, Status, Plan, Quota, Credits, and Warm-up headers.
- Adds OpenSpec coverage for the dashboard account list-view behavior.

## Screenshot

No screenshot is attached to avoid accidentally exposing sensitive account information. The list view was verified locally in the Vite preview with real data, but account identifiers are sensitive and should not be uploaded unless fully redacted.

## Validation

- `npm test -- src/features/dashboard/components/account-list.test.tsx src/features/dashboard/components/dashboard-page.test.tsx src/hooks/use-dashboard-preferences.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- Browser smoke test at `http://127.0.0.1:5173/dashboard`

Not run: `openspec validate add-dashboard-account-list-view --strict` because the `openspec` CLI is not installed locally.
