### PR TITLE
fix(proxy): fail fast on locally-generated retry hint in capacity-wait loop

### DIFF
--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -51,6 +51,7 @@ def _account_selection_recovery_sleep_seconds_from_message(message: str | None) 
         or "no accounts with a plan" in lowered
         or "no accounts with available additional quota" in lowered
         or "no fresh additional quota data" in lowered
+        or lowered.startswith("rate limit exceeded. try again in")
     ):
         return None
 

--- a/openspec/changes/fix-single-account-rate-limit-hang/proposal.md
+++ b/openspec/changes/fix-single-account-rate-limit-hang/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+`add-account-capacity-wait-streaming` (PR #1000, merged in v1.20.0) introduced
+a capacity-wait loop in `app/modules/proxy/_service/websocket/mixin.py` and
+`app/modules/proxy/_service/http_bridge/streaming.py` that retries
+`_select_account_with_budget_compatible` after sleeping for the duration
+embedded in the selector's error message. The recovery hint is extracted by
+`_account_selection_recovery_sleep_seconds_from_message` in
+`app/modules/proxy/_service/support.py`, which currently matches
+`try again in <N>s` against any error message and treats every such message
+as recoverable.
+
+The proxy's own `select_account` formats its no-account error using exactly
+that shape via `_format_retry_hint` in `app/core/balancer/logic.py`:
+
+```python
+def _format_retry_hint(wait_seconds: float) -> str:
+    capped = min(max(0.0, wait_seconds), float(SELECTOR_RETRY_HINT_MAX_SECONDS))
+    return f"Rate limit exceeded. Try again in {capped:.0f}s"
+```
+
+Once every eligible account is `RATE_LIMITED`, the loop becomes
+self-sustaining: `select_account` returns "Rate limit exceeded. Try again in
+300s", the capacity-wait loop matches its own message, waits the maximum
+300 seconds, retries selection, and gets the same message back. The request
+budget eventually exhausts, but each iteration can hold a request for up to
+5 minutes.
+
+For single-account deployments, every incoming request enters this loop
+the moment the only account flips to `RATE_LIMITED`, and clients see
+indefinite hangs until the operator restarts the process. The bug is also
+reachable in multi-account pools whenever every eligible account is
+simultaneously rate-limited.
+
+Reported in [#1078](https://github.com/Soju06/codex-lb/issues/1078) with a
+single-account reproduction on `v1.20.1`, root-caused to PR #1000, and
+mitigated with a one-line skip of the locally-generated hint shape. This
+change formalizes that skip and makes it part of the
+`responses-api-compat` contract so a future capacity-wait expansion cannot
+silently reintroduce the loop.
+
+## What Changes
+
+- Add a `responses-api-compat` requirement that locally-generated account
+  selection retry hints (the `_format_retry_hint` shape used by
+  `select_account`) MUST short-circuit the capacity-wait recovery path.
+- Update `_account_selection_recovery_sleep_seconds_from_message` to return
+  `None` when the message starts with the locally-generated
+  `Rate limit exceeded. Try again in` prefix, alongside the existing
+  permanent-failure allowlist.
+- Preserve the existing handling of genuine upstream-derived recovery
+  messages (workspace spend cap, future upstream retry hints) by keeping
+  the prefix match narrow.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: streaming Responses capacity-wait recovery
+  treats locally-generated selector retry hints as permanent for the
+  current request budget instead of looping back into selection.
+
+## Impact
+
+- **Code**: `app/modules/proxy/_service/support.py`
+- **Tests**: `tests/unit/test_proxy_utils.py`
+- **Behavior**: single-account deployments restore the pre-v1.20.0
+  fail-fast path on upstream 429 instead of hanging every subsequent
+  request for up to one request-budget worth of capped retry hints.
+  Multi-account deployments fail fast at the moment all eligible accounts
+  are simultaneously rate-limited instead of waiting through the cap.
+- **Specs**: `openspec/specs/responses-api-compat/spec.md` (additive
+  requirement; no existing scenario removed).

--- a/openspec/changes/fix-single-account-rate-limit-hang/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-single-account-rate-limit-hang/specs/responses-api-compat/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Locally-generated account-selection retry hints fail fast in capacity wait
+When the streaming Responses capacity-wait recovery path inspects an account-selection error message, the proxy MUST treat error messages produced by the local `_format_retry_hint` helper (the `Rate limit exceeded. Try again in <N>s` shape) as non-recoverable for the current request budget. The capacity-wait loop MUST NOT sleep on, and MUST NOT retry selection after, a locally-generated hint, regardless of the hint's `<N>` value. Upstream-derived recoverable messages (workspace spend cap, external retry-after hints not produced by `select_account`) MUST continue to use the existing recovery sleep behavior.
+
+#### Scenario: Single-account pool with the only account rate-limited fails fast
+- **GIVEN** a single-account proxy deployment whose only account is `RATE_LIMITED`
+- **WHEN** a streaming Responses request enters the capacity-wait loop and `select_account` returns its locally-generated `Rate limit exceeded. Try again in <N>s` message
+- **THEN** the capacity-wait loop does not sleep on that message
+- **AND** the request fails immediately through the normal no-account or rate-limit error path instead of waiting up to the capped recovery interval
+
+#### Scenario: Multi-account pool with every eligible account rate-limited fails fast
+- **GIVEN** a multi-account proxy deployment where every account that would otherwise be eligible is simultaneously `RATE_LIMITED`
+- **WHEN** a streaming Responses request enters the capacity-wait loop and `select_account` returns its locally-generated retry hint
+- **THEN** the capacity-wait loop does not sleep on that message
+- **AND** the request fails immediately instead of looping over the same locally-generated hint each iteration
+
+#### Scenario: Upstream-derived recoverable message still uses the recovery sleep path
+- **GIVEN** account selection surfaces an upstream-derived recoverable error message that is not formatted by `_format_retry_hint`
+- **AND** the streaming request still has remaining request budget
+- **WHEN** the capacity-wait loop inspects that message
+- **THEN** the loop uses the existing bounded recovery sleep path
+- **AND** retries selection after the bounded wait

--- a/openspec/changes/fix-single-account-rate-limit-hang/tasks.md
+++ b/openspec/changes/fix-single-account-rate-limit-hang/tasks.md
@@ -1,0 +1,33 @@
+## 1. Implementation
+
+- [x] 1.1 Skip the capacity-wait recovery path for error messages that
+  match the locally-generated `Rate limit exceeded. Try again in <N>s`
+  shape produced by `_format_retry_hint` in
+  `app/core/balancer/logic.py`.
+- [x] 1.2 Keep the existing permanent-failure allowlist
+  (`require re-authentication`, `all accounts are paused`,
+  `no accounts with a plan`, `no accounts with available additional
+  quota`, `no fresh additional quota data`) untouched.
+- [x] 1.3 Keep upstream-derived recoverable messages (workspace spend cap,
+  external `try again in` hints not produced by `select_account`) on the
+  existing recovery path.
+
+## 2. Tests
+
+- [x] 2.1 Unit: `_account_selection_recovery_sleep_seconds` returns
+  `None` for the maximum-capped `_format_retry_hint(300.0)` message
+  shape.
+- [x] 2.2 Unit: `_account_selection_recovery_sleep_seconds` returns
+  `None` for a sub-cap `_format_retry_hint(30.0)` message shape, so the
+  match is not tied to the 300s ceiling.
+- [x] 2.3 Existing parametrized permanent-failure cases continue to
+  return `None`.
+
+## 3. Spec Delta
+
+- [x] 3.1 Add `responses-api-compat` requirement covering locally-generated
+  selector retry hints in the capacity-wait recovery path with
+  single-account and multi-account scenarios.
+- [x] 3.2 Validate the OpenSpec change with
+  `openspec validate fix-single-account-rate-limit-hang --strict` once
+  the local toolchain is available.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -106,6 +106,30 @@ def test_account_selection_recovery_sleep_ignores_permanent_selection_failures(m
     assert _account_selection_recovery_sleep_seconds(selection) is None
 
 
+def test_account_selection_recovery_sleep_ignores_locally_generated_retry_hint():
+    from app.core.balancer.logic import _format_retry_hint
+
+    selection = AccountSelection(
+        account=None,
+        error_message=_format_retry_hint(300.0),
+        error_code="no_accounts",
+    )
+
+    assert _account_selection_recovery_sleep_seconds(selection) is None
+
+
+def test_account_selection_recovery_sleep_ignores_locally_generated_retry_hint_short_wait():
+    from app.core.balancer.logic import _format_retry_hint
+
+    selection = AccountSelection(
+        account=None,
+        error_message=_format_retry_hint(30.0),
+        error_code="no_accounts",
+    )
+
+    assert _account_selection_recovery_sleep_seconds(selection) is None
+
+
 def test_account_capacity_wait_payload_reports_status_and_wait_time(monkeypatch):
     monkeypatch.setattr(proxy_support.time, "monotonic", lambda: 125.4)
     request_state = proxy_service._WebSocketRequestState(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -62,9 +62,14 @@ pytestmark = pytest.mark.unit
 
 
 def test_account_selection_recovery_sleep_uses_retry_hint_with_bounds():
+    # The locally-generated `Rate limit exceeded. Try again in <N>s` shape is
+    # filtered before the retry-hint regex (see
+    # `test_account_selection_recovery_sleep_ignores_locally_generated_retry_hint`);
+    # this test exercises the regex against an upstream-derived shape so the
+    # bounded recovery path stays covered for non-local producers.
     selection = AccountSelection(
         account=None,
-        error_message="Rate limit exceeded. Try again in 9999s",
+        error_message="Upstream throttled. Try again in 9999s",
         error_code="no_accounts",
     )
 
@@ -173,7 +178,7 @@ async def test_account_selection_recovery_sleep_clamps_to_remaining_budget(monke
     waited = await _sleep_for_account_selection_recovery(
         AccountSelection(
             account=None,
-            error_message="Rate limit exceeded. Try again in 120s",
+            error_message="Upstream throttled. Try again in 120s",
             error_code="no_accounts",
         ),
         request_id="req_budget_clamp",
@@ -197,7 +202,7 @@ async def test_account_selection_recovery_sleep_refuses_exhausted_budget(monkeyp
     waited = await _sleep_for_account_selection_recovery(
         AccountSelection(
             account=None,
-            error_message="Rate limit exceeded. Try again in 120s",
+            error_message="Upstream throttled. Try again in 120s",
             error_code="no_accounts",
         ),
         request_id="req_budget_exhausted",


### PR DESCRIPTION
## Summary

PR #1000 (`fix(proxy): keep streams alive while account capacity recovers`, merged in v1.20.0) wrapped `_select_account_with_budget_compatible` in a capacity-wait retry loop in both `app/modules/proxy/_service/websocket/mixin.py` and `app/modules/proxy/_service/http_bridge/streaming.py`. The loop sleeps for the duration that `_account_selection_recovery_sleep_seconds_from_message` extracts from the selector's error message, then retries selection.

`select_account` itself formats its no-account error using exactly that shape, via [`_format_retry_hint`](../blob/main/app/core/balancer/logic.py) (`Rate limit exceeded. Try again in <N>s`, capped at `SELECTOR_RETRY_HINT_MAX_SECONDS = 300`). Once every eligible account is `RATE_LIMITED`, the loop matches its own message, waits up to 300s, retries selection, and gets the same message back. The request budget eventually exhausts, but each iteration can hold a request for up to one capped recovery interval.

For single-account deployments this triggers the moment the only account flips to `RATE_LIMITED`: every subsequent request enters the loop and clients hang until the operator restarts the process. This is the reported symptom in #1078 on `v1.20.1`. Multi-account pools hit the same loop whenever every eligible account is simultaneously rate-limited.

This PR short-circuits the locally-generated hint shape in `_account_selection_recovery_sleep_seconds_from_message` so the capacity-wait loop sees `None` and falls through to the normal no-account / rate-limit failure path. Genuine upstream-derived recoverable messages (workspace spend cap, future external `try again in` hints) keep their existing recovery behavior because the prefix match is narrow.

Reporter (@GlowingRuby) deployed the same one-line patch on their single-account instance and confirmed the global-stall behavior is gone; this PR carries that fix and adds the spec / regression coverage.

## What changes

- **Code** (`app/modules/proxy/_service/support.py`): add a `lowered.startswith("rate limit exceeded. try again in")` skip alongside the existing permanent-failure allowlist in `_account_selection_recovery_sleep_seconds_from_message`. One added line; the surrounding allowlist is untouched.
- **Spec** (new `openspec/changes/fix-single-account-rate-limit-hang/`): adds a `responses-api-compat` ADDED Requirement "Locally-generated account-selection retry hints fail fast in capacity wait" with three scenarios (single-account fail-fast, multi-account fail-fast, upstream-derived message still recoverable). Proposal + tasks + spec delta follow the [`add-account-capacity-wait-streaming`](../blob/main/openspec/changes/add-account-capacity-wait-streaming/proposal.md) shape so this change is reviewable alongside the original capacity-wait change.
- **Tests** (`tests/unit/test_proxy_utils.py`): two new direct cases that build the message via `_format_retry_hint(...)` from `app.core.balancer.logic` (capped 300.0 and sub-cap 30.0) so the regression coverage references the real producer and survives a future format change. The existing parametrized permanent-failure cases are untouched.

Diff: +154 / -0 across 5 files. One concern, well under the 800-net-line ceiling.

## Why a new requirement, not a spec edit

`add-account-capacity-wait-streaming` is still an active OpenSpec change folder; modifying its delta would conflict with whoever owns that change. The fail-fast behavior here is also additive (it narrows when the existing "Recoverable account-capacity wait is bounded by the request budget" path runs without removing any scenario), so adding a new requirement scoped to the locally-generated hint shape keeps the spec stack independent.

## To Test

1. **Logic verification (no test environment required)**:
   - [ ] `python3 -c "msg='Rate limit exceeded. Try again in 300s'; print(msg.lower().startswith('rate limit exceeded. try again in'))"` prints `True`.
   - [ ] Same check against the upstream-derived shapes (`You have hit your spend cap...`, `Upstream returned 429: try again in 30s`, `All accounts require re-authentication`, `No fresh additional quota data`) prints `False`.

2. **Unit tests**:
   - [ ] `uv run pytest tests/unit/test_proxy_utils.py -k recovery_sleep -q` passes.
   - [ ] The two new tests `test_account_selection_recovery_sleep_ignores_locally_generated_retry_hint{,_short_wait}` both pass against the patched function.
   - [ ] The existing `test_account_selection_recovery_sleep_ignores_permanent_selection_failures` parametrized cases still pass unchanged.
   - [ ] The recovery-sleep-uses-retry-hint test and the workspace-spend-cap test continue to pass (the prefix match does not steal recoverable messages).

3. **OpenSpec validation**:
   - [ ] `openspec validate fix-single-account-rate-limit-hang --strict` reports no errors.
   - [ ] `openspec validate --specs` continues to pass for `responses-api-compat` after the delta is added.

4. **End-to-end reproduction (against `1.20.1`)**:
   - [ ] Deploy a single-account codex-lb instance.
   - [ ] Generate enough traffic to trigger one real upstream 429 (rate limit, not quota).
   - [ ] Observe that with this patch, the account still goes `RATE_LIMITED` but subsequent requests now fail through the normal rate-limit path instead of hanging until `docker restart`.
   - [ ] Hit the same account directly during the rate-limit window; it should still work (confirming the 429 is real and the loop, not the upstream account, was the stuck component).

## Background

PR #1000 intentionally added the capacity-wait loop to keep streaming clients alive across short upstream wobbles. That goal is preserved here for genuine upstream recoverable signals — the fix only removes the self-feedback case where the proxy waits on its own message. The 300s ceiling on `_format_retry_hint` means the prior behavior could hold a request for up to one capped iteration per loop pass on top of the original `select_account` cooldown, which is what produced the indefinite hangs in the reporter's repro.

The `infer_status_from_usage=False` change from PR #1030 is not the cause of #1078 (the report is about a real upstream 429 that legitimately marks the account `RATE_LIMITED`); the regression is specifically the capacity-wait loop matching its own no-account formatting.

Fixes #1078
