### PR TITLE
ci(helm): speed up kind smoke path

### DIFF
--- a/deploy/helm/codex-lb/templates/_helpers.tpl
+++ b/deploy/helm/codex-lb/templates/_helpers.tpl
@@ -181,6 +181,19 @@ Image string — resolves registry/repository:tag with optional digest override
 {{- end }}
 
 {{/*
+Helm test image string — resolves registry/repository:tag with optional digest override
+*/}}
+{{- define "codex-lb.testImage" -}}
+{{- $registry := .Values.global.imageRegistry | default .Values.test.image.registry }}
+{{- $repository := .Values.test.image.repository }}
+{{- if .Values.test.image.digest }}
+{{- printf "%s/%s@%s" $registry $repository .Values.test.image.digest }}
+{{- else }}
+{{- printf "%s/%s:%s" $registry $repository .Values.test.image.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
 Merged nodeSelector: global.nodeSelector + local nodeSelector (local wins).
 */}}
 {{- define "codex-lb.nodeSelector" -}}

--- a/deploy/helm/codex-lb/templates/tests/test-connection.yaml
+++ b/deploy/helm/codex-lb/templates/tests/test-connection.yaml
@@ -22,8 +22,8 @@ spec:
   {{- end }}
   containers:
     - name: test-health
-      image: {{ printf "%s/library/busybox:1.37" (.Values.global.imageRegistry | default "docker.io") }}
-      imagePullPolicy: IfNotPresent
+      image: {{ include "codex-lb.testImage" . }}
+      imagePullPolicy: {{ .Values.test.image.pullPolicy }}
       securityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true
@@ -34,10 +34,32 @@ spec:
         - sh
         - -c
         - |
-          echo "=== Health endpoint ==="
-          wget --spider --timeout=10 http://{{ include "codex-lb.fullname" . }}:{{ .Values.service.port | default 2455 }}/health || exit 1
-          echo "Health check passed!"
+          if command -v python >/dev/null 2>&1; then
+            python - <<'PY'
+          import sys
+          import urllib.request
 
-          echo "=== Startup probe ==="
-          wget -qO- --timeout=10 http://{{ include "codex-lb.fullname" . }}:{{ .Values.service.port | default 2455 }}/health/ready || exit 1
-          echo "Readiness check passed!"
+          checks = [
+              ("Health endpoint", "http://{{ include "codex-lb.fullname" . }}:{{ .Values.service.port | default 2455 }}/health"),
+              ("Startup probe", "http://{{ include "codex-lb.fullname" . }}:{{ .Values.service.port | default 2455 }}/health/ready"),
+          ]
+          for name, url in checks:
+              print(f"=== {name} ===")
+              try:
+                  with urllib.request.urlopen(url, timeout=10) as response:
+                      if response.status >= 400:
+                          raise RuntimeError(f"{url} returned HTTP {response.status}")
+              except Exception as exc:
+                  print(exc, file=sys.stderr)
+                  raise SystemExit(1) from exc
+          print("Health checks passed!")
+          PY
+          else
+            echo "=== Health endpoint ==="
+            wget --spider --timeout=10 http://{{ include "codex-lb.fullname" . }}:{{ .Values.service.port | default 2455 }}/health || exit 1
+            echo "Health check passed!"
+
+            echo "=== Startup probe ==="
+            wget -qO- --timeout=10 http://{{ include "codex-lb.fullname" . }}:{{ .Values.service.port | default 2455 }}/health/ready || exit 1
+            echo "Readiness check passed!"
+          fi

--- a/deploy/helm/codex-lb/values.schema.json
+++ b/deploy/helm/codex-lb/values.schema.json
@@ -22,6 +22,37 @@
       },
       "required": ["repository"]
     },
