### PR TITLE
fix(release): guard stable artifact publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,32 @@ jobs:
             --base-ref "origin/${BASE_REF}" \
             --head-ref "${HEAD_REF}"
 
+  stable-release-guard:
+    name: Stable release guard
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch PR base branch
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --force
+
+      - name: Require complete release-please stable promotions
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          python -m scripts.guard_stable_release \
+            --base-ref "origin/${BASE_REF}" \
+            --head-ref "${HEAD_REF}"
+
   frontend-lint:
     name: Frontend lint (eslint)
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,3 +385,23 @@ jobs:
           draft: false
           prerelease: ${{ needs.release-metadata.outputs.is_prerelease == 'true' }}
           make_latest: ${{ needs.release-metadata.outputs.make_latest }}
+
+  withdraw-failed-release:
+    name: Withdraw failed public release
+    needs: [release-metadata, build, publish-to-pypi, docker-image, helm-chart, create-github-release]
+    runs-on: ubuntu-24.04
+    if: >-
+      ${{
+        always() &&
+        github.event_name == 'release' &&
+        (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+      }}
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Make incomplete release draft again
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft

--- a/openspec/changes/stabilize-release-artifact-publishing/proposal.md
+++ b/openspec/changes/stabilize-release-artifact-publishing/proposal.md
@@ -1,0 +1,23 @@
+# Change: Stabilize release artifact publishing
+
+## Problem
+
+A stable GitHub Release can become visible before the release publishing workflow has successfully built and published PyPI, Docker, and Helm artifacts. The `v1.20.0` incident showed a second gap: the release-please stable PR promoted most release-managed files to `1.20.0` while `uv.lock` remained on `1.20.0-beta.3`, causing the Release workflow to fail after the public GitHub Release already existed.
+
+## Solution
+
+- Add a stable release PR guard that rejects release-please stable promotions unless every release-managed version field agrees and advances together
+- Add a Release workflow failure cleanup job that withdraws a release-event GitHub Release back to draft when publishing fails, so dashboard/latest-release consumers do not keep advertising a non-installable stable release
+- Restore current main release metadata consistency by moving the editable codex-lb `uv.lock` entry back to the current stable version
+
+## Changes
+
+- Stable release PRs from `release-please--branches--main` are guarded separately from beta release PRs
+- Release-managed version fields must be consistent before a stable promotion can pass CI
+- Failed release-event publishing attempts make the corresponding GitHub Release draft again
+
+## Out of scope
+
+- Rewriting the release channel model
+- Automatically cutting the next patch release
+- Changing dashboard update semantics beyond preventing failed public releases from remaining latest

--- a/openspec/changes/stabilize-release-artifact-publishing/specs/release-management/spec.md
+++ b/openspec/changes/stabilize-release-artifact-publishing/specs/release-management/spec.md
@@ -1,0 +1,34 @@
+# release-management Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Stable release promotions guard every release-managed version field
+
+Stable release promotion pull requests SHALL fail CI unless every release-managed version field agrees on the stable version and every field that previously held the prior release train version advances together. The guarded fields SHALL include `pyproject.toml`, `app/__init__.py`, `frontend/package.json`, both Helm chart version fields, and the editable `codex-lb` entry in `uv.lock`.
+
+#### Scenario: release-please stable PR misses uv.lock
+
+- **GIVEN** a beta-tested release train has release-managed files at `1.20.0-beta.3`
+- **AND** a release-please stable PR changes `pyproject.toml`, `app/__init__.py`, `frontend/package.json`, and Helm chart versions to `1.20.0`
+- **BUT** leaves `uv.lock` at `1.20.0-beta.3`
+- **WHEN** CI evaluates the stable release guard
+- **THEN** the guard fails before the PR can merge
+- **AND** the failure identifies `uv.lock` as a release-managed version field that must be updated
+
+#### Scenario: release-please stable PR updates all release-managed fields
+
+- **GIVEN** a beta-tested release train has release-managed files at `1.20.0-beta.3`
+- **WHEN** a release-please stable PR changes all release-managed version fields to `1.20.0`
+- **THEN** the stable release guard passes
+
+### Requirement: Failed release publishing withdraws public release metadata
+
+If the Release workflow is triggered by a public GitHub Release event and any required publishing job fails, the workflow SHALL make that GitHub Release draft again before exiting. This prevents `/releases/latest` and dashboard update checks from advertising a version whose PyPI, Docker, or Helm artifacts are incomplete.
+
+#### Scenario: stable release workflow fails before artifacts publish
+
+- **GIVEN** GitHub Release `v1.20.0` was published and triggered the Release workflow
+- **AND** the workflow fails before PyPI, Docker, and Helm artifacts are all published
+- **WHEN** the failure cleanup job runs
+- **THEN** the GitHub Release is changed back to draft
+- **AND** the release no longer appears as the public latest release

--- a/openspec/changes/stabilize-release-artifact-publishing/tasks.md
+++ b/openspec/changes/stabilize-release-artifact-publishing/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+- [x] Add OpenSpec delta for stable artifact publishing safeguards
+- [x] Add stable release PR guard with regression coverage for missing `uv.lock` promotion
+- [x] Add release failure cleanup to hide incomplete public releases
+- [x] Restore current release-managed metadata consistency for `uv.lock`
+- [x] Run targeted unit tests for release guards
+- [x] Run OpenSpec validation
+- [x] Run release version verification
+- [ ] Open PR and watch CI / review gates

--- a/scripts/guard_stable_release.py
+++ b/scripts/guard_stable_release.py
@@ -115,13 +115,19 @@ def guard_stable_pull_request(root: Path, event_path: str, base_ref: str, head_r
         return
 
     expected_changed = sorted(current_versions)
-    if head_ref != RELEASE_PLEASE_BRANCH:
-        raise GuardError(
-            "Stable release promotions must come from the release-please branch.\n"
-            f"Expected head branch: {RELEASE_PLEASE_BRANCH}\n"
-            f"Actual head branch: {head_ref or '<unknown>'}\n"
-            f"Changed release fields: {', '.join(changed)}"
-        )
+    if head_ref:
+        if head_ref != RELEASE_PLEASE_BRANCH:
+            raise GuardError(
+                "Stable release promotions must come from the release-please branch.\n"
+                f"Expected head branch: {RELEASE_PLEASE_BRANCH}\n"
+                f"Actual head branch: {head_ref}\n"
+                f"Changed release fields: {', '.join(changed)}"
+            )
+    elif pr is not None:
+        raise GuardError("Could not determine the stable release PR head branch.")
+    else:
+        print("No PR head branch available; relying on the pull_request stable release guard for branch ownership.")
+
     if pr is not None:
         require_canonical_head_repository(event, pr)
 

--- a/scripts/guard_stable_release.py
+++ b/scripts/guard_stable_release.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Guard stable release PRs against partial release-managed version promotion.
+
+This script is intentionally stdlib-only so it can run early in GitHub Actions,
+before project dependencies are installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+from scripts.guard_beta_release import (
+    GuardError,
+    canonical_repository,
+    load_event,
+    pull_request,
+    require_canonical_head_repository,
+)
+from scripts.release_versions import (
+    canonical_release_version_for_file,
+    parse_version,
+    read_project_versions,
+)
+
+RELEASE_PLEASE_BRANCH = "release-please--branches--main"
+
+
+def _canonical_versions(versions: Mapping[str, str]) -> dict[str, str]:
+    return {name: canonical_release_version_for_file(name, version) for name, version in versions.items()}
+
+
+def _read_project_versions_at_ref(root: Path, ref: str) -> dict[str, str]:
+    # Reuse the beta guard's ref reader indirectly by checking out file content is
+    # deliberately avoided here; instead invoke the existing public helper by
+    # running it against a temporary index-less materialization would be overkill.
+    # The stable guard only needs a small fixed set of version fields, so keep this
+    # logic local and stdlib-only.
+    import json
+    import re
+    import subprocess
+
+    def git_show(path: str) -> str:
+        return subprocess.check_output(["git", "show", f"{ref}:{path}"], cwd=root, text=True)
+
+    def find(pattern: str, text: str, name: str) -> str:
+        match = re.search(pattern, text, flags=re.MULTILINE)
+        if not match:
+            raise GuardError(f"could not find {name} in {ref}")
+        return match.group(1)
+
+    pyproject_text = git_show("pyproject.toml")
+    try:
+        import tomllib
+
+        pyproject_data = tomllib.loads(pyproject_text)
+        project = pyproject_data.get("project")
+        pyproject_version = project.get("version") if isinstance(project, dict) else None
+    except Exception as exc:  # pragma: no cover - defensive corruption path
+        raise GuardError(f"could not read pyproject version at {ref}: {exc}") from exc
+    if not isinstance(pyproject_version, str) or not pyproject_version:
+        raise GuardError(f"could not find pyproject version in {ref}")
+
+    package_data = json.loads(git_show("frontend/package.json"))
+    chart_text = git_show("deploy/helm/codex-lb/Chart.yaml")
+    uv_text = git_show("uv.lock")
+    return {
+        "pyproject.toml": pyproject_version,
+        "app/__init__.py": find(r'^__version__ = "([^"]+)"', git_show("app/__init__.py"), "app version"),
+        "frontend/package.json": package_data["version"],
+        "deploy/helm/codex-lb/Chart.yaml version": find(r"^version: (.+)$", chart_text, "chart version"),
+        "deploy/helm/codex-lb/Chart.yaml appVersion": find(r"^appVersion: (.+)$", chart_text, "chart appVersion"),
+        "uv.lock": find(
+            r'\[\[package\]\]\nname = "codex-lb"\nversion = "([^"]+)"\nsource = \{ editable = "\." \}',
+            uv_text,
+            "uv.lock codex-lb version",
+        ),
+    }
+
+
+def _changed_version_fields(base_versions: Mapping[str, str], current_versions: Mapping[str, str]) -> list[str]:
+    base = _canonical_versions(base_versions)
+    current = _canonical_versions(current_versions)
+    return sorted(name for name, current_version in current.items() if base.get(name) != current_version)
+
+
+def _require_consistent_current_versions(current_versions: Mapping[str, str]) -> str:
+    canonical = _canonical_versions(current_versions)
+    unique_versions = set(canonical.values())
+    if len(unique_versions) != 1:
+        detail = ", ".join(f"{name}={version!r}" for name, version in sorted(canonical.items()))
+        raise GuardError(f"Stable release-managed version files must agree before promotion: {detail}")
+    return next(iter(unique_versions))
+
+
+def guard_stable_pull_request(root: Path, event_path: str, base_ref: str, head_ref: str) -> None:
+    event = load_event(event_path)
+    pr = pull_request(event)
+    if pr is not None:
+        head_ref = head_ref or str(pr.get("head", {}).get("ref") or "")
+
+    current_versions = read_project_versions(root)
+    base_versions = _read_project_versions_at_ref(root, base_ref)
+    changed = _changed_version_fields(base_versions, current_versions)
+    if "pyproject.toml" not in changed:
+        print("No stable release promotion detected; stable release guard passed.")
+        return
+
+    release = parse_version(canonical_release_version_for_file("pyproject.toml", current_versions["pyproject.toml"]))
+    if release.channel != "stable":
+        print(f"Release promotion target {release.version} is not stable; stable release guard passed.")
+        return
+
+    expected_changed = sorted(current_versions)
+    if head_ref != RELEASE_PLEASE_BRANCH:
+        raise GuardError(
+            "Stable release promotions must come from the release-please branch.\n"
+            f"Expected head branch: {RELEASE_PLEASE_BRANCH}\n"
+            f"Actual head branch: {head_ref or '<unknown>'}\n"
+            f"Changed release fields: {', '.join(changed)}"
+        )
+    if pr is not None:
+        require_canonical_head_repository(event, pr)
+
+    current_version = _require_consistent_current_versions(current_versions)
+    if changed != expected_changed:
+        missing = sorted(set(expected_changed) - set(changed))
+        raise GuardError(
+            "Stable release promotions must advance every release-managed version field together.\n"
+            f"Version: {current_version}\n"
+            f"Changed fields: {', '.join(changed)}\n"
+            f"Missing changed fields: {', '.join(missing)}"
+        )
+
+    source = canonical_repository(event, pr or {}) or head_ref
+    print(f"Stable release guard passed for {current_version} from {source}.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument("--base-ref", default="origin/main", help="base ref for PR diff checks")
+    parser.add_argument("--head-ref", default=os.environ.get("GITHUB_HEAD_REF", ""), help="PR head branch name")
+    parser.add_argument("--event-path", default=os.environ.get("GITHUB_EVENT_PATH", ""), help="GitHub event JSON path")
+    args = parser.parse_args()
+
+    try:
+        guard_stable_pull_request(Path(args.root).resolve(), args.event_path, args.base_ref, args.head_ref)
+    except GuardError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_guard_stable_release.py
+++ b/tests/unit/test_guard_stable_release.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -8,9 +9,11 @@ from tests.unit.test_guard_beta_release import event_file, git, init_repo_with_b
 
 
 def run_stable_guard(project_root: Path, repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {key: value for key, value in os.environ.items() if key not in {"GITHUB_EVENT_PATH", "GITHUB_HEAD_REF"}}
     return subprocess.run(
         [sys.executable, "-m", "scripts.guard_stable_release", "--root", str(repo_root), *args],
         cwd=project_root,
+        env=env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tests/unit/test_guard_stable_release.py
+++ b/tests/unit/test_guard_stable_release.py
@@ -105,6 +105,30 @@ def test_stable_guard_rejects_stable_promotion_from_non_release_please_branch(tm
     assert "Actual head branch: fix/manual-stable-promotion" in result.stderr
 
 
+def test_stable_guard_accepts_merge_queue_without_head_ref_after_pr_gate(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_with_beta_commit(repo, version="1.20.0-beta.3")
+    base = git(repo, "rev-parse", "HEAD")
+
+    update_project_versions(repo, "1.20.0")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "chore(main): release 1.20.0")
+
+    result = run_stable_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        base,
+        "--head-ref",
+        "",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "No PR head branch available" in result.stdout
+    assert "Stable release guard passed for 1.20.0" in result.stdout
+
+
 def test_stable_guard_allows_non_promotion_metadata_repair_branch(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/unit/test_guard_stable_release.py
+++ b/tests/unit/test_guard_stable_release.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.unit.test_guard_beta_release import event_file, git, init_repo_with_beta_commit, update_project_versions
+
+
+def run_stable_guard(project_root: Path, repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "scripts.guard_stable_release", "--root", str(repo_root), *args],
+        cwd=project_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def test_stable_guard_rejects_release_please_pr_missing_uv_lock_update(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_with_beta_commit(repo, version="1.20.0-beta.3")
+    base = git(repo, "rev-parse", "HEAD")
+
+    update_project_versions(repo, "1.20.0")
+    (repo / "uv.lock").write_text(
+        '[[package]]\nname = "codex-lb"\nversion = "1.20.0-beta.3"\nsource = { editable = "." }\n',
+        encoding="utf-8",
+    )
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "chore(main): release 1.20.0")
+    sha = git(repo, "rev-parse", "HEAD")
+    event = event_file(tmp_path, head_ref="release-please--branches--main", head_sha=sha, body="")
+
+    result = run_stable_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        base,
+        "--head-ref",
+        "release-please--branches--main",
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 1
+    assert "Stable release-managed version files must agree" in result.stderr
+    assert "uv.lock='1.20.0-beta.3'" in result.stderr
+    assert "pyproject.toml='1.20.0'" in result.stderr
+
+
+def test_stable_guard_accepts_consistent_release_please_stable_pr(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_with_beta_commit(repo, version="1.20.0-beta.3")
+    base = git(repo, "rev-parse", "HEAD")
+
+    update_project_versions(repo, "1.20.0")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "chore(main): release 1.20.0")
+    sha = git(repo, "rev-parse", "HEAD")
+    event = event_file(tmp_path, head_ref="release-please--branches--main", head_sha=sha, body="")
+
+    result = run_stable_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        base,
+        "--head-ref",
+        "release-please--branches--main",
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Stable release guard passed for 1.20.0" in result.stdout
+
+
+def test_stable_guard_rejects_stable_promotion_from_non_release_please_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_with_beta_commit(repo, version="1.20.0-beta.3")
+    base = git(repo, "rev-parse", "HEAD")
+
+    update_project_versions(repo, "1.20.0")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "chore(main): release 1.20.0")
+    sha = git(repo, "rev-parse", "HEAD")
+    event = event_file(tmp_path, head_ref="fix/manual-stable-promotion", head_sha=sha, body="")
+
+    result = run_stable_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        base,
+        "--head-ref",
+        "fix/manual-stable-promotion",
+        "--event-path",
+        str(event),
+    )
+
+    assert result.returncode == 1
+    assert "Stable release promotions must come from the release-please branch" in result.stderr
+    assert "Actual head branch: fix/manual-stable-promotion" in result.stderr
+
+
+def test_stable_guard_allows_non_promotion_metadata_repair_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    init_repo_with_beta_commit(repo, version="1.20.0-beta.3")
+    update_project_versions(repo, "1.20.0")
+    (repo / "uv.lock").write_text(
+        '[[package]]\nname = "codex-lb"\nversion = "1.20.0-beta.3"\nsource = { editable = "." }\n',
+        encoding="utf-8",
+    )
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "chore(main): release 1.20.0 with stale lock")
+    base = git(repo, "rev-parse", "HEAD")
+
+    (repo / "uv.lock").write_text(
+        '[[package]]\nname = "codex-lb"\nversion = "1.20.0"\nsource = { editable = "." }\n',
+        encoding="utf-8",
+    )
+    git(repo, "add", "uv.lock")
+    git(repo, "commit", "-m", "fix(release): restore uv lock version")
+
+    result = run_stable_guard(
+        Path(__file__).resolve().parents[2],
+        repo,
+        "--base-ref",
+        base,
+        "--head-ref",
+        "fix/stable-release-artifact-gate",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "No stable release promotion detected" in result.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.20.0-beta.3"
+version = "1.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Adds a stable release guard so release-please promotions fail CI when any release-managed version field is left behind, including the editable `codex-lb` entry in `uv.lock`
- Adds Release workflow cleanup that moves a public release back to draft if artifact publishing fails, preventing `/releases/latest` and dashboard update checks from advertising an incomplete version
- Restores current release metadata consistency by moving the `uv.lock` codex-lb entry from `1.20.0-beta.3` to `1.20.0`

## Test Plan

- `uv run pytest tests/unit/test_guard_beta_release.py tests/unit/test_guard_stable_release.py -q`
- `uvx ruff check . && uvx ruff format --check .`
- `uv run ty check`
- `openspec validate stabilize-release-artifact-publishing --strict`
- `uv run python -m scripts.verify_release_version --tag v1.20.0`
- YAML parse smoke for `.github/workflows/ci.yml` and `.github/workflows/release.yml`

Fixes #1046
Related #1045
Related #1047
