### PR TITLE
fix(proxy): keep local usage snapshots advisory

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -580,24 +580,15 @@ def select_account(
         return _planner_cost(state, routing_costs), state.last_selected_at or 0.0, state.account_id
 
     if routing_strategy == "single_account":
-        candidate_pool = [state for state in available if not _usage_exhausted(state)]
-        if not candidate_pool:
-            return SelectionResult(None, "Selected account is exhausted or unavailable")
-        selected = min(candidate_pool, key=lambda state: state.account_id)
+        selected = min(available, key=lambda state: state.account_id)
         return SelectionResult(selected, None)
 
     if routing_strategy == "sequential_drain":
-        candidate_pool = [state for state in available if not _usage_exhausted(state)]
-        if not candidate_pool:
-            return SelectionResult(None, "No available accounts")
-        selected = min(candidate_pool, key=_sequential_drain_sort_key)
+        selected = min(available, key=_sequential_drain_sort_key)
         return SelectionResult(selected, None)
 
     if routing_strategy == "reset_drain":
-        candidate_pool = [state for state in available if not _usage_exhausted(state)]
-        if not candidate_pool:
-            return SelectionResult(None, "No available accounts")
-        selected = min(candidate_pool, key=lambda state: _reset_drain_sort_key(state, current))
+        selected = min(available, key=lambda state: _reset_drain_sort_key(state, current))
         return SelectionResult(selected, None)
 
     healthy = [s for s in available if s.health_tier == HEALTH_TIER_HEALTHY]
@@ -879,12 +870,6 @@ def _configured_capacity_credits(state: AccountState) -> float:
     if state.capacity_credits is not None and state.capacity_credits > 0:
         return state.capacity_credits
     return _fallback_secondary_capacity_credits(state.plan_type)
-
-
-def _usage_exhausted(state: AccountState) -> bool:
-    primary_used = state.used_percent if state.used_percent is not None else 0.0
-    secondary_used = state.secondary_used_percent if state.secondary_used_percent is not None else primary_used
-    return primary_used >= 100.0 or secondary_used >= 100.0
 
 
 def _sequential_drain_sort_key(state: AccountState) -> tuple[float, str, str]:

--- a/app/core/usage/quota.py
+++ b/app/core/usage/quota.py
@@ -39,18 +39,18 @@ def apply_usage_quota(
                     reset_at = None
             else:
                 used_percent = 100.0
-                if infer_status_from_usage or status == AccountStatus.QUOTA_EXCEEDED:
+                if infer_status_from_usage:
                     if secondary_reset is not None:
                         reset_at = secondary_reset
                     status = AccountStatus.QUOTA_EXCEEDED
                     return status, used_percent, reset_at
-        elif status == AccountStatus.QUOTA_EXCEEDED:
+        if status == AccountStatus.QUOTA_EXCEEDED:
             if runtime_reset and runtime_reset > time.time():
                 reset_at = runtime_reset
             else:
                 status = AccountStatus.ACTIVE
                 reset_at = None
-    elif status == AccountStatus.QUOTA_EXCEEDED and secondary_reset is not None:
+    elif status == AccountStatus.QUOTA_EXCEEDED and secondary_reset is not None and infer_status_from_usage:
         reset_at = secondary_reset
 
     if has_credit_override and status == AccountStatus.QUOTA_EXCEEDED:
@@ -62,7 +62,7 @@ def apply_usage_quota(
     if primary_used is not None:
         if primary_used >= 100.0:
             used_percent = 100.0
-            if infer_status_from_usage or status == AccountStatus.RATE_LIMITED:
+            if infer_status_from_usage:
                 if primary_reset is not None:
                     reset_at = primary_reset
                 else:

--- a/app/core/usage/quota.py
+++ b/app/core/usage/quota.py
@@ -39,9 +39,9 @@ def apply_usage_quota(
                     reset_at = None
             else:
                 used_percent = 100.0
-                if secondary_reset is not None:
-                    reset_at = secondary_reset
                 if infer_status_from_usage or status == AccountStatus.QUOTA_EXCEEDED:
+                    if secondary_reset is not None:
+                        reset_at = secondary_reset
                     status = AccountStatus.QUOTA_EXCEEDED
                     return status, used_percent, reset_at
         elif status == AccountStatus.QUOTA_EXCEEDED:
@@ -62,11 +62,11 @@ def apply_usage_quota(
     if primary_used is not None:
         if primary_used >= 100.0:
             used_percent = 100.0
-            if primary_reset is not None:
-                reset_at = primary_reset
-            else:
-                reset_at = _fallback_primary_reset(primary_window_minutes) or reset_at
             if infer_status_from_usage or status == AccountStatus.RATE_LIMITED:
+                if primary_reset is not None:
+                    reset_at = primary_reset
+                else:
+                    reset_at = _fallback_primary_reset(primary_window_minutes) or reset_at
                 status = AccountStatus.RATE_LIMITED
                 return status, used_percent, reset_at
         if status == AccountStatus.RATE_LIMITED:

--- a/app/core/usage/quota.py
+++ b/app/core/usage/quota.py
@@ -18,6 +18,7 @@ def apply_usage_quota(
     credits_has: bool | None = None,
     credits_unlimited: bool | None = None,
     credits_balance: float | None = None,
+    infer_status_from_usage: bool = True,
 ) -> tuple[AccountStatus, float | None, float | None]:
     used_percent = primary_used
     reset_at = runtime_reset
@@ -37,11 +38,12 @@ def apply_usage_quota(
                     status = AccountStatus.ACTIVE
                     reset_at = None
             else:
-                status = AccountStatus.QUOTA_EXCEEDED
                 used_percent = 100.0
                 if secondary_reset is not None:
                     reset_at = secondary_reset
-                return status, used_percent, reset_at
+                if infer_status_from_usage or status == AccountStatus.QUOTA_EXCEEDED:
+                    status = AccountStatus.QUOTA_EXCEEDED
+                    return status, used_percent, reset_at
         elif status == AccountStatus.QUOTA_EXCEEDED:
             if runtime_reset and runtime_reset > time.time():
                 reset_at = runtime_reset
@@ -59,13 +61,14 @@ def apply_usage_quota(
 
     if primary_used is not None:
         if primary_used >= 100.0:
-            status = AccountStatus.RATE_LIMITED
             used_percent = 100.0
             if primary_reset is not None:
                 reset_at = primary_reset
             else:
                 reset_at = _fallback_primary_reset(primary_window_minutes) or reset_at
-            return status, used_percent, reset_at
+            if infer_status_from_usage or status == AccountStatus.RATE_LIMITED:
+                status = AccountStatus.RATE_LIMITED
+                return status, used_percent, reset_at
         if status == AccountStatus.RATE_LIMITED:
             if runtime_reset and runtime_reset > time.time():
                 reset_at = runtime_reset

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1941,6 +1941,7 @@ def _state_from_account(
         credits_has=credits_has,
         credits_unlimited=credits_unlimited,
         credits_balance=credits_balance,
+        infer_status_from_usage=False,
     )
 
     if status == AccountStatus.QUOTA_EXCEEDED:

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1881,7 +1881,10 @@ def _state_from_account(
     db_reset_at = (
         None if ignore_zero_capacity_primary_runtime_reset else (float(account.reset_at) if account.reset_at else None)
     )
-    effective_runtime_reset = db_reset_at or runtime.reset_at
+    if status_seed in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED) or runtime.blocked_at is not None:
+        effective_runtime_reset = db_reset_at or runtime.reset_at
+    else:
+        effective_runtime_reset = None
     effective_blocked_at = float(account.blocked_at) if account.blocked_at is not None else runtime.blocked_at
 
     if (

--- a/openspec/changes/account-scoped-upstream-admission/context.md
+++ b/openspec/changes/account-scoped-upstream-admission/context.md
@@ -1,0 +1,8 @@
+# Context
+
+The proxy should maintain a hard distinction between upstream-account state and local advisory data:
+
+- Upstream/account state: statuses produced by selected-account upstream responses, authentication state, explicit operator account pause/deactivation, and account-local concurrency caps
+- Advisory local data: usage snapshots, synthetic planner costs, budget pressure, and dashboard estimates
+
+Foreground user traffic should fail open toward upstream unless blocked by upstream-proven account state, authentication/operator state, explicit API-key policy, or local capacity. Opportunistic/synthetic traffic may remain more conservative because it is an explicit local burn policy rather than a normal user request path.

--- a/openspec/changes/account-scoped-upstream-admission/proposal.md
+++ b/openspec/changes/account-scoped-upstream-admission/proposal.md
@@ -1,0 +1,27 @@
+# Change: account-scoped upstream admission
+
+## Problem
+
+codex-lb can currently turn local usage snapshots and synthetic quota estimates into account unavailability before a request reaches upstream. That makes local dashboards or planner data act as an upstream availability oracle, causing `no_accounts` / retry-hint failures even when the upstream account might still accept real traffic.
+
+The proxy should only fail closed before upstream for explicit local policy or local capacity guards. Upstream rate/quota failures should remain account-scoped because Codex/OpenAI exposes account credentials as the authoritative blast boundary here; local model/transport/request-kind dimensions are diagnostic metadata, not upstream policy dimensions.
+
+## Solution
+
+- Keep account status gates authoritative only for persisted upstream/account states and explicit local capacity guards
+- Treat usage snapshots as routing pressure, ordering, and operator visibility data, not a hard pre-upstream block for foreground traffic
+- Keep local account response-create/stream caps as explicit local overload reasons
+- Preserve opportunistic burn safeguards as explicitly local policy, separate from normal foreground proxy routing
+
+## Changes
+
+- Add account-routing requirements that foreground selection MUST NOT reject solely because local standard usage is at or above 100 percent
+- Add account-routing requirements that upstream 429/quota penalties are account-scoped by default unless upstream evidence proves a narrower scope
+- Add regression coverage for active accounts with exhausted local usage snapshots remaining selectable
+
+## Out of scope
+
+- Changing explicit API-key spend/concurrency limits
+- Removing account-local response-create/stream caps
+- Introducing model- or transport-scoped upstream cooldowns
+- Production rollout

--- a/openspec/changes/account-scoped-upstream-admission/specs/account-routing/spec.md
+++ b/openspec/changes/account-scoped-upstream-admission/specs/account-routing/spec.md
@@ -20,6 +20,14 @@ Foreground proxy account selection MUST NOT reject an otherwise active account s
 - **THEN** the account remains eligible for upstream routing
 - **AND** the local secondary usage snapshot is not promoted into a persisted upstream quota-exceeded state before an upstream response proves quota exhaustion
 
+#### Scenario: Advisory usage reset is not persisted as an account block
+
+- **GIVEN** an upstream account is persisted as active
+- **AND** its latest local usage snapshot reports 100 percent usage with a future reset
+- **WHEN** foreground account selection evaluates and persists selection state for the active account
+- **THEN** the account-level blocking reset remains unset
+- **AND** a later upstream rate-limit response without reset metadata is governed by upstream retry/backoff cooldown rather than the advisory usage reset
+
 ### Requirement: Upstream rate and quota penalties are account-scoped by default
 
 When upstream returns rate-limit or quota-exhaustion evidence for a selected account, the proxy MUST apply that penalty to the selected upstream account identity. The proxy MUST NOT invent model-scoped, transport-scoped, or request-kind-scoped upstream cooldown semantics unless upstream documentation or captured upstream response metadata proves that narrower upstream scope.

--- a/openspec/changes/account-scoped-upstream-admission/specs/account-routing/spec.md
+++ b/openspec/changes/account-scoped-upstream-admission/specs/account-routing/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Foreground routing treats local usage snapshots as non-authoritative
+
+Foreground proxy account selection MUST NOT reject an otherwise active account solely because local standard usage snapshots, synthetic planner costs, or inferred budget pressure report that the account has reached or exceeded 100 percent usage. Such local usage data MAY influence ranking, health/drain decisions, opportunistic burn policy, dashboards, and diagnostics, but it MUST NOT be reported as upstream rate limiting and MUST NOT produce `no_accounts` before an upstream attempt when no explicit local policy or local capacity guard is exhausted.
+
+#### Scenario: Active account at local primary usage exhaustion is still selectable
+
+- **GIVEN** an upstream account is persisted as active
+- **AND** its latest local primary usage snapshot reports 100 percent usage with a future reset
+- **WHEN** foreground account selection evaluates the account
+- **THEN** the account remains eligible for upstream routing
+- **AND** the selection result does not report a local `Rate limit exceeded` or `no_accounts` failure
+
+#### Scenario: Active account at local secondary usage exhaustion is still selectable
+
+- **GIVEN** an upstream account is persisted as active
+- **AND** its latest local secondary usage snapshot reports 100 percent usage with a future reset
+- **WHEN** foreground account selection evaluates the account
+- **THEN** the account remains eligible for upstream routing
+- **AND** the local secondary usage snapshot is not promoted into a persisted upstream quota-exceeded state before an upstream response proves quota exhaustion
+
+### Requirement: Upstream rate and quota penalties are account-scoped by default
+
+When upstream returns rate-limit or quota-exhaustion evidence for a selected account, the proxy MUST apply that penalty to the selected upstream account identity. The proxy MUST NOT invent model-scoped, transport-scoped, or request-kind-scoped upstream cooldown semantics unless upstream documentation or captured upstream response metadata proves that narrower upstream scope.
+
+#### Scenario: Upstream 429 marks only the selected account
+
+- **GIVEN** account A is selected for a request
+- **AND** upstream returns a rate-limit response for that request
+- **WHEN** the proxy records the penalty
+- **THEN** it marks account A as rate-limited or cooling down
+- **AND** it does not create model-scoped or transport-scoped upstream cooldown buckets without upstream evidence

--- a/openspec/changes/account-scoped-upstream-admission/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/account-scoped-upstream-admission/specs/proxy-admission-control/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Local overload reasons are stable and distinguishable
+
+Local Responses overload failures MUST expose stable low-cardinality reason fields in logs and metrics so operators can distinguish `bridge_queue_full`, `response_create_gate_timeout`, `hard_affinity_saturated`, `previous_response_owner_unavailable`, `global_admission_timeout`, `capacity_exhausted_active_sessions`, `account_response_create_cap`, and `account_stream_cap`. These local reasons MUST NOT be reported as upstream rate limits. Local usage snapshots and synthetic budget pressure MUST NOT be converted into local overload unless an explicit operator-configured local admission policy is exhausted.
+
+#### Scenario: Bridge queue saturation is not ambiguous
+
+- **WHEN** a local HTTP bridge queue rejects a request
+- **THEN** logs and metrics use the stable reason `bridge_queue_full`
+- **AND** they do not use the ambiguous alias `queue_full`
+
+#### Scenario: Account cap rejection is local overload
+
+- **WHEN** every eligible account is unavailable because of account-local caps
+- **THEN** the HTTP response is a local overload response with `Retry-After`
+- **AND** logs and metrics identify `account_response_create_cap` or `account_stream_cap`
+
+#### Scenario: Usage snapshot exhaustion is not local overload
+
+- **GIVEN** at least one account is active and below explicit local concurrency caps
+- **AND** local usage snapshots report exhausted standard budget
+- **WHEN** foreground proxy routing evaluates the request
+- **THEN** the request is not rejected as local overload solely because of those snapshots

--- a/openspec/changes/account-scoped-upstream-admission/tasks.md
+++ b/openspec/changes/account-scoped-upstream-admission/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Update account-routing spec for account-scoped upstream penalties and non-authoritative local usage snapshots
+- [x] Add RED tests proving foreground routing still selects active accounts whose local usage snapshot is exhausted
+- [x] Implement selection/status changes so local usage snapshots do not synthesize upstream unavailability
+- [x] Preserve explicit local cap behavior and local overload error codes
+- [x] Run targeted tests and OpenSpec validation

--- a/tests/integration/test_load_balancer_integration.py
+++ b/tests/integration/test_load_balancer_integration.py
@@ -37,7 +37,7 @@ async def _repo_factory() -> AsyncIterator[ProxyRepositories]:
 
 
 @pytest.mark.asyncio
-async def test_load_balancer_skips_secondary_quota(db_setup):
+async def test_load_balancer_deprioritizes_secondary_usage_without_persisting_quota_exceeded(db_setup):
     encryptor = TokenEncryptor()
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
@@ -111,7 +111,7 @@ async def test_load_balancer_skips_secondary_quota(db_setup):
         refreshed = await session.get(Account, account_a.id)
         assert refreshed is not None
         await session.refresh(refreshed)
-        assert refreshed.status == AccountStatus.QUOTA_EXCEEDED
+        assert refreshed.status == AccountStatus.ACTIVE
 
 
 @pytest.mark.asyncio
@@ -167,7 +167,7 @@ async def test_load_balancer_reactivates_after_secondary_reset(db_setup):
 
 
 @pytest.mark.asyncio
-async def test_load_balancer_treats_weekly_only_primary_as_quota_window(db_setup):
+async def test_load_balancer_treats_weekly_only_primary_as_advisory_quota_window(db_setup):
     encryptor = TokenEncryptor()
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
@@ -235,7 +235,7 @@ async def test_load_balancer_treats_weekly_only_primary_as_quota_window(db_setup
         refreshed_free = await session.get(Account, free_account.id)
         assert refreshed_free is not None
         await session.refresh(refreshed_free)
-        assert refreshed_free.status == AccountStatus.QUOTA_EXCEEDED
+        assert refreshed_free.status == AccountStatus.ACTIVE
 
 
 @pytest.mark.asyncio
@@ -354,7 +354,7 @@ async def test_load_balancer_prefers_newer_weekly_primary_over_stale_secondary(d
         refreshed_free = await session.get(Account, free_account.id)
         assert refreshed_free is not None
         await session.refresh(refreshed_free)
-        assert refreshed_free.status == AccountStatus.QUOTA_EXCEEDED
+        assert refreshed_free.status == AccountStatus.ACTIVE
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1461,7 +1461,8 @@ def test_state_from_account_keeps_active_account_selectable_when_primary_usage_s
 
     assert state.status == AccountStatus.ACTIVE
     assert state.used_percent == 100.0
-    assert state.reset_at == future_reset
+    assert state.reset_at is None
+    assert state.primary_reset_at == future_reset
     selection = select_account([state], routing_strategy="single_account")
     assert selection.account is not None
     assert selection.account.account_id == state.account_id
@@ -1488,6 +1489,7 @@ def test_state_from_account_keeps_active_account_selectable_when_secondary_usage
     )
 
     assert state.status == AccountStatus.ACTIVE
+    assert state.reset_at is None
     assert state.secondary_used_percent == 100.0
     assert state.secondary_reset_at == future_reset
     selection = select_account([state], routing_strategy="single_account")
@@ -1558,6 +1560,7 @@ def test_state_from_account_treats_monthly_usage_as_advisory_long_window_pressur
     )
 
     assert state.status == AccountStatus.ACTIVE
+    assert state.reset_at is None
     assert state.secondary_used_percent == 100.0
     assert state.secondary_reset_at == future_reset
     assert state.capacity_credits == usage_core.capacity_for_plan("free", "monthly")

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1499,6 +1499,34 @@ def test_state_from_account_clears_stale_advisory_account_reset_for_active_accou
     assert now + 0.18 <= state.cooldown_until <= now + 0.22
 
 
+def test_state_from_account_uses_runtime_cooldown_not_advisory_reset_after_resetless_rate_limit(
+    monkeypatch,
+):
+    now = 1_700_000_000.0
+    future_reset = int(now + 300)
+    cooldown_until = now + 0.2
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.RATE_LIMITED, reset_at=None),
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=100.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+        ),
+        secondary_entry=None,
+        runtime=RuntimeState(cooldown_until=cooldown_until, blocked_at=now - 1),
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent == 100.0
+    assert state.reset_at is None
+    assert state.primary_reset_at == future_reset
+    assert state.cooldown_until == cooldown_until
+
+
 def test_state_from_account_keeps_active_account_selectable_when_secondary_usage_snapshot_is_exhausted(
     monkeypatch,
 ):

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1468,6 +1468,37 @@ def test_state_from_account_keeps_active_account_selectable_when_primary_usage_s
     assert selection.account.account_id == state.account_id
 
 
+def test_state_from_account_clears_stale_advisory_account_reset_for_active_account(monkeypatch):
+    now = 1_700_000_000.0
+    future_reset = int(now + 300)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE, reset_at=future_reset),
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=100.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+        ),
+        secondary_entry=None,
+        runtime=RuntimeState(reset_at=future_reset),
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent == 100.0
+    assert state.reset_at is None
+    assert state.primary_reset_at == future_reset
+
+    handle_rate_limit(state, {"message": "rate limit"})
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.reset_at is None
+    assert state.cooldown_until is not None
+    assert now + 0.18 <= state.cooldown_until <= now + 0.22
+
+
 def test_state_from_account_keeps_active_account_selectable_when_secondary_usage_snapshot_is_exhausted(
     monkeypatch,
 ):

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -621,13 +621,13 @@ def test_select_account_single_account_returns_selected_candidate():
     assert result.account.account_id == "selected"
 
 
-def test_select_account_single_account_rejects_exhausted_candidate():
+def test_select_account_single_account_uses_active_candidate_even_if_local_usage_exhausted():
     states = [
         AccountState("selected", AccountStatus.ACTIVE, used_percent=100.0, secondary_used_percent=20.0),
     ]
     result = select_account(states, routing_strategy="single_account")
-    assert result.account is None
-    assert result.error_message == "Selected account is exhausted or unavailable"
+    assert result.account is not None
+    assert result.account.account_id == "selected"
 
 
 def test_select_account_sequential_drain_uses_lowest_capacity_first_until_exhausted():
@@ -647,7 +647,7 @@ def test_select_account_sequential_drain_uses_lowest_capacity_first_until_exhaus
     assert result.account.account_id == "free"
 
 
-def test_select_account_sequential_drain_skips_exhausted_lowest_capacity_account():
+def test_select_account_sequential_drain_keeps_lowest_capacity_active_candidate_when_local_usage_exhausted():
     states = [
         AccountState(
             "free", AccountStatus.ACTIVE, used_percent=100.0, secondary_used_percent=99.0, capacity_credits=1_134.0
@@ -661,7 +661,7 @@ def test_select_account_sequential_drain_skips_exhausted_lowest_capacity_account
     ]
     result = select_account(states, routing_strategy="sequential_drain")
     assert result.account is not None
-    assert result.account.account_id == "plus"
+    assert result.account.account_id == "free"
 
 
 def test_select_account_sequential_drain_does_not_switch_on_draining_health_tier():
@@ -1439,6 +1439,62 @@ def _epoch_to_naive_utc(epoch: float) -> datetime:
     return datetime.fromtimestamp(epoch, timezone.utc).replace(tzinfo=None)
 
 
+def test_state_from_account_keeps_active_account_selectable_when_primary_usage_snapshot_is_exhausted(
+    monkeypatch,
+):
+    now = 1_700_000_000.0
+    future_reset = int(now + 300)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE),
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=100.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+        ),
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+    assert state.used_percent == 100.0
+    assert state.reset_at == future_reset
+    selection = select_account([state], routing_strategy="single_account")
+    assert selection.account is not None
+    assert selection.account.account_id == state.account_id
+
+
+def test_state_from_account_keeps_active_account_selectable_when_secondary_usage_snapshot_is_exhausted(
+    monkeypatch,
+):
+    now = 1_700_000_000.0
+    future_reset = int(now + 7 * 24 * 3600)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE),
+        primary_entry=None,
+        secondary_entry=_make_test_usage(
+            window="secondary",
+            used_percent=100.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+        ),
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+    assert state.secondary_used_percent == 100.0
+    assert state.secondary_reset_at == future_reset
+    selection = select_account([state], routing_strategy="single_account")
+    assert selection.account is not None
+    assert selection.account.account_id == state.account_id
+
+
 def test_state_from_account_zeroes_stale_exhausted_primary_usage_after_reset(monkeypatch):
     now = 1_700_000_000.0
     monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
@@ -1482,7 +1538,7 @@ def test_state_from_account_zeroes_stale_exhausted_secondary_usage_after_reset(m
     assert state.secondary_reset_at is None
 
 
-def test_state_from_account_treats_monthly_usage_as_long_window_quota(monkeypatch):
+def test_state_from_account_treats_monthly_usage_as_advisory_long_window_pressure(monkeypatch):
     now = 1_700_000_000.0
     future_reset = int(now + 30 * 24 * 3600)
     monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
@@ -1501,7 +1557,7 @@ def test_state_from_account_treats_monthly_usage_as_long_window_quota(monkeypatc
         runtime=RuntimeState(),
     )
 
-    assert state.status == AccountStatus.QUOTA_EXCEEDED
+    assert state.status == AccountStatus.ACTIVE
     assert state.secondary_used_percent == 100.0
     assert state.secondary_reset_at == future_reset
     assert state.capacity_credits == usage_core.capacity_for_plan("free", "monthly")

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -2684,7 +2684,9 @@ async def test_select_account_allows_plus_plan_without_additional_quota_rows(mon
 
 
 @pytest.mark.asyncio
-async def test_select_account_keeps_standard_quota_for_plus_gated_model_without_additional_rows(monkeypatch) -> None:
+async def test_select_account_treats_standard_quota_as_advisory_for_plus_gated_model_without_additional_rows(
+    monkeypatch,
+) -> None:
     account = _make_account("acc-plus-standard-exhausted", "plus-standard-exhausted@example.com")
     now = utcnow()
     now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
@@ -2717,7 +2719,8 @@ async def test_select_account_keeps_standard_quota_for_plus_gated_model_without_
     )
     selection = await balancer.select_account(model="gpt-5.3-codex-spark")
 
-    assert selection.account is None
+    assert selection.account is not None
+    assert selection.account.id == account.id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -563,7 +563,7 @@ async def test_reconcile_recoverable_account_statuses_restores_quota_exceeded_fr
 
 
 @pytest.mark.asyncio
-async def test_reconcile_recoverable_account_statuses_recovers_quota_exceeded_when_only_primary_snapshot_is_exhausted(
+async def test_reconcile_recoverable_account_statuses_recovers_quota_exceeded_and_clears_advisory_primary_reset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     now = 1_700_000_000.0
@@ -612,7 +612,7 @@ async def test_reconcile_recoverable_account_statuses_recovers_quota_exceeded_wh
 
     assert recovered == 1
     assert account.status == AccountStatus.ACTIVE
-    assert account.reset_at == primary_reset
+    assert account.reset_at is None
     assert account.blocked_at is None
     assert len(accounts_repo.status_updates) == 1
 

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -563,7 +563,7 @@ async def test_reconcile_recoverable_account_statuses_restores_quota_exceeded_fr
 
 
 @pytest.mark.asyncio
-async def test_reconcile_recoverable_account_statuses_does_not_demote_quota_exceeded_to_rate_limited(
+async def test_reconcile_recoverable_account_statuses_recovers_quota_exceeded_when_only_primary_snapshot_is_exhausted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     now = 1_700_000_000.0
@@ -610,11 +610,11 @@ async def test_reconcile_recoverable_account_statuses_does_not_demote_quota_exce
         accounts=[account],
     )
 
-    assert recovered == 0
-    assert account.status == AccountStatus.QUOTA_EXCEEDED
-    assert account.reset_at == secondary_reset
-    assert account.blocked_at == blocked_at
-    assert accounts_repo.status_updates == []
+    assert recovered == 1
+    assert account.status == AccountStatus.ACTIVE
+    assert account.reset_at == primary_reset
+    assert account.blocked_at is None
+    assert len(accounts_repo.status_updates) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Treat foreground local usage snapshots as advisory pressure instead of upstream availability gates
- Keep active accounts selectable when local primary or secondary usage snapshots report 100% usage
- Preserve persisted upstream/account states and explicit local capacity guards as hard admission gates
- Add OpenSpec deltas for account-scoped upstream penalties and local admission boundaries

## Validation

- `uv run pytest tests/unit/test_load_balancer.py tests/unit/test_proxy_load_balancer_refresh.py tests/unit/test_usage_refresh_scheduler_recovery.py tests/integration/test_load_balancer_integration.py -q` → 258 passed, 3 skipped
- `uvx ruff check .` → All checks passed
- `uvx ruff format --check .` → 634 files already formatted
- `uv run ty check` → All checks passed
- `openspec validate account-scoped-upstream-admission --strict` → valid
- `openspec validate --specs` → 30 passed, 0 failed

## Notes

This keeps synthetic usage/planner data available for ranking, diagnostics, and dashboards, but prevents it from producing foreground `no_accounts` before an upstream attempt unless an explicit local policy or capacity guard is actually exhausted.
