### PR TITLE
chore: release v1.20.0-beta.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.20.0b3"
+version = "1.20.0-beta.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.20.0-beta.3 for the 1.20.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.20.0-beta.3 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #806; no manual beta workflow dispatch is required.

## Changes since v1.20.0-beta.2
- fix(security): harden CodeQL alert surfaces (#935) (
2992b8)
- fix(accounts): dedupe request usage rows by request id (#904) (
86e235)
- feat(accounts): add account list sort controls (#897) (
0e413e)
- feat(accounts): add dashboard action for account force-probe (#895) (
72222c)
- feat(api-keys): add key overview usage stats (#900) (
ed8caa)
- feat(ui): log the User-Agent and store it in database (#882) (
1a8e11)
- feat(dashboard): support weekly pace working days (#901) (
7abbcf)
- fix(acc): create `monthly` window for the `free` account due to the policy change (#909) (
50b9ad)
- feat: add reports page with cost/token charts and CSV export (#854) (
f5fcfa)
- feat(auth): proactively refresh stale active accounts (#928) (
163326)
- fix(repo): remove Codex sandbox-breaking symlink (#942) (
1b0383)
- fix(docker): pin Postgres upgrade helper digest (#945) (
66a622)
- fix(report-ui): fix language and onHover Tooltip alignment (#961) (
094d47)
- fix(proxy): bridge codex compaction triggers (#977) (
bf1ded)
- feat(dashboard-ui): Multiple dashboard changes (#973) (
fc0064)
- feat(ui): polish proxy and account dashboard UX (#937) (
522cae)
- fix: normalize responses instruction messages (#950) (
603c79)
- fix(accounts): preserve shared workspace account slots (#974) (
dd4436)
- fix(report): Multiple fixes and enhances on report (#990) (
776dfa)
- fix(proxy): keep streams alive while account capacity recovers (#1000) (
8d8061)
- feat(proxy): add SOCKS4/SOCKS5 outbound proxy support via env vars (#1008) (
c8fcc6)
- feat(dashboard-auth): add read-only guest access (#703) (
1f02ec)
- fix(proxy): keep local usage snapshots advisory (#1030) (
ceb671)

## Release-candidate validation
Validated candidate: bd6695a7b33dc6814dece7fe8cf6829af7ae2b4f

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [ ] Backend/unit/integration gates
- [ ] Frontend tests/build
- [ ] Wheel/package validation
- [ ] Docker/container smoke
- [ ] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==1.20.0b3" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.20.0-beta.3
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.20.0-beta.3 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.20.0.
