### PR TITLE
perf(dashboard): split request log page count

### DIFF
--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -378,8 +378,7 @@ class RequestLogsRepository:
             exclude_soft_deleted=True,
         )
 
-        total_col = func.count().over().label("_total")
-        stmt = select(RequestLog, total_col).order_by(RequestLog.requested_at.desc(), RequestLog.id.desc())
+        stmt = select(RequestLog).order_by(RequestLog.requested_at.desc(), RequestLog.id.desc())
         stmt = self._apply_related_search_joins(stmt, filters.needs_related_search_joins)
         if filters.conditions:
             stmt = stmt.where(and_(*filters.conditions))
@@ -388,11 +387,8 @@ class RequestLogsRepository:
         if limit:
             stmt = stmt.limit(limit)
         result = await self._session.execute(stmt)
-        rows = result.all()
-        if not rows:
-            return [], await self._count_recent(filters)
-        logs = [row[0] for row in rows]
-        total = rows[0][1]
+        logs = list(result.scalars().all())
+        total = await self._count_recent(filters)
         return logs, total
 
     async def _count_recent(self, filters: _RequestLogFilters) -> int:

--- a/openspec/changes/optimize-dashboard-request-logs/notes.md
+++ b/openspec/changes/optimize-dashboard-request-logs/notes.md
@@ -1,0 +1,56 @@
+# Notes: dashboard API performance evidence
+
+## Production evidence from 10.0.0.113
+
+Read-only service timings after manual `ANALYZE` on 2026-06-17:
+
+```text
+request_logs.list_recent_25: 18.620s
+request_logs.filter_options: 2.051s
+dashboard.overview_7d: 1.256s
+dashboard.projections: 4.186s
+api_key.trends: 0.012s
+api_key.usage_7d: 0.023s
+```
+
+`ANALYZE` corrected stale PostgreSQL statistics:
+
+```text
+request_logs n_live_tup: ~13K -> 1,380,746
+usage_history n_live_tup: ~13K -> 936,752
+additional_usage_history n_live_tup: ~13K -> 633,128
+api_key_usage_reservations n_live_tup: ~14K -> 1,716,925
+```
+
+But the request-log list endpoint stayed slow because the bottleneck is query shape, not only stats.
+
+## Root cause
+
+The old request-log page query added `count(*) OVER()` to the same row query that also had `ORDER BY requested_at DESC, id DESC LIMIT 25`. On production-shaped data PostgreSQL materialized the full filtered set before returning the first page.
+
+Measured SQL comparison:
+
+```text
+page-only latest 26 rows: ~0.3ms
+separate exact count: ~300-400ms
+window-count paginated query: ~8.5s SQL / double-digit seconds service-level
+```
+
+## Immediate fix
+
+Keep the public response contract intact, but split the query:
+
+```text
+SELECT request_logs ... ORDER BY requested_at DESC, id DESC LIMIT/OFFSET
+SELECT count(id) ... same filters
+```
+
+## Follow-up optimization direction
+
+The same source-structured principle should be applied to the other dashboard surfaces:
+
+- request-log filter options: cache or incrementally summarize distinct facets
+- dashboard overview: maintain request-log bucket/activity summaries by source time bucket
+- projections: maintain usage-history window snapshots instead of scanning raw 7d primary/secondary histories every poll
+
+These are intentionally out of scope for this hotfix because they introduce new summary/storage contracts.

--- a/openspec/changes/optimize-dashboard-request-logs/proposal.md
+++ b/openspec/changes/optimize-dashboard-request-logs/proposal.md
@@ -1,0 +1,30 @@
+# Change: Optimize dashboard request log pagination
+
+## Problem
+
+Production dashboard request-log listing on 10.0.0.113 is slow because the repository combines pagination with `count(*) OVER()` in the same query. PostgreSQL must materialize the full filtered request-log result before returning the first page. In a measured production case, `GET /api/request-logs?limit=25&offset=0` materialized roughly 1.1M rows, spilled hundreds of MB to temp storage, and made the service method take double-digit seconds.
+
+The dashboard still needs stable pagination metadata, but the hot page fetch must not be coupled to a full-result window aggregate.
+
+## Solution
+
+Split request-log pagination into two query shapes:
+
+1. Page query: fetch only the requested page ordered latest-first
+2. Count query: compute exact total separately for the same filters
+
+This preserves the existing API contract (`requests`, `total`, `hasMore`) while letting PostgreSQL use the existing latest-first index for the page query instead of materializing the entire filtered result before applying `LIMIT`.
+
+## Changes
+
+- Add a query-caching/query-shape requirement for dashboard request-log pagination
+- Update `RequestLogsRepository.list_recent()` to avoid `count(*) OVER()` on the paginated row query
+- Add regression coverage that captures emitted SQL and rejects window-count pagination
+- Document the broader source-structured dashboard optimization direction for projections/filter facets
+
+## Out of scope
+
+- Removing exact `total` from the public API response
+- Adding dashboard projection snapshot tables in this change
+- Reworking filter-option facets into cached/source-structured summaries in this change
+- Production rollout/deploy in this PR

