### PR TITLE
chore: release v1.20.1-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.20.0"  # x-release-please-version
+__version__ = "1.20.1-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.20.0
-appVersion: 1.20.0
+version: 1.20.1-beta.1
+appVersion: 1.20.1-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.20.0",
+  "version": "1.20.1-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.20.0"
+version = "1.20.1-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.20.0"
+version = "1.20.1-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.20.1-beta.1 for the 1.20.1 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.20.1-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1039; no manual beta workflow dispatch is required.

## Changes since v1.20.0
- perf(dashboard): split request log page count (#1038) (ea6dc8b)
- fix(release): guard stable artifact publishing (#1049) (
30aa30)

## Release-candidate validation
Validated candidate: 46179d2dcbe287c3a0d3ea471e83d7a98b353ed1

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [ ] Backend/unit/integration gates
- [ ] Frontend tests/build
- [ ] Wheel/package validation
- [ ] Docker/container smoke
- [ ] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==1.20.1b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.20.1-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.20.1-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.20.1.
