### PR TITLE
feat(proxy): add SOCKS4/SOCKS5 outbound proxy support via env vars

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -737,6 +737,25 @@
         "test",
         "doc"
       ]
+    },
+    {
+      "login": "n3crosis",
+      "name": "n3crosis",
+      "avatar_url": "https://avatars.githubusercontent.com/u/11072158?v=4",
+      "profile": "https://github.com/n3crosis",
+      "contributions": [
+        "code",
+        "test"
+      ]
+    },
+    {
+      "login": "copilot",
+      "name": "copilot",
+      "avatar_url": "https://github.com/copilot.png",
+      "profile": "https://github.com/copilot",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -581,6 +581,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/softkleenex"><img src="https://avatars.githubusercontent.com/u/92619941?v=4?s=100" width="100px;" alt="softkleenex"/><br /><sub><b>softkleenex</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=softkleenex" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=softkleenex" title="Tests">⚠️</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/plastictaste"><img src="https://avatars.githubusercontent.com/u/261646970?v=4?s=100" width="100px;" alt="plastictaste"/><br /><sub><b>plastictaste</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=plastictaste" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=plastictaste" title="Tests">⚠️</a> <a href="https://github.com/Soju06/codex-lb/commits?author=plastictaste" title="Documentation">📖</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/n3crosis"><img src="https://avatars.githubusercontent.com/u/11072158?v=4?s=100" width="100px;" alt="n3crosis"/><br /><sub><b>n3crosis</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=n3crosis" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=n3crosis" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/copilot"><img src="https://github.com/copilot.png?s=100" width="100px;" alt="copilot"/><br /><sub><b>copilot</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=copilot" title="Code">💻</a></td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
 import ssl
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -11,6 +12,7 @@ from types import TracebackType
 import aiohttp
 import certifi
 from aiohttp_retry import RetryClient
+from aiohttp_socks import ProxyConnector
 
 from app.core.config.settings import get_settings
 
@@ -37,6 +39,17 @@ _http_client: _ManagedHttpClient | None = None
 _http_client_lock = asyncio.Lock()
 _retired_http_clients: list[_ManagedHttpClient] = []
 _closing_http_clients: list[_ManagedHttpClient] = []
+
+
+def _socks_proxy_url() -> str | None:
+    for var in (
+        "SOCKS_PROXY", "ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY",
+        "socks_proxy", "all_proxy", "https_proxy", "http_proxy",
+    ):
+        val = os.environ.get(var, "").strip()
+        if val.lower().startswith(("socks5://", "socks5h://", "socks4://", "socks4a://")):
+            return val
+    return None
 
 
 def _build_ssl_context() -> ssl.SSLContext:
@@ -71,23 +84,39 @@ class HttpClientLease:
 
 async def _build_http_client() -> HttpClient:
     settings = get_settings()
-    connector = aiohttp.TCPConnector(
-        limit=settings.http_connector_limit,
-        limit_per_host=settings.http_connector_limit_per_host,
-        ssl=_build_ssl_context(),
-    )
+    socks_url = _socks_proxy_url()
+    if socks_url:
+        connector = ProxyConnector.from_url(
+            socks_url,
+            limit=settings.http_connector_limit,
+            limit_per_host=settings.http_connector_limit_per_host,
+            ssl=_build_ssl_context(),
+        )
+    else:
+        connector = aiohttp.TCPConnector(
+            limit=settings.http_connector_limit,
+            limit_per_host=settings.http_connector_limit_per_host,
+            ssl=_build_ssl_context(),
+        )
     session = aiohttp.ClientSession(
         connector=connector,
         timeout=aiohttp.ClientTimeout(total=None),
         trust_env=True,
     )
     try:
-        # Match direct Codex transport unless operators explicitly override or
-        # standard outbound proxy env vars are present.
+        if socks_url:
+            ws_connector: aiohttp.TCPConnector | ProxyConnector = ProxyConnector.from_url(
+                socks_url,
+                ssl=_build_ssl_context(),
+            )
+            ws_trust_env = False
+        else:
+            ws_connector = aiohttp.TCPConnector(ssl=_build_ssl_context())
+            ws_trust_env = settings.upstream_websocket_trust_env
         websocket_session = aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(ssl=_build_ssl_context()),
+            connector=ws_connector,
             timeout=aiohttp.ClientTimeout(total=None),
-            trust_env=settings.upstream_websocket_trust_env,
+            trust_env=ws_trust_env,
         )
     except Exception:
         await session.close()

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -58,9 +58,15 @@ def _socks_proxy_url() -> str | None:
         val = os.environ.get(var, "").strip()
         lowered = val.lower()
         if var in ("SOCKS_PROXY", "socks_proxy") and lowered.startswith("http://"):
-            val = f"socks5h://{val.split('://', 1)[1]}"
+            val = f"socks5://{val.split('://', 1)[1]}"
             lowered = val.lower()
         if lowered.startswith(("socks5://", "socks5h://", "socks4://", "socks4a://")):
+            # python-socks only accepts socks5://, socks4://, and http://; normalise
+            # the extended variants (socks5h, socks4a) that it rejects.
+            if lowered.startswith("socks5h://"):
+                val = "socks5://" + val[len("socks5h://"):]
+            elif lowered.startswith("socks4a://"):
+                val = "socks4://" + val[len("socks4a://"):]
             return val
     return None
 

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -57,7 +57,7 @@ def _socks_proxy_url() -> str | None:
             continue
         val = os.environ.get(var, "").strip()
         lowered = val.lower()
-        if var in ("SOCKS_PROXY", "socks_proxy") and lowered.startswith(("http://", "https://")):
+        if var in ("SOCKS_PROXY", "socks_proxy") and lowered.startswith("http://"):
             val = f"socks5h://{val.split('://', 1)[1]}"
             lowered = val.lower()
         if lowered.startswith(("socks5://", "socks5h://", "socks4://", "socks4a://")):
@@ -97,19 +97,20 @@ class HttpClientLease:
 
 async def _build_http_client() -> HttpClient:
     settings = get_settings()
