### PR TITLE
fix(websocket): avoid fresh retry for tool-output deltas

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -839,6 +839,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "zvladru",
+      "name": "zvladru",
+      "avatar_url": "https://avatars.githubusercontent.com/u/30793959?v=4",
+      "profile": "https://github.com/zvladru",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -390,6 +390,34 @@ def _websocket_continuity_anchor_for_payload(
     )
 
 
+_WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE = {
+    "function_call_output": "function_call",
+    "custom_tool_call_output": "custom_tool_call",
+    "apply_patch_call_output": "apply_patch_call",
+}
+_WEBSOCKET_TOOL_CALL_ITEM_TYPES = frozenset(_WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE.values())
+
+
+def _websocket_input_items_are_self_contained_fresh_replay(input_items: list[JsonValue]) -> bool:
+    seen_call_ids_by_type: dict[str, set[str]] = {item_type: set() for item_type in _WEBSOCKET_TOOL_CALL_ITEM_TYPES}
+    for item in input_items:
+        if not isinstance(item, dict):
+            continue
+        item_type = _websocket_input_item_type(item)
+        call_id_value = item.get("call_id")
+        call_id = call_id_value if isinstance(call_id_value, str) and call_id_value else None
+        if item_type in _WEBSOCKET_TOOL_CALL_ITEM_TYPES:
+            if call_id is not None:
+                seen_call_ids_by_type[item_type].add(call_id)
+            continue
+        call_item_type = _WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE.get(item_type or "")
+        if call_item_type is None:
+            continue
+        if call_id is None or call_id not in seen_call_ids_by_type[call_item_type]:
+            return False
+    return True
+
+
 def _websocket_client_previous_response_full_resend_is_retry_safe(
     *,
     previous_response_id: str | None,
@@ -400,6 +428,8 @@ def _websocket_client_previous_response_full_resend_is_retry_safe(
         return False
     input_items = cast(list[JsonValue], input_value)
     if len(input_items) <= 1:
+        return False
+    if not _websocket_input_items_are_self_contained_fresh_replay(input_items):
         return False
     if (
         continuity_state is not None

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1415,6 +1415,8 @@ class _WebSocketMixin:
                     cast(list[JsonValue], original_full_resend_input)
                 )
             )
+            if not request_state.fresh_upstream_request_is_retry_safe:
+                request_state.fresh_upstream_request_text = None
             _facade().logger.info(
                 "websocket_session_anchor_injected request_id=%s response_id=%s original_items=%s trimmed_to=%s",
                 request_state.request_id,

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1390,6 +1390,7 @@ class _WebSocketMixin:
         request_state.useragent_group = useragent_group
         request_state.client_ip = client_ip
         request_state.expose_stale_previous_response_classifier = codex_session_affinity
+        original_full_resend_input: JsonValue | None = None
         if session_anchor is not None:
             request_state.proxy_injected_previous_response_id = True
             request_state.input_item_count = original_input_item_count or request_state.input_item_count
@@ -1402,11 +1403,11 @@ class _WebSocketMixin:
                     request_state=request_state,
                     transport=_REQUEST_TRANSPORT_WEBSOCKET,
                 )
-            original_full_resend_input = (
-                original_full_resend_payload.get("input")
-                if isinstance(original_full_resend_payload, dict)
-                else original_full_resend_payload.input
-            )
+                original_full_resend_input = (
+                    original_full_resend_payload.get("input")
+                    if isinstance(original_full_resend_payload, dict)
+                    else original_full_resend_payload.input
+                )
             request_state.fresh_upstream_request_is_retry_safe = bool(
                 request_state.fresh_upstream_request_text is not None
                 and isinstance(original_full_resend_input, list)

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -390,6 +390,7 @@ from app.modules.proxy._service.websocket.helpers import (
     _websocket_event_error_param,
     _websocket_event_error_type,
     _websocket_full_resend_conflicts_with_visible_pending,
+    _websocket_input_items_are_self_contained_fresh_replay,
     _websocket_precreated_auth_error_code,
     _websocket_precreated_retry_error_code,
     _websocket_receive_timeout_for_pending_requests,
@@ -1401,7 +1402,18 @@ class _WebSocketMixin:
                     request_state=request_state,
                     transport=_REQUEST_TRANSPORT_WEBSOCKET,
                 )
-            request_state.fresh_upstream_request_is_retry_safe = request_state.fresh_upstream_request_text is not None
+            original_full_resend_input = (
+                original_full_resend_payload.get("input")
+                if isinstance(original_full_resend_payload, dict)
+                else original_full_resend_payload.input
+            )
+            request_state.fresh_upstream_request_is_retry_safe = bool(
+                request_state.fresh_upstream_request_text is not None
+                and isinstance(original_full_resend_input, list)
+                and _websocket_input_items_are_self_contained_fresh_replay(
+                    cast(list[JsonValue], original_full_resend_input)
+                )
+            )
             _facade().logger.info(
                 "websocket_session_anchor_injected request_id=%s response_id=%s original_items=%s trimmed_to=%s",
                 request_state.request_id,

--- a/openspec/changes/fix-websocket-tool-output-delta-retry/proposal.md
+++ b/openspec/changes/fix-websocket-tool-output-delta-retry/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+WebSocket `previous_response_not_found` recovery may safely replay a full
+Responses resend without the stale anchor, but tool-output-only deltas are not
+self-contained. Replaying those deltas as a fresh turn can orphan tool outputs
+from their matching tool calls and mutate the conversation incorrectly.
+
+## What Changes
+
+- Classify tool-output-only WebSocket follow-ups as unsafe for fresh retry.
+- Preserve fresh retry for full resend payloads that contain enough context.
+- Document the retry boundary and cover it with regression tests.
+
+## Impact
+
+- Tool-output deltas fail closed on stale anchors instead of being replayed as
+  unrelated fresh turns.
+- Full resend recovery behavior remains unchanged.

--- a/openspec/changes/fix-websocket-tool-output-delta-retry/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-websocket-tool-output-delta-retry/specs/responses-api-compat/spec.md
@@ -2,10 +2,10 @@
 
 ### Requirement: WebSocket tool-output deltas are not fresh-retryable
 
-When a direct WebSocket Responses request includes `previous_response_id` and
+The service MUST NOT replay a direct WebSocket Responses request as a fresh turn
+without the previous-response anchor when it includes `previous_response_id` and
 only carries tool output items for tool calls that are not present in the same
-payload, the service MUST NOT replay that payload as a fresh turn without the
-previous-response anchor after an upstream `previous_response_not_found`.
+payload after an upstream `previous_response_not_found`.
 
 #### Scenario: output-only WebSocket tool delta is not replayed as a fresh turn
 
@@ -16,5 +16,5 @@ previous-response anchor after an upstream `previous_response_not_found`.
   matching tool-call items in the same payload
 - **AND** upstream emits `previous_response_not_found` before assigning a
   response id
-- **THEN** the service does not replay that payload as a fresh turn without
+- **THEN** the service MUST NOT replay that payload as a fresh turn without
   `previous_response_id`

--- a/openspec/changes/fix-websocket-tool-output-delta-retry/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-websocket-tool-output-delta-retry/specs/responses-api-compat/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: WebSocket tool-output deltas are not fresh-retryable
+
+When a direct WebSocket Responses request includes `previous_response_id` and
+only carries tool output items for tool calls that are not present in the same
+payload, the service MUST NOT replay that payload as a fresh turn without the
+previous-response anchor after an upstream `previous_response_not_found`.
+
+#### Scenario: output-only WebSocket tool delta is not replayed as a fresh turn
+
+- **WHEN** a WebSocket `/v1/responses` or `/backend-api/codex/responses`
+  follow-up has `previous_response_id`
+- **AND** the request payload carries `function_call_output`,
+  `custom_tool_call_output`, or `apply_patch_call_output` items without their
+  matching tool-call items in the same payload
+- **AND** upstream emits `previous_response_not_found` before assigning a
+  response id
+- **THEN** the service does not replay that payload as a fresh turn without
+  `previous_response_id`

--- a/openspec/changes/fix-websocket-tool-output-delta-retry/tasks.md
+++ b/openspec/changes/fix-websocket-tool-output-delta-retry/tasks.md
@@ -1,0 +1,3 @@
+- [x] 1. Detect output-only WebSocket tool deltas as unsafe for fresh retry.
+- [x] 2. Keep full resend stale-anchor recovery retry-safe.
+- [x] 3. Update OpenSpec and focused regression coverage.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -103,7 +103,7 @@ When an HTTP bridge session receives an anonymous upstream `previous_response_no
 - **AND** the downstream error code is not `previous_response_not_found`
 
 ### Requirement: WebSocket full-resend previous-response misses retry without stale anchor
-When a direct WebSocket `response.create` request includes both `previous_response_id` and a full resend payload, the service MUST retain a safe replay body without `previous_response_id`. If upstream rejects the anchor with `previous_response_not_found` before `response.created`, the service MUST reconnect and replay the retained full payload as a fresh turn instead of forwarding the raw upstream invalid-request error.
+When a direct WebSocket `response.create` request includes both `previous_response_id` and a self-contained full resend payload, the service MUST retain a safe replay body without `previous_response_id`. If upstream rejects the anchor with `previous_response_not_found` before `response.created`, the service MUST reconnect and replay the retained full payload as a fresh turn instead of forwarding the raw upstream invalid-request error. A payload that only carries incremental tool outputs for tool calls that are not also present in the same request is not self-contained and MUST NOT be replayed as a fresh turn without `previous_response_id`.
 
 #### Scenario: full-resend WebSocket follow-up loses just-completed anchor
 - **WHEN** a WebSocket `/v1/responses` or `/backend-api/codex/responses` follow-up has `previous_response_id`
@@ -112,6 +112,13 @@ When a direct WebSocket `response.create` request includes both `previous_respon
 - **THEN** the service reconnects the upstream WebSocket
 - **AND** it replays the same request without `previous_response_id`
 - **AND** the downstream client receives the recovered response events, not the raw `previous_response_not_found` error
+
+#### Scenario: output-only WebSocket tool delta is not replayed as a fresh turn
+- **WHEN** a WebSocket `/v1/responses` or `/backend-api/codex/responses` follow-up has `previous_response_id`
+- **AND** the request payload carries `function_call_output`, `custom_tool_call_output`, or `apply_patch_call_output` items without their matching tool-call items in the same payload
+- **AND** upstream emits `previous_response_not_found` before assigning a response id
+- **THEN** the service MUST NOT replay that payload as a fresh turn without `previous_response_id`
+- **AND** the downstream client receives a retryable continuity failure rather than a fabricated fresh turn
 
 ### Requirement: Public Responses errors mask previous-response misses
 Public Responses endpoints MUST NOT return an OpenAI-shaped `previous_response_not_found` error to clients. If a lower layer still raises or collects that error, the API layer MUST rewrite it to a retryable `stream_incomplete` continuity failure and remove the missing response id from the public payload.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11773,7 +11773,7 @@ async def test_prepare_websocket_response_create_request_does_not_fresh_retry_in
     assert upstream_payload["previous_response_id"] == "resp_completed_anchor"
     assert upstream_payload["input"] == [new_input]
     assert prepared.request_state.proxy_injected_previous_response_id is True
-    assert prepared.request_state.fresh_upstream_request_text is not None
+    assert prepared.request_state.fresh_upstream_request_text is None
     assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11661,6 +11661,7 @@ async def test_prepare_websocket_response_create_request_injects_anchor_for_code
 
     historical_input: list[JsonValue] = [
         {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
+        {"type": "function_call", "name": "shell_command", "call_id": "call_old", "arguments": "{}"},
         {"type": "function_call_output", "call_id": "call_old", "output": "old output"},
     ]
     new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "next question"}]}
@@ -11697,7 +11698,7 @@ async def test_prepare_websocket_response_create_request_injects_anchor_for_code
     assert upstream_payload["input"] == [new_input]
     assert prepared.request_state.previous_response_id == "resp_completed_anchor"
     assert prepared.request_state.proxy_injected_previous_response_id is True
-    assert prepared.request_state.input_item_count == 3
+    assert prepared.request_state.input_item_count == 4
     assert prepared.request_state.input_full_fingerprint == proxy_service._fingerprint_input_items(
         [*historical_input, new_input]
     )
@@ -11706,6 +11707,74 @@ async def test_prepare_websocket_response_create_request_injects_anchor_for_code
     fresh_payload = json.loads(prepared.request_state.fresh_upstream_request_text)
     assert "previous_response_id" not in fresh_payload
     assert fresh_payload["input"] == [*historical_input, new_input]
+
+
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_does_not_fresh_retry_injected_tool_output_delta(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_trim_tool_delta",
+        name="ws-trim-tool-delta",
+        key_prefix="sk-ws-trim-tool",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    historical_input: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_delta", "output": "ok"},
+    ]
+    new_input: JsonValue = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_input_count=len(historical_input),
+        last_completed_response_id="resp_completed_anchor",
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "input": [*historical_input, new_input],
+            },
+        ),
+        headers={"session_id": "turn_ws_trim_tool_delta"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_completed_anchor"
+    assert upstream_payload["input"] == [new_input]
+    assert prepared.request_state.proxy_injected_previous_response_id is True
+    assert prepared.request_state.fresh_upstream_request_text is not None
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14713,6 +14713,81 @@ async def test_process_upstream_websocket_text_transparently_retries_precreated_
 
 
 @pytest.mark.asyncio
+async def test_process_upstream_websocket_text_does_not_fresh_retry_injected_tool_output_previous_response_not_found(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_tool_delta_prev_nf")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    trimmed_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "previous_response_id": "resp_completed_anchor",
+        "input": [{"type": "function_call_output", "call_id": "call_delta", "output": "ok"}],
+    }
+    full_retry_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "input": [
+            {"type": "function_call_output", "call_id": "call_delta", "output": "ok"},
+            {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+        ],
+    }
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_tool_delta_prev_nf",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(trimmed_payload, separators=(",", ":")),
+        previous_response_id="resp_completed_anchor",
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_text=json.dumps(full_retry_payload, separators=(",", ":")),
+        fresh_upstream_request_is_retry_safe=False,
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "previous_response_not_found",
+            "message": "Previous response with id 'resp_completed_anchor' not found.",
+            "param": "previous_response_id",
+        },
+    }
+
+    downstream_text = await service._process_upstream_websocket_text(
+        json.dumps(upstream_payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert '"type":"response.failed"' in downstream_text
+    assert '"code":"stream_incomplete"' in downstream_text
+    assert "previous_response_not_found" not in downstream_text
+    finalize_request_state.assert_awaited_once()
+    handle_stream_error.assert_not_awaited()
+    assert upstream_control.suppress_downstream_event is False
+    assert upstream_control.replay_request_state is None
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_maps_previous_response_usage_limit_to_upstream_unavailable(
     monkeypatch,
 ):

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11779,6 +11779,69 @@ async def test_prepare_websocket_response_create_request_captures_client_full_re
     assert fresh_payload["input"] == full_resend_input
 
 
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_does_not_fresh_retry_tool_output_delta(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_tool_delta",
+        name="ws-tool-delta",
+        key_prefix="sk-ws-tool-delta",
+        allowed_models=["gpt-5.1"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    tool_output_delta: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_delta_a", "output": "ok"},
+        {"type": "function_call_output", "call_id": "call_delta_b", "output": "ok"},
+        {"type": "function_call_output", "call_id": "call_delta_c", "output": "ok"},
+    ]
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.1",
+                "previous_response_id": "resp_client_anchor",
+                "input": tool_output_delta,
+            },
+        ),
+        headers={"session_id": "turn_ws_tool_delta"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=None,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_client_anchor"
+    assert upstream_payload["input"] == tool_output_delta
+    assert prepared.request_state.previous_response_id == "resp_client_anchor"
+    assert prepared.request_state.fresh_upstream_request_is_retry_safe is False
+    assert prepared.request_state.fresh_upstream_request_text is None
+
+
 def test_websocket_client_previous_response_full_resend_retry_requires_matching_prefix() -> None:
     stored_prefix: list[JsonValue] = [{"role": "user", "content": [{"type": "input_text", "text": "old question"}]}]
     continuity_state = proxy_service._WebSocketContinuityState(
@@ -11799,6 +11862,56 @@ def test_websocket_client_previous_response_full_resend_retry_requires_matching_
             continuity_state=continuity_state,
         )
         is False
+    )
+
+
+def test_websocket_client_previous_response_full_resend_retry_rejects_tool_output_delta() -> None:
+    tool_output_delta: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_a", "output": "ok"},
+        {"type": "function_call_output", "call_id": "call_b", "output": "ok"},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=tool_output_delta,
+            continuity_state=None,
+        )
+        is False
+    )
+
+
+def test_websocket_client_previous_response_full_resend_retry_rejects_output_before_call() -> None:
+    reordered_tool_history: list[JsonValue] = [
+        {"type": "function_call_output", "call_id": "call_late", "output": "ok"},
+        {"type": "function_call", "name": "shell_command", "call_id": "call_late", "arguments": "{}"},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=reordered_tool_history,
+            continuity_state=None,
+        )
+        is False
+    )
+
+
+def test_websocket_client_previous_response_full_resend_retry_allows_self_contained_tool_history() -> None:
+    self_contained_tool_history: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "run a command"}]},
+        {"type": "function_call", "name": "shell_command", "call_id": "call_ok", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_ok", "output": "ok"},
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=self_contained_tool_history,
+            continuity_state=None,
+        )
+        is True
     )
 
 


