### PR TITLE
fix(quota-planner): normalize decision datetimes for persistence

### DIFF
--- a/app/modules/quota_planner/repository.py
+++ b/app/modules/quota_planner/repository.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from sqlalchemy import Integer, and_, cast, func, literal, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.utils.time import utcnow
+from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import (
     Account,
     QuotaPlannerDecision,
@@ -19,6 +19,21 @@ from app.db.session import sqlite_writer_section
 from app.modules.quota_planner.logic import PlannerSettings, encode_working_days, parse_working_days
 
 _SETTINGS_ID = 1
+
+
+def _to_db_naive_utc(value: datetime | None) -> datetime | None:
+    """Normalize a decision datetime for the timezone-naive DB columns.
+
+    ``QuotaPlannerDecision.scheduled_at`` / ``executed_at`` are timezone-naive
+    ``DateTime`` columns. Persisting timezone-aware instants into them fails on
+    Postgres/asyncpg ("can't subtract offset-naive and offset-aware datetimes").
+    Aware values are converted to UTC and stripped of ``tzinfo`` so the absolute
+    instant is preserved; naive values are returned unchanged.
+    """
+
+    if value is None:
+        return None
+    return to_utc_naive(value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -100,8 +115,8 @@ class QuotaPlannerRepository:
             mode=mode,
             action=action,
             account_id=account_id,
-            scheduled_at=scheduled_at,
-            executed_at=executed_at,
+            scheduled_at=_to_db_naive_utc(scheduled_at),
+            executed_at=_to_db_naive_utc(executed_at),
             score=score,
             reason=reason,
             forecast_snapshot_hash=forecast_snapshot_hash,
@@ -138,7 +153,7 @@ class QuotaPlannerRepository:
         if reason is not None:
             values["reason"] = reason
         if executed_at is not None:
-            values["executed_at"] = executed_at
+            values["executed_at"] = _to_db_naive_utc(executed_at)
         if state_after_json is not None:
             values["state_after_json"] = state_after_json
         stmt = update(QuotaPlannerDecision).where(QuotaPlannerDecision.id == decision_id).values(**values)

--- a/openspec/changes/fix-quota-planner-db-datetimes/proposal.md
+++ b/openspec/changes/fix-quota-planner-db-datetimes/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+After deploying codex-lb 1.20.0-beta.3 to a Postgres-backed host (10.0.0.113),
+the quota planner tick fails with:
+
+```
+Quota planner tick failed
+TypeError: can't subtract offset-naive and offset-aware datetimes
+```
+
+The quota phase scheduler plans actions with timezone-aware UTC datetimes
+(`datetime.now(timezone.utc)` and aware `scheduled_at` / `target_peak_at`), then
+persists those aware values into the timezone-naive SQLAlchemy `DateTime`
+columns `QuotaPlannerDecision.scheduled_at` and `QuotaPlannerDecision.executed_at`.
+asyncpg/Postgres rejects mixing offset-aware and offset-naive datetimes on those
+naive columns, so the planner loop raises and every tick is logged as failed.
+
+SQLite silently stores the aware value, which is why the bug only surfaced in
+production on Postgres.
+
+## What Changes
+
+- Normalize timezone-aware datetimes to naive UTC before they are written to the
+  timezone-naive `QuotaPlannerDecision.scheduled_at` and `executed_at` columns,
+  in both the insert path (`log_decision`) and the update path
+  (`update_decision_status`).
+- Preserve naive inputs unchanged so existing callers keep working.
+- Keep externally visible JSON audit snapshots (e.g. `target_peak_at`,
+  `scheduled_at` inside `state_before_json`) as ISO strings with timezone
+  offsets; this fix only sanitizes the DB-bound column values, not audit JSON.
+- Add regression coverage proving the repository sanitizes aware values before
+  persistence, guarding the Postgres path that failed in production.
+
+## Impact
+
+- Restores quota planner ticks on Postgres deployments.
+- Aligns quota planner persistence with the repository-wide convention of
+  storing naive UTC in `DateTime` columns (see `app/core/utils/time.py`).
+- No schema migration: columns remain timezone-naive `DateTime`; only the
+  values bound to them are normalized.

--- a/openspec/changes/fix-quota-planner-db-datetimes/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/fix-quota-planner-db-datetimes/specs/quota-phase-planner/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Quota planner decisions persist naive UTC instants
+
+The quota phase planner SHALL normalize timezone-aware datetimes to naive UTC
+before persisting them to the timezone-naive `QuotaPlannerDecision.scheduled_at`
+and `executed_at` columns. When a planned or executed instant is timezone-aware,
+the persisted column value MUST equal that instant converted to UTC with its
+`tzinfo` removed, preserving the absolute instant. Naive datetimes MUST be
+persisted unchanged. JSON audit snapshots MAY continue to record the same
+instants as ISO-8601 strings that include a timezone offset.
+
+#### Scenario: Aware planned instant is stored as naive UTC
+
+- **GIVEN** the scheduler logs a decision with a timezone-aware UTC
+  `scheduled_at`
+- **WHEN** the repository persists the decision row
+- **THEN** the stored `scheduled_at` is timezone-naive
+- **AND** it equals the original instant expressed in UTC
+
+#### Scenario: Aware executed instant is stored as naive UTC on update
+
+- **GIVEN** a decision is updated with a timezone-aware UTC `executed_at`
+- **WHEN** the repository writes the status update
+- **THEN** the stored `executed_at` is timezone-naive
+- **AND** it equals the original instant expressed in UTC
+
+#### Scenario: Naive instants persist unchanged
+
+- **GIVEN** a decision is logged or updated with a timezone-naive datetime
+- **WHEN** the repository persists the value
+- **THEN** the stored value is unchanged and remains timezone-naive

--- a/openspec/changes/fix-quota-planner-db-datetimes/tasks.md
+++ b/openspec/changes/fix-quota-planner-db-datetimes/tasks.md
@@ -1,0 +1,11 @@
+- [x] Add an OpenSpec requirement that the quota phase planner MUST normalize
+  timezone-aware instants to naive UTC before persisting them to the
+  timezone-naive `QuotaPlannerDecision.scheduled_at` / `executed_at` columns,
+  while JSON audit snapshots may keep ISO offset strings.
+- [x] Add a RED regression test asserting `QuotaPlannerRepository.log_decision`
+  and `update_decision_status` sanitize aware `scheduled_at` / `executed_at`
+  into naive UTC while preserving the instant.
+- [x] Normalize aware datetimes to naive UTC in the repository insert and update
+  paths via a small explicit helper; leave naive inputs unchanged.
+- [x] Run focused quota planner unit and integration tests.
+- [x] Run OpenSpec strict validation for this change.

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -105,6 +106,105 @@ async def test_quota_planner_decisions_api_returns_recent_decisions(async_client
     assert by_key["test-decision-new"]["reason"] == "new"
     assert by_key["test-decision-new"]["details"]["target_peak_at"] == "2026-05-18T13:00:00+00:00"
     assert by_key["test-decision-new"]["details"]["warmup_cycle"] == "20260518:warmup_cycle:1"
+
+
+@pytest.mark.asyncio
+async def test_quota_planner_repository_persists_naive_utc_decision_datetimes(monkeypatch, db_setup):
+    del db_setup
+    aware_scheduled = datetime(2026, 5, 18, 13, 0, tzinfo=timezone.utc)
+    aware_executed = datetime(2026, 5, 18, 13, 30, tzinfo=timezone.utc)
+
+    # SQLite's aiosqlite driver silently strips tzinfo on read, so we inspect the
+    # exact values the repository binds to the timezone-naive columns. asyncpg/Postgres
+    # raises "can't subtract offset-naive and offset-aware datetimes" if these are aware,
+    # so the repository MUST sanitize them before persistence.
+    bound_scheduled: list[object] = []
+    original_add = AsyncSession.add
+
+    def capture_add(self, instance, *args, **kwargs):
+        if isinstance(instance, QuotaPlannerDecision):
+            bound_scheduled.append(instance.scheduled_at)
+        return original_add(self, instance, *args, **kwargs)
+
+    monkeypatch.setattr(AsyncSession, "add", capture_add)
+
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        decision = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="aware-datetime-persistence",
+            account_id=None,
+            scheduled_at=aware_scheduled,
+            score=1.0,
+            reason="aware",
+            status="planned",
+        )
+
+    assert bound_scheduled, "log_decision should construct a decision row"
+    bound_value = bound_scheduled[-1]
+    assert isinstance(bound_value, datetime)
+    # Guards the Postgres path: timezone-naive columns must not receive aware datetimes.
+    assert bound_value.tzinfo is None
+    # The absolute instant must be preserved (converted to UTC).
+    assert bound_value == aware_scheduled.replace(tzinfo=None)
+
+    monkeypatch.undo()
+
+    # update_decision_status binds executed_at via an UPDATE ... values() statement.
+    # Capture the bound value from the compiled statement parameters.
+    bound_executed: list[object] = []
+    original_scalar = AsyncSession.scalar
+
+    async def capture_scalar(self, statement, *args, **kwargs):
+        values = getattr(statement, "_values", None)
+        if values:
+            for col, bind in values.items():
+                if getattr(col, "name", None) == "executed_at":
+                    bound_executed.append(getattr(bind, "value", bind))
+        return await original_scalar(self, statement, *args, **kwargs)
+
+    monkeypatch.setattr(AsyncSession, "scalar", capture_scalar)
+
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        updated = await repo.update_decision_status(
+            decision.id,
+            status="executed",
+            executed_at=aware_executed,
+        )
+        assert updated is not None
+
+    assert bound_executed, "update_decision_status should bind executed_at"
+    update_value = bound_executed[-1]
+    assert isinstance(update_value, datetime)
+    assert update_value.tzinfo is None
+    assert update_value == aware_executed.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_quota_planner_repository_preserves_naive_decision_datetimes(db_setup):
+    del db_setup
+    naive_scheduled = datetime(2026, 5, 18, 9, 0)
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        decision = await repo.log_decision(
+            mode="shadow",
+            action="reserve",
+            idempotency_key="naive-datetime-persistence",
+            account_id=None,
+            scheduled_at=naive_scheduled,
+            score=1.0,
+            reason="naive",
+            status="skipped",
+        )
+
+    async with SessionLocal() as session:
+        stored = await session.get(QuotaPlannerDecision, decision.id)
+        assert stored is not None
+        assert stored.scheduled_at is not None
+        assert stored.scheduled_at == naive_scheduled
+        assert stored.scheduled_at.tzinfo is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Normalize quota planner decision datetimes before writing to timezone-naive DB columns
- Cover both `log_decision()` inserts and `update_decision_status()` updates
- Add regression coverage for aware UTC inputs and naive passthrough
- Add OpenSpec change for the quota planner persistence contract

## Root cause
113 prod logged `Quota planner tick failed` with asyncpg/Postgres:

```text
TypeError: can't subtract offset-naive and offset-aware datetimes
```

Planner actions are produced from timezone-aware UTC scheduler instants, but `quota_planner_decisions.scheduled_at` and `executed_at` are timezone-naive `DateTime` columns. Passing aware datetimes into those columns can fail at the asyncpg bind/encode layer.

## Test Plan
- `uv run pytest tests/unit/test_quota_planner.py tests/integration/test_quota_planner_api.py -q`
- `openspec validate fix-quota-planner-db-datetimes --strict`
- `uvx ruff check .`
- `uvx ruff format --check .`
- `uv run ty check`

## Notes
- No schema migration: this preserves the existing naive-UTC DB contract
- JSON audit snapshots may still retain ISO strings with timezone offsets for operator context
