### PR TITLE
fix(proxy): replay stale websocket anchors before fail-closed

### DIFF
--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -180,6 +180,27 @@ _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS = 5.0
 _HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD = 100
 
 
+def _request_kind_from_headers(headers: Mapping[str, str] | None) -> str:
+    if not headers:
+        return "normal"
+    raw_turn_metadata = headers.get("x-codex-turn-metadata") or headers.get("X-Codex-Turn-Metadata")
+    if not isinstance(raw_turn_metadata, str):
+        return "normal"
+    try:
+        turn_metadata = json.loads(raw_turn_metadata)
+    except json.JSONDecodeError:
+        return "normal"
+    if not isinstance(turn_metadata, dict):
+        return "normal"
+    raw_request_kind = turn_metadata.get("request_kind")
+    if not isinstance(raw_request_kind, str):
+        return "normal"
+    request_kind = raw_request_kind.strip()
+    if request_kind in {"normal", "prewarm"}:
+        return request_kind
+    return "normal"
+
+
 class _HTTPBridgeRequestSubmitMixin:
     def _prepare_http_bridge_request(
         self: Any,
@@ -198,6 +219,7 @@ class _HTTPBridgeRequestSubmitMixin:
             attach_event_queue=True,
             transport=_REQUEST_TRANSPORT_HTTP,
             client_metadata=_response_create_client_metadata(payload.to_payload(), headers=headers),
+            headers=headers,
             session_id=_owner_lookup_session_id_from_headers(headers),
             request_log_id=request_id or get_request_id() or ensure_request_id(None),
         )
@@ -214,6 +236,7 @@ class _HTTPBridgeRequestSubmitMixin:
         attach_event_queue: bool,
         transport: str,
         client_metadata: Mapping[str, JsonValue] | None,
+        headers: Mapping[str, str] | None = None,
         session_id: str | None = None,
         request_id: str | None = None,
         request_log_id: str | None = None,
@@ -266,6 +289,7 @@ class _HTTPBridgeRequestSubmitMixin:
             session_id=_normalize_session_id(session_id),
             input_item_count=input_item_count,
             input_full_fingerprint=input_full_fingerprint,
+            request_kind=_request_kind_from_headers(headers),
         )
         if deduped_replayed_input_count is not None:
             request_state.input_item_count = deduped_replayed_input_count

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -184,6 +184,22 @@ def _request_kind_from_headers(headers: Mapping[str, str] | None) -> str:
     if not headers:
         return "normal"
     raw_turn_metadata = headers.get("x-codex-turn-metadata") or headers.get("X-Codex-Turn-Metadata")
+    return _request_kind_from_turn_metadata_value(raw_turn_metadata)
+
+
+def _request_kind_from_client_metadata(
+    client_metadata: Mapping[str, JsonValue] | None,
+    headers: Mapping[str, str] | None,
+) -> str:
+    if client_metadata:
+        raw_turn_metadata = client_metadata.get("x-codex-turn-metadata")
+        request_kind = _request_kind_from_turn_metadata_value(raw_turn_metadata)
+        if request_kind != "normal":
+            return request_kind
+    return _request_kind_from_headers(headers)
+
+
+def _request_kind_from_turn_metadata_value(raw_turn_metadata: object) -> str:
     if not isinstance(raw_turn_metadata, str):
         return "normal"
     try:
@@ -289,7 +305,7 @@ class _HTTPBridgeRequestSubmitMixin:
             session_id=_normalize_session_id(session_id),
             input_item_count=input_item_count,
             input_full_fingerprint=input_full_fingerprint,
-            request_kind=_request_kind_from_headers(headers),
+            request_kind=_request_kind_from_client_metadata(client_metadata, headers),
         )
         if deduped_replayed_input_count is not None:
             request_state.input_item_count = deduped_replayed_input_count

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -679,7 +679,17 @@ class _HTTPBridgeUpstreamEventsMixin:
                     event_type,
                 ) = _build_stream_incomplete_terminal_event_for_request(status_request_state)
 
-        if event_type == "response.completed" and terminal_request_state is not None:
+        completed_usage = (
+            event.response.usage if event_type == "response.completed" and event and event.response else None
+        )
+        completed_empty_prewarm = (
+            event_type == "response.completed"
+            and terminal_request_state is not None
+            and terminal_request_state.request_kind == "prewarm"
+            and completed_usage is not None
+            and completed_usage.output_tokens == 0
+        )
+        if event_type == "response.completed" and terminal_request_state is not None and not completed_empty_prewarm:
             # Record the completed response id regardless of input shape so
             # subsequent turns (including ones that never populated
             # input_item_count, e.g. string inputs) can still reuse this
