### PR TITLE
fix(sse): split SSE event blocks only on CR/LF/CRLF (Closes #1010)

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -779,7 +779,7 @@ def _remaining_total_timeout(timeout_seconds: float | None, started_at: float, n
 
 
 def _find_sse_separator(buffer: bytes | bytearray) -> tuple[int, int] | None:
-    separators = (b"\r\n\r\n", b"\n\n")
+    separators = (b"\r\n\r\n", b"\n\n", b"\r\r")
     positions = [(buffer.find(separator), len(separator)) for separator in separators]
     valid_positions = [position for position in positions if position[0] >= 0]
     if not valid_positions:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -9,6 +9,7 @@ import ipaddress
 import json
 import logging
 import os
+import re
 import socket
 import time
 from contextlib import asynccontextmanager
@@ -95,6 +96,7 @@ _SSE_EVENT_TYPE_ALIASES = {
     "response.audio.delta": "response.output_audio.delta",
     "response.audio_transcript.delta": "response.output_audio_transcript.delta",
 }
+_SSE_LINE_BOUNDARY_RE = re.compile(r"\r\n|\r|\n")
 _RESPONSE_STREAM_TERMINAL_EVENT_TYPES = frozenset(
     {
         "response.completed",
@@ -1009,12 +1011,16 @@ def _normalize_sse_event_block(event_block: str) -> str:
         line_separator = "\n"
         terminator = "\n\n"
         body = event_block[: -len(terminator)]
+    elif event_block.endswith("\r\r"):
+        line_separator = "\r"
+        terminator = "\r\r"
+        body = event_block[: -len(terminator)]
     else:
         line_separator = "\r\n" if "\r\n" in event_block else "\n"
         terminator = ""
         body = event_block
 
-    lines = body.splitlines()
+    lines = _SSE_LINE_BOUNDARY_RE.split(body)
     if not lines:
         return event_block
 

--- a/app/core/utils/sse.py
+++ b/app/core/utils/sse.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from collections.abc import AsyncIterator, Mapping
 
 from app.core.errors import ResponseFailedEvent
@@ -9,6 +10,12 @@ from app.core.types import JsonValue
 from app.core.utils.json_guards import is_json_dict
 
 type JsonPayload = Mapping[str, JsonValue] | ResponseFailedEvent
+
+# The SSE spec delimits lines only by CR, LF, or CRLF. str.splitlines() also
+# breaks on other Unicode boundaries (VT, FF, FS/GS/RS, NEL, U+2028, U+2029),
+# and U+2028/U+2029 are valid *unescaped* inside JSON strings, so splitting on
+# them would corrupt a data: payload that legitimately contains one.
+_SSE_LINE_BOUNDARY = re.compile(r"\r\n|\r|\n")
 
 SSE_KEEPALIVE_FRAME = ": keepalive\n\n"
 CODEX_KEEPALIVE_FRAME = 'event: codex.keepalive\ndata: {"type":"codex.keepalive"}\n\n'
@@ -105,7 +112,7 @@ def extract_sse_data(event_block: str) -> str | None:
 
 def _extract_sse_data_lines(event_block: str) -> list[str] | None:
     data_lines: list[str] = []
-    for raw_line in event_block.splitlines():
+    for raw_line in _SSE_LINE_BOUNDARY.split(event_block):
         if not raw_line:
             continue
         if raw_line.startswith(":"):

--- a/openspec/changes/fix-sse-crlf-line-boundaries/proposal.md
+++ b/openspec/changes/fix-sse-crlf-line-boundaries/proposal.md
@@ -1,0 +1,23 @@
+# Change: fix SSE CR/LF line boundary parsing
+
+## Why
+
+Streaming Responses traffic can contain unescaped Unicode line-separator
+characters inside JSON string values. Python's `str.splitlines()` treats those
+characters as line breaks, which can corrupt an otherwise valid `data:` payload
+before JSON decoding.
+
+## What Changes
+
+- Define the Responses SSE parser contract so only CR, LF, and CRLF delimit SSE
+  lines.
+- Preserve Unicode separator characters such as U+2028 and U+2029 when they
+  appear inside a `data:` payload.
+- Keep existing multi-line `data:` joining semantics for CR/LF/CRLF-delimited
+  blocks.
+
+## Impact
+
+Clients streaming Responses events with Unicode line separators inside JSON
+strings keep receiving valid events instead of dropped or malformed parser
+results.

--- a/openspec/changes/fix-sse-crlf-line-boundaries/proposal.md
+++ b/openspec/changes/fix-sse-crlf-line-boundaries/proposal.md
@@ -11,10 +11,13 @@ before JSON decoding.
 
 - Define the Responses SSE parser contract so only CR, LF, and CRLF delimit SSE
   lines.
+- Treat CR-only blank lines as complete HTTP streaming SSE event separators.
 - Preserve Unicode separator characters such as U+2028 and U+2029 when they
   appear inside a `data:` payload.
 - Keep existing multi-line `data:` joining semantics for CR/LF/CRLF-delimited
   blocks.
+- Preserve the original SSE event terminator style when normalizing legacy
+  upstream event aliases.
 
 ## Impact
 

--- a/openspec/changes/fix-sse-crlf-line-boundaries/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-sse-crlf-line-boundaries/specs/responses-api-compat/spec.md
@@ -9,6 +9,10 @@ U+2028 LINE SEPARATOR or U+2029 PARAGRAPH SEPARATOR when those characters appear
 inside the payload value. Multi-line `data:` fields delimited by CR, LF, or CRLF
 MUST continue to be joined with `\n` before JSON decoding.
 
+The streaming HTTP receive path MUST also treat CR-only blank lines (`\r\r`) as
+complete SSE event separators, and any normalization of legacy event aliases
+MUST preserve the event block's original CR, LF, or CRLF terminator style.
+
 #### Scenario: Unicode separators inside JSON strings are preserved
 
 - **WHEN** an upstream Responses SSE event contains a `data:` JSON payload whose
@@ -22,3 +26,11 @@ MUST continue to be joined with `\n` before JSON decoding.
   delimited by CR, LF, or CRLF
 - **THEN** the parser joins the field values with `\n`
 - **AND** continues JSON decoding against the joined payload
+
+#### Scenario: CR-only event separators dispatch complete events
+
+- **WHEN** the HTTP streaming receive path receives an upstream SSE event ending
+  in a CR-only blank line
+- **THEN** it dispatches that event without waiting for EOF or an LF delimiter
+- **AND** legacy event alias normalization preserves the CR-only blank-line
+  terminator

--- a/openspec/changes/fix-sse-crlf-line-boundaries/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-sse-crlf-line-boundaries/specs/responses-api-compat/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Responses SSE parsing uses only CR/LF line boundaries
+
+When parsing streamed Responses Server-Sent Events, the service MUST treat only
+CR (`\r`), LF (`\n`), and CRLF (`\r\n`) as SSE line boundaries. The parser MUST
+NOT split a `data:` field on other Unicode line-boundary characters such as
+U+2028 LINE SEPARATOR or U+2029 PARAGRAPH SEPARATOR when those characters appear
+inside the payload value. Multi-line `data:` fields delimited by CR, LF, or CRLF
+MUST continue to be joined with `\n` before JSON decoding.
+
+#### Scenario: Unicode separators inside JSON strings are preserved
+
+- **WHEN** an upstream Responses SSE event contains a `data:` JSON payload whose
+  string value includes unescaped U+2028 or U+2029
+- **THEN** the parser preserves those characters inside the JSON string
+- **AND** the event remains available to downstream response-event processing
+
+#### Scenario: CR/LF-delimited multi-line data still joins
+
+- **WHEN** an upstream Responses SSE event contains multiple `data:` lines
+  delimited by CR, LF, or CRLF
+- **THEN** the parser joins the field values with `\n`
+- **AND** continues JSON decoding against the joined payload

--- a/openspec/changes/fix-sse-crlf-line-boundaries/tasks.md
+++ b/openspec/changes/fix-sse-crlf-line-boundaries/tasks.md
@@ -2,4 +2,6 @@
 - [x] Preserve Unicode line separators inside SSE `data:` payloads.
 - [x] Add parser regression coverage for Unicode line separators and CR/LF/CRLF
       multi-line `data:` joins.
+- [x] Add streaming receive and alias-normalization coverage for CR-only SSE
+      event separators.
 - [x] Validate the OpenSpec change and focused SSE tests.

--- a/openspec/changes/fix-sse-crlf-line-boundaries/tasks.md
+++ b/openspec/changes/fix-sse-crlf-line-boundaries/tasks.md
@@ -1,0 +1,5 @@
+- [x] Add Responses compatibility coverage for SSE CR/LF-only line boundaries.
+- [x] Preserve Unicode line separators inside SSE `data:` payloads.
+- [x] Add parser regression coverage for Unicode line separators and CR/LF/CRLF
+      multi-line `data:` joins.
+- [x] Validate the OpenSpec change and focused SSE tests.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1868,6 +1868,14 @@ def test_find_sse_separator_prefers_earliest_separator():
     assert result == (10, 2)
 
 
+def test_find_sse_separator_accepts_cr_only_blank_line():
+    buffer = b"event: one\r\rdata: two\n\n"
+
+    result = proxy_module._find_sse_separator(buffer)
+
+    assert result == (10, 2)
+
+
 def test_pop_sse_event_returns_first_event_and_mutates_buffer():
     buffer = bytearray(b"data: one\n\ndata: two\n\n")
 
@@ -2899,6 +2907,16 @@ async def test_iter_sse_events_handles_large_single_line_without_chunk_too_big()
     assert len(chunks) == 1
     assert chunks[0].startswith("data: ")
     assert chunks[0].endswith("\n\n")
+
+
+@pytest.mark.asyncio
+async def test_iter_sse_events_accepts_cr_only_blank_line_separator():
+    response = _DummyResponse([b'data: {"type":"response.completed"}\r\r'])
+    stream = proxy_module._iter_sse_events(cast(proxy_module.SSEResponse, response), 1.0, 1024)
+
+    chunks = [chunk async for chunk in stream]
+
+    assert chunks == ['data: {"type":"response.completed"}\r\r']
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1860,6 +1860,27 @@ def test_normalize_sse_event_block_rewrites_response_text_alias():
     assert normalized.endswith("\n\n")
 
 
+def test_normalize_sse_event_block_rewrites_response_text_alias_with_cr_only_terminator():
+    block = 'data: {"type":"response.text.delta","delta":"hi"}\r\r'
+
+    normalized = proxy_module._normalize_sse_event_block(block)
+
+    assert '"type":"response.output_text.delta"' in normalized
+    assert normalized.endswith("\r\r")
+    assert not normalized.endswith("\n")
+
+
+def test_normalize_sse_event_block_preserves_unicode_line_separator_in_alias_payload():
+    payload = {"type": "response.text.delta", "delta": "a\u2028b"}
+    block = "data: " + json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\r\r"
+
+    normalized = proxy_module._normalize_sse_event_block(block)
+
+    assert '"type":"response.output_text.delta"' in normalized
+    assert '"delta":"a\\u2028b"' in normalized
+    assert normalized.endswith("\r\r")
+
+
 def test_find_sse_separator_prefers_earliest_separator():
     buffer = b"event: one\n\ndata: two\r\n\r\n"
 

--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import AsyncIterator
 
 import pytest
 
-from app.core.utils.sse import CODEX_KEEPALIVE_FRAME, SSE_KEEPALIVE_FRAME, format_sse_event, inject_sse_keepalives
+from app.core.openai.parsing import parse_sse_event
+from app.core.utils.sse import (
+    CODEX_KEEPALIVE_FRAME,
+    SSE_KEEPALIVE_FRAME,
+    extract_sse_data,
+    format_sse_event,
+    inject_sse_keepalives,
+    parse_sse_data_json,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -66,3 +75,41 @@ async def test_inject_sse_keepalives_can_emit_codex_event_frame():
 async def test_inject_sse_keepalives_keepalive_frame_is_sse_comment():
     assert SSE_KEEPALIVE_FRAME.startswith(":")
     assert SSE_KEEPALIVE_FRAME.endswith("\n\n")
+
+
+def test_extract_sse_data_preserves_unicode_line_separators():
+    # U+2028 / U+2029 are valid *unescaped* inside JSON strings. The SSE spec
+    # delimits lines only by CR/LF/CRLF, so they must not split a data: payload.
+    payload = {"type": "response.output_text.delta", "delta": "line1\u2028line2\u2029end"}
+    block = "event: response.output_text.delta\ndata: " + json.dumps(payload, ensure_ascii=False) + "\n\n"
+
+    data = extract_sse_data(block)
+
+    assert data is not None
+    assert json.loads(data) == payload
+
+
+def test_parse_sse_data_json_preserves_unicode_line_separators():
+    payload = {"type": "response.completed", "response": {"id": "resp_1", "status": "completed", "note": "a\u2028b"}}
+    block = "data: " + json.dumps(payload, ensure_ascii=False) + "\n\n"
+
+    assert parse_sse_data_json(block) == payload
+
+
+def test_parse_sse_event_parses_payload_with_unicode_line_separators():
+    # The proxy receive path relies on parse_sse_event for terminal-event
+    # detection, dedupe, and usage; an unescaped U+2028 used to drop the event.
+    payload = {"type": "response.output_text.delta", "delta": "x\u2028y\u2029z"}
+    block = "event: response.output_text.delta\ndata: " + json.dumps(payload, ensure_ascii=False) + "\n\n"
+
+    event = parse_sse_event(block)
+
+    assert event is not None
+    assert event.type == "response.output_text.delta"
+
+
+def test_extract_sse_data_joins_crlf_multiline_data():
+    # CR, LF, and CRLF all remain valid line boundaries after the fix.
+    block = "data: line1\r\ndata: line2\rdata: line3\n\n"
+
+    assert extract_sse_data(block) == "line1\nline2\nline3"


### PR DESCRIPTION
## Summary

Closes #1010

`_extract_sse_data_lines` in `app/core/utils/sse.py` split SSE event blocks with `str.splitlines()`. `splitlines()` breaks on a wide set of Unicode boundaries (`\v`, `\f`, `\x1c`-`\x1e`, NEL U+0085, U+2028, U+2029), whereas the SSE spec delimits lines only by CR, LF, or CRLF.

U+2028 / U+2029 are valid unescaped characters inside JSON strings, and models emit them in text. When an upstream Responses event carried one in its JSON payload, `splitlines()` split the `data:` line mid-string, the reassembled value failed `json.loads`, and `parse_sse_event` returned `None`. The raw block was still forwarded to the client, but the event became invisible to receive-path logic such as terminal-event detection, tool-call dedupe, and usage accounting.

## Fix

- split SSE data lines on CR, LF, or CRLF only instead of `str.splitlines()`
- treat CR-only blank lines as complete HTTP streaming SSE event separators
- preserve CR-only event terminators when normalizing legacy upstream event aliases such as `response.text.delta`
- document the parser/framer contract in OpenSpec

## Tests

- `uv run pytest tests/unit/test_sse.py tests/unit/test_proxy_utils.py -q`
- `uv run ruff check app/core/clients/proxy.py app/core/utils/sse.py tests/unit/test_proxy_utils.py tests/unit/test_sse.py`
- `openspec validate --specs`
- `git diff --check`