+    "test": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": "string",
+              "description": "Helm test pod image registry"
+            },
+            "repository": {
+              "type": "string",
+              "description": "Helm test pod image repository"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Helm test pod image tag"
+            },
+            "digest": {
+              "type": "string",
+              "description": "Helm test pod image digest"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "description": "Helm test pod image pull policy"
+            }
+          }
+        }
+      }
+    },
     "auth": {
       "type": "object",
       "properties": {

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -38,6 +38,20 @@ image:
   # @param image.pullSecrets Container image pull secrets
   pullSecrets: []
 
+# @section Helm test parameters
+test:
+  image:
+    # @param test.image.registry Helm test pod image registry
+    registry: docker.io
+    # @param test.image.repository Helm test pod image repository
+    repository: library/busybox
+    # @param test.image.tag Helm test pod image tag
+    tag: "1.37"
+    # @param test.image.digest Helm test pod image digest (overrides tag when set)
+    digest: ""
+    # @param test.image.pullPolicy Helm test pod image pull policy
+    pullPolicy: IfNotPresent
+
 # @section Workload parameters
 # @param replicaCount Number of replicas
 replicaCount: 2

--- a/openspec/changes/optimize-helm-smoke-fast-path/proposal.md
+++ b/openspec/changes/optimize-helm-smoke-fast-path/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+The kind-based Helm smoke path currently pulls the chart test pod image from Docker Hub even after CI has already built and loaded the application image into kind. That external pull adds avoidable latency and failure risk to the smoke gate.
+
+## What Changes
+
+- Make the Helm test pod image configurable while keeping the default equivalent to the existing BusyBox test pod.
+- Override the CI smoke test pod image to the already-built kind-loaded application image.
+- Keep external DB smoke coverage focused on external database wiring by running one app replica.
+- Add timestamped step logs around major smoke phases.
+
+## Impact
+
+- Production chart defaults remain equivalent.
+- CI smoke logs show phase timing more clearly.
+- No `docs/` or changelog updates.

--- a/openspec/changes/optimize-helm-smoke-fast-path/proposal.md
+++ b/openspec/changes/optimize-helm-smoke-fast-path/proposal.md
@@ -8,6 +8,7 @@ The kind-based Helm smoke path currently pulls the chart test pod image from Doc
 - Override the CI smoke test pod image to the already-built kind-loaded application image.
 - Keep external DB smoke coverage focused on external database wiring by running one app replica.
 - Add timestamped step logs around major smoke phases.
+- Bound `helm test` waits with a configurable timeout so failing test pods do not spend Helm's default timeout window.
 
 ## Impact
 

--- a/openspec/changes/optimize-helm-smoke-fast-path/specs/deployment-installation/spec.md
+++ b/openspec/changes/optimize-helm-smoke-fast-path/specs/deployment-installation/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Helm install modes are smoke-tested
+
+The project MUST run automated Helm smoke installs for the easy-setup install modes in CI. CI Helm smoke installs MUST avoid avoidable external image pulls for chart test pods when the application image has already been built and loaded into the disposable cluster. Smoke scripts MUST emit timestamped logs for major phases so CI output identifies where time is spent.
+
+#### Scenario: Bundled and external DB modes are smoke tested
+
+- **WHEN** CI runs Helm smoke installation checks
+- **THEN** it installs the chart on a disposable Kubernetes cluster in bundled mode
+- **AND** it installs the chart on a disposable Kubernetes cluster in external DB mode
+- **AND** both installs reach a healthy testable state
+
+#### Scenario: CI Helm test uses the loaded application image
+
+- **WHEN** CI runs kind-based Helm smoke checks after loading the application image into the cluster
+- **THEN** the Helm test pod image is overridden to the loaded application image
+- **AND** the chart default test pod image remains equivalent to `docker.io/library/busybox:1.37` for normal installs
+
+#### Scenario: External DB smoke uses a single app replica
+
+- **WHEN** CI runs the external DB smoke installation
+- **THEN** the application release is installed with one replica
+- **AND** the smoke still validates external database mode by using an external PostgreSQL release
+
+#### Scenario: Helm smoke phases are timestamped
+
+- **WHEN** CI runs kind-based Helm smoke checks
+- **THEN** major phases emit UTC timestamped log lines

--- a/openspec/changes/optimize-helm-smoke-fast-path/specs/deployment-installation/spec.md
+++ b/openspec/changes/optimize-helm-smoke-fast-path/specs/deployment-installation/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Helm install modes are smoke-tested
 
-The project MUST run automated Helm smoke installs for the easy-setup install modes in CI. CI Helm smoke installs MUST avoid avoidable external image pulls for chart test pods when the application image has already been built and loaded into the disposable cluster. Smoke scripts MUST emit timestamped logs for major phases so CI output identifies where time is spent.
+The project MUST run automated Helm smoke installs for the easy-setup install modes in CI. CI Helm smoke installs MUST avoid avoidable external image pulls for chart test pods when the application image has already been built and loaded into the disposable cluster. Smoke scripts MUST emit timestamped logs for major phases so CI output identifies where time is spent. Smoke scripts MUST bound Helm test waits with a configurable timeout.
 
 #### Scenario: Bundled and external DB modes are smoke tested
 
@@ -27,3 +27,9 @@ The project MUST run automated Helm smoke installs for the easy-setup install mo
 
 - **WHEN** CI runs kind-based Helm smoke checks
 - **THEN** major phases emit UTC timestamped log lines
+
+#### Scenario: Helm test wait is bounded
+
+- **WHEN** CI runs kind-based Helm smoke checks
+- **THEN** each `helm test` invocation uses the configured Helm test timeout
+- **AND** the default timeout is shorter than Helm's default wait window

--- a/openspec/changes/optimize-helm-smoke-fast-path/tasks.md
+++ b/openspec/changes/optimize-helm-smoke-fast-path/tasks.md
@@ -1,4 +1,5 @@
 - [x] 1. Add regression coverage for configurable Helm test pod image, CI smoke overrides, external DB replica override, and timestamped smoke logging.
 - [x] 2. Add chart values/schema/template support for the Helm test image while preserving the BusyBox default.
 - [x] 3. Update kind smoke script to use the loaded CI image for Helm tests, set external DB replicas to one, and log major phases with UTC timestamps.
-- [x] 4. Run targeted pytest, Helm chart validation where available, `openspec validate --specs`, and `git diff --check`.
+- [x] 4. Bound kind smoke `helm test` waits with a configurable timeout and add focused script coverage.
+- [x] 5. Run targeted pytest, Helm chart validation where available, `openspec validate --specs`, and `git diff --check`.

--- a/openspec/changes/optimize-helm-smoke-fast-path/tasks.md
+++ b/openspec/changes/optimize-helm-smoke-fast-path/tasks.md
@@ -1,0 +1,4 @@
+- [x] 1. Add regression coverage for configurable Helm test pod image, CI smoke overrides, external DB replica override, and timestamped smoke logging.
+- [x] 2. Add chart values/schema/template support for the Helm test image while preserving the BusyBox default.
+- [x] 3. Update kind smoke script to use the loaded CI image for Helm tests, set external DB replicas to one, and log major phases with UTC timestamps.
+- [x] 4. Run targeted pytest, Helm chart validation where available, `openspec validate --specs`, and `git diff --check`.

--- a/scripts/helm-kind-smoke.sh
+++ b/scripts/helm-kind-smoke.sh
@@ -10,6 +10,7 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io}"
 IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-soju06/codex-lb}"
 IMAGE_TAG="${IMAGE_TAG:-ci}"
 DB_PASSWORD="${DB_PASSWORD:-smoke-password}"