@@ -710,7 +720,12 @@ class _HTTPBridgeUpstreamEventsMixin:
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
             await _release_websocket_response_create_gate(created_request_state, session.response_create_gate)
 
-        if response_id is not None and matched_request_state is not None and event_type == "response.completed":
+        if (
+            response_id is not None
+            and matched_request_state is not None
+            and event_type == "response.completed"
+            and not completed_empty_prewarm
+        ):
             await self._register_http_bridge_previous_response_id(
                 session,
                 response_id,

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -325,6 +325,7 @@ class _WebSocketRequestState:
     upstream_proxy_fail_closed_reason: str | None = None
     useragent: str | None = None
     useragent_group: str | None = None
+    request_kind: str = "normal"
     downstream_visible: bool = False
     suppress_next_created_downstream: bool = False
     replay_downstream_response_id: str | None = None

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1221,6 +1221,7 @@ class _WebSocketMixin:
                 attach_event_queue=False,
                 transport=_REQUEST_TRANSPORT_WEBSOCKET,
                 client_metadata=client_metadata,
+                headers=headers,
                 session_id=session_id,
             )
         except ProxyResponseError:
@@ -2848,14 +2849,22 @@ class _WebSocketMixin:
             )
             if handled_auth_failure:
                 return text
-        event, payload, event_type, downstream_text = _maybe_rewrite_websocket_previous_response_not_found_event(
-            request_state=request_state,
-            event=event,
-            payload=payload,
-            event_type=event_type,
-            upstream_control=upstream_control,
-            original_text=text,
+        retry_safe_previous_response_not_found = (
+            retry_is_previous_response_not_found
+            and request_state.fresh_upstream_request_is_retry_safe
+            and bool(request_state.fresh_upstream_request_text)
         )
+        if retry_safe_previous_response_not_found:
+            downstream_text = text
+        else:
+            event, payload, event_type, downstream_text = _maybe_rewrite_websocket_previous_response_not_found_event(
+                request_state=request_state,
+                event=event,
+                payload=payload,
+                event_type=event_type,
+                upstream_control=upstream_control,
+                original_text=text,
+            )
         if retry_error_code is None:
             retry_error_code = _websocket_precreated_retry_error_code(
                 request_state,
@@ -2867,6 +2876,7 @@ class _WebSocketMixin:
             retry_error_code in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES
             and request_state.previous_response_id is not None
             and request_state.preferred_account_id is not None
+            and not retry_safe_previous_response_not_found
         ):
             await proxy._handle_stream_error(
                 account,
@@ -2916,7 +2926,16 @@ class _WebSocketMixin:
             if retry_error_code is not None:
                 return downstream_text
 
-        if event_type == "response.completed" and continuity_state is not None:
+        completed_usage = (
+            event.response.usage if event_type == "response.completed" and event and event.response else None
+        )
+        completed_empty_prewarm = (
+            event_type == "response.completed"
+            and request_state.request_kind == "prewarm"
+            and completed_usage is not None
+            and completed_usage.output_tokens == 0
+        )
+        if event_type == "response.completed" and continuity_state is not None and not completed_empty_prewarm:
             _record_websocket_continuity_completion(
                 continuity_state,
                 request_state=request_state,
@@ -3228,7 +3247,15 @@ class _WebSocketMixin:
             error_message=error_message,
             error=error_payload,
         )
+        completed_empty_prewarm = (
+            event_type == "response.completed"
+            and request_state.request_kind == "prewarm"
+            and usage is not None
+            and usage.output_tokens == 0
+        )
         if event_type in {"response.failed", "response.incomplete", "error"}:
+            settlement.record_success = False
+        if completed_empty_prewarm:
             settlement.record_success = False
         if event_type in {"response.failed", "error"}:
             settlement.account_health_error = _facade()._should_penalize_stream_error(error_code) and not getattr(
@@ -3308,6 +3335,7 @@ class _WebSocketMixin:
                 upstream_proxy_fail_closed_reason=request_state.upstream_proxy_fail_closed_reason,
                 useragent=request_state.useragent,
                 useragent_group=request_state.useragent_group,
+                request_kind=request_state.request_kind,
             )
 
     async def _write_websocket_connect_failure(
@@ -3348,6 +3376,7 @@ class _WebSocketMixin:
             upstream_proxy_fail_closed_reason=request_state.upstream_proxy_fail_closed_reason,
             useragent=request_state.useragent,
             useragent_group=request_state.useragent_group,
+            request_kind=request_state.request_kind,
         )
 
     async def _emit_websocket_connect_failure(
@@ -3548,6 +3577,7 @@ class _WebSocketMixin:
                 upstream_proxy_fail_closed_reason=request_state.upstream_proxy_fail_closed_reason,
                 useragent=request_state.useragent,
                 useragent_group=request_state.useragent_group,
+                request_kind=request_state.request_kind,
             )
 
     async def _emit_websocket_terminal_error(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11408,6 +11408,115 @@ async def test_finalize_websocket_request_state_updates_balancer_state(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_finalize_websocket_request_state_does_not_record_empty_prewarm_success(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_ws_empty_prewarm")
+    record_success = AsyncMock()
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    completed_payload: dict[str, JsonValue] = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_ws_empty_prewarm",
+            "usage": {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+        },
+    }
+    completed_event = parse_sse_event(f"data: {json.dumps(completed_payload)}\n\n")
+    assert completed_event is not None
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_empty_prewarm",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_kind="prewarm",
+        session_id="sid_empty_prewarm",
+    )
+
+    await service._finalize_websocket_request_state(
+        request_state,
+        account=account,
+        account_id_value=account.id,
+        event=completed_event,
+        event_type="response.completed",
+        payload=completed_payload,
+        api_key=None,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    record_success.assert_not_awaited()
+    handle_stream_error.assert_not_awaited()
+    assert ("resp_ws_empty_prewarm", None, None) not in service._websocket_previous_response_account_index
+    assert (
+        "resp_ws_empty_prewarm",
+        None,
+        "sid_empty_prewarm",
+    ) not in service._websocket_previous_response_account_index
+    assert request_logs.calls[-1]["request_id"] == "resp_ws_empty_prewarm"
+    assert request_logs.calls[-1]["request_kind"] == "prewarm"
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_does_not_update_continuity_for_empty_prewarm(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    account = _make_account("acc_ws_empty_prewarm_continuity")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=1,
+        last_completed_response_id="resp_visible_before_prewarm",
+        last_completed_input_prefix_fingerprint="visible_fingerprint",
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_empty_prewarm_continuity",
+        response_id="resp_ws_empty_prewarm_continuity",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_kind="prewarm",
+        input_item_count=2,
+        input_full_fingerprint="prewarm_fingerprint",
+    )
+    pending_requests = deque([request_state])
+    upstream_payload: dict[str, JsonValue] = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_ws_empty_prewarm_continuity",
+            "usage": {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+        },
+    }
+
+    await service._process_upstream_websocket_text(
+        json.dumps(upstream_payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        response_create_gate=asyncio.Semaphore(1),
+        continuity_state=continuity_state,
+    )
+
+    finalize_request_state.assert_awaited_once()
+    assert continuity_state.last_completed_response_id == "resp_visible_before_prewarm"
+    assert continuity_state.last_completed_input_count == 1
+    assert continuity_state.last_completed_input_prefix_fingerprint == "visible_fingerprint"
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_does_not_match_foreign_response_id_to_only_pending_request(
     monkeypatch,
 ):
@@ -14842,7 +14951,7 @@ def test_websocket_continuity_response_ids_include_replay_downstream_alias_once(
 
 
 @pytest.mark.asyncio
-async def test_process_upstream_websocket_text_retries_precreated_previous_response_not_found(monkeypatch):
+async def test_process_upstream_websocket_text_retries_precreated_previous_response_not_found(monkeypatch, caplog):
     """A precreated retry-safe full-resend turn (with both
     ``fresh_upstream_request_is_retry_safe=True`` and
     ``fresh_upstream_request_text`` populated by the request-prep path) must
@@ -14884,6 +14993,7 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
         awaiting_response_created=True,
         request_text=json.dumps(request_payload, separators=(",", ":")),
         previous_response_id="resp_anchor",
+        preferred_account_id=account.id,
         fresh_upstream_request_text=json.dumps(fresh_request_payload, separators=(",", ":")),
         fresh_upstream_request_is_retry_safe=True,
         error_code_override="upstream_unavailable",
@@ -14933,6 +15043,7 @@ async def test_process_upstream_websocket_text_retries_precreated_previous_respo
     assert pending_request.error_type_override is None
     assert pending_request.error_param_override is None
     assert pending_request.error_http_status_override is None
+    assert "continuity_fail_closed surface=websocket_stream reason=previous_response_not_found" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -20450,6 +20561,25 @@ def test_prepare_http_bridge_request_persists_useragent_on_request_state():
 
     assert request_state.useragent == "opencode/1.15.13 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14"
     assert request_state.useragent_group == "opencode"
+
+
+def test_prepare_response_bridge_request_state_preserves_codex_request_kind():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hello", "input": []})
+
+    request_state, _text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=proxy_service._REQUEST_TRANSPORT_WEBSOCKET,
+        client_metadata=None,
+        headers={"x-codex-turn-metadata": json.dumps({"request_kind": "prewarm"})},
+    )
+
+    assert request_state.request_kind == "prewarm"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -20582,6 +20582,25 @@ def test_prepare_response_bridge_request_state_preserves_codex_request_kind():
     assert request_state.request_kind == "prewarm"
 
 
+def test_prepare_response_bridge_request_state_reads_codex_request_kind_from_client_metadata():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hello", "input": []})
+
+    request_state, _text_data = service._prepare_response_bridge_request_state(
+        payload,
+        api_key=None,
+        api_key_reservation=None,
+        include_type_field=True,
+        attach_event_queue=False,
+        transport=proxy_service._REQUEST_TRANSPORT_WEBSOCKET,
+        client_metadata={"x-codex-turn-metadata": json.dumps({"request_kind": "prewarm"})},
+        headers={},
+    )
+
+    assert request_state.request_kind == "prewarm"
+
+
 @pytest.mark.asyncio
 async def test_http_bridge_tool_call_dedupe_survives_upstream_reconnect():
     request_logs = _RequestLogsRecorder()
@@ -21224,6 +21243,73 @@ async def test_http_bridge_prewarm_times_out_on_silent_upstream(monkeypatch):
     assert not session.pending_requests
     assert session.upstream_control.reconnect_requested is False
     assert session.upstream_control.retire_after_drain is False
+
+
+@pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_does_not_anchor_empty_prewarm(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_http_bridge_empty_prewarm")
+    record_success = AsyncMock()
+
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", AsyncMock(return_value=True))
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_http_bridge_empty_prewarm",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_kind="prewarm",
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+        input_item_count=2,
+        input_full_fingerprint="prewarm_fingerprint",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-empty-prewarm", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+        codex_session=True,
+        last_completed_response_id="resp_visible_before_prewarm",
+        last_completed_input_count=1,
+        last_completed_input_prefix_fingerprint="visible_fingerprint",
+    )
+    service._http_bridge_sessions[session.key] = session
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_http_bridge_empty_prewarm",
+                    "usage": {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    record_success.assert_not_awaited()
+    assert session.last_completed_response_id == "resp_visible_before_prewarm"
+    assert session.last_completed_input_count == 1
+    assert session.last_completed_input_prefix_fingerprint == "visible_fingerprint"
+    assert "resp_http_bridge_empty_prewarm" not in session.previous_response_ids
+    assert not service._http_bridge_previous_response_index
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replay retry-safe WebSocket `previous_response_not_found` with the prepared no-anchor body before continuity fail-closed handling
- preserve Codex `request_kind` from `x-codex-turn-metadata`, including when it arrives through effective `client_metadata`
- prevent empty `prewarm` completions from updating account success, direct websocket continuity anchors, HTTP bridge session anchors, or HTTP bridge previous-response aliases

Related to #991.

## Tests
- `uv run pytest -q tests/unit/test_proxy_utils.py::test_prepare_response_bridge_request_state_preserves_codex_request_kind tests/unit/test_proxy_utils.py::test_prepare_response_bridge_request_state_reads_codex_request_kind_from_client_metadata tests/unit/test_proxy_utils.py::test_finalize_websocket_request_state_does_not_record_empty_prewarm_success tests/unit/test_proxy_utils.py::test_process_upstream_websocket_text_does_not_update_continuity_for_empty_prewarm tests/unit/test_proxy_utils.py::test_process_http_bridge_upstream_text_does_not_anchor_empty_prewarm`
- `uv run pytest -q tests/unit/test_proxy_utils.py -k 'previous_response_not_found or prewarm or request_kind'`
- `uv run ruff check app/modules/proxy/_service/http_bridge/request_submit.py app/modules/proxy/_service/http_bridge/upstream_events.py app/modules/proxy/_service/websocket/mixin.py tests/unit/test_proxy_utils.py`
- `uv run ty check`
- `git diff --check`
