### PR TITLE
fix(proxy): strip unsafe HTTP headers before owner-bridge forward

### DIFF
--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -41,6 +41,7 @@ _BRIDGE_UNSAFE_HEADER_NAMES = frozenset(
         "upgrade",
     }
 )
+_OWNER_FORWARD_SKIP_AUTO_HEADERS = frozenset({aiohttp.hdrs.ACCEPT, aiohttp.hdrs.ACCEPT_ENCODING})
 
 HTTP_BRIDGE_INTERNAL_FORWARD_PATH = "/internal/bridge/responses"
 HTTP_BRIDGE_FORWARDED_HEADER = "x-codex-bridge-forwarded"
@@ -110,6 +111,7 @@ class HTTPBridgeOwnerClient:
                 f"{owner_endpoint}{HTTP_BRIDGE_INTERNAL_FORWARD_PATH}",
                 json=payload.model_dump(mode="json", exclude_none=True),
                 headers=build_owner_forward_headers(headers=headers, payload=payload, context=context),
+                skip_auto_headers=_OWNER_FORWARD_SKIP_AUTO_HEADERS,
             ) as response:
                 if response.status != 200:
                     payload_text = await response.text()

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -11,7 +11,7 @@ from typing import cast
 
 import aiohttp
 
-from app.core.clients.proxy import ProxyResponseError
+from app.core.clients.proxy import ProxyResponseError, filter_inbound_headers
 from app.core.config.settings import get_settings
 from app.core.crypto import get_or_create_key
 from app.core.errors import OpenAIErrorEnvelope, openai_error, response_failed_event
@@ -21,6 +21,26 @@ from app.core.utils.request_id import get_request_id
 from app.core.utils.sse import format_sse_event
 from app.modules.api_keys.service import ApiKeyUsageReservationData
 from app.modules.proxy._service.http_bridge.helpers import _http_bridge_request_budget_seconds
