### PR TITLE
Harden Codex retry and bridge recovery

### DIFF
--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -215,6 +215,9 @@ _SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
 )
 _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS = 5.0
 _HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD = 100
+_HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR = "_codex_lb_started_at"
+_HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS = 120.0
+_HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER = 6.0
 
 
 class _HTTPBridgeMixin(
@@ -260,6 +263,102 @@ class _HTTPBridgeMixin(
             return max(visible_pending_count, session.queued_request_count)
         finally:
             session.pending_lock.release()
+
+    def http_bridge_activity_snapshot_nowait(self) -> dict[str, int | bool]:
+        inflight_cleanup = self._cleanup_http_bridge_inflight_sessions_nowait()
+        live_sessions = 0
+        pending_or_queued_requests = 0
+        pending_unknown_sessions = 0
+
+        for session in list(self._http_bridge_sessions.values()):
+            if session.closed:
+                continue
+            live_sessions += 1
+            pending_count = self._http_bridge_pending_count_nowait(session, context="drain_status")
+            if pending_count is None:
+                pending_unknown_sessions += 1
+            else:
+                pending_or_queued_requests += max(0, pending_count)
+
+        inflight_session_creates = len(self._http_bridge_inflight_sessions)
+        active_cleanup_tasks = sum(1 for task in self._background_cleanup_tasks if not task.done())
+        restart_blocking = (
+            pending_or_queued_requests > 0 or pending_unknown_sessions > 0 or inflight_session_creates > 0
+        )
+        return {
+            "http_bridge_live_sessions": live_sessions,
+            "http_bridge_pending_or_queued_requests": pending_or_queued_requests,
+            "http_bridge_pending_unknown_sessions": pending_unknown_sessions,
+            "http_bridge_inflight_session_creates": inflight_session_creates,
+            "http_bridge_inflight_session_create_oldest_age_seconds": inflight_cleanup["oldest_age_seconds"],
+            "http_bridge_stale_inflight_session_creates": inflight_cleanup["stale"],
+            "http_bridge_cleaned_inflight_session_creates": inflight_cleanup["cleaned"],
+            "http_bridge_background_cleanup_tasks": active_cleanup_tasks,
+            "http_bridge_restart_blocking": restart_blocking,
+        }
+
+    def _cleanup_http_bridge_inflight_sessions_nowait(self) -> dict[str, int]:
+        now = _service_time().monotonic()
+        stale_after_seconds = self._http_bridge_stale_inflight_seconds()
+        cleaned = 0
+        stale = 0
+        oldest_age_seconds = 0
+        for key, future in list(self._http_bridge_inflight_sessions.items()):
+            current_future = self._http_bridge_inflight_sessions.get(key)
+            if current_future is not future:
+                continue
+            started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
+            age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+            oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
+            cleanup_reason: str | None = None
+            cleanup_exc: BaseException | None = None
+            if future.done():
+                cleanup_reason = "done"
+            elif isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
+                stale += 1
+                cleanup_reason = "stale"
+                cleanup_exc = _http_bridge_startup_wait_timeout_error(
+                    "http_bridge_inflight_session_stale",
+                    code="capacity_exhausted_active_sessions",
+                )
+            if cleanup_reason is None:
+                continue
+            self._http_bridge_inflight_sessions.pop(key, None)
+            cleaned += 1
+            if cleanup_exc is not None and not future.done():
+                future.set_exception(cleanup_exc)
+                future.exception()
+            elif future.done() and not future.cancelled():
+                try:
+                    future.exception()
+                except Exception:
+                    pass
+            logger.warning(
+                "http_bridge_inflight_session_create_cleanup reason=%s bridge_kind=%s bridge_key=%s"
+                " age_seconds=%d stale_after_seconds=%d done=%s cancelled=%s",
+                cleanup_reason,
+                key.affinity_kind,
+                _hash_identifier(key.affinity_key),
+                int(age_seconds),
+                int(stale_after_seconds),
+                future.done(),
+                future.cancelled(),
+            )
+        return {
+            "cleaned": cleaned,
+            "stale": stale,
+            "oldest_age_seconds": oldest_age_seconds,
+        }
+
+    def _http_bridge_stale_inflight_seconds(self) -> float:
+        try:
+            admission_timeout = _proxy_admission_wait_timeout_seconds()
+        except Exception:
+            admission_timeout = 10.0
+        return max(
+            _HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS,
+            admission_timeout * _HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER,
+        )
 
     async def _close_http_bridge_session_bounded(
         self,
@@ -1253,6 +1352,11 @@ class _HTTPBridgeMixin(
                                 )
                         else:
                             inflight_future = asyncio.get_running_loop().create_future()
+                            setattr(
+                                inflight_future,
+                                _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR,
+                                _service_time().monotonic(),
+                            )
                             self._http_bridge_inflight_sessions[key] = inflight_future
                             owns_creation = True
 

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -396,6 +396,34 @@ def _websocket_continuity_anchor_for_payload(
     )
 
 
+_WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE = {
+    "function_call_output": "function_call",
+    "custom_tool_call_output": "custom_tool_call",
+    "apply_patch_call_output": "apply_patch_call",
+}
+_WEBSOCKET_TOOL_CALL_ITEM_TYPES = frozenset(_WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE.values())
+
+
+def _websocket_input_items_are_self_contained_fresh_replay(input_items: list[JsonValue]) -> bool:
+    seen_call_ids_by_type: dict[str, set[str]] = {item_type: set() for item_type in _WEBSOCKET_TOOL_CALL_ITEM_TYPES}
+    for item in input_items:
+        if not isinstance(item, dict):
+            continue
+        item_type = _websocket_input_item_type(item)
+        call_id_value = item.get("call_id")
+        call_id = call_id_value if isinstance(call_id_value, str) and call_id_value else None
+        if item_type in _WEBSOCKET_TOOL_CALL_ITEM_TYPES:
+            if call_id is not None:
+                seen_call_ids_by_type[item_type].add(call_id)
+            continue
+        call_item_type = _WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE.get(item_type or "")
+        if call_item_type is None:
+            continue
+        if call_id is None or call_id not in seen_call_ids_by_type[call_item_type]:
+            return False
+    return True
+
+
 def _websocket_client_previous_response_full_resend_is_retry_safe(
     *,
     previous_response_id: str | None,
@@ -406,6 +434,8 @@ def _websocket_client_previous_response_full_resend_is_retry_safe(
         return False
     input_items = cast(list[JsonValue], input_value)
     if len(input_items) <= 1:
+        return False
+    if not _websocket_input_items_are_self_contained_fresh_replay(input_items):
         return False
     if (
         continuity_state is not None

--- a/app/modules/quota_planner/repository.py
+++ b/app/modules/quota_planner/repository.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from sqlalchemy import Integer, and_, cast, func, literal, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.utils.time import utcnow
+from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import (
     Account,
     QuotaPlannerDecision,
@@ -100,8 +100,8 @@ class QuotaPlannerRepository:
             mode=mode,
             action=action,
             account_id=account_id,
-            scheduled_at=scheduled_at,
-            executed_at=executed_at,
+            scheduled_at=_quota_planner_db_timestamp(scheduled_at),
+            executed_at=_quota_planner_db_timestamp(executed_at),
             score=score,
             reason=reason,
             forecast_snapshot_hash=forecast_snapshot_hash,
@@ -138,7 +138,7 @@ class QuotaPlannerRepository:
         if reason is not None:
             values["reason"] = reason
         if executed_at is not None:
-            values["executed_at"] = executed_at
+            values["executed_at"] = _quota_planner_db_timestamp(executed_at)
         if state_after_json is not None:
             values["state_after_json"] = state_after_json
         stmt = update(QuotaPlannerDecision).where(QuotaPlannerDecision.id == decision_id).values(**values)
@@ -160,6 +160,7 @@ class QuotaPlannerRepository:
         return row
 
     async def count_executed_warmups_since(self, since: datetime) -> int:
+        since = to_utc_naive(since)
         stmt = select(func.count(QuotaPlannerDecision.id)).where(
             and_(
                 QuotaPlannerDecision.action == "warmup",
@@ -170,6 +171,7 @@ class QuotaPlannerRepository:
         return int(await self._session.scalar(stmt) or 0)
 
     async def warmup_cost_since(self, since: datetime) -> float:
+        since = to_utc_naive(since)
         stmt = select(func.coalesce(func.sum(RequestLog.cost_usd), 0.0)).where(
             and_(
                 RequestLog.request_kind == "warmup",
@@ -215,7 +217,7 @@ class QuotaPlannerRepository:
     ) -> QuotaWindowObservation:
         row = QuotaWindowObservation(
             account_id=account_id,
-            observed_at=observed_at or utcnow(),
+            observed_at=_quota_planner_db_timestamp(observed_at) or utcnow(),
             model=model,
             primary_remaining_percent=primary_remaining_percent,
             primary_reset_at=primary_reset_at,
@@ -236,7 +238,7 @@ class QuotaPlannerRepository:
         since: datetime | None = None,
         bucket_seconds: int = 900,
     ) -> list[DemandBin]:
-        since = since or (utcnow() - timedelta(days=28))
+        since = to_utc_naive(since) if since is not None else (utcnow() - timedelta(days=28))
         bind = self._session.get_bind()
         dialect = bind.dialect.name if bind else "sqlite"
         if dialect == "postgresql":
@@ -294,6 +296,12 @@ class QuotaPlannerRepository:
             )
             for row in result.all()
         ]
+
+
+def _quota_planner_db_timestamp(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return to_utc_naive(value)
 
 
 def _settings_from_row(row: QuotaPlannerSettings) -> PlannerSettings:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -59,6 +59,72 @@ def _make_bridge_session(
     )
 
 
+@pytest.mark.asyncio
+async def test_http_bridge_activity_snapshot_counts_pending_and_inflight_sessions():
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-drain-status",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        response_id=None,
+        awaiting_response_created=True,
+        event_queue=None,
+        transport="http",
+        skip_request_log=True,
+    )
+    session = _make_bridge_session(
+        pending_requests=deque([request_state]),
+        queued_request_count=2,
+    )
+    service._http_bridge_sessions[session.key] = session
+    service._http_bridge_inflight_sessions[
+        proxy_service._HTTPBridgeSessionKey("session_header", "inflight-drain-status", None)
+    ] = asyncio.Future()
+
+    snapshot = service.http_bridge_activity_snapshot_nowait()
+
+    assert snapshot == {
+        "http_bridge_live_sessions": 1,
+        "http_bridge_pending_or_queued_requests": 2,
+        "http_bridge_pending_unknown_sessions": 0,
+        "http_bridge_inflight_session_creates": 1,
+        "http_bridge_inflight_session_create_oldest_age_seconds": 0,
+        "http_bridge_stale_inflight_session_creates": 0,
+        "http_bridge_cleaned_inflight_session_creates": 0,
+        "http_bridge_background_cleanup_tasks": 0,
+        "http_bridge_restart_blocking": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_activity_snapshot_cleans_stale_inflight_session(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "stale-inflight-drain-status", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    setattr(inflight_future, "_codex_lb_started_at", -1000.0)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda settings=None: 0.001)
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.service"):
+        snapshot = service.http_bridge_activity_snapshot_nowait()
+
+    assert key not in service._http_bridge_inflight_sessions
+    assert snapshot["http_bridge_inflight_session_creates"] == 0
+    assert snapshot["http_bridge_stale_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_cleaned_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_restart_blocking"] is False
+    assert "http_bridge_inflight_session_create_cleanup" in caplog.text
+    with pytest.raises(ProxyResponseError):
+        await inflight_future
+
+
 async def _wait_for_close_await(close_session: AsyncMock, session: proxy_service._HTTPBridgeSession) -> None:
     for _ in range(10):
         if any(call.args == (session,) for call in close_session.await_args_list):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9613,6 +9613,69 @@ async def test_prepare_websocket_response_create_request_captures_client_full_re
     assert fresh_payload["input"] == full_resend_input
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_does_not_fresh_retry_tool_output_delta(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_tool_delta",
+        name="ws-tool-delta",
+        key_prefix="sk-ws-tool-delta",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    tool_output_delta: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_delta_a", "output": "ok"},
+        {"type": "function_call_output", "call_id": "call_delta_b", "output": "ok"},
+        {"type": "function_call_output", "call_id": "call_delta_c", "output": "ok"},
+    ]
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_client_anchor",
+                "input": tool_output_delta,
+            },
+        ),
+        headers={"session_id": "turn_ws_tool_delta"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=None,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_client_anchor"
+    assert upstream_payload["input"] == tool_output_delta
+    assert prepared.request_state.previous_response_id == "resp_client_anchor"
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
+    assert prepared.request_state.fresh_upstream_request_text is None
+
+
 def test_websocket_client_previous_response_full_resend_retry_requires_matching_prefix() -> None:
     stored_prefix: list[JsonValue] = [{"role": "user", "content": [{"type": "input_text", "text": "old question"}]}]
     continuity_state = proxy_service._WebSocketContinuityState(
@@ -9633,6 +9696,56 @@ def test_websocket_client_previous_response_full_resend_retry_requires_matching_
             continuity_state=continuity_state,
         )
         is False
+    )
+
+
+def test_websocket_client_previous_response_full_resend_retry_rejects_tool_output_delta() -> None:
+    tool_output_delta: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_a", "output": "ok"},
+        {"type": "function_call_output", "call_id": "call_b", "output": "ok"},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=tool_output_delta,
+            continuity_state=None,
+        )
+        is False
+    )
+
+
+def test_websocket_client_previous_response_full_resend_retry_rejects_output_before_call() -> None:
+    reordered_tool_history: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_late", "output": "ok"},
+        {"type": "function_call", "name": "shell_command", "call_id": "call_late", "arguments": "{}"},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=reordered_tool_history,
+            continuity_state=None,
+        )
+        is False
+    )
+
+
+def test_websocket_client_previous_response_full_resend_retry_allows_self_contained_tool_history() -> None:
+    self_contained_tool_history: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "run a command"}]},
+        {"type": "function_call", "name": "shell_command", "call_id": "call_ok", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_ok", "output": "ok"},
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=self_contained_tool_history,
+            continuity_state=None,
+        )
+        is True
     )
 
 

