### PR TITLE
fix(proxy): harden HTTP bridge websocket headers and 1011 affinity

### DIFF
--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -27,7 +27,7 @@ from app.core.clients.codex import (
     create_codex_session,
     require_route_or_direct_egress_opt_in,
 )
-from app.core.clients.proxy import ProxyResponseError, filter_inbound_headers
+from app.core.clients.proxy import _HOP_BY_HOP_HEADER_NAMES, ProxyResponseError, filter_inbound_headers
 from app.core.config.settings import get_settings
 from app.core.conversation_archive import archive_bytes, archive_text
 from app.core.errors import OpenAIErrorDetail, OpenAIErrorEnvelope, openai_error
@@ -37,18 +37,18 @@ from app.core.upstream_proxy import ResolvedUpstreamRoute
 from app.core.utils.proxy_env import resolve_websocket_proxy_from_env
 from app.core.utils.request_id import get_request_id
 
-_WEBSOCKET_HOP_BY_HOP_HEADERS = {
-    "accept",
-    "connection",
-    "content-type",
-    "cookie",
-    "sec-websocket-extensions",
-    "sec-websocket-key",
-    "sec-websocket-protocol",
-    "sec-websocket-version",
-    "upgrade",
-}
+_WEBSOCKET_HOP_BY_HOP_HEADERS = _HOP_BY_HOP_HEADER_NAMES | frozenset(
+    {
+        "accept-encoding",
+        "cookie",
+        "sec-websocket-extensions",
+        "sec-websocket-key",
+        "sec-websocket-protocol",
+        "sec-websocket-version",
+    }
+)
 _RESPONSES_WEBSOCKET_BETA_HEADER = "responses_websockets=2026-02-06"
+_RESPONSES_WEBSOCKET_INCOMPATIBLE_BETA_HEADERS = frozenset({"responses=experimental"})
 
 
 @dataclass(slots=True)
@@ -157,7 +157,10 @@ class CodexResponsesWebSocket:
                 error=codex_transport_error_message("websocket receive", self._endpoint_id, exc),
             )
         if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING, aiohttp.WSMsgType.CLOSED):
-            return UpstreamWebSocketMessage(kind="close")
+            return UpstreamWebSocketMessage(
+                kind="close",
+                close_code=_aiohttp_ws_close_code(self._websocket, msg),
+            )
         if msg.type == aiohttp.WSMsgType.ERROR:
             exception = msg.data if isinstance(msg.data, BaseException) else None
             return UpstreamWebSocketMessage(
@@ -286,9 +289,19 @@ class ArchivingResponsesWebSocket:
         return self._wrapped.response_header(name)
 
 
-def filter_inbound_websocket_headers(headers: dict[str, str]) -> dict[str, str]:
+def _connection_header_tokens(headers: Mapping[str, str]) -> set[str]:
+    tokens: set[str] = set()
+    for key, value in headers.items():
+        if key.lower() != "connection":
+            continue
+        tokens.update(token.strip().lower() for token in value.split(",") if token.strip())
+    return tokens
+
+
+def filter_inbound_websocket_headers(headers: Mapping[str, str]) -> dict[str, str]:
     filtered = filter_inbound_headers(headers)
-    return {key: value for key, value in filtered.items() if key.lower() not in _WEBSOCKET_HOP_BY_HOP_HEADERS}
+    blocked_header_names = _WEBSOCKET_HOP_BY_HOP_HEADERS | _connection_header_tokens(filtered)
+    return {key: value for key, value in filtered.items() if key.lower() not in blocked_header_names}
 
 
 def _build_upstream_websocket_headers(
@@ -296,7 +309,7 @@ def _build_upstream_websocket_headers(
     access_token: str,
     account_id: str | None,
 ) -> dict[str, str]:
-    headers = {key: value for key, value in inbound.items() if key.lower() != "cookie"}
+    headers = filter_inbound_websocket_headers(inbound)
     lower_keys = {key.lower() for key in headers}
     if "x-request-id" not in lower_keys and "request-id" not in lower_keys:
         request_id = get_request_id()
@@ -312,7 +325,11 @@ def _build_upstream_websocket_headers(
 def _ensure_responses_websocket_beta_header(headers: dict[str, str]) -> None:
     header_key = next((key for key in headers if key.lower() == "openai-beta"), "openai-beta")
     current_value = headers.get(header_key, "")
-    beta_tokens = [token.strip() for token in current_value.split(",") if token.strip()]
+    beta_tokens = [
+        token.strip()
+        for token in current_value.split(",")
+        if token.strip() and token.strip().lower() not in _RESPONSES_WEBSOCKET_INCOMPATIBLE_BETA_HEADERS
+    ]
     if _RESPONSES_WEBSOCKET_BETA_HEADER.lower() not in {token.lower() for token in beta_tokens}:
         beta_tokens.append(_RESPONSES_WEBSOCKET_BETA_HEADER)
     headers[header_key] = ", ".join(beta_tokens)
@@ -325,6 +342,13 @@ def _pop_header_case_insensitive(headers: dict[str, str], name: str) -> str | No
             continue
         return headers.pop(key)
     return None
+
+
+def _aiohttp_ws_close_code(websocket: Any, message: aiohttp.WSMessage) -> int | None:
+    if isinstance(message.data, int):
+        return message.data
+    close_code = getattr(websocket, "close_code", None)
+    return close_code if isinstance(close_code, int) else None
 
 
 def _responses_websocket_url(base_url: str) -> str:

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -125,6 +125,7 @@ from app.modules.proxy._service.http_bridge.service_stubs import (
     _service_time,
     _upstream_turn_state_from_socket,
     _websocket_connect_deadline,
+    _websocket_safe_headers_with_turn_state,
 )
 from app.modules.proxy._service.http_bridge.streaming import _HTTPBridgeStreamingMixin
 from app.modules.proxy._service.http_bridge.upstream_events import _HTTPBridgeUpstreamEventsMixin
@@ -569,6 +570,10 @@ class _HTTPBridgeMixin(
                 and key.affinity_key == durable_lookup.canonical_key
                 and key.affinity_kind != "turn_state_header"
             )
+            require_preferred_account = (previous_response_id is not None and preferred_account_id is not None) or (
+                preferred_account_id is not None
+                and (key.strength == "hard" or not fallback_on_preferred_account_unavailable)
+            )
 
             async with self._http_bridge_lock:
                 if (
@@ -589,7 +594,7 @@ class _HTTPBridgeMixin(
                                 session=alias_session,
                                 previous_response_id=previous_response_id,
                                 preferred_account_id=preferred_account_id,
-                                require_preferred_account=not fallback_on_preferred_account_unavailable,
+                                require_preferred_account=require_preferred_account,
                             )
                         ):
                             self._http_bridge_turn_state_index.pop(alias_index_key, None)
@@ -623,7 +628,7 @@ class _HTTPBridgeMixin(
                                     session=previous_session,
                                     previous_response_id=previous_response_id,
                                     preferred_account_id=preferred_account_id,
-                                    require_preferred_account=not fallback_on_preferred_account_unavailable,
+                                    require_preferred_account=require_preferred_account,
                                 )
                             ):
                                 key = previous_session.key
@@ -675,7 +680,7 @@ class _HTTPBridgeMixin(
                         session=existing,
                         previous_response_id=previous_response_id,
                         preferred_account_id=preferred_account_id,
-                        require_preferred_account=not fallback_on_preferred_account_unavailable,
+                        require_preferred_account=require_preferred_account,
                     )
                 ):
                     current_instance = settings.http_responses_session_bridge_instance_id
@@ -1357,7 +1362,7 @@ class _HTTPBridgeMixin(
                         session=session,
                         previous_response_id=previous_response_id,
                         preferred_account_id=preferred_account_id,
-                        require_preferred_account=not fallback_on_preferred_account_unavailable,
+                        require_preferred_account=require_preferred_account,
                     )
                 ):
                     current_instance = settings.http_responses_session_bridge_instance_id