+HELM_TEST_TIMEOUT="${HELM_TEST_TIMEOUT:-60s}"
 
 log_step() {
   printf '[%s] [helm-kind-smoke] %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*" >&2
@@ -24,7 +25,7 @@ wait_for_release() {
   log_step "listing pods for ${release} in ${namespace}"
   kubectl --context "${KUBE_CONTEXT}" -n "${namespace}" get pods
   log_step "running helm test for ${release} in ${namespace}"
-  helm test "${release}" --namespace "${namespace}" --kube-context "${KUBE_CONTEXT}"
+  helm test "${release}" --namespace "${namespace}" --kube-context "${KUBE_CONTEXT}" --timeout "${HELM_TEST_TIMEOUT}"
 }
 
 dump_namespace_debug() {

--- a/scripts/helm-kind-smoke.sh
+++ b/scripts/helm-kind-smoke.sh
@@ -11,12 +11,19 @@ IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-soju06/codex-lb}"
 IMAGE_TAG="${IMAGE_TAG:-ci}"
 DB_PASSWORD="${DB_PASSWORD:-smoke-password}"
 
+log_step() {
+  printf '[%s] [helm-kind-smoke] %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$*" >&2
+}
+
+log_step "building Helm dependencies"
 helm dependency build "${CHART_DIR}" >/dev/null
 
 wait_for_release() {
   local release="$1"
   local namespace="$2"
+  log_step "listing pods for ${release} in ${namespace}"
   kubectl --context "${KUBE_CONTEXT}" -n "${namespace}" get pods
+  log_step "running helm test for ${release} in ${namespace}"
   helm test "${release}" --namespace "${namespace}" --kube-context "${KUBE_CONTEXT}"
 }
 
@@ -44,6 +51,7 @@ install_bundled() {
 
   trap 'dump_namespace_debug "${namespace}"' ERR
 
+  log_step "installing bundled release ${release}"
   helm upgrade --install "${release}" "${CHART_DIR}" \
     --kube-context "${KUBE_CONTEXT}" \
     --namespace "${namespace}" \
@@ -53,6 +61,10 @@ install_bundled() {
     --set image.repository="${IMAGE_REPOSITORY}" \
     --set image.tag="${IMAGE_TAG}" \
     --set image.pullPolicy=IfNotPresent \
+    --set test.image.registry="${IMAGE_REGISTRY}" \
+    --set test.image.repository="${IMAGE_REPOSITORY}" \
+    --set test.image.tag="${IMAGE_TAG}" \
+    --set test.image.pullPolicy=IfNotPresent \
     --set postgresql.auth.password="${DB_PASSWORD}" \
     --set config.sessionBridgeCodexPrewarmEnabled=false \
     --set ingress.enabled=true \
@@ -85,6 +97,7 @@ print(base64.urlsafe_b64encode(os.urandom(32)).decode())
 PY
 )
 
+  log_step "installing external PostgreSQL release ${db_release}"
   helm upgrade --install "${db_release}" oci://registry-1.docker.io/bitnamicharts/postgresql \
     --kube-context "${KUBE_CONTEXT}" \
     --namespace "${namespace}" \
@@ -96,11 +109,13 @@ PY
     --wait \
     --timeout 10m
 
+  log_step "creating external DB application secret ${app_secret}"
   kubectl --context "${KUBE_CONTEXT}" -n "${namespace}" delete secret "${app_secret}" --ignore-not-found
   kubectl --context "${KUBE_CONTEXT}" -n "${namespace}" create secret generic "${app_secret}" \
     --from-literal=database-url="postgresql+asyncpg://codexlb:${DB_PASSWORD}@${db_release}-postgresql:5432/codexlb" \
     --from-literal=encryption-key="${encryption_key}"
 
+  log_step "installing external DB release ${release}"
   helm upgrade --install "${release}" "${CHART_DIR}" \
     --kube-context "${KUBE_CONTEXT}" \
     --namespace "${namespace}" \
@@ -110,7 +125,12 @@ PY
     --set image.repository="${IMAGE_REPOSITORY}" \
     --set image.tag="${IMAGE_TAG}" \
     --set image.pullPolicy=IfNotPresent \
+    --set test.image.registry="${IMAGE_REGISTRY}" \
+    --set test.image.repository="${IMAGE_REPOSITORY}" \
+    --set test.image.tag="${IMAGE_TAG}" \
+    --set test.image.pullPolicy=IfNotPresent \
     --set auth.existingSecret="${app_secret}" \
+    --set replicaCount=1 \
     --wait \
     --timeout 10m
 

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -366,6 +366,56 @@ def test_bundled_kind_smoke_preserves_primary_ingress_paths() -> None:
     assert "--wait \\" in script
 
 
+def test_helm_test_pod_uses_configurable_default_image() -> None:
+    rendered = _helm_template(
+        "--show-only",
+        "templates/tests/test-connection.yaml",
+    )
+
+    assert "image: docker.io/library/busybox:1.37" in rendered
+    assert "imagePullPolicy: IfNotPresent" in rendered
+
+
+def test_helm_test_pod_image_can_be_overridden() -> None:
+    rendered = _helm_template(
+        "--show-only",
+        "templates/tests/test-connection.yaml",
+        "--set",
+        "test.image.registry=ghcr.io",
+        "--set",
+        "test.image.repository=soju06/codex-lb",
+        "--set",
+        "test.image.tag=ci",
+        "--set",
+        "test.image.pullPolicy=Never",
+    )
+
+    assert "image: ghcr.io/soju06/codex-lb:ci" in rendered
+    assert "imagePullPolicy: Never" in rendered
+    assert "docker.io/library/busybox:1.37" not in rendered
+
+
+def test_kind_smoke_overrides_helm_test_image_and_external_db_replicas() -> None:
+    script = (_REPO_ROOT / "scripts" / "helm-kind-smoke.sh").read_text()
+
+    assert '--set test.image.registry="${IMAGE_REGISTRY}"' in script
+    assert '--set test.image.repository="${IMAGE_REPOSITORY}"' in script
+    assert '--set test.image.tag="${IMAGE_TAG}"' in script
+    assert "--set test.image.pullPolicy=IfNotPresent" in script
+    assert "--set replicaCount=1" in script
+
+
+def test_kind_smoke_logs_timestamped_major_steps() -> None:
+    script = (_REPO_ROOT / "scripts" / "helm-kind-smoke.sh").read_text()
+
+    assert 'date -u +"%Y-%m-%dT%H:%M:%SZ"' in script
+    assert "log_step" in script
+    assert 'log_step "building Helm dependencies"' in script
+    assert 'log_step "installing bundled release ${release}"' in script
+    assert 'log_step "installing external PostgreSQL release ${db_release}"' in script
+    assert 'log_step "running helm test for ${release} in ${namespace}"' in script
+
+
 def test_auto_advertise_bridge_url_uses_service_port() -> None:
     rendered = _helm_template(
         "--show-only",

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -454,6 +454,16 @@ def test_kind_smoke_logs_timestamped_major_steps() -> None:
     assert 'log_step "running helm test for ${release} in ${namespace}"' in script
 
 
+def test_kind_smoke_bounds_helm_test_wait() -> None:
+    script = (_REPO_ROOT / "scripts" / "helm-kind-smoke.sh").read_text()
+
+    assert 'HELM_TEST_TIMEOUT="${HELM_TEST_TIMEOUT:-60s}"' in script
+    assert (
+        'helm test "${release}" --namespace "${namespace}" --kube-context "${KUBE_CONTEXT}" '
+        '--timeout "${HELM_TEST_TIMEOUT}"'
+    ) in script
+
+
 def test_auto_advertise_bridge_url_uses_service_port() -> None:
     rendered = _helm_template(
         "--show-only",

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 pytestmark = pytest.mark.unit
 
@@ -44,6 +45,28 @@ def _helm_template(*args: str) -> str:
         text=True,
     )
     return completed.stdout
+
+
+def _helm_documents(rendered: str) -> list[dict]:
+    return [document for document in yaml.safe_load_all(rendered) if document]
+
+
+def _smoke_install_command(script: str, log_message: str) -> str:
+    lines = script.splitlines()
+    start = next(index for index, line in enumerate(lines) if f'log_step "{log_message}"' in line)
+    command_start = next(
+        index for index in range(start + 1, len(lines)) if re.match(r"\s*helm upgrade --install\b", lines[index])
+    )
+    command_lines = []
+    for line in lines[command_start:]:
+        command_lines.append(line.strip())
+        if not line.rstrip().endswith("\\"):
+            break
+    return " ".join(command_lines).replace("\\", " ")
+
+
+def _command_sets_value(command: str, value: str) -> bool:
+    return re.search(rf"(?:^|\s)--set(?:\s+|=){re.escape(value)}(?:\s|$)", command) is not None
 
 
 def _deployment_annotation(rendered: str, key: str) -> str:
@@ -394,15 +417,30 @@ def test_helm_test_pod_image_can_be_overridden() -> None:
     assert "imagePullPolicy: Never" in rendered
     assert "docker.io/library/busybox:1.37" not in rendered
 
+    (test_pod,) = _helm_documents(rendered)
+    (container,) = test_pod["spec"]["containers"]
+    assert container["command"][:2] == ["sh", "-c"]
+    script = container["command"][2]
+    assert "if command -v python >/dev/null 2>&1; then" in script
+    assert "python - <<'PY'" in script
+    assert "import urllib.request" in script
+    assert "urllib.request.urlopen(url, timeout=10)" in script
+    assert "else" in script
+    assert "wget --spider --timeout=10 http://codex-lb:2455/health || exit 1" in script
+    assert "wget -qO- --timeout=10 http://codex-lb:2455/health/ready || exit 1" in script
+
 
 def test_kind_smoke_overrides_helm_test_image_and_external_db_replicas() -> None:
     script = (_REPO_ROOT / "scripts" / "helm-kind-smoke.sh").read_text()
+    bundled_install = _smoke_install_command(script, "installing bundled release ${release}")
+    external_db_install = _smoke_install_command(script, "installing external DB release ${release}")
 
     assert '--set test.image.registry="${IMAGE_REGISTRY}"' in script
     assert '--set test.image.repository="${IMAGE_REPOSITORY}"' in script
     assert '--set test.image.tag="${IMAGE_TAG}"' in script
     assert "--set test.image.pullPolicy=IfNotPresent" in script
-    assert "--set replicaCount=1" in script
+    assert _command_sets_value(external_db_install, "replicaCount=1")
+    assert not _command_sets_value(bundled_install, "replicaCount=1")
 
 
 def test_kind_smoke_logs_timestamped_major_steps() -> None:


### PR DESCRIPTION
## Summary
- Make the Helm test pod image configurable while preserving the default `docker.io/library/busybox:1.37` behavior
- Override kind smoke Helm tests to use the already-built `ghcr.io/soju06/codex-lb:ci` image
- Run the external DB smoke with one app replica and add UTC timestamped phase logs for future bottleneck analysis

## Test Plan
- `uv run pytest tests/unit/test_helm_external_secrets.py -q`
- `openspec validate optimize-helm-smoke-fast-path --strict`
- `openspec validate --specs`
- `uvx ruff check tests/unit/test_helm_external_secrets.py`
- `uvx ruff format --check tests/unit/test_helm_external_secrets.py`
- `uv run ty check`
- `git diff --check`
- `make helm-check`