--- a/tests/unit/test_quota_planner.py
+++ b/tests/unit/test_quota_planner.py
@@ -18,7 +18,7 @@ from app.modules.quota_planner.logic import (
     plan_shadow_actions,
     simulate_pool,
 )
-from app.modules.quota_planner.repository import DemandBin
+from app.modules.quota_planner.repository import DemandBin, _quota_planner_db_timestamp
 
 pytestmark = pytest.mark.unit
 
@@ -90,6 +90,13 @@ def test_planner_settings_default_to_nonblocking_shadow_mode() -> None:
     assert settings.prewarm_enabled is True
     assert settings.allow_synthetic_traffic is False
     assert settings.dry_run is True
+
+
+def test_quota_planner_db_timestamp_normalizes_aware_datetimes_to_naive_utc() -> None:
+    scheduled_at = datetime(2026, 6, 18, 8, 30, tzinfo=timezone(timedelta(hours=3)))
+
+    assert _quota_planner_db_timestamp(scheduled_at) == datetime(2026, 6, 18, 5, 30)
+    assert _quota_planner_db_timestamp(None) is None
 
 
 def test_candidate_start_times_do_not_floor_now_into_the_past() -> None:


### PR DESCRIPTION
## Summary
- Prevent fresh WebSocket retries for previous_response_id payloads that contain tool outputs without matching tool calls.
- Add stale HTTP bridge inflight-session cleanup diagnostics for drain/status paths.
- Normalize quota planner timestamps to naive UTC before database writes and comparisons.

## Tests
- uv run pytest -q tests/unit/test_proxy_http_bridge.py::test_http_bridge_activity_snapshot_counts_pending_and_inflight_sessions tests/unit/test_proxy_http_bridge.py::test_http_bridge_activity_snapshot_cleans_stale_inflight_session tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_inflight_wait_times_out tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_capacity_wait_times_out tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_does_not_fresh_retry_tool_output_delta tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_captures_client_full_resend_anchor_replay tests/unit/test_proxy_utils.py::test_websocket_client_previous_response_full_resend_retry_rejects_tool_output_delta tests/unit/test_proxy_utils.py::test_websocket_client_previous_response_full_resend_retry_allows_self_contained_tool_history tests/unit/test_quota_planner.py