### PR TITLE
fix(api-keys): keep assigned account picker from closing dialog

### DIFF
--- a/frontend/src/features/api-keys/components/account-multi-select.tsx
+++ b/frontend/src/features/api-keys/components/account-multi-select.tsx
@@ -178,7 +178,7 @@ export function AccountMultiSelect({
 
   return (
     <div className="space-y-1.5">
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             type="button"

--- a/frontend/src/features/api-keys/components/api-key-edit-dialog.test.tsx
+++ b/frontend/src/features/api-keys/components/api-key-edit-dialog.test.tsx
@@ -140,6 +140,7 @@ describe("ApiKeyEditDialog", () => {
   it("submits selected assigned accounts", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
     server.use(
       http.get("/api/accounts", () =>
         HttpResponse.json({
@@ -160,7 +161,7 @@ describe("ApiKeyEditDialog", () => {
         open
         busy={false}
         apiKey={createApiKey()}
-        onOpenChange={vi.fn()}
+        onOpenChange={onOpenChange}
         onSubmit={onSubmit}
       />,
     );
@@ -168,7 +169,9 @@ describe("ApiKeyEditDialog", () => {
     await user.click(await screen.findByRole("button", { name: "All accounts" }));
     await user.click(screen.getByRole("menuitemcheckbox", { name: /primary@example\.com/i }));
     await user.click(screen.getByRole("menuitemcheckbox", { name: /secondary@example\.com/i }));
-    await user.keyboard("{Escape}");
+    await user.click(screen.getByPlaceholderText("e.g. gpt-5.3-codex"));
+    expect(onOpenChange).not.toHaveBeenCalled();
+
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {

--- a/openspec/changes/fix-api-key-assigned-account-dialog-dismissal/.openspec.yaml
+++ b/openspec/changes/fix-api-key-assigned-account-dialog-dismissal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/fix-api-key-assigned-account-dialog-dismissal/proposal.md
+++ b/openspec/changes/fix-api-key-assigned-account-dialog-dismissal/proposal.md
@@ -1,0 +1,14 @@
+# fix-api-key-assigned-account-dialog-dismissal
+
+## Summary
+
+Fix the API key edit dialog so selecting assigned accounts does not make the dialog dismiss before the operator can save.
+
+## Motivation
+
+The Assigned accounts picker is rendered inside the edit dialog but uses a portaled dropdown. After selecting an account, subsequent clicks can be treated as an outside interaction by the dialog stack, closing the edit dialog and discarding the pending assignment change before Save can be clicked.
+
+## Scope
+
+- Frontend API key edit/create account picker interaction only.
+- No backend contract or database changes.

--- a/openspec/changes/fix-api-key-assigned-account-dialog-dismissal/specs/api-keys/spec.md
+++ b/openspec/changes/fix-api-key-assigned-account-dialog-dismissal/specs/api-keys/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Frontend API Key management
+
+The SPA settings page SHALL include an API Key management section with: a toggle for `apiKeyAuthEnabled`, a key list table showing prefix/name/models/limit/usage/expiry/status, a create dialog (name, model selection, assigned-account selection, weekly limit, expiry date), and key actions (edit, delete, regenerate). On key creation, the SPA MUST display the plain key in a copy-able dialog with a warning that it will not be shown again, and the copy action MUST remain functional in secure and non-secure contexts.
+
+The create and edit dialogs SHALL expose an `Apply to codex /model` checkbox directly below `Allowed models`. The checkbox SHALL default to unchecked for new keys and SHALL edit the stored API key value for existing keys.
+
+The Assigned accounts picker inside API key create and edit dialogs MUST NOT dismiss the parent dialog while the operator is selecting accounts or moving focus back to other controls in the same dialog. The pending assigned-account selection MUST remain saveable through the dialog's Save action.
+
+#### Scenario: Edit assigned accounts remains saveable
+
+- **WHEN** an admin opens the edit API key dialog
+- **AND** selects one or more accounts from the Assigned accounts picker
+- **AND** clicks another control in the same dialog without first pressing Escape
+- **THEN** the edit dialog remains open
+- **AND** clicking Save submits the selected assigned account IDs

--- a/openspec/changes/fix-api-key-assigned-account-dialog-dismissal/tasks.md
+++ b/openspec/changes/fix-api-key-assigned-account-dialog-dismissal/tasks.md
@@ -1,0 +1,3 @@
+- [x] Keep the Assigned accounts dropdown from dismissing the parent API key dialog during account selection.
+- [x] Add regression coverage for selecting assigned accounts and saving without first pressing Escape.
+- [ ] Validate the frontend tests and OpenSpec specs.


### PR DESCRIPTION
Set the assigned-account dropdown to non-modal mode so its portaled menu does not trigger the parent API key dialog's outside-dismiss handling when focus returns to the form.

Update the edit-dialog regression test to select accounts and click another in-dialog control before saving, proving the draft remains saveable without pressing Escape first.

<!--
Thanks for contributing to codex-lb! 🙏
Fill in the sections below. Delete sections that don't apply.
-->

## Summary

<!-- One or two sentences: what does this PR change and why? -->

## Type of change

<!-- Check the box that matches your PR. Commit titles must follow Conventional Commits. -->

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: <!-- e.g. Closes #123, Fixes #456 -->

## OpenSpec

<!--
codex-lb is OpenSpec-first. If this PR changes observable behavior, requirements,
contracts, or schema, it needs an OpenSpec change under openspec/changes/<change>/.

If this PR touches an upstream-mimicking code path (Codex CLI / ChatGPT request
shape, image pipeline, response.create framing, etc.), it must stay
**codex-faithful** — i.e. preserve the exact wire format the real upstream
emits. Call out anything that intentionally diverges, and link the spec section
that records the divergence.
-->

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: <!-- openspec/changes/<change>/ -->

## Changes

<!-- Bulleted list of the substantive changes. Group by area if multiple. -->

-
-

## Test plan

<!--
How did you verify this works? Paste the commands you ran and the relevant outputs.
Required: unit tests for new logic, integration tests for new endpoints.
-->

```
# uv run pytest tests/unit/test_<area>.py -q
# uv run pytest tests/integration/test_<area>.py -q
```

## Screenshots / output (optional)

<!-- For dashboard / UI changes: before/after screenshots. For proxy behavior: example request + response, or a log excerpt. -->

## Checklist

- [ ] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [ ] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [ ] CHANGELOG is **not** edited by hand (release-please handles it).
