### PR TITLE
fix(proxy): avoid shielded-future log on startup probe timeout

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2624,6 +2624,31 @@ async def _read_first_stream_item(stream: AsyncIterator[str]) -> str:
     return await anext(stream)
 
 
+def _retrieve_first_stream_task_exception(task: asyncio.Task[str]) -> None:
+    # Retrieve a finished probe task's exception so an abandoned task does not
+    # surface asyncio's "exception was never retrieved" warning. Consumers that
+    # await the task still re-raise it.
+    if not task.cancelled():
+        task.exception()
+
+
+def _create_first_stream_probe_task(stream: AsyncIterator[str]) -> asyncio.Task[str]:
+    """Create the first-stream-item probe task.
+
+    ``_probe_stream_startup_error`` / ``_probe_chat_stream_startup_error`` race
+    this task against a timeout. On timeout the task keeps running and is handed
+    to the streamed response for consumption. If the wrapping stream is dropped
+    before the task is awaited -- for example the request is torn down while the
+    upstream is still blocked on the response-create admission gate -- the task
+    would otherwise finish with an unretrieved ``ProxyResponseError`` and asyncio
+    would log it. The done-callback retrieves the result in that abandoned case
+    without hiding the error from consumers that do await the task.
+    """
+    task = asyncio.create_task(_read_first_stream_item(stream))
+    task.add_done_callback(_retrieve_first_stream_task_exception)
+    return task
+
+
 async def _probe_stream_startup_error(
     stream: AsyncIterator[str],
     *,
@@ -2632,14 +2657,17 @@ async def _probe_stream_startup_error(
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     if timeout_seconds is None:
         timeout_seconds = _STREAM_STARTUP_ERROR_PROBE_SECONDS
-    first_task = asyncio.create_task(_read_first_stream_item(stream))
-    try:
-        first = await asyncio.wait_for(
-            asyncio.shield(first_task),
-            timeout=timeout_seconds,
-        )
-    except TimeoutError:
+    first_task = _create_first_stream_probe_task(stream)
+    done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
+    if not done:
+        # Probe window elapsed before the first item arrived. Hand the still-
+        # running task off to be consumed by the streamed response. asyncio.wait
+        # (rather than wait_for + shield) never cancels the task on timeout,
+        # avoiding the Python 3.14 "exception in shielded future" log when the
+        # upstream later returns an error such as a 429 from the admission gate.
         return _prepend_first_task(first_task, stream), None
+    try:
+        first = first_task.result()
     except StopAsyncIteration:
         return _prepend_first(None, stream), None
     except ProxyResponseError as exc:
@@ -2944,14 +2972,12 @@ async def _probe_chat_stream_startup_error(
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     buffered: list[str] = []
     for _ in range(max_startup_events):
-        first_task = asyncio.create_task(_read_first_stream_item(stream))
-        try:
-            first = await asyncio.wait_for(
-                asyncio.shield(first_task),
-                timeout=timeout_seconds,
-            )
-        except TimeoutError:
+        first_task = _create_first_stream_probe_task(stream)
+        done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
+        if not done:
             return _prepend_items(buffered, _prepend_first_task(first_task, stream)), None
+        try:
+            first = first_task.result()
         except StopAsyncIteration:
             return _prepend_items(buffered, _prepend_first(None, stream)), None
         except ProxyResponseError as exc:
@@ -2982,9 +3008,16 @@ async def _prepend_items(items: list[str], stream: AsyncIterator[str]) -> AsyncI
 
 async def _prepend_first_task(first_task: asyncio.Task[str], stream: AsyncIterator[str]) -> AsyncIterator[str]:
     try:
-        yield await first_task
+        first = await first_task
     except StopAsyncIteration:
         return
+    finally:
+        # If the wrapping stream is closed before the first item is consumed
+        # (client disconnect, request teardown), cancel the still-running probe
+        # task so it does not hold the upstream connection open.
+        if not first_task.done():
+            first_task.cancel()
+    yield first
     async for line in stream:
         yield line
 

--- a/openspec/changes/quiet-timed-out-startup-probe-diagnostic/proposal.md
+++ b/openspec/changes/quiet-timed-out-startup-probe-diagnostic/proposal.md
@@ -1,0 +1,41 @@
+# Quiet the timed-out startup-probe shielded-future diagnostic
+
+## Problem
+
+The streaming proxy probes the first upstream event before committing to a
+streamed response (`_probe_stream_startup_error` and
+`_probe_chat_stream_startup_error`). The probe raced the first item against a
+short timeout using `asyncio.wait_for(asyncio.shield(first_task), timeout)`. When
+the first item took longer than the probe window -- for example while the
+upstream was still blocked on the response-create admission gate -- `wait_for`
+cancelled the shield's outer future. If `first_task` then finished with a
+`ProxyResponseError` (such as a 429 from the admission gate), Python 3.14's
+`asyncio.shield` reported the inner exception through the loop exception handler
+as `ProxyResponseError exception in shielded future`. This logged a spurious
+ERROR even though the same error was already delivered to the caller through the
+streamed response.
+
+## Solution
+
+Race the probe task with `asyncio.wait({first_task}, timeout=...)` instead of
+`wait_for` + `shield`. `asyncio.wait` never cancels the task on timeout and does
+not wrap it in a shield, so the timed-out task is simply handed to the streamed
+response for consumption without emitting the shielded-future diagnostic. A
+done-callback retrieves the task's result if the wrapping stream is dropped
+before the task is awaited (the request is torn down mid-probe), so an abandoned
+task does not trip the "exception was never retrieved" warning either. Consumers
+that await the task still observe the upstream error unchanged.
+
+## Changes
+
+- Replace `wait_for` + `shield` with `asyncio.wait` in both startup probes
+- Retrieve the probe task's exception via a done-callback for the abandoned case
+- Cancel the still-running probe task when the wrapping stream is closed early
+- Add regression coverage asserting no shielded-future diagnostic on the
+  timeout-then-upstream-error path
+
+## Out of scope
+
+- Changing the probe timeout windows
+- Changing how startup errors are classified or surfaced to clients
+- Changing the admission gate behavior itself

--- a/openspec/changes/quiet-timed-out-startup-probe-diagnostic/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/quiet-timed-out-startup-probe-diagnostic/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Startup probe timeouts do not emit shielded-future diagnostics
+
+When the streaming proxy's startup probe times out waiting for the first upstream
+event and the probed task later fails with an upstream error, the system SHALL
+deliver that error through the streamed response without emitting an
+`exception in shielded future` or `exception was never retrieved` diagnostic to
+the asyncio loop exception handler.
+
+#### Scenario: Timed-out probe whose upstream later returns 429
+
+- **GIVEN** the startup probe times out before the first upstream event arrives
+- **WHEN** the probed task subsequently fails with a 429 from the admission gate
+- **THEN** the upstream error is surfaced to the caller through the streamed response
+- **AND** no `exception in shielded future` diagnostic is logged
+
+#### Scenario: Probe stream dropped before the first item is consumed
+
+- **GIVEN** the startup probe times out and hands the running task to the response
+- **WHEN** the wrapping stream is dropped before the task is awaited
+- **THEN** the probed task's failure does not log an `exception was never retrieved` warning

--- a/openspec/changes/quiet-timed-out-startup-probe-diagnostic/tasks.md
+++ b/openspec/changes/quiet-timed-out-startup-probe-diagnostic/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Replace `wait_for` + `shield` with `asyncio.wait` in `_probe_stream_startup_error` and `_probe_chat_stream_startup_error`
+- [x] Retrieve the probe task's exception via a done-callback for the abandoned-stream case
+- [x] Cancel the still-running probe task when the wrapping stream is closed early
+- [x] Add regression coverage in `tests/unit/test_responses_streaming_timeout_hardening.py`
+- [x] Document the proxy-runtime-observability requirement delta (proposal + ADDED requirement with GIVEN/WHEN/THEN scenarios)
+- [x] Run `uv run --frozen ruff check .` and `uv run --frozen ruff format --check .`
+- [x] Run `uv run --frozen pytest tests/unit/test_responses_streaming_timeout_hardening.py`

--- a/tests/unit/test_responses_streaming_timeout_hardening.py
+++ b/tests/unit/test_responses_streaming_timeout_hardening.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
+import gc
 from collections.abc import AsyncIterator
 
 import pytest
 
+from app.core.clients.proxy import ProxyResponseError
+from app.core.resilience.overload import local_overload_error
 from app.core.utils.sse import SSE_KEEPALIVE_FRAME
 from app.modules.proxy import api as proxy_api
 
@@ -12,6 +16,15 @@ pytestmark = pytest.mark.unit
 
 async def _one_event_stream() -> AsyncIterator[str]:
     yield 'event: response.created\ndata: {"type":"response.created"}\n\n'
+
+
+async def _delayed_429_stream() -> AsyncIterator[str]:
+    # The first item only resolves after the startup probe has already timed
+    # out, then the upstream raises a 429 -- mirroring the response-create
+    # admission gate denying admission after the probe window elapsed.
+    await asyncio.sleep(0.05)
+    raise ProxyResponseError(429, local_overload_error("admission gate timed out", code="global_admission_timeout"))
+    yield ""  # pragma: no cover - present only so this is an async generator
 
 
 @pytest.mark.asyncio
@@ -28,3 +41,60 @@ async def test_initial_sse_heartbeat_precedes_openai_contract_event() -> None:
 
     assert first == SSE_KEEPALIVE_FRAME
     assert "response.created" in second
+
+
+@pytest.mark.asyncio
+async def test_startup_probe_timeout_then_upstream_error_is_not_logged() -> None:
+    loop = asyncio.get_running_loop()
+    captured: list[str] = []
+    loop.set_exception_handler(lambda _loop, context: captured.append(str(context.get("message", ""))))
+    try:
+        # The probe times out before the first item arrives, so it hands the
+        # still-running task to the streamed response.
+        stream, startup_error = await proxy_api._probe_stream_startup_error(
+            _delayed_429_stream(),
+            timeout_seconds=0.01,
+        )
+        assert startup_error is None
+
+        # Consuming the handed-off stream surfaces the upstream 429 to the
+        # caller -- and must not also emit an "exception in shielded future"
+        # diagnostic from the timed-out probe task.
+        with pytest.raises(ProxyResponseError):
+            async for _ in stream:
+                pass
+
+        await asyncio.sleep(0)
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(None)
+
+    assert not any("shielded future" in m for m in captured), captured
+
+
+@pytest.mark.asyncio
+async def test_abandoned_startup_probe_task_does_not_warn() -> None:
+    loop = asyncio.get_running_loop()
+    captured: list[str] = []
+    loop.set_exception_handler(lambda _loop, context: captured.append(str(context.get("message", ""))))
+    try:
+        stream, startup_error = await proxy_api._probe_stream_startup_error(
+            _delayed_429_stream(),
+            timeout_seconds=0.01,
+        )
+        assert startup_error is None
+
+        # Drop the wrapping generator without iterating it, as happens when the
+        # request is torn down while still waiting on the admission gate. The
+        # detached probe task then finishes with its 429 and must not log an
+        # "exception was never retrieved" warning when it is collected.
+        del stream
+        await asyncio.sleep(0.1)
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(None)
+
+    leaked = [m for m in captured if "never retrieved" in m.lower() or "shielded future" in m]
+    assert not leaked, f"probe task leaked an unretrieved exception: {captured}"


### PR DESCRIPTION
Closes #976.

## Problem

The streaming startup probes (`_probe_stream_startup_error`, `_probe_chat_stream_startup_error`) race the first upstream event against a short timeout with `asyncio.wait_for(asyncio.shield(first_task), timeout)`. On timeout, `wait_for` cancels the shield`s outer future. When `first_task` then finishes with a `ProxyResponseError` — for example a 429 raised while the upstream is still blocked on the response-create admission gate — Python 3.14`s `asyncio.shield` reports the inner exception through the loop exception handler:

```
ERROR:    asyncio ProxyResponseError exception in shielded future
future: <Task finished name=... coro=<_read_first_stream_item() done ...> exception=ProxyResponseError("Proxy response error (429)")>
```

This is spurious: the same error is already delivered to the caller through the streamed response. It just surfaces as an unhandled-looking ERROR because `shield` reports the inner result once its outer waiter was cancelled.

## Fix

Race the probe task with `asyncio.wait({first_task}, timeout=...)` instead of `wait_for` + `shield`. `asyncio.wait` never cancels the task on timeout and does not wrap it in a shield, so the timed-out task is simply handed to the streamed response for consumption. A done-callback retrieves the task`s result if the wrapping stream is dropped before the task is awaited (request torn down mid-probe), so an abandoned task does not trip the "exception was never retrieved" warning either. Consumers that await the task still observe the upstream error unchanged.

## Tests

`tests/unit/test_responses_streaming_timeout_hardening.py`:
- `test_startup_probe_timeout_then_upstream_error_is_not_logged` — drives the timeout-then-429 path and asserts no `exception in shielded future` reaches the loop exception handler.
- `test_abandoned_startup_probe_task_does_not_warn` — drops the handed-off stream and asserts no leaked-exception diagnostic.

Both fail on `main` (they capture `ProxyResponseError exception in shielded future`) and pass with this change. Full proxy/streaming unit suite (735 tests) green; `ruff check` + `ruff format --check` clean. OpenSpec delta added under `proxy-runtime-observability`.