### PR TITLE
fix(proxy): oauth blocked when bindings lack route

### DIFF
--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -10,6 +10,10 @@ from datetime import datetime
 from hashlib import sha256
 from typing import Any, Protocol, TypeAlias
 
+from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.core.auth import DEFAULT_PLAN, OpenAIAuthClaims, extract_id_token_claims
 from app.core.auth.refresh import RefreshError, TokenRefreshResult, refresh_access_token, should_refresh
 from app.core.balancer import PERMANENT_FAILURE_CODES, account_status_for_permanent_failure
@@ -18,7 +22,7 @@ from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_upstream_route
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountProxyBinding, AccountStatus
 from app.db.session import get_background_session
 
 
@@ -305,6 +309,14 @@ class AuthManager:
                         transport_error=True,
                         upstream_proxy_fail_closed_reason=exc.reason,
                     ) from exc
+                if route is None and await _account_has_active_proxy_binding(session, account.id):
+                    raise RefreshError(
+                        "upstream_proxy_unavailable",
+                        "Account has an active proxy binding but no route resolved",
+                        False,
+                        transport_error=True,
+                        upstream_proxy_fail_closed_reason="binding_route_unavailable",
+                    )
             return await _call_with_supported_optional_kwargs(
                 refresh_access_token,
                 refresh_token,
@@ -412,3 +424,18 @@ async def _call_with_supported_optional_kwargs(
 
 def _clear_refresh_singleflight_state() -> None:
     _REFRESH_SINGLEFLIGHT.clear()
+
+
+async def _account_has_active_proxy_binding(session: AsyncSession, account_id: str) -> bool:
+    try:
+        result = await session.execute(
+            select(AccountProxyBinding.id)
+            .where(
+                AccountProxyBinding.account_id == account_id,
+                AccountProxyBinding.is_active.is_(True),
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+    except OperationalError:
+        return False

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from aiohttp import web
+from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import (
     DEFAULT_EMAIL,
@@ -37,7 +40,7 @@ from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError, resolve_upstream_route
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountProxyBinding, AccountStatus
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountIdentityConflictError, AccountsRepository
 from app.modules.oauth.schemas import (
@@ -61,14 +64,27 @@ _ACCOUNT_IDENTITY_CONFLICT_MESSAGE = (
 )
 
 
+async def _has_active_proxy_bindings(session: AsyncSession) -> bool:
+    try:
+        result = await session.execute(
+            select(AccountProxyBinding.id).where(AccountProxyBinding.is_active.is_(True)).limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+    except OperationalError:
+        return False
+
+
 async def _oauth_route() -> ResolvedUpstreamRoute | None:
     async with get_background_session() as session:
+        strict = await _has_active_proxy_bindings(session)
         try:
             return await resolve_upstream_route(
                 session,
                 account_id=None,
                 operation="oauth",
                 scope="bootstrap",
+                # strict=True forces default-pool requirement; None defers to dashboard setting
+                strict=strict or None,
             )
         except UpstreamProxyRouteError as exc:
             raise OAuthError(exc.reason, str(exc), status_code=502) from exc

--- a/openspec/changes/fix-oauth-bootstrap-proxy-route/.openspec.yaml
+++ b/openspec/changes/fix-oauth-bootstrap-proxy-route/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/fix-oauth-bootstrap-proxy-route/design.md
+++ b/openspec/changes/fix-oauth-bootstrap-proxy-route/design.md
@@ -1,0 +1,39 @@
+## Context
+
+`_oauth_route()` in `app/modules/oauth/service.py:64-74` calls `resolve_upstream_route` with `account_id=None`. Since the account row is only created inside `_persist_tokens` *after* the token exchange, there is no `account_id` to bind a proxy against during OAuth. All post-login paths correctly pass `account_id=account.id`.
+
+When operators configure per-account proxies after login, the initial token was issued from a different IP (direct egress or default pool) than all subsequent API calls. OpenAI invalidates these sessions, causing "Re-auth required" after hours/days.
+
+## Goals / Non-Goals
+
+**Goals:**
+- OAuth token exchange uses a proxy pool when strict routing is enabled
+- Fail closed instead of silent direct egress when no pool is resolvable
+- Prevent IP split in token refresh when account binding becomes unavailable
+
+**Non-Goals:**
+- No schema changes (no `pending_oauth_pool_id` column) — use the existing default pool mechanism
+- No UI changes for pre-binding a proxy before OAuth start
+- No changes to post-login routing (already correct)
+
+## Decisions
+
+### 1. Use default pool for OAuth bootstrap, not a new pool-hint parameter
+
+**Decision:** `_oauth_route()` queries whether any active `AccountProxyBinding` records exist. If they do, it passes `strict=True` to `resolve_upstream_route()`, which overrides the dashboard's `upstream_proxy_routing_enabled` flag and forces the resolver to require a default pool (or fail closed). When no bindings exist, `strict=None` preserves the previous behavior (defer to dashboard setting or direct egress).
+
+**Why binding-existence, not `upstream_proxy_routing_enabled`:** Per-account proxy bindings work even when the dashboard flag is `False` — the resolver finds the binding before checking the flag. An operator who has bindings but hasn't toggled the dashboard flag would still have OAuth go direct, creating the IP split. Checking binding existence is the more direct signal that the operator cares about proxy routing.
+
+**Why not pool hint:** Requires schema change to `OAuthState`, UI changes, and API parameter plumbing. The default pool already exists for exactly this purpose — bootstrap traffic that has no account binding yet.
+
+### 2. Fail closed in token refresh when binding expected but route is None
+
+**Decision:** In `auth_manager._refresh_tokens`, after `resolve_upstream_route` returns `None`, check if the account has a proxy binding. If it does, raise `RefreshError` instead of allowing direct egress.
+
+**Why:** A binding that becomes inactive between checks (race condition, operator toggle) would silently cause the refresh to go direct, re-introducing the IP split. Failing closed is safer — the refresh fails, the account enters error backoff, and the operator is alerted.
+
+## Risks / Trade-offs
+
+- **[OAuth fails when default pool not configured]** → This is intentional. Operators who enable strict routing MUST configure a default pool. The error message guides them.
+- **[Existing accounts with direct-egress OAuth still have the IP split]** → Out of scope. Operators should re-authenticate after configuring the default pool. A follow-up could add a "force re-auth" button.
+- **[Token refresh fail-closed may increase transient failures]** → The singleflight cache + error backoff already handle transient failures. The permanent failure path only triggers after retries.

--- a/openspec/changes/fix-oauth-bootstrap-proxy-route/proposal.md
+++ b/openspec/changes/fix-oauth-bootstrap-proxy-route/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+OAuth token exchange (initial login and device flow) bypasses per-account proxy routing because `_oauth_route()` calls `resolve_upstream_route` with `account_id=None`. When operators set per-account proxies after login, the initial token was issued from a different IP than all subsequent API calls and token refreshes. OpenAI invalidates these sessions, causing "Re-auth required" failures after hours/days. This is the root cause of issue #1057.
+
+## What Changes
+
+- When any active `AccountProxyBinding` records exist, `_oauth_route()` forces `strict=True` on `resolve_upstream_route()`, causing fail-closed behavior when no default pool is configured and routing through the default pool when one exists.
+- Add fail-closed guard in `auth_manager._refresh_tokens`: when an account has a proxy binding but route resolution returns `None`, raise instead of silently using direct egress.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `outbound-http-clients`: OAuth bootstrap route resolution must fail closed when active proxy bindings exist and no default pool is resolvable. Token refresh must fail closed when an account binding exists but route resolution returns None.

--- a/openspec/changes/fix-oauth-bootstrap-proxy-route/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/fix-oauth-bootstrap-proxy-route/specs/outbound-http-clients/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: OAuth token exchange must use a proxy pool when active proxy bindings exist
+
+When any active `AccountProxyBinding` records exist in the database, OAuth token exchange (authorization code exchange, device code request, and device token poll) MUST resolve a route from the configured default pool before opening a network connection. If no default pool can be resolved, the OAuth operation MUST fail closed with a descriptive error instead of silently falling back to direct egress. When no active proxy bindings exist, direct egress or environment proxy MAY be used as before.
+
+#### Scenario: OAuth fails closed when bindings exist but no default pool is configured
+- **GIVEN** one or more active `AccountProxyBinding` records exist
+- **AND** no default pool is configured
+- **WHEN** the OAuth token exchange is attempted
+- **THEN** the operation MUST fail before opening any network connection
+- **AND** the error MUST indicate that no upstream proxy route is available
+
+#### Scenario: OAuth uses default pool when bindings exist and pool is configured
+- **GIVEN** one or more active `AccountProxyBinding` records exist
+- **AND** a default pool is configured with an active endpoint
+- **WHEN** the OAuth token exchange is attempted
+- **THEN** the request MUST go through the default pool's endpoint
+
+#### Scenario: OAuth preserves direct egress when no proxy bindings exist
+- **GIVEN** no active `AccountProxyBinding` records exist in the database
+- **WHEN** the OAuth token exchange is attempted
+- **THEN** the request MAY use direct egress or environment proxy as before
+
+### Requirement: Token refresh must fail closed when account binding exists but route is unavailable
+
+When an account has an active proxy binding but route resolution returns `None` (e.g., binding toggled inactive, pool deleted), the token refresh MUST raise an error instead of silently falling back to direct egress. This prevents an IP split after the account has been associated with a proxy.
+
+#### Scenario: Refresh fails closed when binding becomes unavailable
+- **GIVEN** an account has an active proxy binding at refresh start time
+- **AND** the binding's pool has no active endpoint at resolution time
+- **WHEN** a token refresh is attempted
+- **THEN** the refresh MUST raise an upstream proxy unavailable error
+- **AND** it MUST NOT silently use direct egress

--- a/openspec/changes/fix-oauth-bootstrap-proxy-route/tasks.md
+++ b/openspec/changes/fix-oauth-bootstrap-proxy-route/tasks.md
@@ -1,0 +1,20 @@
+## 1. Failing test (proves the bug exists)
+
+- [x] 1.1 Write unit test: OAuth `_oauth_route()` with active bindings and no default pool MUST raise instead of returning None (direct egress)
+- [x] 1.2 Write unit test: OAuth `_oauth_route()` with active bindings and a default pool MUST resolve a route from that pool
+- [x] 1.3 Write unit test: `auth_manager._refresh_tokens` with an account that has a proxy binding but route returns None MUST raise RefreshError instead of allowing direct egress
+
+## 2. Fix OAuth bootstrap route resolution
+
+- [x] 2.1 Modify `_oauth_route()` to pass `strict=True` when any active `AccountProxyBinding` records exist, forcing fail-closed behavior when no default pool is configured
+- [x] 2.2 Verify all OAuth call sites (`manual_callback`, `_handle_callback`, `_start_device_flow`, `_poll_device_tokens`) use the updated `_oauth_route()`
+
+## 3. Fix token refresh fail-closed guard
+
+- [x] 3.1 In `auth_manager._refresh_tokens`, when `route is None` and the account has an active proxy binding, raise `RefreshError` with `upstream_proxy_fail_closed_reason`
+
+## 4. Validation
+
+- [x] 4.1 Run `openspec validate --specs` — must pass
+- [x] 4.2 Run `uv run pytest tests/unit/test_oauth_proxy_route.py tests/unit/test_auth_manager.py tests/unit/test_auth_refresh.py tests/unit/test_oauth_client.py tests/unit/test_upstream_proxy_resolver.py -q` — all tests green
+- [x] 4.3 Run `uv run ruff check app/modules/oauth/service.py app/modules/accounts/auth_manager.py` — clean

--- a/tests/unit/test_oauth_proxy_route.py
+++ b/tests/unit/test_oauth_proxy_route.py
@@ -1,0 +1,317 @@
+"""Regression tests for issue #1057: per-account proxy IP leak in OAuth bootstrap.
+
+These tests verify that:
+1. OAuth token exchange fails closed when per-account proxy bindings exist
+   but no default pool is configured (instead of silently using direct egress).
+2. Token refresh fails closed when an account has a proxy binding but route
+   resolution returns None (binding toggled inactive / pool deleted).
+
+Without the fix, both paths silently fall back to direct egress, creating an
+IP split between the initial OAuth / refresh and subsequent per-account-proxy
+API calls. OpenAI detects the IP change and invalidates the session, causing
+"Re-auth required" after hours/days.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import cast
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.auth.refresh import RefreshError
+from app.core.crypto import TokenEncryptor
+from app.db.models import (
+    Account,
+    AccountProxyBinding,
+    AccountStatus,
+    Base,
+    DashboardSettings,
+    ProxyEndpoint,
+    ProxyPool,
+    ProxyPoolMember,
+)
+from app.modules.accounts import auth_manager as auth_manager_module
+from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManager
+from app.modules.oauth import service as oauth_service_module
+from app.modules.oauth.service import OAuthError
+
+pytestmark = pytest.mark.unit
+
+
+def _encryptor() -> TokenEncryptor:
+    return TokenEncryptor(key=Fernet.generate_key())
+
+
+def _account(encryptor: TokenEncryptor, account_id: str = "acc_1") -> Account:
+    token = encryptor.encrypt("token")
+    return Account(
+        id=account_id,
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=token,
+        refresh_token_encrypted=token,
+        id_token_encrypted=token,
+        last_refresh=datetime(2026, 1, 1),
+        status=AccountStatus.ACTIVE,
+    )
+
+
+async def _pool_with_endpoints(session: AsyncSession, encryptor: TokenEncryptor, pool_id: str) -> None:
+    pool = ProxyPool(id=pool_id, name=pool_id)
+    ep = ProxyEndpoint(
+        id=f"{pool_id}_ep_1",
+        name="first",
+        scheme="http",
+        host="proxy-one.test",
+        port=8080,
+    )
+    session.add_all(
+        [
+            pool,
+            ep,
+            ProxyPoolMember(id=f"{pool_id}_m_1", pool=pool, endpoint=ep, sort_order=10),
+        ]
+    )
+
+
+@pytest.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+# ─── Test 1: OAuth fails closed when bindings exist but no default pool ───
+
+
+@pytest.mark.asyncio
+async def test_oauth_route_fails_closed_when_bindings_exist_but_no_default_pool(
+    session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #1057: when per-account proxy bindings exist but no
+    default pool is configured, OAuth MUST fail closed instead of silently
+    falling back to direct egress.
+
+    Without this guard, the initial token exchange goes direct while all
+    subsequent API calls use the per-account proxy — an IP split that causes
+    OpenAI to invalidate the session.
+    """
+
+    @asynccontextmanager
+    async def fake_background_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    monkeypatch.setattr(oauth_service_module, "get_background_session", fake_background_session)
+
+    encryptor = _encryptor()
+    async with session_factory() as session:
+        account = _account(encryptor)
+        await _pool_with_endpoints(session, encryptor, "bound_pool")
+        session.add_all(
+            [
+                account,
+                AccountProxyBinding(id="binding_1", account=account, pool_id="bound_pool"),
+                # upstream_proxy_routing_enabled defaults to False — bindings
+                # work without it, but the default-pool fallback does not.
+            ]
+        )
+        await session.commit()
+
+    # Without fix: _oauth_route() returns None (direct egress).
+    # With fix: _oauth_route() detects active bindings and fails closed.
+    with pytest.raises(OAuthError) as exc_info:
+        await oauth_service_module._oauth_route()
+
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_oauth_route_uses_default_pool_when_bindings_exist(
+    session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When active bindings exist and a default pool is configured,
+    _oauth_route() MUST return a resolved route from that pool."""
+
+    @asynccontextmanager
+    async def fake_background_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    monkeypatch.setattr(oauth_service_module, "get_background_session", fake_background_session)
+
+    encryptor = _encryptor()
+    async with session_factory() as session:
+        account = _account(encryptor)
+        await _pool_with_endpoints(session, encryptor, "default_pool")
+        session.add_all(
+            [
+                account,
+                AccountProxyBinding(id="binding_1", account=account, pool_id="default_pool"),
+                DashboardSettings(
+                    id=1,
+                    upstream_proxy_routing_enabled=False,
+                    upstream_proxy_default_pool_id="default_pool",
+                ),
+            ]
+        )
+        await session.commit()
+
+    route = await oauth_service_module._oauth_route()
+
+    assert route is not None
+    assert route.mode == "default_pool"
+    assert route.pool_id == "default_pool"
+
+
+@pytest.mark.asyncio
+async def test_oauth_route_preserves_direct_egress_when_no_bindings_exist(
+    session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When no active proxy bindings exist, _oauth_route() MUST return None
+    (direct egress) instead of failing closed."""
+
+    @asynccontextmanager
+    async def fake_background_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    monkeypatch.setattr(oauth_service_module, "get_background_session", fake_background_session)
+
+    route = await oauth_service_module._oauth_route()
+
+    assert route is None
+
+
+# ─── Test 2: Token refresh fails closed when binding exists but route is None ───
+
+
+class _DummyRepo:
+    def __init__(self) -> None:
+        self.tokens_payload: dict[str, object] | None = None
+        self.status_payload: dict[str, object] | None = None
+        self.accounts_by_id: dict[str, Account] = {}
+
+    async def get_by_id(self, account_id: str) -> Account | None:
+        return self.accounts_by_id.get(account_id)
+
+    async def update_status(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None = None,
+    ) -> bool:
+        self.status_payload = {
+            "account_id": account_id,
+            "status": status,
+            "deactivation_reason": deactivation_reason,
+        }
+        return True
+
+    async def update_tokens(
+        self,
+        account_id: str,
+        access_token_encrypted: bytes,
+        refresh_token_encrypted: bytes,
+        id_token_encrypted: bytes,
+        last_refresh: datetime,
+        plan_type: str | None = None,
+        email: str | None = None,
+        chatgpt_account_id: str | None = None,
+        workspace_id: str | None = None,
+        workspace_label: str | None = None,
+        seat_type: str | None = None,
+    ) -> bool:
+        self.tokens_payload = {
+            "account_id": account_id,
+            "access_token_encrypted": access_token_encrypted,
+            "refresh_token_encrypted": refresh_token_encrypted,
+            "id_token_encrypted": id_token_encrypted,
+            "last_refresh": last_refresh,
+            "plan_type": plan_type,
+            "email": email,
+            "chatgpt_account_id": chatgpt_account_id,
+            "workspace_id": workspace_id,
+            "workspace_label": workspace_label,
+            "seat_type": seat_type,
+        }
+        return True
+
+    async def workspace_slot_taken(
+        self,
+        *,
+        account_id: str,
+        email: str,
+        chatgpt_account_id: str | None,
+        workspace_id: str,
+    ) -> bool:
+        del account_id
+        return (email, chatgpt_account_id, workspace_id) in set()
+
+
+@pytest.mark.asyncio
+async def test_refresh_fails_closed_when_binding_exists_but_route_returns_none(
+    session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #1057: when an account has a proxy binding but route
+    resolution returns None (binding toggled inactive, pool deleted), the
+    refresh MUST raise instead of silently using direct egress.
+
+    Without this guard, the refresh goes direct, creating an IP split that
+    causes OpenAI to invalidate the session.
+    """
+
+    @asynccontextmanager
+    async def fake_background_session() -> AsyncIterator[AsyncSession]:
+        async with session_factory() as session:
+            yield session
+
+    async def fake_resolve_route(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def unexpected_refresh(_: str, **_kwargs: object):
+        raise AssertionError("refresh_access_token must not run when route is None and account has a binding")
+
+    monkeypatch.setattr(auth_manager_module, "get_background_session", fake_background_session)
+    monkeypatch.setattr(auth_manager_module, "resolve_upstream_route", fake_resolve_route)
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", unexpected_refresh)
+
+    encryptor = TokenEncryptor()
+    async with session_factory() as session:
+        account = _account(encryptor, "acc_binding_none")
+        await _pool_with_endpoints(session, encryptor, "bound_pool")
+        session.add_all(
+            [
+                account,
+                AccountProxyBinding(id="binding_1", account=account, pool_id="bound_pool"),
+            ]
+        )
+        await session.commit()
+
+    repo = _DummyRepo()
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    # Without fix: refresh silently uses direct egress (route=None, allow_direct_egress=True).
+    # With fix: refresh raises RefreshError because account has a binding but route is None.
+    with pytest.raises(RefreshError) as exc_info:
+        await manager.refresh_account(account)
+
+    assert exc_info.value.code == "upstream_proxy_unavailable"
+    assert exc_info.value.transport_error is True
+    assert repo.tokens_payload is None


### PR DESCRIPTION
## Summary
OAuth bootstrap passed account_id=None to the resolver, bypassing per-account proxy routing. Token exchange went direct while all subsequent API calls used the per-account proxy, causing OpenAI to invalidate sessions after hours/days.

## Type of change
- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Fixes #1057

## OpenSpec
- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

## Changes
- `_oauth_route()` forces strict=True when active bindings exist, requiring a default pool or failing closed
- `_refresh_tokens()` raises `RefreshError` when an account has a binding but route resolution returns `None`
- Both binding-check helpers guard `OperationalError` for missing tables

## Test plan
```
uv run pytest tests/unit/test_oauth_proxy_route.py tests/unit/test_auth_manager.py tests/unit/test_auth_refresh.py tests/unit/test_oauth_client.py tests/unit/test_upstream_proxy_resolver.py -q
uv run pytest tests/integration/test_oauth_flow.py -q
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
