### PR TITLE
feat(acc): Accounts banked reset management 

### DIFF
--- a/app/core/clients/rate_limit_reset_credits.py
+++ b/app/core/clients/rate_limit_reset_credits.py
@@ -344,9 +344,7 @@ async def consume_rate_limit_reset_credit(
                 try:
                     return ConsumeCreditResponse.model_validate(data)
                 except ValidationError as exc:
-                    raise RateLimitResetCreditsFetchError(
-                        502, "Invalid consume response payload"
-                    ) from exc
+                    raise RateLimitResetCreditsFetchError(502, "Invalid consume response payload") from exc
     except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
         logger.warning(
             "Rate limit reset credit consume error request_id=%s error=%s",

--- a/app/core/clients/rate_limit_reset_credits.py
+++ b/app/core/clients/rate_limit_reset_credits.py
@@ -309,6 +309,8 @@ async def consume_rate_limit_reset_credit(
     timeout_seconds: float | None = None,
     max_retries: int | None = None,
     client: RetryClient | None = None,
+    route: ResolvedUpstreamRoute | None = None,
+    codex_client: CodexClient | None = None,
     allow_direct_egress: bool = False,
 ) -> ConsumeCreditResponse:
     settings = get_settings()
@@ -323,12 +325,22 @@ async def consume_rate_limit_reset_credit(
         "redeem_request_id": redeem_request_id or str(uuid.uuid4()),
     }
     require_route_or_direct_egress_opt_in(
-        route=None,
+        route=route,
         allow_direct_egress=allow_direct_egress,
         operation="rate limit reset credit consume",
     )
 
     try:
+        if route is not None:
+            return await _consume_via_codex(
+                url=url,
+                route=route,
+                headers=headers,
+                body=body,
+                timeout_seconds=timeout_seconds or settings.usage_fetch_timeout_seconds,
+                retries=retries,
+                codex_client=codex_client,
+            )
         async with lease_retry_client(client) as retry_client:
             async with retry_client.request(
                 "POST",
@@ -341,14 +353,64 @@ async def consume_rate_limit_reset_credit(
                 data = await _safe_json(resp)
                 if resp.status >= 400:
                     raise _fetch_error(data, resp.status)
-                try:
-                    return ConsumeCreditResponse.model_validate(data)
-                except ValidationError as exc:
-                    raise RateLimitResetCreditsFetchError(502, "Invalid consume response payload") from exc
-    except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                return _consume_payload_or_raise(data)
+    except (aiohttp.ClientError, asyncio.TimeoutError, CodexTransportError) as exc:
         logger.warning(
             "Rate limit reset credit consume error request_id=%s error=%s",
             get_request_id(),
             exc,
         )
         raise RateLimitResetCreditsFetchError(0, f"Consume request failed: {exc}") from exc
+
+
+async def _consume_via_codex(
+    *,
+    url: str,
+    route: ResolvedUpstreamRoute,
+    headers: dict[str, str],
+    body: JsonObject,
+    timeout_seconds: float,
+    retries: int,
+    codex_client: CodexClient | None,
+) -> ConsumeCreditResponse:
+    attempts = max(1, retries + 1)
+    owns_codex_client = codex_client is None
+    active_codex_client = codex_client or CodexClient(create_codex_session())
+    try:
+        for attempt in range(attempts):
+            try:
+                resp = await active_codex_client.request(
+                    "POST",
+                    url,
+                    route=route,
+                    headers=headers,
+                    json=body,
+                    timeout=timeout_seconds,
+                )
+            except CodexTransportError:
+                if attempt < attempts - 1:
+                    await asyncio.sleep(_retry_delay_seconds(attempt))
+                    continue
+                raise
+
+            data = await _safe_codex_json(resp)
+            status = _codex_response_status(resp)
+            if status in RETRYABLE_STATUS and attempt < attempts - 1:
+                await asyncio.sleep(_retry_delay_seconds(attempt))
+                continue
+            if status >= 400:
+                raise _fetch_error(data, status)
+            return _consume_payload_or_raise(data)
+    finally:
+        if owns_codex_client:
+            close = getattr(active_codex_client, "close", None)
+            if callable(close):
+                await close()
+    raise RuntimeError("unreachable rate limit reset credit consume retry state")
+
+
+def _consume_payload_or_raise(data: JsonObject) -> ConsumeCreditResponse:
+    try:
+        return ConsumeCreditResponse.model_validate(data)
+    except ValidationError as exc:
+        raise RateLimitResetCreditsFetchError(502, "Invalid consume response payload") from exc

--- a/app/core/clients/rate_limit_reset_credits.py
+++ b/app/core/clients/rate_limit_reset_credits.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from datetime import datetime
 
 import aiohttp
@@ -276,3 +277,80 @@ def _retry_options(attempts: int) -> ExponentialRetry:
 
 def _retry_delay_seconds(attempt: int) -> float:
     return min(RETRY_MAX_TIMEOUT, RETRY_START_TIMEOUT * (2.0**attempt))
+
+
+class ConsumedCreditPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str | None = None
+    status: str | None = None
+    redeemed_at: datetime | None = None
+
+
+class ConsumeCreditResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    code: str | None = None
+    credit: ConsumedCreditPayload | None = None
+    windows_reset: int | None = None
+
+
+def _consume_url(base_url: str) -> str:
+    return f"{_credits_url(base_url)}/consume"
+
+
+async def consume_rate_limit_reset_credit(
+    *,
+    access_token: str,
+    account_id: str | None,
+    credit_id: str,
+    redeem_request_id: str | None = None,
+    base_url: str | None = None,
+    timeout_seconds: float | None = None,
+    max_retries: int | None = None,
+    client: RetryClient | None = None,
+    allow_direct_egress: bool = False,
+) -> ConsumeCreditResponse:
+    settings = get_settings()
+    usage_base = base_url or settings.upstream_base_url
+    url = _consume_url(usage_base)
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds or settings.usage_fetch_timeout_seconds)
+    retries = max_retries if max_retries is not None else settings.usage_fetch_max_retries
+    headers = _credits_headers(access_token, account_id)
+    retry_options = _retry_options(retries + 1)
+    body = {
+        "credit_id": credit_id,
+        "redeem_request_id": redeem_request_id or str(uuid.uuid4()),
+    }
+    require_route_or_direct_egress_opt_in(
+        route=None,
+        allow_direct_egress=allow_direct_egress,
+        operation="rate limit reset credit consume",
+    )
+
+    try:
+        async with lease_retry_client(client) as retry_client:
+            async with retry_client.request(
+                "POST",
+                url,
+                headers=headers,
+                json=body,
+                timeout=timeout,
+                retry_options=retry_options,
+            ) as resp:
+                data = await _safe_json(resp)
+                if resp.status >= 400:
+                    raise _fetch_error(data, resp.status)
+                try:
+                    return ConsumeCreditResponse.model_validate(data)
+                except ValidationError as exc:
+                    raise RateLimitResetCreditsFetchError(
+                        502, "Invalid consume response payload"
+                    ) from exc
+    except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+        logger.warning(
+            "Rate limit reset credit consume error request_id=%s error=%s",
+            get_request_id(),
+            exc,
+        )
+        raise RateLimitResetCreditsFetchError(0, f"Consume request failed: {exc}") from exc

--- a/app/core/clients/rate_limit_reset_credits.py
+++ b/app/core/clients/rate_limit_reset_credits.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+
+import aiohttp
+from aiohttp_retry import ExponentialRetry, RetryClient
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from app.core.clients.codex import (
+    CodexClient,
+    CodexTransportError,
+    create_codex_session,
+    require_route_or_direct_egress_opt_in,
+)
+from app.core.clients.http import lease_retry_client
+from app.core.config.settings import get_settings
+from app.core.types import JsonObject
+from app.core.upstream_proxy import ResolvedUpstreamRoute
+from app.core.utils.request_id import get_request_id
+
+RETRYABLE_STATUS = {408, 429, 500, 502, 503, 504}
+RETRY_START_TIMEOUT = 0.5
+RETRY_MAX_TIMEOUT = 2.0
+
+logger = logging.getLogger(__name__)
+
+
+class RateLimitResetCreditPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    status: str
+    granted_at: datetime
+    expires_at: datetime
+    redeemed_at: datetime | None = None
+
+
+class RateLimitResetCreditsPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    credits: list[RateLimitResetCreditPayload]
+    available_count: int | None = None
+
+
+class _ErrorDetail(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    code: str | None = None
+    message: str | None = None
+    error_description: str | None = None
+
+
+class _ErrorEnvelope(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    error: _ErrorDetail | str | None = None
+    error_description: str | None = None
+    message: str | None = None
+
+
+class RateLimitResetCreditsFetchError(Exception):
+    def __init__(self, status_code: int, message: str, code: str | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+        self.code = code
+
+
+async def fetch_rate_limit_reset_credits(
+    *,
+    access_token: str,
+    account_id: str | None,
+    base_url: str | None = None,
+    timeout_seconds: float | None = None,
+    max_retries: int | None = None,
+    client: RetryClient | None = None,
+    route: ResolvedUpstreamRoute | None = None,
+    codex_client: CodexClient | None = None,
+    allow_direct_egress: bool = False,
+) -> RateLimitResetCreditsPayload:
+    settings = get_settings()
+    usage_base = base_url or settings.upstream_base_url
+    url = _credits_url(usage_base)
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds or settings.usage_fetch_timeout_seconds)
+    retries = max_retries if max_retries is not None else settings.usage_fetch_max_retries
+    headers = _credits_headers(access_token, account_id)
+    retry_options = _retry_options(retries + 1)
+    require_route_or_direct_egress_opt_in(
+        route=route,
+        allow_direct_egress=allow_direct_egress,
+        operation="rate limit reset credits fetch",
+    )
+
+    try:
+        if route is not None:
+            return await _fetch_via_codex(
+                url=url,
+                route=route,
+                headers=headers,
+                timeout_seconds=timeout_seconds or settings.usage_fetch_timeout_seconds,
+                retries=retries,
+                codex_client=codex_client,
+            )
+        async with lease_retry_client(client) as retry_client:
+            async with retry_client.request(
+                "GET",
+                url,
+                headers=headers,
+                timeout=timeout,
+                retry_options=retry_options,
+            ) as resp:
+                data = await _safe_json(resp)
+                if resp.status >= 400:
+                    raise _fetch_error(data, resp.status)
+                return _payload_or_raise(data)
+    except (aiohttp.ClientError, asyncio.TimeoutError, CodexTransportError) as exc:
+        logger.warning(
+            "Rate limit reset credits fetch error request_id=%s error=%s",
+            get_request_id(),
+            exc,
+        )
+        raise RateLimitResetCreditsFetchError(0, f"Rate limit reset credits fetch failed: {exc}") from exc
+
+
+async def _fetch_via_codex(
+    *,
+    url: str,
+    route: ResolvedUpstreamRoute,
+    headers: dict[str, str],
+    timeout_seconds: float,
+    retries: int,
+    codex_client: CodexClient | None,
+) -> RateLimitResetCreditsPayload:
+    attempts = max(1, retries + 1)
+    owns_codex_client = codex_client is None
+    active_codex_client = codex_client or CodexClient(create_codex_session())
+    try:
+        for attempt in range(attempts):
+            try:
+                resp = await active_codex_client.request(
+                    "GET",
+                    url,
+                    route=route,
+                    headers=headers,
+                    timeout=timeout_seconds,
+                )
+            except CodexTransportError:
+                if attempt < attempts - 1:
+                    await asyncio.sleep(_retry_delay_seconds(attempt))
+                    continue
+                raise
+
+            data = await _safe_codex_json(resp)
+            status = _codex_response_status(resp)
+            if status in RETRYABLE_STATUS and attempt < attempts - 1:
+                await asyncio.sleep(_retry_delay_seconds(attempt))
+                continue
+            if status >= 400:
+                raise _fetch_error(data, status)
+            return _payload_or_raise(data)
+    finally:
+        if owns_codex_client:
+            close = getattr(active_codex_client, "close", None)
+            if callable(close):
+                await close()
+    raise RuntimeError("unreachable rate limit reset credits retry state")
+
+
+def _payload_or_raise(data: JsonObject) -> RateLimitResetCreditsPayload:
+    try:
+        return RateLimitResetCreditsPayload.model_validate(data)
+    except ValidationError as exc:
+        logger.warning(
+            "Rate limit reset credits fetch invalid payload request_id=%s",
+            get_request_id(),
+        )
+        raise RateLimitResetCreditsFetchError(502, "Invalid rate limit reset credits payload") from exc
+
+
+def _fetch_error(payload: JsonObject, status: int) -> RateLimitResetCreditsFetchError:
+    code = _extract_error_code(payload)
+    message = _extract_error_message(payload) or f"Rate limit reset credits fetch failed ({status})"
+    logger.warning(
+        "Rate limit reset credits fetch failed request_id=%s status=%s code=%s message=%s",
+        get_request_id(),
+        status,
+        code,
+        message,
+    )
+    return RateLimitResetCreditsFetchError(status, message, code=code)
+
+
+def _credits_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if "/backend-api" not in normalized:
+        normalized = f"{normalized}/backend-api"
+    return f"{normalized}/wham/rate-limit-reset-credits"
+
+
+def _credits_headers(access_token: str, account_id: str | None) -> dict[str, str]:
+    headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/json"}
+    request_id = get_request_id()
+    if request_id:
+        headers["x-request-id"] = request_id
+    if account_id and not account_id.startswith(("email_", "local_")):
+        headers["chatgpt-account-id"] = account_id
+    return headers
+
+
+async def _safe_json(resp: aiohttp.ClientResponse) -> JsonObject:
+    try:
+        data = await resp.json(content_type=None)
+    except Exception:
+        text = await resp.text()
+        return {"error": {"message": text.strip()}}
+    return data if isinstance(data, dict) else {"error": {"message": str(data)}}
+
+
+async def _safe_codex_json(response: object) -> JsonObject:
+    try:
+        json_method = getattr(response, "json", None)
+        if callable(json_method):
+            data = json_method()
+            if asyncio.iscoroutine(data):
+                data = await data
+            return data if isinstance(data, dict) else {"error": {"message": str(data)}}
+    except Exception:
+        pass
+    content = getattr(response, "content", None)
+    if isinstance(content, bytes):
+        return {"error": {"message": content.decode("utf-8", errors="replace").strip()}}
+    if isinstance(content, str):
+        return {"error": {"message": content.strip()}}
+    return {"error": {"message": ""}}
+
+
+def _codex_response_status(response: object) -> int:
+    value = getattr(response, "status_code", getattr(response, "status", None))
+    if value is None:
+        return 0
+    return int(value)
+
+
+def _extract_error_message(payload: JsonObject) -> str | None:
+    envelope = _ErrorEnvelope.model_validate(payload)
+    error = envelope.error
+    if isinstance(error, _ErrorDetail):
+        return error.message or error.error_description
+    if isinstance(error, str):
+        return envelope.error_description or error
+    return envelope.message
+
+
+def _extract_error_code(payload: JsonObject) -> str | None:
+    envelope = _ErrorEnvelope.model_validate(payload)
+    error = envelope.error
+    if isinstance(error, _ErrorDetail) and isinstance(error.code, str):
+        normalized = error.code.strip().lower()
+        return normalized or None
+    return None
+
+
+def _retry_options(attempts: int) -> ExponentialRetry:
+    return ExponentialRetry(
+        attempts=attempts,
+        start_timeout=RETRY_START_TIMEOUT,
+        max_timeout=RETRY_MAX_TIMEOUT,
+        factor=2.0,
+        statuses=RETRYABLE_STATUS,
+        exceptions={aiohttp.ClientError, asyncio.TimeoutError},
+        retry_all_server_errors=False,
+    )
+
+
+def _retry_delay_seconds(attempt: int) -> float:
+    return min(RETRY_MAX_TIMEOUT, RETRY_START_TIMEOUT * (2.0**attempt))

--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -12,6 +12,7 @@ from app.core.usage import capacity_for_plan
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountsRepository
+from app.modules.accounts.reset_credit_updater import ResetCreditUpdater
 from app.modules.limit_warmup.repository import LimitWarmupRepository
 from app.modules.limit_warmup.service import LimitWarmupService, StreamingLimitWarmupSender
 from app.modules.proxy.account_cache import get_account_selection_cache
@@ -105,7 +106,9 @@ class UsageRefreshScheduler:
                     before_primary = await usage_repo.latest_by_account(window="primary")
                     before_secondary = await usage_repo.latest_by_account(window="secondary")
                     accounts = await accounts_repo.list_accounts()
+                    reset_credit_updater = ResetCreditUpdater(accounts_repo)
                     updater = UsageUpdater(usage_repo, accounts_repo, additional_usage_repo)
+                    await reset_credit_updater.refresh_accounts(accounts)
                     usage_written = await updater.refresh_accounts(accounts, before_primary)
                     if usage_written:
                         after_primary = await usage_repo.latest_by_account(window="primary")

--- a/app/db/alembic/versions/20260615_000000_add_account_rate_limit_reset_credits.py
+++ b/app/db/alembic/versions/20260615_000000_add_account_rate_limit_reset_credits.py
@@ -1,0 +1,91 @@
+"""add account rate limit reset credits
+
+Revision ID: 20260615_000000_add_account_rate_limit_reset_credits
+Revises: 20260611_000000_merge_dashboard_guest_and_weekly_useragent_heads
+Create Date: 2026-06-15 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260615_000000_add_account_rate_limit_reset_credits"
+down_revision = "20260611_000000_merge_dashboard_guest_and_weekly_useragent_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("account_rate_limit_reset_credits"):
+        op.create_table(
+            "account_rate_limit_reset_credits",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("account_id", sa.String(), nullable=False),
+            sa.Column("credit_id", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("granted_at", sa.DateTime(), nullable=False),
+            sa.Column("expires_at", sa.DateTime(), nullable=False),
+            sa.Column("redeemed_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(["account_id"], ["accounts.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "account_id",
+                "credit_id",
+                name="uq_account_rate_limit_reset_credits_account_credit",
+            ),
+        )
+
+    index_names = {index["name"] for index in inspector.get_indexes("account_rate_limit_reset_credits")}
+    if "idx_account_rate_limit_reset_credits_account_id" not in index_names:
+        op.create_index(
+            "idx_account_rate_limit_reset_credits_account_id",
+            "account_rate_limit_reset_credits",
+            ["account_id"],
+            unique=False,
+        )
+    if "idx_account_rate_limit_reset_credits_status" not in index_names:
+        op.create_index(
+            "idx_account_rate_limit_reset_credits_status",
+            "account_rate_limit_reset_credits",
+            ["status"],
+            unique=False,
+        )
+    if "idx_account_rate_limit_reset_credits_expires_at" not in index_names:
+        op.create_index(
+            "idx_account_rate_limit_reset_credits_expires_at",
+            "account_rate_limit_reset_credits",
+            ["expires_at"],
+            unique=False,
+        )
+    if "idx_account_rate_limit_reset_credits_account_status_expires_at" not in index_names:
+        op.create_index(
+            "idx_account_rate_limit_reset_credits_account_status_expires_at",
+            "account_rate_limit_reset_credits",
+            ["account_id", "status", "expires_at"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table("account_rate_limit_reset_credits"):
+        return
+
+    index_names = {index["name"] for index in inspector.get_indexes("account_rate_limit_reset_credits")}
+    if "idx_account_rate_limit_reset_credits_account_status_expires_at" in index_names:
+        op.drop_index(
+            "idx_account_rate_limit_reset_credits_account_status_expires_at",
+            table_name="account_rate_limit_reset_credits",
+        )
+    if "idx_account_rate_limit_reset_credits_expires_at" in index_names:
+        op.drop_index("idx_account_rate_limit_reset_credits_expires_at", table_name="account_rate_limit_reset_credits")
+    if "idx_account_rate_limit_reset_credits_status" in index_names:
+        op.drop_index("idx_account_rate_limit_reset_credits_status", table_name="account_rate_limit_reset_credits")
+    if "idx_account_rate_limit_reset_credits_account_id" in index_names:
+        op.drop_index("idx_account_rate_limit_reset_credits_account_id", table_name="account_rate_limit_reset_credits")
+    op.drop_table("account_rate_limit_reset_credits")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -131,6 +131,34 @@ class Account(Base):
         cascade="all, delete-orphan",
         uselist=False,
     )
+    rate_limit_reset_credits: Mapped[list["AccountRateLimitResetCredit"]] = relationship(
+        "AccountRateLimitResetCredit",
+        back_populates="account",
+        cascade="all, delete-orphan",
+    )
+
+
+class AccountRateLimitResetCredit(Base):
+    __tablename__ = "account_rate_limit_reset_credits"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    account_id: Mapped[str] = mapped_column(String, ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False)
+    credit_id: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    granted_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    redeemed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
+
+    account: Mapped[Account] = relationship("Account", back_populates="rate_limit_reset_credits")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "account_id",
+            "credit_id",
+            name="uq_account_rate_limit_reset_credits_account_credit",
+        ),
+    )
 
 
 class UsageHistory(Base):
@@ -1036,6 +1064,15 @@ Index(
     UsageHistory.id.desc(),
 )
 Index("idx_accounts_email", Account.email)
+Index("idx_account_rate_limit_reset_credits_account_id", AccountRateLimitResetCredit.account_id)
+Index("idx_account_rate_limit_reset_credits_status", AccountRateLimitResetCredit.status)
+Index("idx_account_rate_limit_reset_credits_expires_at", AccountRateLimitResetCredit.expires_at)
+Index(
+    "idx_account_rate_limit_reset_credits_account_status_expires_at",
+    AccountRateLimitResetCredit.account_id,
+    AccountRateLimitResetCredit.status,
+    AccountRateLimitResetCredit.expires_at,
+)
 Index("idx_api_keys_name", ApiKey.name)
 Index("idx_logs_account_time", RequestLog.account_id, RequestLog.requested_at)
 Index("idx_logs_api_key_time", RequestLog.api_key_id, RequestLog.requested_at.desc(), RequestLog.id.desc())

--- a/app/modules/accounts/api.py
+++ b/app/modules/accounts/api.py
@@ -26,6 +26,7 @@ from app.modules.accounts.schemas import (
     AccountProbeRequest,
     AccountProbeResponse,
     AccountReactivateResponse,
+    AccountResetCreditResponse,
     AccountRoutingPolicyUpdateRequest,
     AccountRoutingPolicyUpdateResponse,
     AccountsResponse,
@@ -301,3 +302,33 @@ async def delete_account(
         details={"account_id": account_id, "delete_history": delete_history},
     )
     return AccountDeleteResponse(status="deleted")
+
+
+@router.post("/{account_id}/reset-credit", response_model=AccountResetCreditResponse)
+async def reset_account_credit(
+    request: Request,
+    account_id: str,
+    _write_access=Depends(require_dashboard_write_access),
+    context: AccountsContext = Depends(get_accounts_context),
+) -> AccountResetCreditResponse:
+    from app.core.clients.rate_limit_reset_credits import RateLimitResetCreditsFetchError
+
+    try:
+        result = await context.service.reset_account_credit(account_id)
+    except RateLimitResetCreditsFetchError as exc:
+        raise DashboardConflictError(
+            f"Reset credit consume failed: {exc.message}",
+            code="reset_credit_consume_failed",
+        ) from exc
+    if result is None:
+        raise DashboardNotFoundError("Account not found", code="account_not_found")
+    AuditService.log_async(
+        "account_reset_credit",
+        actor_ip=request.client.host if request.client else None,
+        details={
+            "account_id": result.account_id,
+            "credit_id": result.credit_id,
+            "windows_reset": result.windows_reset,
+        },
+    )
+    return result

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -37,6 +37,7 @@ def build_account_summaries(
     request_usage_by_account: dict[str, AccountRequestUsage] | None = None,
     additional_quotas_by_account: dict[str, list[AccountAdditionalQuota]] | None = None,
     limit_warmups_by_account: dict[str, AccountLimitWarmup] | None = None,
+    available_reset_counts_by_account: dict[str, int] | None = None,
     encryptor: TokenEncryptor,
     include_auth: bool = True,
 ) -> list[AccountSummary]:
@@ -50,6 +51,7 @@ def build_account_summaries(
             request_usage_by_account.get(account.id) if request_usage_by_account else None,
             additional_quotas_by_account.get(account.id) if additional_quotas_by_account else None,
             limit_warmups_by_account.get(account.id) if limit_warmups_by_account else None,
+            (available_reset_counts_by_account or {}).get(account.id, 0),
             encryptor,
             include_auth=include_auth,
             is_email_duplicate=_duplicate_detection_key(account) in duplicate_keys,
@@ -96,6 +98,7 @@ def _account_to_summary(
     request_usage: AccountRequestUsage | None,
     additional_quotas: list[AccountAdditionalQuota] | None,
     limit_warmup: AccountLimitWarmup | None,
+    available_reset_count: int,
     encryptor: TokenEncryptor,
     include_auth: bool = True,
     is_email_duplicate: bool = False,
@@ -261,6 +264,7 @@ def _account_to_summary(
         limit_warmup_enabled=bool(account.limit_warmup_enabled),
         limit_warmup=_limit_warmup_to_status(limit_warmup),
         is_email_duplicate=is_email_duplicate,
+        available_reset_count=available_reset_count,
     )
 
 

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -38,6 +38,7 @@ def build_account_summaries(
     additional_quotas_by_account: dict[str, list[AccountAdditionalQuota]] | None = None,
     limit_warmups_by_account: dict[str, AccountLimitWarmup] | None = None,
     available_reset_counts_by_account: dict[str, int] | None = None,
+    nearest_reset_expiry_by_account: dict[str, datetime] | None = None,
     encryptor: TokenEncryptor,
     include_auth: bool = True,
 ) -> list[AccountSummary]:
@@ -53,6 +54,7 @@ def build_account_summaries(
             limit_warmups_by_account.get(account.id) if limit_warmups_by_account else None,
             (available_reset_counts_by_account or {}).get(account.id, 0),
             encryptor,
+            (nearest_reset_expiry_by_account or {}).get(account.id),
             include_auth=include_auth,
             is_email_duplicate=_duplicate_detection_key(account) in duplicate_keys,
         )
@@ -100,6 +102,7 @@ def _account_to_summary(
     limit_warmup: AccountLimitWarmup | None,
     available_reset_count: int,
     encryptor: TokenEncryptor,
+    nearest_reset_expiry_at: datetime | None = None,
     include_auth: bool = True,
     is_email_duplicate: bool = False,
 ) -> AccountSummary:
@@ -265,6 +268,7 @@ def _account_to_summary(
         limit_warmup=_limit_warmup_to_status(limit_warmup),
         is_email_duplicate=is_email_duplicate,
         available_reset_count=available_reset_count,
+        nearest_reset_expiry_at=nearest_reset_expiry_at,
     )
 
 

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -6,14 +6,15 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import delete, func, or_, select, text, update
-from sqlalchemy.exc import OperationalError
+from sqlalchemy import delete, func, or_, select, text, tuple_, update
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.time import utcnow
 from app.db.models import (
     Account,
     AccountLimitWarmup,
+    AccountRateLimitResetCredit,
     AccountStatus,
     AdditionalUsageHistory,
     ApiKeyAccountAssignment,
@@ -37,6 +38,16 @@ class AccountRequestUsageSummary:
     total_tokens: int
     cached_input_tokens: int
     total_cost_usd: float
+
+
+@dataclass(frozen=True, slots=True)
+class AccountRateLimitResetCreditRecord:
+    account_id: str
+    credit_id: str
+    status: str
+    granted_at: datetime
+    expires_at: datetime
+    redeemed_at: datetime | None
 
 
 class AccountIdentityConflictError(Exception):
@@ -65,6 +76,128 @@ class AccountsRepository:
             stmt = stmt.execution_options(populate_existing=True)
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
+
+    async def insert_rate_limit_reset_credits_if_missing(
+        self,
+        credits: list[AccountRateLimitResetCreditRecord],
+    ) -> int:
+        if not credits:
+            return 0
+
+        pairs = {(credit.account_id, credit.credit_id) for credit in credits}
+        existing = await self._existing_rate_limit_reset_credit_pairs(pairs)
+
+        pending_credits: list[AccountRateLimitResetCreditRecord] = []
+        for credit in credits:
+            pair = (credit.account_id, credit.credit_id)
+            if pair in existing:
+                continue
+            existing.add(pair)
+            pending_credits.append(credit)
+
+        if not pending_credits:
+            return 0
+
+        while pending_credits:
+            rows_to_insert = [
+                AccountRateLimitResetCredit(
+                    account_id=credit.account_id,
+                    credit_id=credit.credit_id,
+                    status=credit.status,
+                    granted_at=credit.granted_at,
+                    expires_at=credit.expires_at,
+                    redeemed_at=credit.redeemed_at,
+                )
+                for credit in pending_credits
+            ]
+
+            async with sqlite_writer_section():
+                self._session.add_all(rows_to_insert)
+                conflict_error: IntegrityError | None = None
+                try:
+                    await self._session.commit()
+                except IntegrityError as exc:
+                    conflict_error = exc
+                    await self._session.rollback()
+                else:
+                    return len(rows_to_insert)
+
+            existing_after_conflict = await self._existing_rate_limit_reset_credit_pairs(
+                {(credit.account_id, credit.credit_id) for credit in pending_credits}
+            )
+            if not existing_after_conflict:
+                assert conflict_error is not None
+                raise conflict_error
+            pending_credits = [
+                credit
+                for credit in pending_credits
+                if (credit.account_id, credit.credit_id) not in existing_after_conflict
+            ]
+
+        return 0
+
+    async def _existing_rate_limit_reset_credit_pairs(self, pairs: set[tuple[str, str]]) -> set[tuple[str, str]]:
+        if not pairs:
+            return set()
+
+        return {
+            (str(account_id), str(credit_id))
+            for account_id, credit_id in (
+                await self._session.execute(
+                    select(
+                        AccountRateLimitResetCredit.account_id,
+                        AccountRateLimitResetCredit.credit_id,
+                    ).where(
+                        tuple_(
+                            AccountRateLimitResetCredit.account_id,
+                            AccountRateLimitResetCredit.credit_id,
+                        ).in_(pairs)
+                    )
+                )
+            ).all()
+        }
+
+    async def expire_rate_limit_reset_credits(
+        self,
+        *,
+        now: datetime | None = None,
+        account_id: str | None = None,
+    ) -> int:
+        stmt = (
+            update(AccountRateLimitResetCredit)
+            .where(AccountRateLimitResetCredit.status == "available")
+            .where(AccountRateLimitResetCredit.expires_at < (now or utcnow()))
+            .values(status="expired")
+        )
+        if account_id is not None:
+            stmt = stmt.where(AccountRateLimitResetCredit.account_id == account_id)
+
+        async with sqlite_writer_section():
+            result = await self._session.execute(stmt)
+            await self._session.commit()
+
+        return int(result.rowcount or 0)
+
+    async def count_available_rate_limit_reset_credits_by_account(
+        self,
+        account_ids: list[str] | None = None,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, int]:
+        stmt = (
+            select(
+                AccountRateLimitResetCredit.account_id,
+                func.count(AccountRateLimitResetCredit.id),
+            )
+            .where(AccountRateLimitResetCredit.status == "available")
+            .where(AccountRateLimitResetCredit.expires_at >= (now or utcnow()))
+            .group_by(AccountRateLimitResetCredit.account_id)
+        )
+        if account_ids:
+            stmt = stmt.where(AccountRateLimitResetCredit.account_id.in_(account_ids))
+
+        result = await self._session.execute(stmt)
+        return {str(account_id): int(count) for account_id, count in result.all()}
 
     async def list_request_usage_summary_by_account(
         self,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -199,6 +199,35 @@ class AccountsRepository:
         result = await self._session.execute(stmt)
         return {str(account_id): int(count) for account_id, count in result.all()}
 
+    async def get_nearest_expiry_available_credit_id(
+        self,
+        account_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> str | None:
+        stmt = (
+            select(AccountRateLimitResetCredit.credit_id)
+            .where(AccountRateLimitResetCredit.account_id == account_id)
+            .where(AccountRateLimitResetCredit.status == "available")
+            .where(AccountRateLimitResetCredit.expires_at >= (now or utcnow()))
+            .order_by(AccountRateLimitResetCredit.expires_at.asc())
+            .limit(1)
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def mark_credit_redeemed(self, account_id: str, credit_id: str) -> bool:
+        stmt = (
+            update(AccountRateLimitResetCredit)
+            .where(AccountRateLimitResetCredit.account_id == account_id)
+            .where(AccountRateLimitResetCredit.credit_id == credit_id)
+            .values(status="redeemed")
+        )
+        async with sqlite_writer_section():
+            result = await self._session.execute(stmt)
+            await self._session.commit()
+        return int(result.rowcount or 0) > 0
+
     async def list_request_usage_summary_by_account(
         self,
         account_ids: list[str] | None = None,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -237,12 +237,55 @@ class AccountsRepository:
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def claim_nearest_expiry_available_credit_id(
+        self,
+        account_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> str | None:
+        current_time = now or utcnow()
+        target_credit_id = (
+            select(AccountRateLimitResetCredit.id)
+            .where(AccountRateLimitResetCredit.account_id == account_id)
+            .where(AccountRateLimitResetCredit.status == "available")
+            .where(AccountRateLimitResetCredit.expires_at >= current_time)
+            .order_by(AccountRateLimitResetCredit.expires_at.asc(), AccountRateLimitResetCredit.id.asc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        stmt = (
+            update(AccountRateLimitResetCredit)
+            .where(AccountRateLimitResetCredit.id == target_credit_id)
+            .where(AccountRateLimitResetCredit.status == "available")
+            .values(status="redeeming")
+            .returning(AccountRateLimitResetCredit.credit_id)
+        )
+        async with sqlite_writer_section():
+            result = await self._session.execute(stmt)
+            await self._session.commit()
+        return result.scalar_one_or_none()
+
+    async def release_claimed_credit(self, account_id: str, credit_id: str) -> bool:
+        stmt = (
+            update(AccountRateLimitResetCredit)
+            .where(AccountRateLimitResetCredit.account_id == account_id)
+            .where(AccountRateLimitResetCredit.credit_id == credit_id)
+            .where(AccountRateLimitResetCredit.status == "redeeming")
+            .values(status="available", redeemed_at=None)
+            .returning(AccountRateLimitResetCredit.id)
+        )
+        async with sqlite_writer_section():
+            result = await self._session.execute(stmt)
+            await self._session.commit()
+        return result.scalar_one_or_none() is not None
+
     async def mark_credit_redeemed(self, account_id: str, credit_id: str) -> bool:
         stmt = (
             update(AccountRateLimitResetCredit)
             .where(AccountRateLimitResetCredit.account_id == account_id)
             .where(AccountRateLimitResetCredit.credit_id == credit_id)
-            .values(status="redeemed")
+            .where(AccountRateLimitResetCredit.status == "redeeming")
+            .values(status="redeemed", redeemed_at=utcnow())
             .returning(AccountRateLimitResetCredit.id)
         )
         async with sqlite_writer_section():

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -168,6 +168,7 @@ class AccountsRepository:
             .where(AccountRateLimitResetCredit.status == "available")
             .where(AccountRateLimitResetCredit.expires_at < (now or utcnow()))
             .values(status="expired")
+            .returning(AccountRateLimitResetCredit.id)
         )
         if account_id is not None:
             stmt = stmt.where(AccountRateLimitResetCredit.account_id == account_id)
@@ -176,7 +177,7 @@ class AccountsRepository:
             result = await self._session.execute(stmt)
             await self._session.commit()
 
-        return int(result.rowcount or 0)
+        return len(result.scalars().all())
 
     async def count_available_rate_limit_reset_credits_by_account(
         self,
@@ -242,11 +243,12 @@ class AccountsRepository:
             .where(AccountRateLimitResetCredit.account_id == account_id)
             .where(AccountRateLimitResetCredit.credit_id == credit_id)
             .values(status="redeemed")
+            .returning(AccountRateLimitResetCredit.id)
         )
         async with sqlite_writer_section():
             result = await self._session.execute(stmt)
             await self._session.commit()
-        return int(result.rowcount or 0) > 0
+        return result.scalar_one_or_none() is not None
 
     async def list_request_usage_summary_by_account(
         self,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -199,6 +199,26 @@ class AccountsRepository:
         result = await self._session.execute(stmt)
         return {str(account_id): int(count) for account_id, count in result.all()}
 
+    async def nearest_reset_expiry_by_account(
+        self,
+        account_ids: list[str] | None = None,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, datetime]:
+        stmt = (
+            select(
+                AccountRateLimitResetCredit.account_id,
+                func.min(AccountRateLimitResetCredit.expires_at),
+            )
+            .where(AccountRateLimitResetCredit.status == "available")
+            .where(AccountRateLimitResetCredit.expires_at >= (now or utcnow()))
+            .group_by(AccountRateLimitResetCredit.account_id)
+        )
+        if account_ids:
+            stmt = stmt.where(AccountRateLimitResetCredit.account_id.in_(account_ids))
+        result = await self._session.execute(stmt)
+        return {str(account_id): expiry for account_id, expiry in result.all()}
+
     async def get_nearest_expiry_available_credit_id(
         self,
         account_id: str,

--- a/app/modules/accounts/reset_credit_updater.py
+++ b/app/modules/accounts/reset_credit_updater.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from app.core.clients.rate_limit_reset_credits import RateLimitResetCreditsPayload, fetch_rate_limit_reset_credits
+from app.core.crypto import TokenEncryptor
+from app.core.upstream_proxy import ResolvedUpstreamRoute, resolve_upstream_route
+from app.core.utils.time import to_utc_naive, utcnow
+from app.db.models import Account, AccountStatus
+from app.db.session import get_background_session
+from app.modules.accounts.repository import AccountRateLimitResetCreditRecord
+
+logger = logging.getLogger(__name__)
+
+
+class ResetCreditAccountsRepositoryPort(Protocol):
+    async def expire_rate_limit_reset_credits(
+        self,
+        *,
+        now: datetime | None = None,
+        account_id: str | None = None,
+    ) -> int: ...
+
+    async def insert_rate_limit_reset_credits_if_missing(
+        self,
+        credits: list[AccountRateLimitResetCreditRecord],
+    ) -> int: ...
+
+
+@dataclass(slots=True)
+class ResetCreditUpdater:
+    repo: ResetCreditAccountsRepositoryPort
+    fetcher: Callable[..., Awaitable[RateLimitResetCreditsPayload]] = fetch_rate_limit_reset_credits
+    now: Callable[[], datetime] = utcnow
+    decrypt_token: Callable[[bytes], str] | None = None
+    route_resolver: Callable[[Account], Awaitable[ResolvedUpstreamRoute | None]] | None = None
+
+    def __post_init__(self) -> None:
+        encryptor = TokenEncryptor()
+        if self.decrypt_token is None:
+            self.decrypt_token = encryptor.decrypt
+        if self.route_resolver is None:
+            self.route_resolver = _resolve_upstream_route_for_account
+
+    async def refresh_accounts(self, accounts: list[Account]) -> int:
+        inserted = 0
+        for account in accounts:
+            if account.status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+                continue
+            try:
+                inserted += await self.refresh_account(account)
+            except Exception as exc:
+                logger.warning(
+                    "Reset credit refresh failed account_id=%s error=%s",
+                    account.id,
+                    exc,
+                    exc_info=True,
+                )
+        return inserted
+
+    async def refresh_account(self, account: Account) -> int:
+        await self.repo.expire_rate_limit_reset_credits(now=self.now(), account_id=account.id)
+        assert self.decrypt_token is not None
+        assert self.route_resolver is not None
+        payload = await self.fetcher(
+            access_token=self.decrypt_token(account.access_token_encrypted),
+            account_id=account.chatgpt_account_id,
+            route=await self.route_resolver(account),
+            allow_direct_egress=True,
+        )
+        credits = [
+            AccountRateLimitResetCreditRecord(
+                account_id=account.id,
+                credit_id=credit.id,
+                status=credit.status,
+                granted_at=to_utc_naive(credit.granted_at),
+                expires_at=to_utc_naive(credit.expires_at),
+                redeemed_at=to_utc_naive(credit.redeemed_at) if credit.redeemed_at is not None else None,
+            )
+            for credit in payload.credits
+        ]
+        return await self.repo.insert_rate_limit_reset_credits_if_missing(credits)
+
+
+async def _resolve_upstream_route_for_account(account: Account) -> ResolvedUpstreamRoute | None:
+    async with get_background_session() as session:
+        return await resolve_upstream_route(
+            session,
+            account_id=account.id,
+            operation="reset_credit_refresh",
+            scope="account",
+        )

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -115,6 +115,7 @@ class AccountSummary(DashboardModel):
     # surface a "delete older" action without requiring the operator to
     # group rows by email themselves. See codex-lb #787 (B).
     is_email_duplicate: bool = False
+    available_reset_count: int = 0
 
 
 class AccountsResponse(DashboardModel):

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -116,6 +116,7 @@ class AccountSummary(DashboardModel):
     # group rows by email themselves. See codex-lb #787 (B).
     is_email_duplicate: bool = False
     available_reset_count: int = 0
+    nearest_reset_expiry_at: datetime | None = None
 
 
 class AccountsResponse(DashboardModel):

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -277,3 +277,10 @@ class AccountAliasRequest(DashboardModel):
 class AccountAliasResponse(DashboardModel):
     account_id: str
     alias: str | None = None
+
+
+class AccountResetCreditResponse(DashboardModel):
+    account_id: str
+    credit_id: str
+    windows_reset: int | None = None
+    status: str = "redeemed"

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -116,9 +116,7 @@ class AccountsService:
         available_reset_counts_by_account = await self._repo.count_available_rate_limit_reset_credits_by_account(
             account_ids
         )
-        nearest_reset_expiry_by_account = await self._repo.nearest_reset_expiry_by_account(
-            account_ids
-        )
+        nearest_reset_expiry_by_account = await self._repo.nearest_reset_expiry_by_account(account_ids)
         request_usage_by_account = {
             account_id: AccountRequestUsage(
                 request_count=row.request_count,

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -111,6 +111,9 @@ class AccountsService:
         limit_warmups_by_account = (
             await self._limit_warmup_repo.latest_by_account(account_ids) if self._limit_warmup_repo else {}
         )
+        available_reset_counts_by_account = await self._repo.count_available_rate_limit_reset_credits_by_account(
+            account_ids
+        )
         request_usage_by_account = {
             account_id: AccountRequestUsage(
                 request_count=row.request_count,
@@ -172,6 +175,7 @@ class AccountsService:
             request_usage_by_account=request_usage_by_account,
             additional_quotas_by_account=additional_quotas_by_account,
             limit_warmups_by_account=limit_warmups_by_account,
+            available_reset_counts_by_account=available_reset_counts_by_account,
             encryptor=self._encryptor,
         )
 

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -22,6 +22,7 @@ from app.core.cache.invalidation import NAMESPACE_API_KEY, get_cache_invalidatio
 from app.core.clients.http import lease_http_session
 from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
+from app.core.exceptions import DashboardConflictError
 from app.core.plan_types import coerce_account_plan_type
 from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
 from app.db.models import Account, AccountStatus
@@ -39,6 +40,7 @@ from app.modules.accounts.schemas import (
     AccountOpenCodeAuthExportResponse,
     AccountProbeResponse,
     AccountRequestUsage,
+    AccountResetCreditResponse,
     AccountSummary,
     AccountTrendsResponse,
     CodexAuthJson,
@@ -543,6 +545,51 @@ class AccountsService:
                 exc,
             )
             return PROBE_NETWORK_FAILURE_STATUS
+
+    async def reset_account_credit(self, account_id: str) -> AccountResetCreditResponse | None:
+        """Redeem the nearest-expiry available rate-limit reset credit."""
+        from app.core.clients.rate_limit_reset_credits import (
+            RateLimitResetCreditsFetchError,
+            consume_rate_limit_reset_credit,
+        )
+
+        account = await self._repo.get_by_id(account_id)
+        if account is None:
+            return None
+
+        credit_id = await self._repo.get_nearest_expiry_available_credit_id(account_id)
+        if credit_id is None:
+            raise DashboardConflictError(
+                "No available rate-limit reset credits for this account",
+                code="no_available_reset_credits",
+            )
+
+        reset_account = account
+        if self._auth_manager is not None:
+            reset_account = await self._auth_manager.ensure_fresh(account, force=False)
+
+        access_token = self._encryptor.decrypt(reset_account.access_token_encrypted)
+
+        try:
+            response = await consume_rate_limit_reset_credit(
+                access_token=access_token,
+                account_id=reset_account.chatgpt_account_id,
+                credit_id=credit_id,
+                allow_direct_egress=True,
+            )
+        except RateLimitResetCreditsFetchError:
+            raise
+
+        await self._repo.mark_credit_redeemed(account_id, credit_id)
+
+        get_account_selection_cache().invalidate()
+
+        return AccountResetCreditResponse(
+            account_id=account_id,
+            credit_id=credit_id,
+            windows_reset=response.windows_reset,
+            status="redeemed",
+        )
 
 
 def _opencode_auth_export_filename(account: Account) -> str:

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -24,6 +24,7 @@ from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.exceptions import DashboardConflictError
 from app.core.plan_types import coerce_account_plan_type
+from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_upstream_route
 from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
 from app.db.models import Account, AccountStatus
 from app.modules.accounts.auth_manager import AuthManager
@@ -550,16 +551,13 @@ class AccountsService:
 
     async def reset_account_credit(self, account_id: str) -> AccountResetCreditResponse | None:
         """Redeem the nearest-expiry available rate-limit reset credit."""
-        from app.core.clients.rate_limit_reset_credits import (
-            RateLimitResetCreditsFetchError,
-            consume_rate_limit_reset_credit,
-        )
+        from app.core.clients.rate_limit_reset_credits import consume_rate_limit_reset_credit
 
         account = await self._repo.get_by_id(account_id)
         if account is None:
             return None
 
-        credit_id = await self._repo.get_nearest_expiry_available_credit_id(account_id)
+        credit_id = await self._repo.claim_nearest_expiry_available_credit_id(account_id)
         if credit_id is None:
             raise DashboardConflictError(
                 "No available rate-limit reset credits for this account",
@@ -573,13 +571,16 @@ class AccountsService:
         access_token = self._encryptor.decrypt(reset_account.access_token_encrypted)
 
         try:
+            route = await self._resolve_upstream_route(reset_account)
             response = await consume_rate_limit_reset_credit(
                 access_token=access_token,
                 account_id=reset_account.chatgpt_account_id,
                 credit_id=credit_id,
-                allow_direct_egress=True,
+                route=route,
+                allow_direct_egress=route is None,
             )
-        except RateLimitResetCreditsFetchError:
+        except Exception:
+            await self._repo.release_claimed_credit(account_id, credit_id)
             raise
 
         await self._repo.mark_credit_redeemed(account_id, credit_id)
@@ -592,6 +593,21 @@ class AccountsService:
             windows_reset=response.windows_reset,
             status="redeemed",
         )
+
+    async def _resolve_upstream_route(self, account: Account):
+        try:
+            return await resolve_upstream_route(
+                self._repo.session,
+                account_id=account.id,
+                operation="reset_credit_consume",
+                scope="account",
+                encryptor=self._encryptor,
+            )
+        except UpstreamProxyRouteError as exc:
+            raise DashboardConflictError(
+                f"Upstream proxy route unavailable: {exc.reason}",
+                code="upstream_proxy_unavailable",
+            ) from exc
 
 
 def _opencode_auth_export_filename(account: Account) -> str:

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -116,6 +116,9 @@ class AccountsService:
         available_reset_counts_by_account = await self._repo.count_available_rate_limit_reset_credits_by_account(
             account_ids
         )
+        nearest_reset_expiry_by_account = await self._repo.nearest_reset_expiry_by_account(
+            account_ids
+        )
         request_usage_by_account = {
             account_id: AccountRequestUsage(
                 request_count=row.request_count,
@@ -178,6 +181,7 @@ class AccountsService:
             additional_quotas_by_account=additional_quotas_by_account,
             limit_warmups_by_account=limit_warmups_by_account,
             available_reset_counts_by_account=available_reset_counts_by_account,
+            nearest_reset_expiry_by_account=nearest_reset_expiry_by_account,
             encryptor=self._encryptor,
         )
 

--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -103,5 +103,11 @@ class DashboardRepository:
     async def latest_limit_warmups_by_account(self, account_ids: list[str]) -> dict[str, AccountLimitWarmup]:
         return await self._limit_warmup_repo.latest_by_account(account_ids)
 
+    async def count_available_rate_limit_reset_credits_by_account(
+        self,
+        account_ids: list[str],
+    ) -> dict[str, int]:
+        return await self._accounts_repo.count_available_rate_limit_reset_credits_by_account(account_ids)
+
     async def get_settings(self) -> DashboardSettings:
         return await self._settings_repo.get_or_create()

--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -109,5 +109,11 @@ class DashboardRepository:
     ) -> dict[str, int]:
         return await self._accounts_repo.count_available_rate_limit_reset_credits_by_account(account_ids)
 
+    async def nearest_reset_expiry_by_account(
+        self,
+        account_ids: list[str],
+    ) -> dict[str, "datetime"]:
+        return await self._accounts_repo.nearest_reset_expiry_by_account(account_ids)
+
     async def get_settings(self) -> DashboardSettings:
         return await self._settings_repo.get_or_create()

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -69,6 +69,9 @@ class DashboardService:
         secondary_usage = await self._repo.latest_usage_by_account("secondary")
         monthly_usage = await self._repo.latest_usage_by_account("monthly")
         limit_warmups_by_account = await self._repo.latest_limit_warmups_by_account(account_ids)
+        available_reset_counts_by_account = (
+            await self._repo.count_available_rate_limit_reset_credits_by_account(account_ids)
+        )
 
         account_summaries = sorted(
             build_account_summaries(
@@ -77,6 +80,7 @@ class DashboardService:
                 secondary_usage=secondary_usage,
                 monthly_usage=monthly_usage,
                 limit_warmups_by_account=limit_warmups_by_account,
+                available_reset_counts_by_account=available_reset_counts_by_account,
                 encryptor=self._encryptor,
                 include_auth=False,
             ),

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -72,6 +72,9 @@ class DashboardService:
         available_reset_counts_by_account = (
             await self._repo.count_available_rate_limit_reset_credits_by_account(account_ids)
         )
+        nearest_reset_expiry_by_account = (
+            await self._repo.nearest_reset_expiry_by_account(account_ids)
+        )
 
         account_summaries = sorted(
             build_account_summaries(
@@ -81,6 +84,7 @@ class DashboardService:
                 monthly_usage=monthly_usage,
                 limit_warmups_by_account=limit_warmups_by_account,
                 available_reset_counts_by_account=available_reset_counts_by_account,
+                nearest_reset_expiry_by_account=nearest_reset_expiry_by_account,
                 encryptor=self._encryptor,
                 include_auth=False,
             ),

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -69,12 +69,10 @@ class DashboardService:
         secondary_usage = await self._repo.latest_usage_by_account("secondary")
         monthly_usage = await self._repo.latest_usage_by_account("monthly")
         limit_warmups_by_account = await self._repo.latest_limit_warmups_by_account(account_ids)
-        available_reset_counts_by_account = (
-            await self._repo.count_available_rate_limit_reset_credits_by_account(account_ids)
+        available_reset_counts_by_account = await self._repo.count_available_rate_limit_reset_credits_by_account(
+            account_ids
         )
-        nearest_reset_expiry_by_account = (
-            await self._repo.nearest_reset_expiry_by_account(account_ids)
-        )
+        nearest_reset_expiry_by_account = await self._repo.nearest_reset_expiry_by_account(account_ids)
 
         account_summaries = sorted(
             build_account_summaries(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthGate } from "@/features/auth/components/auth-gate";
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
 import { AccountsPage } from "@/features/accounts/components/accounts-page";
+import { useAccountsListQuery } from "@/features/accounts/hooks/use-accounts";
 import { ApisPage } from "@/features/apis/components/apis-page";
 import { DashboardPage } from "@/features/dashboard/components/dashboard-page";
 import { ReportsPage } from "@/features/reports/components/reports-page";
@@ -21,6 +22,11 @@ function AppLayout() {
   const startAdminLogin = useAuthStore((state) => state.startAdminLogin);
   const timeFormat = useTimeFormatStore((state) => state.timeFormat);
   const isGuest = role === "guest";
+  const accounts = useAccountsListQuery().data;
+  const availableResetCount = (accounts ?? []).reduce(
+    (total, account) => total + (account.availableResetCount ?? 0),
+    0,
+  );
 
   return (
     <div className="flex min-h-screen flex-col bg-background pb-10" data-time-format={timeFormat}>
@@ -31,6 +37,7 @@ function AppLayout() {
         onAdminLogin={startAdminLogin}
         showAdminLogin={isGuest && passwordRequired}
         showLogout={(role === "admin" && passwordRequired) || (isGuest && guestPasswordRequired)}
+        availableResetCount={availableResetCount}
       />
       <main className="mx-auto w-full max-w-[1500px] flex-1 px-4 py-8 sm:px-6">
         <Outlet />

--- a/frontend/src/components/layout/app-header.test.tsx
+++ b/frontend/src/components/layout/app-header.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+import { AppHeader } from "@/components/layout/app-header";
+
+type HeaderProps = React.ComponentProps<typeof AppHeader>;
+
+function renderHeader(props: Partial<HeaderProps> = {}) {
+  return render(
+    <MemoryRouter>
+      <AppHeader onLogout={vi.fn()} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("AppHeader", () => {
+  it("shows the aggregated available reset count badge on the Accounts link", () => {
+    renderHeader({ availableResetCount: 5 });
+
+    const accountsLink = screen.getByRole("link", { name: /Accounts/ });
+    expect(within(accountsLink).getByTestId("nav-reset-badge")).toHaveTextContent("5");
+  });
+
+  it("hides the badge when there are no available resets", () => {
+    renderHeader({ availableResetCount: 0 });
+
+    expect(screen.queryByTestId("nav-reset-badge")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -33,7 +33,7 @@ function NavResetBadge({ count }: { count: number }) {
     <span
       data-testid="nav-reset-badge"
       aria-label={`${count} rate-limit resets available`}
-      className="absolute -right-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none tabular-nums text-primary-foreground ring-2 ring-background"
+      className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none tabular-nums text-primary-foreground"
     >
       {count}
     </span>
@@ -151,7 +151,7 @@ export function AppHeader({
                     {({ isActive }) => (
                       <span
                         className={cn(
-                          "relative block w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors",
+                          "block w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors",
                           isActive
                             ? "bg-primary/10 text-primary"
                             : "text-muted-foreground hover:bg-muted hover:text-foreground",

--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -21,14 +21,31 @@ export type AppHeaderProps = {
   onAdminLogin?: () => void;
   showAdminLogin?: boolean;
   showLogout?: boolean;
+  availableResetCount?: number;
   className?: string;
 };
+
+function NavResetBadge({ count }: { count: number }) {
+  if (count <= 0) {
+    return null;
+  }
+  return (
+    <span
+      data-testid="nav-reset-badge"
+      aria-label={`${count} rate-limit resets available`}
+      className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none tabular-nums text-primary-foreground"
+    >
+      {count}
+    </span>
+  );
+}
 
 export function AppHeader({
   onLogout,
   onAdminLogin,
   showAdminLogin = false,
   showLogout = true,
+  availableResetCount = 0,
   className,
 }: AppHeaderProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -70,6 +87,7 @@ export function AppHeader({
               }
             >
               {item.label}
+              {item.to === "/accounts" ? <NavResetBadge count={availableResetCount} /> : null}
             </NavLink>
           ))}
         </nav>
@@ -140,6 +158,7 @@ export function AppHeader({
                         )}
                       >
                         {item.label}
+                        {item.to === "/accounts" ? <NavResetBadge count={availableResetCount} /> : null}
                       </span>
                     )}
                   </NavLink>

--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -33,7 +33,7 @@ function NavResetBadge({ count }: { count: number }) {
     <span
       data-testid="nav-reset-badge"
       aria-label={`${count} rate-limit resets available`}
-      className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none tabular-nums text-primary-foreground"
+      className="absolute -right-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none tabular-nums text-primary-foreground ring-2 ring-background"
     >
       {count}
     </span>
@@ -151,7 +151,7 @@ export function AppHeader({
                     {({ isActive }) => (
                       <span
                         className={cn(
-                          "block w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors",
+                          "relative block w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors",
                           isActive
                             ? "bg-primary/10 text-primary"
                             : "text-muted-foreground hover:bg-muted hover:text-foreground",

--- a/frontend/src/features/accounts/api.ts
+++ b/frontend/src/features/accounts/api.ts
@@ -8,6 +8,7 @@ import {
   AccountImportResponseSchema,
   AccountLimitWarmupUpdateRequestSchema,
   AccountLimitWarmupUpdateResponseSchema,
+  AccountResetCreditResponseSchema,
   AccountUpdateRequestSchema,
   AccountsResponseSchema,
   AccountRoutingPolicyUpdateRequestSchema,
@@ -122,6 +123,13 @@ export function deleteAccount(accountId: string, deleteHistory = false) {
   return del(
     `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}${qs}`,
     AccountActionResponseSchema,
+  );
+}
+
+export function resetAccountCredit(accountId: string) {
+  return post(
+    `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/reset-credit`,
+    AccountResetCreditResponseSchema,
   );
 }
 

--- a/frontend/src/features/accounts/components/account-actions.test.tsx
+++ b/frontend/src/features/accounts/components/account-actions.test.tsx
@@ -152,7 +152,8 @@ describe("AccountActions", () => {
     expect(onProbe).not.toHaveBeenCalled();
   });
 
-  it("renders a disabled reset button with the available reset count", () => {
+  it("shows an enabled reset button when resets are available and handler provided", () => {
+    const onResetCredit = vi.fn();
     const account = createAccountSummary({ availableResetCount: 3 });
 
     render(
@@ -168,14 +169,43 @@ describe("AccountActions", () => {
         onSecurityWorkAuthorizedChange={vi.fn()}
         onLimitWarmupChange={vi.fn()}
         onRoutingPolicyChange={vi.fn()}
+        onResetCredit={onResetCredit}
       />,
     );
 
     const resetButton = screen.getByRole("button", { name: /Reset \(3\)/ });
-    expect(resetButton).toBeDisabled();
+    expect(resetButton).toBeEnabled();
   });
 
-  it("disables the reset button when no resets are available", () => {
+  it("opens a confirmation dialog on reset click", async () => {
+    const user = userEvent.setup();
+    const onResetCredit = vi.fn();
+    const account = createAccountSummary({ availableResetCount: 2 });
+
+    render(
+      <AccountActions
+        account={account}
+        busy={false}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onProbe={vi.fn()}
+        onDelete={vi.fn()}
+        onReauth={vi.fn()}
+        onExportAuth={vi.fn()}
+        onSecurityWorkAuthorizedChange={vi.fn()}
+        onLimitWarmupChange={vi.fn()}
+        onRoutingPolicyChange={vi.fn()}
+        onResetCredit={onResetCredit}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Reset \(2\)/ }));
+    expect(screen.getByText("Reset rate limit")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+    expect(onResetCredit).toHaveBeenCalledWith(account.accountId);
+  });
+
+  it("hides the reset button when no resets are available", () => {
     const account = createAccountSummary({ availableResetCount: 0 });
 
     render(
@@ -191,9 +221,10 @@ describe("AccountActions", () => {
         onSecurityWorkAuthorizedChange={vi.fn()}
         onLimitWarmupChange={vi.fn()}
         onRoutingPolicyChange={vi.fn()}
+        onResetCredit={vi.fn()}
       />,
     );
 
-    expect(screen.getByRole("button", { name: /Reset \(0\)/ })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /Reset/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/accounts/components/account-actions.test.tsx
+++ b/frontend/src/features/accounts/components/account-actions.test.tsx
@@ -151,4 +151,49 @@ describe("AccountActions", () => {
 
     expect(onProbe).not.toHaveBeenCalled();
   });
+
+  it("renders a disabled reset button with the available reset count", () => {
+    const account = createAccountSummary({ availableResetCount: 3 });
+
+    render(
+      <AccountActions
+        account={account}
+        busy={false}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onProbe={vi.fn()}
+        onDelete={vi.fn()}
+        onReauth={vi.fn()}
+        onExportAuth={vi.fn()}
+        onSecurityWorkAuthorizedChange={vi.fn()}
+        onLimitWarmupChange={vi.fn()}
+        onRoutingPolicyChange={vi.fn()}
+      />,
+    );
+
+    const resetButton = screen.getByRole("button", { name: /Reset \(3\)/ });
+    expect(resetButton).toBeDisabled();
+  });
+
+  it("disables the reset button when no resets are available", () => {
+    const account = createAccountSummary({ availableResetCount: 0 });
+
+    render(
+      <AccountActions
+        account={account}
+        busy={false}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onProbe={vi.fn()}
+        onDelete={vi.fn()}
+        onReauth={vi.fn()}
+        onExportAuth={vi.fn()}
+        onSecurityWorkAuthorizedChange={vi.fn()}
+        onLimitWarmupChange={vi.fn()}
+        onRoutingPolicyChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Reset \(0\)/ })).toBeDisabled();
+  });
 });

--- a/frontend/src/features/accounts/components/account-actions.tsx
+++ b/frontend/src/features/accounts/components/account-actions.tsx
@@ -22,10 +22,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
 import type {
   AccountRoutingPolicy,
   AccountSummary,
 } from "@/features/accounts/schemas";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+function isResetExpiryUrgent(expiry: string | null | undefined): boolean {
+  if (!expiry) return false;
+  return new Date(expiry).getTime() - Date.now() < SEVEN_DAYS_MS;
+}
 
 export type AccountActionsProps = {
   account: AccountSummary;
@@ -67,6 +75,7 @@ export function AccountActions({
     busy || readOnly || account.status === "paused" || showOperatorRecoveryAction;
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const hasResets = (account.availableResetCount ?? 0) > 0;
+  const isResetUrgent = isResetExpiryUrgent(account.nearestResetExpiryAt);
 
   return (
     <div className="space-y-3 border-t pt-4">
@@ -202,8 +211,11 @@ export function AccountActions({
           <Button
             type="button"
             size="sm"
-            variant="outline"
-            className="h-8 gap-1.5 text-xs"
+            variant="ghost"
+            className={cn(
+              "h-8 gap-1.5 text-xs text-muted-foreground hover:text-foreground",
+              isResetUrgent && "border border-red-500 text-red-600 hover:bg-red-500/10 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300",
+            )}
             disabled={busy || readOnly}
             title="Reset rate-limit credits"
             onClick={() => setResetConfirmOpen(true)}

--- a/frontend/src/features/accounts/components/account-actions.tsx
+++ b/frontend/src/features/accounts/components/account-actions.tsx
@@ -10,7 +10,9 @@ import {
   Trash2,
   Zap,
 } from "lucide-react";
+import { useState } from "react";
 
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -41,6 +43,7 @@ export type AccountActionsProps = {
     accountId: string,
     routingPolicy: AccountRoutingPolicy,
   ) => void;
+  onResetCredit?: (accountId: string) => void;
 };
 
 export function AccountActions({
@@ -56,11 +59,14 @@ export function AccountActions({
   onSecurityWorkAuthorizedChange,
   onLimitWarmupChange,
   onRoutingPolicyChange,
+  onResetCredit,
 }: AccountActionsProps) {
   const showOperatorRecoveryAction =
     account.status === "reauth_required" || account.status === "deactivated";
   const probeDisabled =
     busy || readOnly || account.status === "paused" || showOperatorRecoveryAction;
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+  const hasResets = (account.availableResetCount ?? 0) > 0;
 
   return (
     <div className="space-y-3 border-t pt-4">
@@ -192,17 +198,20 @@ export function AccountActions({
           Export
         </Button>
 
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          className="h-8 gap-1.5 text-xs"
-          disabled
-          title="Reset rate-limit credits"
-        >
-          <RotateCcw className="h-3.5 w-3.5" />
-          Reset ({account.availableResetCount ?? 0})
-        </Button>
+        {hasResets && onResetCredit ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 gap-1.5 text-xs"
+            disabled={busy || readOnly}
+            title="Reset rate-limit credits"
+            onClick={() => setResetConfirmOpen(true)}
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            {`Reset (${account.availableResetCount ?? 0})`}
+          </Button>
+        ) : null}
 
         <Button
           type="button"
@@ -216,6 +225,19 @@ export function AccountActions({
           Delete
         </Button>
       </div>
+
+      <ConfirmDialog
+        open={resetConfirmOpen}
+        title="Reset rate limit"
+        description={`Redeem one rate-limit reset credit for ${account.displayName || account.email}? The nearest-expiry credit will be used.`}
+        confirmLabel="Reset"
+        cancelLabel="Cancel"
+        onOpenChange={setResetConfirmOpen}
+        onConfirm={() => {
+          setResetConfirmOpen(false);
+          onResetCredit?.(account.accountId);
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/features/accounts/components/account-actions.tsx
+++ b/frontend/src/features/accounts/components/account-actions.tsx
@@ -211,9 +211,9 @@ export function AccountActions({
           <Button
             type="button"
             size="sm"
-            variant="ghost"
+            variant="outline"
             className={cn(
-              "h-8 gap-1.5 text-xs text-muted-foreground hover:text-foreground",
+              "h-8 gap-1.5 text-xs",
               isResetUrgent && "border border-red-500 text-red-600 hover:bg-red-500/10 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300",
             )}
             disabled={busy || readOnly}

--- a/frontend/src/features/accounts/components/account-actions.tsx
+++ b/frontend/src/features/accounts/components/account-actions.tsx
@@ -5,6 +5,7 @@ import {
   Play,
   RefreshCw,
   Route,
+  RotateCcw,
   ShieldCheck,
   Trash2,
   Zap,
@@ -189,6 +190,18 @@ export function AccountActions({
         >
           <Download className="h-3.5 w-3.5" />
           Export
+        </Button>
+
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 gap-1.5 text-xs"
+          disabled
+          title="Reset rate-limit credits"
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+          Reset ({account.availableResetCount ?? 0})
         </Button>
 
         <Button

--- a/frontend/src/features/accounts/components/account-detail.tsx
+++ b/frontend/src/features/accounts/components/account-detail.tsx
@@ -37,6 +37,7 @@ export type AccountDetailProps = {
     routingPolicy: AccountRoutingPolicy,
   ) => void;
   onSecurityWorkAuthorizedChange: (accountId: string, enabled: boolean) => void;
+  onResetCredit?: (accountId: string) => void;
   upstreamProxyAdmin?: UpstreamProxyAdmin | null;
   onProxyBindingSave?: (accountId: string, payload: AccountProxyBindingRequest) => Promise<unknown>;
 };
@@ -56,6 +57,7 @@ export function AccountDetail({
   onLimitWarmupChange,
   onRoutingPolicyChange,
   onSecurityWorkAuthorizedChange,
+  onResetCredit,
   upstreamProxyAdmin = null,
   onProxyBindingSave,
 }: AccountDetailProps) {
@@ -151,6 +153,7 @@ export function AccountDetail({
         onLimitWarmupChange={onLimitWarmupChange}
         onRoutingPolicyChange={onRoutingPolicyChange}
         onSecurityWorkAuthorizedChange={onSecurityWorkAuthorizedChange}
+        onResetCredit={onResetCredit}
       />
     </div>
   );

--- a/frontend/src/features/accounts/components/account-list-item.test.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.test.tsx
@@ -224,19 +224,4 @@ describe("AccountListItem", () => {
     expect(screen.queryByText(/Personal \/ unknown workspace/)).not.toBeInTheDocument();
   });
 
-  it("shows an available reset badge when reset count is greater than zero", () => {
-    const account = createAccountSummary({ availableResetCount: 4 });
-
-    render(<AccountListItem account={account} selected={false} onSelect={vi.fn()} />);
-
-    expect(screen.getByTestId("available-reset-badge")).toHaveTextContent("4");
-  });
-
-  it("hides the available reset badge when no resets are available", () => {
-    const account = createAccountSummary({ availableResetCount: 0 });
-
-    render(<AccountListItem account={account} selected={false} onSelect={vi.fn()} />);
-
-    expect(screen.queryByTestId("available-reset-badge")).not.toBeInTheDocument();
-  });
 });

--- a/frontend/src/features/accounts/components/account-list-item.test.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.test.tsx
@@ -223,4 +223,20 @@ describe("AccountListItem", () => {
     expect(screen.queryByText(/Legacy Workspace/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Personal \/ unknown workspace/)).not.toBeInTheDocument();
   });
+
+  it("shows an available reset badge when reset count is greater than zero", () => {
+    const account = createAccountSummary({ availableResetCount: 4 });
+
+    render(<AccountListItem account={account} selected={false} onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId("available-reset-badge")).toHaveTextContent("4");
+  });
+
+  it("hides the available reset badge when no resets are available", () => {
+    const account = createAccountSummary({ availableResetCount: 0 });
+
+    render(<AccountListItem account={account} selected={false} onSelect={vi.fn()} />);
+
+    expect(screen.queryByTestId("available-reset-badge")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/accounts/components/account-list-item.test.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.test.tsx
@@ -224,4 +224,19 @@ describe("AccountListItem", () => {
     expect(screen.queryByText(/Personal \/ unknown workspace/)).not.toBeInTheDocument();
   });
 
+  it("shows a corner reset badge when reset count is greater than zero", () => {
+    const account = createAccountSummary({ availableResetCount: 4 });
+
+    render(<AccountListItem account={account} selected={false} onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId("available-reset-badge")).toHaveTextContent("4");
+  });
+
+  it("hides the corner reset badge when no resets are available", () => {
+    const account = createAccountSummary({ availableResetCount: 0 });
+
+    render(<AccountListItem account={account} selected={false} onSelect={vi.fn()} />);
+
+    expect(screen.queryByTestId("available-reset-badge")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/accounts/components/account-list-item.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.tsx
@@ -107,15 +107,6 @@ export function AccountListItem({
           />
         ) : null}
         <StatusBadge status={status} />
-        {account.availableResetCount > 0 ? (
-          <span
-            data-testid="available-reset-badge"
-            aria-label={`${account.availableResetCount} rate-limit resets available`}
-            className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold tabular-nums text-primary-foreground"
-          >
-            {account.availableResetCount}
-          </span>
-        ) : null}
       </div>
       <div
         className={cn(

--- a/frontend/src/features/accounts/components/account-list-item.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.tsx
@@ -107,6 +107,15 @@ export function AccountListItem({
           />
         ) : null}
         <StatusBadge status={status} />
+        {account.availableResetCount > 0 ? (
+          <span
+            data-testid="available-reset-badge"
+            aria-label={`${account.availableResetCount} rate-limit resets available`}
+            className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold tabular-nums text-primary-foreground"
+          >
+            {account.availableResetCount}
+          </span>
+        ) : null}
       </div>
       <div
         className={cn(

--- a/frontend/src/features/accounts/components/account-list-item.tsx
+++ b/frontend/src/features/accounts/components/account-list-item.tsx
@@ -78,7 +78,7 @@ export function AccountListItem({
       type="button"
       onClick={() => onSelect(account.accountId)}
       className={cn(
-        "w-full rounded-lg px-3 py-2.5 text-left transition-colors",
+        "relative w-full rounded-lg px-3 py-2.5 text-left transition-colors",
         selected ? "bg-primary/8 ring-1 ring-primary/25" : "hover:bg-muted/50",
       )}
     >
@@ -108,6 +108,15 @@ export function AccountListItem({
         ) : null}
         <StatusBadge status={status} />
       </div>
+      {account.availableResetCount > 0 ? (
+        <span
+          data-testid="available-reset-badge"
+          aria-label={`${account.availableResetCount} rate-limit resets available`}
+          className="absolute -right-1.5 -top-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold tabular-nums text-primary-foreground ring-2 ring-background"
+        >
+          {account.availableResetCount}
+        </span>
+      ) : null}
       <div
         className={cn(
           "mt-2 grid gap-2",

--- a/frontend/src/features/accounts/components/account-list.test.tsx
+++ b/frontend/src/features/accounts/components/account-list.test.tsx
@@ -31,7 +31,7 @@ describe("AccountList", () => {
             planType: "plus",
             status: "active",
             limitWarmupEnabled: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-2",
@@ -40,7 +40,7 @@ describe("AccountList", () => {
             planType: "pro",
             status: "paused",
             limitWarmupEnabled: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId="acc-1"
@@ -85,7 +85,7 @@ describe("AccountList", () => {
             resetAtSecondary: "2026-01-01T13:00:00.000Z",
             windowMinutesPrimary: 300,
             windowMinutesSecondary: 10_080,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-visible-early",
@@ -102,7 +102,7 @@ describe("AccountList", () => {
             resetAtSecondary: "2026-01-01T12:10:00.000Z",
             windowMinutesPrimary: 300,
             windowMinutesSecondary: 10_080,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -138,7 +138,7 @@ describe("AccountList", () => {
             resetAtSecondary: "2026-01-01T11:45:00.000Z",
             windowMinutesPrimary: 300,
             windowMinutesSecondary: 10_080,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-fresh",
@@ -155,7 +155,7 @@ describe("AccountList", () => {
             resetAtSecondary: "2026-01-01T12:20:00.000Z",
             windowMinutesPrimary: 300,
             windowMinutesSecondary: 10_080,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -189,7 +189,7 @@ describe("AccountList", () => {
             resetAtSecondary: null,
             windowMinutesPrimary: null,
             windowMinutesSecondary: null,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-early",
@@ -206,7 +206,7 @@ describe("AccountList", () => {
             resetAtSecondary: null,
             windowMinutesPrimary: null,
             windowMinutesSecondary: null,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -233,7 +233,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T12:30:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-a",
@@ -243,7 +243,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T12:10:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -273,7 +273,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T12:10:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-a",
@@ -283,7 +283,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T12:20:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -313,7 +313,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T12:10:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-z",
@@ -323,7 +323,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T12:40:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -352,7 +352,7 @@ describe("AccountList", () => {
             planType: "plus",
             status: "active",
             limitWarmupEnabled: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-stale",
@@ -362,7 +362,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T11:30:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-latest",
@@ -372,7 +372,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T12:40:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-earlier",
@@ -382,7 +382,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             resetAtPrimary: "2026-01-01T12:10:00.000Z",
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -415,7 +415,7 @@ describe("AccountList", () => {
             planType: "plus",
             status: "active",
             limitWarmupEnabled: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -443,7 +443,7 @@ describe("AccountList", () => {
             planType: "plus",
             status: "active",
             limitWarmupEnabled: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -472,7 +472,7 @@ describe("AccountList", () => {
             planType: "plus",
             status: "active",
             limitWarmupEnabled: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-reauth",
@@ -481,7 +481,7 @@ describe("AccountList", () => {
             planType: "pro",
             status: "reauth_required",
             limitWarmupEnabled: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}
@@ -510,7 +510,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             isEmailDuplicate: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "7f9de2ad-7621-4a6f-88bc-ec7f3d914701_91a95cee",
@@ -520,7 +520,7 @@ describe("AccountList", () => {
             status: "active",
             limitWarmupEnabled: false,
             isEmailDuplicate: true,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
           {
             accountId: "acc-3",
@@ -529,7 +529,7 @@ describe("AccountList", () => {
             planType: "pro",
             status: "active",
             limitWarmupEnabled: false,
-            additionalQuotas: [],
+            additionalQuotas: [], availableResetCount: 0,
           },
         ]}
         selectedAccountId={null}

--- a/frontend/src/features/accounts/components/accounts-page.test.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.test.tsx
@@ -63,6 +63,7 @@ function account(overrides: Partial<AccountSummary>): AccountSummary {
     status: "active",
     additionalQuotas: [],
     limitWarmupEnabled: false,
+    availableResetCount: 0,
     ...overrides,
   };
 }

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -45,6 +45,7 @@ export function AccountsPage() {
     deleteMutation,
     routingPolicyMutation,
     exportAuthMutation,
+    resetCreditMutation,
   } = useAccounts();
   const { upstreamProxyQuery, accountBindingMutation } = useUpstreamProxyAdmin();
   const oauth = useOauth();
@@ -186,6 +187,9 @@ export function AccountsPage() {
                 accountId,
                 routingPolicy,
               })
+            }
+            onResetCredit={(accountId) =>
+              void resetCreditMutation.mutateAsync(accountId)
             }
             onSecurityWorkAuthorizedChange={(accountId, enabled) =>
               void updateMutation.mutateAsync({

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -8,8 +8,9 @@ import {
   importAccount,
   listAccounts,
   pauseAccount,
-  reactivateAccount,
   probeAccount,
+  reactivateAccount,
+  resetAccountCredit,
   setAccountAlias,
   updateAccount,
   updateAccountLimitWarmup,
@@ -177,6 +178,18 @@ export function useAccountMutations() {
     },
   });
 
+  const resetCreditMutation = useMutation({
+    mutationFn: (accountId: string) => resetAccountCredit(accountId),
+    onSuccess: (data) => {
+      toast.success(`Rate limit reset redeemed (windows reset: ${data.windowsReset ?? 0})`);
+      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
+      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Reset credit failed");
+    },
+  });
+
   return {
     importMutation,
     pauseMutation,
@@ -188,6 +201,7 @@ export function useAccountMutations() {
     limitWarmupMutation,
     routingPolicyMutation,
     updateMutation,
+    resetCreditMutation,
   };
 }
 

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -216,3 +216,18 @@ export function useAccounts() {
 
   return { accountsQuery, ...mutations };
 }
+
+/**
+ * Read-only access to the accounts list query. Shares the `["accounts", "list"]`
+ * cache key with {@link useAccounts} so consumers (e.g. the header badge) get
+ * deduplicated data without instantiating mutation hooks.
+ */
+export function useAccountsListQuery() {
+  return useQuery({
+    queryKey: ["accounts", "list"],
+    queryFn: listAccounts,
+    select: (data) => data.accounts,
+    refetchInterval: 30_000,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/frontend/src/features/accounts/schemas.test.ts
+++ b/frontend/src/features/accounts/schemas.test.ts
@@ -70,6 +70,29 @@ describe("AccountSummarySchema", () => {
 
     expect(parsed.routingPolicy).toBe("preserve");
   });
+
+  it("defaults availableResetCount to 0 and parses explicit counts", () => {
+    const parsed = AccountSummarySchema.parse({
+      accountId: "acc-1",
+      email: "user@example.com",
+      displayName: "User",
+      planType: "pro",
+      status: "active",
+    });
+
+    expect(parsed.availableResetCount).toBe(0);
+
+    const withResets = AccountSummarySchema.parse({
+      accountId: "acc-1",
+      email: "user@example.com",
+      displayName: "User",
+      planType: "pro",
+      status: "active",
+      availableResetCount: 3,
+    });
+
+    expect(withResets.availableResetCount).toBe(3);
+  });
 });
 
 describe("AccountAuthExportResponseSchema", () => {

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -86,6 +86,7 @@ export const AccountSummarySchema = z.object({
   creditsUnlimited: z.boolean().nullable().optional(),
   creditsBalance: z.number().nullable().optional(),
   availableResetCount: z.number().int().nonnegative().default(0),
+  nearestResetExpiryAt: z.iso.datetime({ offset: true }).nullable().optional(),
   requestUsage: AccountRequestUsageSchema.nullable().optional(),
   auth: AccountAuthSchema.nullable().optional(),
   additionalQuotas: z.array(AccountAdditionalQuotaSchema).default([]),

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -85,6 +85,7 @@ export const AccountSummarySchema = z.object({
   creditsHas: z.boolean().nullable().optional(),
   creditsUnlimited: z.boolean().nullable().optional(),
   creditsBalance: z.number().nullable().optional(),
+  availableResetCount: z.number().int().nonnegative().default(0),
   requestUsage: AccountRequestUsageSchema.nullable().optional(),
   auth: AccountAuthSchema.nullable().optional(),
   additionalQuotas: z.array(AccountAdditionalQuotaSchema).default([]),

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -309,3 +309,13 @@ export type RuntimeConnectAddressResponse = z.infer<
 >;
 export type OAuthState = z.infer<typeof OAuthStateSchema>;
 export type ImportState = z.infer<typeof ImportStateSchema>;
+
+export const AccountResetCreditResponseSchema = z.object({
+  accountId: z.string(),
+  creditId: z.string(),
+  windowsReset: z.number().int().nullable().optional(),
+  status: z.string(),
+});
+export type AccountResetCreditResponse = z.infer<
+  typeof AccountResetCreditResponseSchema
+>;

--- a/frontend/src/features/accounts/sorting.test.ts
+++ b/frontend/src/features/accounts/sorting.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACCOUNT_SORT_OPTIONS,
+  sortAccountsForDisplay,
+} from "@/features/accounts/sorting";
+import { createAccountSummary } from "@/test/mocks/factories";
+
+describe("sortAccountsForDisplay - available resets", () => {
+  it("exposes an available resets sort option", () => {
+    expect(
+      ACCOUNT_SORT_OPTIONS.find((option) => option.value === "available_resets"),
+    ).toEqual({ value: "available_resets", label: "Available resets" });
+  });
+
+  it("sorts accounts by available reset count descending (highest first)", () => {
+    const accounts = [
+      createAccountSummary({
+        accountId: "a-none",
+        displayName: "None Account",
+        availableResetCount: 0,
+      }),
+      createAccountSummary({
+        accountId: "b-high",
+        displayName: "High Account",
+        availableResetCount: 5,
+      }),
+      createAccountSummary({
+        accountId: "c-low",
+        displayName: "Low Account",
+        availableResetCount: 2,
+      }),
+    ];
+
+    const sorted = sortAccountsForDisplay(accounts, "both", "available_resets").map(
+      (account) => account.accountId,
+    );
+
+    expect(sorted).toEqual(["b-high", "c-low", "a-none"]);
+  });
+});

--- a/frontend/src/features/accounts/sorting.ts
+++ b/frontend/src/features/accounts/sorting.ts
@@ -2,13 +2,14 @@ import type { AccountSummary } from "@/features/accounts/schemas";
 import type { AccountQuotaDisplayPreference } from "@/hooks/use-account-quota-display";
 import { parseDate } from "@/utils/formatters";
 
-export type AccountSortMode = "reset_soonest" | "reset_latest" | "name_asc" | "name_desc";
+export type AccountSortMode = "reset_soonest" | "reset_latest" | "name_asc" | "name_desc" | "available_resets";
 
 export const ACCOUNT_SORT_OPTIONS: readonly { value: AccountSortMode; label: string }[] = [
   { value: "reset_soonest", label: "Reset time (soonest)" },
   { value: "reset_latest", label: "Reset time (latest)" },
   { value: "name_asc", label: "Name (A-Z)" },
   { value: "name_desc", label: "Name (Z-A)" },
+  { value: "available_resets", label: "Available resets" },
 ] as const;
 
 export const DEFAULT_ACCOUNT_SORT_MODE: AccountSortMode = "reset_soonest";
@@ -58,7 +59,13 @@ export function sortAccountsForDisplay(
   return accounts
     .slice()
     .sort((left, right) => {
-      if (sortMode === "reset_latest" || sortMode === "reset_soonest") {
+      if (sortMode === "available_resets") {
+        const leftResets = left.availableResetCount ?? 0;
+        const rightResets = right.availableResetCount ?? 0;
+        if (leftResets !== rightResets) {
+          return rightResets - leftResets;
+        }
+      } else if (sortMode === "reset_latest" || sortMode === "reset_soonest") {
         const leftReset = accountResetTimestamp(left, quotaDisplay);
         const rightReset = accountResetTimestamp(right, quotaDisplay);
         const resetComparison = compareResetTimestamps(

--- a/frontend/src/features/dashboard/components/account-card.test.tsx
+++ b/frontend/src/features/dashboard/components/account-card.test.tsx
@@ -108,4 +108,20 @@ describe("AccountCard", () => {
 
     expect(screen.getByRole("button", { name: "Enable limit warm-up for Read Only Account" })).toBeDisabled();
   });
+
+  it("shows an available reset badge when reset count is greater than zero", () => {
+    const account = createAccountSummary({ availableResetCount: 4 });
+
+    render(<AccountCard account={account} />);
+
+    expect(screen.getByTestId("available-reset-badge")).toHaveTextContent("4");
+  });
+
+  it("hides the available reset badge when no resets are available", () => {
+    const account = createAccountSummary({ availableResetCount: 0 });
+
+    render(<AccountCard account={account} />);
+
+    expect(screen.queryByTestId("available-reset-badge")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/dashboard/components/account-card.test.tsx
+++ b/frontend/src/features/dashboard/components/account-card.test.tsx
@@ -109,12 +109,12 @@ describe("AccountCard", () => {
     expect(screen.getByRole("button", { name: "Enable limit warm-up for Read Only Account" })).toBeDisabled();
   });
 
-  it("shows a disabled Reset button when reset count is greater than zero", () => {
+  it("shows an enabled Reset button when reset count is greater than zero", () => {
     const account = createAccountSummary({ availableResetCount: 4 });
 
     render(<AccountCard account={account} />);
 
-    expect(screen.getByRole("button", { name: /Reset \(4\)/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Reset \(4\)/ })).toBeEnabled();
   });
 
   it("hides the Reset button when no resets are available", () => {

--- a/frontend/src/features/dashboard/components/account-card.test.tsx
+++ b/frontend/src/features/dashboard/components/account-card.test.tsx
@@ -109,19 +109,19 @@ describe("AccountCard", () => {
     expect(screen.getByRole("button", { name: "Enable limit warm-up for Read Only Account" })).toBeDisabled();
   });
 
-  it("shows an available reset badge when reset count is greater than zero", () => {
+  it("shows a disabled Reset button when reset count is greater than zero", () => {
     const account = createAccountSummary({ availableResetCount: 4 });
 
     render(<AccountCard account={account} />);
 
-    expect(screen.getByTestId("available-reset-badge")).toHaveTextContent("4");
+    expect(screen.getByRole("button", { name: /Reset \(4\)/ })).toBeDisabled();
   });
 
-  it("hides the available reset badge when no resets are available", () => {
+  it("hides the Reset button when no resets are available", () => {
     const account = createAccountSummary({ availableResetCount: 0 });
 
     render(<AccountCard account={account} />);
 
-    expect(screen.queryByTestId("available-reset-badge")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Reset/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/dashboard/components/account-card.tsx
+++ b/frontend/src/features/dashboard/components/account-card.tsx
@@ -126,7 +126,18 @@ export function AccountCard({ account, showAccountId = false, readOnly = false, 
             </p>
           ) : null}
         </div>
-        <StatusBadge status={status} />
+        <div className="flex items-center gap-2">
+          {account.availableResetCount > 0 ? (
+            <span
+              data-testid="available-reset-badge"
+              aria-label={`${account.availableResetCount} rate-limit resets available`}
+              className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold tabular-nums text-primary-foreground"
+            >
+              {account.availableResetCount}
+            </span>
+          ) : null}
+          <StatusBadge status={status} />
+        </div>
       </div>
 
       {/* Quota bars */}

--- a/frontend/src/features/dashboard/components/account-card.tsx
+++ b/frontend/src/features/dashboard/components/account-card.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/utils/account-status";
 import { formatDateTimeInline, formatPercentNullable, formatQuotaResetLabel, formatSlug } from "@/utils/formatters";
 
-export type AccountAction = "details" | "resume" | "reauth" | "warmup-toggle";
+export type AccountAction = "details" | "resume" | "reauth" | "warmup-toggle" | "reset-credit";
 
 export type AccountCardProps = {
   account: AccountSummary;
@@ -192,8 +192,9 @@ export function AccountCard({ account, showAccountId = false, readOnly = false, 
             size="sm"
             variant="outline"
             className="h-7 gap-1.5 rounded-lg text-xs"
-            disabled
+            disabled={readOnly}
             title="Reset rate-limit credits"
+            onClick={() => onAction?.(account, "reset-credit")}
           >
             <RotateCcw className="h-3.5 w-3.5" />
             {`Reset (${account.availableResetCount ?? 0})`}

--- a/frontend/src/features/dashboard/components/account-card.tsx
+++ b/frontend/src/features/dashboard/components/account-card.tsx
@@ -15,6 +15,13 @@ import { formatDateTimeInline, formatPercentNullable, formatQuotaResetLabel, for
 
 export type AccountAction = "details" | "resume" | "reauth" | "warmup-toggle" | "reset-credit";
 
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+function isResetExpiryUrgent(expiry: string | null | undefined): boolean {
+  if (!expiry) return false;
+  return new Date(expiry).getTime() - Date.now() < SEVEN_DAYS_MS;
+}
+
 export type AccountCardProps = {
   account: AccountSummary;
   showAccountId?: boolean;
@@ -105,6 +112,7 @@ export function AccountCard({ account, showAccountId = false, readOnly = false, 
   const warmupDetail = account.limitWarmup
     ? `${formatSlug(account.limitWarmup.status)} | ${account.limitWarmup.window === "primary" ? "5h" : "weekly"} | ${formatSlug(account.limitWarmup.model)} | ${formatDateTimeInline(account.limitWarmup.completedAt ?? account.limitWarmup.attemptedAt)}`
     : "No attempts";
+  const isResetUrgent = isResetExpiryUrgent(account.nearestResetExpiryAt);
 
   return (
     <div className="card-hover rounded-xl border bg-card p-4">
@@ -190,8 +198,11 @@ export function AccountCard({ account, showAccountId = false, readOnly = false, 
           <Button
             type="button"
             size="sm"
-            variant="outline"
-            className="h-7 gap-1.5 rounded-lg text-xs"
+            variant="ghost"
+            className={cn(
+              "h-7 gap-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground",
+              isResetUrgent && "border border-red-500 text-red-600 hover:bg-red-500/10 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300",
+            )}
             disabled={readOnly}
             title="Reset rate-limit credits"
             onClick={() => onAction?.(account, "reset-credit")}

--- a/frontend/src/features/dashboard/components/account-card.tsx
+++ b/frontend/src/features/dashboard/components/account-card.tsx
@@ -127,15 +127,6 @@ export function AccountCard({ account, showAccountId = false, readOnly = false, 
           ) : null}
         </div>
         <div className="flex items-center gap-2">
-          {account.availableResetCount > 0 ? (
-            <span
-              data-testid="available-reset-badge"
-              aria-label={`${account.availableResetCount} rate-limit resets available`}
-              className="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold tabular-nums text-primary-foreground"
-            >
-              {account.availableResetCount}
-            </span>
-          ) : null}
           <StatusBadge status={status} />
         </div>
       </div>
@@ -195,6 +186,19 @@ export function AccountCard({ account, showAccountId = false, readOnly = false, 
           <ExternalLink className="h-3 w-3" />
           Details
         </Button>
+        {(account.availableResetCount ?? 0) > 0 ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 gap-1.5 rounded-lg text-xs"
+            disabled
+            title="Reset rate-limit credits"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            {`Reset (${account.availableResetCount ?? 0})`}
+          </Button>
+        ) : null}
         {status === "paused" && (
           <Button
             type="button"

--- a/frontend/src/features/dashboard/components/account-list.test.tsx
+++ b/frontend/src/features/dashboard/components/account-list.test.tsx
@@ -232,6 +232,23 @@ describe("AccountList", () => {
     expect(screen.getByRole("button", { name: /Reset \(2\)/ })).toBeEnabled();
   });
 
+  it("disables the Reset button in read-only mode", () => {
+    render(
+      <AccountList
+        readOnly
+        accounts={[
+          createAccountSummary({
+            accountId: "acc-1",
+            displayName: "Reset Account",
+            availableResetCount: 2,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Reset \(2\)/ })).toBeDisabled();
+  });
+
   it("hides the Reset button when no resets are available", () => {
     render(
       <AccountList

--- a/frontend/src/features/dashboard/components/account-list.test.tsx
+++ b/frontend/src/features/dashboard/components/account-list.test.tsx
@@ -215,4 +215,21 @@ describe("AccountList", () => {
 
     expect(rowNames()).toEqual(["Low Account", "Empty Account", "Unknown Account"]);
   });
+
+  it("renders a Resets column with the available reset count", () => {
+    render(
+      <AccountList
+        accounts={[
+          createAccountSummary({
+            accountId: "acc-1",
+            displayName: "Reset Account",
+            availableResetCount: 2,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Resets")).toBeInTheDocument();
+    expect(screen.getByTestId("account-list-resets")).toHaveTextContent("2");
+  });
 });

--- a/frontend/src/features/dashboard/components/account-list.test.tsx
+++ b/frontend/src/features/dashboard/components/account-list.test.tsx
@@ -216,7 +216,7 @@ describe("AccountList", () => {
     expect(rowNames()).toEqual(["Low Account", "Empty Account", "Unknown Account"]);
   });
 
-  it("renders a Resets column with the available reset count", () => {
+  it("shows a disabled Reset button when reset count is greater than zero", () => {
     render(
       <AccountList
         accounts={[
@@ -229,7 +229,22 @@ describe("AccountList", () => {
       />,
     );
 
-    expect(screen.getByText("Resets")).toBeInTheDocument();
-    expect(screen.getByTestId("account-list-resets")).toHaveTextContent("2");
+    expect(screen.getByRole("button", { name: /Reset \(2\)/ })).toBeDisabled();
+  });
+
+  it("hides the Reset button when no resets are available", () => {
+    render(
+      <AccountList
+        accounts={[
+          createAccountSummary({
+            accountId: "acc-1",
+            displayName: "Empty Account",
+            availableResetCount: 0,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /^Reset/ })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/dashboard/components/account-list.test.tsx
+++ b/frontend/src/features/dashboard/components/account-list.test.tsx
@@ -216,7 +216,7 @@ describe("AccountList", () => {
     expect(rowNames()).toEqual(["Low Account", "Empty Account", "Unknown Account"]);
   });
 
-  it("shows a disabled Reset button when reset count is greater than zero", () => {
+  it("shows an enabled Reset button when reset count is greater than zero", () => {
     render(
       <AccountList
         accounts={[
@@ -229,7 +229,7 @@ describe("AccountList", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: /Reset \(2\)/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Reset \(2\)/ })).toBeEnabled();
   });
 
   it("hides the Reset button when no resets are available", () => {

--- a/frontend/src/features/dashboard/components/account-list.tsx
+++ b/frontend/src/features/dashboard/components/account-list.tsx
@@ -14,7 +14,7 @@ import { formatDateTimeInline, formatPercentNullable, formatQuotaResetLabel, for
 
 const ACCOUNT_LIST_VISIBLE_ROWS = 8;
 const ACCOUNT_LIST_ROW_HEIGHT_REM = 4.5;
-const ACCOUNT_LIST_COLUMNS = "minmax(13rem,1.3fr) 7.75rem 5rem minmax(14rem,1.2fr) 6rem minmax(8rem,0.8fr) 6.5rem";
+const ACCOUNT_LIST_COLUMNS = "minmax(13rem,1.3fr) 7.75rem 5rem minmax(14rem,1.2fr) 6rem minmax(8rem,0.8fr) 4.5rem 6.5rem";
 
 type AccountListProps = {
   accounts: AccountSummary[];
@@ -276,7 +276,7 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
       className="overflow-x-auto rounded-lg border bg-card"
     >
       <div
-        className="min-w-[54rem] divide-y overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        className="min-w-[58rem] divide-y overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={{ maxHeight: `${ACCOUNT_LIST_VISIBLE_ROWS * ACCOUNT_LIST_ROW_HEIGHT_REM}rem` }}
       >
         <div
@@ -292,6 +292,7 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
               onSort={handleSort}
             />
           ))}
+          <span>Resets</span>
           <span className="text-right">Actions</span>
         </div>
         {sortedAccounts.map((account, index) => {
@@ -336,6 +337,12 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
                 </p>
                 <p className="truncate text-[11px] text-muted-foreground">{warmupDetail}</p>
               </div>
+              <span
+                data-testid="account-list-resets"
+                className="text-xs tabular-nums text-muted-foreground"
+              >
+                {account.availableResetCount ?? 0}
+              </span>
               <div className="flex justify-end gap-1">
                 <Button
                   type="button"

--- a/frontend/src/features/dashboard/components/account-list.tsx
+++ b/frontend/src/features/dashboard/components/account-list.tsx
@@ -16,6 +16,13 @@ const ACCOUNT_LIST_VISIBLE_ROWS = 8;
 const ACCOUNT_LIST_ROW_HEIGHT_REM = 4.5;
 const ACCOUNT_LIST_COLUMNS = "minmax(13rem,1.3fr) 7.75rem 5rem minmax(14rem,1.2fr) 6rem minmax(8rem,0.8fr) auto";
 
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+function isResetExpiryUrgent(expiry: string | null | undefined): boolean {
+  if (!expiry) return false;
+  return new Date(expiry).getTime() - Date.now() < SEVEN_DAYS_MS;
+}
+
 type AccountListProps = {
   accounts: AccountSummary[];
   readOnly?: boolean;
@@ -306,6 +313,7 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
           const warmupDetail = account.limitWarmup
             ? `${formatSlug(account.limitWarmup.status)} | ${account.limitWarmup.window === "primary" ? "5h" : "weekly"} | ${formatDateTimeInline(account.limitWarmup.completedAt ?? account.limitWarmup.attemptedAt)}`
             : "No attempts";
+          const isResetUrgent = isResetExpiryUrgent(account.nearestResetExpiryAt);
           return (
             <div
               key={account.accountId}
@@ -352,8 +360,11 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
                   <Button
                     type="button"
                     size="sm"
-                    variant="outline"
-                    className="h-7 gap-1 rounded-md px-2 text-xs"
+                    variant="ghost"
+                    className={cn(
+                      "gap-1 rounded-md px-2 text-xs text-muted-foreground hover:text-foreground",
+                      isResetUrgent && "border border-red-500 text-red-600 hover:bg-red-500/10 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300",
+                    )}
                     title="Reset rate-limit credits"
                     onClick={() => onAction?.(account, "reset-credit")}
                   >

--- a/frontend/src/features/dashboard/components/account-list.tsx
+++ b/frontend/src/features/dashboard/components/account-list.tsx
@@ -361,6 +361,7 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
                     type="button"
                     size="sm"
                     variant="ghost"
+                    disabled={readOnly}
                     className={cn(
                       "gap-1 rounded-md px-2 text-xs text-muted-foreground hover:text-foreground",
                       isResetUrgent && "border border-red-500 text-red-600 hover:bg-red-500/10 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300",

--- a/frontend/src/features/dashboard/components/account-list.tsx
+++ b/frontend/src/features/dashboard/components/account-list.tsx
@@ -354,8 +354,8 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
                     size="sm"
                     variant="outline"
                     className="h-7 gap-1 rounded-md px-2 text-xs"
-                    disabled
                     title="Reset rate-limit credits"
+                    onClick={() => onAction?.(account, "reset-credit")}
                   >
                     <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
                     {`Reset (${account.availableResetCount ?? 0})`}

--- a/frontend/src/features/dashboard/components/account-list.tsx
+++ b/frontend/src/features/dashboard/components/account-list.tsx
@@ -14,7 +14,7 @@ import { formatDateTimeInline, formatPercentNullable, formatQuotaResetLabel, for
 
 const ACCOUNT_LIST_VISIBLE_ROWS = 8;
 const ACCOUNT_LIST_ROW_HEIGHT_REM = 4.5;
-const ACCOUNT_LIST_COLUMNS = "minmax(13rem,1.3fr) 7.75rem 5rem minmax(14rem,1.2fr) 6rem minmax(8rem,0.8fr) 4.5rem 6.5rem";
+const ACCOUNT_LIST_COLUMNS = "minmax(13rem,1.3fr) 7.75rem 5rem minmax(14rem,1.2fr) 6rem minmax(8rem,0.8fr) auto";
 
 type AccountListProps = {
   accounts: AccountSummary[];
@@ -292,7 +292,6 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
               onSort={handleSort}
             />
           ))}
-          <span>Resets</span>
           <span className="text-right">Actions</span>
         </div>
         {sortedAccounts.map((account, index) => {
@@ -337,12 +336,6 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
                 </p>
                 <p className="truncate text-[11px] text-muted-foreground">{warmupDetail}</p>
               </div>
-              <span
-                data-testid="account-list-resets"
-                className="text-xs tabular-nums text-muted-foreground"
-              >
-                {account.availableResetCount ?? 0}
-              </span>
               <div className="flex justify-end gap-1">
                 <Button
                   type="button"
@@ -355,6 +348,19 @@ export function AccountList({ accounts, readOnly = false, onAction }: AccountLis
                 >
                   <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
                 </Button>
+                {(account.availableResetCount ?? 0) > 0 ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-7 gap-1 rounded-md px-2 text-xs"
+                    disabled
+                    title="Reset rate-limit credits"
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+                    {`Reset (${account.availableResetCount ?? 0})`}
+                  </Button>
+                ) : null}
                 <Button
                   type="button"
                   size="sm"

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { RefreshCw } from "lucide-react";
 
 import { AlertMessage } from "@/components/alert-message";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useAccountMutations } from "@/features/accounts/hooks/use-accounts";
 import { AccountCards } from "@/features/dashboard/components/account-cards";
 import { AccountList } from "@/features/dashboard/components/account-list";
@@ -49,7 +50,7 @@ export function DashboardPage() {
   const dashboardQuery = useDashboard(overviewTimeframe);
   const projectionsQuery = useDashboardProjections(Boolean(dashboardQuery.data));
   const { filters, logsQuery, optionsQuery, updateFilters } = useRequestLogs();
-  const { resumeMutation, limitWarmupMutation } = useAccountMutations();
+  const { resumeMutation, limitWarmupMutation, resetCreditMutation } = useAccountMutations();
 
   const isRefreshing = dashboardQuery.isFetching || projectionsQuery.isFetching || logsQuery.isFetching;
 
@@ -69,6 +70,8 @@ export function DashboardPage() {
     },
     [searchParams, setSearchParams],
   );
+
+  const [resetConfirmAccount, setResetConfirmAccount] = useState<AccountSummary | null>(null);
 
   const handleAccountAction = useCallback(
     (account: AccountSummary, action: string) => {
@@ -92,9 +95,14 @@ export function DashboardPage() {
             });
           }
           break;
+        case "reset-credit":
+          if (canWrite) {
+            setResetConfirmAccount(account);
+          }
+          break;
       }
     },
-    [canWrite, limitWarmupMutation, navigate, resumeMutation],
+    [canWrite, limitWarmupMutation, navigate, resumeMutation, setResetConfirmAccount],
   );
 
   const overview = dashboardQuery.data;
@@ -290,6 +298,26 @@ export function DashboardPage() {
         </>
       )}
 
+      <ConfirmDialog
+        open={resetConfirmAccount !== null}
+        title="Reset rate limit"
+        description={
+          resetConfirmAccount
+            ? `Redeem one rate-limit reset credit for ${resetConfirmAccount.displayName || resetConfirmAccount.email}? The nearest-expiry credit will be used.`
+            : undefined
+        }
+        confirmLabel="Reset"
+        cancelLabel="Cancel"
+        onOpenChange={(open) => {
+          if (!open) setResetConfirmAccount(null);
+        }}
+        onConfirm={() => {
+          if (resetConfirmAccount) {
+            void resetCreditMutation.mutateAsync(resetConfirmAccount.accountId);
+            setResetConfirmAccount(null);
+          }
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -91,7 +91,7 @@ describe("RecentRequestsTable", () => {
              planType: "plus",
              status: "active",
              limitWarmupEnabled: false,
-             additionalQuotas: [],
+             additionalQuotas: [], availableResetCount: 0,
            },
          ]}
         requests={[

--- a/frontend/src/features/dashboard/utils.test.ts
+++ b/frontend/src/features/dashboard/utils.test.ts
@@ -39,6 +39,7 @@ function account(overrides: Partial<AccountSummary> & Pick<AccountSummary, "acco
     remainingCreditsMonthly: overrides.remainingCreditsMonthly ?? null,
     auth: overrides.auth ?? null,
     additionalQuotas: overrides.additionalQuotas ?? [],
+    availableResetCount: overrides.availableResetCount ?? 0,
     isEmailDuplicate: overrides.isEmailDuplicate,
   };
 }

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -121,6 +121,7 @@ export function createAccountSummary(
 		creditsUnlimited: false,
 		creditsBalance: 932,
 		availableResetCount: 0,
+		nearestResetExpiryAt: null,
 		auth: {
 			access: { expiresAt: offsetIso(30), state: null },
 			refresh: { state: "stored" },

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -120,6 +120,7 @@ export function createAccountSummary(
 		creditsHas: true,
 		creditsUnlimited: false,
 		creditsBalance: 932,
+		availableResetCount: 0,
 		auth: {
 			access: { expiresAt: offsetIso(30), state: null },
 			refresh: { state: "stored" },

--- a/openspec/changes/add-rate-limit-reset-credits/.openspec.yaml
+++ b/openspec/changes/add-rate-limit-reset-credits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/add-rate-limit-reset-credits/context.md
+++ b/openspec/changes/add-rate-limit-reset-credits/context.md
@@ -1,0 +1,51 @@
+## Upstream endpoint
+
+- path: `/wham/rate-limit-reset-credits`
+- auth: `Authorization: Bearer <token>`
+- account header: `chatgpt-account-id`
+
+This fetch runs inside the existing 60-second background refresh loop and is scoped to the same account that is already being refreshed for usage data.
+
+## Persistence rule
+
+- insert new `(account_id, credit_id)` rows only
+- never overwrite existing upstream-fetched fields
+- allow local `available -> expired` transition when `now > expires_at`
+
+## Example
+
+If account `acc_123` refreshes at `12:00:00Z` and upstream returns:
+
+```json
+{
+  "credits": [
+    {
+      "id": "RateLimitResetCredit_one",
+      "status": "available",
+      "granted_at": "2026-06-12T01:29:41Z",
+      "expires_at": "2026-07-12T01:29:41Z",
+      "redeemed_at": null
+    }
+  ],
+  "available_count": 1
+}
+```
+
+codex-lb stores one new row for `(acc_123, RateLimitResetCredit_one)`. A later refresh that returns the same credit does not insert a duplicate or overwrite the stored upstream fields. If a later local refresh pass observes `now > expires_at`, codex-lb changes only the stored status to `expired` so `availableResetCount` drops to zero.
+
+## Failure and edge cases
+
+- A fetch failure for one account does not clear previously stored credits and does not block refresh work for other accounts.
+- The available count is derived from persisted rows, so one transient upstream failure does not zero the UI count for that account.
+- If upstream keeps returning a credit that is already stored, the row remains deduplicated by `(account_id, credit_id)`.
+- If a stored credit expires locally before upstream stops returning it, this change still treats the local `expired` state as authoritative for the available count until a future change defines overwrite or redemption behavior.
+
+## UI notes
+
+- The Accounts navigation badge and per-account badges are intended to use the same compact circular badge style already used elsewhere in the dashboard.
+- The disabled `Reset (N)` control is present for visibility only in this read-only rollout.
+- On the account detail view, the disabled `Reset (N)` control remains positioned next to `Export` so operators can see the intended future workflow entry point without consume behavior in this change.
+
+## Future follow-up
+
+Consume remains a separate change so this rollout is read-only.

--- a/openspec/changes/add-rate-limit-reset-credits/context.md
+++ b/openspec/changes/add-rate-limit-reset-credits/context.md
@@ -15,14 +15,15 @@ This fetch runs inside the existing 60-second background refresh loop and is sco
 - account header: `chatgpt-account-id`
 - body: `{"credit_id": "...", "redeem_request_id": "<uuid4>"}`
 
-The operator-triggered API surface is `POST /api/accounts/{account_id}/reset-credit`, which internally selects the nearest-expiry available credit, generates a UUID v4 `redeem_request_id`, calls the upstream consume endpoint, and marks the credit as `redeemed` on success.
+The operator-triggered API surface is `POST /api/accounts/{account_id}/reset-credit`, which internally atomically claims the nearest-expiry available credit, generates a UUID v4 `redeem_request_id`, resolves any account-bound upstream proxy route, calls the upstream consume endpoint, and marks the credit as `redeemed` on success.
 
 ## Persistence rule
 
 - insert new `(account_id, credit_id)` rows only
 - never overwrite existing upstream-fetched fields
 - allow local `available -> expired` transition when `now > expires_at`
-- allow local `available -> redeemed` transition after a successful consume
+- allow local `available -> redeeming -> redeemed` transition during a successful consume
+- allow local `redeeming -> available` rollback when route resolution or the upstream consume call fails
 
 ## Example
 
@@ -52,6 +53,7 @@ codex-lb stores one new row for `(acc_123, RateLimitResetCredit_one)`. A later r
 - If upstream keeps returning a credit that is already stored, the row remains deduplicated by `(account_id, credit_id)`.
 - If a stored credit expires locally before upstream stops returning it, this change treats the local `expired` state as authoritative for the available count.
 - If the consume endpoint returns an error, the credit remains `available` and the UI shows the error.
+- If an account has an upstream proxy binding, the operator-triggered consume path uses the same resolved route model as other account-scoped upstream requests and only falls back to direct egress when no route resolves.
 
 ## UI notes
 

--- a/openspec/changes/add-rate-limit-reset-credits/context.md
+++ b/openspec/changes/add-rate-limit-reset-credits/context.md
@@ -42,9 +42,11 @@ codex-lb stores one new row for `(acc_123, RateLimitResetCredit_one)`. A later r
 
 ## UI notes
 
-- The Accounts navigation badge and per-account badges are intended to use the same compact circular badge style already used elsewhere in the dashboard.
+- The Accounts navigation badge uses an inline circular badge style on the nav tab.
+- On the Accounts page, each list-item box shows a circular corner badge pinned to the top-right of the box when `availableResetCount > 0`. The badge is hidden when the count is zero.
+- The dashboard account table and account card do NOT show a badge next to the status. Instead, both surfaces show a disabled `Reset (N)` button next to the Details action when `availableResetCount > 0`, and hide it when the count is zero.
 - The disabled `Reset (N)` control is present for visibility only in this read-only rollout.
-- On the account detail view, the disabled `Reset (N)` control remains positioned next to `Export` so operators can see the intended future workflow entry point without consume behavior in this change.
+- On the account detail panel, the disabled `Reset (N)` control is positioned next to `Export` so operators can see the intended future workflow entry point without consume behavior in this change.
 
 ## Future follow-up
 

--- a/openspec/changes/add-rate-limit-reset-credits/context.md
+++ b/openspec/changes/add-rate-limit-reset-credits/context.md
@@ -1,16 +1,28 @@
-## Upstream endpoint
+## Upstream endpoints
 
-- path: `/wham/rate-limit-reset-credits`
+### Fetch
+
+- path: `GET /wham/rate-limit-reset-credits`
 - auth: `Authorization: Bearer <token>`
 - account header: `chatgpt-account-id`
 
 This fetch runs inside the existing 60-second background refresh loop and is scoped to the same account that is already being refreshed for usage data.
+
+### Consume
+
+- path: `POST /wham/rate-limit-reset-credits/consume`
+- auth: `Authorization: Bearer <token>`
+- account header: `chatgpt-account-id`
+- body: `{"credit_id": "...", "redeem_request_id": "<uuid4>"}`
+
+The operator-triggered API surface is `POST /api/accounts/{account_id}/reset-credit`, which internally selects the nearest-expiry available credit, generates a UUID v4 `redeem_request_id`, calls the upstream consume endpoint, and marks the credit as `redeemed` on success.
 
 ## Persistence rule
 
 - insert new `(account_id, credit_id)` rows only
 - never overwrite existing upstream-fetched fields
 - allow local `available -> expired` transition when `now > expires_at`
+- allow local `available -> redeemed` transition after a successful consume
 
 ## Example
 
@@ -38,16 +50,15 @@ codex-lb stores one new row for `(acc_123, RateLimitResetCredit_one)`. A later r
 - A fetch failure for one account does not clear previously stored credits and does not block refresh work for other accounts.
 - The available count is derived from persisted rows, so one transient upstream failure does not zero the UI count for that account.
 - If upstream keeps returning a credit that is already stored, the row remains deduplicated by `(account_id, credit_id)`.
-- If a stored credit expires locally before upstream stops returning it, this change still treats the local `expired` state as authoritative for the available count until a future change defines overwrite or redemption behavior.
+- If a stored credit expires locally before upstream stops returning it, this change treats the local `expired` state as authoritative for the available count.
+- If the consume endpoint returns an error, the credit remains `available` and the UI shows the error.
 
 ## UI notes
 
 - The Accounts navigation badge uses an inline circular badge style on the nav tab.
 - On the Accounts page, each list-item box shows a circular corner badge pinned to the top-right of the box when `availableResetCount > 0`. The badge is hidden when the count is zero.
-- The dashboard account table and account card do NOT show a badge next to the status. Instead, both surfaces show a disabled `Reset (N)` button next to the Details action when `availableResetCount > 0`, and hide it when the count is zero.
-- The disabled `Reset (N)` control is present for visibility only in this read-only rollout.
-- On the account detail panel, the disabled `Reset (N)` control is positioned next to `Export` so operators can see the intended future workflow entry point without consume behavior in this change.
-
-## Future follow-up
-
-Consume remains a separate change so this rollout is read-only.
+- The dashboard account table and account card do NOT show a badge next to the status. Instead, both surfaces show a ghost `Reset (N)` button next to the Details action when `availableResetCount > 0`, and hide it when the count is zero.
+- On the account detail panel, the ghost `Reset (N)` button is positioned next to `Export`.
+- Clicking any Reset button opens a confirmation dialog before executing the consume request.
+- When `nearestResetExpiryAt` is within 7 days, the Reset button applies a red border and red text styling to signal urgency.
+- The urgency check uses a standalone utility function (not inline `Date.now()` in render) to comply with React purity rules.

--- a/openspec/changes/add-rate-limit-reset-credits/design.md
+++ b/openspec/changes/add-rate-limit-reset-credits/design.md
@@ -1,0 +1,111 @@
+## Context
+
+codex-lb already refreshes per-account upstream usage data in a shared 60-second background loop and builds both the Accounts page and dashboard account views from shared `AccountSummary` payloads. The new reset-credit feature needs to fit that shape instead of introducing a separate polling path or frontend-only query model.
+
+The upstream endpoint is undocumented and returns a one-to-many list of reset-credit records per account. The approved scope is read-only: fetch, persist, locally expire, count, and display. Redemption via `POST /wham/rate-limit-reset-credits/consume` is explicitly deferred to a later change.
+
+The main constraints are:
+
+- preserve account ownership by always fetching with the corresponding account bearer token and `chatgpt-account-id`
+- avoid clobbering stored upstream rows once inserted
+- keep transient upstream failures from zeroing visible counts
+- reuse existing account-summary APIs so dashboard and Accounts UI stay aligned
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- add a durable per-account store for upstream reset-credit records
+- refresh reset-credit data inside the existing 60-second background refresh loop
+- derive `availableResetCount` from persisted non-expired rows
+- expose `availableResetCount` through shared account summary payloads used by `/api/accounts` and `/api/dashboard/overview`
+- add Accounts/dashboard/header UI display, badges, and Accounts-page sort behavior
+- keep the OpenSpec change and migration state fully coherent before implementation proceeds
+
+**Non-Goals:**
+
+- no consume/redeem workflow
+- no per-credit drill-down UI
+- no client-side expiry logic or optimistic updates
+- no overwriting of existing stored upstream fields beyond local `expired` transitions
+
+## Decisions
+
+### 1. Store reset credits in a dedicated child table
+
+Reset credits are a one-to-many account resource, so they do not fit the `accounts` row or existing usage-history tables. A dedicated `account_rate_limit_reset_credits` table keyed by `(account_id, credit_id)` preserves the upstream identity, leaves room for future redeem tracking, and supports efficient per-account count queries.
+
+Alternatives considered:
+
+- add JSON or count columns to `accounts`: rejected because it loses per-credit identity and makes future redemption history awkward
+- store rows in `usage_history`: rejected because reset credits are not usage-window samples and have different lifecycle rules
+
+### 2. Refresh reset credits in the existing 60-second scheduler
+
+The existing `UsageRefreshScheduler` already owns the periodic per-account refresh pass, background session lifecycle, and failure isolation. Adding reset-credit fetches there keeps the feature synchronized with usage refresh instead of creating a second scheduler or a frontend-only poller.
+
+Alternatives considered:
+
+- separate background scheduler: rejected because it would duplicate account iteration and drift from usage refresh timing
+- on-demand fetch from dashboard requests: rejected because UI counts would become stale and inconsistent across pages
+
+### 3. Treat insert-once plus local expiry as the persistence rule
+
+The approved behavior is intentionally conservative: new `(account_id, credit_id)` pairs are inserted once, existing upstream fields are not overwritten, and the only local mutation allowed is `status -> expired` when `now > expires_at`. This matches the requested dedupe rule while still allowing the visible count to decay correctly over time.
+
+Alternatives considered:
+
+- always upsert upstream status fields: rejected because it violates the approved “if the entry exists in the database, don’t update it” rule
+- never mutate existing rows locally: rejected because expired stored credits would keep counting forever
+
+### 4. Derive visible counts from persisted rows, not the latest upstream response
+
+`availableResetCount` is computed from stored rows whose status is still `available` and whose `expires_at` is in the future. This makes the UI resilient to transient fetch failures and aligns with the requirement that one failed fetch must not zero visible counts.
+
+Alternatives considered:
+
+- trust `available_count` directly from upstream for rendering: rejected because a failed fetch would produce missing or unstable UI state
+- maintain a separate cached aggregate table: rejected because the count can be derived cheaply from the new indexed child table
+
+### 5. Reuse shared account-summary payloads for all UI surfaces
+
+The Accounts page and dashboard already share `AccountSummary` shapes across backend and frontend. Adding `availableResetCount` there avoids introducing a new endpoint or client-side join logic, and it automatically keeps dashboard cards, account lists, and the Accounts page consistent.
+
+Alternatives considered:
+
+- add a new reset-credit summary endpoint: rejected because it adds avoidable fetch and cache complexity
+- fetch counts only in the header: rejected because the Accounts page and dashboard need the same data
+
+### 6. Keep spec requirements behavioral and move layout nuance to context
+
+The OpenSpec delta specs need to remain durable and testable without freezing incidental styling. The behavioral requirements keep the disabled `Reset (N)` control, sorting, and badge visibility normative, while placement and compact circular badge styling stay in `context.md` and the implementation plan.
+
+Alternatives considered:
+
+- encode all visual detail in `spec.md`: rejected as too brittle for normative requirements
+- remove the disabled control from the spec entirely: rejected because the approved design requires that future workflow entry point to be visible now
+
+## Risks / Trade-offs
+
+- Undocumented upstream endpoint may change shape or error behavior -> keep payload parsing strict for required fields, tolerant of extra fields, and cover failure paths in tests
+- One extra per-account upstream fetch every 60 seconds increases scheduler work -> reuse existing failure isolation and keep count derivation database-backed so transient failures do not cascade into UI regressions
+- Insert-once persistence means upstream status changes other than local expiry are not reconciled in this change -> document that consume/redeem reconciliation is deferred to the follow-up change
+- Shared payload expansion affects both backend and frontend contracts -> add explicit OpenSpec contract requirements and regression tests for `/api/accounts` and `/api/dashboard/overview`
+
+## Migration Plan
+
+1. Add the OpenSpec change artifacts, including this design document, and keep them validated.
+2. Add the Alembic revision for `account_rate_limit_reset_credits` with the foreign key, unique constraint, and count-oriented indexes.
+3. Add ORM/repository support for insert-if-missing, local expiry normalization, and per-account available counts.
+4. Integrate the reset-credit updater into the existing 60-second background refresh loop.
+5. Extend shared account summary payloads with `availableResetCount` and wire the UI rendering/sort/badges.
+6. Verify backend tests, frontend tests, and `openspec validate --specs` before considering the change ready.
+
+Rollback strategy:
+
+- if implementation has not shipped, revert the code and migration together
+- if the migration must stay but the feature is disabled, counts can remain unused because the child table is additive and isolated from existing account-selection behavior
+
+## Open Questions
+
+- None for the read-only rollout. The main remaining questions belong to the future consume change: selection policy for multiple credits, `redeem_request_id` persistence, and how redeemed upstream state should reconcile with insert-once storage.

--- a/openspec/changes/add-rate-limit-reset-credits/proposal.md
+++ b/openspec/changes/add-rate-limit-reset-credits/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Operators need to see banked rate-limit reset credits per account without manually inspecting upstream state.
+Operators need to see banked rate-limit reset credits per account without manually inspecting upstream state, and redeem them when an account is rate-limited.
 
 ## What Changes
 
@@ -9,10 +9,7 @@ Operators need to see banked rate-limit reset credits per account without manual
 - locally mark stored rows `expired` when `now > expires_at`
 - expose `availableResetCount` through shared account payloads
 - show reset counts in dashboard/accounts UI
-
-## Out of Scope
-
-- `POST /wham/rate-limit-reset-credits/consume`
-- `credit_id` selection
-- `redeem_request_id` generation
-- any reset redemption workflow
+- enable operator-triggered redemption via `POST /wham/rate-limit-reset-credits/consume`
+- select the nearest-expiry available credit for redemption
+- show a confirmation dialog before submitting the consume request
+- mark redeemed credits in the local database after a successful consume response

--- a/openspec/changes/add-rate-limit-reset-credits/proposal.md
+++ b/openspec/changes/add-rate-limit-reset-credits/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+Operators need to see banked rate-limit reset credits per account without manually inspecting upstream state.
+
+## What Changes
+
+- fetch `GET /wham/rate-limit-reset-credits` every 60 seconds for refreshable accounts
+- persist new credits keyed by `(account_id, credit_id)`
+- locally mark stored rows `expired` when `now > expires_at`
+- expose `availableResetCount` through shared account payloads
+- show reset counts in dashboard/accounts UI
+
+## Out of Scope
+
+- `POST /wham/rate-limit-reset-credits/consume`
+- `credit_id` selection
+- `redeem_request_id` generation
+- any reset redemption workflow

--- a/openspec/changes/add-rate-limit-reset-credits/specs/database-migrations/spec.md
+++ b/openspec/changes/add-rate-limit-reset-credits/specs/database-migrations/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Reset-credit storage is indexed per account
+
+The database migration MUST create a reset-credit table keyed by `(account_id, credit_id)` and indexed for per-account available-count lookups.
+
+#### Scenario: Migration creates indexed child table
+
+- **GIVEN** the migration upgrades from the previous head
+- **WHEN** the new schema is applied
+- **THEN** the database contains `account_rate_limit_reset_credits`
+- **AND** the table has a foreign key to `accounts`
+- **AND** the table has a unique key on `(account_id, credit_id)`
+- **AND** the table has indexes on `account_id`, `status`, `expires_at`, and `(account_id, status, expires_at)`

--- a/openspec/changes/add-rate-limit-reset-credits/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-rate-limit-reset-credits/specs/frontend-architecture/spec.md
@@ -4,25 +4,32 @@
 
 The accounts and dashboard UI SHALL display the current available reset count from shared account payloads.
 
-Shared account summary payloads exposed to the Accounts page and dashboard UI SHALL include `availableResetCount`.
+Shared account summary payloads exposed to the Accounts page and dashboard UI SHALL include `availableResetCount` and `nearestResetExpiryAt`.
 
 The Accounts page SHALL support a sort mode that orders accounts by available reset count, using the existing sort tie-break behavior afterward.
 
-The dashboard account table and account card SHALL NOT show a reset-count badge next to the status. Instead, the dashboard SHALL show a disabled `Reset (N)` button next to the Details action when `availableResetCount > 0`.
+The dashboard account table and account card SHALL NOT show a reset-count badge next to the status. Instead, the dashboard SHALL show a `Reset (N)` ghost button next to the Details action when `availableResetCount > 0`.
 
 The Accounts page list-item boxes SHALL show a circular corner badge at the top-right of each box when `availableResetCount > 0`.
 
-#### Scenario: Account detail shows disabled reset control
+### Requirement: Reset buttons show urgency styling when nearest expiry is imminent
+
+When `nearestResetExpiryAt` is within 7 days of the current time, the Reset button SHALL apply a red border and red text styling to signal urgency.
+
+When `nearestResetExpiryAt` is null, more than 7 days away, or the account has no available credits, the Reset button SHALL use the default ghost style without urgency styling.
+
+#### Scenario: Account detail shows reset control
 
 - **GIVEN** an account summary includes `availableResetCount = 2`
 - **WHEN** the operator opens the account detail panel
-- **THEN** the actions area includes a disabled `Reset (2)` button next to the Export button
+- **THEN** the actions area includes a ghost `Reset (2)` button next to the Export button
 
-#### Scenario: Shared account summary payload exposes available reset count
+#### Scenario: Shared account summary payload exposes available reset count and nearest expiry
 
 - **WHEN** the Accounts page or dashboard UI receives an account summary payload for an account with available reset credits
 - **THEN** that payload includes `availableResetCount`
-- **AND** the UI uses that field for reset-count rendering without requiring a separate reset-credit detail fetch
+- **AND** that payload includes `nearestResetExpiryAt`
+- **AND** the UI uses those fields for reset-count rendering and urgency styling without requiring a separate reset-credit detail fetch
 
 #### Scenario: Accounts navigation shows aggregate count
 
@@ -36,11 +43,11 @@ The Accounts page list-item boxes SHALL show a circular corner badge at the top-
 - **WHEN** the operator selects the available-reset sort mode on the Accounts page
 - **THEN** the account with the higher available reset count sorts ahead of the lower-count account
 
-#### Scenario: Dashboard shows disabled Reset button next to Details
+#### Scenario: Dashboard shows Reset button next to Details
 
 - **GIVEN** a dashboard account summary includes `availableResetCount = 3`
 - **WHEN** the account appears in the dashboard account table or account card
-- **THEN** a disabled `Reset (3)` button appears next to the Details action
+- **THEN** a ghost `Reset (3)` button appears next to the Details action
 - **AND** no reset-count badge appears next to the account status
 
 #### Scenario: Dashboard hides Reset button when no resets are available
@@ -55,3 +62,15 @@ The Accounts page list-item boxes SHALL show a circular corner badge at the top-
 - **WHEN** the list item renders
 - **THEN** a circular count badge with `2` appears pinned to the top-right corner of the box
 - **AND** the badge is hidden when `availableResetCount = 0`
+
+#### Scenario: Reset button shows urgency styling when expiry is imminent
+
+- **GIVEN** an account summary includes `availableResetCount > 0` and `nearestResetExpiryAt` is 3 days from now
+- **WHEN** the Reset button renders on the account detail panel, dashboard card, or dashboard list
+- **THEN** the button displays a red border and red text styling
+
+#### Scenario: Reset button shows default styling when expiry is not imminent
+
+- **GIVEN** an account summary includes `availableResetCount > 0` and `nearestResetExpiryAt` is 30 days from now
+- **WHEN** the Reset button renders
+- **THEN** the button uses the default ghost style without red border styling

--- a/openspec/changes/add-rate-limit-reset-credits/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-rate-limit-reset-credits/specs/frontend-architecture/spec.md
@@ -56,6 +56,13 @@ When `nearestResetExpiryAt` is null, more than 7 days away, or the account has n
 - **WHEN** the account appears in the dashboard account table or account card
 - **THEN** no `Reset` button is shown
 
+#### Scenario: Read-only dashboard disables Reset button
+
+- **GIVEN** the dashboard is rendered for a read-only user
+- **AND** an account summary includes `availableResetCount = 2`
+- **WHEN** the account appears in the dashboard account table or account card
+- **THEN** the visible `Reset (2)` button is disabled
+
 #### Scenario: Accounts page list item shows corner reset badge
 
 - **GIVEN** an Accounts page list-item box has `availableResetCount = 2`

--- a/openspec/changes/add-rate-limit-reset-credits/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-rate-limit-reset-credits/specs/frontend-architecture/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Accounts UI shows available reset counts
+
+The accounts and dashboard UI SHALL display the current available reset count from shared account payloads.
+
+Shared account summary payloads exposed to the Accounts page and dashboard UI SHALL include `availableResetCount`.
+
+The Accounts page SHALL support a sort mode that orders accounts by available reset count, using the existing sort tie-break behavior afterward.
+
+When an account summary has `availableResetCount > 0`, account cards and account list items SHALL show a per-account badge for that count.
+
+#### Scenario: Account detail shows disabled reset control
+
+- **GIVEN** an account summary includes `availableResetCount = 2`
+- **WHEN** the operator opens the account detail panel
+- **THEN** the actions area includes a disabled `Reset (2)` button
+
+#### Scenario: Shared account summary payload exposes available reset count
+
+- **WHEN** the Accounts page or dashboard UI receives an account summary payload for an account with available reset credits
+- **THEN** that payload includes `availableResetCount`
+- **AND** the UI uses that field for reset-count rendering without requiring a separate reset-credit detail fetch
+
+#### Scenario: Accounts navigation shows aggregate count
+
+- **GIVEN** one or more account summaries have `availableResetCount > 0`
+- **WHEN** the application header renders
+- **THEN** the `Accounts` navigation tab shows an aggregate count badge
+
+#### Scenario: Accounts page sorts by available reset count
+
+- **GIVEN** two or more account summaries have different `availableResetCount` values
+- **WHEN** the operator selects the available-reset sort mode on the Accounts page
+- **THEN** the account with the higher available reset count sorts ahead of the lower-count account
+
+#### Scenario: Account cards and list items show per-account badges
+
+- **GIVEN** an account summary has `availableResetCount = 2`
+- **WHEN** the account appears in an account card or account list item
+- **THEN** the UI shows a badge with count `2` for that account

--- a/openspec/changes/add-rate-limit-reset-credits/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-rate-limit-reset-credits/specs/frontend-architecture/spec.md
@@ -8,13 +8,15 @@ Shared account summary payloads exposed to the Accounts page and dashboard UI SH
 
 The Accounts page SHALL support a sort mode that orders accounts by available reset count, using the existing sort tie-break behavior afterward.
 
-When an account summary has `availableResetCount > 0`, account cards and account list items SHALL show a per-account badge for that count.
+The dashboard account table and account card SHALL NOT show a reset-count badge next to the status. Instead, the dashboard SHALL show a disabled `Reset (N)` button next to the Details action when `availableResetCount > 0`.
+
+The Accounts page list-item boxes SHALL show a circular corner badge at the top-right of each box when `availableResetCount > 0`.
 
 #### Scenario: Account detail shows disabled reset control
 
 - **GIVEN** an account summary includes `availableResetCount = 2`
 - **WHEN** the operator opens the account detail panel
-- **THEN** the actions area includes a disabled `Reset (2)` button
+- **THEN** the actions area includes a disabled `Reset (2)` button next to the Export button
 
 #### Scenario: Shared account summary payload exposes available reset count
 
@@ -26,7 +28,7 @@ When an account summary has `availableResetCount > 0`, account cards and account
 
 - **GIVEN** one or more account summaries have `availableResetCount > 0`
 - **WHEN** the application header renders
-- **THEN** the `Accounts` navigation tab shows an aggregate count badge
+- **THEN** the `Accounts` navigation tab shows an inline aggregate count badge
 
 #### Scenario: Accounts page sorts by available reset count
 
@@ -34,8 +36,22 @@ When an account summary has `availableResetCount > 0`, account cards and account
 - **WHEN** the operator selects the available-reset sort mode on the Accounts page
 - **THEN** the account with the higher available reset count sorts ahead of the lower-count account
 
-#### Scenario: Account cards and list items show per-account badges
+#### Scenario: Dashboard shows disabled Reset button next to Details
 
-- **GIVEN** an account summary has `availableResetCount = 2`
-- **WHEN** the account appears in an account card or account list item
-- **THEN** the UI shows a badge with count `2` for that account
+- **GIVEN** a dashboard account summary includes `availableResetCount = 3`
+- **WHEN** the account appears in the dashboard account table or account card
+- **THEN** a disabled `Reset (3)` button appears next to the Details action
+- **AND** no reset-count badge appears next to the account status
+
+#### Scenario: Dashboard hides Reset button when no resets are available
+
+- **GIVEN** a dashboard account summary includes `availableResetCount = 0`
+- **WHEN** the account appears in the dashboard account table or account card
+- **THEN** no `Reset` button is shown
+
+#### Scenario: Accounts page list item shows corner reset badge
+
+- **GIVEN** an Accounts page list-item box has `availableResetCount = 2`
+- **WHEN** the list item renders
+- **THEN** a circular count badge with `2` appears pinned to the top-right corner of the box
+- **AND** the badge is hidden when `availableResetCount = 0`

--- a/openspec/changes/add-rate-limit-reset-credits/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/add-rate-limit-reset-credits/specs/usage-refresh-policy/spec.md
@@ -35,6 +35,38 @@ Transient reset-credit fetch failures MUST NOT clear previously stored credits o
 - **THEN** the row status becomes `expired`
 - **AND** it is excluded from the available reset count
 
+### Requirement: Operator can redeem a rate-limit reset credit
+
+The system SHALL provide an operator-triggered endpoint that redeems one rate-limit reset credit for a given account by sending `POST /wham/rate-limit-reset-credits/consume` to the upstream API.
+
+The system SHALL select the available credit with the nearest `expires_at` for redemption.
+
+The system SHALL generate a client-side `redeem_request_id` (UUID v4) for each consume request.
+
+On a successful consume response, the system SHALL mark the redeemed credit's status as `redeemed` in the local database and invalidate cached account state.
+
+#### Scenario: Operator triggers reset from account detail
+
+- **GIVEN** an account has at least one available rate-limit reset credit
+- **WHEN** the operator clicks the Reset button in the account detail panel
+- **THEN** a confirmation dialog appears
+- **AND** on confirm, the system selects the nearest-expiry available credit
+- **AND** sends the consume request to the upstream API
+- **AND** marks the credit as redeemed on success
+
+#### Scenario: No available credits
+
+- **GIVEN** an account has zero available rate-limit reset credits
+- **WHEN** the operator attempts to trigger a reset
+- **THEN** the request fails with a clear error
+
+#### Scenario: Operator triggers reset from dashboard
+
+- **GIVEN** a dashboard account card or list row shows a Reset button
+- **WHEN** the operator clicks it
+- **THEN** a confirmation dialog appears
+- **AND** on confirm, the same consume flow executes
+
 #### Scenario: Transient fetch failure preserves stored credits
 
 - **GIVEN** an account has one or more stored reset-credit rows that still count as available

--- a/openspec/changes/add-rate-limit-reset-credits/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/add-rate-limit-reset-credits/specs/usage-refresh-policy/spec.md
@@ -41,9 +41,15 @@ The system SHALL provide an operator-triggered endpoint that redeems one rate-li
 
 The system SHALL select the available credit with the nearest `expires_at` for redemption.
 
+The system SHALL atomically claim that nearest-expiry available credit before sending the upstream consume request so concurrent reset attempts for the same account cannot consume the same stored credit twice.
+
 The system SHALL generate a client-side `redeem_request_id` (UUID v4) for each consume request.
 
+When the target account resolves to an upstream proxy route, the system SHALL send the consume request through that resolved route and SHALL only allow direct egress when no route is selected.
+
 On a successful consume response, the system SHALL mark the redeemed credit's status as `redeemed` in the local database and invalidate cached account state.
+
+If route resolution or the consume request fails after the local claim succeeds, the system SHALL return that credit to the local `available` state.
 
 #### Scenario: Operator triggers reset from account detail
 
@@ -66,6 +72,21 @@ On a successful consume response, the system SHALL mark the redeemed credit's st
 - **WHEN** the operator clicks it
 - **THEN** a confirmation dialog appears
 - **AND** on confirm, the same consume flow executes
+
+#### Scenario: Reset consume honors account-bound proxy routing
+
+- **GIVEN** an account has an explicit upstream proxy pool binding
+- **AND** that account has at least one available rate-limit reset credit
+- **WHEN** the operator confirms a reset-credit redemption
+- **THEN** the system resolves an upstream route for that account before calling `POST /wham/rate-limit-reset-credits/consume`
+- **AND** the request uses that resolved route instead of direct egress
+
+#### Scenario: Concurrent reset requests do not consume the same stored credit twice
+
+- **GIVEN** an account has exactly one available stored rate-limit reset credit
+- **WHEN** two reset-credit requests for that account arrive concurrently
+- **THEN** at most one request claims and consumes that stored credit
+- **AND** the other request selects a different available credit or fails with a clear no-credit conflict
 
 #### Scenario: Transient fetch failure preserves stored credits
 

--- a/openspec/changes/add-rate-limit-reset-credits/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/add-rate-limit-reset-credits/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Reset credits refresh every 60-second scheduler interval
+
+The existing background usage refresh loop MUST fetch `GET /wham/rate-limit-reset-credits` for each refreshable account every 60 seconds.
+
+Each fetch MUST be authenticated with that account's bearer token and MUST include the `chatgpt-account-id` header for the same account.
+
+#### Scenario: New upstream credit is inserted once
+
+- **GIVEN** an account is eligible for background refresh
+- **AND** upstream returns a credit whose `(account_id, credit_id)` pair is not stored
+- **WHEN** the scheduler refresh runs
+- **THEN** the system stores one new row for that credit
+- **AND** subsequent refreshes do not duplicate it
+
+#### Scenario: Refresh fetch uses account-scoped authentication
+
+- **GIVEN** an account is eligible for background refresh
+- **WHEN** the scheduler requests `GET /wham/rate-limit-reset-credits` for that account
+- **THEN** the request uses that account's bearer token for `Authorization`
+- **AND** the request includes that account's `chatgpt-account-id` header
+
+### Requirement: Stored credits expire locally
+
+Stored reset-credit rows MUST transition to `expired` when `now > expires_at`.
+
+Transient reset-credit fetch failures MUST NOT clear previously stored credits or make UI-visible available reset counts drop to zero solely because the fetch failed.
+
+#### Scenario: Expired stored credit stops counting as available
+
+- **GIVEN** a stored credit row has `status = "available"`
+- **AND** its `expires_at` is earlier than the current time
+- **WHEN** the refresh iteration normalizes stored rows
+- **THEN** the row status becomes `expired`
+- **AND** it is excluded from the available reset count
+
+#### Scenario: Transient fetch failure preserves stored credits
+
+- **GIVEN** an account has one or more stored reset-credit rows that still count as available
+- **AND** a later `GET /wham/rate-limit-reset-credits` attempt for that account fails transiently
+- **WHEN** the refresh iteration completes
+- **THEN** the previously stored credit rows remain stored
+- **AND** the available reset count derived from stored rows does not drop to zero solely because that fetch failed

--- a/openspec/changes/add-rate-limit-reset-credits/tasks.md
+++ b/openspec/changes/add-rate-limit-reset-credits/tasks.md
@@ -1,21 +1,22 @@
 ## Specification
 
 - [x] 1.1 Create the OpenSpec proposal, context, and delta specs for reset-credit tracking.
-- [x] 1.2 Keep consume and redemption workflow details explicitly out of scope for this change.
+- [x] 1.2 Bring consume and redemption workflow into scope for this change.
 
 ## Implementation
 
 - [x] 2.1 Add the reset-credit client and payload models.
 - [x] 2.2 Add the ORM model, migration, and repository queries.
 - [x] 2.3 Refresh stored reset credits from the existing 60-second background refresh loop.
-- [x] 2.4 Expose `availableResetCount` in shared account summary payloads.
+- [x] 2.4 Expose `availableResetCount` and `nearestResetExpiryAt` in shared account summary payloads.
 - [x] 2.5 Add Accounts page, dashboard, and header UI counts, badges, and sort behavior.
 - [x] 2.6 Add consume client for `POST /wham/rate-limit-reset-credits/consume`.
 - [x] 2.7 Add operator-triggered reset endpoint with nearest-expiry credit selection and confirmation dialog.
+- [x] 2.8 Add red-border urgency styling on Reset buttons when `nearestResetExpiryAt` is within 7 days.
 
 ## Verification
 
 - [x] 3.1 Verify migration coverage for table shape, uniqueness, and indexes.
 - [x] 3.2 Verify backend tests for fetch, persistence, expiry normalization, and shared payload counts.
-- [x] 3.3 Verify frontend tests for schema parsing, sort behavior, badges, and reset controls.
+- [x] 3.3 Verify frontend tests for schema parsing, sort behavior, badges, reset controls, and urgency styling.
 - [x] 3.4 Run `openspec validate --specs`.

--- a/openspec/changes/add-rate-limit-reset-credits/tasks.md
+++ b/openspec/changes/add-rate-limit-reset-credits/tasks.md
@@ -1,0 +1,19 @@
+## Specification
+
+- [x] 1.1 Create the OpenSpec proposal, context, and delta specs for reset-credit tracking.
+- [x] 1.2 Keep consume and redemption workflow details explicitly out of scope for this change.
+
+## Implementation
+
+- [x] 2.1 Add the reset-credit client and payload models.
+- [x] 2.2 Add the ORM model, migration, and repository queries.
+- [x] 2.3 Refresh stored reset credits from the existing 60-second background refresh loop.
+- [x] 2.4 Expose `availableResetCount` in shared account summary payloads.
+- [x] 2.5 Add Accounts page, dashboard, and header UI counts, badges, and sort behavior.
+
+## Verification
+
+- [x] 3.1 Verify migration coverage for table shape, uniqueness, and indexes.
+- [x] 3.2 Verify backend tests for fetch, persistence, expiry normalization, and shared payload counts.
+- [x] 3.3 Verify frontend tests for schema parsing, sort behavior, badges, and disabled reset controls.
+- [x] 3.4 Run `openspec validate --specs`.

--- a/openspec/changes/add-rate-limit-reset-credits/tasks.md
+++ b/openspec/changes/add-rate-limit-reset-credits/tasks.md
@@ -10,10 +10,12 @@
 - [x] 2.3 Refresh stored reset credits from the existing 60-second background refresh loop.
 - [x] 2.4 Expose `availableResetCount` in shared account summary payloads.
 - [x] 2.5 Add Accounts page, dashboard, and header UI counts, badges, and sort behavior.
+- [x] 2.6 Add consume client for `POST /wham/rate-limit-reset-credits/consume`.
+- [x] 2.7 Add operator-triggered reset endpoint with nearest-expiry credit selection and confirmation dialog.
 
 ## Verification
 
 - [x] 3.1 Verify migration coverage for table shape, uniqueness, and indexes.
 - [x] 3.2 Verify backend tests for fetch, persistence, expiry normalization, and shared payload counts.
-- [x] 3.3 Verify frontend tests for schema parsing, sort behavior, badges, and disabled reset controls.
+- [x] 3.3 Verify frontend tests for schema parsing, sort behavior, badges, and reset controls.
 - [x] 3.4 Run `openspec validate --specs`.

--- a/tests/integration/test_accounts_api.py
+++ b/tests/integration/test_accounts_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from datetime import timedelta
 
 import pytest
 
@@ -345,6 +346,66 @@ async def test_set_and_clear_account_alias(async_client):
     matched = next(a for a in listing.json()["accounts"] if a["accountId"] == expected_account_id)
     assert matched["alias"] is None
     assert matched["displayName"] == email
+
+
+@pytest.mark.asyncio
+async def test_list_accounts_exposes_available_reset_count(async_client):
+    from app.core.crypto import TokenEncryptor
+    from app.core.utils.time import utcnow
+    from app.db.models import Account, AccountStatus
+    from app.db.session import SessionLocal
+    from app.modules.accounts.repository import AccountRateLimitResetCreditRecord, AccountsRepository
+
+    encryptor = TokenEncryptor()
+
+    def _account(account_id: str, email: str, chatgpt_id: str) -> Account:
+        return Account(
+            id=account_id,
+            chatgpt_account_id=chatgpt_id,
+            email=email,
+            plan_type="plus",
+            access_token_encrypted=encryptor.encrypt("access"),
+            refresh_token_encrypted=encryptor.encrypt("refresh"),
+            id_token_encrypted=encryptor.encrypt("id"),
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+            deactivation_reason=None,
+        )
+
+    now = utcnow()
+    future = now + timedelta(days=30)
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("credit-acct", "credit@example.com", "chatgpt_credit"))
+        await repo.insert_rate_limit_reset_credits_if_missing(
+            [
+                AccountRateLimitResetCreditRecord(
+                    account_id="credit-acct",
+                    credit_id="credit_one",
+                    status="available",
+                    granted_at=now,
+                    expires_at=future,
+                    redeemed_at=None,
+                ),
+                AccountRateLimitResetCreditRecord(
+                    account_id="credit-acct",
+                    credit_id="credit_two",
+                    status="available",
+                    granted_at=now,
+                    expires_at=future,
+                    redeemed_at=None,
+                ),
+            ]
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    matched = next(
+        (a for a in response.json()["accounts"] if a["accountId"] == "credit-acct"),
+        None,
+    )
+    assert matched is not None
+    assert matched["availableResetCount"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_accounts_repository.py
+++ b/tests/integration/test_accounts_repository.py
@@ -580,3 +580,52 @@ async def test_insert_rate_limit_reset_credits_if_missing_reraises_non_duplicate
 
         with pytest.raises(IntegrityError):
             await repo.insert_rate_limit_reset_credits_if_missing([credit])
+
+
+@pytest.mark.asyncio
+async def test_claim_nearest_expiry_available_credit_id_claims_credits_in_expiry_order(db_setup):
+    del db_setup
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("acc_claim_order"))
+        await repo.insert_rate_limit_reset_credits_if_missing(
+            [
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_claim_order",
+                    credit_id="credit_soon",
+                    status="available",
+                    granted_at=now - timedelta(days=2),
+                    expires_at=now + timedelta(hours=2),
+                    redeemed_at=None,
+                ),
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_claim_order",
+                    credit_id="credit_later",
+                    status="available",
+                    granted_at=now - timedelta(days=1),
+                    expires_at=now + timedelta(days=1),
+                    redeemed_at=None,
+                ),
+            ]
+        )
+
+        first = await repo.claim_nearest_expiry_available_credit_id("acc_claim_order", now=now)
+        second = await repo.claim_nearest_expiry_available_credit_id("acc_claim_order", now=now)
+        third = await repo.claim_nearest_expiry_available_credit_id("acc_claim_order", now=now)
+        rows = (
+            await session.execute(
+                AccountRateLimitResetCredit.__table__.select()
+                .where(AccountRateLimitResetCredit.account_id == "acc_claim_order")
+                .order_by(AccountRateLimitResetCredit.credit_id)
+            )
+        ).all()
+
+    assert first == "credit_soon"
+    assert second == "credit_later"
+    assert third is None
+    assert [(row.credit_id, row.status) for row in rows] == [
+        ("credit_later", "redeeming"),
+        ("credit_soon", "redeeming"),
+    ]

--- a/tests/integration/test_accounts_repository.py
+++ b/tests/integration/test_accounts_repository.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.elements import ClauseElement
 
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountRateLimitResetCredit, AccountStatus
 from app.db.session import SessionLocal
-from app.modules.accounts.repository import AccountsRepository
+from app.modules.accounts.repository import AccountRateLimitResetCreditRecord, AccountsRepository
 
 
 def _account(
@@ -258,3 +262,321 @@ async def test_upsert_account_slot_adds_third_label_only_workspace_for_same_emai
         ("triton_workspace", "Triton"),
         ("atlas_workspace", "Atlas"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_insert_rate_limit_reset_credits_if_missing_keeps_existing_rows(db_setup):
+    del db_setup
+    granted_at = utcnow() - timedelta(days=2)
+    first_expires_at = utcnow() + timedelta(days=7)
+    duplicate_expires_at = utcnow() + timedelta(days=14)
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("acc_reset_credit"))
+
+        inserted = await repo.insert_rate_limit_reset_credits_if_missing(
+            [
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_reset_credit",
+                    credit_id="credit_one",
+                    status="available",
+                    granted_at=granted_at,
+                    expires_at=first_expires_at,
+                    redeemed_at=None,
+                )
+            ]
+        )
+        assert inserted == 1
+
+        inserted_again = await repo.insert_rate_limit_reset_credits_if_missing(
+            [
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_reset_credit",
+                    credit_id="credit_one",
+                    status="expired",
+                    granted_at=granted_at + timedelta(days=1),
+                    expires_at=duplicate_expires_at,
+                    redeemed_at=granted_at + timedelta(days=3),
+                ),
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_reset_credit",
+                    credit_id="credit_two",
+                    status="available",
+                    granted_at=granted_at,
+                    expires_at=duplicate_expires_at,
+                    redeemed_at=None,
+                ),
+            ]
+        )
+        assert inserted_again == 1
+
+        rows = (
+            await session.execute(
+                AccountRateLimitResetCredit.__table__.select().order_by(AccountRateLimitResetCredit.credit_id)
+            )
+        ).all()
+
+    assert len(rows) == 2
+    assert rows[0].credit_id == "credit_one"
+    assert rows[0].status == "available"
+    assert rows[0].granted_at == granted_at
+    assert rows[0].expires_at == first_expires_at
+    assert rows[0].redeemed_at is None
+    assert rows[1].credit_id == "credit_two"
+
+
+@pytest.mark.asyncio
+async def test_expire_rate_limit_reset_credits_and_count_available_by_account(db_setup):
+    del db_setup
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("acc_reset_one"))
+        await repo.upsert(_account("acc_reset_two"))
+        await repo.insert_rate_limit_reset_credits_if_missing(
+            [
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_reset_one",
+                    credit_id="credit_expired",
+                    status="available",
+                    granted_at=now - timedelta(days=3),
+                    expires_at=now - timedelta(minutes=1),
+                    redeemed_at=None,
+                ),
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_reset_one",
+                    credit_id="credit_available",
+                    status="available",
+                    granted_at=now - timedelta(days=1),
+                    expires_at=now + timedelta(days=1),
+                    redeemed_at=None,
+                ),
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_reset_two",
+                    credit_id="credit_unavailable",
+                    status="redeemed",
+                    granted_at=now - timedelta(days=1),
+                    expires_at=now + timedelta(days=1),
+                    redeemed_at=now - timedelta(hours=1),
+                ),
+            ]
+        )
+
+        counts_before_expiry = await repo.count_available_rate_limit_reset_credits_by_account(
+            ["acc_reset_one", "acc_reset_two"],
+            now=now,
+        )
+        expired = await repo.expire_rate_limit_reset_credits(now=now)
+        counts_after_expiry = await repo.count_available_rate_limit_reset_credits_by_account(
+            ["acc_reset_one", "acc_reset_two"],
+            now=now,
+        )
+        expired_row = await session.get(AccountRateLimitResetCredit, 1)
+
+    assert counts_before_expiry == {"acc_reset_one": 1}
+    assert expired == 1
+    assert counts_after_expiry == {"acc_reset_one": 1}
+    assert expired_row is not None
+    assert expired_row.credit_id == "credit_expired"
+    assert expired_row.status == "expired"
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_reset_credit_at_expiry_boundary_stays_available_until_after_now(db_setup):
+    del db_setup
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("acc_reset_boundary"))
+        await repo.insert_rate_limit_reset_credits_if_missing(
+            [
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_reset_boundary",
+                    credit_id="credit_boundary",
+                    status="available",
+                    granted_at=now - timedelta(days=1),
+                    expires_at=now,
+                    redeemed_at=None,
+                )
+            ]
+        )
+
+        counts_at_boundary = await repo.count_available_rate_limit_reset_credits_by_account(
+            ["acc_reset_boundary"],
+            now=now,
+        )
+        expired_at_boundary = await repo.expire_rate_limit_reset_credits(now=now)
+        counts_after_boundary = await repo.count_available_rate_limit_reset_credits_by_account(
+            ["acc_reset_boundary"],
+            now=now + timedelta(microseconds=1),
+        )
+        expired_after_boundary = await repo.expire_rate_limit_reset_credits(now=now + timedelta(microseconds=1))
+        boundary_row = await session.get(AccountRateLimitResetCredit, 1)
+
+    assert counts_at_boundary == {"acc_reset_boundary": 1}
+    assert expired_at_boundary == 0
+    assert counts_after_boundary == {}
+    assert expired_after_boundary == 1
+    assert boundary_row is not None
+    assert boundary_row.status == "expired"
+
+
+@pytest.mark.asyncio
+async def test_insert_rate_limit_reset_credits_if_missing_handles_commit_time_duplicate_conflict(db_setup, monkeypatch):
+    del db_setup
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("acc_reset_race"))
+        credit = AccountRateLimitResetCreditRecord(
+            account_id="acc_reset_race",
+            credit_id="credit_race",
+            status="available",
+            granted_at=now - timedelta(days=1),
+            expires_at=now + timedelta(days=1),
+            redeemed_at=None,
+        )
+
+        original_commit = session.commit
+        conflict_injected = False
+
+        async def commit_with_duplicate_conflict() -> None:
+            nonlocal conflict_injected
+            if conflict_injected:
+                await original_commit()
+                return
+
+            conflict_injected = True
+            async with SessionLocal() as competing_session:
+                competing_session.add(
+                    AccountRateLimitResetCredit(
+                        account_id=credit.account_id,
+                        credit_id=credit.credit_id,
+                        status=credit.status,
+                        granted_at=credit.granted_at,
+                        expires_at=credit.expires_at,
+                        redeemed_at=credit.redeemed_at,
+                    )
+                )
+                await competing_session.commit()
+            raise IntegrityError("INSERT", {}, Exception("duplicate"))
+
+        monkeypatch.setattr(session, "commit", commit_with_duplicate_conflict)
+
+        inserted = await repo.insert_rate_limit_reset_credits_if_missing([credit])
+        counts = await repo.count_available_rate_limit_reset_credits_by_account(["acc_reset_race"], now=now)
+        rows = (
+            await session.execute(
+                AccountRateLimitResetCredit.__table__.select().where(
+                    AccountRateLimitResetCredit.account_id == "acc_reset_race"
+                )
+            )
+        ).all()
+
+    assert inserted == 0
+    assert counts == {"acc_reset_race": 1}
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_insert_rate_limit_reset_credits_if_missing_retries_remaining_rows_after_mixed_batch_conflict(
+    db_setup, monkeypatch
+):
+    del db_setup
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("acc_reset_mixed_race"))
+        conflicted_credit = AccountRateLimitResetCreditRecord(
+            account_id="acc_reset_mixed_race",
+            credit_id="credit_conflicted",
+            status="available",
+            granted_at=now - timedelta(days=2),
+            expires_at=now + timedelta(days=2),
+            redeemed_at=None,
+        )
+        remaining_credit = AccountRateLimitResetCreditRecord(
+            account_id="acc_reset_mixed_race",
+            credit_id="credit_remaining",
+            status="available",
+            granted_at=now - timedelta(days=1),
+            expires_at=now + timedelta(days=3),
+            redeemed_at=None,
+        )
+
+        original_commit = session.commit
+        conflict_injected = False
+
+        async def commit_with_mixed_batch_conflict() -> None:
+            nonlocal conflict_injected
+            if conflict_injected:
+                await original_commit()
+                return
+
+            conflict_injected = True
+            async with SessionLocal() as competing_session:
+                competing_session.add(
+                    AccountRateLimitResetCredit(
+                        account_id=conflicted_credit.account_id,
+                        credit_id=conflicted_credit.credit_id,
+                        status=conflicted_credit.status,
+                        granted_at=conflicted_credit.granted_at,
+                        expires_at=conflicted_credit.expires_at,
+                        redeemed_at=conflicted_credit.redeemed_at,
+                    )
+                )
+                await competing_session.commit()
+            raise IntegrityError("INSERT", {}, Exception("duplicate"))
+
+        monkeypatch.setattr(session, "commit", commit_with_mixed_batch_conflict)
+
+        inserted = await repo.insert_rate_limit_reset_credits_if_missing([conflicted_credit, remaining_credit])
+        counts = await repo.count_available_rate_limit_reset_credits_by_account(["acc_reset_mixed_race"], now=now)
+        rows = (
+            await session.execute(
+                AccountRateLimitResetCredit.__table__.select()
+                .where(AccountRateLimitResetCredit.account_id == "acc_reset_mixed_race")
+                .order_by(AccountRateLimitResetCredit.credit_id)
+            )
+        ).all()
+
+    assert inserted == 1
+    assert counts == {"acc_reset_mixed_race": 2}
+    assert [row.credit_id for row in rows] == ["credit_conflicted", "credit_remaining"]
+
+
+@pytest.mark.asyncio
+async def test_insert_rate_limit_reset_credits_if_missing_reraises_non_duplicate_integrity_error(db_setup, monkeypatch):
+    del db_setup
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_account("acc_reset_non_duplicate_error"))
+        credit = AccountRateLimitResetCreditRecord(
+            account_id="acc_reset_non_duplicate_error",
+            credit_id="credit_non_duplicate_error",
+            status="available",
+            granted_at=now - timedelta(days=1),
+            expires_at=now + timedelta(days=1),
+            redeemed_at=None,
+        )
+
+        original_execute = session.execute
+
+        async def execute_without_existing_pairs(statement: ClauseElement, *args: object, **kwargs: object):
+            return await original_execute(statement, *args, **kwargs)
+
+        async def commit_with_non_duplicate_integrity_error() -> None:
+            raise IntegrityError("INSERT", {}, Exception("not-a-duplicate"))
+
+        monkeypatch.setattr(session, "execute", execute_without_existing_pairs)
+        monkeypatch.setattr(session, "commit", commit_with_non_duplicate_integrity_error)
+
+        with pytest.raises(IntegrityError):
+            await repo.insert_rate_limit_reset_credits_if_missing([credit])

--- a/tests/integration/test_accounts_repository.py
+++ b/tests/integration/test_accounts_repository.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.sql.elements import ClauseElement
 
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountRateLimitResetCredit, AccountStatus
@@ -569,7 +569,7 @@ async def test_insert_rate_limit_reset_credits_if_missing_reraises_non_duplicate
 
         original_execute = session.execute
 
-        async def execute_without_existing_pairs(statement: ClauseElement, *args: object, **kwargs: object):
+        async def execute_without_existing_pairs(statement: Any, *args: Any, **kwargs: Any) -> Any:
             return await original_execute(statement, *args, **kwargs)
 
         async def commit_with_non_duplicate_integrity_error() -> None:

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -10,7 +10,7 @@ from app.core.crypto import TokenEncryptor
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
-from app.modules.accounts.repository import AccountsRepository
+from app.modules.accounts.repository import AccountRateLimitResetCreditRecord, AccountsRepository
 from app.modules.accounts.schemas import AccountSummary
 from app.modules.dashboard.weekly_pace import _weekly_timing
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -73,6 +73,34 @@ def test_weekly_credit_pace_timing_treats_naive_reset_as_utc():
 
     assert timing is not None
     assert timing[2] == pytest.approx(naive_utc_to_epoch(reset_at) * 1000.0)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_exposes_available_reset_count(async_client, db_setup):
+    now = utcnow().replace(microsecond=0)
+    future = now + timedelta(days=30)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_credit", "credit@example.com"))
+        await accounts_repo.insert_rate_limit_reset_credits_if_missing(
+            [
+                AccountRateLimitResetCreditRecord(
+                    account_id="acc_credit",
+                    credit_id="credit_one",
+                    status="available",
+                    granted_at=now,
+                    expires_at=future,
+                    redeemed_at=None,
+                ),
+            ]
+        )
+
+    response = await async_client.get("/api/dashboard/overview")
+    assert response.status_code == 200
+    payload = response.json()
+    account = next(a for a in payload["accounts"] if a["accountId"] == "acc_credit")
+    assert account["availableResetCount"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -909,9 +909,7 @@ async def test_rate_limit_reset_credit_migration_adds_expected_table_shape(tmp_p
             }
             assert ("accounts", "account_id", "id", "cascade") in fk_actions
 
-            index_rows = (
-                await session.execute(text("PRAGMA index_list(account_rate_limit_reset_credits)"))
-            ).fetchall()
+            index_rows = (await session.execute(text("PRAGMA index_list(account_rate_limit_reset_credits)"))).fetchall()
             index_specs: dict[str, tuple[bool, list[str]]] = {}
             for row in index_rows:
                 if len(row) < 3:

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -870,3 +870,63 @@ async def test_free_account_monthly_migration_renames_only_free_usage_windows(tm
 
     assert free_windows == ["old-primary", "old-secondary", "old-primary"]
     assert paid_windows == ["primary", "secondary", None]
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_reset_credit_migration_adds_expected_table_shape(tmp_path):
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'rate-limit-reset-credits.sqlite'}"
+
+    await to_thread.run_sync(
+        lambda: run_upgrade(
+            db_url,
+            "20260611_000000_merge_dashboard_guest_and_weekly_useragent_heads",
+            bootstrap_legacy=True,
+        )
+    )
+    await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+
+    engine = create_async_engine(db_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as session:
+            table_exists = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM sqlite_master "
+                        "WHERE type='table' AND name='account_rate_limit_reset_credits'"
+                    )
+                )
+            ).scalar_one()
+            assert table_exists == 1
+
+            fk_rows = (
+                await session.execute(text("PRAGMA foreign_key_list(account_rate_limit_reset_credits)"))
+            ).fetchall()
+            fk_actions = {
+                (str(row[2]).lower(), str(row[3]).lower(), str(row[4]).lower(), str(row[6]).lower())
+                for row in fk_rows
+                if len(row) > 6
+            }
+            assert ("accounts", "account_id", "id", "cascade") in fk_actions
+
+            index_rows = (
+                await session.execute(text("PRAGMA index_list(account_rate_limit_reset_credits)"))
+            ).fetchall()
+            index_specs: dict[str, tuple[bool, list[str]]] = {}
+            for row in index_rows:
+                if len(row) < 3:
+                    continue
+                index_name = str(row[1])
+                escaped_name = index_name.replace('"', '""')
+                column_rows = (await session.execute(text(f'PRAGMA index_info("{escaped_name}")'))).fetchall()
+                columns = [str(column_row[2]) for column_row in column_rows if len(column_row) > 2]
+                index_specs[index_name] = (bool(row[2]), columns)
+
+    finally:
+        await engine.dispose()
+
+    assert any(unique and columns == ["account_id", "credit_id"] for unique, columns in index_specs.values())
+    assert any(columns == ["account_id"] for _, columns in index_specs.values())
+    assert any(columns == ["status"] for _, columns in index_specs.values())
+    assert any(columns == ["expires_at"] for _, columns in index_specs.values())
+    assert any(columns == ["account_id", "status", "expires_at"] for _, columns in index_specs.values())

--- a/tests/unit/test_accounts_service_reset_credit.py
+++ b/tests/unit/test_accounts_service_reset_credit.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.crypto import TokenEncryptor
+from app.core.exceptions import DashboardConflictError
+from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
+from app.db.models import Account, AccountStatus
+from app.modules.accounts.service import AccountsService
+
+pytestmark = pytest.mark.unit
+
+_ACCOUNT_ID = "acc_reset_credit"
+_CHATGPT_ACCOUNT_ID = "chatgpt-reset-credit"
+
+
+def _make_account() -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=_ACCOUNT_ID,
+        chatgpt_account_id=_CHATGPT_ACCOUNT_ID,
+        email="reset@example.com",
+        plan_type="pro",
+        access_token_encrypted=encryptor.encrypt("reset-access-token"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=datetime(2026, 6, 16, 12, 0, 0),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+
+
+def _build_service(account: Account | None) -> tuple[AccountsService, AsyncMock]:
+    repo = AsyncMock()
+    repo.get_by_id.return_value = account
+    repo.claim_nearest_expiry_available_credit_id.return_value = "credit_one"
+    repo.session = object()
+    return AccountsService(repo=repo), repo
+
+
+@pytest.mark.asyncio
+async def test_reset_account_credit_uses_resolved_route(monkeypatch) -> None:
+    service, repo = _build_service(_make_account())
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_1",
+        endpoint=ResolvedProxyEndpoint("ep_1", "http", "proxy.test", 8080),
+    )
+    captured_kwargs: dict[str, object] = {}
+
+    async def consume_stub(**kwargs: object) -> SimpleNamespace:
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(windows_reset=2)
+
+    monkeypatch.setattr("app.modules.accounts.service.resolve_upstream_route", AsyncMock(return_value=route))
+    monkeypatch.setattr(
+        "app.core.clients.rate_limit_reset_credits.consume_rate_limit_reset_credit",
+        consume_stub,
+    )
+
+    result = await service.reset_account_credit(_ACCOUNT_ID)
+
+    assert result is not None
+    assert result.credit_id == "credit_one"
+    assert result.windows_reset == 2
+    assert captured_kwargs["route"] is route
+    assert captured_kwargs["allow_direct_egress"] is False
+    repo.claim_nearest_expiry_available_credit_id.assert_awaited_once_with(_ACCOUNT_ID)
+    repo.mark_credit_redeemed.assert_awaited_once_with(_ACCOUNT_ID, "credit_one")
+    repo.release_claimed_credit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reset_account_credit_releases_claim_when_consume_fails(monkeypatch) -> None:
+    service, repo = _build_service(_make_account())
+
+    async def consume_stub(**kwargs: object) -> SimpleNamespace:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("app.modules.accounts.service.resolve_upstream_route", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        "app.core.clients.rate_limit_reset_credits.consume_rate_limit_reset_credit",
+        consume_stub,
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await service.reset_account_credit(_ACCOUNT_ID)
+
+    repo.release_claimed_credit.assert_awaited_once_with(_ACCOUNT_ID, "credit_one")
+    repo.mark_credit_redeemed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reset_account_credit_fails_when_claim_finds_no_available_credit() -> None:
+    service, repo = _build_service(_make_account())
+    repo.claim_nearest_expiry_available_credit_id.return_value = None
+
+    with pytest.raises(DashboardConflictError, match="No available rate-limit reset credits"):
+        await service.reset_account_credit(_ACCOUNT_ID)
+
+    repo.mark_credit_redeemed.assert_not_called()
+    repo.release_claimed_credit.assert_not_called()

--- a/tests/unit/test_rate_limit_reset_credit_refresh.py
+++ b/tests/unit/test_rate_limit_reset_credit_refresh.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.clients.rate_limit_reset_credits import (
+    RateLimitResetCreditPayload,
+    RateLimitResetCreditsFetchError,
+    RateLimitResetCreditsPayload,
+)
+from app.core.usage import refresh_scheduler as refresh_scheduler_module
+from app.db.models import Account, AccountStatus, UsageHistory
+from app.modules.accounts.repository import AccountRateLimitResetCreditRecord
+from app.modules.accounts.reset_credit_updater import ResetCreditUpdater
+
+pytestmark = pytest.mark.unit
+
+
+def _account(account_id: str, *, status: AccountStatus = AccountStatus.ACTIVE) -> Account:
+    return Account(
+        id=account_id,
+        chatgpt_account_id=f"workspace-{account_id}",
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"access-token",
+        refresh_token_encrypted=b"refresh-token",
+        id_token_encrypted=b"id-token",
+        last_refresh=datetime(2025, 1, 1),
+        status=status,
+    )
+
+
+class StubAccountsRepository:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+        self.inserted: list[AccountRateLimitResetCreditRecord] = []
+
+    async def expire_rate_limit_reset_credits(
+        self,
+        *,
+        now: datetime | None = None,
+        account_id: str | None = None,
+    ) -> int:
+        self.calls.append(("expire", cast(str, account_id), now))
+        return 0
+
+    async def insert_rate_limit_reset_credits_if_missing(
+        self,
+        credits: list[AccountRateLimitResetCreditRecord],
+    ) -> int:
+        self.calls.append(("insert", credits[0].account_id if credits else "", list(credits)))
+        self.inserted.extend(credits)
+        return len(credits)
+
+
+@pytest.mark.asyncio
+async def test_reset_credit_updater_expires_before_fetch_and_inserts_new_rows() -> None:
+    now = datetime(2026, 6, 15, 12, 0, 0)
+    repo = StubAccountsRepository()
+    events: list[tuple[str, str]] = []
+
+    async def fetcher(*, access_token: str, account_id: str | None, **_: object) -> RateLimitResetCreditsPayload:
+        events.append(("fetch", cast(str, account_id)))
+        assert access_token == "decrypted-token"
+        return RateLimitResetCreditsPayload(
+            credits=[
+                RateLimitResetCreditPayload(
+                    id="RateLimitResetCredit_one",
+                    status="available",
+                    granted_at=datetime(2026, 6, 12, 1, 29, 41),
+                    expires_at=datetime(2026, 7, 12, 1, 29, 41),
+                    redeemed_at=None,
+                )
+            ],
+            available_count=1,
+        )
+
+    updater = ResetCreditUpdater(
+        repo,
+        fetcher=fetcher,
+        now=lambda: now,
+        decrypt_token=lambda _: "decrypted-token",
+        route_resolver=AsyncMock(return_value=None),
+    )
+
+    inserted = await updater.refresh_accounts([_account("acc_one")])
+
+    assert inserted == 1
+    assert [call[0] for call in repo.calls] == ["expire", "insert"]
+    assert events == [("fetch", "workspace-acc_one")]
+    assert repo.inserted == [
+        AccountRateLimitResetCreditRecord(
+            account_id="acc_one",
+            credit_id="RateLimitResetCredit_one",
+            status="available",
+            granted_at=datetime(2026, 6, 12, 1, 29, 41),
+            expires_at=datetime(2026, 7, 12, 1, 29, 41),
+            redeemed_at=None,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reset_credit_updater_isolates_per_account_failures() -> None:
+    repo = StubAccountsRepository()
+
+    async def fetcher(*, account_id: str | None, **_: object) -> RateLimitResetCreditsPayload:
+        if account_id == "workspace-acc_fail":
+            raise RateLimitResetCreditsFetchError(503, "busy")
+        return RateLimitResetCreditsPayload(
+            credits=[
+                RateLimitResetCreditPayload(
+                    id="RateLimitResetCredit_two",
+                    status="available",
+                    granted_at=datetime(2026, 6, 12, 1, 29, 41),
+                    expires_at=datetime(2026, 7, 12, 1, 29, 41),
+                    redeemed_at=None,
+                )
+            ],
+            available_count=1,
+        )
+
+    updater = ResetCreditUpdater(
+        repo,
+        fetcher=fetcher,
+        decrypt_token=lambda _: "decrypted-token",
+        route_resolver=AsyncMock(return_value=None),
+    )
+
+    inserted = await updater.refresh_accounts([_account("acc_fail"), _account("acc_ok")])
+
+    assert inserted == 1
+    assert [credit.account_id for credit in repo.inserted] == ["acc_ok"]
+    assert [call[:2] for call in repo.calls] == [
+        ("expire", "acc_fail"),
+        ("expire", "acc_ok"),
+        ("insert", "acc_ok"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reset_credit_updater_empty_accounts_returns_zero_without_repo_calls() -> None:
+    repo = StubAccountsRepository()
+
+    updater = ResetCreditUpdater(
+        repo,
+        fetcher=AsyncMock(),
+        decrypt_token=lambda _: "decrypted-token",
+        route_resolver=AsyncMock(return_value=None),
+    )
+
+    inserted = await updater.refresh_accounts([])
+
+    assert inserted == 0
+    assert repo.calls == []
+
+
+@pytest.mark.asyncio
+async def test_reset_credit_updater_empty_credits_payload_inserts_zero() -> None:
+    repo = StubAccountsRepository()
+
+    async def fetcher(**_: object) -> RateLimitResetCreditsPayload:
+        return RateLimitResetCreditsPayload(credits=[], available_count=0)
+
+    updater = ResetCreditUpdater(
+        repo,
+        fetcher=fetcher,
+        decrypt_token=lambda _: "decrypted-token",
+        route_resolver=AsyncMock(return_value=None),
+    )
+
+    inserted = await updater.refresh_accounts([_account("acc_one")])
+
+    assert inserted == 0
+    assert repo.inserted == []
+    assert [call[0] for call in repo.calls] == ["expire", "insert"]
+
+
+@pytest.mark.asyncio
+async def test_reset_credit_updater_all_accounts_fail_returns_zero() -> None:
+    repo = StubAccountsRepository()
+
+    async def fetcher(*, account_id: str | None, **_: object) -> RateLimitResetCreditsPayload:
+        raise RateLimitResetCreditsFetchError(503, "busy")
+
+    updater = ResetCreditUpdater(
+        repo,
+        fetcher=fetcher,
+        decrypt_token=lambda _: "decrypted-token",
+        route_resolver=AsyncMock(return_value=None),
+    )
+
+    inserted = await updater.refresh_accounts([_account("acc_one"), _account("acc_two")])
+
+    assert inserted == 0
+    assert repo.inserted == []
+    assert [call[:2] for call in repo.calls] == [
+        ("expire", "acc_one"),
+        ("expire", "acc_two"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reset_credit_updater_skips_reauth_and_deactivated_accounts() -> None:
+    repo = StubAccountsRepository()
+    fetched: list[str] = []
+
+    async def fetcher(*, account_id: str | None, **_: object) -> RateLimitResetCreditsPayload:
+        fetched.append(cast(str, account_id))
+        return RateLimitResetCreditsPayload(credits=[], available_count=0)
+
+    updater = ResetCreditUpdater(
+        repo,
+        fetcher=fetcher,
+        decrypt_token=lambda _: "decrypted-token",
+        route_resolver=AsyncMock(return_value=None),
+    )
+
+    accounts = [
+        _account("acc_reauth", status=AccountStatus.REAUTH_REQUIRED),
+        _account("acc_deactivated", status=AccountStatus.DEACTIVATED),
+        _account("acc_active"),
+    ]
+
+    inserted = await updater.refresh_accounts(accounts)
+
+    assert inserted == 0
+    assert fetched == ["workspace-acc_active"]
+    assert [call[:2] for call in repo.calls] == [
+        ("expire", "acc_active"),
+        ("insert", ""),
+    ]
+
+
+class FakeSession:
+    async def __aenter__(self) -> object:
+        return object()
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+class StubUsageRepository:
+    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_usage_refresh_scheduler_runs_reset_credit_updater() -> None:
+    scheduler = refresh_scheduler_module.UsageRefreshScheduler(interval_seconds=60, enabled=True)
+    accounts = [_account("acc_one"), _account("acc_two")]
+    leader = SimpleNamespace(try_acquire=AsyncMock(return_value=True))
+    usage_updater = SimpleNamespace(refresh_accounts=AsyncMock(return_value=False))
+    reset_updater = SimpleNamespace(refresh_accounts=AsyncMock(return_value=1))
+
+    monkeypatches = pytest.MonkeyPatch()
+    monkeypatches.setattr(refresh_scheduler_module, "_get_leader_election", lambda: leader)
+    monkeypatches.setattr(refresh_scheduler_module, "get_background_session", FakeSession)
+    monkeypatches.setattr(refresh_scheduler_module, "UsageRepository", lambda session: StubUsageRepository())
+    monkeypatches.setattr(
+        refresh_scheduler_module,
+        "AccountsRepository",
+        lambda session: SimpleNamespace(list_accounts=AsyncMock(return_value=accounts)),
+    )
+    monkeypatches.setattr(refresh_scheduler_module, "AdditionalUsageRepository", lambda session: object())
+    monkeypatches.setattr(refresh_scheduler_module, "SettingsRepository", lambda session: object())
+    monkeypatches.setattr(refresh_scheduler_module, "LimitWarmupRepository", lambda session: object())
+    monkeypatches.setattr(refresh_scheduler_module, "RequestLogsRepository", lambda session: object())
+    monkeypatches.setattr(refresh_scheduler_module, "UsageUpdater", lambda *args: usage_updater)
+    monkeypatches.setattr(refresh_scheduler_module, "ResetCreditUpdater", lambda repo: reset_updater)
+    monkeypatches.setattr(
+        refresh_scheduler_module,
+        "get_rate_limit_headers_cache",
+        lambda: SimpleNamespace(invalidate=AsyncMock()),
+    )
+    monkeypatches.setattr(
+        refresh_scheduler_module,
+        "get_account_selection_cache",
+        lambda: SimpleNamespace(invalidate=lambda: None),
+    )
+
+    try:
+        await scheduler._refresh_once()
+    finally:
+        monkeypatches.undo()
+
+    leader.try_acquire.assert_awaited_once()
+    reset_updater.refresh_accounts.assert_awaited_once_with(accounts)
+    usage_updater.refresh_accounts.assert_awaited_once_with(accounts, {})

--- a/tests/unit/test_rate_limit_reset_credits_client.py
+++ b/tests/unit/test_rate_limit_reset_credits_client.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.core.clients.rate_limit_reset_credits import (
     RateLimitResetCreditsFetchError,
+    consume_rate_limit_reset_credit,
     fetch_rate_limit_reset_credits,
 )
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
@@ -80,6 +81,7 @@ class StubRetryClient:
         method: str,
         url: str,
         headers: dict[str, str] | None = None,
+        json: dict[str, object] | None = None,
         timeout: object | None = None,
         retry_options: object | None = None,
     ) -> StubRequestContext:
@@ -212,3 +214,47 @@ async def test_fetch_rate_limit_reset_credits_preserves_error_code() -> None:
 
     assert excinfo.value.status_code == 401
     assert excinfo.value.code == "account_deactivated"
+
+
+@pytest.mark.asyncio
+async def test_consume_rate_limit_reset_credit_uses_resolved_codex_route() -> None:
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_1",
+        endpoint=ResolvedProxyEndpoint("ep_1", "http", "proxy.test", 8080),
+    )
+    client = StubCodexClient(
+        responses=[
+            StubCodexResponse(
+                payload={
+                    "code": "ok",
+                    "credit": {
+                        "id": "credit_one",
+                        "status": "redeemed",
+                        "redeemed_at": "2026-06-16T12:00:00Z",
+                    },
+                    "windows_reset": 2,
+                }
+            )
+        ]
+    )
+
+    payload = await consume_rate_limit_reset_credit(
+        access_token="access-token",
+        account_id="acc_test",
+        credit_id="credit_one",
+        redeem_request_id="redeem-123",
+        base_url="http://usage.test/backend-api",
+        timeout_seconds=2.0,
+        route=route,
+        codex_client=cast(Any, client),
+    )
+
+    assert payload.windows_reset == 2
+    assert client.calls[0]["route"] is route
+    assert client.calls[0]["method"] == "POST"
+    assert client.calls[0]["url"] == "http://usage.test/backend-api/wham/rate-limit-reset-credits/consume"
+    assert client.calls[0]["json"] == {
+        "credit_id": "credit_one",
+        "redeem_request_id": "redeem-123",
+    }

--- a/tests/unit/test_rate_limit_reset_credits_client.py
+++ b/tests/unit/test_rate_limit_reset_credits_client.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+
+from app.core.clients.rate_limit_reset_credits import (
+    RateLimitResetCreditsFetchError,
+    fetch_rate_limit_reset_credits,
+)
+from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
+
+pytestmark = pytest.mark.unit
+
+
+class StubResponse:
+    def __init__(self, status: int, payload: dict | None, text: str) -> None:
+        self.status = status
+        self._payload = payload
+        self._text = text
+
+    async def json(self, content_type: str | None = None) -> dict:
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+    async def text(self) -> str:
+        return self._text
+
+
+@dataclass
+class ResetCreditClientState:
+    calls: int = 0
+    auth: str | None = None
+    account: str | None = None
+
+
+class StubRequestContext:
+    def __init__(
+        self,
+        responses: list[StubResponse],
+        state: ResetCreditClientState,
+        headers: dict[str, str],
+        retry_options: object | None,
+    ) -> None:
+        self._responses = responses
+        self._state = state
+        self._headers = headers
+        self._retry_options = retry_options
+
+    async def __aenter__(self) -> StubResponse:
+        attempts = getattr(self._retry_options, "attempts", 1)
+        statuses = set(getattr(self._retry_options, "statuses", set()))
+        response: StubResponse | None = None
+        for attempt in range(attempts):
+            index = min(self._state.calls, len(self._responses) - 1)
+            response = self._responses[index]
+            self._state.calls += 1
+            self._state.auth = self._headers.get("Authorization")
+            self._state.account = self._headers.get("chatgpt-account-id")
+            if response.status in statuses and attempt < attempts - 1:
+                continue
+            return response
+        if response is None:
+            response = StubResponse(500, None, "no response")
+        return response
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class StubRetryClient:
+    def __init__(self, responses: list[StubResponse], state: ResetCreditClientState) -> None:
+        self._responses = responses
+        self._state = state
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str] | None = None,
+        timeout: object | None = None,
+        retry_options: object | None = None,
+    ) -> StubRequestContext:
+        return StubRequestContext(self._responses, self._state, headers or {}, retry_options)
+
+
+class StubCodexResponse:
+    def __init__(self, status_code: int = 200, payload: dict | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload or {
+            "credits": [
+                {
+                    "id": "RateLimitResetCredit_one",
+                    "status": "available",
+                    "granted_at": "2026-06-12T01:29:41Z",
+                    "expires_at": "2026-07-12T01:29:41Z",
+                    "redeemed_at": None,
+                }
+            ],
+            "available_count": 1,
+        }
+
+
+class StubCodexClient:
+    def __init__(self, responses: list[StubCodexResponse] | None = None) -> None:
+        self._responses = responses or [StubCodexResponse()]
+        self.calls: list[dict[str, object]] = []
+
+    async def request(self, method: str, url: str, *, route: ResolvedUpstreamRoute, **kwargs: object) -> object:
+        self.calls.append({"method": method, "url": url, "route": route, **kwargs})
+        index = min(len(self.calls) - 1, len(self._responses) - 1)
+        return self._responses[index]
+
+
+@pytest.mark.asyncio
+async def test_fetch_rate_limit_reset_credits_retries_and_returns_payload() -> None:
+    state = ResetCreditClientState()
+    responses = [
+        StubResponse(503, None, "busy"),
+        StubResponse(
+            200,
+            {
+                "credits": [
+                    {
+                        "id": "RateLimitResetCredit_one",
+                        "status": "available",
+                        "granted_at": "2026-06-12T01:29:41Z",
+                        "expires_at": "2026-07-12T01:29:41Z",
+                        "redeemed_at": None,
+                    }
+                ],
+                "available_count": 1,
+            },
+            "",
+        ),
+    ]
+    client = StubRetryClient(responses, state)
+
+    payload = await fetch_rate_limit_reset_credits(
+        access_token="access-token",
+        account_id="acc_test",
+        base_url="http://usage.test/backend-api",
+        max_retries=1,
+        timeout_seconds=2.0,
+        client=cast(Any, client),
+        allow_direct_egress=True,
+    )
+
+    assert payload.available_count == 1
+    assert payload.credits[0].id == "RateLimitResetCredit_one"
+    assert state.calls == 2
+    assert state.auth == "Bearer access-token"
+    assert state.account == "acc_test"
+
+
+@pytest.mark.asyncio
+async def test_fetch_rate_limit_reset_credits_uses_resolved_codex_route() -> None:
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_1",
+        endpoint=ResolvedProxyEndpoint("ep_1", "http", "proxy.test", 8080),
+    )
+    client = StubCodexClient()
+
+    payload = await fetch_rate_limit_reset_credits(
+        access_token="access-token",
+        account_id="acc_test",
+        base_url="http://usage.test/backend-api",
+        timeout_seconds=2.0,
+        route=route,
+        codex_client=cast(Any, client),
+        allow_direct_egress=True,
+    )
+
+    assert payload.available_count == 1
+    assert client.calls[0]["route"] is route
+    assert client.calls[0]["method"] == "GET"
+    assert client.calls[0]["url"] == "http://usage.test/backend-api/wham/rate-limit-reset-credits"
+
+
+@pytest.mark.asyncio
+async def test_fetch_rate_limit_reset_credits_preserves_error_code() -> None:
+    state = ResetCreditClientState()
+    responses = [
+        StubResponse(
+            401,
+            {
+                "error": {
+                    "code": "account_deactivated",
+                    "message": "Your OpenAI account has been deactivated.",
+                }
+            },
+            "",
+        )
+    ]
+    client = StubRetryClient(responses, state)
+
+    with pytest.raises(RateLimitResetCreditsFetchError) as excinfo:
+        await fetch_rate_limit_reset_credits(
+            access_token="access-token",
+            account_id="acc_test",
+            base_url="http://usage.test/backend-api",
+            timeout_seconds=1.0,
+            client=cast(Any, client),
+            allow_direct_egress=True,
+        )
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.code == "account_deactivated"


### PR DESCRIPTION
The PR is in draft mode because I don't test the reset just yet.
If anyone want to try that, you are more than welcomed to clone this PR and report the result
Once I test the reset when I have reached my limit and successfully reset I will convert it to ready state

## Summary

Add rate-limit reset credit tracking, display, and operator-triggered redemption. Fetches `GET /wham/rate-limit-reset-credits` in the existing 60s refresh loop, persists credits locally, exposes `availableResetCount`/`nearestResetExpiryAt` in shared account payloads, and surfaces reset counts with badges + ghost Reset buttons across the dashboard and accounts UI. Supports operator-triggered consume via `POST /api/accounts/{account_id}/reset-credit`.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue:  #989 

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/add-rate-limit-reset-credits/`

## Changes

- Added `RateLimitResetCreditsClient` (`app/core/clients/rate_limit_reset_credits.py`) that fetches `GET /wham/rate-limit-reset-credits` and calls `POST /wham/rate-limit-reset-credits/consume`
- Added ORM model `AccountRateLimitResetCredit` and Alembic migration with indexes on `(account_id, credit_id)`, `status`, and `expires_at`
- Added `ResetCreditUpdater` (`app/modules/accounts/reset_credit_updater.py`) that runs in the 60s background refresh loop to normalize stored credits
- Extended account repository with insert-if-not-exists, expiry normalization, and redeem queries
- Added `POST /api/accounts/{account_id}/reset-credit` endpoint with nearest-expiry credit selection and confirmation dialog
- Added `availableResetCount` and `nearestResetExpiryAt` to shared account summary payloads
- Accounts page list items show circular top-right corner badges; dashboard surfaces show ghost `Reset (N)` buttons
- Added red-border urgency styling on Reset buttons when `nearestResetExpiryAt` is within 7 days
- Accounts navigation tab shows an inline aggregate count badge
- Added "Available Resets" sort mode to Accounts page
- Added confirmation dialog UX before executing consume requests

## Test plan

```
# Backend unit tests — reset credit client and refresh logic
uv run pytest tests/unit/test_rate_limit_reset_credits_client.py -q
uv run pytest tests/unit/test_rate_limit_reset_credit_refresh.py -q

# Integration — account API, repository, dashboard, migrations
uv run pytest tests/integration/test_accounts_api.py -q
uv run pytest tests/integration/test_accounts_repository.py -q
uv run pytest tests/integration/test_dashboard_overview.py -q
uv run pytest tests/integration/test_migrations.py -q

# Frontend — schema parsing, sort behavior, badges, reset controls, urgency styling
uv run node_modules/.bin/vitest run frontend/src/features/accounts/schemas.test.ts
uv run node_modules/.bin/vitest run frontend/src/features/accounts/sorting.test.ts
uv run node_modules/.bin/vitest run frontend/src/features/accounts/components/account-actions.test.tsx
uv run node_modules/.bin/vitest run frontend/src/features/accounts/components/account-list.test.tsx
uv run node_modules/.bin/vitest run frontend/src/features/accounts/components/account-list-item.test.tsx
uv run node_modules/.bin/vitest run frontend/src/features/dashboard/components/account-card.test.tsx
uv run node_modules/.bin/vitest run frontend/src/features/dashboard/components/account-list.test.tsx
uv run node_modules/.bin/vitest run frontend/src/components/layout/app-header.test.tsx
```

<img width="456" height="201" alt="螢幕截圖 2026-06-16 01 15 54" src="https://github.com/user-attachments/assets/8a080bed-0bbf-4663-93aa-0e8b76282da3" />

Credits to @aaamosh for the endpoint discovery and the implementation

