### PR TITLE
fix(http-bridge): clean stale inflight session futures

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -839,6 +839,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "zvladru",
+      "name": "zvladru",
+      "avatar_url": "https://avatars.githubusercontent.com/u/30793959?v=4",
+      "profile": "https://github.com/zvladru",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/modules/health/api.py
+++ b/app/modules/health/api.py
@@ -130,14 +130,28 @@ async def internal_drain_status(request: Request) -> HealthCheckResponse:
 
     import app.core.shutdown as shutdown_state
 
-    return HealthCheckResponse(
-        status="ok",
-        checks={
-            "draining": str(shutdown_state.is_draining()).lower(),
-            "bridge_drain_active": str(shutdown_state.is_bridge_drain_active()).lower(),
-            "in_flight": str(shutdown_state.get_in_flight()),
-        },
-    )
+    checks = {
+        "draining": str(shutdown_state.is_draining()).lower(),
+        "bridge_drain_active": str(shutdown_state.is_bridge_drain_active()).lower(),
+        "in_flight": str(shutdown_state.get_in_flight()),
+    }
+
+    app = getattr(request, "app", None)
+    app_state = getattr(app, "state", None)
+    proxy_service = getattr(app_state, "proxy_service", None)
+    if proxy_service is not None and hasattr(proxy_service, "http_bridge_activity_snapshot_nowait"):
+        try:
+            bridge_activity = proxy_service.http_bridge_activity_snapshot_nowait()
+            checks.update(
+                {
+                    key: str(value).lower() if isinstance(value, bool) else str(value)
+                    for key, value in bridge_activity.items()
+                }
+            )
+        except Exception as exc:
+            checks["http_bridge_activity_error"] = type(exc).__name__
+
+    return HealthCheckResponse(status="ok", checks=checks)
 
 
 def _bridge_readiness_failure_detail(bridge_ring: BridgeRingInfo) -> str | None:

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -174,6 +174,10 @@ from app.modules.proxy.ring_membership import (
 logger = logging.getLogger("app.modules.proxy.service")
 T = TypeVar("T")
 
+_HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR = "_codex_lb_started_at"
+_HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS = 120.0
+_HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER = 6.0
+
 
 @dataclass(frozen=True, slots=True)
 class _HTTPBridgeRuntimeConfig:
@@ -220,6 +224,17 @@ def _proxy_admission_wait_timeout_seconds(settings: Any | None = None) -> float:
     return cast(Callable[[Any | None], float], _service_global("_proxy_admission_wait_timeout_seconds"))(settings)
 
 
+def _http_bridge_stale_inflight_seconds() -> float:
+    try:
+        admission_timeout = _proxy_admission_wait_timeout_seconds()
+    except Exception:
+        admission_timeout = 10.0
+    return max(
+        _HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS,
+        admission_timeout * _HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER,
+    )
+
+
 def _normalize_responses_request_payload_for_bridge(payload: ResponsesRequest) -> ResponsesRequest:
     return cast(
         Callable[[ResponsesRequest], ResponsesRequest],
@@ -246,6 +261,147 @@ def _http_bridge_startup_wait_timeout_error(
 ) -> ProxyResponseError:
     message = f"codex-lb is temporarily overloaded during {stage}"
     return ProxyResponseError(429, local_overload_error(message, code=code))
+
+
+def _http_bridge_pending_count_nowait(
+    session: "_HTTPBridgeSession",
+    *,
+    context: str,
+) -> int | None:
+    try:
+        session.pending_lock.acquire_nowait()
+    except Exception as exc:
+        if type(exc).__name__ not in {"WouldBlock", "RuntimeError"}:
+            raise
+        logger.warning(
+            "http_bridge_pending_count_unavailable context=%s bridge_kind=%s bridge_key=%s account_id=%s model=%s",
+            context,
+            session.key.affinity_kind,
+            _hash_identifier(session.key.affinity_key),
+            session.account.id,
+            session.request_model,
+        )
+        return None
+    try:
+        request_counts_against_queue = _service_global("_http_bridge_request_counts_against_queue")
+        visible_pending_count = sum(
+            1 for request_state in session.pending_requests if request_counts_against_queue(request_state)
+        )
+        return max(visible_pending_count, session.queued_request_count)
+    finally:
+        session.pending_lock.release()
+
+
+def _cleanup_http_bridge_inflight_sessions_nowait(service: Any) -> dict[str, int]:
+    now = _service_time().monotonic()
+    stale_after_seconds = _http_bridge_stale_inflight_seconds()
+    cleaned = 0
+    stale = 0
+    oldest_age_seconds = 0
+    try:
+        service._http_bridge_lock.acquire_nowait()
+    except Exception as exc:
+        if type(exc).__name__ not in {"WouldBlock", "RuntimeError"}:
+            raise
+        for future in service._http_bridge_inflight_sessions.values():
+            started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
+            age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+            oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
+            if isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
+                stale += 1
+        return {
+            "cleaned": 0,
+            "stale": stale,
+            "oldest_age_seconds": oldest_age_seconds,
+        }
+    try:
+        for key, future in list(service._http_bridge_inflight_sessions.items()):
+            current_future = service._http_bridge_inflight_sessions.get(key)
+            if current_future is not future:
+                continue
+            started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
+            age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+            oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
+            cleanup_reason: str | None = None
+            is_stale = isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds
+            if is_stale:
+                stale += 1
+            if future.done():
+                cleanup_reason = "done"
+            if cleanup_reason is None:
+                continue
+            service._http_bridge_inflight_sessions.pop(key, None)
+            cleaned += 1
+            if future.done() and not future.cancelled():
+                try:
+                    future.exception()
+                except Exception:
+                    pass
+            logger.warning(
+                "http_bridge_inflight_session_create_cleanup reason=%s bridge_kind=%s bridge_key=%s"
+                " age_seconds=%d stale_after_seconds=%d done=%s cancelled=%s",
+                cleanup_reason,
+                key.affinity_kind,
+                _hash_identifier(key.affinity_key),
+                int(age_seconds),
+                int(stale_after_seconds),
+                future.done(),
+                future.cancelled(),
+            )
+    finally:
+        service._http_bridge_lock.release()
+    return {
+        "cleaned": cleaned,
+        "stale": stale,
+        "oldest_age_seconds": oldest_age_seconds,
+    }
+
+
+def http_bridge_activity_snapshot_nowait(service: Any) -> dict[str, int | bool]:
+    inflight_cleanup = _cleanup_http_bridge_inflight_sessions_nowait(service)
+    live_sessions = 0
+    pending_or_queued_requests = 0
+    pending_unknown_sessions = 0
+
+    for session in list(service._http_bridge_sessions.values()):
+        if session.closed:
+            continue
+        live_sessions += 1
+        pending_count = _http_bridge_pending_count_nowait(session, context="drain_status")
+        if pending_count is None:
+            pending_unknown_sessions += 1
+        else:
+            pending_or_queued_requests += max(0, pending_count)
+
+    inflight_session_creates = len(service._http_bridge_inflight_sessions)
+    active_cleanup_tasks = sum(
+        1
+        for task in service._background_cleanup_tasks
+        if not task.done()
+        and (
+            task.get_name().startswith("proxy-http_bridge_session_close-")
+            or task.get_name().startswith("http-bridge-close-")
+        )
+    )
+    bridge_active = (
+        live_sessions > 0
+        or pending_or_queued_requests > 0
+        or pending_unknown_sessions > 0
+        or inflight_session_creates > 0
+    )
+    restart_blocking = pending_or_queued_requests > 0 or pending_unknown_sessions > 0 or inflight_session_creates > 0
+    return {
+        "http_bridge_live_sessions": live_sessions,
+        "http_bridge_pending_or_queued_requests": pending_or_queued_requests,
+        "http_bridge_pending_unknown_sessions": pending_unknown_sessions,
+        "http_bridge_inflight_session_creates": inflight_session_creates,
+        "http_bridge_inflight_session_create_oldest_age_seconds": inflight_cleanup["oldest_age_seconds"],
+        "http_bridge_stale_inflight_session_creates": inflight_cleanup["stale"],
+        "http_bridge_cleaned_inflight_session_creates": inflight_cleanup["cleaned"],
+        "http_bridge_background_cleanup_tasks": active_cleanup_tasks,
+        "http_bridge_active": bridge_active,
+        "http_bridge_restart_blocking": restart_blocking,
+    }
 
 
 def _log_http_bridge_startup_wait_timeout(

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -65,6 +65,7 @@ from app.modules.proxy._service.compact import (
 )
 from app.modules.proxy._service.http_bridge.account_sessions import _HTTPBridgeAccountSessionsMixin
 from app.modules.proxy._service.http_bridge.helpers import (
+    _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR,
     _active_http_bridge_instance_ring,
     _durable_bridge_lookup_active_owner,
     _durable_bridge_lookup_allows_local_reuse,
@@ -101,6 +102,12 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _record_bridge_drain_recovery_allowed,
     _record_bridge_first_turn_timeout,
     _record_bridge_reattach,
+)
+from app.modules.proxy._service.http_bridge.helpers import (
+    _http_bridge_pending_count_nowait as helpers_http_bridge_pending_count_nowait,
+)
+from app.modules.proxy._service.http_bridge.helpers import (
+    http_bridge_activity_snapshot_nowait as helpers_http_bridge_activity_snapshot_nowait,
 )
 from app.modules.proxy._service.http_bridge.owner_forwarding import _HTTPBridgeOwnerForwardingMixin
 from app.modules.proxy._service.http_bridge.protocol import _HTTPBridgeServiceProtocol
@@ -216,9 +223,6 @@ _SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
 )
 _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS = 5.0
 _HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD = 100
-_HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR = "_codex_lb_started_at"
-_HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS = 120.0
-_HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER = 6.0
 
 
 class _HTTPBridgeMixin(
@@ -238,146 +242,16 @@ class _HTTPBridgeMixin(
             )
             return max(visible_pending_count, session.queued_request_count)
 
+    def http_bridge_activity_snapshot_nowait(self) -> dict[str, int | bool]:
+        return helpers_http_bridge_activity_snapshot_nowait(self)
+
     def _http_bridge_pending_count_nowait(
         self,
         session: "_HTTPBridgeSession",
         *,
         context: str,
     ) -> int | None:
-        try:
-            session.pending_lock.acquire_nowait()
-        except (anyio.WouldBlock, RuntimeError):
-            logger.warning(
-                "http_bridge_pending_count_unavailable context=%s bridge_kind=%s bridge_key=%s account_id=%s model=%s",
-                context,
-                session.key.affinity_kind,
-                _hash_identifier(session.key.affinity_key),
-                session.account.id,
-                session.request_model,
-            )
-            return None
-        try:
-            visible_pending_count = sum(
-                1
-                for request_state in session.pending_requests
-                if _http_bridge_request_counts_against_queue(request_state)
-            )
-            return max(visible_pending_count, session.queued_request_count)
-        finally:
-            session.pending_lock.release()
-
-    def http_bridge_activity_snapshot_nowait(self) -> dict[str, int | bool]:
-        inflight_cleanup = self._cleanup_http_bridge_inflight_sessions_nowait()
-        live_sessions = 0
-        pending_or_queued_requests = 0
-        pending_unknown_sessions = 0
-
-        for session in list(self._http_bridge_sessions.values()):
-            if session.closed:
-                continue
-            live_sessions += 1
-            pending_count = self._http_bridge_pending_count_nowait(session, context="drain_status")
-            if pending_count is None:
-                pending_unknown_sessions += 1
-            else:
-                pending_or_queued_requests += max(0, pending_count)
-
-        inflight_session_creates = len(self._http_bridge_inflight_sessions)
-        active_cleanup_tasks = sum(1 for task in self._background_cleanup_tasks if not task.done())
-        restart_blocking = (
-            pending_or_queued_requests > 0 or pending_unknown_sessions > 0 or inflight_session_creates > 0
-        )
-        return {
-            "http_bridge_live_sessions": live_sessions,
-            "http_bridge_pending_or_queued_requests": pending_or_queued_requests,
-            "http_bridge_pending_unknown_sessions": pending_unknown_sessions,
-            "http_bridge_inflight_session_creates": inflight_session_creates,
-            "http_bridge_inflight_session_create_oldest_age_seconds": inflight_cleanup["oldest_age_seconds"],
-            "http_bridge_stale_inflight_session_creates": inflight_cleanup["stale"],
-            "http_bridge_cleaned_inflight_session_creates": inflight_cleanup["cleaned"],
-            "http_bridge_background_cleanup_tasks": active_cleanup_tasks,
-            "http_bridge_restart_blocking": restart_blocking,
-        }
-
-    def _cleanup_http_bridge_inflight_sessions_nowait(self) -> dict[str, int]:
-        now = _service_time().monotonic()
-        stale_after_seconds = self._http_bridge_stale_inflight_seconds()
-        cleaned = 0
-        stale = 0
-        oldest_age_seconds = 0
-        try:
-            self._http_bridge_lock.acquire_nowait()
-        except (anyio.WouldBlock, RuntimeError):
-            for future in self._http_bridge_inflight_sessions.values():
-                started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
-                age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
-                oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
-                if isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
-                    stale += 1
-            return {
-                "cleaned": 0,
-                "stale": stale,
-                "oldest_age_seconds": oldest_age_seconds,
-            }
-        try:
-            for key, future in list(self._http_bridge_inflight_sessions.items()):
-                current_future = self._http_bridge_inflight_sessions.get(key)
-                if current_future is not future:
-                    continue
-                started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
-                age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
-                oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
-                cleanup_reason: str | None = None
-                cleanup_exc: BaseException | None = None
-                if future.done():
-                    cleanup_reason = "done"
-                elif isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
-                    stale += 1
-                    cleanup_reason = "stale"
-                    cleanup_exc = _http_bridge_startup_wait_timeout_error(
-                        "http_bridge_inflight_session_stale",
-                        code="capacity_exhausted_active_sessions",
-                    )
-                if cleanup_reason is None:
-                    continue
-                self._http_bridge_inflight_sessions.pop(key, None)
-                cleaned += 1
-                if cleanup_exc is not None and not future.done():
-                    future.set_exception(cleanup_exc)
-                    future.exception()
-                elif future.done() and not future.cancelled():
-                    try:
-                        future.exception()
-                    except Exception:
-                        pass
-                logger.warning(
-                    "http_bridge_inflight_session_create_cleanup reason=%s bridge_kind=%s bridge_key=%s"
-                    " age_seconds=%d stale_after_seconds=%d done=%s cancelled=%s",
-                    cleanup_reason,
-                    key.affinity_kind,
-                    _hash_identifier(key.affinity_key),
-                    int(age_seconds),
-                    int(stale_after_seconds),
-                    future.done(),
-                    future.cancelled(),
-                )
-        finally:
-            self._http_bridge_lock.release()
-        return {
-            "cleaned": cleaned,
-            "stale": stale,
-            "oldest_age_seconds": oldest_age_seconds,
-        }
-
-    def _http_bridge_stale_inflight_seconds(self) -> float:
-        try:
-            admission_timeout = _proxy_admission_wait_timeout_seconds()
-        except Exception:
-            admission_timeout = 10.0
-        return max(
-            _HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS,
-            admission_timeout * _HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER,
-        )
+        return helpers_http_bridge_pending_count_nowait(session, context=context)
 
     async def _close_http_bridge_session_bounded(
         self,

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -216,6 +216,9 @@ _SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
 )
 _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS = 5.0
 _HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD = 100
+_HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR = "_codex_lb_started_at"
+_HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS = 120.0
+_HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER = 6.0
 
 
 class _HTTPBridgeMixin(
@@ -262,6 +265,102 @@ class _HTTPBridgeMixin(
             return max(visible_pending_count, session.queued_request_count)
         finally:
             session.pending_lock.release()
+
+    def http_bridge_activity_snapshot_nowait(self) -> dict[str, int | bool]:
+        inflight_cleanup = self._cleanup_http_bridge_inflight_sessions_nowait()
+        live_sessions = 0
+        pending_or_queued_requests = 0
+        pending_unknown_sessions = 0
+
+        for session in list(self._http_bridge_sessions.values()):
+            if session.closed:
+                continue
+            live_sessions += 1
+            pending_count = self._http_bridge_pending_count_nowait(session, context="drain_status")
+            if pending_count is None:
+                pending_unknown_sessions += 1
+            else:
+                pending_or_queued_requests += max(0, pending_count)
+
+        inflight_session_creates = len(self._http_bridge_inflight_sessions)
+        active_cleanup_tasks = sum(1 for task in self._background_cleanup_tasks if not task.done())
+        restart_blocking = (
+            pending_or_queued_requests > 0 or pending_unknown_sessions > 0 or inflight_session_creates > 0
+        )
+        return {
+            "http_bridge_live_sessions": live_sessions,
+            "http_bridge_pending_or_queued_requests": pending_or_queued_requests,
+            "http_bridge_pending_unknown_sessions": pending_unknown_sessions,
+            "http_bridge_inflight_session_creates": inflight_session_creates,
+            "http_bridge_inflight_session_create_oldest_age_seconds": inflight_cleanup["oldest_age_seconds"],
+            "http_bridge_stale_inflight_session_creates": inflight_cleanup["stale"],
+            "http_bridge_cleaned_inflight_session_creates": inflight_cleanup["cleaned"],
+            "http_bridge_background_cleanup_tasks": active_cleanup_tasks,
+            "http_bridge_restart_blocking": restart_blocking,
+        }
+
+    def _cleanup_http_bridge_inflight_sessions_nowait(self) -> dict[str, int]:
+        now = _service_time().monotonic()
+        stale_after_seconds = self._http_bridge_stale_inflight_seconds()
+        cleaned = 0
+        stale = 0
+        oldest_age_seconds = 0
+        for key, future in list(self._http_bridge_inflight_sessions.items()):
+            current_future = self._http_bridge_inflight_sessions.get(key)
+            if current_future is not future:
+                continue
+            started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
+            age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+            oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
+            cleanup_reason: str | None = None
+            cleanup_exc: BaseException | None = None
+            if future.done():
+                cleanup_reason = "done"
+            elif isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
+                stale += 1
+                cleanup_reason = "stale"
+                cleanup_exc = _http_bridge_startup_wait_timeout_error(
+                    "http_bridge_inflight_session_stale",
+                    code="capacity_exhausted_active_sessions",
+                )
+            if cleanup_reason is None:
+                continue
+            self._http_bridge_inflight_sessions.pop(key, None)
+            cleaned += 1
+            if cleanup_exc is not None and not future.done():
+                future.set_exception(cleanup_exc)
+                future.exception()
+            elif future.done() and not future.cancelled():
+                try:
+                    future.exception()
+                except Exception:
+                    pass
+            logger.warning(
+                "http_bridge_inflight_session_create_cleanup reason=%s bridge_kind=%s bridge_key=%s"
+                " age_seconds=%d stale_after_seconds=%d done=%s cancelled=%s",
+                cleanup_reason,
+                key.affinity_kind,
+                _hash_identifier(key.affinity_key),
+                int(age_seconds),
+                int(stale_after_seconds),
+                future.done(),
+                future.cancelled(),
+            )
+        return {
+            "cleaned": cleaned,
+            "stale": stale,
+            "oldest_age_seconds": oldest_age_seconds,
+        }
+
+    def _http_bridge_stale_inflight_seconds(self) -> float:
+        try:
+            admission_timeout = _proxy_admission_wait_timeout_seconds()
+        except Exception:
+            admission_timeout = 10.0
+        return max(
+            _HTTP_BRIDGE_STALE_INFLIGHT_MIN_SECONDS,
+            admission_timeout * _HTTP_BRIDGE_STALE_INFLIGHT_TIMEOUT_MULTIPLIER,
+        )
 
     async def _close_http_bridge_session_bounded(
         self,
@@ -1262,6 +1361,11 @@ class _HTTPBridgeMixin(
                                 )
                         else:
                             inflight_future = asyncio.get_running_loop().create_future()
+                            setattr(
+                                inflight_future,
+                                _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR,
+                                _service_time().monotonic(),
+                            )
                             self._http_bridge_inflight_sessions[key] = inflight_future
                             owns_creation = True
 

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -305,47 +305,64 @@ class _HTTPBridgeMixin(
         cleaned = 0
         stale = 0
         oldest_age_seconds = 0
-        for key, future in list(self._http_bridge_inflight_sessions.items()):
-            current_future = self._http_bridge_inflight_sessions.get(key)
-            if current_future is not future:
-                continue
-            started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
-            age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
-            oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
-            cleanup_reason: str | None = None
-            cleanup_exc: BaseException | None = None
-            if future.done():
-                cleanup_reason = "done"
-            elif isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
-                stale += 1
-                cleanup_reason = "stale"
-                cleanup_exc = _http_bridge_startup_wait_timeout_error(
-                    "http_bridge_inflight_session_stale",
-                    code="capacity_exhausted_active_sessions",
-                )
-            if cleanup_reason is None:
-                continue
-            self._http_bridge_inflight_sessions.pop(key, None)
-            cleaned += 1
-            if cleanup_exc is not None and not future.done():
-                future.set_exception(cleanup_exc)
-                future.exception()
-            elif future.done() and not future.cancelled():
-                try:
+        try:
+            self._http_bridge_lock.acquire_nowait()
+        except (anyio.WouldBlock, RuntimeError):
+            for future in self._http_bridge_inflight_sessions.values():
+                started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
+                age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+                oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
+                if isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
+                    stale += 1
+            return {
+                "cleaned": 0,
+                "stale": stale,
+                "oldest_age_seconds": oldest_age_seconds,
+            }
+        try:
+            for key, future in list(self._http_bridge_inflight_sessions.items()):
+                current_future = self._http_bridge_inflight_sessions.get(key)
+                if current_future is not future:
+                    continue
+                started_at = getattr(future, _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR, None)
+                age_seconds = max(0.0, now - started_at) if isinstance(started_at, (int, float)) else 0.0
+                oldest_age_seconds = max(oldest_age_seconds, int(age_seconds))
+                cleanup_reason: str | None = None
+                cleanup_exc: BaseException | None = None
+                if future.done():
+                    cleanup_reason = "done"
+                elif isinstance(started_at, (int, float)) and age_seconds >= stale_after_seconds:
+                    stale += 1
+                    cleanup_reason = "stale"
+                    cleanup_exc = _http_bridge_startup_wait_timeout_error(
+                        "http_bridge_inflight_session_stale",
+                        code="capacity_exhausted_active_sessions",
+                    )
+                if cleanup_reason is None:
+                    continue
+                self._http_bridge_inflight_sessions.pop(key, None)
+                cleaned += 1
+                if cleanup_exc is not None and not future.done():
+                    future.set_exception(cleanup_exc)
                     future.exception()
-                except Exception:
-                    pass
-            logger.warning(
-                "http_bridge_inflight_session_create_cleanup reason=%s bridge_kind=%s bridge_key=%s"
-                " age_seconds=%d stale_after_seconds=%d done=%s cancelled=%s",
-                cleanup_reason,
-                key.affinity_kind,
-                _hash_identifier(key.affinity_key),
-                int(age_seconds),
-                int(stale_after_seconds),
-                future.done(),
-                future.cancelled(),
-            )
+                elif future.done() and not future.cancelled():
+                    try:
+                        future.exception()
+                    except Exception:
+                        pass
+                logger.warning(
+                    "http_bridge_inflight_session_create_cleanup reason=%s bridge_kind=%s bridge_key=%s"
+                    " age_seconds=%d stale_after_seconds=%d done=%s cancelled=%s",
+                    cleanup_reason,
+                    key.affinity_kind,
+                    _hash_identifier(key.affinity_key),
+                    int(age_seconds),
+                    int(stale_after_seconds),
+                    future.done(),
+                    future.cancelled(),
+                )
+        finally:
+            self._http_bridge_lock.release()
         return {
             "cleaned": cleaned,
             "stale": stale,

--- a/openspec/changes/document-http-bridge-drain-activity/proposal.md
+++ b/openspec/changes/document-http-bridge-drain-activity/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+Operators use `/internal/drain/status` to decide when a replica can be safely
+removed. HTTP bridge sessions can have queued or in-flight work that is not
+visible through the previous drain-status payload, and stale in-flight session
+creation markers can make a draining replica look busy forever.
+
+## What Changes
+
+- Expose HTTP bridge activity counters in the internal drain-status payload.
+- Clean stale or completed in-flight HTTP bridge session creation markers when
+  building that activity snapshot.
+- Keep the snapshot bounded and non-blocking so drain probes remain safe.
+
+## Impact
+
+- Drain automation can distinguish active bridge work from stale local markers.
+- Operators get low-cardinality counts for pending bridge sessions and cleaned
+  stale in-flight creates.

--- a/openspec/changes/document-http-bridge-drain-activity/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/document-http-bridge-drain-activity/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Drain status exposes HTTP bridge activity
+
+The internal `/internal/drain/status` payload MUST include bounded HTTP bridge
+activity counters when the proxy service exposes bridge activity. The snapshot
+MUST be non-blocking and MUST include whether HTTP bridge work is active, the
+number of visible pending or queued bridge requests, the number of live bridge
+sessions, the number of in-flight bridge session creations, the oldest in-flight
+creation age in seconds, how many in-flight create markers are older than the
+stale threshold, and how many completed in-flight create markers were cleaned
+while building the snapshot. The HTTP bridge background cleanup task count MUST
+include only active HTTP bridge close/cleanup tasks, not unrelated work stored in
+shared background task registries.
+
+#### Scenario: Drain status reports bridge work
+
+- **WHEN** `/internal/drain/status` is requested while the proxy service has
+  HTTP bridge sessions, queued work, or in-flight bridge session creation
+- **THEN** the response includes HTTP bridge activity counters
+- **AND** `http_bridge_active` is true when any pending, queued, session, or
+  in-flight create count is non-zero
+
+#### Scenario: Completed in-flight bridge creates are cleaned from drain status
+
+- **WHEN** an in-flight HTTP bridge session creation marker is completed,
+- **AND** `/internal/drain/status` builds the bridge activity snapshot
+- **THEN** the completed marker is removed from the local in-flight create map
+- **AND** the payload reports the cleaned marker count without
+  blocking the health request
+
+#### Scenario: Live stale-age bridge creates are reported but not expired
+
+- **WHEN** an in-flight HTTP bridge session creation marker is older than the
+  stale in-flight threshold but has not completed
+- **AND** `/internal/drain/status` builds the bridge activity snapshot
+- **THEN** the marker remains in the local in-flight create map
+- **AND** the payload reports the stale marker count without completing the
+  live session creation future

--- a/openspec/changes/document-http-bridge-drain-activity/tasks.md
+++ b/openspec/changes/document-http-bridge-drain-activity/tasks.md
@@ -1,0 +1,4 @@
+- [x] 1. Expose HTTP bridge activity in `/internal/drain/status`.
+- [x] 2. Clean stale/completed in-flight bridge session create markers during the snapshot.
+- [x] 3. Add focused health and bridge regression coverage.
+- [x] 4. Validate OpenSpec and focused tests.

--- a/tests/unit/test_health_probes.py
+++ b/tests/unit/test_health_probes.py
@@ -456,6 +456,7 @@ async def test_internal_drain_status_reports_bridge_activity():
                 "http_bridge_pending_or_queued_requests": 1,
                 "http_bridge_pending_unknown_sessions": 0,
                 "http_bridge_inflight_session_creates": 1,
+                "http_bridge_active": True,
                 "http_bridge_restart_blocking": True,
             }
         )
@@ -476,6 +477,7 @@ async def test_internal_drain_status_reports_bridge_activity():
     assert response.checks["http_bridge_live_sessions"] == "2"
     assert response.checks["http_bridge_pending_or_queued_requests"] == "1"
     assert response.checks["http_bridge_inflight_session_creates"] == "1"
+    assert response.checks["http_bridge_active"] == "true"
     assert response.checks["http_bridge_restart_blocking"] == "true"
 
 

--- a/tests/unit/test_health_probes.py
+++ b/tests/unit/test_health_probes.py
@@ -446,6 +446,40 @@ async def test_internal_drain_status_reports_shutdown_state():
 
 
 @pytest.mark.asyncio
+async def test_internal_drain_status_reports_bridge_activity():
+    from app.modules.health.api import internal_drain_status
+
+    proxy_service = SimpleNamespace(
+        http_bridge_activity_snapshot_nowait=MagicMock(
+            return_value={
+                "http_bridge_live_sessions": 2,
+                "http_bridge_pending_or_queued_requests": 1,
+                "http_bridge_pending_unknown_sessions": 0,
+                "http_bridge_inflight_session_creates": 1,
+                "http_bridge_restart_blocking": True,
+            }
+        )
+    )
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        app=SimpleNamespace(state=SimpleNamespace(proxy_service=proxy_service)),
+    )
+
+    with (
+        patch("app.core.shutdown.is_draining", return_value=False),
+        patch("app.core.shutdown.is_bridge_drain_active", return_value=False),
+        patch("app.core.shutdown.get_in_flight", return_value=0),
+    ):
+        response = await internal_drain_status(cast(Any, request))
+
+    assert response.checks is not None
+    assert response.checks["http_bridge_live_sessions"] == "2"
+    assert response.checks["http_bridge_pending_or_queued_requests"] == "1"
+    assert response.checks["http_bridge_inflight_session_creates"] == "1"
+    assert response.checks["http_bridge_restart_blocking"] == "true"
+
+
+@pytest.mark.asyncio
 async def test_internal_drain_status_rejects_non_loopback_clients():
     from app.modules.health.api import internal_drain_status
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -79,6 +79,72 @@ def _make_bridge_session(
     )
 
 
+@pytest.mark.asyncio
+async def test_http_bridge_activity_snapshot_counts_pending_and_inflight_sessions():
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-drain-status",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        response_id=None,
+        awaiting_response_created=True,
+        event_queue=None,
+        transport="http",
+        skip_request_log=True,
+    )
+    session = _make_bridge_session(
+        pending_requests=deque([request_state]),
+        queued_request_count=2,
+    )
+    service._http_bridge_sessions[session.key] = session
+    service._http_bridge_inflight_sessions[
+        proxy_service._HTTPBridgeSessionKey("session_header", "inflight-drain-status", None)
+    ] = asyncio.Future()
+
+    snapshot = service.http_bridge_activity_snapshot_nowait()
+
+    assert snapshot == {
+        "http_bridge_live_sessions": 1,
+        "http_bridge_pending_or_queued_requests": 2,
+        "http_bridge_pending_unknown_sessions": 0,
+        "http_bridge_inflight_session_creates": 1,
+        "http_bridge_inflight_session_create_oldest_age_seconds": 0,
+        "http_bridge_stale_inflight_session_creates": 0,
+        "http_bridge_cleaned_inflight_session_creates": 0,
+        "http_bridge_background_cleanup_tasks": 0,
+        "http_bridge_restart_blocking": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_activity_snapshot_cleans_stale_inflight_session(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "stale-inflight-drain-status", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    setattr(inflight_future, "_codex_lb_started_at", -1000.0)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda settings=None: 0.001)
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.service"):
+        snapshot = service.http_bridge_activity_snapshot_nowait()
+
+    assert key not in service._http_bridge_inflight_sessions
+    assert snapshot["http_bridge_inflight_session_creates"] == 0
+    assert snapshot["http_bridge_stale_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_cleaned_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_restart_blocking"] is False
+    assert "http_bridge_inflight_session_create_cleanup" in caplog.text
+    with pytest.raises(ProxyResponseError):
+        await inflight_future
+
+
 async def _wait_for_close_await(close_session: AsyncMock, session: proxy_service._HTTPBridgeSession) -> None:
     for _ in range(10):
         if any(call.args == (session,) for call in close_session.await_args_list):

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -145,6 +145,29 @@ async def test_http_bridge_activity_snapshot_cleans_stale_inflight_session(
         await inflight_future
 
 
+@pytest.mark.asyncio
+async def test_http_bridge_activity_snapshot_skips_inflight_cleanup_when_registry_locked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "locked-stale-inflight-drain-status", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    setattr(inflight_future, "_codex_lb_started_at", -1000.0)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda settings=None: 0.001)
+
+    async with service._http_bridge_lock:
+        snapshot = service.http_bridge_activity_snapshot_nowait()
+
+    assert key in service._http_bridge_inflight_sessions
+    assert not inflight_future.done()
+    assert snapshot["http_bridge_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_stale_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_cleaned_inflight_session_creates"] == 0
+    assert snapshot["http_bridge_restart_blocking"] is True
+
+
 async def _wait_for_close_await(close_session: AsyncMock, session: proxy_service._HTTPBridgeSession) -> None:
     for _ in range(10):
         if any(call.args == (session,) for call in close_session.await_args_list):

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -115,12 +115,30 @@ async def test_http_bridge_activity_snapshot_counts_pending_and_inflight_session
         "http_bridge_stale_inflight_session_creates": 0,
         "http_bridge_cleaned_inflight_session_creates": 0,
         "http_bridge_background_cleanup_tasks": 0,
+        "http_bridge_active": True,
         "http_bridge_restart_blocking": True,
     }
 
 
 @pytest.mark.asyncio
-async def test_http_bridge_activity_snapshot_cleans_stale_inflight_session(
+async def test_http_bridge_activity_snapshot_counts_only_bridge_cleanup_tasks():
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    bridge_task = asyncio.create_task(asyncio.sleep(60), name="proxy-http_bridge_session_close-test")
+    api_key_task = asyncio.create_task(asyncio.sleep(60), name="proxy-stream-api-key-settle-test")
+    service._background_cleanup_tasks.update({bridge_task, api_key_task})
+
+    try:
+        snapshot = service.http_bridge_activity_snapshot_nowait()
+    finally:
+        bridge_task.cancel()
+        api_key_task.cancel()
+        await asyncio.gather(bridge_task, api_key_task, return_exceptions=True)
+
+    assert snapshot["http_bridge_background_cleanup_tasks"] == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_activity_snapshot_cleans_completed_stale_inflight_session(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -128,6 +146,7 @@ async def test_http_bridge_activity_snapshot_cleans_stale_inflight_session(
     key = proxy_service._HTTPBridgeSessionKey("session_header", "stale-inflight-drain-status", None)
     inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
     setattr(inflight_future, "_codex_lb_started_at", -1000.0)
+    inflight_future.set_result(_make_bridge_session())
     service._http_bridge_inflight_sessions[key] = inflight_future
 
     monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda settings=None: 0.001)
@@ -139,10 +158,32 @@ async def test_http_bridge_activity_snapshot_cleans_stale_inflight_session(
     assert snapshot["http_bridge_inflight_session_creates"] == 0
     assert snapshot["http_bridge_stale_inflight_session_creates"] == 1
     assert snapshot["http_bridge_cleaned_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_active"] is False
     assert snapshot["http_bridge_restart_blocking"] is False
     assert "http_bridge_inflight_session_create_cleanup" in caplog.text
-    with pytest.raises(ProxyResponseError):
-        await inflight_future
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_activity_snapshot_does_not_expire_live_inflight_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "live-stale-inflight-drain-status", None)
+    inflight_future: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    setattr(inflight_future, "_codex_lb_started_at", -1000.0)
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    monkeypatch.setattr(proxy_service, "_proxy_admission_wait_timeout_seconds", lambda settings=None: 0.001)
+
+    snapshot = service.http_bridge_activity_snapshot_nowait()
+
+    assert key in service._http_bridge_inflight_sessions
+    assert not inflight_future.done()
+    assert snapshot["http_bridge_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_stale_inflight_session_creates"] == 1
+    assert snapshot["http_bridge_cleaned_inflight_session_creates"] == 0
+    assert snapshot["http_bridge_active"] is True
+    assert snapshot["http_bridge_restart_blocking"] is True
 
 
 @pytest.mark.asyncio
@@ -165,6 +206,7 @@ async def test_http_bridge_activity_snapshot_skips_inflight_cleanup_when_registr
     assert snapshot["http_bridge_inflight_session_creates"] == 1
     assert snapshot["http_bridge_stale_inflight_session_creates"] == 1
     assert snapshot["http_bridge_cleaned_inflight_session_creates"] == 0
+    assert snapshot["http_bridge_active"] is True
     assert snapshot["http_bridge_restart_blocking"] is True
 
 


### PR DESCRIPTION
## Problem

The HTTP bridge tracks in-flight session creation futures in `_http_bridge_inflight_sessions`. If a creation path leaves behind a completed or stale pending future, drain/status can keep reporting an in-flight session create without enough context to explain or recover from it.

That makes graceful maintenance harder: a restart can appear blocked by a stale bridge create rather than by real queued work.

## Changes

- Timestamp newly-created HTTP bridge in-flight session futures.
- Add a non-blocking cleanup pass to `http_bridge_activity_snapshot_nowait()`.
- Remove completed in-flight session-create futures from the tracking map.
- Treat very old pending in-flight futures as stale, remove them, and complete them with a capacity-style `ProxyResponseError` so waiters are released.
- Add snapshot counters for oldest age, stale count, and cleanup count.
- Log structured cleanup diagnostics with bridge kind/key hash, age, threshold, done/cancelled state, and cleanup reason.

## Impact

Normal bridge session creation is unchanged. The new path only affects done leftovers or pending futures older than the stale threshold (`max(120s, admission_timeout * 6)`). Drain/status can now self-heal stale in-flight session-create bookkeeping and explain what was cleaned up.

## Tests

- `uv run pytest -q tests/unit/test_proxy_http_bridge.py::test_http_bridge_activity_snapshot_counts_pending_and_inflight_sessions tests/unit/test_proxy_http_bridge.py::test_http_bridge_activity_snapshot_cleans_stale_inflight_session tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_inflight_wait_times_out tests/unit/test_proxy_http_bridge.py::test_get_or_create_http_bridge_session_capacity_wait_times_out`