### PR TITLE
fix(quota-planner): normalize datetimes before database use

### DIFF
--- a/app/modules/quota_planner/repository.py
+++ b/app/modules/quota_planner/repository.py
@@ -312,6 +312,7 @@ class QuotaPlannerRepository:
             for row in result.all()
         ]
 
+
 def _settings_from_row(row: QuotaPlannerSettings) -> PlannerSettings:
     return PlannerSettings(
         mode=row.mode,

--- a/app/modules/quota_planner/repository.py
+++ b/app/modules/quota_planner/repository.py
@@ -175,6 +175,7 @@ class QuotaPlannerRepository:
         return row
 
     async def count_executed_warmups_since(self, since: datetime) -> int:
+        since = to_utc_naive(since)
         stmt = select(func.count(QuotaPlannerDecision.id)).where(
             and_(
                 QuotaPlannerDecision.action == "warmup",
@@ -185,6 +186,7 @@ class QuotaPlannerRepository:
         return int(await self._session.scalar(stmt) or 0)
 
     async def warmup_cost_since(self, since: datetime) -> float:
+        since = to_utc_naive(since)
         stmt = select(func.coalesce(func.sum(RequestLog.cost_usd), 0.0)).where(
             and_(
                 RequestLog.request_kind == "warmup",
@@ -230,7 +232,7 @@ class QuotaPlannerRepository:
     ) -> QuotaWindowObservation:
         row = QuotaWindowObservation(
             account_id=account_id,
-            observed_at=observed_at or utcnow(),
+            observed_at=_to_db_naive_utc(observed_at) or utcnow(),
             model=model,
             primary_remaining_percent=primary_remaining_percent,
             primary_reset_at=primary_reset_at,
@@ -251,7 +253,7 @@ class QuotaPlannerRepository:
         since: datetime | None = None,
         bucket_seconds: int = 900,
     ) -> list[DemandBin]:
-        since = since or (utcnow() - timedelta(days=28))
+        since = to_utc_naive(since) if since is not None else (utcnow() - timedelta(days=28))
         bind = self._session.get_bind()
         dialect = bind.dialect.name if bind else "sqlite"
         if dialect == "postgresql":
@@ -309,7 +311,6 @@ class QuotaPlannerRepository:
             )
             for row in result.all()
         ]
-
 
 def _settings_from_row(row: QuotaPlannerSettings) -> PlannerSettings:
     return PlannerSettings(

--- a/openspec/changes/fix-quota-planner-datetime-normalization/proposal.md
+++ b/openspec/changes/fix-quota-planner-datetime-normalization/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+Quota planner repository methods accept caller-supplied datetimes for warmup
+counts, cost aggregation, demand bins, and window observations. Timezone-aware
+values can cross the database boundary from API or scheduler code, but database
+comparisons and inserts expect the project-standard naive UTC representation.
+
+## What Changes
+
+- Normalize quota planner repository datetime inputs to naive UTC before
+  binding them into database comparisons or persisted observation rows.
+- Cover aware datetime inputs across warmup counts, warmup cost aggregation,
+  demand bin aggregation, and quota window observations.
+
+## Impact
+
+- PostgreSQL and SQLite planner queries receive the same UTC-normalized
+  boundary values.
+- Operators avoid planner failures or missed demand windows caused by mixed
+  aware and naive datetime inputs.

--- a/openspec/changes/fix-quota-planner-datetime-normalization/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/fix-quota-planner-datetime-normalization/specs/quota-phase-planner/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Planner repository datetime boundaries are UTC-normalized
+
+Quota phase planner repository methods MUST normalize timezone-aware datetime
+inputs to naive UTC before binding those values into database comparisons or
+persisted planner observation timestamps.
+
+#### Scenario: Aware datetimes are accepted at repository boundaries
+
+- **GIVEN** quota planner repository calls receive timezone-aware datetime
+  values for warmup decision queries, demand aggregation, or quota window
+  observations
+- **WHEN** those calls bind the values into database statements
+- **THEN** the bound values use naive UTC timestamps
+- **AND** the queries return rows that match the equivalent UTC instant

--- a/openspec/changes/fix-quota-planner-datetime-normalization/tasks.md
+++ b/openspec/changes/fix-quota-planner-datetime-normalization/tasks.md
@@ -1,0 +1,3 @@
+- [x] 1. Normalize quota planner repository datetime inputs before database binding.
+- [x] 2. Add regression coverage for aware datetime inputs at the repository boundary.
+- [x] 3. Validate OpenSpec and focused quota planner tests.

--- a/tests/unit/test_quota_planner.py
+++ b/tests/unit/test_quota_planner.py
@@ -5,7 +5,8 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from app.core.balancer import AccountState
-from app.db.models import AccountStatus
+from app.db.models import Account, AccountStatus, RequestLog
+from app.db.session import SessionLocal
 from app.modules.quota_planner.logic import (
     DemandForecastSlot,
     PlannerAction,
@@ -18,7 +19,7 @@ from app.modules.quota_planner.logic import (
     plan_shadow_actions,
     simulate_pool,
 )
-from app.modules.quota_planner.repository import DemandBin, _to_db_naive_utc
+from app.modules.quota_planner.repository import DemandBin, QuotaPlannerRepository, _to_db_naive_utc
 
 pytestmark = pytest.mark.unit
 
@@ -97,6 +98,87 @@ def test_to_db_naive_utc_normalizes_aware_datetimes() -> None:
 
     assert _to_db_naive_utc(scheduled_at) == datetime(2026, 6, 18, 5, 30)
     assert _to_db_naive_utc(None) is None
+
+
+@pytest.mark.asyncio
+async def test_quota_planner_repository_normalizes_aware_datetimes_at_session_boundary(db_setup) -> None:
+    del db_setup
+    tz_plus_3 = timezone(timedelta(hours=3))
+    scheduled_at = datetime(2026, 6, 18, 8, 30, tzinfo=tz_plus_3)
+    executed_at = datetime(2026, 6, 18, 9, 0, tzinfo=tz_plus_3)
+    observed_at = datetime(2026, 6, 18, 9, 15, tzinfo=tz_plus_3)
+    aware_since = datetime(2026, 6, 18, 8, 30, tzinfo=tz_plus_3)
+
+    async with SessionLocal() as session:
+        session.add(
+            Account(
+                id="quota-planner-aware-account",
+                email="quota-planner-aware@example.com",
+                plan_type="plus",
+                access_token_encrypted=b"access",
+                refresh_token_encrypted=b"refresh",
+                id_token_encrypted=b"id",
+                last_refresh=datetime(2026, 6, 18, 5, 0),
+                status=AccountStatus.ACTIVE,
+            )
+        )
+        await session.commit()
+
+        repo = QuotaPlannerRepository(session)
+        decision = await repo.log_decision(
+            mode="shadow",
+            action="warmup",
+            idempotency_key="quota-planner-aware-boundary",
+            account_id="quota-planner-aware-account",
+            scheduled_at=scheduled_at,
+            status="planned",
+        )
+
+        assert decision.scheduled_at == datetime(2026, 6, 18, 5, 30)
+
+        updated = await repo.update_decision_status(
+            decision.id,
+            status="executed",
+            executed_at=executed_at,
+            expected_status="planned",
+        )
+
+        assert updated is not None
+        assert updated.executed_at == datetime(2026, 6, 18, 6, 0)
+
+        observation = await repo.add_window_observation(
+            account_id="quota-planner-aware-account",
+            source="warmup_probe",
+            observed_at=observed_at,
+            model="gpt-5.4-mini",
+            confidence="observed",
+        )
+
+        assert observation.observed_at == datetime(2026, 6, 18, 6, 15)
+
+        session.add(
+            RequestLog(
+                request_id="quota-planner-aware-warmup",
+                request_kind="warmup",
+                requested_at=datetime(2026, 6, 18, 6, 30),
+                model="gpt-5.4-mini",
+                status="ok",
+                input_tokens=12,
+                cached_input_tokens=3,
+                output_tokens=4,
+                cost_usd=0.25,
+            )
+        )
+        await session.commit()
+
+        assert await repo.count_executed_warmups_since(aware_since) == 1
+        assert await repo.warmup_cost_since(aware_since) == pytest.approx(0.25)
+
+        bins = await repo.aggregate_demand_bins(since=aware_since)
+
+        assert len(bins) == 1
+        assert bins[0].request_count == 1
+        assert bins[0].cost_usd == pytest.approx(0.25)
 
 
 def test_candidate_start_times_do_not_floor_now_into_the_past() -> None:

--- a/tests/unit/test_quota_planner.py
+++ b/tests/unit/test_quota_planner.py
@@ -18,7 +18,7 @@ from app.modules.quota_planner.logic import (
     plan_shadow_actions,
     simulate_pool,
 )
-from app.modules.quota_planner.repository import DemandBin
+from app.modules.quota_planner.repository import DemandBin, _to_db_naive_utc
 
 pytestmark = pytest.mark.unit
 
@@ -90,6 +90,13 @@ def test_planner_settings_default_to_nonblocking_shadow_mode() -> None:
     assert settings.prewarm_enabled is True
     assert settings.allow_synthetic_traffic is False
     assert settings.dry_run is True
+
+
+def test_to_db_naive_utc_normalizes_aware_datetimes() -> None:
+    scheduled_at = datetime(2026, 6, 18, 8, 30, tzinfo=timezone(timedelta(hours=3)))
+
+    assert _to_db_naive_utc(scheduled_at) == datetime(2026, 6, 18, 5, 30)
+    assert _to_db_naive_utc(None) is None
 
 
 def test_candidate_start_times_do_not_floor_now_into_the_past() -> None:


### PR DESCRIPTION
## Problem

The quota planner can handle timezone-aware datetimes from scheduler/runtime code, while the database columns and query comparisons are treated as UTC-naive timestamps. In Postgres setups this can surface as scheduler/database errors when aware values are written to `timestamp without time zone` columns or compared against naive stored values.

## Changes

- Add a small repository helper that normalizes optional datetimes to naive UTC before database use.
- Normalize `scheduled_at`, `executed_at`, and quota-window `observed_at` values before writes.
- Normalize `since` bounds before executed-warmup counts, warmup-cost queries, and demand-history queries.

## Impact

This keeps the quota planner's database boundary consistent: application code may pass aware datetimes, while persistence/query code stores and compares naive UTC values. It avoids scheduler failures caused by timezone-aware values reaching naive DB fields.

## Tests

- `uv run pytest -q tests/unit/test_quota_planner.py`