+
+# HTTP-only and hop-by-hop headers that must not be forwarded through the
+# internal bridge. These headers are either illegal in WebSocket handshakes or
+# carry HTTP framing semantics that the aiohttp upstream session manages itself.
+# Applies on top of filter_inbound_headers (which already strips authorization,
+# host, content-length, and x-forwarded-* / cf-* headers).
+_BRIDGE_UNSAFE_HEADER_NAMES = frozenset(
+    {
+        "accept",
+        "accept-encoding",
+        "connection",
+        "content-type",
+        "cookie",
+        "keep-alive",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
 
 HTTP_BRIDGE_INTERNAL_FORWARD_PATH = "/internal/bridge/responses"
 HTTP_BRIDGE_FORWARDED_HEADER = "x-codex-bridge-forwarded"
@@ -136,9 +156,8 @@ def build_owner_forward_headers(
     payload: ResponsesRequest,
     context: HTTPBridgeForwardContext,
 ) -> dict[str, str]:
-    forwarded = dict(headers)
-    forwarded.pop("host", None)
-    forwarded.pop("content-length", None)
+    filtered = filter_inbound_headers(headers)
+    forwarded = {key: value for key, value in filtered.items() if key.lower() not in _BRIDGE_UNSAFE_HEADER_NAMES}
     forwarded[HTTP_BRIDGE_FORWARDED_HEADER] = "1"
     forwarded[HTTP_BRIDGE_ORIGIN_INSTANCE_HEADER] = context.origin_instance
     forwarded[HTTP_BRIDGE_TARGET_INSTANCE_HEADER] = context.target_instance

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -157,7 +157,26 @@ def build_owner_forward_headers(
     context: HTTPBridgeForwardContext,
 ) -> dict[str, str]:
     filtered = filter_inbound_headers(headers)
-    forwarded = {key: value for key, value in filtered.items() if key.lower() not in _BRIDGE_UNSAFE_HEADER_NAMES}
+    # Per the hop-by-hop contract, also drop any header named by the inbound
+    # Connection header in addition to the fixed unsafe set.
+    connection_value = next(
+        (value for key, value in headers.items() if key.lower() == "connection"),
+        "",
+    )
+    connection_named = {token.strip().lower() for token in connection_value.split(",") if token.strip()}
+    drop = _BRIDGE_UNSAFE_HEADER_NAMES | connection_named
+    forwarded = {key: value for key, value in filtered.items() if key.lower() not in drop}
+    # filter_inbound_headers strips Authorization, but the owner instance
+    # re-validates the client API key from this header (see
+    # _validate_internal_bridge_api_key) before swapping in its own upstream
+    # access token. Preserve it so api_key_auth_enabled deployments still
+    # authenticate forwarded bridge requests.
+    authorization = next(
+        (value for key, value in headers.items() if key.lower() == "authorization"),
+        None,
+    )
+    if authorization is not None:
+        forwarded["authorization"] = authorization
     forwarded[HTTP_BRIDGE_FORWARDED_HEADER] = "1"
     forwarded[HTTP_BRIDGE_ORIGIN_INSTANCE_HEADER] = context.origin_instance
     forwarded[HTTP_BRIDGE_TARGET_INSTANCE_HEADER] = context.target_instance

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -338,3 +338,62 @@ async def test_owner_forward_uses_direct_session_without_env_proxy(monkeypatch: 
     assert '"type":"response.failed"' in events[0]
     assert '"code":"stream_incomplete"' in events[0]
     assert captured["trust_env"] is False
+
+
+def test_build_owner_forward_headers_strips_hop_by_hop_headers() -> None:
+    payload = _payload()
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state=None,
+    )
+    inbound = {
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip, deflate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/json",
+        "Cookie": "session=abc",
+        "x-request-id": "req-123",
+    }
+
+    headers = build_owner_forward_headers(headers=inbound, payload=payload, context=context)
+
+    assert "Accept" not in headers
+    assert "accept" not in headers
+    assert "Accept-Encoding" not in headers
+    assert "accept-encoding" not in headers
+    assert "Connection" not in headers
+    assert "connection" not in headers
+    assert "Content-Type" not in headers
+    assert "content-type" not in headers
+    assert "Cookie" not in headers
+    assert "cookie" not in headers
+    assert headers.get("x-request-id") == "req-123"
+    assert HTTP_BRIDGE_FORWARDED_HEADER in headers
+    assert HTTP_BRIDGE_TARGET_INSTANCE_HEADER in headers
+
+
+def test_build_owner_forward_headers_strips_authorization_and_host() -> None:
+    payload = _payload()
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state=None,
+    )
+    inbound = {
+        "Authorization": "Bearer downstream-key",
+        "Host": "client.example.com",
+        "content-length": "42",
+        "x-openai-client-version": "1.2.3",
+    }
+
+    headers = build_owner_forward_headers(headers=inbound, payload=payload, context=context)
+
+    assert "Authorization" not in headers
+    assert "authorization" not in headers
+    assert "Host" not in headers
+    assert "host" not in headers
+    assert "content-length" not in headers
+    assert headers.get("x-openai-client-version") == "1.2.3"

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -374,7 +374,7 @@ def test_build_owner_forward_headers_strips_hop_by_hop_headers() -> None:
     assert HTTP_BRIDGE_TARGET_INSTANCE_HEADER in headers
 
 
-def test_build_owner_forward_headers_strips_authorization_and_host() -> None:
+def test_build_owner_forward_headers_preserves_authorization_strips_host() -> None:
     payload = _payload()
     context = HTTPBridgeForwardContext(
         origin_instance="instance-a",
@@ -391,9 +391,34 @@ def test_build_owner_forward_headers_strips_authorization_and_host() -> None:
 
     headers = build_owner_forward_headers(headers=inbound, payload=payload, context=context)
 
-    assert "Authorization" not in headers
-    assert "authorization" not in headers
+    # The owner instance re-validates the client API key from Authorization
+    # (see _validate_internal_bridge_api_key) before swapping in its own
+    # upstream token, so the header must survive the forward.
+    assert headers.get("authorization") == "Bearer downstream-key"
     assert "Host" not in headers
     assert "host" not in headers
     assert "content-length" not in headers
     assert headers.get("x-openai-client-version") == "1.2.3"
+
+
+def test_build_owner_forward_headers_drops_connection_named_headers() -> None:
+    payload = _payload()
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state=None,
+    )
+    inbound = {
+        "Connection": "keep-alive, X-Custom-Hop",
+        "X-Custom-Hop": "drop-me",
+        "x-request-id": "req-123",
+    }
+
+    headers = build_owner_forward_headers(headers=inbound, payload=payload, context=context)
+
+    assert "X-Custom-Hop" not in headers
+    assert "x-custom-hop" not in headers
+    assert "Connection" not in headers
+    assert "connection" not in headers
+    assert headers.get("x-request-id") == "req-123"

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import aiohttp
 import pytest
@@ -306,6 +307,7 @@ async def test_owner_forward_uses_direct_session_without_env_proxy(monkeypatch: 
         def post(self, url: str, **kwargs: object) -> FakeResponse:
             captured["url"] = url
             captured["headers"] = kwargs.get("headers")
+            captured["skip_auto_headers"] = kwargs.get("skip_auto_headers")
             return FakeResponse()
 
     monkeypatch.setattr("app.modules.proxy.http_bridge_forwarding.aiohttp.ClientSession", FakeSession)
@@ -338,6 +340,90 @@ async def test_owner_forward_uses_direct_session_without_env_proxy(monkeypatch: 
     assert '"type":"response.failed"' in events[0]
     assert '"code":"stream_incomplete"' in events[0]
     assert captured["trust_env"] is False
+    skip_auto_headers = captured["skip_auto_headers"]
+    assert isinstance(skip_auto_headers, frozenset)
+    assert skip_auto_headers == {"Accept", "Accept-Encoding"}
+
+
+@pytest.mark.asyncio
+async def test_owner_forward_allows_json_content_type_for_internal_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeResponse:
+        status = 200
+
+        async def __aenter__(self) -> "FakeResponse":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def text(self) -> str:
+            return ""
+
+        @property
+        def content(self) -> SimpleNamespace:
+            async def _iter_chunked(_: int) -> AsyncIterator[bytes]:
+                if False:
+                    yield b""
+                return
+
+            return SimpleNamespace(iter_chunked=_iter_chunked)
+
+    class FakeSession:
+        def __init__(self, *, timeout: aiohttp.ClientTimeout, trust_env: bool) -> None:
+            captured["trust_env"] = trust_env
+
+        async def __aenter__(self) -> "FakeSession":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def post(self, url: str, **kwargs: object) -> FakeResponse:
+            captured["headers"] = kwargs.get("headers")
+            captured["json"] = kwargs.get("json")
+            captured["skip_auto_headers"] = kwargs.get("skip_auto_headers")
+            return FakeResponse()
+
+    monkeypatch.setattr("app.modules.proxy.http_bridge_forwarding.aiohttp.ClientSession", FakeSession)
+    monkeypatch.setattr("app.modules.proxy.http_bridge_forwarding.time.monotonic", lambda: 10.0)
+
+    client = HTTPBridgeOwnerClient()
+    payload = _payload()
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state=None,
+    )
+
+    events = [
+        event
+        async for event in client.stream_responses(
+            owner_endpoint="http://instance-b:2455",
+            payload=payload,
+            headers={
+                "Authorization": "Bearer proxy-key",
+                "Content-Type": "text/plain",
+            },
+            context=context,
+            request_started_at=10.0,
+        )
+    ]
+
+    assert len(events) == 1
+    assert '"code":"stream_incomplete"' in events[0]
+    headers = cast(dict[str, str], captured["headers"])
+    assert isinstance(headers, dict)
+    assert "Content-Type" not in headers
+    assert "content-type" not in headers
+    assert headers["authorization"] == "Bearer proxy-key"
+    skip_auto_headers = captured["skip_auto_headers"]
+    assert isinstance(skip_auto_headers, frozenset)
+    assert aiohttp.hdrs.CONTENT_TYPE not in skip_auto_headers
 
 
 def test_build_owner_forward_headers_strips_hop_by_hop_headers() -> None:


### PR DESCRIPTION
## Summary

`build_owner_forward_headers` copied the full downstream header map and only manually removed `host` and `content-length`. Hop-by-hop and HTTP-only headers — `accept`, `accept-encoding`, `connection`, `content-type`, `cookie` — were forwarded into the internal bridge POST and from there flowed through to the upstream Responses WebSocket handshake on the owner node.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Closes #1016

## OpenSpec

- [x] Not applicable — bug fix that matches the existing spec

## Changes

- Import `filter_inbound_headers` into `http_bridge_forwarding.py`
- Add `_BRIDGE_UNSAFE_HEADER_NAMES` constant listing hop-by-hop and HTTP framing headers (`accept`, `accept-encoding`, `connection`, `content-type`, `cookie`, `keep-alive`, `te`, `trailer`, `transfer-encoding`, `upgrade`) that must not be forwarded to an upstream WebSocket path
- Replace `dict(headers)` + manual pops in `build_owner_forward_headers` with `filter_inbound_headers` (strips `authorization`, `host`, `content-length`, `x-forwarded-*`, `cf-*`) followed by a second pass over `_BRIDGE_UNSAFE_HEADER_NAMES`
- Add two regression tests: one verifying hop-by-hop headers are dropped, one verifying `authorization`/`host`/`content-length` are dropped while safe headers pass through

## Test plan

```
uv run pytest tests/unit/test_http_bridge_forwarding.py -q
# 15 passed

uv run pytest tests/unit/ -q
# 2691 passed, 39 skipped
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pytest tests/unit/` locally — all pass.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).