### PR TITLE
feat+fix(report): reports enhancements

### DIFF
--- a/app/modules/reports/api.py
+++ b/app/modules/reports/api.py
@@ -25,6 +25,7 @@ async def get_reports(
     report_timezone: Annotated[str | None, Query(alias="timezone")] = None,
     account_id: Annotated[list[str] | None, Query()] = None,
     model: Annotated[str | None, Query()] = None,
+    useragent_group: Annotated[str | None, Query()] = None,
 ) -> ReportsResponse:
     try:
         return await context.service.get_reports(
@@ -33,6 +34,7 @@ async def get_reports(
             report_timezone=report_timezone,
             account_ids=account_id,
             model=model,
+            useragent_group=useragent_group,
         )
     except DailyReportRangeTooLargeError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -14,6 +14,7 @@ _INTERNAL_LIMIT_WARMUP_SOURCE = "limit_warmup"
 _INTERNAL_WARMUP_REQUEST_KINDS = ("warmup", "limit_warmup")
 _SQLITE_COMPOUND_SELECT_LIMIT = 500
 MAX_DAILY_REPORT_DAYS = 730
+UNKNOWN_USERAGENT_GROUP = "Unknown"
 
 
 class DailyReportRangeTooLargeError(ValueError):
@@ -223,20 +224,20 @@ class ReportsRepository:
         model: str | None = None,
         useragent_group: str | None = None,
     ) -> list[UserAgentAggregateRow]:
+        useragent_group_bucket = _useragent_group_bucket_expr()
         conditions = [
             *_report_conditions(start_date, end_date, account_ids, model, useragent_group),
-            RequestLog.useragent_group.is_not(None),
-            func.trim(RequestLog.useragent_group) != "",
+            or_(RequestLog.useragent_group.is_(None), func.trim(RequestLog.useragent_group) != ""),
         ]
 
         stmt = (
             select(
-                RequestLog.useragent_group,
+                useragent_group_bucket.label("useragent_group"),
                 func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
                 func.count().label("request_count"),
             )
             .where(and_(*conditions))
-            .group_by(RequestLog.useragent_group)
+            .group_by(useragent_group_bucket)
             .order_by(func.coalesce(func.sum(RequestLog.cost_usd), 0.0).desc())
         )
         result = await self._session.execute(stmt)
@@ -278,8 +279,9 @@ class ReportsRepository:
             conditions.append(RequestLog.account_id.in_(account_ids))
         if model:
             conditions.append(RequestLog.model == model)
-        if useragent_group:
-            conditions.append(RequestLog.useragent_group == useragent_group)
+        useragent_group_clause = _useragent_group_filter_clause(useragent_group)
+        if useragent_group_clause is not None:
+            conditions.append(useragent_group_clause)
 
         result = await self._session.execute(select(func.min(RequestLog.requested_at)).where(and_(*conditions)))
         value = result.scalar_one_or_none()