### PR DESCRIPTION
## Problem

Codex Desktop can send a `response.create` request with `previous_response_id` and an `input` delta that contains only `function_call_output` items. That payload is valid only while the upstream response history remains anchored by `previous_response_id`.

The proxy's fresh retry preparation could previously treat a multi-item client resend as safe to replay without that upstream anchor. For tool-output-only deltas, that creates a fresh request containing `function_call_output` items without the matching prior `function_call` items, which can be rejected upstream with errors like:

`No tool call found for function call output with call_id ...`

## Changes

- Require tool-output items in a fresh replay candidate to be self-contained: each `function_call_output`, `custom_tool_call_output`, or `apply_patch_call_output` must have a matching earlier call item with the same `call_id` in the replayed input.
- Reject tool-output-only deltas and output-before-call histories as fresh-retry candidates.
- Preserve the normal anchored request path with `previous_response_id`; this only disables unsafe fresh replay construction.
- Keep self-contained full histories retry-safe.

## Impact

This prevents the proxy from manufacturing an invalid fresh retry for Codex tool-output deltas. Normal text requests and full self-contained replay payloads continue to behave as before.

## Tests

- `uv run pytest -q tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_does_not_fresh_retry_tool_output_delta tests/unit/test_proxy_utils.py::test_prepare_websocket_response_create_request_captures_client_full_resend_anchor_replay tests/unit/test_proxy_utils.py::test_websocket_client_previous_response_full_resend_retry_rejects_tool_output_delta tests/unit/test_proxy_utils.py::test_websocket_client_previous_response_full_resend_retry_rejects_output_before_call tests/unit/test_proxy_utils.py::test_websocket_client_previous_response_full_resend_retry_allows_self_contained_tool_history`