@@ -1386,9 +1391,6 @@ class _HTTPBridgeMixin(
 
             created_session: _HTTPBridgeSession | None = None
             session_registered = False
-            require_preferred_account = (previous_response_id is not None and preferred_account_id is not None) or (
-                preferred_account_id is not None and not fallback_on_preferred_account_unavailable
-            )
             try:
                 create_session = self._create_http_bridge_session
                 create_kwargs: dict[str, Any] = {
@@ -1400,7 +1402,9 @@ class _HTTPBridgeMixin(
                     "request_stage": request_stage,
                     "preferred_account_id": preferred_account_id,
                     "require_preferred_account": require_preferred_account,
-                    "fallback_on_preferred_account_unavailable": fallback_on_preferred_account_unavailable,
+                    "fallback_on_preferred_account_unavailable": (
+                        fallback_on_preferred_account_unavailable and not require_preferred_account
+                    ),
                     "request_usage_budget": request_usage_budget,
                     "request_deadline": request_deadline,
                 }
@@ -1955,7 +1959,9 @@ class _HTTPBridgeMixin(
                     account,
                     timeout_seconds=_remaining_budget_seconds(deadline),
                 )
-                connect_headers = _headers_with_turn_state(headers, _sticky_key_from_turn_state_header(headers))
+                connect_headers = _websocket_safe_headers_with_turn_state(
+                    headers, _sticky_key_from_turn_state_header(headers)
+                )
                 upstream = await _call_with_supported_optional_kwargs(
                     self._open_upstream_websocket_with_budget,
                     account,
@@ -1979,7 +1985,9 @@ class _HTTPBridgeMixin(
                         force=True,
                         timeout_seconds=_remaining_budget_seconds(deadline),
                     )
-                    connect_headers = _headers_with_turn_state(headers, _sticky_key_from_turn_state_header(headers))
+                    connect_headers = _websocket_safe_headers_with_turn_state(
+                        headers, _sticky_key_from_turn_state_header(headers)
+                    )
                     upstream = await self._open_upstream_websocket_with_budget(
                         account,
                         connect_headers,
@@ -2146,7 +2154,9 @@ class _HTTPBridgeMixin(
         )
         settings = await _service_get_settings_cache().get()
         session.api_key = request_state.api_key
-        skip_same_account = session.last_upstream_close_code in _UPSTREAM_CLOSE_CODES_SKIP_SAME_ACCOUNT_RETRY
+        close_skips_account = session.last_upstream_close_code in _UPSTREAM_CLOSE_CODES_SKIP_SAME_ACCOUNT_RETRY
+        hard_close_account_bound = session.key.strength == "hard" and close_skips_account
+        skip_same_account = session.key.strength != "hard" and close_skips_account
         forced_refresh_account_id = request_state.force_refresh_account_id
         excluded_account_ids: set[str] = set(request_state.excluded_account_ids)
         if skip_same_account:
@@ -2154,6 +2164,8 @@ class _HTTPBridgeMixin(
         retry_same_account_once = not skip_same_account and session.account.id not in excluded_account_ids
         if skip_same_account:
             preferred_candidate_id: str | None = None
+        elif hard_close_account_bound and session.account.id not in excluded_account_ids:
+            preferred_candidate_id = session.account.id
         elif forced_refresh_account_id is not None:
             preferred_candidate_id = forced_refresh_account_id
         elif request_state.preferred_account_id is not None:
@@ -2173,6 +2185,18 @@ class _HTTPBridgeMixin(
             if lease is session.account_lease:
                 session.account_lease = None
             await self._load_balancer.release_account_lease(lease)
+
+        async def release_selected_account_lease_and_reraise_if_hard_close_bound() -> None:
+            if hard_close_account_bound:
+                await release_selected_account_lease()
+                raise
+
+        async def abandon_selected_account_retry(selected_account: Any) -> None:
+            nonlocal preferred_candidate_id
+            await release_selected_account_lease_and_reraise_if_hard_close_bound()
+            excluded_account_ids.add(selected_account.id)
+            preferred_candidate_id = None
+            await release_selected_account_lease()
 
         while True:
             reuse_current_account_lease = (
@@ -2199,12 +2223,18 @@ class _HTTPBridgeMixin(
                 estimated_lease_tokens=_estimated_lease_tokens_from_request_usage_budget(
                     request_state.request_usage_budget
                 ),
-                fallback_on_preferred_account_unavailable=not reuse_current_account_lease,
+                fallback_on_preferred_account_unavailable=(
+                    not reuse_current_account_lease and not hard_close_account_bound
+                ),
             )
             account = selection.account
             if account is None:
                 await release_selected_account_lease()
-                if reuse_current_account_lease and _remaining_budget_seconds(deadline) > 0:
+                if (
+                    reuse_current_account_lease
+                    and not hard_close_account_bound
+                    and _remaining_budget_seconds(deadline) > 0
+                ):
                     preferred_candidate_id = None
                     continue
                 if await _sleep_for_account_selection_recovery(
@@ -2222,6 +2252,8 @@ class _HTTPBridgeMixin(
                     retry_same_account_once = not skip_same_account and session.account.id not in excluded_account_ids
                     if skip_same_account:
                         preferred_candidate_id = None
+                    elif hard_close_account_bound and session.account.id not in excluded_account_ids:
+                        preferred_candidate_id = session.account.id
                     elif forced_refresh_account_id is not None:
                         preferred_candidate_id = forced_refresh_account_id
                     elif request_state.preferred_account_id is not None:
@@ -2263,9 +2295,8 @@ class _HTTPBridgeMixin(
                 )
                 if force_refresh and request_state.force_refresh_account_id == account.id:
                     request_state.force_refresh_account_id = None
-                connect_headers = _headers_with_turn_state(
-                    session.headers,
-                    _preferred_http_bridge_reconnect_turn_state(session),
+                connect_headers = _websocket_safe_headers_with_turn_state(
+                    session.headers, _preferred_http_bridge_reconnect_turn_state(session)
                 )
                 upstream = await self._open_upstream_websocket_with_budget(
                     account,
@@ -2289,9 +2320,8 @@ class _HTTPBridgeMixin(
                         force=True,
                         timeout_seconds=_remaining_budget_seconds(deadline),
                     )
-                    connect_headers = _headers_with_turn_state(
-                        session.headers,
-                        _preferred_http_bridge_reconnect_turn_state(session),
+                    connect_headers = _websocket_safe_headers_with_turn_state(
+                        session.headers, _preferred_http_bridge_reconnect_turn_state(session)
                     )
                     upstream = await self._open_upstream_websocket_with_budget(
                         account,
@@ -2310,16 +2340,12 @@ class _HTTPBridgeMixin(
                         await release_selected_account_lease()
                         raise
                     await self._handle_proxy_error(account, retry_exc)
-                    excluded_account_ids.add(account.id)
-                    preferred_candidate_id = None
-                    await release_selected_account_lease()
+                    await abandon_selected_account_retry(account)
                     continue
                 except RefreshError as refresh_exc:
                     if refresh_exc.is_permanent:
                         await self._load_balancer.mark_permanent_failure(account, refresh_exc.code)
-                    excluded_account_ids.add(account.id)
-                    preferred_candidate_id = None
-                    await release_selected_account_lease()
+                    await abandon_selected_account_retry(account)
                     continue
             except RefreshError as exc:
                 if exc.is_permanent:
@@ -2329,9 +2355,7 @@ class _HTTPBridgeMixin(
                         retry_same_account_once = False
                         await release_selected_account_lease()
                         continue
-                    excluded_account_ids.add(account.id)
-                    preferred_candidate_id = None
-                    await release_selected_account_lease()
+                    await abandon_selected_account_retry(account)
                     continue
                 await release_selected_account_lease()
                 raise
@@ -2341,9 +2365,7 @@ class _HTTPBridgeMixin(
                         retry_same_account_once = False
                         await release_selected_account_lease()
                         continue
-                    excluded_account_ids.add(account.id)
-                    preferred_candidate_id = None
-                    await release_selected_account_lease()
+                    await abandon_selected_account_retry(account)
                     continue
                 await release_selected_account_lease()
                 raise

--- a/app/modules/proxy/_service/http_bridge/service_stubs.py
+++ b/app/modules/proxy/_service/http_bridge/service_stubs.py
@@ -17,6 +17,7 @@ from app.core.clients.proxy import (
 )
 from app.core.clients.proxy import stream_responses as core_stream_responses
 from app.core.clients.proxy import thread_goal_request as core_thread_goal_request
+from app.core.clients.proxy_websocket import filter_inbound_websocket_headers
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.openai.requests import ResponsesRequest
@@ -292,6 +293,10 @@ def _openai_error_envelope_from_response_failed_payload(*args: Any, **kwargs: An
 
 def _headers_with_turn_state(*args: Any, **kwargs: Any) -> Any:
     return _service_global("_headers_with_turn_state")(*args, **kwargs)
+
+
+def _websocket_safe_headers_with_turn_state(headers: Mapping[str, str], turn_state: str | None) -> dict[str, str]:
+    return cast(dict[str, str], _headers_with_turn_state(filter_inbound_websocket_headers(dict(headers)), turn_state))
 
 
 def _headers_with_authorization(*args: Any, **kwargs: Any) -> Any:

--- a/openspec/changes/harden-http-bridge-hard-affinity-1011/proposal.md
+++ b/openspec/changes/harden-http-bridge-hard-affinity-1011/proposal.md
@@ -1,0 +1,23 @@
+# Proposal: Harden HTTP bridge hard-affinity 1011 retries
+
+## Problem
+
+Codex-compatible clients can use the HTTP/SSE Responses route. That route uses the HTTP responses bridge, which opens an upstream WebSocket on behalf of the client.
+
+When the upstream WebSocket closes with code `1011` before `response.completed`, the bridge currently treats the pending pre-created request as replayable and skips retrying on the same account. For hard continuity keys such as `session_header`, that can re-send the same logical session on another account and produce repeated `stream_incomplete` failures.
+
+The same bridge path can also forward downstream HTTP/SSE request headers into the upstream WebSocket connection. In local reproduction this produced upstream WebSocket requests carrying HTTP-only headers and an incompatible `OpenAI-Beta: responses=experimental` token, which caused repeated upstream closes before `response.created`.
+
+## Change
+
+- Preserve account ownership for hard HTTP bridge keys during pre-created replay after upstream close `1011`.
+- Continue allowing soft-affinity bridge sessions to skip the failed account for `1011`.
+- Filter HTTP-only and hop-by-hop headers before HTTP bridge create/reconnect opens the upstream responses WebSocket.
+- Normalize upstream responses WebSocket beta headers by removing HTTP Responses beta tokens and preserving `responses_websockets=2026-02-06`.
+- Add regression coverage for hard `session_header` replay, HTTP bridge header filtering, and WebSocket beta normalization.
+
+## Impact
+
+Hard continuity retries remain bounded to the owning account. If that account cannot complete the replay, the request fails with the existing retryable stream error instead of fanning out across unrelated accounts.
+
+HTTP bridge upstream WebSocket connections use the same WebSocket-safe header shape as direct Codex WebSocket connections, while preserving continuity headers required for affinity.

--- a/openspec/changes/harden-http-bridge-hard-affinity-1011/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/harden-http-bridge-hard-affinity-1011/specs/sticky-session-operations/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Hard HTTP bridge reconnects remain account-bound after upstream close
+
+When an HTTP responses bridge session uses a hard continuity key such as `turn_state_header` or `session_header`, replay or reconnect handling MUST NOT route the same pending request to a different upstream account solely because the prior upstream WebSocket closed with code `1011`.
+
+Soft-affinity bridge sessions MAY continue to exclude the failed account for transient upstream close recovery when no hard continuity dependency is present.
+
+#### Scenario: session-header bridge replay preserves owner account after 1011
+
+- **GIVEN** an HTTP bridge session is keyed by `session_header`
+- **AND** its upstream WebSocket closes with code `1011` before `response.completed`
+- **WHEN** the bridge attempts a pre-created replay or reconnect for the pending request
+- **THEN** the account selector is called with the current session account as the preferred account
+- **AND** the current session account is not excluded solely because of the `1011` close
+- **AND** the request is not replayed on another account unless an explicit non-1011 account-failure path requires it
+
+### Requirement: HTTP bridge upstream WebSocket connects use WebSocket-safe headers
+
+When HTTP responses bridge code opens or reconnects an upstream responses WebSocket, it MUST remove HTTP-only and hop-by-hop inbound headers before passing headers to the upstream WebSocket connector.
+
+The upstream responses WebSocket header builder MUST NOT forward HTTP Responses API beta tokens such as `responses=experimental`; it MUST send the responses WebSocket beta token required by the upstream WebSocket protocol.
+
+The sanitized header set MUST preserve Codex continuity headers such as `session_id`, `x-codex-session-id`, and `x-codex-turn-state` when those headers are required for affinity.
+
+#### Scenario: HTTP bridge create filters HTTP request headers
+
+- **GIVEN** an HTTP responses bridge request contains HTTP request headers such as `accept`, `accept-encoding`, `content-type`, `connection`, `authorization`, `cookie`, or `host`
+- **WHEN** the bridge opens a new upstream responses WebSocket
+- **THEN** those HTTP-only or hop-by-hop headers are not forwarded to the upstream WebSocket connector
+- **AND** the continuity `session_id` header remains available for upstream affinity
+
+#### Scenario: HTTP bridge reconnect filters HTTP request headers
+
+- **GIVEN** an HTTP responses bridge session is reconnecting an upstream responses WebSocket
+- **AND** the session stores HTTP request headers from the original downstream request
+- **WHEN** reconnect prepares the upstream WebSocket headers
+- **THEN** HTTP-only and hop-by-hop headers are filtered before the upstream WebSocket connector is called
+- **AND** the selected `x-codex-turn-state` remains available for upstream continuity
+
+#### Scenario: upstream WebSocket beta header excludes HTTP Responses token
+
+- **GIVEN** a responses WebSocket connect request receives `OpenAI-Beta: responses=experimental`
+- **WHEN** upstream WebSocket headers are built
+- **THEN** `responses=experimental` is not forwarded
+- **AND** `responses_websockets=2026-02-06` is present

--- a/openspec/changes/harden-http-bridge-hard-affinity-1011/tasks.md
+++ b/openspec/changes/harden-http-bridge-hard-affinity-1011/tasks.md
@@ -1,0 +1,8 @@
+## Tasks
+
+- [x] Add an OpenSpec delta for hard-affinity HTTP bridge retry behavior.
+- [x] Add a regression test proving `session_header` bridge reconnect does not exclude the current account after upstream close `1011`.
+- [x] Update HTTP bridge reconnect account selection to preserve hard-affinity account ownership.
+- [x] Add HTTP bridge upstream WebSocket header filtering for create and reconnect paths.
+- [x] Normalize responses WebSocket beta headers so HTTP Responses beta tokens are not forwarded upstream.
+- [x] Run targeted tests and `openspec validate --specs`. HTTP bridge + websocket client unit tests, ruff, local HTTP/WebSocket smokes, repo-wide OpenSpec validation, and strict change validation passed.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -19,7 +19,11 @@ from fastapi import WebSocket
 
 from app.core.auth.refresh import RefreshError
 from app.core.clients.proxy import ProxyResponseError
-from app.core.clients.proxy_websocket import UpstreamResponsesWebSocket, UpstreamWebSocketMessage
+from app.core.clients.proxy_websocket import (
+    CodexResponsesWebSocket,
+    UpstreamResponsesWebSocket,
+    UpstreamWebSocketMessage,
+)
 from app.core.config.settings import Settings
 from app.core.errors import openai_error
 from app.db.models import AccountStatus, HttpBridgeSessionState
@@ -1832,6 +1836,433 @@ async def test_reconnect_http_bridge_session_preserves_exclusions_after_capacity
 
     assert len(selection_kwargs) == 3
     assert selection_kwargs[2]["exclude_account_ids"] == {"acc-request-state", session.account.id}
+
+
+@pytest.mark.asyncio
+async def test_create_http_bridge_session_filters_http_headers_for_upstream_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    captured_headers: list[dict[str, str]] = []
+
+    async def select_account(_deadline: float, **_: object) -> proxy_service.AccountSelection:
+        return proxy_service.AccountSelection(
+            account=cast(Any, SimpleNamespace(id="acc-bridge", status=AccountStatus.ACTIVE)),
+            error_message=None,
+            error_code=None,
+        )
+
+    async def ensure_fresh(account: object, **_: object) -> object:
+        return account
+
+    async def open_upstream(_account: object, headers: dict[str, str], **_: object) -> UpstreamResponsesWebSocket:
+        captured_headers.append(dict(headers))
+        return cast(UpstreamResponsesWebSocket, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+
+    async def fake_relay(_session: proxy_service._HTTPBridgeSession) -> None:
+        return None
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", open_upstream)
+    monkeypatch.setattr(service, "_relay_http_bridge_upstream_messages", fake_relay)
+
+    session = await service._create_http_bridge_session(
+        proxy_service._HTTPBridgeSessionKey("session_header", "sid-filtered", None),
+        headers={
+            "accept": "text/event-stream",
+            "accept-encoding": "gzip, deflate, br, zstd",
+            "authorization": "Bearer client-key",
+            "connection": "keep-alive, x-handshake-debug",
+            "content-type": "application/json",
+            "cookie": "session=client-cookie",
+            "host": "127.0.0.1:3455",
+            "keep-alive": "timeout=5",
+            "proxy-authorization": "Basic secret",
+            "proxy-connection": "keep-alive",
+            "session_id": "sid-filtered",
+            "te": "trailers",
+            "trailer": "x-trailer",
+            "transfer-encoding": "chunked",
+            "upgrade": "websocket",
+            "user-agent": "pi",
+            "x-handshake-debug": "1",
+        },
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-filtered",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+    )
+
+    if session.upstream_reader is not None:
+        await session.upstream_reader
+    assert captured_headers
+    forwarded = {key.lower(): value for key, value in captured_headers[0].items()}
+    assert forwarded["session_id"] == "sid-filtered"
+    assert forwarded["user-agent"] == "pi"
+    assert "accept" not in forwarded
+    assert "accept-encoding" not in forwarded
+    assert "authorization" not in forwarded
+    assert "connection" not in forwarded
+    assert "content-type" not in forwarded
+    assert "cookie" not in forwarded
+    assert "host" not in forwarded
+    assert "keep-alive" not in forwarded
+    assert "proxy-authorization" not in forwarded
+    assert "proxy-connection" not in forwarded
+    assert "te" not in forwarded
+    assert "trailer" not in forwarded
+    assert "transfer-encoding" not in forwarded
+    assert "upgrade" not in forwarded
+    assert "x-handshake-debug" not in forwarded
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_filters_http_headers_for_upstream_websocket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session()
+    session.headers = {
+        "accept": "text/event-stream",
+        "accept-encoding": "gzip, deflate, br, zstd",
+        "authorization": "Bearer client-key",
+        "connection": "keep-alive, x-handshake-debug",
+        "content-type": "application/json",
+        "cookie": "session=client-cookie",
+        "host": "127.0.0.1:3455",
+        "keep-alive": "timeout=5",
+        "proxy-authorization": "Basic secret",
+        "proxy-connection": "keep-alive",
+        "session_id": "sid-filtered",
+        "te": "trailers",
+        "trailer": "x-trailer",
+        "transfer-encoding": "chunked",
+        "upgrade": "websocket",
+        "user-agent": "pi",
+        "x-handshake-debug": "1",
+    }
+    session.upstream_turn_state = "upstream-turn-state"
+    captured_headers: list[dict[str, str]] = []
+
+    async def select_account(_deadline: float, **_: object) -> proxy_service.AccountSelection:
+        return proxy_service.AccountSelection(account=session.account, error_message=None, error_code=None)
+
+    async def ensure_fresh(account: object, **_: object) -> object:
+        return account
+
+    async def open_upstream(_account: object, headers: dict[str, str], **_: object) -> UpstreamResponsesWebSocket:
+        captured_headers.append(dict(headers))
+        return cast(UpstreamResponsesWebSocket, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-filter-reconnect",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", open_upstream)
+
+    await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert captured_headers
+    forwarded = {key.lower(): value for key, value in captured_headers[0].items()}
+    assert forwarded["session_id"] == "sid-filtered"
+    assert forwarded["user-agent"] == "pi"
+    assert forwarded["x-codex-turn-state"] == "upstream-turn-state"
+    assert "accept" not in forwarded
+    assert "accept-encoding" not in forwarded
+    assert "authorization" not in forwarded
+    assert "connection" not in forwarded
+    assert "content-type" not in forwarded
+    assert "cookie" not in forwarded
+    assert "host" not in forwarded
+    assert "keep-alive" not in forwarded
+    assert "proxy-authorization" not in forwarded
+    assert "proxy-connection" not in forwarded
+    assert "te" not in forwarded
+    assert "trailer" not in forwarded
+    assert "transfer-encoding" not in forwarded
+    assert "upgrade" not in forwarded
+    assert "x-handshake-debug" not in forwarded
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_preserves_hard_account_after_1011(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-hard-1011", None),
+        key_value="sid-hard-1011",
+    )
+    session.last_upstream_close_code = 1011
+    selection_kwargs: list[dict[str, object]] = []
+
+    async def select_account(_deadline: float, **kwargs: object) -> proxy_service.AccountSelection:
+        selection_kwargs.append(kwargs)
+        return proxy_service.AccountSelection(account=session.account, error_message=None, error_code=None)
+
+    async def ensure_fresh(account: object, **_: object) -> object:
+        return account
+
+    upstream = cast(Any, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-1011",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", AsyncMock(return_value=upstream))
+
+    await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert selection_kwargs[0]["preferred_account_id"] == "acc-bridge"
+    exclude_account_ids = cast(set[str], selection_kwargs[0]["exclude_account_ids"])
+    assert "acc-bridge" not in exclude_account_ids
+    assert session.account.id == "acc-bridge"
+    assert session.last_upstream_close_code is None
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_keeps_hard_1011_pinned_after_lease_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-hard-1011-lease", None),
+        key_value="sid-hard-1011-lease",
+    )
+    session.last_upstream_close_code = 1011
+    session.account_lease = proxy_service.AccountLease(
+        lease_id="lease-hard-1011",
+        account_id=session.account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    selection_kwargs: list[dict[str, object]] = []
+
+    async def select_account(_deadline: float, **kwargs: object) -> proxy_service.AccountSelection:
+        selection_kwargs.append(kwargs)
+        if len(selection_kwargs) == 1:
+            return proxy_service.AccountSelection(
+                account=None,
+                error_message="Account stream capacity is exhausted",
+                error_code="account_stream_cap",
+            )
+        return proxy_service.AccountSelection(account=session.account, error_message=None, error_code=None)
+
+    async def ensure_fresh(account: object, **_: object) -> object:
+        return account
+
+    sleep_calls = 0
+
+    async def sleep_for_recovery(*_args: object, **_kwargs: object) -> bool:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        return sleep_calls == 1
+
+    upstream = cast(Any, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-1011-lease",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", AsyncMock(return_value=upstream))
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", AsyncMock())
+    monkeypatch.setattr(http_bridge_mixin_module, "_sleep_for_account_selection_recovery", sleep_for_recovery)
+
+    await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert len(selection_kwargs) == 2
+    assert selection_kwargs[0]["preferred_account_id"] == "acc-bridge"
+    assert selection_kwargs[0]["fallback_on_preferred_account_unavailable"] is False
+    assert selection_kwargs[1]["preferred_account_id"] == "acc-bridge"
+    assert selection_kwargs[1]["fallback_on_preferred_account_unavailable"] is False
+    assert session.account.id == "acc-bridge"
+    assert session.last_upstream_close_code is None
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_fails_closed_after_hard_1011_owner_connect_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-hard-1011-connect-error", None),
+        key_value="sid-hard-1011-connect-error",
+    )
+    session.last_upstream_close_code = 1011
+    other_account = cast(Any, SimpleNamespace(id="acc-other", status=AccountStatus.ACTIVE))
+    selection_kwargs: list[dict[str, object]] = []
+
+    async def select_account(_deadline: float, **kwargs: object) -> proxy_service.AccountSelection:
+        selection_kwargs.append(kwargs)
+        account = session.account if len(selection_kwargs) <= 2 else other_account
+        return proxy_service.AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def ensure_fresh(account: object, **_: object) -> object:
+        return account
+
+    async def open_upstream(account: object, _headers: dict[str, str], **_: object) -> UpstreamResponsesWebSocket:
+        if getattr(account, "id", None) == "acc-bridge":
+            raise aiohttp.ClientError("owner reconnect failed")
+        return cast(UpstreamResponsesWebSocket, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-1011-connect-error",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", open_upstream)
+
+    with pytest.raises(aiohttp.ClientError):
+        await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert len(selection_kwargs) == 2
+    assert selection_kwargs[0]["preferred_account_id"] == "acc-bridge"
+    assert selection_kwargs[1]["preferred_account_id"] == "acc-bridge"
+    assert session.account.id == "acc-bridge"
+    assert session.last_upstream_close_code == 1011
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_ignores_stale_preferred_account_after_1011(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-hard-stale-owner-1011", None),
+        key_value="sid-hard-stale-owner-1011",
+    )
+    session.last_upstream_close_code = 1011
+    selection_kwargs: list[dict[str, object]] = []
+
+    async def select_account(_deadline: float, **kwargs: object) -> proxy_service.AccountSelection:
+        selection_kwargs.append(kwargs)
+        return proxy_service.AccountSelection(account=session.account, error_message=None, error_code=None)
+
+    async def ensure_fresh(account: object, **_: object) -> object:
+        return account
+
+    upstream = cast(Any, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-stale-owner-1011",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        preferred_account_id="acc-stale-owner",
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", AsyncMock(return_value=upstream))
+
+    await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert selection_kwargs[0]["preferred_account_id"] == "acc-bridge"
+    assert selection_kwargs[0]["fallback_on_preferred_account_unavailable"] is False
+    assert session.account.id == "acc-bridge"
 
 
 async def test_select_account_with_budget_required_file_pin_does_not_fallback_on_account_cap(
@@ -9983,6 +10414,101 @@ async def test_get_or_create_http_bridge_session_soft_mismatch_rebinds_locally(
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_hard_preferred_owner_is_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-hard-owner", None)
+    created_session = _make_bridge_session(key=key, key_value="sid-hard-owner")
+    create_session = AsyncMock(return_value=created_session)
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-b"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a", "instance-b"])),
+    )
+
+    resolved = await service._get_or_create_http_bridge_session(
+        key,
+        headers={"x-codex-session-id": "sid-hard-owner"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-hard-owner",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+        allow_forward_to_owner=False,
+        gateway_safe_mode=True,
+        request_stage="follow_up",
+        preferred_account_id="acc-owner",
+        fallback_on_preferred_account_unavailable=True,
+    )
+
+    assert resolved is created_session
+    create_call = create_session.await_args
+    assert create_call is not None
+    assert create_call.kwargs["preferred_account_id"] == "acc-owner"
+    assert create_call.kwargs["require_preferred_account"] is True
+    assert create_call.kwargs["fallback_on_preferred_account_unavailable"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_hard_preferred_owner_blocks_stale_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-hard-owner-stale", None)
+    stale_session = _make_bridge_session(key=key, key_value="sid-hard-owner-stale")
+    stale_session.account = cast(Any, SimpleNamespace(id="acc-stale", status=AccountStatus.ACTIVE))
+    created_session = _make_bridge_session(key=key, key_value="sid-hard-owner-stale")
+    create_session = AsyncMock(return_value=created_session)
+    service._http_bridge_sessions[key] = stale_session
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-b"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a", "instance-b"])),
+    )
+
+    resolved = await service._get_or_create_http_bridge_session(
+        key,
+        headers={"x-codex-session-id": "sid-hard-owner-stale"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-hard-owner-stale",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+        allow_forward_to_owner=False,
+        gateway_safe_mode=True,
+        request_stage="follow_up",
+        preferred_account_id="acc-owner",
+        fallback_on_preferred_account_unavailable=True,
+    )
+
+    assert resolved is created_session
+    assert resolved is not stale_session
+    create_call = create_session.await_args
+    assert create_call is not None
+    assert create_call.kwargs["require_preferred_account"] is True
+    assert create_call.kwargs["fallback_on_preferred_account_unavailable"] is False
+
+
+@pytest.mark.asyncio
 async def test_create_http_bridge_session_fails_closed_when_previous_response_owner_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -10445,6 +10971,33 @@ async def test_http_bridge_reader_marks_session_closed_before_reconnect_close(
 
     assert session.closed is True
     close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_preserves_routed_aiohttp_close_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    routed_websocket = SimpleNamespace(
+        close=AsyncMock(),
+        receive=AsyncMock(
+            return_value=aiohttp.WSMessage(
+                aiohttp.WSMsgType.CLOSE,
+                1011,
+                "upstream unavailable",
+            )
+        ),
+    )
+    session = _make_bridge_session(key_value="bridge-routed-close-code")
+    session.upstream = CodexResponsesWebSocket(routed_websocket)
+    service._http_bridge_sessions[session.key] = session
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+
+    await service._relay_http_bridge_upstream_messages(session)
+
+    assert session.last_upstream_close_code == 1011
+    assert session.closed is True
+    routed_websocket.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -348,6 +348,69 @@ async def test_connect_responses_websocket_appends_required_beta_header(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_connect_responses_websocket_drops_http_responses_beta_and_encoding_header(monkeypatch):
+    fake_connection = _FakeConnection()
+    seen: dict[str, object] = {}
+
+    async def fake_websocket_connect(url: str, **kwargs):
+        seen["url"] = url
+        seen["kwargs"] = kwargs
+        return fake_connection
+
+    monkeypatch.setattr(proxy_websocket_module, "get_http_client", lambda: _UnexpectedHttpClient(), raising=False)
+    monkeypatch.setattr(proxy_websocket_module, "websocket_connect", fake_websocket_connect, raising=False)
+    monkeypatch.setattr(
+        proxy_websocket_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            upstream_base_url="https://chatgpt.com/backend-api",
+            upstream_connect_timeout_seconds=7.0,
+            max_sse_event_bytes=4321,
+            upstream_websocket_trust_env=False,
+        ),
+    )
+
+    await connect_responses_websocket(
+        {
+            "Connection": "keep-alive, X-Handshake-Debug",
+            "Keep-Alive": "timeout=5",
+            "Proxy-Authorization": "Basic secret",
+            "Proxy-Connection": "keep-alive",
+            "TE": "trailers",
+            "Trailer": "X-Trailer",
+            "Transfer-Encoding": "chunked",
+            "Upgrade": "websocket",
+            "X-Handshake-Debug": "1",
+            "accept-encoding": "gzip, deflate, br, zstd",
+            "OpenAI-Beta": "responses=experimental, assistants=v2",
+            "session_id": "session-1",
+        },
+        "access-token",
+        None,
+        allow_direct_egress=True,
+    )
+
+    kwargs = cast(dict[str, object], seen["kwargs"])
+    additional_headers = cast(dict[str, str], kwargs["additional_headers"])
+    lowered_headers = {key.lower(): value for key, value in additional_headers.items()}
+    for header_name in (
+        "accept-encoding",
+        "connection",
+        "keep-alive",
+        "proxy-authorization",
+        "proxy-connection",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+        "x-handshake-debug",
+    ):
+        assert header_name not in lowered_headers
+    assert additional_headers["OpenAI-Beta"] == "assistants=v2, responses_websockets=2026-02-06"
+    assert additional_headers["session_id"] == "session-1"
+
+
+@pytest.mark.asyncio
 async def test_connect_responses_websocket_maps_invalid_status(monkeypatch):
     async def fake_websocket_connect(url: str, **kwargs):
         raise InvalidStatus(


### PR DESCRIPTION
## Summary

Harden the HTTP Responses bridge so downstream HTTP request headers are not forwarded into upstream Responses WebSocket handshakes, and keep hard-affinity bridge reconnects account-bound after upstream close `1011`.

Fixes #1016

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Fixes #1016

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/harden-http-bridge-hard-affinity-1011/`

## Changes

- Filter HTTP-only and hop-by-hop downstream headers before HTTP bridge create/reconnect opens an upstream Responses WebSocket.
- Normalize Responses WebSocket beta headers by dropping HTTP Responses beta tokens and preserving `responses_websockets=2026-02-06`.
- Preserve hard-affinity bridge account ownership after upstream close `1011`, while keeping soft-affinity reroute behavior available.
- Add OpenSpec coverage and focused regressions for create/reconnect header filtering, beta normalization, and hard-affinity `1011` retries.

## Test plan

```bash
uv run pytest tests/unit/test_proxy_http_bridge.py tests/unit/test_proxy_websocket_client.py -q
# 205 passed in 6.40s

uv run python scripts/check_proxy_architecture.py
# proxy architecture checks passed

uv run ruff check .
# All checks passed!

uv run ruff format --check .
# 634 files already formatted

make typecheck
# All checks passed!

OPENSPEC_TELEMETRY=0 openspec validate --specs
# Totals: 30 passed, 0 failed (30 items)

OPENSPEC_TELEMETRY=0 openspec validate harden-http-bridge-hard-affinity-1011 --strict --no-interactive
# Change 'harden-http-bridge-hard-affinity-1011' is valid

OPENSPEC_TELEMETRY=0 openspec instructions apply --change harden-http-bridge-hard-affinity-1011 --json
# progress: 6/6 tasks complete; state: all_done
```

## Screenshots / output (optional)

N/A.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).