### PR TITLE
test(ci): isolate beta release guard env

### DIFF
--- a/tests/unit/test_guard_beta_release.py
+++ b/tests/unit/test_guard_beta_release.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -93,9 +94,21 @@ Validated candidate: {sha}
 
 
 def run_guard(project_root: Path, repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    github_env_keys = (
+        "BETA_RELEASE_PR_BODY",
+        "GITHUB_EVENT_NAME",
+        "GITHUB_EVENT_PATH",
+        "GITHUB_HEAD_REF",
+        "GITHUB_REPOSITORY",
+    )
+    for key in github_env_keys:
+        env.pop(key, None)
+
     return subprocess.run(
         [sys.executable, "-m", "scripts.guard_beta_release", "--root", str(repo_root), *args],
         cwd=project_root,
+        env=env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- Isolate `tests/unit/test_guard_beta_release.py` subprocess runs from ambient GitHub Actions env vars
- Prevent `GITHUB_EVENT_NAME` / `GITHUB_EVENT_PATH` inherited from the CI runner from turning local fallback guard cases into a GitHub push-event no-op

## Root cause
The failing unit test intentionally runs `scripts.guard_beta_release` without an event payload so it can exercise the explicit `--base-ref` / `--head-ref` fallback path. On GitHub Actions, the subprocess inherited `GITHUB_EVENT_NAME=push` and `GITHUB_EVENT_PATH`, so the guard loaded the workflow event, found no `pull_request`, printed `No pull_request payload; beta release PR guard is a no-op for this event.`, and skipped the assertion path.

## Test Plan
- `GITHUB_EVENT_NAME=push GITHUB_EVENT_PATH=/tmp/nonexistent-event uv run pytest -q tests/unit/test_guard_beta_release.py`
- `make test-unit`
- `uvx ruff check . && uvx ruff format --check .`
- `uv run ty check`
- `openspec validate --specs`