--- a/openspec/changes/optimize-dashboard-request-logs/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-dashboard-request-logs/specs/query-caching/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard reads avoid hot-path full-history recomputation
+
+The system SHALL keep dashboard hot-path database reads bounded by the data needed for the requested response whenever the existing API contract allows it. Dashboard query shapes MUST NOT combine a limited page fetch with an unbounded window aggregate that forces the database to materialize the entire filtered result before returning the page.
+
+`GET /api/request-logs` MUST fetch request-log rows using a latest-first limited page query. If the response includes exact total metadata, the exact count MUST be computed using a separate count query or an equivalent cached/source-structured summary, not by adding `count(*) OVER()` to the paginated row query.
+
+#### Scenario: Request-log page query does not materialize the full filtered result
+
+- **GIVEN** the request-log table contains many rows matching the active filters
+- **WHEN** the dashboard requests `GET /api/request-logs?limit=25&offset=0`
+- **THEN** the row-fetch query returns only the requested page ordered by newest request first
+- **AND** the row-fetch query does not include `count(*) OVER()` or an equivalent unbounded window aggregate
+- **AND** the response still includes correct `total` and `hasMore` metadata
+
+#### Scenario: Source-structured summaries remain available for broader dashboard optimization
+
+- **GIVEN** a dashboard read repeatedly aggregates large raw histories such as request logs or usage history
+- **WHEN** the aggregation cost dominates dashboard latency
+- **THEN** the system MAY move that read to a cached, incremental, or source-structured summary so the dashboard does not repeatedly scan raw history on every poll
+- **AND** the summary contract MUST preserve the externally visible dashboard semantics

--- a/openspec/changes/optimize-dashboard-request-logs/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-dashboard-request-logs/specs/query-caching/spec.md
@@ -1,4 +1,4 @@
-## MODIFIED Requirements
+## ADDED Requirements
 
 ### Requirement: Dashboard reads avoid hot-path full-history recomputation
 

--- a/openspec/changes/optimize-dashboard-request-logs/tasks.md
+++ b/openspec/changes/optimize-dashboard-request-logs/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Add OpenSpec requirement for request-log pagination query shape
+- [x] Add RED regression test proving request-log list does not use `count(*) OVER()`
+- [x] Split request-log page query from exact count query
+- [x] Run focused request-log tests
+- [x] Run OpenSpec validation
+- [x] Run formatting/lint/type gates or document blockers

--- a/tests/integration/test_request_logs_list_count.py
+++ b/tests/integration/test_request_logs_list_count.py
@@ -161,6 +161,46 @@ async def test_list_recent_without_search_avoids_related_joins(db_setup):
 
 
 @pytest.mark.asyncio
+async def test_list_recent_uses_separate_count_instead_of_window_count(db_setup):
+    statements: list[str] = []
+
+    def _capture(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        now = utcnow()
+        async with SessionLocal() as session:
+            accounts_repo = AccountsRepository(session)
+            repo = RequestLogsRepository(session)
+            await accounts_repo.upsert(_make_account("acc_window_count"))
+            for i in range(5):
+                await repo.add_log(
+                    account_id="acc_window_count",
+                    request_id=f"req_window_count_{i}",
+                    model="gpt-5.1",
+                    input_tokens=10,
+                    output_tokens=20,
+                    latency_ms=100,
+                    status="success",
+                    error_code=None,
+                    requested_at=now - timedelta(minutes=i),
+                )
+
+            statements.clear()
+            logs, total = await repo.list_recent(limit=3, offset=0)
+
+        assert len(logs) == 3
+        assert total == 5
+        request_log_selects = [statement for statement in statements if "FROM request_logs" in statement]
+        assert len(request_log_selects) >= 2
+        assert any("count(" in statement.lower() for statement in request_log_selects)
+        assert all("OVER" not in statement.upper() for statement in request_log_selects)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+
+@pytest.mark.asyncio
 async def test_list_recent_with_search_keeps_related_joins(db_setup):
     statements: list[str] = []
 


### PR DESCRIPTION
## Summary

- Splits dashboard request-log pagination from exact total counting so the hot row query no longer uses `count(*) OVER()`
- Preserves the existing `requests`, `total`, and `hasMore` API contract
- Adds regression coverage that captures emitted SQL and rejects window-count pagination
- Adds an OpenSpec change documenting the dashboard query-shape contract and the follow-up source-structured optimization direction

## Production evidence

On 10.0.0.113, `ANALYZE` corrected stale PostgreSQL stats but did not fix request-log latency, confirming the bottleneck is query shape rather than only planner statistics

Measured production shape before this code change:

```text
request_logs.list_recent_25: 18.620s
request_logs.filter_options: 2.051s
dashboard.overview_7d: 1.256s
dashboard.projections: 4.186s
```

SQL comparison from the same production data shape:

```text
page-only latest rows: ~0.3ms
separate exact count: ~300-400ms
window-count paginated query: ~8.5s SQL / double-digit seconds service-level
```

## Test Plan

- `uv run pytest tests/integration/test_request_logs_list_count.py::test_list_recent_uses_separate_count_instead_of_window_count -q`
- `uv run pytest tests/integration/test_request_logs_list_count.py tests/integration/test_request_logs_api.py tests/integration/test_request_logs_filters.py tests/test_request_logs_options_api.py tests/unit/test_request_logs_repository.py -q`
- `openspec validate optimize-dashboard-request-logs --strict`
- `uvx ruff check app/modules/request_logs/repository.py tests/integration/test_request_logs_list_count.py`
- `uvx ruff format --check app/modules/request_logs/repository.py tests/integration/test_request_logs_list_count.py`
- `uv run ty check app/modules/request_logs/repository.py tests/integration/test_request_logs_list_count.py`

## Follow-up

This PR fixes the highest-impact hot path without changing the public response contract. Broader source-structured optimizations remain follow-up work:

- cache or incrementally summarize request-log filter facets
- maintain dashboard request-log bucket/activity summaries
- maintain usage-history projection snapshots instead of scanning raw 7d windows on every poll
