### PR TITLE
chore: release v1.20.2-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.20.1"  # x-release-please-version
+__version__ = "1.20.2-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.20.1
-appVersion: 1.20.1
+version: 1.20.2-beta.1
+appVersion: 1.20.2-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.20.1",
+  "version": "1.20.2-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.20.1"
+version = "1.20.2-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.20.1"
+version = "1.20.2-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.20.2-beta.1 for the 1.20.2 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.20.2-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1087; no manual beta workflow dispatch is required.

## Changes since v1.20.1
- fix(quota-planner): normalize decision datetimes for persistence (#1034) (9f5ae7c)
- fix(proxy): avoid shielded-future log on startup probe timeout (#1076) (21c03e)
- fix(ci): ignore stale and resolved Codex inline findings (#981) (384e9b)
- fix(models): hide unsupported API models (#887) (c5714c)
- fix(dashboard): correct weekly credits pace display (#955) (30b363)
- fix(proxy): normalize non-native upstream requests to Codex CLI fingerprint (#1089) (8616e4)

## Release-candidate validation
Validated candidate: f936fd1261669b5d669a811d0e1b2acbb01b4ce7

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI run 28167880256 on f936fd12: `Tests (pytest, unit)`, `Tests (pytest, PostgreSQL)`, `Tests (pytest, e2e)`, `Tests (pytest, integration-bridge)`, `Tests (pytest, integration-core)`, `Migration check (alembic)` + `(PostgreSQL)` all green.
- [x] Frontend tests/build — CI run 28167880256 on f936fd12: `Frontend tests (vitest + coverage)`, `Frontend build (vite)`, `Frontend type check (tsc)`, `Frontend lint (eslint)` all green.
- [x] Wheel/package validation — CI `Package (build)` green on f936fd12, plus local `uv build` on the candidate worktree produced `codex_lb-1.20.2b1-py3-none-any.whl` and `codex_lb-1.20.2b1.tar.gz` (version 1.20.2b1 verified).
- [x] Docker/container smoke — CI `Docker build` green on f936fd12, plus local image build from the candidate worktree (`docker build`) and a container boot smoke (`codex-lb --help` via the entrypoint loads `app.cli` and prints usage; Python import + entrypoint healthy).
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this beta bumps release-managed version metadata only; its sole code change since v1.20.1 is #1089 (upstream fingerprint normalization), whose live upstream path was validated against production before #1089 was merged. No additional live upstream/account smoke is required for the version-only beta bump.

## Install after publish
```bash
uvx --from "codex-lb==1.20.2b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.20.2-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.20.2-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.20.2.