@@ -302,9 +304,25 @@ def _report_conditions(
         conditions.append(RequestLog.account_id.in_(account_ids))
     if model:
         conditions.append(RequestLog.model == model)
-    if useragent_group:
-        conditions.append(RequestLog.useragent_group == useragent_group)
+    useragent_group_clause = _useragent_group_filter_clause(useragent_group)
+    if useragent_group_clause is not None:
+        conditions.append(useragent_group_clause)
     return conditions
+
+
+def _useragent_group_bucket_expr():
+    return case(
+        (RequestLog.useragent_group.is_(None), literal(UNKNOWN_USERAGENT_GROUP)),
+        else_=RequestLog.useragent_group,
+    )
+
+
+def _useragent_group_filter_clause(useragent_group: str | None):
+    if not useragent_group:
+        return None
+    if useragent_group == UNKNOWN_USERAGENT_GROUP:
+        return RequestLog.useragent_group.is_(None)
+    return RequestLog.useragent_group == useragent_group
 
 
 def _normal_traffic_clause():
@@ -323,6 +341,7 @@ def _daily_rows_stmt(
     model: str | None,
     useragent_group: str | None,
 ):
+    useragent_group_clause = _useragent_group_filter_clause(useragent_group)
     day_range_rows = [
         select(
             literal(report_date).label("report_date"),
@@ -356,7 +375,7 @@ def _daily_rows_stmt(
                     _normal_traffic_clause(),
                     *([RequestLog.account_id.in_(account_ids)] if account_ids else []),
                     *([RequestLog.model == model] if model else []),
-                    *([RequestLog.useragent_group == useragent_group] if useragent_group else []),
+                    *([useragent_group_clause] if useragent_group_clause is not None else []),
                 ),
             )
         )

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -15,6 +15,7 @@ _INTERNAL_WARMUP_REQUEST_KINDS = ("warmup", "limit_warmup")
 _SQLITE_COMPOUND_SELECT_LIMIT = 500
 MAX_DAILY_REPORT_DAYS = 730
 UNKNOWN_USERAGENT_GROUP = "Unknown"
+MISSING_USERAGENT_GROUP = "Missing User-Agent"
 
 
 class DailyReportRangeTooLargeError(ValueError):
@@ -312,7 +313,7 @@ def _report_conditions(
 
 def _useragent_group_bucket_expr():
     return case(
-        (RequestLog.useragent_group.is_(None), literal(UNKNOWN_USERAGENT_GROUP)),
+        (RequestLog.useragent_group.is_(None), literal(MISSING_USERAGENT_GROUP)),
         else_=RequestLog.useragent_group,
     )
 
@@ -320,7 +321,7 @@ def _useragent_group_bucket_expr():
 def _useragent_group_filter_clause(useragent_group: str | None):
     if not useragent_group:
         return None
-    if useragent_group == UNKNOWN_USERAGENT_GROUP:
+    if useragent_group == MISSING_USERAGENT_GROUP:
         return RequestLog.useragent_group.is_(None)
     return RequestLog.useragent_group == useragent_group
 

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -47,12 +47,20 @@ class SummaryAggregateRow:
 class ModelAggregateRow:
     model: str
     cost_usd: float
+    request_count: int
 
 
 @dataclass(frozen=True)
 class AccountAggregateRow:
     account_id: str | None
     alias: str | None
+    cost_usd: float
+    request_count: int
+
+
+@dataclass(frozen=True)
+class UserAgentAggregateRow:
+    useragent_group: str
     cost_usd: float
     request_count: int
 
@@ -68,6 +76,7 @@ class ReportsRepository:
         timezone_info: ZoneInfo | timezone,
         account_ids: list[str] | None = None,
         model: str | None = None,
+        useragent_group: str | None = None,
     ) -> list[DailyReportAggregateRow]:
         window_days = (end_date - start_date).days + 1
         if window_days > MAX_DAILY_REPORT_DAYS:
@@ -80,7 +89,7 @@ class ReportsRepository:
         # SQLite caps compound SELECTs at 500 terms, so long report ranges are
         # executed in chunks instead of building a single oversized UNION ALL.
         for day_ranges_batch in batched(day_ranges, _SQLITE_COMPOUND_SELECT_LIMIT):
-            stmt = _daily_rows_stmt(list(day_ranges_batch), account_ids, model)
+            stmt = _daily_rows_stmt(list(day_ranges_batch), account_ids, model, useragent_group)
             result = await self._session.execute(stmt)
             rows.extend(
                 DailyReportAggregateRow(
@@ -103,8 +112,9 @@ class ReportsRepository:
         end_date: datetime,
         account_ids: list[str] | None = None,
         model: str | None = None,
+        useragent_group: str | None = None,
     ) -> SummaryAggregateRow:
-        conditions = _report_conditions(start_date, end_date, account_ids, model)
+        conditions = _report_conditions(start_date, end_date, account_ids, model, useragent_group)
 
         result = await self._session.execute(
             select(
@@ -137,9 +147,10 @@ class ReportsRepository:
         end_date: datetime,
         account_ids: list[str] | None = None,
         model: str | None = None,
+        useragent_group: str | None = None,
     ) -> list[ModelAggregateRow]:
         conditions = [
-            *_report_conditions(start_date, end_date, account_ids, model),
+            *_report_conditions(start_date, end_date, account_ids, model, useragent_group),
             RequestLog.model.is_not(None),
         ]
 
@@ -147,6 +158,7 @@ class ReportsRepository:
             select(
                 RequestLog.model,
                 func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
+                func.count().label("request_count"),
             )
             .where(and_(*conditions))
             .group_by(RequestLog.model)
@@ -157,6 +169,7 @@ class ReportsRepository:
             ModelAggregateRow(
                 model=row.model,
                 cost_usd=float(row.cost_usd),
+                request_count=int(row.request_count),
             )
             for row in result.all()
         ]
@@ -167,8 +180,9 @@ class ReportsRepository:
         end_date: datetime,
         account_ids: list[str] | None = None,
         model: str | None = None,
+        useragent_group: str | None = None,
     ) -> list[AccountAggregateRow]:
-        conditions = _report_conditions(start_date, end_date, account_ids, model)
+        conditions = _report_conditions(start_date, end_date, account_ids, model, useragent_group)
 
         stmt = (
             select(
@@ -201,15 +215,50 @@ class ReportsRepository:
             for row in rows
         ]
 
+    async def aggregate_by_useragent(
+        self,
+        start_date: datetime,
+        end_date: datetime,
+        account_ids: list[str] | None = None,
+        model: str | None = None,
+        useragent_group: str | None = None,
+    ) -> list[UserAgentAggregateRow]:
+        conditions = [
+            *_report_conditions(start_date, end_date, account_ids, model, useragent_group),
+            RequestLog.useragent_group.is_not(None),
+            func.trim(RequestLog.useragent_group) != "",
+        ]
+
+        stmt = (
+            select(
+                RequestLog.useragent_group,
+                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
+                func.count().label("request_count"),
+            )
+            .where(and_(*conditions))
+            .group_by(RequestLog.useragent_group)
+            .order_by(func.coalesce(func.sum(RequestLog.cost_usd), 0.0).desc())
+        )
+        result = await self._session.execute(stmt)
+        return [
+            UserAgentAggregateRow(
+                useragent_group=row.useragent_group,
+                cost_usd=float(row.cost_usd),
+                request_count=int(row.request_count),
+            )
+            for row in result.all()
+        ]
+
     async def count_active_accounts(
         self,
         start_date: datetime,
         end_date: datetime,
         account_ids: list[str] | None = None,
         model: str | None = None,
+        useragent_group: str | None = None,
     ) -> int:
         conditions = [
-            *_report_conditions(start_date, end_date, account_ids, model),
+            *_report_conditions(start_date, end_date, account_ids, model, useragent_group),
             RequestLog.account_id.is_not(None),
         ]
 
@@ -222,12 +271,15 @@ class ReportsRepository:
         self,
         account_ids: list[str] | None = None,
         model: str | None = None,
+        useragent_group: str | None = None,
     ) -> datetime | None:
         conditions = [_normal_traffic_clause()]
         if account_ids:
             conditions.append(RequestLog.account_id.in_(account_ids))
         if model:
             conditions.append(RequestLog.model == model)
+        if useragent_group:
+            conditions.append(RequestLog.useragent_group == useragent_group)
 
         result = await self._session.execute(select(func.min(RequestLog.requested_at)).where(and_(*conditions)))
         value = result.scalar_one_or_none()
@@ -239,6 +291,7 @@ def _report_conditions(
     end_date: datetime,
     account_ids: list[str] | None,
     model: str | None,
+    useragent_group: str | None,
 ) -> list:
     conditions = [
         RequestLog.requested_at >= start_date,
@@ -249,6 +302,8 @@ def _report_conditions(
         conditions.append(RequestLog.account_id.in_(account_ids))
     if model:
         conditions.append(RequestLog.model == model)
+    if useragent_group:
+        conditions.append(RequestLog.useragent_group == useragent_group)
     return conditions
 
 
@@ -266,6 +321,7 @@ def _daily_rows_stmt(
     day_ranges: list[tuple[str, datetime, datetime]],
     account_ids: list[str] | None,
     model: str | None,
+    useragent_group: str | None,
 ):
     day_range_rows = [
         select(
@@ -300,6 +356,7 @@ def _daily_rows_stmt(
                     _normal_traffic_clause(),
                     *([RequestLog.account_id.in_(account_ids)] if account_ids else []),
                     *([RequestLog.model == model] if model else []),
+                    *([RequestLog.useragent_group == useragent_group] if useragent_group else []),
                 ),
             )
         )

--- a/app/modules/reports/schemas.py
+++ b/app/modules/reports/schemas.py
@@ -19,6 +19,7 @@ class DailyReportRow(DashboardModel):
 class ModelCostEntry(DashboardModel):
     model: str
     cost_usd: float
+    requests: int = 0
     percentage: float = 0.0
 
 
@@ -27,6 +28,13 @@ class AccountCostEntry(DashboardModel):
     alias: str | None = None
     cost_usd: float = 0.0
     requests: int = 0
+
+
+class UserAgentCostEntry(DashboardModel):
+    useragent: str
+    cost_usd: float = 0.0
+    requests: int = 0
+    percentage: float = 0.0
 
 
 class ReportSummary(DashboardModel):
@@ -58,3 +66,4 @@ class ReportsResponse(DashboardModel):
     daily: list[DailyReportRow] = Field(default_factory=list)
     by_model: list[ModelCostEntry] = Field(default_factory=list)
     by_account: list[AccountCostEntry] = Field(default_factory=list)
+    by_useragent: list[UserAgentCostEntry] = Field(default_factory=list)

--- a/app/modules/reports/service.py
+++ b/app/modules/reports/service.py
@@ -13,6 +13,7 @@ from app.modules.reports.schemas import (
     ReportComparisonPrevious,
     ReportsResponse,
     ReportSummary,
+    UserAgentCostEntry,
 )
 
 
@@ -27,6 +28,7 @@ class ReportsService:
         report_timezone: str | None = None,
         account_ids: list[str] | None = None,
         model: str | None = None,
+        useragent_group: str | None = None,
     ) -> ReportsResponse:
         timezone_info = _resolve_timezone(report_timezone)
         now = utcnow().replace(tzinfo=timezone.utc).astimezone(timezone_info)
@@ -46,20 +48,22 @@ class ReportsService:
         previous_start_at = _local_midnight_to_utc_naive(previous_start_date, timezone_info)
         previous_end_at = _local_midnight_to_utc_naive(previous_end_date + timedelta(days=1), timezone_info)
 
-        summary = await self._repository.aggregate_summary(start_at, end_at, account_ids, model)
+        summary = await self._repository.aggregate_summary(start_at, end_at, account_ids, model, useragent_group)
         previous_summary = await self._repository.aggregate_summary(
             previous_start_at,
             previous_end_at,
             account_ids,
             model,
+            useragent_group,
         )
-        earliest_activity_at = await self._repository.earliest_report_activity_at(account_ids, model)
+        earliest_activity_at = await self._repository.earliest_report_activity_at(account_ids, model, useragent_group)
         daily_rows = await self._repository.aggregate_daily_rows(
             start_date,
             end_date,
             timezone_info,
             account_ids,
             model,
+            useragent_group,
         )
         daily = [
             DailyReportRow(
@@ -74,12 +78,20 @@ class ReportsService:
             )
             for row in daily_rows
         ]
-        by_model = await self._repository.aggregate_by_model(start_at, end_at, account_ids, model)
-        by_account = await self._repository.aggregate_by_account(start_at, end_at, account_ids, model)
+        by_model = await self._repository.aggregate_by_model(start_at, end_at, account_ids, model, useragent_group)
+        by_account = await self._repository.aggregate_by_account(start_at, end_at, account_ids, model, useragent_group)
+        by_useragent = await self._repository.aggregate_by_useragent(
+            start_at,
+            end_at,
+            account_ids,
+            model,
+            useragent_group,
+        )
 
         day_count = max((end_at.date() - start_at.date()).days, 1)
 
         model_total = sum(m.cost_usd for m in by_model)
+        useragent_total = sum(u.cost_usd for u in by_useragent)
         comparison = ReportComparison(
             can_compare=earliest_activity_at is not None and earliest_activity_at <= previous_start_at,
             previous=ReportComparisonPrevious(
@@ -107,6 +119,7 @@ class ReportsService:
                 ModelCostEntry(
                     model=m.model,
                     cost_usd=round(m.cost_usd, 4),
+                    requests=m.request_count,
                     percentage=round((m.cost_usd / model_total * 100), 1) if model_total > 0 else 0,
                 )
                 for m in by_model
@@ -119,6 +132,15 @@ class ReportsService:
                     requests=a.request_count,
                 )
                 for a in by_account
+            ],
+            by_useragent=[
+                UserAgentCostEntry(
+                    useragent=u.useragent_group,
+                    cost_usd=round(u.cost_usd, 4),
+                    requests=u.request_count,
+                    percentage=round((u.cost_usd / useragent_total * 100), 1) if useragent_total > 0 else 0,
+                )
+                for u in by_useragent
             ],
         )
 

--- a/frontend/src/features/reports/api.ts
+++ b/frontend/src/features/reports/api.ts
@@ -6,6 +6,7 @@ export type ReportsParams = {
   endDate?: string;
   accountId?: string[];
   model?: string;
+  useragent?: string;
   timezone?: string;
 };
 
@@ -14,6 +15,7 @@ export function getReports(params: ReportsParams = {}) {
   if (params.startDate) query.set("start_date", params.startDate);
   if (params.endDate) query.set("end_date", params.endDate);
   if (params.model) query.set("model", params.model);
+  if (params.useragent) query.set("useragent_group", params.useragent);
   if (params.timezone) query.set("timezone", params.timezone);
   if (params.accountId) {
     for (const id of params.accountId) {

--- a/frontend/src/features/reports/components/cost-per-day-chart.test.tsx
+++ b/frontend/src/features/reports/components/cost-per-day-chart.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CostPerDayChart } from "./cost-per-day-chart";
 
-let capturedProps: { margin?: unknown } | null = null;
+let capturedProps: { margin?: unknown; data?: unknown } | null = null;
 
 vi.mock("recharts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("recharts")>();
@@ -12,7 +12,7 @@ vi.mock("recharts", async (importOriginal) => {
   return {
     ...actual,
     ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-    AreaChart: (props: { children: ReactNode; margin?: unknown }) => {
+    AreaChart: (props: { children: ReactNode; margin?: unknown; data?: unknown }) => {
       capturedProps = props;
       return <div data-testid="cost-area-chart" />;
     },
@@ -32,6 +32,8 @@ describe("CostPerDayChart", () => {
   it("uses equal left and right chart margins", () => {
     render(
       <CostPerDayChart
+        startDate="2026-06-05"
+        endDate="2026-06-05"
         data={[
           {
             date: "2026-06-05",
@@ -48,5 +50,42 @@ describe("CostPerDayChart", () => {
     );
 
     expect(capturedProps?.margin).toEqual({ top: 5, right: 10, left: 10, bottom: 0 });
+  });
+
+  it("fills missing selected days with zero-value rows", () => {
+    render(
+      <CostPerDayChart
+        startDate="2026-06-05"
+        endDate="2026-06-07"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 150,
+            inputTokens: 5_400_000,
+            outputTokens: 59_000,
+            cachedInputTokens: 0,
+            costUsd: 3.77,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-07",
+            requests: 179,
+            inputTokens: 6_800_000,
+            outputTokens: 73_000,
+            cachedInputTokens: 0,
+            costUsd: 4.54,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    expect(capturedProps?.data).toEqual([
+      { date: "06-05", cost: 3.77 },
+      { date: "06-06", cost: 0 },
+      { date: "06-07", cost: 4.54 },
+    ]);
   });
 });

--- a/frontend/src/features/reports/components/cost-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/cost-per-day-chart.tsx
@@ -8,14 +8,17 @@ import {
   ResponsiveContainer,
 } from "@/components/lazy-recharts";
 import type { DailyReportRow } from "../schemas";
+import { buildContinuousDailyRows } from "../daily-series";
 import { ChartTooltip } from "./chart-tooltip";
 
 export type CostPerDayChartProps = {
+  startDate: string;
+  endDate: string;
   data: DailyReportRow[];
 };
 
-export function CostPerDayChart({ data }: CostPerDayChartProps) {
-  const chartData = data.map((d) => ({
+export function CostPerDayChart({ startDate, endDate, data }: CostPerDayChartProps) {
+  const chartData = buildContinuousDailyRows(startDate, endDate, data).map((d) => ({
     date: d.date.slice(5),
     cost: d.costUsd,
   }));

--- a/frontend/src/features/reports/components/daily-detail-table.test.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { DailyDetailTable } from "./daily-detail-table";
@@ -69,5 +70,213 @@ describe("DailyDetailTable", () => {
     expect(
       screen.queryByTestId("daily-breakdown-row-2026-06-06"),
     ).not.toBeInTheDocument();
+  });
+
+  it("sorts by day descending by default", () => {
+    render(
+      <DailyDetailTable
+        startDate="2026-06-05"
+        endDate="2026-06-07"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 1,
+            inputTokens: 100,
+            outputTokens: 20,
+            cachedInputTokens: 0,
+            costUsd: 1,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-07",
+            requests: 3,
+            inputTokens: 300,
+            outputTokens: 40,
+            cachedInputTokens: 50,
+            costUsd: 2,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    const rows = screen.getAllByTestId(/daily-breakdown-row-/);
+
+    expect(rows.map((row) => row.getAttribute("data-testid"))).toEqual([
+      "daily-breakdown-row-2026-06-07",
+      "daily-breakdown-row-2026-06-06",
+      "daily-breakdown-row-2026-06-05",
+    ]);
+  });
+
+  it("toggles sorting when a header is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DailyDetailTable
+        startDate="2026-06-05"
+        endDate="2026-06-07"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 8,
+            inputTokens: 100,
+            outputTokens: 20,
+            cachedInputTokens: 0,
+            costUsd: 1,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-06",
+            requests: 2,
+            inputTokens: 200,
+            outputTokens: 30,
+            cachedInputTokens: 0,
+            costUsd: 2,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-07",
+            requests: 5,
+            inputTokens: 300,
+            outputTokens: 40,
+            cachedInputTokens: 0,
+            costUsd: 3,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /reqs/i }));
+
+    let rows = screen.getAllByTestId(/daily-breakdown-row-/);
+    expect(rows.map((row) => row.getAttribute("data-testid"))).toEqual([
+      "daily-breakdown-row-2026-06-06",
+      "daily-breakdown-row-2026-06-07",
+      "daily-breakdown-row-2026-06-05",
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /reqs/i }));
+
+    rows = screen.getAllByTestId(/daily-breakdown-row-/);
+    expect(rows.map((row) => row.getAttribute("data-testid"))).toEqual([
+      "daily-breakdown-row-2026-06-05",
+      "daily-breakdown-row-2026-06-07",
+      "daily-breakdown-row-2026-06-06",
+    ]);
+  });
+
+  it.each([
+    ["Day", "daily-breakdown-row-2026-06-05"],
+    ["Reqs", "daily-breakdown-row-2026-06-06"],
+    ["Input Tokens", "daily-breakdown-row-2026-06-05"],
+    ["Output Tokens", "daily-breakdown-row-2026-06-05"],
+    ["Cost", "daily-breakdown-row-2026-06-05"],
+    ["Accounts", "daily-breakdown-row-2026-06-06"],
+  ])("sorts by %s when its header is clicked", async (headerLabel, expectedFirstRow) => {
+    cleanup();
+    const user = userEvent.setup();
+
+    render(
+      <DailyDetailTable
+        startDate="2026-06-05"
+        endDate="2026-06-07"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 8,
+            inputTokens: 100,
+            outputTokens: 20,
+            cachedInputTokens: 0,
+            costUsd: 1,
+            activeAccounts: 3,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-06",
+            requests: 2,
+            inputTokens: 200,
+            outputTokens: 30,
+            cachedInputTokens: 0,
+            costUsd: 2,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-07",
+            requests: 5,
+            inputTokens: 300,
+            outputTokens: 40,
+            cachedInputTokens: 0,
+            costUsd: 3,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: headerLabel }));
+
+    expect(screen.getAllByTestId(/daily-breakdown-row-/)[0]).toHaveAttribute(
+      "data-testid",
+      expectedFirstRow,
+    );
+  });
+
+  it("renders cached tokens inline inside the input tokens cell", () => {
+    render(
+      <DailyDetailTable
+        startDate="2026-06-05"
+        endDate="2026-06-05"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 1,
+            inputTokens: 1_200_000,
+            outputTokens: 20,
+            cachedInputTokens: 960_000,
+            costUsd: 1,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    const row = screen.getByTestId("daily-breakdown-row-2026-06-05");
+    expect(within(row).getByText("1.2M")).toBeInTheDocument();
+    expect(within(row).getByText("(960K)")).toBeInTheDocument();
+  });
+
+  it("renders zero cached tokens explicitly when both token values are zero", () => {
+    render(
+      <DailyDetailTable
+        startDate="2026-06-05"
+        endDate="2026-06-05"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 1,
+            inputTokens: 0,
+            outputTokens: 20,
+            cachedInputTokens: 0,
+            costUsd: 1,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    const row = screen.getByTestId("daily-breakdown-row-2026-06-05");
+    expect(within(row).getByText("0")).toBeInTheDocument();
+    expect(within(row).getByText("(0)")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/reports/components/daily-detail-table.test.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.test.tsx
@@ -1,8 +1,12 @@
 import userEvent from "@testing-library/user-event";
 import { cleanup, render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DailyDetailTable } from "./daily-detail-table";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("DailyDetailTable", () => {
   it("fills missing days with zero rows and keeps the body scrollable", () => {
@@ -172,6 +176,71 @@ describe("DailyDetailTable", () => {
     ]);
   });
 
+  it("exports csv rows in chronological order regardless of visible sort", async () => {
+    const user = userEvent.setup();
+    const blobText = vi.fn(async () => "");
+    const createObjectURL = vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+      blobText.mockImplementation(() => blob.text());
+      return "blob:daily-breakdown";
+    });
+    const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(
+      <DailyDetailTable
+        startDate="2026-06-05"
+        endDate="2026-06-07"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 8,
+            inputTokens: 100,
+            outputTokens: 20,
+            cachedInputTokens: 1,
+            costUsd: 1,
+            activeAccounts: 3,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-06",
+            requests: 2,
+            inputTokens: 200,
+            outputTokens: 30,
+            cachedInputTokens: 2,
+            costUsd: 2,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-07",
+            requests: 5,
+            inputTokens: 300,
+            outputTokens: 40,
+            cachedInputTokens: 3,
+            costUsd: 3,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /reqs/i }));
+    await user.click(screen.getByRole("button", { name: /csv/i }));
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:daily-breakdown");
+    await expect(blobText()).resolves.toBe(
+      [
+        "Date,Requests,Input Tokens,Output Tokens,Cached Tokens,Cost USD,Active Accounts,Errors",
+        "2026-06-05,8,100,20,1,1.0000,3,0",
+        "2026-06-06,2,200,30,2,2.0000,1,0",
+        "2026-06-07,5,300,40,3,3.0000,2,0",
+      ].join("\n"),
+    );
+  });
+
   it.each([
     ["Day", "daily-breakdown-row-2026-06-05"],
     ["Reqs", "daily-breakdown-row-2026-06-06"],
@@ -228,6 +297,74 @@ describe("DailyDetailTable", () => {
       "data-testid",
       expectedFirstRow,
     );
+  });
+
+  it("shows visible sort icons for active and inactive sortable headers", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DailyDetailTable
+        startDate="2026-06-05"
+        endDate="2026-06-07"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 1,
+            inputTokens: 100,
+            outputTokens: 20,
+            cachedInputTokens: 0,
+            costUsd: 1,
+            activeAccounts: 3,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-06",
+            requests: 2,
+            inputTokens: 200,
+            outputTokens: 30,
+            cachedInputTokens: 0,
+            costUsd: 2,
+            activeAccounts: 1,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-07",
+            requests: 3,
+            inputTokens: 300,
+            outputTokens: 40,
+            cachedInputTokens: 0,
+            costUsd: 3,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    const dayHeader = screen.getByRole("button", { name: /day/i });
+    const reqsHeader = screen.getByRole("button", { name: /reqs/i });
+    const dayIcon = dayHeader.querySelector('[data-testid="sort-icon-desc"]');
+    const reqsIcon = reqsHeader.querySelector('[data-testid="sort-icon-none"]');
+
+    expect(dayIcon).toBeTruthy();
+    expect(dayIcon).toHaveAttribute("data-sort-icon", "down");
+    expect(dayIcon).toHaveClass("text-foreground");
+    expect(reqsIcon).toBeTruthy();
+    expect(reqsIcon).toHaveAttribute("data-sort-icon", "up-down");
+    expect(reqsIcon).toHaveClass("text-muted-foreground/60");
+
+    await user.click(reqsHeader);
+
+    const activeReqsIcon = reqsHeader.querySelector('[data-testid="sort-icon-asc"]');
+    const inactiveDayIcon = dayHeader.querySelector('[data-testid="sort-icon-none"]');
+
+    expect(reqsHeader).toHaveAttribute("aria-sort", "ascending");
+    expect(activeReqsIcon).toBeTruthy();
+    expect(activeReqsIcon).toHaveAttribute("data-sort-icon", "up");
+    expect(activeReqsIcon).toHaveClass("text-foreground");
+    expect(inactiveDayIcon).toBeTruthy();
+    expect(inactiveDayIcon).toHaveAttribute("data-sort-icon", "up-down");
+    expect(inactiveDayIcon).toHaveClass("text-muted-foreground/60");
   });
 
   it("renders cached tokens inline inside the input tokens cell", () => {

--- a/frontend/src/features/reports/components/daily-detail-table.test.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.test.tsx
@@ -180,6 +180,9 @@ describe("DailyDetailTable", () => {
     const user = userEvent.setup();
     const blobText = vi.fn(async () => "");
     const createObjectURL = vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+      if (!(blob instanceof Blob)) {
+        throw new TypeError("expected Blob export payload");
+      }
       blobText.mockImplementation(() => blob.text());
       return "blob:daily-breakdown";
     });

--- a/frontend/src/features/reports/components/daily-detail-table.test.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.test.tsx
@@ -344,10 +344,12 @@ describe("DailyDetailTable", () => {
       />,
     );
 
-    const dayHeader = screen.getByRole("button", { name: /day/i });
-    const reqsHeader = screen.getByRole("button", { name: /reqs/i });
-    const dayIcon = dayHeader.querySelector('[data-testid="sort-icon-desc"]');
-    const reqsIcon = reqsHeader.querySelector('[data-testid="sort-icon-none"]');
+    const dayHeader = screen.getByRole("columnheader", { name: /day/i });
+    const reqsHeader = screen.getByRole("columnheader", { name: /reqs/i });
+    const dayButton = screen.getByRole("button", { name: /day/i });
+    const reqsButton = screen.getByRole("button", { name: /reqs/i });
+    const dayIcon = dayButton.querySelector('[data-testid="sort-icon-desc"]');
+    const reqsIcon = reqsButton.querySelector('[data-testid="sort-icon-none"]');
 
     expect(dayIcon).toBeTruthy();
     expect(dayIcon).toHaveAttribute("data-sort-icon", "down");
@@ -356,12 +358,20 @@ describe("DailyDetailTable", () => {
     expect(reqsIcon).toHaveAttribute("data-sort-icon", "up-down");
     expect(reqsIcon).toHaveClass("text-muted-foreground/60");
 
-    await user.click(reqsHeader);
+    expect(dayHeader).toHaveAttribute("aria-sort", "descending");
+    expect(reqsHeader).toHaveAttribute("aria-sort", "none");
+    expect(dayButton).not.toHaveAttribute("aria-sort");
+    expect(reqsButton).not.toHaveAttribute("aria-sort");
 
-    const activeReqsIcon = reqsHeader.querySelector('[data-testid="sort-icon-asc"]');
-    const inactiveDayIcon = dayHeader.querySelector('[data-testid="sort-icon-none"]');
+    await user.click(reqsButton);
 
+    const activeReqsIcon = reqsButton.querySelector('[data-testid="sort-icon-asc"]');
+    const inactiveDayIcon = dayButton.querySelector('[data-testid="sort-icon-none"]');
+
+    expect(dayHeader).toHaveAttribute("aria-sort", "none");
     expect(reqsHeader).toHaveAttribute("aria-sort", "ascending");
+    expect(dayButton).not.toHaveAttribute("aria-sort");
+    expect(reqsButton).not.toHaveAttribute("aria-sort");
     expect(activeReqsIcon).toBeTruthy();
     expect(activeReqsIcon).toHaveAttribute("data-sort-icon", "up");
     expect(activeReqsIcon).toHaveClass("text-foreground");

--- a/frontend/src/features/reports/components/daily-detail-table.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.tsx
@@ -160,13 +160,16 @@ function SortableHeader({
   const Icon = isActive ? (direction === "asc" ? ArrowUp : ArrowDown) : ArrowUpDown;
   const iconTestId = isActive ? (direction === "asc" ? "sort-icon-asc" : "sort-icon-desc") : "sort-icon-none";
   const iconVariant = isActive ? (direction === "asc" ? "up" : "down") : "up-down";
+  const ariaSort = isActive ? (direction === "asc" ? "ascending" : "descending") : "none";
 
   return (
-    <th className={`pb-2 ${align === "left" ? "pr-4" : align === "right" ? "pr-4 text-right" : ""} font-medium`}>
+    <th
+      className={`pb-2 ${align === "left" ? "pr-4" : align === "right" ? "pr-4 text-right" : ""} font-medium`}
+      aria-sort={ariaSort}
+    >
       <button
         type="button"
         className={`flex w-full items-center gap-1 ${align === "left" ? "justify-start text-left" : "justify-end text-right"} font-medium text-inherit`}
-        aria-sort={isActive ? (direction === "asc" ? "ascending" : "descending") : "none"}
         onClick={onClick}
       >
         <span>{label}</span>

--- a/frontend/src/features/reports/components/daily-detail-table.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Download } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { buildContinuousDailyRows } from "../daily-series";
 import type { DailyReportRow } from "../schemas";
@@ -29,6 +29,7 @@ export function DailyDetailTable({ startDate, endDate, data }: DailyDetailTableP
     direction: "desc",
   });
   const rows = sortRows(buildContinuousDailyRows(startDate, endDate, data), sort);
+  const csvRows = sortRows(rows, { key: "date", direction: "asc" });
 
   const toggleSort = (key: SortKey) => {
     setSort((current) =>
@@ -46,7 +47,7 @@ export function DailyDetailTable({ startDate, endDate, data }: DailyDetailTableP
           variant="outline"
           size="sm"
           className="h-7 gap-1 text-xs"
-          onClick={() => exportCSV(rows)}
+          onClick={() => exportCSV(csvRows)}
         >
           <Download className="h-3 w-3" />
           CSV
@@ -156,15 +157,25 @@ function SortableHeader({
   direction,
   onClick,
 }: SortableHeaderProps) {
+  const Icon = isActive ? (direction === "asc" ? ArrowUp : ArrowDown) : ArrowUpDown;
+  const iconTestId = isActive ? (direction === "asc" ? "sort-icon-asc" : "sort-icon-desc") : "sort-icon-none";
+  const iconVariant = isActive ? (direction === "asc" ? "up" : "down") : "up-down";
+
   return (
     <th className={`pb-2 ${align === "left" ? "pr-4" : align === "right" ? "pr-4 text-right" : ""} font-medium`}>
       <button
         type="button"
-        className={`w-full ${align === "left" ? "text-left" : "text-right"} font-medium text-inherit`}
+        className={`flex w-full items-center gap-1 ${align === "left" ? "justify-start text-left" : "justify-end text-right"} font-medium text-inherit`}
         aria-sort={isActive ? (direction === "asc" ? "ascending" : "descending") : "none"}
         onClick={onClick}
       >
-        {label}
+        <span>{label}</span>
+        <Icon
+          aria-hidden="true"
+          data-testid={iconTestId}
+          data-sort-icon={iconVariant}
+          className={`h-3 w-3 shrink-0 ${isActive ? "text-foreground" : "text-muted-foreground/60"}`}
+        />
       </button>
     </th>
   );

--- a/frontend/src/features/reports/components/daily-detail-table.tsx
+++ b/frontend/src/features/reports/components/daily-detail-table.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { Download } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { buildContinuousDailyRows } from "../daily-series";
 import type { DailyReportRow } from "../schemas";
 import { formatReportBucketDate } from "../date";
 
@@ -11,6 +13,9 @@ export type DailyDetailTableProps = {
 
 const DAILY_BREAKDOWN_SCROLL_HEIGHT_CLASS = "max-h-[17.5rem]";
 
+type SortKey = "date" | "requests" | "inputTokens" | "outputTokens" | "costUsd" | "activeAccounts";
+type SortDirection = "asc" | "desc";
+
 function formatTokens(v: number): string {
   if (v >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
   if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
@@ -19,7 +24,19 @@ function formatTokens(v: number): string {
 }
 
 export function DailyDetailTable({ startDate, endDate, data }: DailyDetailTableProps) {
-  const rows = buildContinuousRows(startDate, endDate, data);
+  const [sort, setSort] = useState<{ key: SortKey; direction: SortDirection }>({
+    key: "date",
+    direction: "desc",
+  });
+  const rows = sortRows(buildContinuousDailyRows(startDate, endDate, data), sort);
+
+  const toggleSort = (key: SortKey) => {
+    setSort((current) =>
+      current.key === key
+        ? { key, direction: current.direction === "asc" ? "desc" : "asc" }
+        : { key, direction: "asc" },
+    );
+  };
 
   return (
     <div className="rounded-xl border bg-card p-5">
@@ -40,12 +57,43 @@ export function DailyDetailTable({ startDate, endDate, data }: DailyDetailTableP
           <ColumnGroup />
           <thead>
             <tr className="border-b text-left text-muted-foreground">
-              <th className="pb-2 pr-4 font-medium">Day</th>
-              <th className="pb-2 pr-4 text-right font-medium">Reqs</th>
-              <th className="pb-2 pr-4 text-right font-medium">Input Tokens</th>
-              <th className="pb-2 pr-4 text-right font-medium">Output Tokens</th>
-              <th className="pb-2 pr-4 text-right font-medium">Cost</th>
-              <th className="pb-2 text-right font-medium">Accounts</th>
+              <SortableHeader
+                align="left"
+                label="Day"
+                isActive={sort.key === "date"}
+                direction={sort.direction}
+                onClick={() => toggleSort("date")}
+              />
+              <SortableHeader
+                label="Reqs"
+                isActive={sort.key === "requests"}
+                direction={sort.direction}
+                onClick={() => toggleSort("requests")}
+              />
+              <SortableHeader
+                label="Input Tokens"
+                isActive={sort.key === "inputTokens"}
+                direction={sort.direction}
+                onClick={() => toggleSort("inputTokens")}
+              />
+              <SortableHeader
+                label="Output Tokens"
+                isActive={sort.key === "outputTokens"}
+                direction={sort.direction}
+                onClick={() => toggleSort("outputTokens")}
+              />
+              <SortableHeader
+                label="Cost"
+                isActive={sort.key === "costUsd"}
+                direction={sort.direction}
+                onClick={() => toggleSort("costUsd")}
+              />
+              <SortableHeader
+                label="Accounts"
+                isActive={sort.key === "activeAccounts"}
+                direction={sort.direction}
+                onClick={() => toggleSort("activeAccounts")}
+              />
             </tr>
           </thead>
         </table>
@@ -69,7 +117,10 @@ export function DailyDetailTable({ startDate, endDate, data }: DailyDetailTableP
                     {row.requests}
                   </td>
                   <td className="py-2.5 pr-4 text-right text-foreground">
-                    {formatTokens(row.inputTokens)}
+                    <span>{formatTokens(row.inputTokens)}</span>{" "}
+                    <span className="text-[11px] text-muted-foreground">
+                      ({formatTokens(row.cachedInputTokens)})
+                    </span>
                   </td>
                   <td className="py-2.5 pr-4 text-right text-foreground">
                     {formatTokens(row.outputTokens)}
@@ -90,6 +141,35 @@ export function DailyDetailTable({ startDate, endDate, data }: DailyDetailTableP
   );
 }
 
+type SortableHeaderProps = {
+  align?: "left" | "right";
+  label: string;
+  isActive: boolean;
+  direction: SortDirection;
+  onClick: () => void;
+};
+
+function SortableHeader({
+  align = "right",
+  label,
+  isActive,
+  direction,
+  onClick,
+}: SortableHeaderProps) {
+  return (
+    <th className={`pb-2 ${align === "left" ? "pr-4" : align === "right" ? "pr-4 text-right" : ""} font-medium`}>
+      <button
+        type="button"
+        className={`w-full ${align === "left" ? "text-left" : "text-right"} font-medium text-inherit`}
+        aria-sort={isActive ? (direction === "asc" ? "ascending" : "descending") : "none"}
+        onClick={onClick}
+      >
+        {label}
+      </button>
+    </th>
+  );
+}
+
 function ColumnGroup() {
   return (
     <colgroup>
@@ -107,51 +187,24 @@ function formatDate(iso: string): string {
   return formatReportBucketDate(iso);
 }
 
-function buildContinuousRows(
-  startDate: string,
-  endDate: string,
+function sortRows(
   rows: DailyReportRow[],
+  sort: { key: SortKey; direction: SortDirection },
 ): DailyReportRow[] {
-  if (!isISODate(startDate) || !isISODate(endDate) || startDate > endDate) {
-    return rows;
-  }
+  const sorted = [...rows].sort((left, right) => {
+    const leftValue = left[sort.key];
+    const rightValue = right[sort.key];
 
-  const rowsByDate = new Map(rows.map((row) => [row.date, row]));
-  const continuousRows: DailyReportRow[] = [];
+    if (leftValue < rightValue) {
+      return sort.direction === "asc" ? -1 : 1;
+    }
+    if (leftValue > rightValue) {
+      return sort.direction === "asc" ? 1 : -1;
+    }
+    return 0;
+  });
 
-  for (let current = startDate; current <= endDate; current = nextISODate(current)) {
-    continuousRows.push(rowsByDate.get(current) ?? createZeroRow(current));
-  }
-
-  return continuousRows;
-}
-
-function nextISODate(date: string): string {
-  const nextDate = new Date(`${date}T00:00:00Z`);
-  nextDate.setUTCDate(nextDate.getUTCDate() + 1);
-  return nextDate.toISOString().slice(0, 10);
-}
-
-function isISODate(value: string): boolean {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-    return false;
-  }
-
-  const parsed = new Date(`${value}T00:00:00Z`);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
-}
-
-function createZeroRow(date: string): DailyReportRow {
-  return {
-    date,
-    requests: 0,
-    inputTokens: 0,
-    outputTokens: 0,
-    cachedInputTokens: 0,
-    costUsd: 0,
-    activeAccounts: 0,
-    errorCount: 0,
-  };
+  return sorted;
 }
 
 function exportCSV(rows: DailyReportRow[]) {

--- a/frontend/src/features/reports/components/distribution-metric-format.ts
+++ b/frontend/src/features/reports/components/distribution-metric-format.ts
@@ -1,0 +1,10 @@
+import type { DistributionMetric } from "./distribution-metric-toggle";
+import { formatCompactNumber } from "@/utils/formatters";
+
+export function formatDistributionMetricValue(
+  value: number,
+  metric: DistributionMetric,
+): string {
+  const formatted = formatCompactNumber(value);
+  return metric === "cost" ? `$${formatted}` : formatted;
+}

--- a/frontend/src/features/reports/components/distribution-metric-toggle.tsx
+++ b/frontend/src/features/reports/components/distribution-metric-toggle.tsx
@@ -1,0 +1,40 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type DistributionMetric = "cost" | "req";
+
+type DistributionMetricToggleProps = {
+  metric: DistributionMetric;
+  onChange: (metric: DistributionMetric) => void;
+};
+
+const OPTIONS: DistributionMetric[] = ["cost", "req"];
+
+export function DistributionMetricToggle({ metric, onChange }: DistributionMetricToggleProps) {
+  return (
+    <div className="inline-flex rounded-md border bg-muted/30 p-0.5">
+      {OPTIONS.map((option) => {
+        const isActive = option === metric;
+
+        return (
+          <Button
+            key={option}
+            type="button"
+            size="sm"
+            variant="ghost"
+            aria-pressed={isActive}
+            className={cn(
+              "h-6 rounded-[5px] px-2 text-[11px] font-semibold uppercase tracking-wide",
+              isActive
+                ? "bg-background text-foreground shadow-sm hover:bg-background"
+                : "text-muted-foreground hover:bg-transparent hover:text-foreground",
+            )}
+            onClick={() => onChange(option)}
+          >
+            {option}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/features/reports/components/model-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.test.tsx
@@ -69,6 +69,20 @@ vi.mock("recharts", async (importOriginal) => {
 });
 
 describe("ModelDistributionDonut", () => {
+  it("shows the total label and compact cost total in the donut center by default", () => {
+    render(
+      <ModelDistributionDonut
+        data={[
+          { model: "gpt-5", costUsd: 430, requests: 2, percentage: 30 },
+          { model: "gpt-5-pro", costUsd: 1000, requests: 10, percentage: 70 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("model-distribution-center-label")).toHaveTextContent("Total");
+    expect(screen.getByTestId("model-distribution-center-value")).toHaveTextContent("$1.43K");
+  });
+
   it("pads legend value cells to the longest formatted cost", () => {
     render(
       <ModelDistributionDonut
@@ -98,9 +112,9 @@ describe("ModelDistributionDonut", () => {
       />,
     );
 
-    expect(screen.queryByTestId("model-distribution-center-cost")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("model-distribution-center-value")).toHaveTextContent("$60.05");
     const tooltipRow = screen.getByText("Cost").parentElement;
 
     expect(tooltipRow).not.toBeNull();
@@ -132,8 +146,28 @@ describe("ModelDistributionDonut", () => {
     expect(screen.getByText("20.0%")).toBeInTheDocument();
     expect(screen.getByText("80.0%")).toBeInTheDocument();
     expect(screen.getByText(/^8$/)).toBeInTheDocument();
+    expect(screen.getByTestId("model-distribution-center-value")).toHaveTextContent("10");
     expect(screen.getByTestId("model-distribution-pie")).toHaveAttribute("data-key", "requests");
     expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("uses compact request totals in the center and legend when request mode is active", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelDistributionDonut
+        data={[
+          { model: "gpt-5", costUsd: 42.02, requests: 500_000_000, percentage: 40 },
+          { model: "o3", costUsd: 18.03, requests: 1_000_000_000, percentage: 60 },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^req$/i }));
+
+    expect(screen.getByTestId("model-distribution-center-value")).toHaveTextContent("1.5B");
+    expect(screen.getByText("500M")).toBeInTheDocument();
+    expect(screen.getByText("1B")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/reports/components/model-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.test.tsx
@@ -1,15 +1,9 @@
-import { cloneElement, isValidElement, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import userEvent from "@testing-library/user-event";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ModelDistributionDonut } from "./model-distribution-donut";
-
-type MockTooltipContentProps = {
-  names?: {
-    requests?: unknown;
-  };
-};
 
 vi.mock("recharts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("recharts")>();
@@ -52,25 +46,6 @@ vi.mock("recharts", async (importOriginal) => {
       </div>
     ),
     Cell: () => null,
-    Tooltip: ({ content }: { content: ReactNode }) => {
-      if (!isValidElement<MockTooltipContentProps>(content)) {
-        return null;
-      }
-
-      const dataKey = content.props.names?.requests ? "requests" : "costUsd";
-
-      return cloneElement(content, {
-        active: true,
-        payload: [
-          {
-            dataKey,
-            name: dataKey,
-            value: dataKey === "requests" ? 2 : 42.02,
-            color: "#3b82f6",
-          },
-        ],
-      } as Record<string, unknown>);
-    },
   };
 });
 
@@ -165,7 +140,7 @@ describe("ModelDistributionDonut", () => {
     expect(largeCostLegendValue).toHaveStyle({ minWidth: "7ch" });
   });
 
-  it("defaults to cost mode", () => {
+  it("defaults to cost mode without rendering a donut tooltip", () => {
     render(
       <ModelDistributionDonut
         data={[
@@ -178,16 +153,12 @@ describe("ModelDistributionDonut", () => {
     expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByTestId("model-distribution-center-value")).toHaveTextContent("$60.05");
-    const tooltipRow = screen.getByText("Cost").parentElement;
-
-    expect(tooltipRow).not.toBeNull();
-    expect(within(tooltipRow as HTMLElement).getByText("Cost")).toBeInTheDocument();
-    expect(within(tooltipRow as HTMLElement).getByText("$42.02")).toBeInTheDocument();
     expect(screen.getByText("$18.03")).toBeInTheDocument();
     expect(screen.getByTestId("model-distribution-pie")).toHaveAttribute("data-key", "costUsd");
+    expect(screen.queryByText(/^Cost$/)).not.toBeInTheDocument();
   });
 
-  it("switches to request mode for slices, tooltip, legend values, and percentages", async () => {
+  it("switches to request mode for slices, legend values, and percentages without rendering a donut tooltip", async () => {
     const user = userEvent.setup();
 
     render(
@@ -201,11 +172,6 @@ describe("ModelDistributionDonut", () => {
 
     await user.click(screen.getByRole("button", { name: /^req$/i }));
 
-    const tooltipRow = screen.getByText("Requests").parentElement;
-
-    expect(tooltipRow).not.toBeNull();
-    expect(within(tooltipRow as HTMLElement).getByText("Requests")).toBeInTheDocument();
-    expect(within(tooltipRow as HTMLElement).getByText("2")).toBeInTheDocument();
     expect(screen.getByText("20.0%")).toBeInTheDocument();
     expect(screen.getByText("80.0%")).toBeInTheDocument();
     expect(screen.getByText(/^8$/)).toBeInTheDocument();
@@ -213,6 +179,7 @@ describe("ModelDistributionDonut", () => {
     expect(screen.getByTestId("model-distribution-pie")).toHaveAttribute("data-key", "requests");
     expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByText(/^Requests$/)).not.toBeInTheDocument();
   });
 
   it("uses compact request totals in the center and legend when request mode is active", async () => {

--- a/frontend/src/features/reports/components/model-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.test.tsx
@@ -69,6 +69,25 @@ vi.mock("recharts", async (importOriginal) => {
 });
 
 describe("ModelDistributionDonut", () => {
+  it("pads legend value cells to the longest formatted cost", () => {
+    render(
+      <ModelDistributionDonut
+        data={[
+          { model: "gpt-5", costUsd: 42.02, requests: 2, percentage: 24.0 },
+          { model: "gpt-5-pro", costUsd: 128.55, requests: 10, percentage: 76.0 },
+        ]}
+      />,
+    );
+
+    const smallCostLegendValue = screen.getAllByText("$42.02").at(-1);
+    const largeCostLegendValue = screen.getAllByText("$128.55").at(-1);
+
+    expect(smallCostLegendValue).toBeDefined();
+    expect(largeCostLegendValue).toBeDefined();
+    expect(smallCostLegendValue).toHaveStyle({ minWidth: "7ch" });
+    expect(largeCostLegendValue).toHaveStyle({ minWidth: "7ch" });
+  });
+
   it("defaults to cost mode", () => {
     render(
       <ModelDistributionDonut

--- a/frontend/src/features/reports/components/model-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.test.tsx
@@ -1,8 +1,15 @@
 import { cloneElement, isValidElement, type ReactNode } from "react";
+import userEvent from "@testing-library/user-event";
 import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ModelDistributionDonut } from "./model-distribution-donut";
+
+type MockTooltipContentProps = {
+  names?: {
+    requests?: unknown;
+  };
+};
 
 vi.mock("recharts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("recharts")>();
@@ -40,30 +47,41 @@ vi.mock("recharts", async (importOriginal) => {
     ),
     Cell: () => null,
     Tooltip: ({ content }: { content: ReactNode }) => {
-      if (!isValidElement(content)) {
+      if (!isValidElement<MockTooltipContentProps>(content)) {
         return null;
       }
 
+      const dataKey = content.props.names?.requests ? "requests" : "costUsd";
+
       return cloneElement(content, {
         active: true,
-        payload: [{ dataKey: "costUsd", name: "costUsd", value: 42.02, color: "#3b82f6" }],
+        payload: [
+          {
+            dataKey,
+            name: dataKey,
+            value: dataKey === "requests" ? 2 : 42.02,
+            color: "#3b82f6",
+          },
+        ],
       } as Record<string, unknown>);
     },
   };
 });
 
 describe("ModelDistributionDonut", () => {
-  it("does not render a center cost value", () => {
+  it("defaults to cost mode", () => {
     render(
       <ModelDistributionDonut
         data={[
-          { model: "gpt-5", costUsd: 42.02, percentage: 70 },
-          { model: "o3", costUsd: 18.03, percentage: 30 },
+          { model: "gpt-5", costUsd: 42.02, requests: 2, percentage: 70 },
+          { model: "o3", costUsd: 18.03, requests: 8, percentage: 30 },
         ]}
       />,
     );
 
     expect(screen.queryByTestId("model-distribution-center-cost")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "false");
     const tooltipRow = screen.getByText("Cost").parentElement;
 
     expect(tooltipRow).not.toBeNull();
@@ -71,5 +89,32 @@ describe("ModelDistributionDonut", () => {
     expect(within(tooltipRow as HTMLElement).getByText("$42.02")).toBeInTheDocument();
     expect(screen.getByText("$18.03")).toBeInTheDocument();
     expect(screen.getByTestId("model-distribution-pie")).toHaveAttribute("data-key", "costUsd");
+  });
+
+  it("switches to request mode for slices, tooltip, legend values, and percentages", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelDistributionDonut
+        data={[
+          { model: "gpt-5", costUsd: 42.02, requests: 2, percentage: 70 },
+          { model: "o3", costUsd: 18.03, requests: 8, percentage: 30 },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^req$/i }));
+
+    const tooltipRow = screen.getByText("Requests").parentElement;
+
+    expect(tooltipRow).not.toBeNull();
+    expect(within(tooltipRow as HTMLElement).getByText("Requests")).toBeInTheDocument();
+    expect(within(tooltipRow as HTMLElement).getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("20.0%")).toBeInTheDocument();
+    expect(screen.getByText("80.0%")).toBeInTheDocument();
+    expect(screen.getByText(/^8$/)).toBeInTheDocument();
+    expect(screen.getByTestId("model-distribution-pie")).toHaveAttribute("data-key", "requests");
+    expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "true");
   });
 });

--- a/frontend/src/features/reports/components/model-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.test.tsx
@@ -1,6 +1,6 @@
 import { cloneElement, isValidElement, type ReactNode } from "react";
 import userEvent from "@testing-library/user-event";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ModelDistributionDonut } from "./model-distribution-donut";
@@ -25,13 +25,19 @@ vi.mock("recharts", async (importOriginal) => {
       dataKey,
       onMouseEnter,
       onMouseLeave,
+      shape,
     }: {
       data: Array<{ model: string }>;
       dataKey: string;
       onMouseEnter?: (entry: { model: string }, index: number) => void;
       onMouseLeave?: (entry: { model: string }, index: number) => void;
+      shape?: unknown;
     }) => (
-      <div data-testid="model-distribution-pie" data-key={dataKey}>
+      <div
+        data-testid="model-distribution-pie"
+        data-key={dataKey}
+        data-shape={shape ? "true" : "false"}
+      >
         {data.map((entry, index) => (
           <button
             key={entry.model}
@@ -69,6 +75,63 @@ vi.mock("recharts", async (importOriginal) => {
 });
 
 describe("ModelDistributionDonut", () => {
+  it("highlights the matching legend row when a legend item is hovered", () => {
+    render(
+      <ModelDistributionDonut
+        data={[
+          { model: "gpt-5", costUsd: 42.02, requests: 2, percentage: 70 },
+          { model: "o3", costUsd: 18.03, requests: 8, percentage: 30 },
+        ]}
+      />,
+    );
+
+    const legendRow = screen.getByTestId("model-distribution-legend-0");
+
+    expect(screen.getByTestId("model-distribution-pie")).toHaveAttribute("data-shape", "true");
+    expect(legendRow).toHaveAttribute("data-active", "false");
+
+    fireEvent.mouseEnter(legendRow);
+    expect(legendRow).toHaveAttribute("data-active", "true");
+
+    fireEvent.mouseLeave(legendRow);
+    expect(legendRow).toHaveAttribute("data-active", "false");
+  });
+
+  it("highlights the matching legend row when a pie slice is hovered", () => {
+    render(
+      <ModelDistributionDonut
+        data={[
+          { model: "gpt-5", costUsd: 42.02, requests: 2, percentage: 70 },
+          { model: "o3", costUsd: 18.03, requests: 8, percentage: 30 },
+        ]}
+      />,
+    );
+
+    const slice = screen.getByTestId("model-slice-0");
+    const legendRow = screen.getByTestId("model-distribution-legend-0");
+
+    fireEvent.mouseEnter(slice);
+    expect(legendRow).toHaveAttribute("data-active", "true");
+  });
+
+  it("limits the legend viewport to four visible rows before scrolling", () => {
+    render(
+      <ModelDistributionDonut
+        data={Array.from({ length: 5 }, (_, index) => ({
+          model: `model-${index + 1}`,
+          costUsd: index + 1,
+          requests: index + 1,
+          percentage: 20,
+        }))}
+      />,
+    );
+
+    expect(screen.getByTestId("model-distribution-legend-list")).toHaveStyle({
+      maxHeight: "calc(4 * 2rem)",
+    });
+    expect(screen.getByTestId("model-distribution-legend-4")).toBeInTheDocument();
+  });
+
   it("shows the total label and compact cost total in the donut center by default", () => {
     render(
       <ModelDistributionDonut
@@ -169,5 +232,28 @@ describe("ModelDistributionDonut", () => {
     expect(screen.getByTestId("model-distribution-center-value")).toHaveTextContent("1.5B");
     expect(screen.getByText("500M")).toBeInTheDocument();
     expect(screen.getByText("1B")).toBeInTheDocument();
+  });
+
+  it("scrolls the hovered pie item into view in the legend list", () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    render(
+      <ModelDistributionDonut
+        data={Array.from({ length: 5 }, (_, index) => ({
+          model: `model-${index + 1}`,
+          costUsd: 5 - index,
+          requests: index + 1,
+          percentage: 20,
+        }))}
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId("model-slice-4"));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
   });
 });

--- a/frontend/src/features/reports/components/model-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { Cell, Pie, PieChart, ResponsiveContainer, Sector, Tooltip, type PieSectorShapeProps } from "@/components/lazy-recharts";
+import { Cell, Pie, PieChart, ResponsiveContainer, Sector, type PieSectorShapeProps } from "@/components/lazy-recharts";
 import type { ModelCostEntry } from "../schemas";
-import { ChartTooltip } from "./chart-tooltip";
 import { DistributionMetricToggle, type DistributionMetric } from "./distribution-metric-toggle";
 import { formatDistributionMetricValue } from "./distribution-metric-format";
 
@@ -118,14 +117,6 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                   <Cell key={entry.id} fill={entry.fill} />
                 ))}
               </Pie>
-              <Tooltip
-                content={
-                  <ChartTooltip
-                    names={isCostMetric ? { costUsd: "Cost" } : { requests: "Requests" }}
-                    formatValue={(value) => formatDistributionMetricValue(value, metric)}
-                  />
-                }
-              />
             </PieChart>
           </ResponsiveContainer>
         </div>

--- a/frontend/src/features/reports/components/model-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.tsx
@@ -3,6 +3,7 @@ import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "@/components/
 import type { ModelCostEntry } from "../schemas";
 import { ChartTooltip } from "./chart-tooltip";
 import { DistributionMetricToggle, type DistributionMetric } from "./distribution-metric-toggle";
+import { formatDistributionMetricValue } from "./distribution-metric-format";
 
 export type ModelDistributionDonutProps = {
   data: ModelCostEntry[];
@@ -12,11 +13,19 @@ const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ec4899", "#8b5cf6", "#06b6d4"
 
 export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
   const [metric, setMetric] = useState<DistributionMetric>("cost");
+  const totalCost = data.reduce((sum, entry) => sum + entry.costUsd, 0);
   const totalRequests = data.reduce((sum, entry) => sum + entry.requests, 0);
   const isCostMetric = metric === "cost";
+  const totalMetricLabel = formatDistributionMetricValue(
+    isCostMetric ? totalCost : totalRequests,
+    metric,
+  );
   const chartData = data.map((entry) => ({
     ...entry,
-    metricLabel: isCostMetric ? `$${entry.costUsd.toFixed(2)}` : String(entry.requests),
+    metricLabel: formatDistributionMetricValue(
+      isCostMetric ? entry.costUsd : entry.requests,
+      metric,
+    ),
     metricPercentage: isCostMetric
       ? entry.percentage
       : totalRequests > 0
@@ -36,6 +45,20 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
       </div>
       <div className="mt-4 flex items-center gap-4">
         <div className="relative h-[140px] w-[140px] shrink-0">
+          <div className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center text-center">
+            <span
+              className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground"
+              data-testid="model-distribution-center-label"
+            >
+              Total
+            </span>
+            <span
+              className="max-w-[76px] text-sm font-semibold leading-tight tabular-nums text-foreground"
+              data-testid="model-distribution-center-value"
+            >
+              {totalMetricLabel}
+            </span>
+          </div>
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
@@ -56,9 +79,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                 content={
                   <ChartTooltip
                     names={isCostMetric ? { costUsd: "Cost" } : { requests: "Requests" }}
-                    formatValue={(value, dataKey) =>
-                      dataKey === "requests" ? String(value) : `$${value.toFixed(2)}`
-                    }
+                    formatValue={(value) => formatDistributionMetricValue(value, metric)}
                   />
                 }
               />

--- a/frontend/src/features/reports/components/model-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "@/components/lazy-recharts";
+import { useEffect, useRef, useState } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Sector, Tooltip, type PieSectorShapeProps } from "@/components/lazy-recharts";
 import type { ModelCostEntry } from "../schemas";
 import { ChartTooltip } from "./chart-tooltip";
 import { DistributionMetricToggle, type DistributionMetric } from "./distribution-metric-toggle";
@@ -10,9 +10,21 @@ export type ModelDistributionDonutProps = {
 };
 
 const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ec4899", "#8b5cf6", "#06b6d4"];
+const ACTIVE_RADIUS_OFFSET = 4;
+const LEGEND_VISIBLE_COUNT = 4;
+const LEGEND_ROW_HEIGHT_REM = 2;
+
+type ChartDatum = ModelCostEntry & {
+  id: string;
+  fill: string;
+  metricLabel: string;
+  metricPercentage: number;
+};
 
 export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
   const [metric, setMetric] = useState<DistributionMetric>("cost");
+  const [activeLegendId, setActiveLegendId] = useState<string | null>(null);
+  const legendRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const totalCost = data.reduce((sum, entry) => sum + entry.costUsd, 0);
   const totalRequests = data.reduce((sum, entry) => sum + entry.requests, 0);
   const isCostMetric = metric === "cost";
@@ -20,8 +32,10 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
     isCostMetric ? totalCost : totalRequests,
     metric,
   );
-  const chartData = data.map((entry) => ({
+  const chartData: ChartDatum[] = data.map((entry, index) => ({
     ...entry,
+    id: entry.model,
+    fill: COLORS[index % COLORS.length],
     metricLabel: formatDistributionMetricValue(
       isCostMetric ? entry.costUsd : entry.requests,
       metric,
@@ -36,6 +50,32 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
     (maxLength, entry) => Math.max(maxLength, entry.metricLabel.length),
     0,
   );
+
+  useEffect(() => {
+    if (!activeLegendId) {
+      return;
+    }
+
+    legendRefs.current[activeLegendId]?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeLegendId]);
+
+  const renderSlice = (props: PieSectorShapeProps) => {
+    const datum = props.payload as ChartDatum | undefined;
+    const isHighlighted = props.isActive || datum?.id === activeLegendId;
+
+    return (
+      <Sector
+        {...props}
+        outerRadius={
+          typeof props.outerRadius === "number"
+            ? props.outerRadius + (isHighlighted ? ACTIVE_RADIUS_OFFSET : 0)
+            : 65 + (isHighlighted ? ACTIVE_RADIUS_OFFSET : 0)
+        }
+        stroke={isHighlighted ? "hsl(var(--background))" : "none"}
+        strokeWidth={isHighlighted ? 2 : 0}
+      />
+    );
+  };
 
   return (
     <div className="rounded-xl border bg-card p-5">
@@ -70,9 +110,12 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                 innerRadius={45}
                 outerRadius={65}
                 strokeWidth={0}
+                shape={renderSlice}
+                onMouseEnter={(entry: ChartDatum) => setActiveLegendId(entry.id)}
+                onMouseLeave={() => setActiveLegendId(null)}
               >
-                {chartData.map((entry, i) => (
-                  <Cell key={entry.model} fill={COLORS[i % COLORS.length]} />
+                {chartData.map((entry) => (
+                  <Cell key={entry.id} fill={entry.fill} />
                 ))}
               </Pie>
               <Tooltip
@@ -86,16 +129,31 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
             </PieChart>
           </ResponsiveContainer>
         </div>
-        <div className="flex-1 space-y-1.5 text-xs">
+        <div
+          className="flex-1 overflow-y-auto text-xs [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          data-testid="model-distribution-legend-list"
+          style={{ maxHeight: `calc(${LEGEND_VISIBLE_COUNT} * ${LEGEND_ROW_HEIGHT_REM}rem)` }}
+        >
           {chartData.map((entry, i) => (
-            <div
-              key={entry.model}
-              className="flex items-center justify-between rounded-md px-2 py-1 hover:bg-muted/50"
+            <button
+              ref={(node) => {
+                legendRefs.current[entry.id] = node;
+              }}
+              type="button"
+              key={entry.id}
+              className="flex h-8 w-full items-center justify-between rounded-md border px-2 py-1 text-left transition-all hover:bg-muted/50"
+              style={{ borderColor: activeLegendId === entry.id ? entry.fill : "transparent" }}
+              onMouseEnter={() => setActiveLegendId(entry.id)}
+              onMouseLeave={() => setActiveLegendId(null)}
+              onFocus={() => setActiveLegendId(entry.id)}
+              onBlur={() => setActiveLegendId(null)}
+              data-active={activeLegendId === entry.id ? "true" : "false"}
+              data-testid={`model-distribution-legend-${i}`}
             >
               <div className="flex items-center gap-2">
                 <span
                   className="h-2.5 w-2.5 shrink-0 rounded-[3px]"
-                  style={{ background: COLORS[i % COLORS.length] }}
+                  style={{ background: entry.fill }}
                 />
                 <span className="text-foreground">{entry.model}</span>
               </div>
@@ -108,7 +166,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                   {entry.metricLabel}
                 </span>
               </div>
-            </div>
+            </button>
           ))}
         </div>
       </div>

--- a/frontend/src/features/reports/components/model-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/model-distribution-donut.tsx
@@ -16,12 +16,17 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
   const isCostMetric = metric === "cost";
   const chartData = data.map((entry) => ({
     ...entry,
+    metricLabel: isCostMetric ? `$${entry.costUsd.toFixed(2)}` : String(entry.requests),
     metricPercentage: isCostMetric
       ? entry.percentage
       : totalRequests > 0
         ? (entry.requests / totalRequests) * 100
         : 0,
   }));
+  const maxMetricLabelLength = chartData.reduce(
+    (maxLength, entry) => Math.max(maxLength, entry.metricLabel.length),
+    0,
+  );
 
   return (
     <div className="rounded-xl border bg-card p-5">
@@ -74,9 +79,12 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                 <span className="text-foreground">{entry.model}</span>
               </div>
               <div className="flex items-center gap-3">
-                <span className="text-muted-foreground">{entry.metricPercentage.toFixed(1)}%</span>
-                <span className="font-medium text-foreground">
-                  {isCostMetric ? `$${entry.costUsd.toFixed(2)}` : entry.requests}
+                <span className="tabular-nums text-muted-foreground">{entry.metricPercentage.toFixed(1)}%</span>
+                <span
+                  className="inline-block text-right font-medium tabular-nums text-foreground"
+                  style={{ minWidth: `${maxMetricLabelLength}ch` }}
+                >
+                  {entry.metricLabel}
                 </span>
               </div>
             </div>

--- a/frontend/src/features/reports/components/reports-filters.test.tsx
+++ b/frontend/src/features/reports/components/reports-filters.test.tsx
@@ -9,6 +9,7 @@ const FILTERS: ReportsFiltersState = {
   endDate: "2026-06-07",
   accountId: [],
   model: "",
+  useragent: "",
 };
 
 describe("ReportsFilters", () => {
@@ -25,6 +26,7 @@ describe("ReportsFilters", () => {
         selectedPresetDays={7}
         accountOptions={[{ value: "acc_one", label: "Primary account", isEmail: false }]}
         modelOptions={[]}
+        useragentOptions={[]}
         onPresetSelect={vi.fn()}
         onFiltersChange={onFiltersChange}
       />,
@@ -48,6 +50,7 @@ describe("ReportsFilters", () => {
           { value: "gpt-5.1", label: "gpt-5.1" },
           { value: "gpt-5.2", label: "gpt-5.2" },
         ]}
+        useragentOptions={[]}
         onPresetSelect={vi.fn()}
         onFiltersChange={onFiltersChange}
       />,
@@ -62,6 +65,33 @@ describe("ReportsFilters", () => {
     });
   });
 
+  it("keeps the reports user-agent filter as a single selected value", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    render(
+      <ReportsFilters
+        filters={{ ...FILTERS, useragent: "CLI" }}
+        selectedPresetDays={7}
+        accountOptions={[]}
+        modelOptions={[]}
+        useragentOptions={[
+          { value: "CLI", label: "CLI" },
+          { value: "SDK", label: "SDK" },
+        ]}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={onFiltersChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^CLI$/i }));
+    await user.click(await screen.findByRole("menuitemcheckbox", { name: /^SDK$/i }));
+
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...FILTERS,
+      useragent: "SDK",
+    });
+  });
+
   it("renders the selected preset as pressed and forwards preset clicks", () => {
     const onFiltersChange = vi.fn();
     const onPresetSelect = vi.fn();
@@ -72,6 +102,7 @@ describe("ReportsFilters", () => {
         selectedPresetDays={30}
         accountOptions={[]}
         modelOptions={[]}
+        useragentOptions={[]}
         onPresetSelect={onPresetSelect}
         onFiltersChange={onFiltersChange}
       />,
@@ -100,6 +131,7 @@ describe("ReportsFilters", () => {
         selectedPresetDays={30}
         accountOptions={[]}
         modelOptions={[]}
+        useragentOptions={[]}
         onPresetSelect={vi.fn()}
         onFiltersChange={vi.fn()}
       />,

--- a/frontend/src/features/reports/components/reports-filters.tsx
+++ b/frontend/src/features/reports/components/reports-filters.tsx
@@ -10,6 +10,7 @@ export type ReportsFiltersState = {
   endDate: string;
   accountId: string[];
   model: string;
+  useragent: string;
 };
 
 export type ReportsFiltersProps = {
@@ -17,6 +18,7 @@ export type ReportsFiltersProps = {
   selectedPresetDays: number | null;
   accountOptions: MultiSelectOption[];
   modelOptions: MultiSelectOption[];
+  useragentOptions: MultiSelectOption[];
   onPresetSelect: (days: number) => void;
   onFiltersChange: (filters: ReportsFiltersState) => void;
 };
@@ -32,6 +34,7 @@ export function ReportsFilters({
   selectedPresetDays,
   accountOptions,
   modelOptions,
+  useragentOptions,
   onPresetSelect,
   onFiltersChange,
 }: ReportsFiltersProps) {
@@ -67,6 +70,14 @@ export function ReportsFilters({
         options={modelOptions}
         onChange={(models) =>
           onFiltersChange({ ...filters, model: models.at(-1) ?? "" })
+        }
+      />
+      <MultiSelectFilter
+        label="UserAgent"
+        values={filters.useragent ? [filters.useragent] : []}
+        options={useragentOptions}
+        onChange={(useragents) =>
+          onFiltersChange({ ...filters, useragent: useragents.at(-1) ?? "" })
         }
       />
 

--- a/frontend/src/features/reports/components/reports-page.test.tsx
+++ b/frontend/src/features/reports/components/reports-page.test.tsx
@@ -453,7 +453,9 @@ describe("ReportsPage", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /accounts/i }),
+      screen
+        .getAllByRole("button", { name: /accounts/i })
+        .find((button) => button.getAttribute("aria-haspopup") === "menu"),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/reports/components/reports-page.test.tsx
+++ b/frontend/src/features/reports/components/reports-page.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
@@ -60,6 +60,7 @@ const EMPTY_REPORT: ReportsResponse = {
   },
   daily: [],
   byModel: [],
+  byUseragent: [],
   byAccount: [],
 };
 
@@ -134,6 +135,7 @@ describe("ReportsPage", () => {
         startDate: expect.any(String),
         endDate: expect.any(String),
         model: "",
+        useragent: "",
       }),
       "America/Los_Angeles",
     );
@@ -307,10 +309,16 @@ describe("ReportsPage", () => {
         data: {
           ...EMPTY_REPORT,
           byModel: filters.model
-            ? [{ model: "gpt-5.1", costUsd: 1, percentage: 100 }]
+            ? [{ model: "gpt-5.1", costUsd: 1, requests: 1, percentage: 100 }]
+              : [
+                  { model: "gpt-5.1", costUsd: 1, requests: 1, percentage: 50 },
+                  { model: "gpt-5.2", costUsd: 1, requests: 1, percentage: 50 },
+                ],
+          byUseragent: filters.model
+            ? [{ useragent: "CLI", costUsd: 1, requests: 1, percentage: 100 }]
             : [
-                { model: "gpt-5.1", costUsd: 1, percentage: 50 },
-                { model: "gpt-5.2", costUsd: 1, percentage: 50 },
+                { useragent: "CLI", costUsd: 1, requests: 1, percentage: 50 },
+                { useragent: "SDK", costUsd: 1, requests: 1, percentage: 50 },
               ],
         },
         isLoading: false,
@@ -323,6 +331,35 @@ describe("ReportsPage", () => {
 
     expect(
       await screen.findByRole("menuitemcheckbox", { name: /gpt-5.2/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps user-agent options from the relaxed reports catalog", async () => {
+    const user = userEvent.setup();
+    useReportsMock.mockImplementation((filters) =>
+      asUseReportsResult({
+        data: {
+          ...EMPTY_REPORT,
+          byModel: [
+            { model: "gpt-5.1", costUsd: 1, requests: 1, percentage: 100 },
+          ],
+          byUseragent: filters.useragent
+            ? [{ useragent: "CLI", costUsd: 1, requests: 1, percentage: 100 }]
+            : [
+                { useragent: "CLI", costUsd: 1, requests: 1, percentage: 50 },
+                { useragent: "SDK", costUsd: 1, requests: 1, percentage: 50 },
+              ],
+        },
+        isLoading: false,
+      }),
+    );
+
+    renderWithProviders(<ReportsPage initialFilters={{ useragent: "CLI" }} />);
+
+    await user.click(screen.getByRole("button", { name: /^CLI$/i }));
+
+    expect(
+      await screen.findByRole("menuitemcheckbox", { name: /^SDK$/i }),
     ).toBeInTheDocument();
   });
 
@@ -399,13 +436,18 @@ describe("ReportsPage", () => {
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
-  it("shows model option load failures instead of hiding empty selector silently", async () => {
+  it("shows one shared catalog failure for model and user-agent options", async () => {
     useReportsMock.mockImplementation((filters) =>
-      filters.model
+      filters.model || filters.useragent
         ? asUseReportsResult({
             data: {
               ...EMPTY_REPORT,
-              byModel: [{ model: "gpt-5.1", costUsd: 1, percentage: 100 }],
+              byModel: [
+                { model: "gpt-5.1", costUsd: 1, requests: 1, percentage: 100 },
+              ],
+              byUseragent: [
+                { useragent: "CLI", costUsd: 1, requests: 1, percentage: 100 },
+              ],
             },
             isLoading: false,
             isError: false,
@@ -414,22 +456,95 @@ describe("ReportsPage", () => {
         : asUseReportsResult({
             isLoading: false,
             isError: true,
-            error: new Error("model catalog endpoint unavailable"),
+            error: new Error("shared catalog endpoint unavailable"),
             refetch: vi.fn(),
             data: undefined,
           }),
     );
 
-    renderWithProviders(<ReportsPage initialFilters={{ model: "gpt-5.1" }} />);
+    renderWithProviders(
+      <ReportsPage initialFilters={{ model: "gpt-5.1", useragent: "CLI" }} />,
+    );
 
     expect(
       await screen.findByText(
-        /Failed to load model options: model catalog endpoint unavailable/i,
+        /Failed to load model and user-agent options: shared catalog endpoint unavailable/i,
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /gpt-5.1/i }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^CLI$/i })).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Failed to load model options:/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Failed to load user-agent options:/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an independent user-agent distribution card below the model card", async () => {
+    useReportsMock.mockImplementation(() =>
+      asUseReportsResult({
+        data: {
+          ...EMPTY_REPORT,
+          byModel: [{ model: "gpt-5.1", costUsd: 12, requests: 3, percentage: 100 }],
+          byUseragent: [
+            { useragent: "CLI", costUsd: 10, requests: 2, percentage: 100 },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(<ReportsPage />);
+
+    const modelCard = await screen.findByText("Distribution by Model");
+    const useragentCard = await screen.findByText("Distribution by UserAgent");
+
+    expect(modelCard.compareDocumentPosition(useragentCard)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("keeps the model and user-agent metric toggles independent", async () => {
+    const user = userEvent.setup();
+
+    useReportsMock.mockImplementation(() =>
+      asUseReportsResult({
+        data: {
+          ...EMPTY_REPORT,
+          byModel: [
+            { model: "gpt-5.1", costUsd: 12, requests: 3, percentage: 100 },
+          ],
+          byUseragent: [
+            { useragent: "CLI", costUsd: 10, requests: 2, percentage: 100 },
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(<ReportsPage />);
+
+    const modelCard = (await screen.findByText("Distribution by Model")).closest("div.rounded-xl.border.bg-card.p-5");
+    const useragentCard = (await screen.findByText("Distribution by UserAgent")).closest("div.rounded-xl.border.bg-card.p-5");
+
+    expect(modelCard).not.toBeNull();
+    expect(useragentCard).not.toBeNull();
+
+    await user.click(within(useragentCard as HTMLElement).getByRole("button", { name: /^req$/i }));
+
+    expect(within(modelCard as HTMLElement).getByRole("button", { name: /^cost$/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(within(useragentCard as HTMLElement).getByRole("button", { name: /^req$/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   it("shows account option load failures instead of hiding empty selector silently", async () => {

--- a/frontend/src/features/reports/components/reports-page.test.tsx
+++ b/frontend/src/features/reports/components/reports-page.test.tsx
@@ -327,7 +327,9 @@ describe("ReportsPage", () => {
 
     renderWithProviders(<ReportsPage initialFilters={{ model: "gpt-5.1" }} />);
 
-    await user.click(screen.getByRole("button", { name: /gpt-5.1/i }));
+    await user.click(
+      screen.getByRole("button", { name: /gpt-5.1/i, expanded: false }),
+    );
 
     expect(
       await screen.findByRole("menuitemcheckbox", { name: /gpt-5.2/i }),
@@ -356,7 +358,9 @@ describe("ReportsPage", () => {
 
     renderWithProviders(<ReportsPage initialFilters={{ useragent: "CLI" }} />);
 
-    await user.click(screen.getByRole("button", { name: /^CLI$/i }));
+    await user.click(
+      screen.getByRole("button", { name: /^CLI$/i, expanded: false }),
+    );
 
     expect(
       await screen.findByRole("menuitemcheckbox", { name: /^SDK$/i }),
@@ -472,9 +476,11 @@ describe("ReportsPage", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /gpt-5.1/i }),
+      screen.getByRole("button", { name: /gpt-5.1/i, expanded: false }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^CLI$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^CLI$/i, expanded: false }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText(/Failed to load model options:/i),
     ).not.toBeInTheDocument();

--- a/frontend/src/features/reports/components/reports-page.tsx
+++ b/frontend/src/features/reports/components/reports-page.tsx
@@ -11,6 +11,7 @@ import { ReportsSummaryCards } from "./reports-summary-cards";
 import type { CostPerDayChartProps } from "./cost-per-day-chart";
 import type { TokensPerDayChartProps } from "./tokens-per-day-chart";
 import type { ModelDistributionDonutProps } from "./model-distribution-donut";
+import type { UseragentDistributionDonutProps } from "./useragent-distribution-donut";
 import { DailyDetailTable } from "./daily-detail-table";
 import { daysAgoLocalISO, getBrowserReportsTimeZone, localDateISO } from "../date";
 
@@ -29,6 +30,13 @@ const ModelDistributionDonut = lazy(() =>
     default: (props: ModelDistributionDonutProps) => <module.ModelDistributionDonut {...props} />,
   })),
 );
+const UseragentDistributionDonut = lazy(() =>
+  import("./useragent-distribution-donut").then((module) => ({
+    default: (props: UseragentDistributionDonutProps) => (
+      <module.UseragentDistributionDonut {...props} />
+    ),
+  })),
+);
 
 const REPORTS_TIMEZONE_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_PRESET_DAYS = 7;
@@ -38,6 +46,7 @@ const createDefaultFilters = (): ReportsFiltersState => ({
   endDate: localDateISO(),
   accountId: [],
   model: "",
+  useragent: "",
 });
 
 export type ReportsPageProps = {
@@ -80,11 +89,11 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
   }, []);
 
   const reportsQuery = useReports(filters, reportsTimeZone);
-  const modelCatalogFilters = useMemo(
-    () => ({ ...filters, model: "" }),
+  const filterCatalogFilters = useMemo(
+    () => ({ ...filters, model: "", useragent: "" }),
     [filters],
   );
-  const modelCatalogQuery = useReports(modelCatalogFilters, reportsTimeZone);
+  const filterCatalogQuery = useReports(filterCatalogFilters, reportsTimeZone);
   const {
     data: accountsData,
     error: accountsError,
@@ -110,25 +119,34 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
 
   const modelOptions = useMemo(
     () =>
-      (modelCatalogQuery.data?.byModel ?? []).map((entry) => ({
+      (filterCatalogQuery.data?.byModel ?? []).map((entry) => ({
         value: entry.model,
         label: entry.model,
       })),
-    [modelCatalogQuery.data],
+    [filterCatalogQuery.data],
+  );
+
+  const useragentOptions = useMemo(
+    () =>
+      (filterCatalogQuery.data?.byUseragent ?? []).map((entry) => ({
+        value: entry.useragent,
+        label: entry.useragent,
+      })),
+    [filterCatalogQuery.data],
   );
 
   const mainReportsError = getErrorMessageOrNull(reportsQuery.error);
-  const modelOptionsError = getErrorMessageOrNull(modelCatalogQuery.error);
+  const sharedOptionsError = getErrorMessageOrNull(filterCatalogQuery.error);
   const accountOptionsError = getErrorMessageOrNull(accountsError);
 
   const hasAnyError = Boolean(
-    mainReportsError || modelOptionsError || accountOptionsError,
+    mainReportsError || sharedOptionsError || accountOptionsError,
   );
 
   const handleRetry = async () => {
     await Promise.allSettled([
       reportsQuery.refetch(),
-      modelCatalogQuery.refetch(),
+      filterCatalogQuery.refetch(),
       refetchAccounts(),
     ]);
   };
@@ -168,6 +186,7 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
         selectedPresetDays={selectedPresetDays}
         accountOptions={accountOptions}
         modelOptions={modelOptions}
+        useragentOptions={useragentOptions}
         onPresetSelect={handlePresetSelect}
         onFiltersChange={handleFiltersChange}
       />
@@ -177,9 +196,9 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
           Failed to load report data: {mainReportsError}
         </AlertMessage>
       ) : null}
-      {modelOptionsError ? (
+      {sharedOptionsError ? (
         <AlertMessage variant="error">
-          Failed to load model options: {modelOptionsError}
+          Failed to load model and user-agent options: {sharedOptionsError}
         </AlertMessage>
       ) : null}
       {accountOptionsError ? (
@@ -215,9 +234,12 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
             </Suspense>
           </div>
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-            <div className="lg:col-span-1">
+            <div className="space-y-4 lg:col-span-1">
               <Suspense fallback={<div className="h-[220px] rounded-xl border bg-card" />}>
                 <ModelDistributionDonut data={reportsQuery.data.byModel} />
+              </Suspense>
+              <Suspense fallback={<div className="h-[220px] rounded-xl border bg-card" />}>
+                <UseragentDistributionDonut data={reportsQuery.data.byUseragent} />
               </Suspense>
             </div>
             <div className="lg:col-span-2">

--- a/frontend/src/features/reports/components/reports-page.tsx
+++ b/frontend/src/features/reports/components/reports-page.tsx
@@ -200,10 +200,18 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
           />
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
             <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
-              <CostPerDayChart data={reportsQuery.data.daily} />
+              <CostPerDayChart
+                startDate={filters.startDate}
+                endDate={filters.endDate}
+                data={reportsQuery.data.daily}
+              />
             </Suspense>
             <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
-              <TokensPerDayChart data={reportsQuery.data.daily} />
+              <TokensPerDayChart
+                startDate={filters.startDate}
+                endDate={filters.endDate}
+                data={reportsQuery.data.daily}
+              />
             </Suspense>
           </div>
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">

--- a/frontend/src/features/reports/components/reports-summary-cards.test.tsx
+++ b/frontend/src/features/reports/components/reports-summary-cards.test.tsx
@@ -10,9 +10,9 @@ describe("ReportsSummaryCards", () => {
       <ReportsSummaryCards
         summary={{
           totalCostUsd: 15,
-          totalInputTokens: 300,
-          totalOutputTokens: 150,
-          totalCachedTokens: 0,
+          totalInputTokens: 1_600_000_000,
+          totalOutputTokens: 13_000_000,
+          totalCachedTokens: 990_000_000,
           totalRequests: 1500,
           totalErrors: 0,
           activeAccounts: 3,
@@ -23,7 +23,7 @@ describe("ReportsSummaryCards", () => {
           canCompare: true,
           previous: {
             totalCostUsd: 10,
-            totalTokens: 900,
+            totalTokens: 3_206_000_000,
             totalRequests: 1000,
           },
         }}
@@ -48,7 +48,9 @@ describe("ReportsSummaryCards", () => {
       "dark:text-emerald-400",
     );
 
-    expect(within(tokensCard).getByText("Input 300 · Output 150")).toBeInTheDocument();
+    expect(
+      within(tokensCard).getByText("Input 1.6B · Cache 990M · Output 13.0M"),
+    ).toBeInTheDocument();
     expect(within(requestsCard).getByText("avg 500/day · 3 accounts")).toBeInTheDocument();
   });
 
@@ -140,5 +142,38 @@ describe("ReportsSummaryCards", () => {
     );
 
     expect(screen.queryByText(/^[▲▼] \d+%$/)).not.toBeInTheDocument();
+  });
+
+  it("preserves trailing zeroes for unrelated whole K and B values", () => {
+    render(
+      <ReportsSummaryCards
+        summary={{
+          totalCostUsd: 15,
+          totalInputTokens: 100_000_000_000,
+          totalOutputTokens: 0,
+          totalCachedTokens: 0,
+          totalRequests: 100_000,
+          totalErrors: 0,
+          activeAccounts: 3,
+          avgCostPerDay: 5,
+          avgRequestsPerDay: 500,
+        }}
+        comparison={{
+          canCompare: false,
+          previous: {
+            totalCostUsd: 0,
+            totalTokens: 0,
+            totalRequests: 0,
+          },
+        }}
+      />,
+    );
+
+    const tokensCard = screen.getByTestId("report-summary-card-Tokens");
+    const requestsCard = screen.getByTestId("report-summary-card-Requests");
+
+    expect(within(tokensCard).getByText("100.0B")).toBeInTheDocument();
+    expect(within(tokensCard).getByText("Input 100.0B · Cache 0 · Output 0")).toBeInTheDocument();
+    expect(within(requestsCard).getByText("100.0K")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/reports/components/reports-summary-cards.tsx
+++ b/frontend/src/features/reports/components/reports-summary-cards.tsx
@@ -23,7 +23,7 @@ export function ReportsSummaryCards({ summary, comparison }: ReportsSummaryCards
     {
       label: "Tokens",
       value: formatNumber(summary.totalInputTokens + summary.totalOutputTokens),
-      sub: `Input ${formatNumber(summary.totalInputTokens)} · Output ${formatNumber(summary.totalOutputTokens)}`,
+      sub: `Input ${formatNumber(summary.totalInputTokens)} · Cache ${formatNumber(summary.totalCachedTokens)} · Output ${formatNumber(summary.totalOutputTokens)}`,
       comparison: buildComparison(
         summary.totalInputTokens + summary.totalOutputTokens,
         comparison.previous.totalTokens,
@@ -67,10 +67,18 @@ export function ReportsSummaryCards({ summary, comparison }: ReportsSummaryCards
 }
 
 function formatNumber(n: number): string {
-  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  if (n >= 1_000_000_000) return formatCompactNumber(n / 1_000_000_000, "B");
+  if (n >= 1_000_000) return formatCompactNumber(n / 1_000_000, "M");
+  if (n >= 1_000) return formatCompactNumber(n / 1_000, "K");
   return String(n);
+}
+
+function formatCompactNumber(value: number, suffix: "B" | "M" | "K"): string {
+  if (suffix === "M" && value >= 100 && Number.isInteger(value)) {
+    return `${value.toFixed(0)}${suffix}`;
+  }
+
+  return `${value.toFixed(1)}${suffix}`;
 }
 
 function buildComparison(

--- a/frontend/src/features/reports/components/tokens-per-day-chart.test.tsx
+++ b/frontend/src/features/reports/components/tokens-per-day-chart.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TokensPerDayChart } from "./tokens-per-day-chart";
 
-let capturedProps: { margin?: unknown } | null = null;
+let capturedProps: { margin?: unknown; data?: unknown } | null = null;
 
 vi.mock("recharts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("recharts")>();
@@ -12,7 +12,7 @@ vi.mock("recharts", async (importOriginal) => {
   return {
     ...actual,
     ResponsiveContainer: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-    AreaChart: (props: { children: ReactNode; margin?: unknown }) => {
+    AreaChart: (props: { children: ReactNode; margin?: unknown; data?: unknown }) => {
       capturedProps = props;
       return <div data-testid="tokens-area-chart" />;
     },
@@ -32,6 +32,8 @@ describe("TokensPerDayChart", () => {
   it("uses equal left and right chart margins", () => {
     render(
       <TokensPerDayChart
+        startDate="2026-06-05"
+        endDate="2026-06-05"
         data={[
           {
             date: "2026-06-05",
@@ -48,5 +50,42 @@ describe("TokensPerDayChart", () => {
     );
 
     expect(capturedProps?.margin).toEqual({ top: 5, right: 10, left: 10, bottom: 0 });
+  });
+
+  it("fills missing selected days with zero-value rows", () => {
+    render(
+      <TokensPerDayChart
+        startDate="2026-06-05"
+        endDate="2026-06-07"
+        data={[
+          {
+            date: "2026-06-05",
+            requests: 150,
+            inputTokens: 5_400_000,
+            outputTokens: 59_000,
+            cachedInputTokens: 0,
+            costUsd: 3.77,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+          {
+            date: "2026-06-07",
+            requests: 179,
+            inputTokens: 6_800_000,
+            outputTokens: 73_000,
+            cachedInputTokens: 0,
+            costUsd: 4.54,
+            activeAccounts: 2,
+            errorCount: 0,
+          },
+        ]}
+      />,
+    );
+
+    expect(capturedProps?.data).toEqual([
+      { date: "06-05", input: 5_400_000, output: 59_000 },
+      { date: "06-06", input: 0, output: 0 },
+      { date: "06-07", input: 6_800_000, output: 73_000 },
+    ]);
   });
 });

--- a/frontend/src/features/reports/components/tokens-per-day-chart.tsx
+++ b/frontend/src/features/reports/components/tokens-per-day-chart.tsx
@@ -8,9 +8,12 @@ import {
   ResponsiveContainer,
 } from "@/components/lazy-recharts";
 import type { DailyReportRow } from "../schemas";
+import { buildContinuousDailyRows } from "../daily-series";
 import { ChartTooltip } from "./chart-tooltip";
 
 export type TokensPerDayChartProps = {
+  startDate: string;
+  endDate: string;
   data: DailyReportRow[];
 };
 
@@ -21,8 +24,8 @@ function formatTokens(v: number): string {
   return String(v);
 }
 
-export function TokensPerDayChart({ data }: TokensPerDayChartProps) {
-  const chartData = data.map((d) => ({
+export function TokensPerDayChart({ startDate, endDate, data }: TokensPerDayChartProps) {
+  const chartData = buildContinuousDailyRows(startDate, endDate, data).map((d) => ({
     date: d.date.slice(5),
     input: d.inputTokens,
     output: d.outputTokens,

--- a/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
@@ -57,6 +57,20 @@ vi.mock("recharts", async (importOriginal) => {
 });
 
 describe("UseragentDistributionDonut", () => {
+  it("shows the total label and compact cost total in the donut center by default", () => {
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "CLI", costUsd: 430, requests: 8, percentage: 30 },
+          { useragent: "SDK", costUsd: 1000, requests: 4, percentage: 70 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("useragent-distribution-center-label")).toHaveTextContent("Total");
+    expect(screen.getByTestId("useragent-distribution-center-value")).toHaveTextContent("$1.43K");
+  });
+
   it("renders Missing User-Agent with a fixed grey legend dot", () => {
     render(
       <UseragentDistributionDonut
@@ -112,7 +126,7 @@ describe("UseragentDistributionDonut", () => {
     await user.click(screen.getByRole("button", { name: /^req$/i }));
 
     const smallRequestLegendValue = screen.getAllByText(/^8$/).at(-1);
-    const largeRequestLegendValue = screen.getAllByText(/^1200$/).at(-1);
+    const largeRequestLegendValue = screen.getAllByText("1.2K").at(-1);
 
     expect(smallRequestLegendValue).toBeDefined();
     expect(largeRequestLegendValue).toBeDefined();
@@ -132,12 +146,13 @@ describe("UseragentDistributionDonut", () => {
 
     expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("useragent-distribution-center-value")).toHaveTextContent("$20");
     const tooltipRow = screen.getByText("Cost").parentElement;
 
     expect(tooltipRow).not.toBeNull();
-    expect(within(tooltipRow as HTMLElement).getByText("$12.50")).toBeInTheDocument();
+    expect(within(tooltipRow as HTMLElement).getByText("$12.5")).toBeInTheDocument();
     expect(screen.getByText("62.5%")).toBeInTheDocument();
-    expect(screen.getByText("$7.50")).toBeInTheDocument();
+    expect(screen.getByText("$7.5")).toBeInTheDocument();
     expect(screen.getByTestId("useragent-distribution-pie")).toHaveAttribute("data-key", "costUsd");
   });
 
@@ -162,6 +177,26 @@ describe("UseragentDistributionDonut", () => {
     expect(screen.getByText("66.7%")).toBeInTheDocument();
     expect(screen.getByText("33.3%")).toBeInTheDocument();
     expect(screen.getByText(/^4$/)).toBeInTheDocument();
+    expect(screen.getByTestId("useragent-distribution-center-value")).toHaveTextContent("12");
     expect(screen.getByTestId("useragent-distribution-pie")).toHaveAttribute("data-key", "requests");
+  });
+
+  it("uses compact request totals in the center and legend when request mode is active", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "CLI", costUsd: 12.5, requests: 500_000_000, percentage: 40 },
+          { useragent: "SDK", costUsd: 7.5, requests: 1_000_000_000, percentage: 60 },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^req$/i }));
+
+    expect(screen.getByTestId("useragent-distribution-center-value")).toHaveTextContent("1.5B");
+    expect(screen.getByText("500M")).toBeInTheDocument();
+    expect(screen.getByText("1B")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
@@ -1,6 +1,6 @@
 import { cloneElement, isValidElement, type ReactNode } from "react";
 import userEvent from "@testing-library/user-event";
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { UseragentDistributionDonut } from "./useragent-distribution-donut";
@@ -23,13 +23,31 @@ vi.mock("recharts", async (importOriginal) => {
     Pie: ({
       data,
       dataKey,
+      onMouseEnter,
+      onMouseLeave,
+      shape,
     }: {
       data: Array<{ useragent: string }>;
       dataKey: string;
+      onMouseEnter?: (entry: { useragent: string }, index: number) => void;
+      onMouseLeave?: (entry: { useragent: string }, index: number) => void;
+      shape?: unknown;
     }) => (
-      <div data-testid="useragent-distribution-pie" data-key={dataKey}>
-        {data.map((entry) => (
-          <div key={entry.useragent}>{entry.useragent}</div>
+      <div
+        data-testid="useragent-distribution-pie"
+        data-key={dataKey}
+        data-shape={shape ? "true" : "false"}
+      >
+        {data.map((entry, index) => (
+          <button
+            key={entry.useragent}
+            type="button"
+            data-testid={`useragent-slice-${index}`}
+            onMouseEnter={() => onMouseEnter?.(entry, index)}
+            onMouseLeave={() => onMouseLeave?.(entry, index)}
+          >
+            {entry.useragent}
+          </button>
         ))}
       </div>
     ),
@@ -57,6 +75,60 @@ vi.mock("recharts", async (importOriginal) => {
 });
 
 describe("UseragentDistributionDonut", () => {
+  it("highlights the matching legend row when a legend item is hovered", () => {
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "CLI", costUsd: 12.5, requests: 8, percentage: 62.5 },
+          { useragent: "SDK", costUsd: 7.5, requests: 4, percentage: 37.5 },
+        ]}
+      />,
+    );
+
+    const legendRow = screen.getByTestId("useragent-distribution-legend-0");
+
+    expect(screen.getByTestId("useragent-distribution-pie")).toHaveAttribute("data-shape", "true");
+    expect(legendRow).toHaveAttribute("data-active", "false");
+
+    fireEvent.mouseEnter(legendRow);
+    expect(legendRow).toHaveAttribute("data-active", "true");
+
+    fireEvent.mouseLeave(legendRow);
+    expect(legendRow).toHaveAttribute("data-active", "false");
+  });
+
+  it("highlights the matching legend row when a pie slice is hovered", () => {
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "CLI", costUsd: 12.5, requests: 8, percentage: 62.5 },
+          { useragent: "SDK", costUsd: 7.5, requests: 4, percentage: 37.5 },
+        ]}
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId("useragent-slice-0"));
+    expect(screen.getByTestId("useragent-distribution-legend-0")).toHaveAttribute("data-active", "true");
+  });
+
+  it("limits the legend viewport to four visible rows before scrolling", () => {
+    render(
+      <UseragentDistributionDonut
+        data={Array.from({ length: 5 }, (_, index) => ({
+          useragent: `UA-${index + 1}`,
+          costUsd: index + 1,
+          requests: index + 1,
+          percentage: 20,
+        }))}
+      />,
+    );
+
+    expect(screen.getByTestId("useragent-distribution-legend-list")).toHaveStyle({
+      maxHeight: "calc(4 * 2rem)",
+    });
+    expect(screen.getByTestId("useragent-distribution-legend-4")).toBeInTheDocument();
+  });
+
   it("shows the total label and compact cost total in the donut center by default", () => {
     render(
       <UseragentDistributionDonut
@@ -198,5 +270,28 @@ describe("UseragentDistributionDonut", () => {
     expect(screen.getByTestId("useragent-distribution-center-value")).toHaveTextContent("1.5B");
     expect(screen.getByText("500M")).toBeInTheDocument();
     expect(screen.getByText("1B")).toBeInTheDocument();
+  });
+
+  it("scrolls the hovered pie item into view in the legend list", () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    render(
+      <UseragentDistributionDonut
+        data={Array.from({ length: 5 }, (_, index) => ({
+          useragent: `UA-${index + 1}`,
+          costUsd: 5 - index,
+          requests: index + 1,
+          percentage: 20,
+        }))}
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByTestId("useragent-slice-4"));
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest", inline: "nearest" });
   });
 });

--- a/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
@@ -1,15 +1,9 @@
-import { cloneElement, isValidElement, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import userEvent from "@testing-library/user-event";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { UseragentDistributionDonut } from "./useragent-distribution-donut";
-
-type MockTooltipContentProps = {
-  names?: {
-    requests?: unknown;
-  };
-};
 
 vi.mock("recharts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("recharts")>();
@@ -52,25 +46,6 @@ vi.mock("recharts", async (importOriginal) => {
       </div>
     ),
     Cell: () => null,
-    Tooltip: ({ content }: { content: ReactNode }) => {
-      if (!isValidElement<MockTooltipContentProps>(content)) {
-        return null;
-      }
-
-      const dataKey = content.props.names?.requests ? "requests" : "costUsd";
-
-      return cloneElement(content, {
-        active: true,
-        payload: [
-          {
-            dataKey,
-            name: dataKey,
-            value: dataKey === "requests" ? 8 : 12.5,
-            color: "#3b82f6",
-          },
-        ],
-      } as Record<string, unknown>);
-    },
   };
 });
 
@@ -206,7 +181,7 @@ describe("UseragentDistributionDonut", () => {
     expect(largeRequestLegendValue).toHaveStyle({ minWidth: "4ch" });
   });
 
-  it("defaults to cost mode", () => {
+  it("defaults to cost mode without rendering a donut tooltip", () => {
     render(
       <UseragentDistributionDonut
         data={[
@@ -219,16 +194,13 @@ describe("UseragentDistributionDonut", () => {
     expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByTestId("useragent-distribution-center-value")).toHaveTextContent("$20");
-    const tooltipRow = screen.getByText("Cost").parentElement;
-
-    expect(tooltipRow).not.toBeNull();
-    expect(within(tooltipRow as HTMLElement).getByText("$12.5")).toBeInTheDocument();
     expect(screen.getByText("62.5%")).toBeInTheDocument();
     expect(screen.getByText("$7.5")).toBeInTheDocument();
     expect(screen.getByTestId("useragent-distribution-pie")).toHaveAttribute("data-key", "costUsd");
+    expect(screen.queryByText(/^Cost$/)).not.toBeInTheDocument();
   });
 
-  it("switches to request mode for slices, tooltip, legend values, and percentages", async () => {
+  it("switches to request mode for slices, legend values, and percentages without rendering a donut tooltip", async () => {
     const user = userEvent.setup();
 
     render(
@@ -242,15 +214,12 @@ describe("UseragentDistributionDonut", () => {
 
     await user.click(screen.getByRole("button", { name: /^req$/i }));
 
-    const tooltipRow = screen.getByText("Requests").parentElement;
-
-    expect(tooltipRow).not.toBeNull();
-    expect(within(tooltipRow as HTMLElement).getByText("8")).toBeInTheDocument();
     expect(screen.getByText("66.7%")).toBeInTheDocument();
     expect(screen.getByText("33.3%")).toBeInTheDocument();
     expect(screen.getByText(/^4$/)).toBeInTheDocument();
     expect(screen.getByTestId("useragent-distribution-center-value")).toHaveTextContent("12");
     expect(screen.getByTestId("useragent-distribution-pie")).toHaveAttribute("data-key", "requests");
+    expect(screen.queryByText(/^Requests$/)).not.toBeInTheDocument();
   });
 
   it("uses compact request totals in the center and legend when request mode is active", async () => {

--- a/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
@@ -1,0 +1,104 @@
+import { cloneElement, isValidElement, type ReactNode } from "react";
+import userEvent from "@testing-library/user-event";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { UseragentDistributionDonut } from "./useragent-distribution-donut";
+
+type MockTooltipContentProps = {
+  names?: {
+    requests?: unknown;
+  };
+};
+
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+      <div data-testid="responsive-container">{children}</div>
+    ),
+    PieChart: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Pie: ({
+      data,
+      dataKey,
+    }: {
+      data: Array<{ useragent: string }>;
+      dataKey: string;
+    }) => (
+      <div data-testid="useragent-distribution-pie" data-key={dataKey}>
+        {data.map((entry) => (
+          <div key={entry.useragent}>{entry.useragent}</div>
+        ))}
+      </div>
+    ),
+    Cell: () => null,
+    Tooltip: ({ content }: { content: ReactNode }) => {
+      if (!isValidElement<MockTooltipContentProps>(content)) {
+        return null;
+      }
+
+      const dataKey = content.props.names?.requests ? "requests" : "costUsd";
+
+      return cloneElement(content, {
+        active: true,
+        payload: [
+          {
+            dataKey,
+            name: dataKey,
+            value: dataKey === "requests" ? 8 : 12.5,
+            color: "#3b82f6",
+          },
+        ],
+      } as Record<string, unknown>);
+    },
+  };
+});
+
+describe("UseragentDistributionDonut", () => {
+  it("defaults to cost mode", () => {
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "CLI", costUsd: 12.5, requests: 8, percentage: 62.5 },
+          { useragent: "SDK", costUsd: 7.5, requests: 4, percentage: 37.5 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /^cost$/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /^req$/i })).toHaveAttribute("aria-pressed", "false");
+    const tooltipRow = screen.getByText("Cost").parentElement;
+
+    expect(tooltipRow).not.toBeNull();
+    expect(within(tooltipRow as HTMLElement).getByText("$12.50")).toBeInTheDocument();
+    expect(screen.getByText("62.5%")).toBeInTheDocument();
+    expect(screen.getByText("$7.50")).toBeInTheDocument();
+    expect(screen.getByTestId("useragent-distribution-pie")).toHaveAttribute("data-key", "costUsd");
+  });
+
+  it("switches to request mode for slices, tooltip, legend values, and percentages", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "CLI", costUsd: 12.5, requests: 8, percentage: 62.5 },
+          { useragent: "SDK", costUsd: 7.5, requests: 4, percentage: 37.5 },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^req$/i }));
+
+    const tooltipRow = screen.getByText("Requests").parentElement;
+
+    expect(tooltipRow).not.toBeNull();
+    expect(within(tooltipRow as HTMLElement).getByText("8")).toBeInTheDocument();
+    expect(screen.getByText("66.7%")).toBeInTheDocument();
+    expect(screen.getByText("33.3%")).toBeInTheDocument();
+    expect(screen.getByText(/^4$/)).toBeInTheDocument();
+    expect(screen.getByTestId("useragent-distribution-pie")).toHaveAttribute("data-key", "requests");
+  });
+});

--- a/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
@@ -57,7 +57,27 @@ vi.mock("recharts", async (importOriginal) => {
 });
 
 describe("UseragentDistributionDonut", () => {
-  it("renders Unknown with a fixed grey legend dot", () => {
+  it("renders Missing User-Agent with a fixed grey legend dot", () => {
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "Missing User-Agent", costUsd: 12.5, requests: 8, percentage: 62.5 },
+          { useragent: "SDK", costUsd: 7.5, requests: 4, percentage: 37.5 },
+        ]}
+      />,
+    );
+
+    const unknownLegendLabel = screen.getAllByText("Missing User-Agent").at(-1);
+    const unknownLegendRow = unknownLegendLabel?.closest("div.flex.items-center.gap-2");
+
+    expect(unknownLegendLabel).toBeDefined();
+    expect(unknownLegendRow).not.toBeNull();
+    expect((unknownLegendRow?.firstElementChild as HTMLElement) ?? null).toHaveStyle({
+      background: "#9ca3af",
+    });
+  });
+
+  it("keeps a real Unknown bucket on the normal palette", () => {
     render(
       <UseragentDistributionDonut
         data={[
@@ -73,7 +93,7 @@ describe("UseragentDistributionDonut", () => {
     expect(unknownLegendLabel).toBeDefined();
     expect(unknownLegendRow).not.toBeNull();
     expect((unknownLegendRow?.firstElementChild as HTMLElement) ?? null).toHaveStyle({
-      background: "#9ca3af",
+      background: "#3b82f6",
     });
   });
 

--- a/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.test.tsx
@@ -57,6 +57,49 @@ vi.mock("recharts", async (importOriginal) => {
 });
 
 describe("UseragentDistributionDonut", () => {
+  it("renders Unknown with a fixed grey legend dot", () => {
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "Unknown", costUsd: 12.5, requests: 8, percentage: 62.5 },
+          { useragent: "SDK", costUsd: 7.5, requests: 4, percentage: 37.5 },
+        ]}
+      />,
+    );
+
+    const unknownLegendLabel = screen.getAllByText("Unknown").at(-1);
+    const unknownLegendRow = unknownLegendLabel?.closest("div.flex.items-center.gap-2");
+
+    expect(unknownLegendLabel).toBeDefined();
+    expect(unknownLegendRow).not.toBeNull();
+    expect((unknownLegendRow?.firstElementChild as HTMLElement) ?? null).toHaveStyle({
+      background: "#9ca3af",
+    });
+  });
+
+  it("pads legend value cells to the longest formatted request total", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <UseragentDistributionDonut
+        data={[
+          { useragent: "CLI", costUsd: 12.5, requests: 8, percentage: 10 },
+          { useragent: "SDK", costUsd: 120.75, requests: 1200, percentage: 90 },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^req$/i }));
+
+    const smallRequestLegendValue = screen.getAllByText(/^8$/).at(-1);
+    const largeRequestLegendValue = screen.getAllByText(/^1200$/).at(-1);
+
+    expect(smallRequestLegendValue).toBeDefined();
+    expect(largeRequestLegendValue).toBeDefined();
+    expect(smallRequestLegendValue).toHaveStyle({ minWidth: "4ch" });
+    expect(largeRequestLegendValue).toHaveStyle({ minWidth: "4ch" });
+  });
+
   it("defaults to cost mode", () => {
     render(
       <UseragentDistributionDonut

--- a/frontend/src/features/reports/components/useragent-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "@/components/lazy-recharts";
+import { useEffect, useRef, useState } from "react";
+import { Cell, Pie, PieChart, ResponsiveContainer, Sector, Tooltip, type PieSectorShapeProps } from "@/components/lazy-recharts";
 import type { UseragentCostEntry } from "../schemas";
 import { ChartTooltip } from "./chart-tooltip";
 import { DistributionMetricToggle, type DistributionMetric } from "./distribution-metric-toggle";
@@ -12,6 +12,17 @@ export type UseragentDistributionDonutProps = {
 const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ec4899", "#8b5cf6", "#06b6d4"];
 const UNKNOWN_COLOR = "#9ca3af";
 const MISSING_USERAGENT_LABEL = "Missing User-Agent";
+const ACTIVE_RADIUS_OFFSET = 4;
+const LEGEND_VISIBLE_COUNT = 4;
+const LEGEND_ROW_HEIGHT_REM = 2;
+
+type ChartDatum = UseragentCostEntry & {
+  id: string;
+  fill: string;
+  metricLabel: string;
+  metricValue: number;
+  metricPercentage: number;
+};
 
 function getUseragentColor(useragent: string, index: number) {
   return useragent === MISSING_USERAGENT_LABEL ? UNKNOWN_COLOR : COLORS[index % COLORS.length];
@@ -19,6 +30,8 @@ function getUseragentColor(useragent: string, index: number) {
 
 export function UseragentDistributionDonut({ data }: UseragentDistributionDonutProps) {
   const [metric, setMetric] = useState<DistributionMetric>("cost");
+  const [activeLegendId, setActiveLegendId] = useState<string | null>(null);
+  const legendRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const totalCost = data.reduce((sum, entry) => sum + entry.costUsd, 0);
   const totalRequests = data.reduce((sum, entry) => sum + entry.requests, 0);
   const isCostMetric = metric === "cost";
@@ -26,8 +39,10 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
     isCostMetric ? totalCost : totalRequests,
     metric,
   );
-  const chartData = data.map((entry) => ({
+  const chartData: ChartDatum[] = data.map((entry, index) => ({
     ...entry,
+    id: `${entry.useragent}-${index}`,
+    fill: getUseragentColor(entry.useragent, index),
     metricLabel: formatDistributionMetricValue(
       isCostMetric ? entry.costUsd : entry.requests,
       metric,
@@ -43,6 +58,32 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
     (maxLength, entry) => Math.max(maxLength, entry.metricLabel.length),
     0,
   );
+
+  useEffect(() => {
+    if (!activeLegendId) {
+      return;
+    }
+
+    legendRefs.current[activeLegendId]?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeLegendId]);
+
+  const renderSlice = (props: PieSectorShapeProps) => {
+    const datum = props.payload as ChartDatum | undefined;
+    const isHighlighted = props.isActive || datum?.id === activeLegendId;
+
+    return (
+      <Sector
+        {...props}
+        outerRadius={
+          typeof props.outerRadius === "number"
+            ? props.outerRadius + (isHighlighted ? ACTIVE_RADIUS_OFFSET : 0)
+            : 65 + (isHighlighted ? ACTIVE_RADIUS_OFFSET : 0)
+        }
+        stroke={isHighlighted ? "hsl(var(--background))" : "none"}
+        strokeWidth={isHighlighted ? 2 : 0}
+      />
+    );
+  };
 
   return (
     <div className="rounded-xl border bg-card p-5">
@@ -77,9 +118,12 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
                 innerRadius={45}
                 outerRadius={65}
                 strokeWidth={0}
+                shape={renderSlice}
+                onMouseEnter={(entry: ChartDatum) => setActiveLegendId(entry.id)}
+                onMouseLeave={() => setActiveLegendId(null)}
               >
-                {chartData.map((entry, i) => (
-                  <Cell key={entry.useragent} fill={getUseragentColor(entry.useragent, i)} />
+                {chartData.map((entry) => (
+                  <Cell key={entry.id} fill={entry.fill} />
                 ))}
               </Pie>
               <Tooltip
@@ -93,16 +137,31 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
             </PieChart>
           </ResponsiveContainer>
         </div>
-        <div className="flex-1 space-y-1.5 text-xs">
+        <div
+          className="flex-1 overflow-y-auto text-xs [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          data-testid="useragent-distribution-legend-list"
+          style={{ maxHeight: `calc(${LEGEND_VISIBLE_COUNT} * ${LEGEND_ROW_HEIGHT_REM}rem)` }}
+        >
           {chartData.map((entry, i) => (
-            <div
-              key={entry.useragent}
-              className="flex items-center justify-between rounded-md px-2 py-1 hover:bg-muted/50"
+            <button
+              ref={(node) => {
+                legendRefs.current[entry.id] = node;
+              }}
+              type="button"
+              key={entry.id}
+              className="flex h-8 w-full items-center justify-between rounded-md border px-2 py-1 text-left transition-all hover:bg-muted/50"
+              style={{ borderColor: activeLegendId === entry.id ? entry.fill : "transparent" }}
+              onMouseEnter={() => setActiveLegendId(entry.id)}
+              onMouseLeave={() => setActiveLegendId(null)}
+              onFocus={() => setActiveLegendId(entry.id)}
+              onBlur={() => setActiveLegendId(null)}
+              data-active={activeLegendId === entry.id ? "true" : "false"}
+              data-testid={`useragent-distribution-legend-${i}`}
             >
               <div className="flex items-center gap-2">
                 <span
                   className="h-2.5 w-2.5 shrink-0 rounded-[3px]"
-                  style={{ background: getUseragentColor(entry.useragent, i) }}
+                  style={{ background: entry.fill }}
                 />
                 <span className="text-foreground">{entry.useragent}</span>
               </div>
@@ -115,7 +174,7 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
                   {entry.metricLabel}
                 </span>
               </div>
-            </div>
+            </button>
           ))}
         </div>
       </div>

--- a/frontend/src/features/reports/components/useragent-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.tsx
@@ -10,9 +10,10 @@ export type UseragentDistributionDonutProps = {
 
 const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ec4899", "#8b5cf6", "#06b6d4"];
 const UNKNOWN_COLOR = "#9ca3af";
+const MISSING_USERAGENT_LABEL = "Missing User-Agent";
 
 function getUseragentColor(useragent: string, index: number) {
-  return useragent === "Unknown" ? UNKNOWN_COLOR : COLORS[index % COLORS.length];
+  return useragent === MISSING_USERAGENT_LABEL ? UNKNOWN_COLOR : COLORS[index % COLORS.length];
 }
 
 export function UseragentDistributionDonut({ data }: UseragentDistributionDonutProps) {

--- a/frontend/src/features/reports/components/useragent-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.tsx
@@ -9,6 +9,11 @@ export type UseragentDistributionDonutProps = {
 };
 
 const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ec4899", "#8b5cf6", "#06b6d4"];
+const UNKNOWN_COLOR = "#9ca3af";
+
+function getUseragentColor(useragent: string, index: number) {
+  return useragent === "Unknown" ? UNKNOWN_COLOR : COLORS[index % COLORS.length];
+}
 
 export function UseragentDistributionDonut({ data }: UseragentDistributionDonutProps) {
   const [metric, setMetric] = useState<DistributionMetric>("cost");
@@ -16,6 +21,7 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
   const isCostMetric = metric === "cost";
   const chartData = data.map((entry) => ({
     ...entry,
+    metricLabel: isCostMetric ? `$${entry.costUsd.toFixed(2)}` : String(entry.requests),
     metricValue: isCostMetric ? entry.costUsd : entry.requests,
     metricPercentage: isCostMetric
       ? entry.percentage
@@ -23,6 +29,10 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
         ? (entry.requests / totalRequests) * 100
         : 0,
   }));
+  const maxMetricLabelLength = chartData.reduce(
+    (maxLength, entry) => Math.max(maxLength, entry.metricLabel.length),
+    0,
+  );
 
   return (
     <div className="rounded-xl border bg-card p-5">
@@ -45,7 +55,7 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
                 strokeWidth={0}
               >
                 {chartData.map((entry, i) => (
-                  <Cell key={entry.useragent} fill={COLORS[i % COLORS.length]} />
+                  <Cell key={entry.useragent} fill={getUseragentColor(entry.useragent, i)} />
                 ))}
               </Pie>
               <Tooltip
@@ -70,14 +80,17 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
               <div className="flex items-center gap-2">
                 <span
                   className="h-2.5 w-2.5 shrink-0 rounded-[3px]"
-                  style={{ background: COLORS[i % COLORS.length] }}
+                  style={{ background: getUseragentColor(entry.useragent, i) }}
                 />
                 <span className="text-foreground">{entry.useragent}</span>
               </div>
               <div className="flex items-center gap-3">
-                <span className="text-muted-foreground">{entry.metricPercentage.toFixed(1)}%</span>
-                <span className="font-medium text-foreground">
-                  {isCostMetric ? `$${entry.costUsd.toFixed(2)}` : entry.requests}
+                <span className="tabular-nums text-muted-foreground">{entry.metricPercentage.toFixed(1)}%</span>
+                <span
+                  className="inline-block text-right font-medium tabular-nums text-foreground"
+                  style={{ minWidth: `${maxMetricLabelLength}ch` }}
+                >
+                  {entry.metricLabel}
                 </span>
               </div>
             </div>

--- a/frontend/src/features/reports/components/useragent-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.tsx
@@ -1,21 +1,22 @@
 import { useState } from "react";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "@/components/lazy-recharts";
-import type { ModelCostEntry } from "../schemas";
+import type { UseragentCostEntry } from "../schemas";
 import { ChartTooltip } from "./chart-tooltip";
 import { DistributionMetricToggle, type DistributionMetric } from "./distribution-metric-toggle";
 
-export type ModelDistributionDonutProps = {
-  data: ModelCostEntry[];
+export type UseragentDistributionDonutProps = {
+  data: UseragentCostEntry[];
 };
 
 const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ec4899", "#8b5cf6", "#06b6d4"];
 
-export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
+export function UseragentDistributionDonut({ data }: UseragentDistributionDonutProps) {
   const [metric, setMetric] = useState<DistributionMetric>("cost");
   const totalRequests = data.reduce((sum, entry) => sum + entry.requests, 0);
   const isCostMetric = metric === "cost";
   const chartData = data.map((entry) => ({
     ...entry,
+    metricValue: isCostMetric ? entry.costUsd : entry.requests,
     metricPercentage: isCostMetric
       ? entry.percentage
       : totalRequests > 0
@@ -26,7 +27,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
   return (
     <div className="rounded-xl border bg-card p-5">
       <div className="flex items-start justify-between gap-3">
-        <div className="text-sm font-semibold text-foreground">Distribution by Model</div>
+        <div className="text-sm font-semibold text-foreground">Distribution by UserAgent</div>
         <DistributionMetricToggle metric={metric} onChange={setMetric} />
       </div>
       <div className="mt-4 flex items-center gap-4">
@@ -36,7 +37,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
               <Pie
                 data={chartData}
                 dataKey={isCostMetric ? "costUsd" : "requests"}
-                nameKey="model"
+                nameKey="useragent"
                 cx="50%"
                 cy="50%"
                 innerRadius={45}
@@ -44,7 +45,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                 strokeWidth={0}
               >
                 {chartData.map((entry, i) => (
-                  <Cell key={entry.model} fill={COLORS[i % COLORS.length]} />
+                  <Cell key={entry.useragent} fill={COLORS[i % COLORS.length]} />
                 ))}
               </Pie>
               <Tooltip
@@ -63,7 +64,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
         <div className="flex-1 space-y-1.5 text-xs">
           {chartData.map((entry, i) => (
             <div
-              key={entry.model}
+              key={entry.useragent}
               className="flex items-center justify-between rounded-md px-2 py-1 hover:bg-muted/50"
             >
               <div className="flex items-center gap-2">
@@ -71,7 +72,7 @@ export function ModelDistributionDonut({ data }: ModelDistributionDonutProps) {
                   className="h-2.5 w-2.5 shrink-0 rounded-[3px]"
                   style={{ background: COLORS[i % COLORS.length] }}
                 />
-                <span className="text-foreground">{entry.model}</span>
+                <span className="text-foreground">{entry.useragent}</span>
               </div>
               <div className="flex items-center gap-3">
                 <span className="text-muted-foreground">{entry.metricPercentage.toFixed(1)}%</span>

--- a/frontend/src/features/reports/components/useragent-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { Cell, Pie, PieChart, ResponsiveContainer, Sector, Tooltip, type PieSectorShapeProps } from "@/components/lazy-recharts";
+import { Cell, Pie, PieChart, ResponsiveContainer, Sector, type PieSectorShapeProps } from "@/components/lazy-recharts";
 import type { UseragentCostEntry } from "../schemas";
-import { ChartTooltip } from "./chart-tooltip";
 import { DistributionMetricToggle, type DistributionMetric } from "./distribution-metric-toggle";
 import { formatDistributionMetricValue } from "./distribution-metric-format";
 
@@ -126,14 +125,6 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
                   <Cell key={entry.id} fill={entry.fill} />
                 ))}
               </Pie>
-              <Tooltip
-                content={
-                  <ChartTooltip
-                    names={isCostMetric ? { costUsd: "Cost" } : { requests: "Requests" }}
-                    formatValue={(value) => formatDistributionMetricValue(value, metric)}
-                  />
-                }
-              />
             </PieChart>
           </ResponsiveContainer>
         </div>

--- a/frontend/src/features/reports/components/useragent-distribution-donut.tsx
+++ b/frontend/src/features/reports/components/useragent-distribution-donut.tsx
@@ -3,6 +3,7 @@ import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "@/components/
 import type { UseragentCostEntry } from "../schemas";
 import { ChartTooltip } from "./chart-tooltip";
 import { DistributionMetricToggle, type DistributionMetric } from "./distribution-metric-toggle";
+import { formatDistributionMetricValue } from "./distribution-metric-format";
 
 export type UseragentDistributionDonutProps = {
   data: UseragentCostEntry[];
@@ -18,11 +19,19 @@ function getUseragentColor(useragent: string, index: number) {
 
 export function UseragentDistributionDonut({ data }: UseragentDistributionDonutProps) {
   const [metric, setMetric] = useState<DistributionMetric>("cost");
+  const totalCost = data.reduce((sum, entry) => sum + entry.costUsd, 0);
   const totalRequests = data.reduce((sum, entry) => sum + entry.requests, 0);
   const isCostMetric = metric === "cost";
+  const totalMetricLabel = formatDistributionMetricValue(
+    isCostMetric ? totalCost : totalRequests,
+    metric,
+  );
   const chartData = data.map((entry) => ({
     ...entry,
-    metricLabel: isCostMetric ? `$${entry.costUsd.toFixed(2)}` : String(entry.requests),
+    metricLabel: formatDistributionMetricValue(
+      isCostMetric ? entry.costUsd : entry.requests,
+      metric,
+    ),
     metricValue: isCostMetric ? entry.costUsd : entry.requests,
     metricPercentage: isCostMetric
       ? entry.percentage
@@ -43,6 +52,20 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
       </div>
       <div className="mt-4 flex items-center gap-4">
         <div className="relative h-[140px] w-[140px] shrink-0">
+          <div className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center text-center">
+            <span
+              className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground"
+              data-testid="useragent-distribution-center-label"
+            >
+              Total
+            </span>
+            <span
+              className="max-w-[76px] text-sm font-semibold leading-tight tabular-nums text-foreground"
+              data-testid="useragent-distribution-center-value"
+            >
+              {totalMetricLabel}
+            </span>
+          </div>
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
@@ -63,9 +86,7 @@ export function UseragentDistributionDonut({ data }: UseragentDistributionDonutP
                 content={
                   <ChartTooltip
                     names={isCostMetric ? { costUsd: "Cost" } : { requests: "Requests" }}
-                    formatValue={(value, dataKey) =>
-                      dataKey === "requests" ? String(value) : `$${value.toFixed(2)}`
-                    }
+                    formatValue={(value) => formatDistributionMetricValue(value, metric)}
                   />
                 }
               />

--- a/frontend/src/features/reports/daily-series.ts
+++ b/frontend/src/features/reports/daily-series.ts
@@ -1,0 +1,48 @@
+import type { DailyReportRow } from "./schemas";
+
+export function buildContinuousDailyRows(
+  startDate: string,
+  endDate: string,
+  rows: DailyReportRow[],
+): DailyReportRow[] {
+  if (!isISODate(startDate) || !isISODate(endDate) || startDate > endDate) {
+    return rows;
+  }
+
+  const rowsByDate = new Map(rows.map((row) => [row.date, row]));
+  const continuousRows: DailyReportRow[] = [];
+
+  for (let current = startDate; current <= endDate; current = nextISODate(current)) {
+    continuousRows.push(rowsByDate.get(current) ?? createZeroRow(current));
+  }
+
+  return continuousRows;
+}
+
+function nextISODate(date: string): string {
+  const nextDate = new Date(`${date}T00:00:00Z`);
+  nextDate.setUTCDate(nextDate.getUTCDate() + 1);
+  return nextDate.toISOString().slice(0, 10);
+}
+
+function isISODate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function createZeroRow(date: string): DailyReportRow {
+  return {
+    date,
+    requests: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedInputTokens: 0,
+    costUsd: 0,
+    activeAccounts: 0,
+    errorCount: 0,
+  };
+}

--- a/frontend/src/features/reports/hooks/use-reports.test.tsx
+++ b/frontend/src/features/reports/hooks/use-reports.test.tsx
@@ -29,6 +29,7 @@ vi.mock("@/lib/api-client", () => ({
     },
     daily: [],
     byModel: [],
+    byUseragent: [],
     byAccount: [],
   }),
 }));
@@ -74,6 +75,7 @@ describe("useReports", () => {
             endDate: "2030-01-15",
             accountId: ["acct_123"],
             model: "gpt-5.1",
+            useragent: "claude-code",
           },
           "America/Los_Angeles",
         ),
@@ -87,6 +89,7 @@ describe("useReports", () => {
     expect(searchParams.get("start_date")).toBe("2030-01-09");
     expect(searchParams.get("end_date")).toBe("2030-01-15");
     expect(searchParams.get("model")).toBe("gpt-5.1");
+    expect(searchParams.get("useragent_group")).toBe("claude-code");
     expect(searchParams.getAll("account_id")).toEqual(["acct_123"]);
     expect(searchParams.get("timezone")).toBe("America/Los_Angeles");
   });
@@ -98,6 +101,7 @@ describe("useReports", () => {
       endDate: "2030-01-15",
       accountId: ["acct_123"],
       model: "gpt-5.1",
+      useragent: "claude-code",
     };
 
     const { result, rerender } = renderHook(
@@ -136,6 +140,7 @@ describe("useReports", () => {
       endDate: "2030-01-15",
       accountId: ["acct_123"],
       model: "gpt-5.1",
+      useragent: "claude-code",
     };
 
     const { result } = renderHook(() => useReports(filters, "America/Los_Angeles"), {
@@ -168,11 +173,13 @@ describe("useReports", () => {
 
     const { result } = renderHook(
       () =>
-        useReports({
-          startDate: "2030-01-09",
+        useReports(
+          {
+            startDate: "2030-01-09",
             endDate: "2030-01-15",
             accountId: ["acct_123"],
             model: "gpt-5.1",
+            useragent: "claude-code",
           },
           undefined,
         ),
@@ -186,7 +193,49 @@ describe("useReports", () => {
     expect(searchParams.get("start_date")).toBe("2030-01-09");
     expect(searchParams.get("end_date")).toBe("2030-01-15");
     expect(searchParams.get("model")).toBe("gpt-5.1");
+    expect(searchParams.get("useragent_group")).toBe("claude-code");
     expect(searchParams.getAll("account_id")).toEqual(["acct_123"]);
     expect(searchParams.has("timezone")).toBe(false);
+  });
+
+  it("refetches when the useragent filter changes", async () => {
+    const queryClient = createTestQueryClient();
+
+    const { result, rerender } = renderHook(
+      ({ useragent }) =>
+        useReports(
+          {
+            startDate: "2030-01-09",
+            endDate: "2030-01-15",
+            accountId: ["acct_123"],
+            model: "gpt-5.1",
+            useragent,
+          },
+          "America/Los_Angeles",
+        ),
+      {
+        wrapper: createWrapper(queryClient),
+        initialProps: { useragent: "claude-code" },
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    rerender({ useragent: "chatgpt-app" });
+
+    await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2));
+
+    const [firstUrl] = getMock.mock.calls[0] ?? [];
+    const [secondUrl] = getMock.mock.calls[1] ?? [];
+    expect(
+      new URL(String(firstUrl), "http://localhost").searchParams.get(
+        "useragent_group",
+      ),
+    ).toBe("claude-code");
+    expect(
+      new URL(String(secondUrl), "http://localhost").searchParams.get(
+        "useragent_group",
+      ),
+    ).toBe("chatgpt-app");
   });
 });

--- a/frontend/src/features/reports/hooks/use-reports.ts
+++ b/frontend/src/features/reports/hooks/use-reports.ts
@@ -6,6 +6,7 @@ type ReportsFilterState = {
   endDate: string | undefined;
   accountId: string[];
   model: string | undefined;
+  useragent?: string | undefined;
 };
 
 export function useReports(
@@ -20,6 +21,7 @@ export function useReports(
         endDate: filters.endDate,
         accountId: filters.accountId.length > 0 ? filters.accountId : undefined,
         model: filters.model || undefined,
+        useragent: filters.useragent || undefined,
         timezone: timeZone,
       }),
     refetchInterval: 60_000,

--- a/frontend/src/features/reports/schemas.test.ts
+++ b/frontend/src/features/reports/schemas.test.ts
@@ -25,7 +25,22 @@ describe("ReportsResponseSchema", () => {
         },
       },
       daily: [],
-      byModel: [],
+      byModel: [
+        {
+          model: "gpt-5.1",
+          costUsd: 12.5,
+          requests: 25,
+          percentage: 100,
+        },
+      ],
+      byUseragent: [
+        {
+          useragent: "claude-code",
+          costUsd: 12.5,
+          requests: 25,
+          percentage: 100,
+        },
+      ],
       byAccount: [],
     });
 
@@ -33,6 +48,8 @@ describe("ReportsResponseSchema", () => {
     expect(parsed.comparison.previous.totalCostUsd).toBe(10);
     expect(parsed.comparison.previous.totalTokens).toBe(400);
     expect(parsed.comparison.previous.totalRequests).toBe(20);
+    expect(parsed.byModel[0]?.requests).toBe(25);
+    expect(parsed.byUseragent[0]?.useragent).toBe("claude-code");
   });
 
   it("rejects payloads without the comparison block", () => {
@@ -51,6 +68,7 @@ describe("ReportsResponseSchema", () => {
         },
         daily: [],
         byModel: [],
+        byUseragent: [],
         byAccount: [],
       }),
     ).toThrow(/comparison/i);
@@ -75,8 +93,81 @@ describe("ReportsResponseSchema", () => {
         },
         daily: [],
         byModel: [],
+        byUseragent: [],
         byAccount: [],
       }),
     ).toThrow(/previous/i);
+  });
+
+  it("rejects byModel entries without request totals", () => {
+    expect(() =>
+      ReportsResponseSchema.parse({
+        summary: {
+          totalCostUsd: 12.5,
+          totalInputTokens: 300,
+          totalOutputTokens: 200,
+          totalCachedTokens: 0,
+          totalRequests: 25,
+          totalErrors: 1,
+          activeAccounts: 3,
+          avgCostPerDay: 4.17,
+          avgRequestsPerDay: 8.33,
+        },
+        comparison: {
+          canCompare: true,
+          previous: {
+            totalCostUsd: 10,
+            totalTokens: 400,
+            totalRequests: 20,
+          },
+        },
+        daily: [],
+        byModel: [
+          {
+            model: "gpt-5.1",
+            costUsd: 12.5,
+            percentage: 100,
+          },
+        ],
+        byUseragent: [],
+        byAccount: [],
+      }),
+    ).toThrow(/requests/i);
+  });
+
+  it("rejects payloads without useragent breakdowns", () => {
+    expect(() =>
+      ReportsResponseSchema.parse({
+        summary: {
+          totalCostUsd: 12.5,
+          totalInputTokens: 300,
+          totalOutputTokens: 200,
+          totalCachedTokens: 0,
+          totalRequests: 25,
+          totalErrors: 1,
+          activeAccounts: 3,
+          avgCostPerDay: 4.17,
+          avgRequestsPerDay: 8.33,
+        },
+        comparison: {
+          canCompare: true,
+          previous: {
+            totalCostUsd: 10,
+            totalTokens: 400,
+            totalRequests: 20,
+          },
+        },
+        daily: [],
+        byModel: [
+          {
+            model: "gpt-5.1",
+            costUsd: 12.5,
+            requests: 25,
+            percentage: 100,
+          },
+        ],
+        byAccount: [],
+      }),
+    ).toThrow(/byUseragent/i);
   });
 });

--- a/frontend/src/features/reports/schemas.ts
+++ b/frontend/src/features/reports/schemas.ts
@@ -14,6 +14,14 @@ const DailyReportRowSchema = z.object({
 const ModelCostEntrySchema = z.object({
   model: z.string(),
   costUsd: z.number(),
+  requests: z.number(),
+  percentage: z.number(),
+});
+
+const UseragentCostEntrySchema = z.object({
+  useragent: z.string(),
+  costUsd: z.number(),
+  requests: z.number(),
   percentage: z.number(),
 });
 
@@ -52,11 +60,13 @@ export const ReportsResponseSchema = z.object({
   comparison: ReportComparisonSchema,
   daily: z.array(DailyReportRowSchema),
   byModel: z.array(ModelCostEntrySchema),
+  byUseragent: z.array(UseragentCostEntrySchema),
   byAccount: z.array(AccountCostEntrySchema),
 });
 
 export type DailyReportRow = z.infer<typeof DailyReportRowSchema>;
 export type ModelCostEntry = z.infer<typeof ModelCostEntrySchema>;
+export type UseragentCostEntry = z.infer<typeof UseragentCostEntrySchema>;
 export type AccountCostEntry = z.infer<typeof AccountCostEntrySchema>;
 export type ReportSummary = z.infer<typeof ReportSummarySchema>;
 export type ReportComparison = z.infer<typeof ReportComparisonSchema>;

--- a/frontend/src/utils/formatters.test.ts
+++ b/frontend/src/utils/formatters.test.ts
@@ -58,6 +58,8 @@ describe("formatters", () => {
   it("formats number-like values", () => {
     expect(formatNumber(1200)).toBe("1,200");
     expect(formatCompactNumber(1200)).toMatch(/K$/);
+    expect(formatCompactNumber(1430)).toBe("1.43K");
+    expect(formatCompactNumber(1_500_000_000)).toBe("1.5B");
     expect(formatCurrency(12)).toMatch(/^\$/);
     expect(formatNumber("abc")).toBe("--");
   });

--- a/openspec/changes/add-reports-page/design.md
+++ b/openspec/changes/add-reports-page/design.md
@@ -4,7 +4,8 @@ The reports page is intended as a read-only dashboard surface for historical bil
 It uses `/api/reports` to return:
 
 - Daily totals (`date`, request count, token counts, costs)
-- Model totals (cost and percent share)
+- Model totals (cost, request count, and percent share)
+- User-agent totals (cost, request count, and percent share)
 - Account totals (`accountId`, alias, cost, request count)
 
 `accountId` can be `null` when the request log row has no surviving account (deleted account rows or legacy data). The UI should treat it as a nullable, user-visible bucket that keeps history intact.
@@ -19,3 +20,8 @@ For SQLite, `/api/reports` uses `strftime("%Y-%m-%d", requested_at)` for date gr
 
 ### 3) Reuse existing dashboard styling patterns
 The reports page reuses existing dashboard chart/table/surface patterns and exposes filtering by date, model, and account through existing query param conventions.
+
+### 4) Keep donut totals tied to the active metric
+The model and user-agent distribution donuts show a center label/value stack with `Total` above the active metric value.
+When the toggle is set to `cost`, the center and legend values show compact USD totals such as `$1.43K`.
+When the toggle is set to `req`, the center and legend values show compact request totals such as `1.5B`.

--- a/openspec/changes/add-reports-page/proposal.md
+++ b/openspec/changes/add-reports-page/proposal.md
@@ -1,11 +1,11 @@
 # Proposal: add-reports-page
 
 ## Why
-Operators need a dashboard view of cost and token usage trends over time, with filtering by date range, model, and account.
+Operators need a dashboard view of cost and request trends over time, with filtering by date range, model, account, and user-agent context.
 
 ## What Changes
-- Add `GET /api/reports` with aggregated cost and token usage by day, model, and account.
-- Add a new dashboard `/reports` page with summary cards, daily charts, model distribution donut, and a CSV export path.
+- Add `GET /api/reports` with aggregated cost, request, model, user-agent, and account reporting.
+- Add a new dashboard `/reports` page with summary cards, daily charts, model and user-agent distribution donuts, center totals that follow the active metric toggle, and a CSV export path.
 - Render unknown/deleted-account request history safely by allowing report account identifiers to be nullable.
 
 ## Capabilities

--- a/openspec/changes/add-reports-page/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-reports-page/specs/frontend-architecture/spec.md
@@ -37,9 +37,18 @@ The `/reports` page SHALL render both `Distribution by Model` and `Distribution 
 Each card SHALL show `Total` above the donut center value.
 When the distribution metric toggle is `cost`, the center value and legend values SHALL show compact USD formatting with up to two decimal places and `K`, `M`, or `B` suffixes when applicable.
 When the distribution metric toggle is `req`, the center value and legend values SHALL show compact request formatting with up to two decimal places and `K`, `M`, or `B` suffixes when applicable.
+Each distribution legend SHALL keep at most four rows visible before vertical scrolling, and any overflow scrollbar SHALL remain visually hidden while preserving scroll interaction.
+Hovering a donut slice SHALL highlight the matching legend row, and hovering a legend row SHALL highlight the matching donut slice.
 
 #### Scenario: Distribution donuts follow the active metric
 - **WHEN** report data includes model and user-agent distribution rows
 - **THEN** `/reports` renders both `Distribution by Model` and `Distribution by UserAgent`
 - **AND** each donut center shows `Total` on one line and the active metric total on the next line
 - **AND** switching a donut card from `cost` to `req` updates that card's center and legend values from compact USD totals to compact request totals
+
+#### Scenario: Distribution donuts sync hover state with a scrollable legend
+- **WHEN** report data includes more than four model or user-agent distribution rows
+- **THEN** each distribution legend shows four visible rows before vertical scrolling the remainder
+- **AND** the scrollbar stays visually hidden while scrolling still works
+- **AND** hovering any donut slice highlights the matching legend row
+- **AND** hovering any legend row highlights the matching donut slice

--- a/openspec/changes/add-reports-page/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-reports-page/specs/frontend-architecture/spec.md
@@ -29,4 +29,17 @@ The dashboard surface SHALL expose a reports page at route `/reports` and route 
 - **WHEN** an authenticated operator opens `/reports`
 - **THEN** the page loads the aggregated reports payload from `GET /api/reports`
 - **AND** allows filtering by date range, model, and account
-- **AND** uses the returned payload to render summary cards, daily charts, and model distribution
+- **AND** uses the returned payload to render summary cards, daily charts, and model and user-agent distribution donuts
+
+### Requirement: Reports distribution donuts show active-metric totals
+
+The `/reports` page SHALL render both `Distribution by Model` and `Distribution by UserAgent` cards.
+Each card SHALL show `Total` above the donut center value.
+When the distribution metric toggle is `cost`, the center value and legend values SHALL show compact USD formatting with up to two decimal places and `K`, `M`, or `B` suffixes when applicable.
+When the distribution metric toggle is `req`, the center value and legend values SHALL show compact request formatting with up to two decimal places and `K`, `M`, or `B` suffixes when applicable.
+
+#### Scenario: Distribution donuts follow the active metric
+- **WHEN** report data includes model and user-agent distribution rows
+- **THEN** `/reports` renders both `Distribution by Model` and `Distribution by UserAgent`
+- **AND** each donut center shows `Total` on one line and the active metric total on the next line
+- **AND** switching a donut card from `cost` to `req` updates that card's center and legend values from compact USD totals to compact request totals

--- a/openspec/changes/add-reports-page/tasks.md
+++ b/openspec/changes/add-reports-page/tasks.md
@@ -2,7 +2,8 @@
 
 ## 1. Specs
 - [x] 1.1 Add `/api/reports` and reports page report-payload requirements.
-- [ ] 1.2 Validate OpenSpec changes.
+- [x] 1.2 Update the reports donut requirements for model and user-agent center totals.
+- [x] 1.3 Validate OpenSpec changes.
 
 ## 2. Backend
 - [x] 2.1 Add nullable `accountId` handling in report DTO/schema and aggregation.
@@ -11,8 +12,11 @@
 ## 3. Frontend
 - [x] 3.1 Allow nullable `accountId` in frontend reports schema.
 - [x] 3.2 Expose account and model controls in the reports filter bar.
+- [x] 3.3 Show center totals in the model and user-agent distribution donuts.
+- [x] 3.4 Compact-format report donut totals and legend values for cost and request metrics.
 
 ## 4. Verification
 - [x] 4.1 Run focused integration test for `/api/reports` with SQLite date aggregation.
 - [x] 4.2 Run `ruff check` on report modules.
 - [x] 4.3 Run `ty` check for report modules.
+- [x] 4.4 Run focused frontend report donut tests.

--- a/openspec/changes/add-reports-useragent-distribution/proposal.md
+++ b/openspec/changes/add-reports-useragent-distribution/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Operators can currently filter reports by account and model, and can only see one distribution card grouped by model. Request logs already persist normalized `useragent_group` values, but the reports surface cannot filter or summarize usage by client type.
+
+## What Changes
+
+- Add a `UserAgent` filter to `/reports` beside the existing `Model` filter, using normalized `request_logs.useragent_group` values.
+- Extend `GET /api/reports` so reports can be filtered by an explicit `useragent_group` request parameter.
+- Extend the reports payload with `byUseragent` entries and request counts for `byModel` entries.
+- Keep `UserAgent` filter option discovery on the same relaxed `GET /api/reports` query already used to populate report filter choices, rather than adding a separate endpoint.
+- Add a `Distribution by UserAgent` card below `Distribution by Model`.
+- Add a compact `cost` / `req` toggle to both distribution cards, defaulting to `cost`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `frontend-architecture`: `/reports` now exposes a user-agent filter, an additional user-agent distribution card, and switchable cost/request distribution views.
+
+## Impact
+
+- Backend: `app/modules/reports/*` request filtering and aggregation.
+- Frontend: `frontend/src/features/reports/*` schemas, filters, page wiring, and distribution components.
+- Tests: backend reports repository/service/API coverage plus focused frontend reports schema, hook, filter, page, and donut tests.

--- a/openspec/changes/add-reports-useragent-distribution/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-reports-useragent-distribution/specs/frontend-architecture/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Reports page exposes a visible user-agent filter
+
+The dashboard SHALL render `/reports` with a visible `UserAgent` filter beside the existing `Model` filter. The `UserAgent` filter SHALL be single-select, SHALL use normalized `request_logs.useragent_group` values for its choices, and SHALL filter the reports payload by sending `useragent_group` on `GET /api/reports` requests.
+
+#### Scenario: Reports page shows the user-agent filter
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the page exposes a visible `UserAgent` filter beside `Model`
+
+#### Scenario: Reports page requests filtered data by normalized user-agent group
+- **WHEN** an authenticated operator selects a `UserAgent` value on `/reports`
+- **THEN** the page refetches `GET /api/reports` with `useragent_group` set to the selected normalized `request_logs.useragent_group` value
+
+#### Scenario: Reports page reuses the relaxed reports query for user-agent filter choices
+- **WHEN** `/reports` loads or refreshes filter choices
+- **THEN** the page obtains `UserAgent` filter options from the same relaxed `GET /api/reports` query flow used for report filter-option discovery
+- **AND** the page does not require a separate endpoint to load `UserAgent` choices
+
+#### Scenario: Reports page shows one shared relaxed-catalog error for report filter choices
+- **WHEN** the relaxed `GET /api/reports` query for report filter-option discovery fails
+- **THEN** the page shows one page-owned error describing the combined `Model` and `UserAgent` option loading failure
+- **AND** the page does not show separate duplicate relaxed-catalog errors for `Model` and `UserAgent`
+
+### Requirement: Reports page renders a user-agent distribution card
+
+The dashboard SHALL render `/reports` with a `Distribution by UserAgent` card placed below `Distribution by Model`, using aggregated `request_logs.useragent_group` values from `GET /api/reports`.
+
+#### Scenario: Reports page shows user-agent distribution data
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the page renders `Distribution by UserAgent` below `Distribution by Model`
+
+### Requirement: Reports distribution cards toggle between cost and requests
+
+The dashboard SHALL render both `/reports` distribution cards with an upper-right `cost` / `req` toggle that defaults to `cost` and changes the donut slices, tooltip values, percentages, and legend values to match the selected metric.
+
+#### Scenario: Distribution cards default to cost mode
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** both distribution cards render in `cost` mode by default
+
+#### Scenario: Distribution cards can switch to request mode
+- **WHEN** an authenticated operator activates `req` on either distribution card
+- **THEN** that card renders request-count slices, request-count values, and request-based percentages

--- a/openspec/changes/add-reports-useragent-distribution/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-reports-useragent-distribution/specs/frontend-architecture/spec.md
@@ -32,7 +32,7 @@ The dashboard SHALL render `/reports` with a `Distribution by UserAgent` card pl
 
 ### Requirement: Reports distribution cards toggle between cost and requests
 
-The dashboard SHALL render both `/reports` distribution cards with an upper-right `cost` / `req` toggle that defaults to `cost` and changes the donut slices, tooltip values, percentages, and legend values to match the selected metric.
+The dashboard SHALL render both `/reports` distribution cards with an upper-right `cost` / `req` toggle that defaults to `cost` and changes the donut slices, percentages, and legend values to match the selected metric. The `Distribution by Model` and `Distribution by UserAgent` donuts SHALL NOT render hover tooltips.
 
 #### Scenario: Distribution cards default to cost mode
 - **WHEN** an authenticated operator opens `/reports`

--- a/openspec/changes/add-reports-useragent-distribution/tasks.md
+++ b/openspec/changes/add-reports-useragent-distribution/tasks.md
@@ -1,0 +1,25 @@
+## 1. Spec
+
+- [x] 1.1 Add a `frontend-architecture` delta covering the `UserAgent` filter, the `useragent_group` request contract, shared relaxed reports-query option discovery, the `Distribution by UserAgent` section, and the `cost` / `req` toggles.
+
+## 2. Backend Reports Contract
+
+- [x] 2.1 Extend `GET /api/reports` to accept a `useragent_group` filter parameter and apply normalized `request_logs.useragent_group` matching.
+- [x] 2.2 Extend reports response schemas so `byModel` includes `requests` and the payload includes `byUseragent`.
+- [x] 2.3 Aggregate reports by `request_logs.useragent_group` and apply the optional filter across all report aggregates.
+
+## 3. Frontend Reports Wiring
+
+- [x] 3.1 Extend reports frontend schemas and query wiring so `/reports` sends `useragent_group` on filtered `GET /api/reports` requests and consumes the new response fields.
+- [x] 3.2 Add a visible `UserAgent` filter beside `Model` using normalized `request_logs.useragent_group` values, and keep filter-option discovery on the same relaxed `GET /api/reports` query already used for report filter choices.
+- [x] 3.3 Render `Distribution by UserAgent` below `Distribution by Model`.
+- [x] 3.4 Add independent `cost` / `req` toggles to both distribution cards, defaulting to `cost`.
+
+## 4. Verification
+
+- [x] 4.1 Add or update focused backend tests for user-agent aggregation and filtering.
+- [x] 4.2 Add or update focused frontend tests for reports schemas, query params, filters, page wiring, and both distribution cards.
+- [x] 4.3 Run `openspec validate add-reports-useragent-distribution --strict`.
+- [x] 4.4 Run the focused backend and frontend reports test targets.
+- [x] 4.5 Run `bun run typecheck`.
+- [x] 4.6 Run `uv run openspec validate --specs`.

--- a/openspec/changes/fix-reports-unknown-useragent-bucket/proposal.md
+++ b/openspec/changes/fix-reports-unknown-useragent-bucket/proposal.md
@@ -2,13 +2,13 @@
 
 ## Why
 
-The reports user-agent distribution currently drops traffic whose normalized `request_logs.useragent_group` is `null`. That hides unknown-client usage from the `Distribution by UserAgent` card and leaves operators without a stable way to inspect or visually identify those rows.
+The reports user-agent distribution currently collides real normalized `request_logs.useragent_group = "Unknown"` traffic with rows whose normalized `request_logs.useragent_group` is `null`. That merges distinct populations in the `Distribution by UserAgent` card and breaks drill-down totals because the `useragent_group=Unknown` filter currently resolves only to null-backed rows.
 
 ## What Changes
 
-- Aggregate `request_logs.useragent_group = null` into an `Unknown` bucket in `GET /api/reports` `byUseragent` results.
-- Treat `useragent_group=Unknown` on `GET /api/reports` as a filter for those null-backed rows.
-- Render the `Unknown` user-agent distribution bucket with a fixed gray legend dot and slice color.
+- Aggregate `request_logs.useragent_group = null` into a distinct `Missing User-Agent` bucket in `GET /api/reports` `byUseragent` results.
+- Preserve real `request_logs.useragent_group = "Unknown"` traffic as its own `Unknown` bucket and filter target.
+- Render the `Missing User-Agent` user-agent distribution bucket with a fixed gray legend dot and slice color.
 
 ## Capabilities
 

--- a/openspec/changes/fix-reports-unknown-useragent-bucket/proposal.md
+++ b/openspec/changes/fix-reports-unknown-useragent-bucket/proposal.md
@@ -1,0 +1,23 @@
+# Proposal: fix-reports-unknown-useragent-bucket
+
+## Why
+
+The reports user-agent distribution currently drops traffic whose normalized `request_logs.useragent_group` is `null`. That hides unknown-client usage from the `Distribution by UserAgent` card and leaves operators without a stable way to inspect or visually identify those rows.
+
+## What Changes
+
+- Aggregate `request_logs.useragent_group = null` into an `Unknown` bucket in `GET /api/reports` `byUseragent` results.
+- Treat `useragent_group=Unknown` on `GET /api/reports` as a filter for those null-backed rows.
+- Render the `Unknown` user-agent distribution bucket with a fixed gray legend dot and slice color.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `frontend-architecture`: reports user-agent distribution and filtering now preserve unknown user-agent traffic as an explicit `Unknown` bucket.
+
+## Impact
+
+- Backend: `app/modules/reports/repository.py` user-agent aggregation and filtering.
+- Frontend: `frontend/src/features/reports/components/useragent-distribution-donut.tsx` bucket color handling.
+- Tests: focused reports repository, reports API, and user-agent donut coverage.

--- a/openspec/changes/fix-reports-unknown-useragent-bucket/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-reports-unknown-useragent-bucket/specs/frontend-architecture/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Reports user-agent distribution preserves unknown buckets
+
+`GET /api/reports` SHALL aggregate request-log rows whose normalized `request_logs.useragent_group` is `null` into a `byUseragent` bucket labeled `Unknown`. When `/reports` or `GET /api/reports` is filtered with `useragent_group=Unknown`, the system SHALL match those same null-backed rows. The `/reports` `Distribution by UserAgent` card SHALL render the `Unknown` bucket with a fixed gray legend marker and slice color instead of a rotated palette color.
+
+#### Scenario: Reports payload includes unknown user-agent traffic
+
+- **WHEN** `GET /api/reports` aggregates request logs that include one or more rows with `request_logs.useragent_group = null`
+- **THEN** the response `byUseragent` array includes an entry with `useragent: "Unknown"`
+- **AND** that entry aggregates the null-backed rows' request counts and costs
+
+#### Scenario: Reports filter matches unknown user-agent traffic
+
+- **WHEN** `/reports` or `GET /api/reports` requests `useragent_group=Unknown`
+- **THEN** the returned report aggregates include only rows whose normalized `request_logs.useragent_group` is `null`
+
+#### Scenario: Reports page renders the unknown user-agent bucket with fixed gray styling
+
+- **WHEN** `/reports` renders `Distribution by UserAgent` data that includes `useragent: "Unknown"`
+- **THEN** the `Unknown` legend dot uses a fixed gray color
+- **AND** the matching donut slice uses that same fixed gray color

--- a/openspec/changes/fix-reports-unknown-useragent-bucket/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-reports-unknown-useragent-bucket/specs/frontend-architecture/spec.md
@@ -1,22 +1,26 @@
 ## ADDED Requirements
 
-### Requirement: Reports user-agent distribution preserves unknown buckets
+### Requirement: Reports user-agent distribution preserves unknown buckets without collisions
 
-`GET /api/reports` SHALL aggregate request-log rows whose normalized `request_logs.useragent_group` is `null` into a `byUseragent` bucket labeled `Unknown`. When `/reports` or `GET /api/reports` is filtered with `useragent_group=Unknown`, the system SHALL match those same null-backed rows. The `/reports` `Distribution by UserAgent` card SHALL render the `Unknown` bucket with a fixed gray legend marker and slice color instead of a rotated palette color.
+`GET /api/reports` SHALL aggregate request-log rows whose normalized `request_logs.useragent_group` is `null` into a `byUseragent` bucket labeled `Missing User-Agent`. Real normalized `request_logs.useragent_group = "Unknown"` rows SHALL remain in a separate `Unknown` bucket. When `/reports` or `GET /api/reports` is filtered with `useragent_group=Missing User-Agent`, the system SHALL match those same null-backed rows, while `useragent_group=Unknown` SHALL match only real `"Unknown"` rows. The `/reports` `Distribution by UserAgent` card SHALL render the `Missing User-Agent` bucket with a fixed gray legend marker and slice color instead of a rotated palette color.
 
-#### Scenario: Reports payload includes unknown user-agent traffic
+#### Scenario: Reports payload includes missing and real Unknown user-agent traffic
 
 - **WHEN** `GET /api/reports` aggregates request logs that include one or more rows with `request_logs.useragent_group = null`
-- **THEN** the response `byUseragent` array includes an entry with `useragent: "Unknown"`
-- **AND** that entry aggregates the null-backed rows' request counts and costs
+- **AND** one or more rows with normalized `request_logs.useragent_group = "Unknown"`
+- **THEN** the response `byUseragent` array includes an entry with `useragent: "Missing User-Agent"`
+- **AND** that entry aggregates only the null-backed rows' request counts and costs
+- **AND** the response separately includes an entry with `useragent: "Unknown"` for the real normalized `"Unknown"` rows
 
-#### Scenario: Reports filter matches unknown user-agent traffic
+#### Scenario: Reports filters distinguish missing and real Unknown user-agent traffic
 
-- **WHEN** `/reports` or `GET /api/reports` requests `useragent_group=Unknown`
+- **WHEN** `/reports` or `GET /api/reports` requests `useragent_group=Missing User-Agent`
 - **THEN** the returned report aggregates include only rows whose normalized `request_logs.useragent_group` is `null`
+- **WHEN** `/reports` or `GET /api/reports` requests `useragent_group=Unknown`
+- **THEN** the returned report aggregates include only rows whose normalized `request_logs.useragent_group` is the real string `"Unknown"`
 
-#### Scenario: Reports page renders the unknown user-agent bucket with fixed gray styling
+#### Scenario: Reports page renders the missing user-agent bucket with fixed gray styling
 
-- **WHEN** `/reports` renders `Distribution by UserAgent` data that includes `useragent: "Unknown"`
-- **THEN** the `Unknown` legend dot uses a fixed gray color
+- **WHEN** `/reports` renders `Distribution by UserAgent` data that includes `useragent: "Missing User-Agent"`
+- **THEN** the `Missing User-Agent` legend dot uses a fixed gray color
 - **AND** the matching donut slice uses that same fixed gray color

--- a/openspec/changes/fix-reports-unknown-useragent-bucket/tasks.md
+++ b/openspec/changes/fix-reports-unknown-useragent-bucket/tasks.md
@@ -6,12 +6,12 @@
 
 ## 2. Backend Reports Behavior
 
-- [x] 2.1 Aggregate `request_logs.useragent_group = null` into a `byUseragent` bucket labeled `Unknown`.
-- [x] 2.2 Treat `useragent_group=Unknown` as a filter for null-backed report rows.
+- [x] 2.1 Aggregate `request_logs.useragent_group = null` into a `byUseragent` bucket labeled `Missing User-Agent`.
+- [x] 2.2 Preserve real `useragent_group=Unknown` traffic as its own bucket while filtering `Missing User-Agent` to null-backed report rows.
 
 ## 3. Frontend Reports Rendering
 
-- [x] 3.1 Render the `Unknown` `Distribution by UserAgent` bucket with a fixed gray legend dot and slice color.
+- [x] 3.1 Render the `Missing User-Agent` `Distribution by UserAgent` bucket with a fixed gray legend dot and slice color.
 
 ## 4. Verification
 

--- a/openspec/changes/fix-reports-unknown-useragent-bucket/tasks.md
+++ b/openspec/changes/fix-reports-unknown-useragent-bucket/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: fix-reports-unknown-useragent-bucket
+
+## 1. Spec
+
+- [x] 1.1 Add a `frontend-architecture` delta for preserving null user-agent traffic as `Unknown` in reports filtering and distribution rendering.
+
+## 2. Backend Reports Behavior
+
+- [x] 2.1 Aggregate `request_logs.useragent_group = null` into a `byUseragent` bucket labeled `Unknown`.
+- [x] 2.2 Treat `useragent_group=Unknown` as a filter for null-backed report rows.
+
+## 3. Frontend Reports Rendering
+
+- [x] 3.1 Render the `Unknown` `Distribution by UserAgent` bucket with a fixed gray legend dot and slice color.
+
+## 4. Verification
+
+- [x] 4.1 Add or update focused backend tests for unknown user-agent aggregation and filtering.
+- [x] 4.2 Add or update focused frontend tests for the `Unknown` user-agent legend rendering.
+- [x] 4.3 Run `uv run pytest -q tests/unit/test_reports_repository.py::test_aggregate_by_useragent_groups_null_as_unknown_and_excludes_blank_groups tests/integration/test_reports_api.py::test_reports_api_supports_useragent_group_filter_and_breakdown`.
+- [x] 4.4 Run `bun run test src/features/reports/components/useragent-distribution-donut.test.tsx src/features/reports/components/model-distribution-donut.test.tsx`.
+- [x] 4.5 Run `uv run openspec validate fix-reports-unknown-useragent-bucket --strict`.
+- [x] 4.6 Run `uv run openspec validate --specs`.

--- a/openspec/changes/improve-reports-daily-breakdown/.openspec.yaml
+++ b/openspec/changes/improve-reports-daily-breakdown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/improve-reports-daily-breakdown/design.md
+++ b/openspec/changes/improve-reports-daily-breakdown/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`DailyDetailTable` currently owns the only continuous-day fill logic on `/reports`. It builds zero-valued rows for missing dates between `startDate` and `endDate`, but `CostPerDayChart` and `TokensPerDayChart` still map the raw API payload directly. The result is one selected-range representation in the table and another in the charts.
+
+The table also renders fixed headers and row order without any client-side sorting state. Cached input tokens are already part of each `DailyReportRow` and are exported in the CSV, but they are not surfaced in the visible table cells.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use one normalized daily series for the reports charts and Daily Breakdown table.
+- Make every visible Daily Breakdown column sortable while preserving a predictable default order.
+- Surface cached input tokens inline in the Input Tokens column without adding a new visible column.
+- Cover the new reports behavior with focused component tests.
+
+**Non-Goals:**
+
+- Changing the `/api/reports` response shape or adding new backend fields.
+- Adding persisted sort preferences, server-side sorting, or new report filters.
+- Changing CSV columns beyond continuing to export the existing cached-token field.
+
+## Decisions
+
+### 1. Extract continuous selected-range row building into a shared reports helper
+
+The existing `DailyDetailTable` date-fill logic will move into a shared reports utility so both charts and the table consume the same normalized `DailyReportRow[]`.
+
+Rationale:
+
+- This is the smallest way to remove chart/table drift.
+- The date-fill behavior is already accepted on the table, so reusing it avoids inventing a second continuity rule for charts.
+- Keeping the helper in the reports feature preserves the behavior as UI shaping instead of moving it into generic query code.
+
+Alternative considered:
+
+- Normalize rows independently inside each chart: rejected because it duplicates date-range logic and invites future drift.
+
+### 2. Keep sorting local to `DailyDetailTable`
+
+The Daily Breakdown table will own a local sort key and direction, defaulted to `date desc`, and will derive sorted rows from the normalized daily series before rendering and CSV export.
+
+Rationale:
+
+- Sorting is a table-only interaction and should not affect charts.
+- Local state keeps the change contained and avoids broadening the reports page filter contract.
+- Exporting the currently sorted rows matches what the operator sees.
+
+Alternative considered:
+
+- Store sorting in page-level state: rejected because no other reports surface consumes it.
+
+### 3. Render cached tokens as muted secondary text within the Input Tokens cell
+
+The Input Tokens cell will display the primary token total followed by cached input tokens in parentheses using smaller muted text, including zero values.
+
+Rationale:
+
+- This exposes already-available data without widening the table.
+- Showing `0` explicitly avoids ambiguous blank cells for missing or zero cached tokens.
+- A secondary visual treatment keeps the main token total dominant.
+
+Alternative considered:
+
+- Reintroduce a separate visible Cached Tokens column: rejected because the request explicitly places cached tokens inside the Input Tokens column and the current six-column layout is already compact.
+
+## Risks / Trade-offs
+
+- Shared date normalization could be reused incorrectly outside the selected-range reports flow. → Mitigation: keep the helper scoped inside `frontend/src/features/reports` and name it around reports daily rows.
+- Client-side sorting after zero-fill means more synthetic rows participate in the sort order. → Mitigation: this matches the requested full-range behavior and keeps all columns sorting over the same rendered dataset.
+- Muted cached-token text could be overlooked on dense tables. → Mitigation: keep the cached count explicit in parentheses and preserve it in CSV export.

--- a/openspec/changes/improve-reports-daily-breakdown/design.md
+++ b/openspec/changes/improve-reports-daily-breakdown/design.md
@@ -2,7 +2,7 @@
 
 `DailyDetailTable` currently owns the only continuous-day fill logic on `/reports`. It builds zero-valued rows for missing dates between `startDate` and `endDate`, but `CostPerDayChart` and `TokensPerDayChart` still map the raw API payload directly. The result is one selected-range representation in the table and another in the charts.
 
-The table also renders fixed headers and row order without any client-side sorting state. Cached input tokens are already part of each `DailyReportRow` and are exported in the CSV, but they are not surfaced in the visible table cells.
+The table also renders fixed headers and row order without any client-side sorting state. Cached input tokens are already part of each `DailyReportRow` and are exported in the CSV, but they are not surfaced in the visible table cells. The Tokens summary card also omits cached-token totals, and the sortable headers do not expose visible sort state.
 
 ## Goals / Non-Goals
 
@@ -11,6 +11,9 @@ The table also renders fixed headers and row order without any client-side sorti
 - Use one normalized daily series for the reports charts and Daily Breakdown table.
 - Make every visible Daily Breakdown column sortable while preserving a predictable default order.
 - Surface cached input tokens inline in the Input Tokens column without adding a new visible column.
+- Surface cached token totals in the `/reports` Tokens summary subtitle.
+- Keep Daily Breakdown CSV export in ascending chronological day order regardless of interactive table sorting.
+- Show visible inactive and active sort indicators on sortable Daily Breakdown headers.
 - Cover the new reports behavior with focused component tests.
 
 **Non-Goals:**
@@ -35,36 +38,52 @@ Alternative considered:
 
 - Normalize rows independently inside each chart: rejected because it duplicates date-range logic and invites future drift.
 
-### 2. Keep sorting local to `DailyDetailTable`
+### 2. Keep sorting local to `DailyDetailTable` while exporting chronological CSV rows
 
-The Daily Breakdown table will own a local sort key and direction, defaulted to `date desc`, and will derive sorted rows from the normalized daily series before rendering and CSV export.
+The Daily Breakdown table will own a local sort key and direction, defaulted to `date desc`, and will derive sorted rows from the normalized daily series before rendering. CSV export will sort a separate copy of the rendered-day rows by `date asc` immediately before file generation.
 
 Rationale:
 
 - Sorting is a table-only interaction and should not affect charts.
 - Local state keeps the change contained and avoids broadening the reports page filter contract.
-- Exporting the currently sorted rows matches what the operator sees.
+- Exporting chronological rows gives operators a stable file order that does not depend on the last interactive table sort.
 
 Alternative considered:
 
 - Store sorting in page-level state: rejected because no other reports surface consumes it.
+- Export the currently visible table order: rejected because the request explicitly requires ascending `Day` order regardless of the current table sort.
 
-### 3. Render cached tokens as muted secondary text within the Input Tokens cell
+### 3. Render cached tokens in the summary subtitle and table without adding new columns
 
-The Input Tokens cell will display the primary token total followed by cached input tokens in parentheses using smaller muted text, including zero values.
+The Tokens summary card subtitle will display `Input`, `Cache`, and `Output` totals in that order. The Daily Breakdown Input Tokens cell will continue to display the primary token total followed by cached input tokens in parentheses using smaller muted text, including zero values.
 
 Rationale:
 
-- This exposes already-available data without widening the table.
+- This exposes already-available cache data in both the top-level summary and row-level table without changing the API shape.
+- The summary subtitle keeps all token totals in one line with the existing compact card layout.
 - Showing `0` explicitly avoids ambiguous blank cells for missing or zero cached tokens.
-- A secondary visual treatment keeps the main token total dominant.
 
 Alternative considered:
 
-- Reintroduce a separate visible Cached Tokens column: rejected because the request explicitly places cached tokens inside the Input Tokens column and the current six-column layout is already compact.
+- Add a separate cached-token summary card or visible table column: rejected because the request is a presentation refinement within the existing cards and six-column table.
+
+### 4. Show visible sort-state icons on sortable headers
+
+Each sortable Daily Breakdown header will render an icon even when inactive. Inactive columns will show a muted gray unsorted indicator, and the active sorted column will show the current ascending or descending direction in the same bright foreground treatment as the active header label.
+
+Rationale:
+
+- The current headers are clickable but visually silent, so a persistent affordance makes sorting discoverable.
+- Keeping the inactive icon muted preserves emphasis on the active column while still signaling interactivity.
+- Direction-specific active icons let operators confirm the current sort state without re-reading row values.
+
+Alternative considered:
+
+- Show icons only on the active column: rejected because the user explicitly wants a no-sort indicator on unsorted columns.
 
 ## Risks / Trade-offs
 
 - Shared date normalization could be reused incorrectly outside the selected-range reports flow. → Mitigation: keep the helper scoped inside `frontend/src/features/reports` and name it around reports daily rows.
 - Client-side sorting after zero-fill means more synthetic rows participate in the sort order. → Mitigation: this matches the requested full-range behavior and keeps all columns sorting over the same rendered dataset.
 - Muted cached-token text could be overlooked on dense tables. → Mitigation: keep the cached count explicit in parentheses and preserve it in CSV export.
+- Sort icons could add visual noise in dense headers. → Mitigation: use the existing muted/foreground contrast so inactive columns stay low-emphasis while the active one remains clear.

--- a/openspec/changes/improve-reports-daily-breakdown/implementation-plan.md
+++ b/openspec/changes/improve-reports-daily-breakdown/implementation-plan.md
@@ -1,0 +1,216 @@
+# Reports Daily Breakdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/reports` charts and table use the same continuous selected-range daily series, add sortable Daily Breakdown columns with default newest-first ordering, and render cached input tokens inline in the Input Tokens column.
+
+**Architecture:** Keep the daily-row normalization inside the reports feature as a shared helper, then have the charts and table derive their rendered data from that helper. Keep sorting as local table UI state so the interaction does not affect page filters or chart rendering.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, Recharts, OpenSpec
+
+---
+
+### Task 1: Add failing regression tests for chart day-filling
+
+**Files:**
+- Modify: `frontend/src/features/reports/components/cost-per-day-chart.test.tsx`
+- Modify: `frontend/src/features/reports/components/tokens-per-day-chart.test.tsx`
+- Test: `frontend/src/features/reports/components/cost-per-day-chart.test.tsx`
+- Test: `frontend/src/features/reports/components/tokens-per-day-chart.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+it("fills missing selected days with zero-value rows", () => {
+  render(
+    <CostPerDayChart
+      startDate="2026-06-05"
+      endDate="2026-06-07"
+      data={[
+        {
+          date: "2026-06-05",
+          requests: 150,
+          inputTokens: 5_400_000,
+          outputTokens: 59_000,
+          cachedInputTokens: 0,
+          costUsd: 3.77,
+          activeAccounts: 2,
+          errorCount: 0,
+        },
+        {
+          date: "2026-06-07",
+          requests: 179,
+          inputTokens: 6_800_000,
+          outputTokens: 73_000,
+          cachedInputTokens: 0,
+          costUsd: 4.54,
+          activeAccounts: 2,
+          errorCount: 0,
+        },
+      ]}
+    />,
+  );
+
+  expect(capturedProps?.data).toEqual([
+    { date: "06-05", cost: 3.77 },
+    { date: "06-06", cost: 0 },
+    { date: "06-07", cost: 4.54 },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test frontend/src/features/reports/components/cost-per-day-chart.test.tsx frontend/src/features/reports/components/tokens-per-day-chart.test.tsx`
+Expected: FAIL because the chart props do not accept `startDate` / `endDate` and the missing day is not inserted.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export type CostPerDayChartProps = {
+  startDate: string;
+  endDate: string;
+  data: DailyReportRow[];
+};
+
+const chartData = buildContinuousDailyRows(startDate, endDate, data).map((d) => ({
+  date: d.date.slice(5),
+  cost: d.costUsd,
+}));
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test frontend/src/features/reports/components/cost-per-day-chart.test.tsx frontend/src/features/reports/components/tokens-per-day-chart.test.tsx`
+Expected: PASS
+
+### Task 2: Add failing regression tests for table sorting and cached-token rendering
+
+**Files:**
+- Modify: `frontend/src/features/reports/components/daily-detail-table.test.tsx`
+- Test: `frontend/src/features/reports/components/daily-detail-table.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+it("sorts by day descending by default", () => {
+  render(
+    <DailyDetailTable
+      startDate="2026-06-05"
+      endDate="2026-06-07"
+      data={[
+        { date: "2026-06-05", requests: 1, inputTokens: 100, outputTokens: 20, cachedInputTokens: 0, costUsd: 1, activeAccounts: 1, errorCount: 0 },
+        { date: "2026-06-07", requests: 3, inputTokens: 300, outputTokens: 40, cachedInputTokens: 50, costUsd: 2, activeAccounts: 2, errorCount: 0 },
+      ]}
+    />,
+  );
+
+  const rows = screen.getAllByTestId(/daily-breakdown-row-/);
+  expect(rows.map((row) => row.getAttribute("data-testid"))).toEqual([
+    "daily-breakdown-row-2026-06-07",
+    "daily-breakdown-row-2026-06-06",
+    "daily-breakdown-row-2026-06-05",
+  ]);
+});
+
+it("toggles sorting when a header is clicked", async () => {
+  const user = userEvent.setup();
+  render(/* table with different request counts */);
+  await user.click(screen.getByRole("button", { name: /reqs/i }));
+  await user.click(screen.getByRole("button", { name: /reqs/i }));
+  expect(screen.getAllByTestId(/daily-breakdown-row-/)[0]).toHaveAttribute(
+    "data-testid",
+    "daily-breakdown-row-2026-06-07",
+  );
+});
+
+it("renders cached tokens inline inside the input tokens cell", () => {
+  render(/* row with inputTokens 1200000 and cachedInputTokens 960000 */);
+  expect(screen.getByText("1.2M")).toBeInTheDocument();
+  expect(screen.getByText("(960K)")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the table test to verify it fails**
+
+Run: `bun test frontend/src/features/reports/components/daily-detail-table.test.tsx`
+Expected: FAIL because the table renders ascending dates, has no sortable headers, and does not render cached tokens inline.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+const [sort, setSort] = useState<{ key: SortKey; direction: "asc" | "desc" }>({
+  key: "date",
+  direction: "desc",
+});
+
+const sortedRows = sortDailyRows(rows, sort);
+
+<button type="button" onClick={() => toggleSort("requests")}>Reqs</button>
+
+<td>
+  <span>{formatTokens(row.inputTokens)}</span>{" "}
+  <span className="text-[11px] text-muted-foreground">({formatTokens(row.cachedInputTokens)})</span>
+</td>
+```
+
+- [ ] **Step 4: Run the table test to verify it passes**
+
+Run: `bun test frontend/src/features/reports/components/daily-detail-table.test.tsx`
+Expected: PASS
+
+### Task 3: Extract the shared daily-series helper and wire the page
+
+**Files:**
+- Create: `frontend/src/features/reports/daily-series.ts`
+- Modify: `frontend/src/features/reports/components/daily-detail-table.tsx`
+- Modify: `frontend/src/features/reports/components/cost-per-day-chart.tsx`
+- Modify: `frontend/src/features/reports/components/tokens-per-day-chart.tsx`
+- Modify: `frontend/src/features/reports/components/reports-page.tsx`
+
+- [ ] **Step 1: Write the shared helper**
+
+```ts
+export function buildContinuousDailyRows(startDate: string, endDate: string, rows: DailyReportRow[]): DailyReportRow[] {
+  if (!isISODate(startDate) || !isISODate(endDate) || startDate > endDate) {
+    return rows;
+  }
+
+  const rowsByDate = new Map(rows.map((row) => [row.date, row]));
+  const continuousRows: DailyReportRow[] = [];
+
+  for (let current = startDate; current <= endDate; current = nextISODate(current)) {
+    continuousRows.push(rowsByDate.get(current) ?? createZeroRow(current));
+  }
+
+  return continuousRows;
+}
+```
+
+- [ ] **Step 2: Update page and components to use the helper**
+
+Run the page through one normalized data path by passing `startDate` and `endDate` to both chart components and importing the helper in the table component.
+
+- [ ] **Step 3: Run focused reports tests**
+
+Run: `bun test frontend/src/features/reports/components/cost-per-day-chart.test.tsx frontend/src/features/reports/components/tokens-per-day-chart.test.tsx frontend/src/features/reports/components/daily-detail-table.test.tsx`
+Expected: PASS
+
+### Task 4: Update OpenSpec task tracking and run final verification
+
+**Files:**
+- Modify: `openspec/changes/improve-reports-daily-breakdown/tasks.md`
+
+- [ ] **Step 1: Mark completed implementation tasks in OpenSpec**
+
+Change completed task checkboxes from `- [ ]` to `- [x]` in `openspec/changes/improve-reports-daily-breakdown/tasks.md`.
+
+- [ ] **Step 2: Run OpenSpec validation**
+
+Run: `openspec validate improve-reports-daily-breakdown --strict`
+Expected: `Change 'improve-reports-daily-breakdown' is valid`
+
+- [ ] **Step 3: Run final frontend verification**
+
+Run: `bun test frontend/src/features/reports/components/cost-per-day-chart.test.tsx frontend/src/features/reports/components/tokens-per-day-chart.test.tsx frontend/src/features/reports/components/daily-detail-table.test.tsx`
+Expected: PASS

--- a/openspec/changes/improve-reports-daily-breakdown/proposal.md
+++ b/openspec/changes/improve-reports-daily-breakdown/proposal.md
@@ -2,7 +2,7 @@
 
 The `/reports` page currently renders chart series directly from the API daily rows while the Daily Breakdown table fills missing selected dates locally. When the API omits a zero-usage day, the charts show a gap in the selected range that does not match the table.
 
-Operators also need the Daily Breakdown table to be easier to inspect: the visible columns are not sortable, the default ordering is not newest-first, and cached input tokens are only available in CSV output instead of the rendered Input Tokens column.
+Operators also need the Daily Breakdown table to be easier to inspect: the visible columns are not sortable, the default ordering is not newest-first, cached input tokens are only available in CSV output instead of the rendered Input Tokens column, the Tokens summary subtitle omits cached-token totals, CSV export order follows the current table sort instead of a stable chronological order, and sortable headers do not expose visible sort state.
 
 ## What Changes
 
@@ -10,6 +10,9 @@ Operators also need the Daily Breakdown table to be easier to inspect: the visib
 - Reuse the same continuous daily-row normalization for the Daily Breakdown table so the reports page uses one consistent daily series.
 - Add sortable headers to every visible Daily Breakdown column and default the table to sorting `Day` in descending order.
 - Render cached input tokens inline in the Daily Breakdown `Input Tokens` column as muted secondary text in `main (cached)` format, including `0 (0)` when no input or cached tokens are present.
+- Add cached totals to the `/reports` Tokens summary subtitle in `Input ... · Cache ... · Output ...` format.
+- Export Daily Breakdown CSV rows in ascending `Day` order regardless of the visible table sort state.
+- Show a muted unsorted icon on inactive sortable headers and a directional active icon on the current sorted header.
 - Keep `/reports` data loading on `GET /api/reports` and avoid API or schema changes.
 
 ## Capabilities
@@ -18,10 +21,10 @@ Operators also need the Daily Breakdown table to be easier to inspect: the visib
 
 ### Modified Capabilities
 
-- `frontend-architecture`: `/reports` daily charts and the Daily Breakdown table now define continuous selected-range day filling, explicit table sorting behavior, and cached-token rendering within the Input Tokens column.
+- `frontend-architecture`: `/reports` daily charts and the Daily Breakdown table now define continuous selected-range day filling, explicit table sorting behavior, visible sort indicators, stable chronological CSV export, cached-token rendering within the Input Tokens column, and cached-token totals in the Tokens summary subtitle.
 
 ## Impact
 
-- Frontend: `frontend/src/features/reports/components/*` daily charts and table rendering, plus a shared reports daily-series helper.
-- Tests: reports chart and table component tests covering missing-day fill, default sort order, sortable headers, and cached-token rendering.
-- Specs: `frontend-architecture` delta for reports chart continuity and Daily Breakdown interaction/presentation behavior.
+- Frontend: `frontend/src/features/reports/components/*` daily charts, summary cards, and table rendering, plus a shared reports daily-series helper.
+- Tests: reports chart, summary-card, and table component tests covering missing-day fill, default sort order, visible sort indicators, chronological CSV export, and cached-token rendering.
+- Specs: `frontend-architecture` delta for reports chart continuity and `/reports` summary/table interaction and presentation behavior.

--- a/openspec/changes/improve-reports-daily-breakdown/proposal.md
+++ b/openspec/changes/improve-reports-daily-breakdown/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `/reports` page currently renders chart series directly from the API daily rows while the Daily Breakdown table fills missing selected dates locally. When the API omits a zero-usage day, the charts show a gap in the selected range that does not match the table.
+
+Operators also need the Daily Breakdown table to be easier to inspect: the visible columns are not sortable, the default ordering is not newest-first, and cached input tokens are only available in CSV output instead of the rendered Input Tokens column.
+
+## What Changes
+
+- Fill missing `/reports` daily rows with zero-valued records across the full selected date range before rendering the cost and token charts.
+- Reuse the same continuous daily-row normalization for the Daily Breakdown table so the reports page uses one consistent daily series.
+- Add sortable headers to every visible Daily Breakdown column and default the table to sorting `Day` in descending order.
+- Render cached input tokens inline in the Daily Breakdown `Input Tokens` column as muted secondary text in `main (cached)` format, including `0 (0)` when no input or cached tokens are present.
+- Keep `/reports` data loading on `GET /api/reports` and avoid API or schema changes.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `frontend-architecture`: `/reports` daily charts and the Daily Breakdown table now define continuous selected-range day filling, explicit table sorting behavior, and cached-token rendering within the Input Tokens column.
+
+## Impact
+
+- Frontend: `frontend/src/features/reports/components/*` daily charts and table rendering, plus a shared reports daily-series helper.
+- Tests: reports chart and table component tests covering missing-day fill, default sort order, sortable headers, and cached-token rendering.
+- Specs: `frontend-architecture` delta for reports chart continuity and Daily Breakdown interaction/presentation behavior.

--- a/openspec/changes/improve-reports-daily-breakdown/specs/frontend-architecture/spec.md
+++ b/openspec/changes/improve-reports-daily-breakdown/specs/frontend-architecture/spec.md
@@ -27,6 +27,15 @@ The dashboard SHALL render `/reports` `Daily Breakdown` with sortable visible co
 - **THEN** the table sorts by that column
 - **AND** activating the same header again toggles the sort direction between ascending and descending
 
+### Requirement: Reports Tokens summary subtitle shows cached totals
+
+The dashboard SHALL render the `/reports` `Tokens` summary-card subtitle as `Input <value> · Cache <value> · Output <value>` using the current report summary totals for input, cached input, and output tokens.
+
+#### Scenario: Tokens subtitle includes cached total
+
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the `Tokens` summary card subtitle includes formatted `Input`, `Cache`, and `Output` token totals in that order
+
 ### Requirement: Daily Breakdown shows cached input tokens inline
 
 The dashboard SHALL render `/reports` `Daily Breakdown` `Input Tokens` cells as the input-token total followed by the cached input-token total in parentheses using muted secondary text.
@@ -41,3 +50,36 @@ The dashboard SHALL render `/reports` `Daily Breakdown` `Input Tokens` cells as 
 - **WHEN** a `Daily Breakdown` row has `cachedInputTokens = 0`
 - **THEN** the `Input Tokens` cell renders the primary input-token value followed by `(0)`
 - **AND** if `inputTokens = 0` the full rendered value is `0 (0)`
+
+### Requirement: Daily Breakdown CSV export stays chronological
+
+The dashboard SHALL export `/reports` `Daily Breakdown` CSV rows in ascending `Day` order regardless of the current visible table sort key or direction.
+
+#### Scenario: CSV export ignores visible descending day sort
+
+- **WHEN** an authenticated operator exports the `Daily Breakdown` CSV while the visible table is sorted newest-first
+- **THEN** the CSV rows are written from the earliest day to the latest day
+
+#### Scenario: CSV export ignores non-day visible sort
+
+- **WHEN** an authenticated operator exports the `Daily Breakdown` CSV while the visible table is sorted by another column
+- **THEN** the CSV rows are still written from the earliest day to the latest day
+
+### Requirement: Daily Breakdown sortable headers show visible sort state
+
+The dashboard SHALL render a visible sort icon on every sortable `/reports` `Daily Breakdown` header. Inactive sortable headers SHALL show a muted gray unsorted indicator, and the active sorted header SHALL show a bright directional indicator matching the current ascending or descending sort direction.
+
+#### Scenario: Inactive sortable headers show unsorted indicator
+
+- **WHEN** an authenticated operator views `/reports`
+- **THEN** each sortable `Daily Breakdown` header shows a visible unsorted icon when that column is not the active sort column
+
+#### Scenario: Active sortable header shows ascending indicator
+
+- **WHEN** an authenticated operator activates a `Daily Breakdown` header and the table sort is ascending for that column
+- **THEN** that header shows the active ascending sort icon instead of the muted unsorted icon
+
+#### Scenario: Active sortable header shows descending indicator
+
+- **WHEN** an authenticated operator activates the same `Daily Breakdown` header again and the table sort becomes descending
+- **THEN** that header shows the active descending sort icon instead of the muted unsorted icon

--- a/openspec/changes/improve-reports-daily-breakdown/specs/frontend-architecture/spec.md
+++ b/openspec/changes/improve-reports-daily-breakdown/specs/frontend-architecture/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Reports daily charts fill missing selected days with zero-value rows
+
+The dashboard SHALL render `/reports` `Cost by Day` and `Tokens by Day` charts from a continuous daily series covering every selected day from the current `startDate` through `endDate`. When `GET /api/reports` omits a selected date, the page SHALL insert a zero-value daily row for that date before rendering both charts.
+
+#### Scenario: Missing API dates render as zero-value chart points
+
+- **WHEN** an authenticated operator views `/reports` for a selected date range and the `daily` response omits one or more selected dates
+- **THEN** the `Cost by Day` chart includes a point for every selected day from `startDate` through `endDate`
+- **AND** each omitted date renders with `costUsd = 0`
+- **AND** the `Tokens by Day` chart includes a point for every selected day from `startDate` through `endDate`
+- **AND** each omitted date renders with `inputTokens = 0`, `outputTokens = 0`, `cachedInputTokens = 0`, `requests = 0`, `activeAccounts = 0`, and `errorCount = 0`
+
+### Requirement: Daily Breakdown supports explicit visible-column sorting
+
+The dashboard SHALL render `/reports` `Daily Breakdown` with sortable visible columns for `Day`, `Reqs`, `Input Tokens`, `Output Tokens`, `Cost`, and `Accounts`. The default sort SHALL be `Day` descending.
+
+#### Scenario: Daily Breakdown defaults to newest day first
+
+- **WHEN** an authenticated operator opens `/reports`
+- **THEN** the `Daily Breakdown` rows are ordered by `Day` descending by default
+
+#### Scenario: Daily Breakdown toggles sorting for a visible column
+
+- **WHEN** an authenticated operator activates any `Daily Breakdown` visible-column header
+- **THEN** the table sorts by that column
+- **AND** activating the same header again toggles the sort direction between ascending and descending
+
+### Requirement: Daily Breakdown shows cached input tokens inline
+
+The dashboard SHALL render `/reports` `Daily Breakdown` `Input Tokens` cells as the input-token total followed by the cached input-token total in parentheses using muted secondary text.
+
+#### Scenario: Input Tokens cell shows cached input token count
+
+- **WHEN** a `Daily Breakdown` row has non-zero `inputTokens` and `cachedInputTokens`
+- **THEN** the `Input Tokens` cell renders `<formatted inputTokens> (<formatted cachedInputTokens>)`
+
+#### Scenario: Input Tokens cell shows zero cached tokens explicitly
+
+- **WHEN** a `Daily Breakdown` row has `cachedInputTokens = 0`
+- **THEN** the `Input Tokens` cell renders the primary input-token value followed by `(0)`
+- **AND** if `inputTokens = 0` the full rendered value is `0 (0)`

--- a/openspec/changes/improve-reports-daily-breakdown/tasks.md
+++ b/openspec/changes/improve-reports-daily-breakdown/tasks.md
@@ -1,0 +1,23 @@
+## 1. Spec
+
+- [x] 1.1 Add a `frontend-architecture` delta for reports chart continuity, Daily Breakdown sorting, and cached-token cell rendering.
+
+## 2. Shared daily series
+
+- [x] 2.1 Extract the reports continuous-day fill logic into a shared helper within `frontend/src/features/reports`.
+- [x] 2.2 Update `CostPerDayChart` and `TokensPerDayChart` to render from the shared selected-range daily series.
+- [x] 2.3 Update `DailyDetailTable` to consume the same shared selected-range daily series.
+
+## 3. Daily Breakdown interactions
+
+- [x] 3.1 Add sortable headers for `Day`, `Reqs`, `Input Tokens`, `Output Tokens`, `Cost`, and `Accounts`.
+- [x] 3.2 Default the Daily Breakdown sort to `Day` descending and toggle direction when the active header is selected again.
+- [x] 3.3 Render cached input tokens as muted secondary text inside the `Input Tokens` cell, including `0 (0)` when both values are zero.
+
+## 4. Verification
+
+- [x] 4.1 Add or update tests that prove both reports charts fill missing selected dates with zero-value rows.
+- [x] 4.2 Add or update tests that prove Daily Breakdown defaults to day-descending order and can sort each visible column.
+- [x] 4.3 Add or update tests that prove the `Input Tokens` cell renders cached tokens, including zero-value cases.
+- [x] 4.4 Run `openspec validate improve-reports-daily-breakdown --strict`.
+- [x] 4.5 Run the relevant frontend test targets for the reports charts and Daily Breakdown table.

--- a/openspec/changes/improve-reports-daily-breakdown/tasks.md
+++ b/openspec/changes/improve-reports-daily-breakdown/tasks.md
@@ -1,6 +1,7 @@
 ## 1. Spec
 
 - [x] 1.1 Add a `frontend-architecture` delta for reports chart continuity, Daily Breakdown sorting, and cached-token cell rendering.
+- [x] 1.2 Extend the same `frontend-architecture` delta for the Tokens summary cache subtitle, chronological CSV export, and visible sort-state icons.
 
 ## 2. Shared daily series
 
@@ -13,6 +14,9 @@
 - [x] 3.1 Add sortable headers for `Day`, `Reqs`, `Input Tokens`, `Output Tokens`, `Cost`, and `Accounts`.
 - [x] 3.2 Default the Daily Breakdown sort to `Day` descending and toggle direction when the active header is selected again.
 - [x] 3.3 Render cached input tokens as muted secondary text inside the `Input Tokens` cell, including `0 (0)` when both values are zero.
+- [x] 3.4 Render cached totals in the `/reports` Tokens summary subtitle as `Input ... · Cache ... · Output ...`.
+- [x] 3.5 Export Daily Breakdown CSV rows in ascending `Day` order regardless of the current visible table sort.
+- [x] 3.6 Render a muted unsorted icon for inactive sortable headers and a directional active icon for the sorted header.
 
 ## 4. Verification
 
@@ -21,3 +25,6 @@
 - [x] 4.3 Add or update tests that prove the `Input Tokens` cell renders cached tokens, including zero-value cases.
 - [x] 4.4 Run `openspec validate improve-reports-daily-breakdown --strict`.
 - [x] 4.5 Run the relevant frontend test targets for the reports charts and Daily Breakdown table.
+- [x] 4.6 Add or update tests that prove the `/reports` Tokens summary subtitle includes cached totals.
+- [x] 4.7 Add or update tests that prove CSV export stays chronological and sortable headers expose visible sort-state icons.
+- [x] 4.8 Re-run `openspec validate improve-reports-daily-breakdown --strict` and the focused reports frontend tests.

--- a/openspec/specs/frontend-architecture/spec.md
+++ b/openspec/specs/frontend-architecture/spec.md
@@ -595,14 +595,16 @@ The dashboard SHALL render `/reports` with the following exact page-owned user-f
 - `Cost by Day`
 - `Tokens by Day`
 - `Distribution by Model`
+- `Distribution by UserAgent`
 - `Daily Breakdown`
 - `Day`
 - `Input Tokens`
 - `Output Tokens`
 - `Cost`
 - `Accounts`
+- `Total`
 - `Failed to load report data:`
-- `Failed to load model options:`
+- `Failed to load model and user-agent options:`
 - `Failed to load account options:`
 - `Some report data could not be loaded. Try reloading.`
 - `Retry`
@@ -615,16 +617,29 @@ Backend-provided strings, account values, model values, and raw server error pay
 - **THEN** the page title is `Cost Report`
 - **AND** the subtitle is `Usage history by date range`
 - **AND** the summary cards include `Total Cost` and `Requests`
-- **AND** the chart and table section titles include `Cost by Day`, `Tokens by Day`, `Distribution by Model`, and `Daily Breakdown`
+- **AND** the chart and table section titles include `Cost by Day`, `Tokens by Day`, `Distribution by Model`, `Distribution by UserAgent`, and `Daily Breakdown`
 - **AND** the daily table headings include `Day`, `Input Tokens`, `Output Tokens`, `Cost`, and `Accounts`
 
 #### Scenario: Reports page state labels are English
 
 - **WHEN** `/reports` renders a loading, empty, or error state
 - **THEN** the loading label is `Loading...`
-- **AND** page-owned error wrappers use `Failed to load report data:`, `Failed to load model options:`, and `Failed to load account options:` when those failures render
+- **AND** page-owned error wrappers use `Failed to load report data:`, `Failed to load model and user-agent options:`, and `Failed to load account options:` when those failures render
 - **AND** the retry warning is `Some report data could not be loaded. Try reloading.`
 - **AND** the retry button label is `Retry`
+
+### Requirement: Reports distribution donuts show compact active-metric totals
+
+The `/reports` page SHALL render both `Distribution by Model` and `Distribution by UserAgent` cards with a donut-center total that uses the page-owned label `Total` above the current metric value.
+When a donut card is in `cost` mode, its center total and legend values SHALL display compact USD values with up to two fractional digits and `K`, `M`, or `B` suffixes when applicable.
+When a donut card is in `req` mode, its center total and legend values SHALL display compact request values with up to two fractional digits and `K`, `M`, or `B` suffixes when applicable.
+
+#### Scenario: Reports distribution donut totals switch with the selected metric
+
+- **WHEN** `/reports` renders model or user-agent distribution data
+- **THEN** each distribution donut shows `Total` in the center above the total value
+- **AND** `cost` mode uses compact USD totals such as `$1.43K`
+- **AND** `req` mode uses compact request totals such as `1.5B`
 
 ### Requirement: Reports page loads report data from the reports endpoint
 

--- a/tests/integration/test_reports_api.py
+++ b/tests/integration/test_reports_api.py
@@ -1276,8 +1276,9 @@ async def test_reports_api_supports_useragent_group_filter_and_breakdown(async_c
 
     payload = response.json()
     assert payload["byUseragent"] == [
-        {"useragent": "opencode", "costUsd": 0.8, "requests": 1, "percentage": 53.3},
-        {"useragent": "CodexCLI", "costUsd": 0.7, "requests": 1, "percentage": 46.7},
+        {"useragent": "opencode", "costUsd": 0.8, "requests": 1, "percentage": 40.0},
+        {"useragent": "CodexCLI", "costUsd": 0.7, "requests": 1, "percentage": 35.0},
+        {"useragent": "Unknown", "costUsd": 0.5, "requests": 1, "percentage": 25.0},
     ]
 
     filtered_response = await async_client.get(
@@ -1293,11 +1294,29 @@ async def test_reports_api_supports_useragent_group_filter_and_breakdown(async_c
     filtered_payload = filtered_response.json()
     assert filtered_payload["summary"]["totalRequests"] == 1
     assert filtered_payload["summary"]["totalCostUsd"] == 0.8
-    assert filtered_payload["byModel"] == [
-        {"model": "gpt-5.1", "costUsd": 0.8, "requests": 1, "percentage": 100.0}
-    ]
+    assert filtered_payload["byModel"] == [{"model": "gpt-5.1", "costUsd": 0.8, "requests": 1, "percentage": 100.0}]
     assert filtered_payload["byUseragent"] == [
         {"useragent": "opencode", "costUsd": 0.8, "requests": 1, "percentage": 100.0}
+    ]
+
+    unknown_filtered_response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-01",
+            "useragent_group": "Unknown",
+        },
+    )
+    assert unknown_filtered_response.status_code == 200
+
+    unknown_filtered_payload = unknown_filtered_response.json()
+    assert unknown_filtered_payload["summary"]["totalRequests"] == 1
+    assert unknown_filtered_payload["summary"]["totalCostUsd"] == 0.5
+    assert unknown_filtered_payload["byModel"] == [
+        {"model": "gpt-5.4", "costUsd": 0.5, "requests": 1, "percentage": 100.0}
+    ]
+    assert unknown_filtered_payload["byUseragent"] == [
+        {"useragent": "Unknown", "costUsd": 0.5, "requests": 1, "percentage": 100.0}
     ]
 
 

--- a/tests/integration/test_reports_api.py
+++ b/tests/integration/test_reports_api.py
@@ -1242,6 +1242,18 @@ async def test_reports_api_supports_useragent_group_filter_and_breakdown(async_c
                 ),
                 RequestLog(
                     account_id="acc_reports_useragent",
+                    request_id="report-useragent-real-unknown",
+                    requested_at=start_at,
+                    model="gpt-5.0",
+                    useragent_group="Unknown",
+                    status="success",
+                    input_tokens=7,
+                    output_tokens=1,
+                    cached_input_tokens=0,
+                    cost_usd=0.4,
+                ),
+                RequestLog(
+                    account_id="acc_reports_useragent",
                     request_id="report-useragent-blank",
                     requested_at=start_at,
                     model="gpt-5.3",
@@ -1276,9 +1288,10 @@ async def test_reports_api_supports_useragent_group_filter_and_breakdown(async_c
 
     payload = response.json()
     assert payload["byUseragent"] == [
-        {"useragent": "opencode", "costUsd": 0.8, "requests": 1, "percentage": 40.0},
-        {"useragent": "CodexCLI", "costUsd": 0.7, "requests": 1, "percentage": 35.0},
-        {"useragent": "Unknown", "costUsd": 0.5, "requests": 1, "percentage": 25.0},
+        {"useragent": "opencode", "costUsd": 0.8, "requests": 1, "percentage": 33.3},
+        {"useragent": "CodexCLI", "costUsd": 0.7, "requests": 1, "percentage": 29.2},
+        {"useragent": "Missing User-Agent", "costUsd": 0.5, "requests": 1, "percentage": 20.8},
+        {"useragent": "Unknown", "costUsd": 0.4, "requests": 1, "percentage": 16.7},
     ]
 
     filtered_response = await async_client.get(
@@ -1311,12 +1324,32 @@ async def test_reports_api_supports_useragent_group_filter_and_breakdown(async_c
 
     unknown_filtered_payload = unknown_filtered_response.json()
     assert unknown_filtered_payload["summary"]["totalRequests"] == 1
-    assert unknown_filtered_payload["summary"]["totalCostUsd"] == 0.5
+    assert unknown_filtered_payload["summary"]["totalCostUsd"] == 0.4
     assert unknown_filtered_payload["byModel"] == [
-        {"model": "gpt-5.4", "costUsd": 0.5, "requests": 1, "percentage": 100.0}
+        {"model": "gpt-5.0", "costUsd": 0.4, "requests": 1, "percentage": 100.0}
     ]
     assert unknown_filtered_payload["byUseragent"] == [
-        {"useragent": "Unknown", "costUsd": 0.5, "requests": 1, "percentage": 100.0}
+        {"useragent": "Unknown", "costUsd": 0.4, "requests": 1, "percentage": 100.0}
+    ]
+
+    missing_useragent_filtered_response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-01",
+            "useragent_group": "Missing User-Agent",
+        },
+    )
+    assert missing_useragent_filtered_response.status_code == 200
+
+    missing_useragent_filtered_payload = missing_useragent_filtered_response.json()
+    assert missing_useragent_filtered_payload["summary"]["totalRequests"] == 1
+    assert missing_useragent_filtered_payload["summary"]["totalCostUsd"] == 0.5
+    assert missing_useragent_filtered_payload["byModel"] == [
+        {"model": "gpt-5.4", "costUsd": 0.5, "requests": 1, "percentage": 100.0}
+    ]
+    assert missing_useragent_filtered_payload["byUseragent"] == [
+        {"useragent": "Missing User-Agent", "costUsd": 0.5, "requests": 1, "percentage": 100.0}
     ]
 
 

--- a/tests/integration/test_reports_api.py
+++ b/tests/integration/test_reports_api.py
@@ -169,7 +169,7 @@ async def test_reports_api_includes_preserved_deleted_account_history(async_clie
             "outputTokens": 7,
         }
     ]
-    assert payload["byModel"] == [{"model": "gpt-5.1", "costUsd": 0.42, "percentage": 100.0}]
+    assert payload["byModel"] == [{"model": "gpt-5.1", "costUsd": 0.42, "requests": 1, "percentage": 100.0}]
     assert payload["byAccount"] == [
         {
             "accountId": None,
@@ -1024,7 +1024,7 @@ async def test_reports_api_excludes_warmup_logs(async_client, db_setup):
     assert payload["summary"]["totalRequests"] == 1
     assert payload["summary"]["totalInputTokens"] == 6
     assert payload["summary"]["totalCostUsd"] == 0.4
-    assert payload["byModel"] == [{"model": "gpt-5.1", "costUsd": 0.4, "percentage": 100.0}]
+    assert payload["byModel"] == [{"model": "gpt-5.1", "costUsd": 0.4, "requests": 1, "percentage": 100.0}]
     assert payload["byAccount"] == [
         {
             "accountId": "acc_reports_warmup",
@@ -1105,7 +1105,7 @@ async def test_reports_api_applies_account_and_model_filters(async_client, db_se
             "requests": 1,
         }
     ]
-    assert payload["byModel"] == [{"model": "gpt-5.1", "costUsd": 0.8, "percentage": 100.0}]
+    assert payload["byModel"] == [{"model": "gpt-5.1", "costUsd": 0.8, "requests": 1, "percentage": 100.0}]
 
 
 async def test_reports_api_includes_unpriced_models_in_model_breakdown(async_client, db_setup):
@@ -1149,8 +1149,8 @@ async def test_reports_api_includes_unpriced_models_in_model_breakdown(async_cli
     payload = response.json()
     assert payload["summary"]["totalRequests"] == 2
     assert payload["byModel"] == [
-        {"model": "gpt-priced", "costUsd": 0.8, "percentage": 100.0},
-        {"model": "gpt-unpriced", "costUsd": 0.0, "percentage": 0.0},
+        {"model": "gpt-priced", "costUsd": 0.8, "requests": 1, "percentage": 100.0},
+        {"model": "gpt-unpriced", "costUsd": 0.0, "requests": 1, "percentage": 0.0},
     ]
     assert payload["byAccount"] == [
         {
@@ -1208,6 +1208,97 @@ async def test_reports_api_summary_counts_range_accounts_and_calendar_days(async
     assert payload["summary"]["activeAccounts"] == 2
     assert payload["summary"]["avgCostPerDay"] == 0.5
     assert payload["summary"]["avgRequestsPerDay"] == 0.67
+
+
+async def test_reports_api_supports_useragent_group_filter_and_breakdown(async_client, db_setup):
+    start_at = _naive_utc(datetime(2026, 6, 1, 16, 0, 0, tzinfo=timezone.utc))
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_useragent", "reports-useragent@example.com"))
+        session.add_all(
+            [
+                RequestLog(
+                    account_id="acc_reports_useragent",
+                    request_id="report-useragent-match-1",
+                    requested_at=start_at,
+                    model="gpt-5.1",
+                    useragent_group="opencode",
+                    status="success",
+                    input_tokens=8,
+                    output_tokens=2,
+                    cached_input_tokens=0,
+                    cost_usd=0.8,
+                ),
+                RequestLog(
+                    account_id="acc_reports_useragent",
+                    request_id="report-useragent-match-2",
+                    requested_at=start_at,
+                    model="gpt-5.2",
+                    useragent_group="CodexCLI",
+                    status="success",
+                    input_tokens=7,
+                    output_tokens=2,
+                    cached_input_tokens=0,
+                    cost_usd=0.7,
+                ),
+                RequestLog(
+                    account_id="acc_reports_useragent",
+                    request_id="report-useragent-blank",
+                    requested_at=start_at,
+                    model="gpt-5.3",
+                    useragent_group="",
+                    status="success",
+                    input_tokens=6,
+                    output_tokens=2,
+                    cached_input_tokens=0,
+                    cost_usd=0.6,
+                ),
+                RequestLog(
+                    account_id="acc_reports_useragent",
+                    request_id="report-useragent-null",
+                    requested_at=start_at,
+                    model="gpt-5.4",
+                    useragent_group=None,
+                    status="success",
+                    input_tokens=5,
+                    output_tokens=2,
+                    cached_input_tokens=0,
+                    cost_usd=0.5,
+                ),
+            ]
+        )
+        await session.commit()
+
+    response = await async_client.get(
+        "/api/reports",
+        params={"start_date": "2026-06-01", "end_date": "2026-06-01"},
+    )
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["byUseragent"] == [
+        {"useragent": "opencode", "costUsd": 0.8, "requests": 1, "percentage": 53.3},
+        {"useragent": "CodexCLI", "costUsd": 0.7, "requests": 1, "percentage": 46.7},
+    ]
+
+    filtered_response = await async_client.get(
+        "/api/reports",
+        params={
+            "start_date": "2026-06-01",
+            "end_date": "2026-06-01",
+            "useragent_group": "opencode",
+        },
+    )
+    assert filtered_response.status_code == 200
+
+    filtered_payload = filtered_response.json()
+    assert filtered_payload["summary"]["totalRequests"] == 1
+    assert filtered_payload["summary"]["totalCostUsd"] == 0.8
+    assert filtered_payload["byModel"] == [
+        {"model": "gpt-5.1", "costUsd": 0.8, "requests": 1, "percentage": 100.0}
+    ]
+    assert filtered_payload["byUseragent"] == [
+        {"useragent": "opencode", "costUsd": 0.8, "requests": 1, "percentage": 100.0}
+    ]
 
 
 async def test_reports_api_summary_uses_sql_range_totals_not_rounded_daily_rows(async_client, db_setup):

--- a/tests/unit/test_reports_repository.py
+++ b/tests/unit/test_reports_repository.py
@@ -239,7 +239,9 @@ async def test_report_filters_apply_to_all_aggregates_including_earliest_activit
 
 
 @pytest.mark.asyncio
-async def test_aggregate_by_useragent_excludes_null_and_blank_groups(async_session: AsyncSession) -> None:
+async def test_aggregate_by_useragent_groups_null_as_unknown_and_excludes_blank_groups(
+    async_session: AsyncSession,
+) -> None:
     repo = ReportsRepository(async_session)
 
     async_session.add(_make_account("acc_reports_useragents", "reports-useragents@example.com"))
@@ -305,4 +307,5 @@ async def test_aggregate_by_useragent_excludes_null_and_blank_groups(async_sessi
     assert [(row.useragent_group, row.cost_usd, row.request_count) for row in rows] == [
         ("opencode", 0.5, 1),
         ("CodexCLI", 0.3, 1),
+        ("Unknown", 0.1, 1),
     ]

--- a/tests/unit/test_reports_repository.py
+++ b/tests/unit/test_reports_repository.py
@@ -162,3 +162,147 @@ async def test_aggregate_daily_rows_rejects_ranges_over_supported_window(
             date(2026, 1, 1),
             timezone.utc,
         )
+
+
+@pytest.mark.asyncio
+async def test_report_filters_apply_to_all_aggregates_including_earliest_activity(
+    async_session: AsyncSession,
+) -> None:
+    repo = ReportsRepository(async_session)
+    matched_at = datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc).replace(tzinfo=None)
+    filtered_out_at = datetime(2026, 5, 30, 9, 0, tzinfo=timezone.utc).replace(tzinfo=None)
+
+    async_session.add(_make_account("acc_reports_filters", "reports-filters@example.com"))
+    async_session.add_all(
+        [
+            RequestLog(
+                account_id="acc_reports_filters",
+                request_id="report-filter-match",
+                requested_at=matched_at,
+                model="gpt-5.1",
+                useragent_group="opencode",
+                status="success",
+                input_tokens=10,
+                output_tokens=4,
+                cached_input_tokens=2,
+                cost_usd=0.25,
+            ),
+            RequestLog(
+                account_id="acc_reports_filters",
+                request_id="report-filter-other-useragent",
+                requested_at=filtered_out_at,
+                model="gpt-5.1",
+                useragent_group="CodexCLI",
+                status="success",
+                input_tokens=100,
+                output_tokens=40,
+                cached_input_tokens=20,
+                cost_usd=2.5,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    summary = await repo.aggregate_summary(
+        datetime(2026, 6, 1, 0, 0),
+        datetime(2026, 6, 2, 0, 0),
+        useragent_group="opencode",
+    )
+    daily_rows = await repo.aggregate_daily_rows(
+        date(2026, 6, 1),
+        date(2026, 6, 1),
+        timezone.utc,
+        useragent_group="opencode",
+    )
+    by_model = await repo.aggregate_by_model(
+        datetime(2026, 6, 1, 0, 0),
+        datetime(2026, 6, 2, 0, 0),
+        useragent_group="opencode",
+    )
+    by_account = await repo.aggregate_by_account(
+        datetime(2026, 6, 1, 0, 0),
+        datetime(2026, 6, 2, 0, 0),
+        useragent_group="opencode",
+    )
+    earliest_activity_at = await repo.earliest_report_activity_at(useragent_group="opencode")
+
+    assert summary.total_requests == 1
+    assert summary.total_cost_usd == 0.25
+    assert len(daily_rows) == 1
+    assert daily_rows[0].requests == 1
+    assert by_model[0].model == "gpt-5.1"
+    assert by_model[0].cost_usd == 0.25
+    assert by_model[0].request_count == 1
+    assert by_account[0].account_id == "acc_reports_filters"
+    assert by_account[0].request_count == 1
+    assert earliest_activity_at == matched_at
+
+
+@pytest.mark.asyncio
+async def test_aggregate_by_useragent_excludes_null_and_blank_groups(async_session: AsyncSession) -> None:
+    repo = ReportsRepository(async_session)
+
+    async_session.add(_make_account("acc_reports_useragents", "reports-useragents@example.com"))
+    async_session.add_all(
+        [
+            RequestLog(
+                account_id="acc_reports_useragents",
+                request_id="report-useragent-opencode",
+                requested_at=datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.1",
+                useragent_group="opencode",
+                status="success",
+                input_tokens=10,
+                output_tokens=4,
+                cached_input_tokens=0,
+                cost_usd=0.5,
+            ),
+            RequestLog(
+                account_id="acc_reports_useragents",
+                request_id="report-useragent-codex",
+                requested_at=datetime(2026, 6, 1, 13, 0, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.2",
+                useragent_group="CodexCLI",
+                status="success",
+                input_tokens=9,
+                output_tokens=3,
+                cached_input_tokens=0,
+                cost_usd=0.3,
+            ),
+            RequestLog(
+                account_id="acc_reports_useragents",
+                request_id="report-useragent-blank",
+                requested_at=datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.3",
+                useragent_group="",
+                status="success",
+                input_tokens=8,
+                output_tokens=2,
+                cached_input_tokens=0,
+                cost_usd=0.2,
+            ),
+            RequestLog(
+                account_id="acc_reports_useragents",
+                request_id="report-useragent-null",
+                requested_at=datetime(2026, 6, 1, 15, 0, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.4",
+                useragent_group=None,
+                status="success",
+                input_tokens=7,
+                output_tokens=1,
+                cached_input_tokens=0,
+                cost_usd=0.1,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    rows = await repo.aggregate_by_useragent(
+        datetime(2026, 6, 1, 0, 0),
+        datetime(2026, 6, 2, 0, 0),
+    )
+
+    assert [(row.useragent_group, row.cost_usd, row.request_count) for row in rows] == [
+        ("opencode", 0.5, 1),
+        ("CodexCLI", 0.3, 1),
+    ]

--- a/tests/unit/test_reports_repository.py
+++ b/tests/unit/test_reports_repository.py
@@ -239,7 +239,7 @@ async def test_report_filters_apply_to_all_aggregates_including_earliest_activit
 
 
 @pytest.mark.asyncio
-async def test_aggregate_by_useragent_groups_null_as_unknown_and_excludes_blank_groups(
+async def test_aggregate_by_useragent_separates_real_unknown_from_missing_groups(
     async_session: AsyncSession,
 ) -> None:
     repo = ReportsRepository(async_session)
@@ -270,6 +270,18 @@ async def test_aggregate_by_useragent_groups_null_as_unknown_and_excludes_blank_
                 output_tokens=3,
                 cached_input_tokens=0,
                 cost_usd=0.3,
+            ),
+            RequestLog(
+                account_id="acc_reports_useragents",
+                request_id="report-useragent-real-unknown",
+                requested_at=datetime(2026, 6, 1, 13, 30, tzinfo=timezone.utc).replace(tzinfo=None),
+                model="gpt-5.0",
+                useragent_group="Unknown",
+                status="success",
+                input_tokens=9,
+                output_tokens=2,
+                cached_input_tokens=0,
+                cost_usd=0.4,
             ),
             RequestLog(
                 account_id="acc_reports_useragents",
@@ -306,6 +318,7 @@ async def test_aggregate_by_useragent_groups_null_as_unknown_and_excludes_blank_
 
     assert [(row.useragent_group, row.cost_usd, row.request_count) for row in rows] == [
         ("opencode", 0.5, 1),
+        ("Unknown", 0.4, 1),
         ("CodexCLI", 0.3, 1),
-        ("Unknown", 0.1, 1),
+        ("Missing User-Agent", 0.1, 1),
     ]

--- a/tests/unit/test_reports_service.py
+++ b/tests/unit/test_reports_service.py
@@ -36,3 +36,108 @@ async def test_get_reports_rejects_oversized_range_after_applying_default_end_da
     repo.aggregate_by_model.assert_not_awaited()
     repo.aggregate_by_account.assert_not_awaited()
     repo.earliest_report_activity_at.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_reports_serializes_useragent_breakdown_and_model_request_counts() -> None:
+    repo = SimpleNamespace(
+        aggregate_summary=AsyncMock(
+            side_effect=[
+                SimpleNamespace(
+                    total_cost_usd=1.2,
+                    total_input_tokens=12,
+                    total_output_tokens=6,
+                    total_cached_tokens=2,
+                    total_requests=2,
+                    total_errors=0,
+                    active_accounts=1,
+                ),
+                SimpleNamespace(
+                    total_cost_usd=0.4,
+                    total_input_tokens=4,
+                    total_output_tokens=2,
+                    total_cached_tokens=0,
+                    total_requests=1,
+                    total_errors=0,
+                    active_accounts=1,
+                ),
+            ]
+        ),
+        aggregate_daily_rows=AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    date="2026-06-01",
+                    requests=2,
+                    input_tokens=12,
+                    output_tokens=6,
+                    cached_input_tokens=2,
+                    cost_usd=1.2,
+                    active_accounts=1,
+                    error_count=0,
+                )
+            ]
+        ),
+        aggregate_by_model=AsyncMock(
+            return_value=[SimpleNamespace(model="gpt-5.1", cost_usd=1.2, request_count=2)]
+        ),
+        aggregate_by_account=AsyncMock(
+            return_value=[
+                SimpleNamespace(account_id="acc_reports", alias="Reports", cost_usd=1.2, request_count=2)
+            ]
+        ),
+        aggregate_by_useragent=AsyncMock(
+            return_value=[SimpleNamespace(useragent_group="opencode", cost_usd=1.2, request_count=2)]
+        ),
+        earliest_report_activity_at=AsyncMock(return_value=datetime(2026, 5, 1, 0, 0, 0)),
+    )
+    service = ReportsService(cast(ReportsRepository, repo))
+
+    result = await service.get_reports(
+        start_date=date(2026, 6, 1),
+        end_date=date(2026, 6, 1),
+        useragent_group="opencode",
+    )
+
+    repo.aggregate_summary.assert_any_await(
+        datetime(2026, 6, 1, 0, 0, 0),
+        datetime(2026, 6, 2, 0, 0, 0),
+        None,
+        None,
+        "opencode",
+    )
+    repo.aggregate_daily_rows.assert_awaited_once_with(
+        date(2026, 6, 1),
+        date(2026, 6, 1),
+        timezone.utc,
+        None,
+        None,
+        "opencode",
+    )
+    repo.aggregate_by_model.assert_awaited_once_with(
+        datetime(2026, 6, 1, 0, 0, 0),
+        datetime(2026, 6, 2, 0, 0, 0),
+        None,
+        None,
+        "opencode",
+    )
+    repo.aggregate_by_account.assert_awaited_once_with(
+        datetime(2026, 6, 1, 0, 0, 0),
+        datetime(2026, 6, 2, 0, 0, 0),
+        None,
+        None,
+        "opencode",
+    )
+    repo.aggregate_by_useragent.assert_awaited_once_with(
+        datetime(2026, 6, 1, 0, 0, 0),
+        datetime(2026, 6, 2, 0, 0, 0),
+        None,
+        None,
+        "opencode",
+    )
+    repo.earliest_report_activity_at.assert_awaited_once_with(None, None, "opencode")
+
+    assert result.by_model[0].model == "gpt-5.1"
+    assert result.by_model[0].requests == 2
+    assert result.by_useragent[0].useragent == "opencode"
+    assert result.by_useragent[0].requests == 2
+    assert result.by_useragent[0].percentage == 100.0

--- a/tests/unit/test_reports_service.py
+++ b/tests/unit/test_reports_service.py
@@ -77,13 +77,9 @@ async def test_get_reports_serializes_useragent_breakdown_and_model_request_coun
                 )
             ]
         ),
-        aggregate_by_model=AsyncMock(
-            return_value=[SimpleNamespace(model="gpt-5.1", cost_usd=1.2, request_count=2)]
-        ),
+        aggregate_by_model=AsyncMock(return_value=[SimpleNamespace(model="gpt-5.1", cost_usd=1.2, request_count=2)]),
         aggregate_by_account=AsyncMock(
-            return_value=[
-                SimpleNamespace(account_id="acc_reports", alias="Reports", cost_usd=1.2, request_count=2)
-            ]
+            return_value=[SimpleNamespace(account_id="acc_reports", alias="Reports", cost_usd=1.2, request_count=2)]
         ),
         aggregate_by_useragent=AsyncMock(
             return_value=[SimpleNamespace(useragent_group="opencode", cost_usd=1.2, request_count=2)]


### PR DESCRIPTION
## Summary

Enhance the `/reports` page with user-agent distribution tracking and filtering, continuous daily-series charts that match the Daily Breakdown table, sortable columns with visible sort-state icons, and cached-token rendering in summary cards and table cells.

## Type of change

- [x] `feat:` — new user-facing feature or capability
- [x] `fix:` — bug fix (no behavior change beyond the bug)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directories:
- `openspec/changes/improve-reports-daily-breakdown/`
- `openspec/changes/add-reports-useragent-distribution/`
- `openspec/changes/fix-reports-unknown-useragent-bucket/`

## Changes

- **User-agent distribution (`GET /api/reports` + dashboard)**: Aggregate `request_logs.useragent_group` into a `byUseragent` breakdown with cost and request counts. Add a `useragent_group` query filter. Render a `Distribution by UserAgent` donut card alongside the existing model donut. Add `cost`/`req` metric toggle to both distribution cards.
- **Unknown user-agent bucket**: Treat `null` `useragent_group` as `"Unknown"` in aggregation and filtering. Render with a fixed gray legend dot and slice color. Exclude blank (`""`) groups.
- **Continuous daily series**: Extract shared `buildContinuousDailyRows()` helper to fill missing selected-range days with zero-valued rows. Wire `CostPerDayChart`, `TokensPerDayChart`, and `DailyDetailTable` through the same normalized series so charts match the table.
- **Sortable Daily Breakdown columns**: Add client-side sort for every visible column (`Day`, `Reqs`, `Input Tokens`, `Output Tokens`, `Cost`, `Accounts`). Default to `Day` descending. Toggle direction on re-click. Show muted unsorted icon on inactive headers and directional icon on active header.
- **Cached tokens everywhere**: Surface `cachedInputTokens` inline in the Input Tokens cell as `main (cached)`. Add cached totals to the Tokens summary card subtitle (`Input … · Cache … · Output …`). Export CSV in ascending chronological order regardless of visible sort.
- **ByModel `requests` field**: Extend `byModel` response schema to include `requests` count alongside `costUsd` and `percentage`.

## Test plan

```
# uv run pytest tests/unit/test_reports_repository.py -q
# uv run pytest tests/unit/test_reports_service.py -q
# uv run pytest tests/integration/test_reports_api.py -q
# bun run test src/features/reports/
```

<img width="1421" height="499" alt="螢幕截圖 2026-06-20 23 53 19" src="https://github.com/user-attachments/assets/94994f17-78e4-4928-8fbb-faaba13fb7e8" />
<img width="477" height="132" alt="螢幕截圖 2026-06-20 18 00 51" src="https://github.com/user-attachments/assets/533d292f-d115-411e-bf96-624156efe54c" />