+    ssl_context = _build_ssl_context()
     socks_url = _socks_proxy_url()
     if socks_url:
         connector = ProxyConnector.from_url(
             socks_url,
             limit=settings.http_connector_limit,
             limit_per_host=settings.http_connector_limit_per_host,
-            ssl=_build_ssl_context(),
+            ssl=ssl_context,
         )
     else:
         connector = aiohttp.TCPConnector(
             limit=settings.http_connector_limit,
             limit_per_host=settings.http_connector_limit_per_host,
-            ssl=_build_ssl_context(),
+            ssl=ssl_context,
         )
     session = aiohttp.ClientSession(
         connector=connector,
@@ -120,11 +121,11 @@ async def _build_http_client() -> HttpClient:
         if socks_url and settings.upstream_websocket_trust_env:
             ws_connector: aiohttp.TCPConnector | ProxyConnector = ProxyConnector.from_url(
                 socks_url,
-                ssl=_build_ssl_context(),
+                ssl=ssl_context,
             )
             ws_trust_env = False
         else:
-            ws_connector = aiohttp.TCPConnector(ssl=_build_ssl_context())
+            ws_connector = aiohttp.TCPConnector(ssl=ssl_context)
             ws_trust_env = settings.upstream_websocket_trust_env
         try:
             websocket_session = aiohttp.ClientSession(

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import os
 import ssl
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from types import TracebackType
 
@@ -26,6 +26,12 @@ class HttpClient:
     retry_client: RetryClient
 
 
+@dataclass(frozen=True, slots=True)
+class _SocksProxyConfig:
+    connector_url: str
+    rdns: bool | None = None
+
+
 @dataclass(slots=True, eq=False)
 class _ManagedHttpClient:
     client: HttpClient
@@ -41,8 +47,8 @@ _retired_http_clients: list[_ManagedHttpClient] = []
 _closing_http_clients: list[_ManagedHttpClient] = []
 
 
-def _socks_proxy_url() -> str | None:
-    request_method_set = bool(os.environ.get("REQUEST_METHOD"))
+def _socks_proxy_config(environ: Mapping[str, str | None] = os.environ) -> _SocksProxyConfig | None:
+    request_method_set = bool(environ.get("REQUEST_METHOD"))
     for var in (
         "SOCKS_PROXY",
         "socks_proxy",
@@ -55,20 +61,29 @@ def _socks_proxy_url() -> str | None:
     ):
         if request_method_set and var in ("HTTP_PROXY", "http_proxy"):
             continue
-        val = os.environ.get(var, "").strip()
+        val = (environ.get(var) or "").strip()
         lowered = val.lower()
         if var in ("SOCKS_PROXY", "socks_proxy") and lowered.startswith("http://"):
             val = f"socks5://{val.split('://', 1)[1]}"
             lowered = val.lower()
         if lowered.startswith(("socks5://", "socks5h://", "socks4://", "socks4a://")):
-            # python-socks only accepts socks5://, socks4://, and http://; normalise
-            # the extended variants (socks5h, socks4a) that it rejects.
             if lowered.startswith("socks5h://"):
-                val = "socks5://" + val[len("socks5h://") :]
+                return _SocksProxyConfig(
+                    connector_url="socks5://" + val[len("socks5h://") :],
+                    rdns=True,
+                )
             elif lowered.startswith("socks4a://"):
-                val = "socks4://" + val[len("socks4a://") :]
-            return val
+                return _SocksProxyConfig(
+                    connector_url="socks4://" + val[len("socks4a://") :],
+                    rdns=True,
+                )
+            return _SocksProxyConfig(connector_url=val)
     return None
+
+
+def _socks_proxy_url(environ: Mapping[str, str | None] = os.environ) -> str | None:
+    config = _socks_proxy_config(environ)
+    return config.connector_url if config else None
 
 
 def _build_ssl_context() -> ssl.SSLContext:
@@ -104,13 +119,17 @@ class HttpClientLease:
 async def _build_http_client() -> HttpClient:
     settings = get_settings()
     ssl_context = _build_ssl_context()
-    socks_url = _socks_proxy_url()
-    if socks_url:
+    proxy_env = (
+        settings.upstream_websocket_proxy_env() if hasattr(settings, "upstream_websocket_proxy_env") else os.environ
+    )
+    socks_config = _socks_proxy_config(proxy_env)
+    if socks_config:
         connector = ProxyConnector.from_url(
-            socks_url,
+            socks_config.connector_url,
             limit=settings.http_connector_limit,
             limit_per_host=settings.http_connector_limit_per_host,
             ssl=ssl_context,
+            rdns=socks_config.rdns,
         )
     else:
         connector = aiohttp.TCPConnector(
@@ -121,13 +140,14 @@ async def _build_http_client() -> HttpClient:
     session = aiohttp.ClientSession(
         connector=connector,
         timeout=aiohttp.ClientTimeout(total=None),
-        trust_env=not socks_url,
+        trust_env=not socks_config,
     )
     try:
-        if socks_url and settings.upstream_websocket_trust_env:
+        if socks_config and settings.upstream_websocket_trust_env:
             ws_connector: aiohttp.TCPConnector | ProxyConnector = ProxyConnector.from_url(
-                socks_url,
+                socks_config.connector_url,
                 ssl=ssl_context,
+                rdns=socks_config.rdns,
             )
             ws_trust_env = False
         else:

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -42,12 +42,25 @@ _closing_http_clients: list[_ManagedHttpClient] = []
 
 
 def _socks_proxy_url() -> str | None:
+    request_method_set = bool(os.environ.get("REQUEST_METHOD"))
     for var in (
-        "SOCKS_PROXY", "ALL_PROXY", "HTTPS_PROXY", "HTTP_PROXY",
-        "socks_proxy", "all_proxy", "https_proxy", "http_proxy",
+        "SOCKS_PROXY",
+        "socks_proxy",
+        "ALL_PROXY",
+        "HTTPS_PROXY",
+        "HTTP_PROXY",
+        "all_proxy",
+        "https_proxy",
+        "http_proxy",
     ):
+        if request_method_set and var in ("HTTP_PROXY", "http_proxy"):
+            continue
         val = os.environ.get(var, "").strip()
-        if val.lower().startswith(("socks5://", "socks5h://", "socks4://", "socks4a://")):
+        lowered = val.lower()
+        if var in ("SOCKS_PROXY", "socks_proxy") and lowered.startswith(("http://", "https://")):
+            val = f"socks5h://{val.split('://', 1)[1]}"
+            lowered = val.lower()
+        if lowered.startswith(("socks5://", "socks5h://", "socks4://", "socks4a://")):
             return val
     return None
 
@@ -101,10 +114,10 @@ async def _build_http_client() -> HttpClient:
     session = aiohttp.ClientSession(
         connector=connector,
         timeout=aiohttp.ClientTimeout(total=None),
-        trust_env=True,
+        trust_env=not socks_url,
     )
     try:
-        if socks_url:
+        if socks_url and settings.upstream_websocket_trust_env:
             ws_connector: aiohttp.TCPConnector | ProxyConnector = ProxyConnector.from_url(
                 socks_url,
                 ssl=_build_ssl_context(),
@@ -113,11 +126,15 @@ async def _build_http_client() -> HttpClient:
         else:
             ws_connector = aiohttp.TCPConnector(ssl=_build_ssl_context())
             ws_trust_env = settings.upstream_websocket_trust_env
-        websocket_session = aiohttp.ClientSession(
-            connector=ws_connector,
-            timeout=aiohttp.ClientTimeout(total=None),
-            trust_env=ws_trust_env,
-        )
+        try:
+            websocket_session = aiohttp.ClientSession(
+                connector=ws_connector,
+                timeout=aiohttp.ClientTimeout(total=None),
+                trust_env=ws_trust_env,
+            )
+        except Exception:
+            await ws_connector.close()
+            raise
     except Exception:
         await session.close()
         raise

--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -64,9 +64,9 @@ def _socks_proxy_url() -> str | None:
             # python-socks only accepts socks5://, socks4://, and http://; normalise
             # the extended variants (socks5h, socks4a) that it rejects.
             if lowered.startswith("socks5h://"):
-                val = "socks5://" + val[len("socks5h://"):]
+                val = "socks5://" + val[len("socks5h://") :]
             elif lowered.startswith("socks4a://"):
-                val = "socks4://" + val[len("socks4a://"):]
+                val = "socks4://" + val[len("socks4a://") :]
             return val
     return None
 

--- a/openspec/changes/add-socks5-proxy-support/proposal.md
+++ b/openspec/changes/add-socks5-proxy-support/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Operators deploying codex-lb in network environments that route egress through a
+SOCKS proxy (corporate networks, VPNs, containerised egress gateways) have no way to
+tunnel the outbound HTTP and WebSocket sessions through that proxy today. `aiohttp`'s
+`trust_env=True` setting only honours HTTP/HTTPS proxy env vars natively; SOCKS
+support requires `aiohttp-socks` and an explicit `ProxyConnector`.
+
+This change adds automatic SOCKS4/SOCKS4a/SOCKS5/SOCKS5h proxy detection via
+standard environment variables so operators can configure egress without code changes.
+
+## What Changes
+
+- Add `aiohttp-socks>=0.10.1` to the project dependencies.
+- Add `_socks_proxy_url()` in `app/core/clients/http.py` that inspects the following
+  env vars in priority order, returning the first value that starts with a SOCKS
+  scheme (`socks5://`, `socks5h://`, `socks4://`, `socks4a://`):
+  `SOCKS_PROXY`, `socks_proxy`, `ALL_PROXY`, `HTTPS_PROXY`, `HTTP_PROXY`,
+  `all_proxy`, `https_proxy`, `http_proxy`.
+  Additional behaviour:
+  - Values are stripped of leading/trailing whitespace.
+  - A bare `http://` scheme in `SOCKS_PROXY`/`socks_proxy` is normalised to
+    `socks5h://` (handles misconfigured env vars).
+  - `HTTP_PROXY`/`http_proxy` are skipped when `REQUEST_METHOD` is set in the
+    environment (CGI/httpoxy security convention).
+- Modify `_build_http_client()`:
+  - When a SOCKS URL is detected, build a `ProxyConnector` (from `aiohttp-socks`)
+    instead of `aiohttp.TCPConnector` for the shared HTTP session.
+  - Set `trust_env=False` on both the HTTP and WebSocket sessions when a
+    `ProxyConnector` is active, to prevent aiohttp from double-proxying.
+  - Route the WebSocket session through the same SOCKS proxy when
+    `upstream_websocket_trust_env=True` (operator opt-in); otherwise use the
+    plain `TCPConnector` for WebSocket connections as before.
+  - Wrap the WebSocket connector/session construction in a `try/except` so the
+    first connector is closed if the second construction fails (connector leak fix).
+- Cover the new behaviour with unit tests in `tests/unit/test_http_client.py`:
+  - `_socks_proxy_url` env var detection (case, whitespace, scheme normalisation).
+  - `init_http_client` uses `ProxyConnector` and `trust_env=False` for both
+    sessions when a SOCKS env var is active.
+
+## Impact
+
+- Operators can now configure SOCKS4/SOCKS5 egress by setting a single env var
+  (e.g. `SOCKS_PROXY=socks5://gateway:1080`). No code or config-file changes
+  required beyond the env var.
+- When no SOCKS env var is set, the code path is identical to before (no behaviour
+  change for existing deployments).
+- `trust_env=False` is set when a `ProxyConnector` is active; this prevents
+  aiohttp from independently picking up a second HTTP/HTTPS proxy from the
+  environment and double-proxying. Operators that previously relied solely on
+  `trust_env=True` for HTTP/HTTPS proxies are unaffected (no SOCKS env var → same
+  behaviour as before).
+- No changes to the proxy request/response contract, account routing, dashboard,
+  OAuth flow, or any other operator-visible surface.

--- a/openspec/changes/add-socks5-proxy-support/proposal.md
+++ b/openspec/changes/add-socks5-proxy-support/proposal.md
@@ -20,7 +20,11 @@ standard environment variables so operators can configure egress without code ch
   Additional behaviour:
   - Values are stripped of leading/trailing whitespace.
   - A bare `http://` scheme in `SOCKS_PROXY`/`socks_proxy` is normalised to
-    `socks5h://` (handles misconfigured env vars).
+    `socks5://` (handles misconfigured env vars while staying parseable by the
+    configured proxy connector).
+  - `socks5h://` and `socks4a://` are normalised to `socks5://` and `socks4://`
+    before building the connector because the installed parser rejects the
+    extended schemes.
   - `HTTP_PROXY`/`http_proxy` are skipped when `REQUEST_METHOD` is set in the
     environment (CGI/httpoxy security convention).
 - Modify `_build_http_client()`:

--- a/openspec/changes/add-socks5-proxy-support/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/add-socks5-proxy-support/specs/outbound-http-clients/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Outbound HTTP and WebSocket sessions transparently tunnel through a SOCKS proxy
+
+When any of the standard proxy environment variables carries a SOCKS URL, the
+outbound HTTP and WebSocket clients MUST use that proxy for all upstream connections.
+Configuring a SOCKS proxy MUST NOT require code changes — setting an environment
+variable MUST be sufficient.
+
+#### Scenario: SOCKS5 proxy is active — HTTP session uses ProxyConnector
+
+- **GIVEN** `SOCKS_PROXY=socks5://gateway:1080` (or any equivalent env var below)
+- **WHEN** the shared outbound HTTP client is initialised
+- **THEN** the HTTP session uses a `ProxyConnector` built from that URL
+- **AND** `trust_env=False` is passed to `aiohttp.ClientSession` to prevent double-proxying
+
+#### Scenario: SOCKS5 proxy is active — WebSocket session routes through proxy when opt-in
+
+- **GIVEN** a SOCKS URL is detected in the environment
+- **AND** `upstream_websocket_trust_env=True` is configured
+- **WHEN** the shared outbound WebSocket client is initialised
+- **THEN** the WebSocket session uses a `ProxyConnector` built from the same SOCKS URL
+- **AND** `trust_env=False` is passed to that session
+
+#### Scenario: SOCKS5 proxy is active — WebSocket session connects directly when not opted in
+
+- **GIVEN** a SOCKS URL is detected in the environment
+- **AND** `upstream_websocket_trust_env` is not set to `True`
+- **WHEN** the shared outbound WebSocket client is initialised
+- **THEN** the WebSocket session uses a plain `TCPConnector` (unchanged behaviour)
+
+#### Scenario: No SOCKS proxy configured — behaviour is identical to before
+
+- **GIVEN** no SOCKS URL is present in any proxy environment variable
+- **WHEN** the shared outbound HTTP client is initialised
+- **THEN** both sessions use `aiohttp.TCPConnector` as before
+- **AND** `trust_env` is passed unchanged per existing settings
+
+### Requirement: SOCKS proxy URL detection follows a defined env var precedence
+
+The service MUST probe the following environment variables in order and return the
+first value that carries a SOCKS scheme:
+
+1. `SOCKS_PROXY`
+2. `socks_proxy`
+3. `ALL_PROXY`
+4. `HTTPS_PROXY`
+5. `HTTP_PROXY`
+6. `all_proxy`
+7. `https_proxy`
+8. `http_proxy`
+
+Accepted schemes: `socks5://`, `socks5h://`, `socks4://`, `socks4a://`.
+
+Additional normalisation rules:
+- Values MUST be stripped of leading/trailing whitespace before inspection.
+- A bare `http://` scheme in `SOCKS_PROXY` or `socks_proxy` MUST be normalised
+  to `socks5h://` (accommodates misconfigured env vars).
+- `HTTP_PROXY` and `http_proxy` MUST be skipped when `REQUEST_METHOD` is set in
+  the environment (httpoxy / CGI security convention).
+
+#### Scenario: Whitespace-padded value is accepted and returned stripped
+
+- **GIVEN** `SOCKS_PROXY="  socks5://gateway:1080  "`
+- **WHEN** the SOCKS URL is resolved
+- **THEN** the returned URL is `socks5://gateway:1080` (no surrounding whitespace)
+
+#### Scenario: Bare `http://` scheme in `SOCKS_PROXY` is normalised
+
+- **GIVEN** `socks_proxy=http://gateway:1080`
+- **WHEN** the SOCKS URL is resolved
+- **THEN** the returned URL is `socks5h://gateway:1080`
+
+#### Scenario: CGI environment skips `HTTP_PROXY`
+
+- **GIVEN** `REQUEST_METHOD=GET` is set
+- **AND** `HTTP_PROXY=socks5://gateway:1080` is the only SOCKS var
+- **WHEN** the SOCKS URL is resolved
+- **THEN** the result is `None` (variable is ignored)

--- a/openspec/changes/add-socks5-proxy-support/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/add-socks5-proxy-support/specs/outbound-http-clients/spec.md
@@ -2,8 +2,9 @@
 
 ### Requirement: Outbound HTTP and WebSocket sessions transparently tunnel through a SOCKS proxy
 
-When any of the standard proxy environment variables carries a SOCKS URL, the
-outbound HTTP and WebSocket clients MUST use that proxy for all upstream connections.
+The outbound HTTP and WebSocket clients MUST use a configured SOCKS proxy for all
+upstream connections when any supported proxy environment variable carries a
+SOCKS URL.
 Configuring a SOCKS proxy MUST NOT require code changes — setting an environment
 variable MUST be sufficient.
 
@@ -50,12 +51,16 @@ first value that carries a SOCKS scheme:
 7. `https_proxy`
 8. `http_proxy`
 
-Accepted schemes: `socks5://`, `socks5h://`, `socks4://`, `socks4a://`.
+Accepted input schemes: `socks5://`, `socks5h://`, `socks4://`, `socks4a://`.
 
 Additional normalisation rules:
 - Values MUST be stripped of leading/trailing whitespace before inspection.
 - A bare `http://` scheme in `SOCKS_PROXY` or `socks_proxy` MUST be normalised
-  to `socks5h://` (accommodates misconfigured env vars).
+  to `socks5://` (accommodates misconfigured env vars while keeping the URL
+  parseable by the configured proxy connector).
+- `socks5h://` and `socks4a://` values MUST be normalised to `socks5://` and
+  `socks4://` before connector construction because the configured proxy parser
+  rejects the extended schemes.
 - `HTTP_PROXY` and `http_proxy` MUST be skipped when `REQUEST_METHOD` is set in
   the environment (httpoxy / CGI security convention).
 
@@ -69,7 +74,13 @@ Additional normalisation rules:
 
 - **GIVEN** `socks_proxy=http://gateway:1080`
 - **WHEN** the SOCKS URL is resolved
-- **THEN** the returned URL is `socks5h://gateway:1080`
+- **THEN** the returned URL is `socks5://gateway:1080`
+
+#### Scenario: Extended SOCKS schemes are normalised before connector use
+
+- **GIVEN** `SOCKS_PROXY=socks5h://gateway:1080`
+- **WHEN** the SOCKS URL is resolved
+- **THEN** the returned URL is `socks5://gateway:1080`
 
 #### Scenario: CGI environment skips `HTTP_PROXY`
 

--- a/openspec/changes/add-socks5-proxy-support/tasks.md
+++ b/openspec/changes/add-socks5-proxy-support/tasks.md
@@ -9,9 +9,11 @@
     `HTTP_PROXY`, `all_proxy`, `https_proxy`, `http_proxy`.
   - Strip whitespace from each value before inspecting.
   - Skip `HTTP_PROXY`/`http_proxy` when `REQUEST_METHOD` is set (httpoxy guard).
-  - Normalise a bare `http://` scheme in `SOCKS_PROXY`/`socks_proxy` to `socks5h://`.
-  - Return the first value whose lowercased form starts with `socks5://`, `socks5h://`,
-    `socks4://`, or `socks4a://`; return `None` if none match.
+  - Normalise a bare `http://` scheme in `SOCKS_PROXY`/`socks_proxy` to `socks5://`.
+  - Normalise `socks5h://` and `socks4a://` to `socks5://` and `socks4://`
+    before passing the URL to `ProxyConnector`.
+  - Return the first value whose lowercased form starts with `socks5://`,
+    `socks5h://`, `socks4://`, or `socks4a://`; return `None` if none match.
 
 ## 3. HTTP client construction
 
@@ -36,7 +38,9 @@
   - `test_socks_proxy_url_strips_whitespace_from_env_value` — leading/trailing spaces
     are stripped before the scheme check and from the returned URL.
   - `test_socks_proxy_url_normalizes_http_scheme_for_socks_proxy_env` — `http://` scheme
-    in `socks_proxy` is normalised to `socks5h://`.
+    in `socks_proxy` is normalised to `socks5://`.
+  - Extended `socks5h://` and `socks4a://` schemes are normalised to connector-supported
+    `socks5://` and `socks4://` URLs.
   - `test_init_http_client_uses_proxy_connector_for_socks_url` — when a SOCKS env var is
     active, both sessions use `ProxyConnector` and `trust_env=False`.
 

--- a/openspec/changes/add-socks5-proxy-support/tasks.md
+++ b/openspec/changes/add-socks5-proxy-support/tasks.md
@@ -1,0 +1,49 @@
+## 1. Dependency
+
+- [x] 1.1 Add `aiohttp-socks>=0.10.1` to the `dependencies` list in `pyproject.toml`.
+
+## 2. SOCKS URL detection
+
+- [x] 2.1 Add `_socks_proxy_url() -> str | None` to `app/core/clients/http.py`.
+  - Probe env vars in order: `SOCKS_PROXY`, `socks_proxy`, `ALL_PROXY`, `HTTPS_PROXY`,
+    `HTTP_PROXY`, `all_proxy`, `https_proxy`, `http_proxy`.
+  - Strip whitespace from each value before inspecting.
+  - Skip `HTTP_PROXY`/`http_proxy` when `REQUEST_METHOD` is set (httpoxy guard).
+  - Normalise a bare `http://` scheme in `SOCKS_PROXY`/`socks_proxy` to `socks5h://`.
+  - Return the first value whose lowercased form starts with `socks5://`, `socks5h://`,
+    `socks4://`, or `socks4a://`; return `None` if none match.
+
+## 3. HTTP client construction
+
+- [x] 3.1 In `_build_http_client()`, call `_socks_proxy_url()` once and store the result.
+- [x] 3.2 When a SOCKS URL is present, build a `ProxyConnector.from_url(socks_url, ...)`
+  with the same `limit`, `limit_per_host`, and SSL context as the plain connector.
+  Otherwise build `aiohttp.TCPConnector` as before.
+- [x] 3.3 Pass `trust_env=not socks_url` to `aiohttp.ClientSession` for the HTTP session.
+- [x] 3.4 For the WebSocket session:
+  - When `socks_url` is set **and** `upstream_websocket_trust_env=True`, build a second
+    `ProxyConnector.from_url(socks_url, ssl=...)` and set `trust_env=False`.
+  - Otherwise build `aiohttp.TCPConnector(ssl=...)` and pass
+    `trust_env=settings.upstream_websocket_trust_env` unchanged.
+- [x] 3.5 Wrap WebSocket connector + session construction in a `try/except` that closes
+  the connector on failure, preventing a connector leak if session construction raises.
+
+## 4. Tests
+
+- [x] 4.1 `tests/unit/test_http_client.py`:
+  - `test_socks_proxy_url_detects_lowercase_socks_proxy` — `socks_proxy` env var returns
+    the value unchanged when it already has a valid SOCKS scheme.
+  - `test_socks_proxy_url_strips_whitespace_from_env_value` — leading/trailing spaces
+    are stripped before the scheme check and from the returned URL.
+  - `test_socks_proxy_url_normalizes_http_scheme_for_socks_proxy_env` — `http://` scheme
+    in `socks_proxy` is normalised to `socks5h://`.
+  - `test_init_http_client_uses_proxy_connector_for_socks_url` — when a SOCKS env var is
+    active, both sessions use `ProxyConnector` and `trust_env=False`.
+
+## 5. Spec delta
+
+- [x] 5.1 Add SOCKS proxy requirements to the `outbound-http-clients` delta spec at
+  `openspec/changes/add-socks5-proxy-support/specs/outbound-http-clients/spec.md`.
+- [x] 5.2 Run `uv run pytest tests/unit/test_http_client.py -q` and confirm clean.
+- [x] 5.3 Run `uv run ruff check app/core/clients/http.py tests/unit/test_http_client.py`
+  and confirm clean.

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -126,6 +126,13 @@ def test_socks_proxy_url_normalizes_socks4a_for_proxy_connector() -> None:
     assert url == "socks4://proxy.example.com:1080"
 
 
+def test_socks_proxy_config_preserves_socks4a_remote_dns() -> None:
+    config = http_module._socks_proxy_config({"SOCKS_PROXY": "socks4a://proxy.example.com:1080"})
+    assert config is not None
+    assert config.connector_url == "socks4://proxy.example.com:1080"
+    assert config.rdns is True
+
+
 def test_socks_proxy_url_skips_http_proxy_when_request_method_set() -> None:
     env = {"REQUEST_METHOD": "GET", "HTTP_PROXY": "socks5://proxy.example.com:1080"}
     with patch.dict("os.environ", env, clear=True):
@@ -177,6 +184,96 @@ async def test_init_http_client_uses_proxy_connector_for_socks_url() -> None:
     # trust_env must be False for both sessions when SOCKS proxy is active (avoids double-proxying)
     assert client_session_cls.call_args_list[0].kwargs["trust_env"] is False
     assert client_session_cls.call_args_list[1].kwargs["trust_env"] is False
+
+    await http_module.close_http_client()
+
+
+@pytest.mark.asyncio
+async def test_init_http_client_uses_settings_proxy_env_for_socks_url() -> None:
+    await http_module.close_http_client()
+
+    http_session = MagicMock()
+    websocket_session = MagicMock()
+    websocket_session.close = AsyncMock()
+    retry_client = MagicMock()
+    retry_client.close = AsyncMock()
+    proxy_connector = MagicMock()
+    ssl_context = MagicMock()
+
+    class _Settings(SimpleNamespace):
+        def upstream_websocket_proxy_env(self):
+            return {"SOCKS_PROXY": "socks5://settings-proxy.example.com:1080"}
+
+    socks_settings = _Settings(
+        http_connector_limit=100,
+        http_connector_limit_per_host=50,
+        upstream_websocket_trust_env=True,
+    )
+
+    with (
+        patch("app.core.clients.http.get_settings", return_value=socks_settings),
+        patch("app.core.clients.http._build_ssl_context", return_value=ssl_context),
+        patch("app.core.clients.http.ProxyConnector") as proxy_connector_cls,
+        patch(
+            "app.core.clients.http.aiohttp.ClientSession",
+            side_effect=[http_session, websocket_session],
+        ) as client_session_cls,
+        patch("app.core.clients.http.RetryClient", return_value=retry_client),
+        patch.dict("os.environ", {}, clear=True),
+    ):
+        ws_proxy_connector = MagicMock()
+        proxy_connector_cls.from_url.side_effect = [proxy_connector, ws_proxy_connector]
+        await http_module.init_http_client()
+
+    assert [call.args[0] for call in proxy_connector_cls.from_url.call_args_list] == [
+        "socks5://settings-proxy.example.com:1080",
+        "socks5://settings-proxy.example.com:1080",
+    ]
+    assert client_session_cls.call_args_list[0].kwargs["connector"] is proxy_connector
+    assert client_session_cls.call_args_list[0].kwargs["trust_env"] is False
+    assert client_session_cls.call_args_list[1].kwargs["connector"] is ws_proxy_connector
+    assert client_session_cls.call_args_list[1].kwargs["trust_env"] is False
+
+    await http_module.close_http_client()
+
+
+@pytest.mark.asyncio
+async def test_init_http_client_preserves_socks4a_remote_dns_for_proxy_connector() -> None:
+    await http_module.close_http_client()
+
+    http_session = MagicMock()
+    websocket_session = MagicMock()
+    websocket_session.close = AsyncMock()
+    retry_client = MagicMock()
+    retry_client.close = AsyncMock()
+    proxy_connector = MagicMock()
+    ssl_context = MagicMock()
+    socks_settings = SimpleNamespace(
+        http_connector_limit=100,
+        http_connector_limit_per_host=50,
+        upstream_websocket_trust_env=True,
+    )
+
+    with (
+        patch("app.core.clients.http.get_settings", return_value=socks_settings),
+        patch("app.core.clients.http._build_ssl_context", return_value=ssl_context),
+        patch("app.core.clients.http.ProxyConnector") as proxy_connector_cls,
+        patch(
+            "app.core.clients.http.aiohttp.ClientSession",
+            side_effect=[http_session, websocket_session],
+        ),
+        patch("app.core.clients.http.RetryClient", return_value=retry_client),
+        patch.dict("os.environ", {"SOCKS_PROXY": "socks4a://proxy.example.com:1080"}, clear=True),
+    ):
+        ws_proxy_connector = MagicMock()
+        proxy_connector_cls.from_url.side_effect = [proxy_connector, ws_proxy_connector]
+        await http_module.init_http_client()
+
+    assert [call.args[0] for call in proxy_connector_cls.from_url.call_args_list] == [
+        "socks4://proxy.example.com:1080",
+        "socks4://proxy.example.com:1080",
+    ]
+    assert [call.kwargs["rdns"] for call in proxy_connector_cls.from_url.call_args_list] == [True, True]
 
     await http_module.close_http_client()
 

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -96,6 +96,60 @@ async def test_init_http_client_creates_tcp_connector_with_limits() -> None:
     await http_module.close_http_client()
 
 
+def test_socks_proxy_url_detects_lowercase_socks_proxy() -> None:
+    with patch.dict("os.environ", {"socks_proxy": "socks5://proxy.example.com:1080"}, clear=False):
+        url = http_module._socks_proxy_url()
+    assert url == "socks5://proxy.example.com:1080"
+
+
+def test_socks_proxy_url_strips_whitespace_from_env_value() -> None:
+    with patch.dict("os.environ", {"SOCKS_PROXY": "  socks5://proxy.example.com:1080  "}, clear=False):
+        url = http_module._socks_proxy_url()
+    assert url == "socks5://proxy.example.com:1080"
+
+
+@pytest.mark.asyncio
+async def test_init_http_client_uses_proxy_connector_for_socks_url() -> None:
+    await http_module.close_http_client()
+
+    http_session = MagicMock()
+    websocket_session = MagicMock()
+    websocket_session.close = AsyncMock()
+    retry_client = MagicMock()
+    retry_client.close = AsyncMock()
+    proxy_connector = MagicMock()
+    ssl_context = MagicMock()
+    socks_settings = SimpleNamespace(
+        http_connector_limit=100,
+        http_connector_limit_per_host=50,
+        upstream_websocket_trust_env=True,
+    )
+
+    with (
+        patch("app.core.clients.http.get_settings", return_value=socks_settings),
+        patch("app.core.clients.http._build_ssl_context", return_value=ssl_context),
+        patch("app.core.clients.http.ProxyConnector") as proxy_connector_cls,
+        patch(
+            "app.core.clients.http.aiohttp.ClientSession",
+            side_effect=[http_session, websocket_session],
+        ) as client_session_cls,
+        patch("app.core.clients.http.RetryClient", return_value=retry_client),
+        patch.dict("os.environ", {"socks_proxy": "socks5://proxy.example.com:1080"}, clear=False),
+    ):
+        proxy_connector_cls.from_url.return_value = proxy_connector
+        client = await http_module.init_http_client()
+
+    assert client.session is http_session
+    assert client.websocket_session is websocket_session
+    assert proxy_connector_cls.from_url.call_count == 2
+    assert client_session_cls.call_args_list[0].kwargs["connector"] is proxy_connector
+    assert client_session_cls.call_args_list[1].kwargs["connector"] is proxy_connector
+    # trust_env must be False for websocket session when SOCKS proxy is active (avoids double-proxying)
+    assert client_session_cls.call_args_list[1].kwargs["trust_env"] is False
+
+    await http_module.close_http_client()
+
+
 def test_build_ssl_context_preserves_default_roots_and_adds_certifi_bundle() -> None:
     with (
         patch("app.core.clients.http.certifi.where", return_value="/tmp/cacert.pem") as certifi_where,

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -111,7 +111,19 @@ def test_socks_proxy_url_strips_whitespace_from_env_value() -> None:
 def test_socks_proxy_url_normalizes_http_scheme_for_socks_proxy_env() -> None:
     with patch.dict("os.environ", {"socks_proxy": "http://proxy.example.com:1080"}, clear=True):
         url = http_module._socks_proxy_url()
-    assert url == "socks5h://proxy.example.com:1080"
+    assert url == "socks5://proxy.example.com:1080"
+
+
+def test_socks_proxy_url_normalizes_socks5h_for_proxy_connector() -> None:
+    with patch.dict("os.environ", {"SOCKS_PROXY": "socks5h://proxy.example.com:1080"}, clear=True):
+        url = http_module._socks_proxy_url()
+    assert url == "socks5://proxy.example.com:1080"
+
+
+def test_socks_proxy_url_normalizes_socks4a_for_proxy_connector() -> None:
+    with patch.dict("os.environ", {"SOCKS_PROXY": "socks4a://proxy.example.com:1080"}, clear=True):
+        url = http_module._socks_proxy_url()
+    assert url == "socks4://proxy.example.com:1080"
 
 
 def test_socks_proxy_url_skips_http_proxy_when_request_method_set() -> None:
@@ -147,7 +159,7 @@ async def test_init_http_client_uses_proxy_connector_for_socks_url() -> None:
             side_effect=[http_session, websocket_session],
         ) as client_session_cls,
         patch("app.core.clients.http.RetryClient", return_value=retry_client),
-        patch.dict("os.environ", {"socks_proxy": "socks5://proxy.example.com:1080"}, clear=True),
+        patch.dict("os.environ", {"socks_proxy": "http://proxy.example.com:1080"}, clear=True),
     ):
         ws_proxy_connector = MagicMock()
         proxy_connector_cls.from_url.side_effect = [proxy_connector, ws_proxy_connector]
@@ -156,6 +168,10 @@ async def test_init_http_client_uses_proxy_connector_for_socks_url() -> None:
     assert client.session is http_session
     assert client.websocket_session is websocket_session
     assert proxy_connector_cls.from_url.call_count == 2
+    assert [call.args[0] for call in proxy_connector_cls.from_url.call_args_list] == [
+        "socks5://proxy.example.com:1080",
+        "socks5://proxy.example.com:1080",
+    ]
     assert client_session_cls.call_args_list[0].kwargs["connector"] is proxy_connector
     assert client_session_cls.call_args_list[1].kwargs["connector"] is ws_proxy_connector
     # trust_env must be False for both sessions when SOCKS proxy is active (avoids double-proxying)

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -83,7 +83,7 @@ async def test_init_http_client_creates_tcp_connector_with_limits() -> None:
     ):
         await http_module.init_http_client()
 
-    assert ssl_context_factory.call_count == 2
+    assert ssl_context_factory.call_count == 1
     assert tcp_connector_cls.call_args_list[0].kwargs == {
         "limit": 100,
         "limit_per_host": 50,
@@ -112,6 +112,13 @@ def test_socks_proxy_url_normalizes_http_scheme_for_socks_proxy_env() -> None:
     with patch.dict("os.environ", {"socks_proxy": "http://proxy.example.com:1080"}, clear=True):
         url = http_module._socks_proxy_url()
     assert url == "socks5h://proxy.example.com:1080"
+
+
+def test_socks_proxy_url_skips_http_proxy_when_request_method_set() -> None:
+    env = {"REQUEST_METHOD": "GET", "HTTP_PROXY": "socks5://proxy.example.com:1080"}
+    with patch.dict("os.environ", env, clear=True):
+        url = http_module._socks_proxy_url()
+    assert url is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -97,15 +97,21 @@ async def test_init_http_client_creates_tcp_connector_with_limits() -> None:
 
 
 def test_socks_proxy_url_detects_lowercase_socks_proxy() -> None:
-    with patch.dict("os.environ", {"socks_proxy": "socks5://proxy.example.com:1080"}, clear=False):
+    with patch.dict("os.environ", {"socks_proxy": "socks5://proxy.example.com:1080"}, clear=True):
         url = http_module._socks_proxy_url()
     assert url == "socks5://proxy.example.com:1080"
 
 
 def test_socks_proxy_url_strips_whitespace_from_env_value() -> None:
-    with patch.dict("os.environ", {"SOCKS_PROXY": "  socks5://proxy.example.com:1080  "}, clear=False):
+    with patch.dict("os.environ", {"SOCKS_PROXY": "  socks5://proxy.example.com:1080  "}, clear=True):
         url = http_module._socks_proxy_url()
     assert url == "socks5://proxy.example.com:1080"
+
+
+def test_socks_proxy_url_normalizes_http_scheme_for_socks_proxy_env() -> None:
+    with patch.dict("os.environ", {"socks_proxy": "http://proxy.example.com:1080"}, clear=True):
+        url = http_module._socks_proxy_url()
+    assert url == "socks5h://proxy.example.com:1080"
 
 
 @pytest.mark.asyncio
@@ -134,17 +140,19 @@ async def test_init_http_client_uses_proxy_connector_for_socks_url() -> None:
             side_effect=[http_session, websocket_session],
         ) as client_session_cls,
         patch("app.core.clients.http.RetryClient", return_value=retry_client),
-        patch.dict("os.environ", {"socks_proxy": "socks5://proxy.example.com:1080"}, clear=False),
+        patch.dict("os.environ", {"socks_proxy": "socks5://proxy.example.com:1080"}, clear=True),
     ):
-        proxy_connector_cls.from_url.return_value = proxy_connector
+        ws_proxy_connector = MagicMock()
+        proxy_connector_cls.from_url.side_effect = [proxy_connector, ws_proxy_connector]
         client = await http_module.init_http_client()
 
     assert client.session is http_session
     assert client.websocket_session is websocket_session
     assert proxy_connector_cls.from_url.call_count == 2
     assert client_session_cls.call_args_list[0].kwargs["connector"] is proxy_connector
-    assert client_session_cls.call_args_list[1].kwargs["connector"] is proxy_connector
-    # trust_env must be False for websocket session when SOCKS proxy is active (avoids double-proxying)
+    assert client_session_cls.call_args_list[1].kwargs["connector"] is ws_proxy_connector
+    # trust_env must be False for both sessions when SOCKS proxy is active (avoids double-proxying)
+    assert client_session_cls.call_args_list[0].kwargs["trust_env"] is False
     assert client_session_cls.call_args_list[1].kwargs["trust_env"] is False
 
     await http_module.close_http_client()


### PR DESCRIPTION
<!--
Thanks for contributing to codex-lb! 🙏
Fill in the sections below. Delete sections that don't apply.
-->

## Summary

Adds SOCKS4/SOCKS4a/SOCKS5/SOCKS5h outbound proxy support to the shared HTTP and
WebSocket clients. When any of the standard proxy environment variables carries a
SOCKS URL, a `ProxyConnector` from `aiohttp-socks` is used instead of the default
`TCPConnector`, and `trust_env` is disabled to prevent double-proxying.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: Closes #407

> **Note**: Issue #407 was previously closed without actually implementing SOCKS proxy support. This PR is the implementation that resolves it.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/add-socks5-proxy-support/`

## Changes

**`pyproject.toml`**
- Added `aiohttp-socks>=0.10.1` dependency.

**`app/core/clients/http.py`**
- New `_socks_proxy_url()` helper: probes `SOCKS_PROXY`, `ALL_PROXY`, `HTTPS_PROXY`,
  `HTTP_PROXY` (and lowercase variants) in priority order; strips whitespace;
  normalises bare `http://` scheme in `SOCKS_PROXY`/`socks_proxy` to `socks5h://`;
  skips `HTTP_PROXY`/`http_proxy` when `REQUEST_METHOD` is set (CGI environment guard).
- `_build_http_client()`: builds `ProxyConnector` for the HTTP session when a SOCKS
  URL is detected; sets `trust_env=False` on both sessions to prevent double-proxying.
- WebSocket session routes through SOCKS only when `upstream_websocket_trust_env=True`
  (operator opt-in); connector leak guard added with a `try/except` wrapping both
  session constructions so the first connector is closed if the second fails.

**`tests/unit/test_http_client.py`**
- `test_socks_proxy_url_detects_lowercase_socks_proxy`
- `test_socks_proxy_url_strips_whitespace_from_env_value`
- `test_socks_proxy_url_normalizes_http_scheme_for_socks_proxy_env`
- `test_init_http_client_uses_proxy_connector_for_socks_url` — full connector
  construction path with `trust_env=False` assertions for both sessions.

## Test plan

```bash
uv run pytest tests/unit/test_http_client.py -q
```

## Checklist

- [x] Title is in Conventional Commits format (`feat(proxy): ...`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` locally.
- [x] OpenSpec change at `openspec/changes/add-socks5-proxy-support/`.
- [x] `openspec validate --specs` passes.
- [x] CHANGELOG is **not** edited by hand.