### PR TITLE
fix(proxy): normalize non-native upstream requests to Codex CLI fingerprint

### DIFF
--- a/app/core/clients/codex_version.py
+++ b/app/core/clients/codex_version.py
@@ -63,6 +63,19 @@ class CodexVersionCache:
             self._cached_version = None
             self._cached_at = 0.0
 
+    def cached_version_or_default(self) -> str:
+        """Return the cached Codex client version without any network I/O.
+
+        Safe to call from synchronous hot paths (e.g. upstream header build).
+        Falls back to the configured client-version default when the cache has
+        not been warmed yet. Cache warming happens via the async
+        ``get_version()`` already invoked by the model-registry refresh cycle.
+        """
+        cached = self._cached_version
+        if cached is not None:
+            return cached
+        return get_settings().model_registry_client_version
+
     async def _fetch_latest_version(self) -> str | None:
         timeout = aiohttp.ClientTimeout(total=_FETCH_TIMEOUT_SECONDS)
         try:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -43,6 +43,7 @@ from app.core.clients.codex import (
     create_codex_session,
     require_route_or_direct_egress_opt_in,
 )
+from app.core.clients.codex_version import get_codex_version_cache
 from app.core.clients.http import acquire_http_client, lease_http_session
 from app.core.config.settings import Settings, get_settings
 from app.core.conversation_archive import archive_json, archive_text
@@ -442,6 +443,83 @@ def filter_inbound_headers(headers: Mapping[str, str]) -> dict[str, str]:
     return {key: value for key, value in headers.items() if not _should_drop_inbound_header(key)}
 
 
+_NATIVE_CODEX_USER_AGENT_PREFIXES: tuple[str, ...] = (
+    "codex_cli_rs",
+    "codex-tui",
+    "codex_exec",
+    "codex_vscode",
+    "codex desktop",
+    "codex ",
+)
+_SDK_FINGERPRINT_HEADER_KEYS: frozenset[str] = frozenset(
+    {
+        "x-openai-client-version",
+        "x-openai-client-os",
+        "x-openai-client-arch",
+        "x-openai-client-id",
+        "x-openai-client-user-agent",
+    }
+)
+_CODEX_CLI_ORIGINATOR = "codex_cli_rs"
+_CHATGPT_ACCOUNT_ID_HEADER = "ChatGPT-Account-Id"
+_DEFAULT_FINGERPRINT_OS = "Mac OS 26.5.0"
+_DEFAULT_FINGERPRINT_ARCH = "arm64"
+_DEFAULT_FINGERPRINT_TERMINAL = "iTerm.app/3.6.10"
+
+
+def build_codex_user_agent(version: str) -> str:
+    """Build a Codex CLI ``User-Agent`` matching ``get_codex_user_agent()`` from
+    ``openai/codex`` (``codex-rs/login/src/auth/default_client.rs``):
+    ``codex_cli_rs/<version> (<os>; <arch>) <terminal>``.
+
+    OS/arch/terminal come from operator-configurable settings; the version is
+    the live Codex client version resolved by the caller. Settings access is
+    defensive (``getattr`` with built-in defaults) so header construction can
+    never raise and fail an otherwise-valid upstream request.
+    """
+    settings = get_settings()
+    os_name = getattr(settings, "codex_fingerprint_os", _DEFAULT_FINGERPRINT_OS)
+    arch = getattr(settings, "codex_fingerprint_arch", _DEFAULT_FINGERPRINT_ARCH)
+    terminal = getattr(settings, "codex_fingerprint_terminal", _DEFAULT_FINGERPRINT_TERMINAL)
+    return f"{_CODEX_CLI_ORIGINATOR}/{version} ({os_name}; {arch}) {terminal}"
+
+
+def _is_native_codex_user_agent(user_agent: str | None) -> bool:
+    if not user_agent:
+        return False
+    lowered = user_agent.strip().lower()
+    return any(lowered.startswith(prefix) for prefix in _NATIVE_CODEX_USER_AGENT_PREFIXES)
+
+
+def _is_native_codex_request(headers: Mapping[str, str]) -> bool:
+    """A request is native when its User-Agent already identifies a Codex
+    client, or it already carries native Codex transport headers (originator in
+    the native set, or any ``x-codex-*`` stream header)."""
+    user_agent = None
+    for key, value in headers.items():
+        if key.lower() == "user-agent":
+            user_agent = value
+            break
+    if _is_native_codex_user_agent(user_agent):
+        return True
+    return _has_native_codex_transport_headers(headers)
+
+
+def _normalize_non_native_upstream_fingerprint(headers: dict[str, str]) -> None:
+    """Rewrite a non-native request's outbound fingerprint to the Codex CLI
+    persona in place: set ``User-Agent`` to a ``codex_cli_rs`` string, strip
+    SDK-only ``x-openai-client-*`` headers, and strip any inbound
+    ``originator`` header (the real Codex CLI omits it for the default
+    originator and lets the backend read it from the User-Agent prefix)."""
+    version = get_codex_version_cache().cached_version_or_default()
+    codex_user_agent = build_codex_user_agent(version)
+    for key in list(headers.keys()):
+        lowered = key.lower()
+        if lowered == "user-agent" or lowered in _SDK_FINGERPRINT_HEADER_KEYS or lowered == "originator":
+            del headers[key]
+    headers["User-Agent"] = codex_user_agent
+
+
 def _build_upstream_headers(
     inbound: Mapping[str, str],
     access_token: str,
@@ -449,16 +527,22 @@ def _build_upstream_headers(
     accept: str = "text/event-stream",
 ) -> dict[str, str]:
     headers = dict(inbound)
+    native = _is_native_codex_request(headers)
     lower_keys = {key.lower() for key in headers}
     if "x-request-id" not in lower_keys and "request-id" not in lower_keys:
         request_id = get_request_id()
         if request_id:
             headers["x-request-id"] = request_id
+    if not native:
+        _normalize_non_native_upstream_fingerprint(headers)
     headers["Authorization"] = f"Bearer {access_token}"
     headers["Accept"] = accept
     headers["Content-Type"] = "application/json"
     if account_id:
-        headers["chatgpt-account-id"] = account_id
+        if native:
+            headers["chatgpt-account-id"] = account_id
+        else:
+            headers[_CHATGPT_ACCOUNT_ID_HEADER] = account_id
     return headers
 
 

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -594,14 +594,26 @@ def _build_upstream_websocket_headers(
         )
     blocked_header_names = _HOP_BY_HOP_HEADER_NAMES | connected_header_tokens
     headers = {key: value for key, value in inbound.items() if key.lower() not in blocked_header_names}
+    native = _is_native_codex_request(headers)
     lower_keys = {key.lower() for key in headers}
     if "x-request-id" not in lower_keys and "request-id" not in lower_keys:
         request_id = get_request_id()
         if request_id:
             headers["x-request-id"] = request_id
+    # Normalize a non-native client's fingerprint regardless of transport. The
+    # ``auto`` transport routes a turn-state continuity follow-up onto the
+    # websocket path even for an HTTP SDK client, so this builder must apply the
+    # same codex_cli_rs persona rewrite as ``_build_upstream_headers``; otherwise
+    # the SDK fingerprint reaches upstream unchanged and the priority-downgrade
+    # mitigation is bypassed for exactly the continuity-token scenario.
+    if not native:
+        _normalize_non_native_upstream_fingerprint(headers)
     headers["Authorization"] = f"Bearer {access_token}"
     if account_id:
-        headers["chatgpt-account-id"] = account_id
+        if native:
+            headers["chatgpt-account-id"] = account_id
+        else:
+            headers[_CHATGPT_ACCOUNT_ID_HEADER] = account_id
     return headers
 
 

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -492,17 +492,27 @@ def _is_native_codex_user_agent(user_agent: str | None) -> bool:
 
 
 def _is_native_codex_request(headers: Mapping[str, str]) -> bool:
-    """A request is native when its User-Agent already identifies a Codex
-    client, or it already carries native Codex transport headers (originator in
-    the native set, or any ``x-codex-*`` stream header)."""
+    """A request is native when its identity headers mark it as a first-party
+    Codex client: either a native Codex ``User-Agent`` prefix, or an
+    ``originator`` header whose value is in the native Codex originator set.
+
+    Transport/continuity headers (``x-codex-turn-state`` and friends) are
+    deliberately NOT treated as native signals: an HTTP SDK client replays the
+    ``x-codex-turn-state`` token the upstream returns for continuity, so keying
+    the exemption on those headers would let a non-native SDK follow-up skip
+    normalization and reach upstream with its downgraded fingerprint intact.
+    """
     user_agent = None
+    originator = None
     for key, value in headers.items():
-        if key.lower() == "user-agent":
+        lowered = key.lower()
+        if lowered == "user-agent":
             user_agent = value
-            break
+        elif lowered == "originator":
+            originator = value
     if _is_native_codex_user_agent(user_agent):
         return True
-    return _has_native_codex_transport_headers(headers)
+    return _is_native_codex_originator(originator)
 
 
 def _normalize_non_native_upstream_fingerprint(headers: dict[str, str]) -> None:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -460,6 +460,13 @@ _SDK_FINGERPRINT_HEADER_KEYS: frozenset[str] = frozenset(
         "x-openai-client-user-agent",
     }
 )
+# OpenAI SDKs (the Stainless-generated clients) attach an ``x-stainless-*``
+# header family (os, arch, runtime, runtime-version, package-version, ...) with
+# a variable suffix. The API layer treats any ``x-stainless-*`` header as an
+# OpenAI SDK signal, so they must be stripped by prefix on a normalized request
+# or upstream can still distinguish SDK traffic from the Codex CLI and apply the
+# downgrade this change is meant to avoid.
+_SDK_FINGERPRINT_HEADER_PREFIXES: tuple[str, ...] = ("x-stainless-",)
 _CODEX_CLI_ORIGINATOR = "codex_cli_rs"
 _CHATGPT_ACCOUNT_ID_HEADER = "ChatGPT-Account-Id"
 _DEFAULT_FINGERPRINT_OS = "Mac OS 26.5.0"
@@ -518,14 +525,19 @@ def _is_native_codex_request(headers: Mapping[str, str]) -> bool:
 def _normalize_non_native_upstream_fingerprint(headers: dict[str, str]) -> None:
     """Rewrite a non-native request's outbound fingerprint to the Codex CLI
     persona in place: set ``User-Agent`` to a ``codex_cli_rs`` string, strip
-    SDK-only ``x-openai-client-*`` headers, and strip any inbound
-    ``originator`` header (the real Codex CLI omits it for the default
+    SDK-only ``x-openai-client-*`` and ``x-stainless-*`` headers, and strip any
+    inbound ``originator`` header (the real Codex CLI omits it for the default
     originator and lets the backend read it from the User-Agent prefix)."""
     version = get_codex_version_cache().cached_version_or_default()
     codex_user_agent = build_codex_user_agent(version)
     for key in list(headers.keys()):
         lowered = key.lower()
-        if lowered == "user-agent" or lowered in _SDK_FINGERPRINT_HEADER_KEYS or lowered == "originator":
+        if (
+            lowered == "user-agent"
+            or lowered in _SDK_FINGERPRINT_HEADER_KEYS
+            or lowered.startswith(_SDK_FINGERPRINT_HEADER_PREFIXES)
+            or lowered == "originator"
+        ):
             del headers[key]
     headers["User-Agent"] = codex_user_agent
 
@@ -734,6 +746,21 @@ def _error_payload_from_websocket_handshake_error(exc: aiohttp.WSServerHandshake
     return openai_error(code, message)
 
 
+def _account_id_for_upstream_log(headers: Mapping[str, str]) -> str | None:
+    """Read the upstream account id from request headers case-insensitively.
+
+    A normalized non-native request carries the id under PascalCase
+    ``ChatGPT-Account-Id`` while native requests use lowercase
+    ``chatgpt-account-id``; a case-sensitive lookup would log ``account_id=None``
+    for normalized SDK traffic and drop the per-account diagnostics this feature
+    exists to provide.
+    """
+    for key, value in headers.items():
+        if key.lower() == "chatgpt-account-id":
+            return value
+    return None
+
+
 def _maybe_log_upstream_request_start(
     *,
     kind: str,
@@ -749,7 +776,7 @@ def _maybe_log_upstream_request_start(
 
     request_id = get_request_id()
     target = _summarize_upstream_target(url)
-    account_id = headers.get("chatgpt-account-id")
+    account_id = _account_id_for_upstream_log(headers)
     header_keys = _interesting_upstream_header_keys(headers)
 
     if settings.log_upstream_request_summary:
@@ -811,7 +838,7 @@ def _maybe_log_upstream_request_complete(
         kind,
         method,
         _summarize_upstream_target(url),
-        headers.get("chatgpt-account-id"),
+        _account_id_for_upstream_log(headers),
         status_code,
         int((time.monotonic() - started_at) * 1000),
         error_code,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -141,6 +141,7 @@ _NATIVE_CODEX_ORIGINATORS = frozenset(
         "codex_chatgpt_desktop",
         "codex_cli_rs",
         "codex_exec",
+        "codex_sdk_ts",
         "codex_vscode",
     }
 )
@@ -447,6 +448,7 @@ _NATIVE_CODEX_USER_AGENT_PREFIXES: tuple[str, ...] = (
     "codex_cli_rs",
     "codex-tui",
     "codex_exec",
+    "codex_sdk_ts",
     "codex_vscode",
     "codex desktop",
     "codex ",

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -27,7 +27,13 @@ from app.core.clients.codex import (
     create_codex_session,
     require_route_or_direct_egress_opt_in,
 )
-from app.core.clients.proxy import ProxyResponseError, filter_inbound_headers
+from app.core.clients.proxy import (
+    _CHATGPT_ACCOUNT_ID_HEADER,
+    ProxyResponseError,
+    _is_native_codex_request,
+    _normalize_non_native_upstream_fingerprint,
+    filter_inbound_headers,
+)
 from app.core.config.settings import get_settings
 from app.core.conversation_archive import archive_bytes, archive_text
 from app.core.errors import OpenAIErrorDetail, OpenAIErrorEnvelope, openai_error
@@ -297,14 +303,26 @@ def _build_upstream_websocket_headers(
     account_id: str | None,
 ) -> dict[str, str]:
     headers = {key: value for key, value in inbound.items() if key.lower() != "cookie"}
+    native = _is_native_codex_request(headers)
     lower_keys = {key.lower() for key in headers}
     if "x-request-id" not in lower_keys and "request-id" not in lower_keys:
         request_id = get_request_id()
         if request_id:
             headers["x-request-id"] = request_id
+    # Normalize a non-native client's fingerprint on the client-facing
+    # ``/v1/responses`` websocket egress too. This builder is the upstream egress
+    # for a direct websocket caller, so without normalization an OpenAI SDK that
+    # speaks the responses websocket protocol would reach upstream with its
+    # ``OpenAI/Python`` / ``x-openai-client-*`` / ``x-stainless-*`` fingerprint
+    # intact and trigger the priority downgrade this change exists to prevent.
+    if not native:
+        _normalize_non_native_upstream_fingerprint(headers)
     headers["Authorization"] = f"Bearer {access_token}"
     if account_id:
-        headers["chatgpt-account-id"] = account_id
+        if native:
+            headers["chatgpt-account-id"] = account_id
+        else:
+            headers[_CHATGPT_ACCOUNT_ID_HEADER] = account_id
     _ensure_responses_websocket_beta_header(headers)
     return headers
 

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -242,6 +242,9 @@ class Settings(BaseSettings):
     model_registry_enabled: bool = True
     model_registry_refresh_interval_seconds: int = Field(default=300, gt=0)
     model_registry_client_version: str = "0.101.0"
+    codex_fingerprint_os: str = "Mac OS 26.5.0"
+    codex_fingerprint_arch: str = "arm64"
+    codex_fingerprint_terminal: str = "iTerm.app/3.6.10"
     model_context_window_overrides: Annotated[dict[str, int], NoDecode] = Field(default_factory=dict)
     proxy_unauthenticated_client_cidrs: Annotated[list[str], NoDecode] = Field(default_factory=list)
     firewall_trust_proxy_headers: bool = False

--- a/openspec/changes/normalize-upstream-codex-fingerprint/proposal.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/proposal.md
@@ -1,0 +1,131 @@
+# Normalize non-native upstream requests to the Codex CLI client fingerprint
+
+## Problem
+
+On production codex-lb (`gpt-5.5`, priority-tier API keys), a large share of
+requests fail with `server_is_overloaded` ("Our servers are currently
+overloaded. Please try again later."). Measured over a 12h prod window:
+
+- `gpt-5.5` overall: **8.94%** of requests (1010/11293) surfaced
+  `server_is_overloaded`.
+- Split by the tier the ChatGPT backend actually applied
+  (`actual_service_tier`): `default` tier = **0.18%** failures, but `auto`
+  tier = **85.04%** failures. ~98.5% of all overload events were `auto`-tier
+  requests.
+- `auto` is not what clients requested. Clients sent
+  `requested_service_tier=priority`; the backend **downgraded** a fraction of
+  them to `auto`, and those downgraded requests are the ones that overload.
+
+The downgrade rate is not uniform across clients sending the same
+`priority` tier. Split by transport + client User-Agent over a 3h window:
+
+| transport | client User-Agent | priority reqs | downgraded→auto |
+|-----------|-------------------|---------------|-----------------|
+| http      | `OpenAI/Python`   | 2231          | **20.3%**       |
+| websocket | `codex-tui` / `codex_exec` / `Codex Desktop` | ~2000 | **2.8–6.0%** |
+| http      | `OpenAI/Python` (other key, woonggi) | 21 | **28.6%** |
+
+The same `OpenAI/Python` http path downgrades at ~20–29% regardless of which
+API key sends it, while native Codex clients (websocket) stay at ~3–6%. This
+is a **client-fingerprint** effect, not a per-key or per-account effect.
+
+Root cause: the ChatGPT/Codex backend whitelists first-party Codex
+originators (`codex_cli_rs`, `codex_vscode`, `codex_sdk_ts`, or anything
+starting with `Codex`; see
+`openai/codex` `codex-rs/login/src/auth/default_client.rs`
+`DEFAULT_ORIGINATOR` and `codex-rs/core/src/client.rs` `add_originator_header`).
+Requests carrying a non-first-party fingerprint (e.g. the `openai` Python SDK's
+`User-Agent: OpenAI/Python x.y.z` plus `x-openai-client-*` headers) are treated
+as second-class API traffic: their requested `priority` tier is more likely to
+be downgraded to `auto`, which the backend sheds first under load.
+
+codex-lb forwards the inbound client's headers verbatim on the http path
+(`app/core/clients/proxy.py::_build_upstream_headers` does `headers =
+dict(inbound)` with no User-Agent / originator normalization), so a
+non-native client's fingerprint reaches the backend unchanged.
+
+## Solution
+
+Normalize **non-native http** upstream requests to the Codex CLI
+(`codex_cli_rs`) client fingerprint inside
+`app/core/clients/proxy.py::_build_upstream_headers`, matching what the
+official Codex CLI sends (`get_codex_user_agent()` in
+`codex-rs/login/src/auth/default_client.rs`):
+
+1. Set `User-Agent` to
+   `codex_cli_rs/<version> (<os>; <arch>) <terminal>`, where `<version>` comes
+   from the existing `CodexVersionCache` (GitHub releases → npm → stale cache →
+   `model_registry_client_version` settings default) and `<os>/<arch>/<terminal>`
+   come from new configurable settings (defaults
+   `Mac OS 26.5.0` / `arm64` / `iTerm.app/3.6.10`).
+2. Strip SDK-only fingerprint headers (`x-openai-client-version`,
+   `x-openai-client-os`, `x-openai-client-arch`, `x-openai-client-id`,
+   `x-openai-client-user-agent`).
+3. Do **not** add an `originator` header: the real Codex CLI omits the
+   `originator` header when the originator equals the default (`codex_cli_rs`)
+   and lets the backend read it from the `User-Agent` prefix. Strip any
+   inbound `originator` header so no SDK-supplied value leaks through.
+4. Use PascalCase `ChatGPT-Account-Id` for the account header, matching Codex
+   CLI (`codex-rs/backend-client/src/client.rs`).
+
+A request is **native** (left untouched) when its User-Agent already begins
+with a known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
+`codex_vscode`, `Codex Desktop`, or `Codex ...`) **or** it already carries
+native Codex transport headers (`originator` in the native set, or any
+`x-codex-*` stream header). websocket requests are unaffected because they use
+`_build_upstream_websocket_headers` and already connect as native Codex
+clients.
+
+## Why this is correct as a behavior change
+
+- `outbound-http-clients` already promises stable, persona-aware outbound
+  headers (the OAuth authorize originator persona requirement). Normalizing the
+  proxy's upstream client fingerprint to the same first-party Codex persona is
+  consistent with that capability's existing intent.
+- No client can depend on its raw `User-Agent` / `x-openai-client-*` reaching
+  the ChatGPT backend: those headers are an upstream-private transport detail,
+  not part of any documented codex-lb request/response contract. codex-lb's own
+  `request_logs.useragent` keeps the original client value for observability;
+  only the upstream wire fingerprint changes.
+- Native Codex clients are explicitly excluded, so the change cannot regress
+  the already-healthy native path.
+
+## Changes
+
+### Spec deltas
+- `outbound-http-clients`: ADD a Requirement covering non-native upstream http
+  request fingerprint normalization (User-Agent, originator omission, SDK
+  header stripping, account-header casing, native-client exemption).
+
+### Code
+- `app/core/clients/codex_version.py::CodexVersionCache` — add a synchronous
+  `cached_version_or_default()` read path (no `await`, no network) for the
+  hot header-build path; background refresh stays on the existing async
+  `get_version()` already called every model-registry refresh cycle.
+- `app/core/clients/proxy.py` — add `build_codex_user_agent(version)` helper
+  and a `_normalize_non_native_upstream_fingerprint()` step; call it from
+  `_build_upstream_headers` for non-native http requests. Add native-client
+  detection by User-Agent prefix combined with the existing
+  `_has_native_codex_transport_headers`.
+- `app/core/config/settings.py` — add `codex_fingerprint_os`,
+  `codex_fingerprint_arch`, `codex_fingerprint_terminal` settings (defaults
+  `Mac OS 26.5.0` / `arm64` / `iTerm.app/3.6.10`).
+
+### Tests
+- `tests/unit/test_proxy_upstream_fingerprint.py` (new) — non-native http UA
+  rewritten to `codex_cli_rs/...`; native UA + websocket unchanged;
+  `x-openai-client-*` and inbound `originator` stripped; no `originator` header
+  added; PascalCase `ChatGPT-Account-Id`; version sourced from cache with
+  settings-default fallback.
+- `tests/unit/test_codex_version_cache.py` — `cached_version_or_default()`
+  returns the cached version when present and the settings default when empty,
+  with no network/await.
+
+## Out of scope
+
+- Changing websocket upstream headers (`_build_upstream_websocket_headers`).
+- Changing native Codex client requests.
+- Per-key rate limiting, account-pool sizing, or retry/backoff policy for
+  `auto`-tier overloads (separate concerns).
+- Auto-detecting the host OS/arch for the fingerprint (intentionally fixed,
+  operator-overridable settings).

--- a/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
@@ -20,9 +20,11 @@ native Codex client requests on any transport.
 
 A request is considered **native** when its inbound `User-Agent` begins with a
 known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
-`codex_vscode`, `Codex Desktop`, or a value starting with `Codex `) OR it
-carries an `originator` header whose value is in the native Codex originator
-set. Transport/continuity headers (`x-codex-turn-state` and other `x-codex-*`
+`codex_sdk_ts`, `codex_vscode`, `Codex Desktop`, or a value starting with
+`Codex `) OR it carries an `originator` header whose value is in the native
+Codex originator set (which MUST include every first-party originator the
+backend whitelists, e.g. `codex_cli_rs`, `codex_vscode`, `codex_sdk_ts`).
+Transport/continuity headers (`x-codex-turn-state` and other `x-codex-*`
 stream headers) MUST NOT be treated as a native signal, because a non-native
 client replays the upstream-issued `x-codex-turn-state` token for continuity;
 treating it as native would let that follow-up reach upstream with its
@@ -67,6 +69,13 @@ in-process cache that is refreshed by existing background refresh paths.
 - **WHEN** an http upstream request arrives with `User-Agent: codex_exec/0.142.1 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.142.1)`
 - **THEN** the outbound `User-Agent` equals the inbound `User-Agent`
 - **AND** the request fingerprint is not normalized
+
+#### Scenario: first-party Codex SDK request is left unchanged
+
+- **WHEN** an http upstream request carries an `originator: codex_sdk_ts` header
+  (a first-party originator the backend whitelists)
+- **THEN** the outbound request is treated as native
+- **AND** its `User-Agent` and `originator` header are not rewritten or stripped
 
 #### Scenario: non-native request replaying a continuity token is still normalized
 

--- a/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
@@ -35,7 +35,8 @@ For a non-native request, the service MUST:
   `arm64`, and `iTerm.app/3.6.10`.
 - Remove SDK-only fingerprint headers `x-openai-client-version`,
   `x-openai-client-os`, `x-openai-client-arch`, `x-openai-client-id`, and
-  `x-openai-client-user-agent`.
+  `x-openai-client-user-agent`, as well as every `x-stainless-*` header (the
+  OpenAI SDK fingerprint family the API layer uses to detect SDK callers).
 - Remove any inbound `originator` header and MUST NOT add an `originator`
   header, matching the Codex CLI behavior of omitting the header when the
   originator equals the default `codex_cli_rs`.
@@ -50,11 +51,12 @@ in-process cache that is refreshed by existing background refresh paths.
 #### Scenario: non-native SDK http request is rewritten to the Codex CLI fingerprint
 
 - **WHEN** an http upstream request arrives with `User-Agent: OpenAI/Python 2.24.0`
-  and `x-openai-client-version` / `x-openai-client-os` headers
+  and `x-openai-client-version` / `x-openai-client-os` / `x-stainless-os` headers
 - **THEN** the outbound `User-Agent` is `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
 - **AND** the `x-openai-client-version`, `x-openai-client-os`,
   `x-openai-client-arch`, `x-openai-client-id`, and `x-openai-client-user-agent`
   headers are absent from the outbound request
+- **AND** every `x-stainless-*` header is absent from the outbound request
 - **AND** no `originator` header is present on the outbound request
 
 #### Scenario: native Codex http request is left unchanged
@@ -95,6 +97,14 @@ in-process cache that is refreshed by existing background refresh paths.
 - **WHEN** a non-native http request is normalized and an upstream account id is present
 - **THEN** the outbound request carries the account id under the PascalCase
   header name `ChatGPT-Account-Id`
+
+#### Scenario: per-account upstream diagnostics survive normalization
+
+- **WHEN** upstream request logging is enabled and a normalized non-native
+  request carries its account id under the PascalCase `ChatGPT-Account-Id` header
+- **THEN** the upstream request start/complete log entries record the account id
+  rather than `None`, so per-account diagnostics are preserved regardless of the
+  header casing produced by normalization
 
 #### Scenario: fingerprint version falls back to the configured default
 

--- a/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
@@ -13,8 +13,12 @@ and MUST NOT modify websocket upstream requests.
 A request is considered **native** when its inbound `User-Agent` begins with a
 known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
 `codex_vscode`, `Codex Desktop`, or a value starting with `Codex `) OR it
-already carries native Codex transport headers (an `originator` header whose
-value is in the native Codex originator set, or any `x-codex-*` stream header).
+carries an `originator` header whose value is in the native Codex originator
+set. Transport/continuity headers (`x-codex-turn-state` and other `x-codex-*`
+stream headers) MUST NOT be treated as a native signal, because a non-native
+http client replays the upstream-issued `x-codex-turn-state` token for
+continuity; treating it as native would let that follow-up reach upstream with
+its downgraded fingerprint intact.
 
 For a non-native http request, the service MUST:
 
@@ -52,11 +56,12 @@ in-process cache that is refreshed by existing background refresh paths.
 - **THEN** the outbound `User-Agent` equals the inbound `User-Agent`
 - **AND** the request fingerprint is not normalized
 
-#### Scenario: request carrying native Codex transport headers is treated as native
+#### Scenario: non-native request replaying a continuity token is still normalized
 
-- **WHEN** an http upstream request arrives with a non-Codex `User-Agent`
-  but includes an `x-codex-turn-state` header
-- **THEN** the request is treated as native and its fingerprint is not normalized
+- **WHEN** an http upstream request arrives with `User-Agent: OpenAI/Python 2.24.0`
+  and an `x-codex-turn-state` continuity header
+- **THEN** the request is treated as non-native and its fingerprint is normalized
+- **AND** the `x-codex-turn-state` header is preserved on the outbound request
 
 #### Scenario: account header uses Codex CLI casing on a normalized request
 

--- a/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
@@ -1,0 +1,73 @@
+# Normalize non-native upstream requests to the Codex CLI client fingerprint
+
+## ADDED Requirements
+
+### Requirement: Non-native upstream http requests use the Codex CLI client fingerprint
+
+The service MUST normalize the outbound client fingerprint to the first-party
+Codex CLI (`codex_cli_rs`) persona when forwarding a proxied http request to
+the upstream Codex backend that did not originate from a native Codex client.
+The service MUST NOT modify the fingerprint of native Codex client requests,
+and MUST NOT modify websocket upstream requests.
+
+A request is considered **native** when its inbound `User-Agent` begins with a
+known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
+`codex_vscode`, `Codex Desktop`, or a value starting with `Codex `) OR it
+already carries native Codex transport headers (an `originator` header whose
+value is in the native Codex originator set, or any `x-codex-*` stream header).
+
+For a non-native http request, the service MUST:
+
+- Set the outbound `User-Agent` to
+  `codex_cli_rs/<version> (<os>; <arch>) <terminal>`, where `<version>` is the
+  cached Codex client version (falling back to the configured client-version
+  default when no cached version is available) and `<os>`, `<arch>`,
+  `<terminal>` are operator-configurable with defaults `Mac OS 26.5.0`,
+  `arm64`, and `iTerm.app/3.6.10`.
+- Remove SDK-only fingerprint headers `x-openai-client-version`,
+  `x-openai-client-os`, `x-openai-client-arch`, `x-openai-client-id`, and
+  `x-openai-client-user-agent`.
+- Remove any inbound `originator` header and MUST NOT add an `originator`
+  header, matching the Codex CLI behavior of omitting the header when the
+  originator equals the default `codex_cli_rs`.
+- Emit the upstream account header as PascalCase `ChatGPT-Account-Id`.
+
+Resolving the fingerprint version for an outbound request MUST NOT perform a
+blocking network call on the request path; the version is read from an
+in-process cache that is refreshed by existing background refresh paths.
+
+#### Scenario: non-native SDK http request is rewritten to the Codex CLI fingerprint
+
+- **WHEN** an http upstream request arrives with `User-Agent: OpenAI/Python 2.24.0`
+  and `x-openai-client-version` / `x-openai-client-os` headers
+- **THEN** the outbound `User-Agent` is `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
+- **AND** the `x-openai-client-version`, `x-openai-client-os`,
+  `x-openai-client-arch`, `x-openai-client-id`, and `x-openai-client-user-agent`
+  headers are absent from the outbound request
+- **AND** no `originator` header is present on the outbound request
+
+#### Scenario: native Codex http request is left unchanged
+
+- **WHEN** an http upstream request arrives with `User-Agent: codex_exec/0.142.1 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.142.1)`
+- **THEN** the outbound `User-Agent` equals the inbound `User-Agent`
+- **AND** the request fingerprint is not normalized
+
+#### Scenario: request carrying native Codex transport headers is treated as native
+
+- **WHEN** an http upstream request arrives with a non-Codex `User-Agent`
+  but includes an `x-codex-turn-state` header
+- **THEN** the request is treated as native and its fingerprint is not normalized
+
+#### Scenario: account header uses Codex CLI casing on a normalized request
+
+- **WHEN** a non-native http request is normalized and an upstream account id is present
+- **THEN** the outbound request carries the account id under the PascalCase
+  header name `ChatGPT-Account-Id`
+
+#### Scenario: fingerprint version falls back to the configured default
+
+- **WHEN** the Codex version cache has no cached version
+- **AND** a non-native http request is normalized
+- **THEN** the outbound `User-Agent` uses the configured client-version default
+  for `<version>`
+- **AND** resolving the version does not perform a network call on the request path

--- a/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
@@ -2,13 +2,18 @@
 
 ## ADDED Requirements
 
-### Requirement: Non-native upstream http requests use the Codex CLI client fingerprint
+### Requirement: Non-native upstream requests use the Codex CLI client fingerprint
 
 The service MUST normalize the outbound client fingerprint to the first-party
-Codex CLI (`codex_cli_rs`) persona when forwarding a proxied http request to
-the upstream Codex backend that did not originate from a native Codex client.
-The service MUST NOT modify the fingerprint of native Codex client requests,
-and MUST NOT modify websocket upstream requests.
+Codex CLI (`codex_cli_rs`) persona when forwarding a proxied request to the
+upstream Codex backend that did not originate from a native Codex client. This
+normalization MUST apply on every upstream transport path (both the http and
+websocket builders), because with `upstream_stream_transport="auto"` a
+non-native client carrying a `x-codex-turn-state` continuity header is routed
+onto the websocket path; normalizing only the http path would let that
+follow-up reach upstream with its downgraded fingerprint intact. The service
+MUST NOT modify the fingerprint of native Codex client requests on any
+transport.
 
 A request is considered **native** when its inbound `User-Agent` begins with a
 known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
@@ -16,11 +21,11 @@ known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
 carries an `originator` header whose value is in the native Codex originator
 set. Transport/continuity headers (`x-codex-turn-state` and other `x-codex-*`
 stream headers) MUST NOT be treated as a native signal, because a non-native
-http client replays the upstream-issued `x-codex-turn-state` token for
-continuity; treating it as native would let that follow-up reach upstream with
-its downgraded fingerprint intact.
+client replays the upstream-issued `x-codex-turn-state` token for continuity;
+treating it as native would let that follow-up reach upstream with its
+downgraded fingerprint intact.
 
-For a non-native http request, the service MUST:
+For a non-native request, the service MUST:
 
 - Set the outbound `User-Agent` to
   `codex_cli_rs/<version> (<os>; <arch>) <terminal>`, where `<version>` is the
@@ -35,6 +40,8 @@ For a non-native http request, the service MUST:
   header, matching the Codex CLI behavior of omitting the header when the
   originator equals the default `codex_cli_rs`.
 - Emit the upstream account header as PascalCase `ChatGPT-Account-Id`.
+- Preserve continuity headers (`x-codex-turn-state` and other `x-codex-*`
+  stream headers) on the outbound request so sticky routing is unaffected.
 
 Resolving the fingerprint version for an outbound request MUST NOT perform a
 blocking network call on the request path; the version is read from an
@@ -62,6 +69,26 @@ in-process cache that is refreshed by existing background refresh paths.
   and an `x-codex-turn-state` continuity header
 - **THEN** the request is treated as non-native and its fingerprint is normalized
 - **AND** the `x-codex-turn-state` header is preserved on the outbound request
+
+#### Scenario: non-native websocket request carrying a continuity token is normalized
+
+- **WHEN** the upstream stream transport resolves to websocket for a non-native
+  request with `User-Agent: OpenAI/Python 2.24.0`, an `x-openai-client-version`
+  header, and an `x-codex-turn-state` continuity header
+- **THEN** the outbound websocket `User-Agent` is
+  `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
+- **AND** the `x-openai-client-*` and `originator` headers are absent from the
+  outbound request
+- **AND** the upstream account id is carried under the PascalCase header name
+  `ChatGPT-Account-Id`
+- **AND** the `x-codex-turn-state` header is preserved on the outbound request
+
+#### Scenario: native Codex websocket request is left unchanged
+
+- **WHEN** the upstream stream transport resolves to websocket for a request
+  with `User-Agent: codex_cli_rs/0.142.0 (Mac OS 27.0.0; arm64) iTerm.app/3.6.10`
+- **THEN** the outbound websocket `User-Agent` equals the inbound `User-Agent`
+- **AND** the account id is carried under the lowercase header `chatgpt-account-id`
 
 #### Scenario: account header uses Codex CLI casing on a normalized request
 

--- a/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
@@ -7,13 +7,16 @@
 The service MUST normalize the outbound client fingerprint to the first-party
 Codex CLI (`codex_cli_rs`) persona when forwarding a proxied request to the
 upstream Codex backend that did not originate from a native Codex client. This
-normalization MUST apply on every upstream transport path (both the http and
-websocket builders), because with `upstream_stream_transport="auto"` a
-non-native client carrying a `x-codex-turn-state` continuity header is routed
-onto the websocket path; normalizing only the http path would let that
-follow-up reach upstream with its downgraded fingerprint intact. The service
-MUST NOT modify the fingerprint of native Codex client requests on any
-transport.
+normalization MUST apply on every upstream egress path: the http builder, the
+internal auto-transport websocket builder, and the client-facing
+`/v1/responses` websocket egress builder
+(`app/core/clients/proxy_websocket.py`). With `upstream_stream_transport="auto"`
+a non-native client carrying a `x-codex-turn-state` continuity header is routed
+onto the internal websocket path, and a direct websocket SDK caller reaches
+upstream through the `/v1/responses` egress builder; normalizing only a subset
+of these paths would let the un-normalized path reach upstream with its
+downgraded fingerprint intact. The service MUST NOT modify the fingerprint of
+native Codex client requests on any transport.
 
 A request is considered **native** when its inbound `User-Agent` begins with a
 known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
@@ -91,6 +94,19 @@ in-process cache that is refreshed by existing background refresh paths.
   with `User-Agent: codex_cli_rs/0.142.0 (Mac OS 27.0.0; arm64) iTerm.app/3.6.10`
 - **THEN** the outbound websocket `User-Agent` equals the inbound `User-Agent`
 - **AND** the account id is carried under the lowercase header `chatgpt-account-id`
+
+#### Scenario: non-native client-facing responses websocket request is normalized
+
+- **WHEN** a non-native SDK connects directly to the `/v1/responses` websocket
+  endpoint with `User-Agent: OpenAI/Python 2.24.0`, `x-openai-client-version`,
+  and `x-stainless-*` headers
+- **THEN** the upstream responses websocket `User-Agent` is
+  `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
+- **AND** the `x-openai-client-*`, `x-stainless-*`, and `originator` headers are
+  absent from the outbound request
+- **AND** the upstream account id is carried under the PascalCase header name
+  `ChatGPT-Account-Id`
+- **AND** the required responses websocket beta header is still present
 
 #### Scenario: account header uses Codex CLI casing on a normalized request
 

--- a/openspec/changes/normalize-upstream-codex-fingerprint/tasks.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+## Implementation
+- [x] T1: Add `CodexVersionCache.cached_version_or_default()` synchronous read
+  path in `app/core/clients/codex_version.py` (returns cached version if set,
+  else `get_settings().model_registry_client_version`; no await, no network).
+- [x] T2: Add `codex_fingerprint_os`, `codex_fingerprint_arch`,
+  `codex_fingerprint_terminal` settings in `app/core/config/settings.py`
+  (defaults `Mac OS 26.5.0` / `arm64` / `iTerm.app/3.6.10`).
+- [x] T3: Add `build_codex_user_agent(version)` helper in
+  `app/core/clients/proxy.py` producing
+  `codex_cli_rs/<version> (<os>; <arch>) <terminal>` (defensive settings access).
+- [x] T4: Add native-client detection by User-Agent prefix
+  (`_is_native_codex_user_agent` / `_is_native_codex_request`) combined with the
+  existing `_has_native_codex_transport_headers`.
+- [x] T5: Add `_normalize_non_native_upstream_fingerprint(headers)` and call it
+  from `_build_upstream_headers` for non-native http requests: rewrite
+  `User-Agent`, strip `x-openai-client-*`, strip inbound `originator`, set
+  PascalCase `ChatGPT-Account-Id`.
+
+## Tests
+- [x] T6: `tests/unit/test_codex_version.py` — `cached_version_or_default()`
+  returns cached value when warmed and settings default when empty; no
+  network/await.
+- [x] T7: `tests/unit/test_proxy_upstream_fingerprint.py` — non-native http UA
+  (`OpenAI/Python 2.24.0`) rewritten to `codex_cli_rs/<ver> (...)`.
+- [x] T8: native UA (`codex_exec/...`, `Codex Desktop/...`) left unchanged.
+- [x] T9: `x-openai-client-*` headers and inbound `originator` stripped on
+  non-native http; no `originator` header added.
+- [x] T10: account header emitted as PascalCase `ChatGPT-Account-Id`.
+- [x] T11: websocket header builder untouched (native path regression guard).
+
+## Spec
+- [x] T12: Add the delta in
+  `openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md`.
+
+## Validation
+- [x] T13: `openspec validate normalize-upstream-codex-fingerprint --strict` → valid.
+- [x] T14: Targeted pytest — new fingerprint + version-cache suites — 27 passed.
+- [x] T15: Broader proxy-client sweep (1006 passed, 3 skipped, 0 new failures;
+  18 pre-existing assertions updated for the intended behavior change).
+- [x] T16: `uvx ruff check .` + `uvx ruff format --check .` + `uv run ty check` clean.

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -556,7 +556,7 @@ async def test_responses_websocket_uses_codex_client_when_route_is_resolved(rout
     client = _WsCodexClient()
 
     websocket = await connect_responses_websocket(
-        {"user-agent": "codex", "Origin": "https://chatgpt.test"},
+        {"user-agent": "codex_cli_rs/0.142.0", "Origin": "https://chatgpt.test"},
         "access",
         "chatgpt_account",
         base_url="https://chatgpt.test/backend-api",
@@ -572,7 +572,8 @@ async def test_responses_websocket_uses_codex_client_when_route_is_resolved(rout
     assert message.text == '{"type":"response.completed"}'
     assert client.calls[0]["url"] == "wss://chatgpt.test/backend-api/codex/responses"
     assert client.calls[0]["route"] is route
-    assert client.calls[0]["headers"]["user-agent"] == "codex"
+    # Native Codex UA is preserved unchanged through the responses websocket egress.
+    assert client.calls[0]["headers"]["user-agent"] == "codex_cli_rs/0.142.0"
     assert client.calls[0]["headers"]["Origin"] == "https://chatgpt.test"
     assert client.websocket.sent == ['{"type":"response.create"}']
     assert client.context.exited is True

--- a/tests/unit/test_codex_version.py
+++ b/tests/unit/test_codex_version.py
@@ -294,3 +294,27 @@ async def test_falls_back_to_stale_cache_when_both_sources_fail():
         v2 = await cache.get_version()
 
     assert v2 == "1.5.0"
+
+
+def test_cached_version_or_default_returns_cached_value_without_io():
+    cache = CodexVersionCache(ttl_seconds=60)
+    cache._cached_version = "0.142.0"
+
+    # Must not touch the network or require an event loop.
+    with patch("app.core.clients.codex_version.aiohttp.ClientSession") as client_session_cls:
+        result = cache.cached_version_or_default()
+
+    assert result == "0.142.0"
+    client_session_cls.assert_not_called()
+
+
+def test_cached_version_or_default_falls_back_to_settings_default_when_empty():
+    cache = CodexVersionCache(ttl_seconds=60)
+    assert cache._cached_version is None
+
+    fake_settings = MagicMock()
+    fake_settings.model_registry_client_version = "0.101.0"
+    with patch("app.core.clients.codex_version.get_settings", return_value=fake_settings):
+        result = cache.cached_version_or_default()
+
+    assert result == "0.101.0"

--- a/tests/unit/test_proxy_upstream_fingerprint.py
+++ b/tests/unit/test_proxy_upstream_fingerprint.py
@@ -109,6 +109,25 @@ def test_native_originator_header_marks_request_native():
     assert headers["originator"] == "codex_vscode"
 
 
+def test_first_party_codex_sdk_ts_originator_is_native():
+    # Regression for the Codex P2 finding: codex_sdk_ts is a first-party Codex
+    # originator the backend whitelists (named in proposal.md). It must be
+    # treated as native so its User-Agent and originator are not rewritten.
+    inbound = {"User-Agent": "OpenAI/Node 5.0.0", "originator": "codex_sdk_ts"}
+    headers = _build_upstream_headers(inbound, "tok", None)
+    assert headers["User-Agent"] == "OpenAI/Node 5.0.0"
+    assert headers["originator"] == "codex_sdk_ts"
+
+
+def test_codex_sdk_ts_user_agent_prefix_is_native():
+    # A codex_sdk_ts User-Agent prefix also identifies a first-party client.
+    native_ua = "codex_sdk_ts/5.0.0 (Mac OS 27.0.0; arm64)"
+    headers = _build_upstream_headers({"User-Agent": native_ua}, "tok", "acct-1")
+    assert headers["User-Agent"] == native_ua
+    assert headers["chatgpt-account-id"] == "acct-1"
+    assert "ChatGPT-Account-Id" not in headers
+
+
 def test_websocket_non_native_sdk_request_is_normalized():
     # Regression for the Codex P1 finding: with upstream_stream_transport="auto",
     # a non-native SDK follow-up that replays x-codex-turn-state is routed onto

--- a/tests/unit/test_proxy_upstream_fingerprint.py
+++ b/tests/unit/test_proxy_upstream_fingerprint.py
@@ -80,11 +80,33 @@ def test_codex_desktop_native_user_agent_is_left_unchanged():
     assert headers["User-Agent"] == native_ua
 
 
-def test_request_with_native_codex_transport_header_is_treated_as_native():
-    # Non-Codex UA but carries an x-codex-* stream header -> native, untouched.
-    inbound = {"User-Agent": "OpenAI/Python 2.24.0", "x-codex-turn-state": "abc"}
+def test_sdk_request_replaying_turn_state_is_still_normalized():
+    # Regression for the Codex P2 finding: an HTTP SDK client replays the
+    # x-codex-turn-state continuity token the upstream returned. That transport
+    # header must NOT make the request count as native, or the downgraded SDK
+    # fingerprint would reach upstream unchanged. The continuity header itself
+    # is preserved (only the fingerprint is normalized).
+    inbound = {
+        "User-Agent": "OpenAI/Python 2.24.0",
+        "x-openai-client-version": "2.24.0",
+        "x-codex-turn-state": "abc",
+    }
+    with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
+        headers = _build_upstream_headers(inbound, "tok", None)
+    assert headers["User-Agent"].startswith("codex_cli_rs/")
+    lowered = _lower_keys(headers)
+    assert "x-openai-client-version" not in lowered
+    # Continuity header is preserved for sticky routing.
+    assert headers["x-codex-turn-state"] == "abc"
+
+
+def test_native_originator_header_marks_request_native():
+    # A native Codex originator header (not the default codex_cli_rs, which the
+    # CLI omits) identifies a first-party client and is left unchanged.
+    inbound = {"User-Agent": "OpenAI/Python 2.24.0", "originator": "codex_vscode"}
     headers = _build_upstream_headers(inbound, "tok", None)
     assert headers["User-Agent"] == "OpenAI/Python 2.24.0"
+    assert headers["originator"] == "codex_vscode"
 
 
 def test_websocket_header_builder_is_untouched_by_normalization():

--- a/tests/unit/test_proxy_upstream_fingerprint.py
+++ b/tests/unit/test_proxy_upstream_fingerprint.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.core.clients import proxy as proxy_module
+from app.core.clients.proxy import (
+    _build_upstream_headers,
+    build_codex_user_agent,
+)
+
+
+def _lower_keys(headers: dict[str, str]) -> set[str]:
+    return {key.lower() for key in headers}
+
+
+def test_build_codex_user_agent_matches_codex_cli_format():
+    ua = build_codex_user_agent("0.142.0")
+    assert ua == "codex_cli_rs/0.142.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10"
+
+
+def test_non_native_sdk_http_request_is_rewritten_to_codex_cli_fingerprint():
+    inbound = {
+        "User-Agent": "OpenAI/Python 2.24.0",
+        "x-openai-client-version": "2.24.0",
+        "x-openai-client-os": "MacOS",
+        "x-openai-client-arch": "arm64",
+        "x-openai-client-id": "abc",
+        "x-openai-client-user-agent": "OpenAI/Python 2.24.0",
+        "originator": "sdk",
+    }
+    with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
+        headers = _build_upstream_headers(inbound, "tok", "acct-123")
+
+    assert headers["User-Agent"] == "codex_cli_rs/0.142.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10"
+    lowered = _lower_keys(headers)
+    assert "x-openai-client-version" not in lowered
+    assert "x-openai-client-os" not in lowered
+    assert "x-openai-client-arch" not in lowered
+    assert "x-openai-client-id" not in lowered
+    assert "x-openai-client-user-agent" not in lowered
+    # No originator header is added; inbound SDK originator is stripped.
+    assert "originator" not in lowered
+
+
+def test_non_native_request_uses_pascalcase_account_header():
+    with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
+        headers = _build_upstream_headers({"User-Agent": "OpenAI/Python 2.24.0"}, "tok", "acct-9")
+
+    assert headers["ChatGPT-Account-Id"] == "acct-9"
+    assert "chatgpt-account-id" not in headers
+
+
+def test_non_native_request_version_falls_back_to_settings_default():
+    cache = proxy_module.get_codex_version_cache()
+    # Real synchronous fallback path: empty cache -> settings default.
+    with patch.object(cache, "_cached_version", None):
+        headers = _build_upstream_headers({"User-Agent": "OpenAI/Python 2.24.0"}, "tok", None)
+
+    ua = headers["User-Agent"]
+    assert ua.startswith("codex_cli_rs/")
+    # The fallback version is the configured client-version default.
+    from app.core.config.settings import get_settings
+
+    assert get_settings().model_registry_client_version in ua
+
+
+def test_native_codex_http_request_is_left_unchanged():
+    native_ua = "codex_exec/0.142.1 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.142.1)"
+    headers = _build_upstream_headers({"User-Agent": native_ua}, "tok", "acct-1")
+
+    assert headers["User-Agent"] == native_ua
+    # Native requests keep the existing lowercase account header.
+    assert headers["chatgpt-account-id"] == "acct-1"
+    assert "ChatGPT-Account-Id" not in headers
+
+
+def test_codex_desktop_native_user_agent_is_left_unchanged():
+    native_ua = "Codex Desktop/0.142.0 (Mac OS 27.0.0; arm64) unknown (Codex Desktop; 26.616.71553)"
+    headers = _build_upstream_headers({"User-Agent": native_ua}, "tok", None)
+    assert headers["User-Agent"] == native_ua
+
+
+def test_request_with_native_codex_transport_header_is_treated_as_native():
+    # Non-Codex UA but carries an x-codex-* stream header -> native, untouched.
+    inbound = {"User-Agent": "OpenAI/Python 2.24.0", "x-codex-turn-state": "abc"}
+    headers = _build_upstream_headers(inbound, "tok", None)
+    assert headers["User-Agent"] == "OpenAI/Python 2.24.0"
+
+
+def test_websocket_header_builder_is_untouched_by_normalization():
+    # The websocket path uses a different builder and must not rewrite the UA.
+    from app.core.clients.proxy import _build_upstream_websocket_headers
+
+    inbound = {"User-Agent": "OpenAI/Python 2.24.0", "x-openai-client-version": "2.24.0"}
+    headers = _build_upstream_websocket_headers(inbound, "tok", "acct-1")
+    assert headers["User-Agent"] == "OpenAI/Python 2.24.0"
+    assert headers["x-openai-client-version"] == "2.24.0"

--- a/tests/unit/test_proxy_upstream_fingerprint.py
+++ b/tests/unit/test_proxy_upstream_fingerprint.py
@@ -109,11 +109,43 @@ def test_native_originator_header_marks_request_native():
     assert headers["originator"] == "codex_vscode"
 
 
-def test_websocket_header_builder_is_untouched_by_normalization():
-    # The websocket path uses a different builder and must not rewrite the UA.
+def test_websocket_non_native_sdk_request_is_normalized():
+    # Regression for the Codex P1 finding: with upstream_stream_transport="auto",
+    # a non-native SDK follow-up that replays x-codex-turn-state is routed onto
+    # the websocket path. The websocket builder must apply the same codex_cli_rs
+    # persona rewrite as the HTTP builder, otherwise the SDK fingerprint reaches
+    # upstream unchanged and the priority-downgrade mitigation is bypassed.
     from app.core.clients.proxy import _build_upstream_websocket_headers
 
-    inbound = {"User-Agent": "OpenAI/Python 2.24.0", "x-openai-client-version": "2.24.0"}
+    inbound = {
+        "User-Agent": "OpenAI/Python 2.24.0",
+        "x-openai-client-version": "2.24.0",
+        "x-codex-turn-state": "abc",
+        "originator": "sdk",
+    }
+    with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
+        headers = _build_upstream_websocket_headers(inbound, "tok", "acct-1")
+
+    assert headers["User-Agent"] == "codex_cli_rs/0.142.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10"
+    lowered = _lower_keys(headers)
+    assert "x-openai-client-version" not in lowered
+    assert "originator" not in lowered
+    # Non-native uses the PascalCase account header, mirroring the HTTP builder.
+    assert headers["ChatGPT-Account-Id"] == "acct-1"
+    assert "chatgpt-account-id" not in headers
+    # Continuity header is preserved for sticky routing.
+    assert headers["x-codex-turn-state"] == "abc"
+
+
+def test_websocket_native_codex_request_is_left_unchanged():
+    # A first-party Codex websocket client must keep its native fingerprint and
+    # the existing lowercase account header.
+    from app.core.clients.proxy import _build_upstream_websocket_headers
+
+    native_ua = "codex_cli_rs/0.142.0 (Mac OS 27.0.0; arm64) iTerm.app/3.6.10"
+    inbound = {"User-Agent": native_ua, "x-codex-turn-state": "abc"}
     headers = _build_upstream_websocket_headers(inbound, "tok", "acct-1")
-    assert headers["User-Agent"] == "OpenAI/Python 2.24.0"
-    assert headers["x-openai-client-version"] == "2.24.0"
+    assert headers["User-Agent"] == native_ua
+    assert headers["chatgpt-account-id"] == "acct-1"
+    assert "ChatGPT-Account-Id" not in headers
+    assert headers["x-codex-turn-state"] == "abc"

--- a/tests/unit/test_proxy_upstream_fingerprint.py
+++ b/tests/unit/test_proxy_upstream_fingerprint.py
@@ -149,3 +149,55 @@ def test_websocket_native_codex_request_is_left_unchanged():
     assert headers["chatgpt-account-id"] == "acct-1"
     assert "ChatGPT-Account-Id" not in headers
     assert headers["x-codex-turn-state"] == "abc"
+
+
+def test_non_native_request_strips_x_stainless_sdk_headers():
+    # Regression for the Codex P2 finding: OpenAI SDKs attach an x-stainless-*
+    # header family the API layer treats as an OpenAI SDK signal. Installing the
+    # codex_cli_rs User-Agent is not enough; the x-stainless-* headers must be
+    # stripped by prefix or upstream can still distinguish SDK traffic and apply
+    # the downgrade this change avoids.
+    inbound = {
+        "User-Agent": "OpenAI/Python 2.24.0",
+        "x-stainless-os": "MacOS",
+        "x-stainless-arch": "arm64",
+        "x-stainless-runtime": "CPython",
+        "x-stainless-runtime-version": "3.13.0",
+        "x-stainless-package-version": "2.24.0",
+        "x-stainless-lang": "python",
+    }
+    with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
+        headers = _build_upstream_headers(inbound, "tok", None)
+    assert headers["User-Agent"].startswith("codex_cli_rs/")
+    assert not any(key.lower().startswith("x-stainless-") for key in headers)
+
+
+def test_websocket_non_native_request_strips_x_stainless_sdk_headers():
+    # The websocket builder must strip x-stainless-* too, for the auto-transport
+    # turn-state continuity path.
+    from app.core.clients.proxy import _build_upstream_websocket_headers
+
+    inbound = {
+        "User-Agent": "OpenAI/Python 2.24.0",
+        "x-stainless-os": "MacOS",
+        "x-stainless-runtime-version": "3.13.0",
+        "x-codex-turn-state": "abc",
+    }
+    with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
+        headers = _build_upstream_websocket_headers(inbound, "tok", None)
+    assert headers["User-Agent"].startswith("codex_cli_rs/")
+    assert not any(key.lower().startswith("x-stainless-") for key in headers)
+    assert headers["x-codex-turn-state"] == "abc"
+
+
+def test_upstream_log_account_id_lookup_is_case_insensitive():
+    # Regression for the Codex P3 finding: a normalized non-native request carries
+    # the account id under PascalCase ChatGPT-Account-Id. The upstream log helper
+    # must read it case-insensitively or per-account diagnostics are lost for
+    # exactly the SDK traffic this feature investigates.
+    from app.core.clients.proxy import _account_id_for_upstream_log
+
+    assert _account_id_for_upstream_log({"ChatGPT-Account-Id": "acct-9"}) == "acct-9"
+    assert _account_id_for_upstream_log({"chatgpt-account-id": "acct-9"}) == "acct-9"
+    assert _account_id_for_upstream_log({"CHATGPT-ACCOUNT-ID": "acct-9"}) == "acct-9"
+    assert _account_id_for_upstream_log({"User-Agent": "x"}) is None

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -386,12 +386,27 @@ def test_request_log_useragent_fields_handle_missing_and_blank_headers(
 
 
 def test_build_upstream_headers_overrides_auth():
+    # No native Codex User-Agent on the inbound request -> the upstream
+    # fingerprint is normalized to the Codex CLI persona and the account header
+    # is emitted in PascalCase (ChatGPT-Account-Id).
     inbound = {"X-Request-Id": "req_1"}
     headers = _build_upstream_headers(inbound, "token", "acc_2")
     assert headers["Authorization"] == "Bearer token"
-    assert headers["chatgpt-account-id"] == "acc_2"
+    assert headers["ChatGPT-Account-Id"] == "acc_2"
+    assert "chatgpt-account-id" not in headers
+    assert headers["User-Agent"].startswith("codex_cli_rs/")
     assert headers["Accept"] == "text/event-stream"
     assert headers["Content-Type"] == "application/json"
+
+
+def test_build_upstream_headers_preserves_native_account_header_casing():
+    # A native Codex client request keeps the existing lowercase account header
+    # and its original User-Agent.
+    native_ua = "codex_exec/0.142.1 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.142.1)"
+    headers = _build_upstream_headers({"User-Agent": native_ua}, "token", "acc_2")
+    assert headers["chatgpt-account-id"] == "acc_2"
+    assert "ChatGPT-Account-Id" not in headers
+    assert headers["User-Agent"] == native_ua
 
 
 def test_build_upstream_headers_accept_override():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -912,7 +912,7 @@ def test_build_upstream_websocket_headers_strip_accept_and_content_type_case_ins
         {
             "accept": "text/event-stream",
             "content-type": "application/json",
-            "User-Agent": "codex-test",
+            "User-Agent": "codex_cli_rs/0.1.0",
         },
         "token",
         "acc_2",
@@ -922,7 +922,7 @@ def test_build_upstream_websocket_headers_strip_accept_and_content_type_case_ins
     assert all(key.lower() != "content-type" for key in headers)
     assert headers["Authorization"] == "Bearer token"
     assert headers["chatgpt-account-id"] == "acc_2"
-    assert headers["User-Agent"] == "codex-test"
+    assert headers["User-Agent"] == "codex_cli_rs/0.1.0"
 
 
 def test_build_upstream_websocket_headers_strip_hop_by_hop_headers_and_connection_tokens():
@@ -934,7 +934,7 @@ def test_build_upstream_websocket_headers_strip_hop_by_hop_headers_and_connectio
             "Transfer-Encoding": "chunked",
             "Proxy-Connection": "keep-alive",
             "X-Handshake-Debug": "1",
-            "User-Agent": "codex-test",
+            "User-Agent": "codex_cli_rs/0.1.0",
         },
         "token",
         "acc_2",
@@ -948,7 +948,7 @@ def test_build_upstream_websocket_headers_strip_hop_by_hop_headers_and_connectio
     assert "X-Handshake-Debug" not in headers
     assert headers["Authorization"] == "Bearer token"
     assert headers["chatgpt-account-id"] == "acc_2"
-    assert headers["User-Agent"] == "codex-test"
+    assert headers["User-Agent"] == "codex_cli_rs/0.1.0"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -968,3 +968,46 @@ async def test_connect_responses_websocket_maps_invalid_proxy(monkeypatch):
 
     assert exc_info.value.status_code == 502
     assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+
+
+def test_responses_websocket_builder_normalizes_non_native_sdk_fingerprint():
+    # Regression for the Codex P2 finding: the client-facing /v1/responses
+    # websocket egress builder must normalize a non-native SDK fingerprint, not
+    # just the internal auto-transport builder, or a direct websocket SDK caller
+    # bypasses the priority-downgrade mitigation.
+    from unittest.mock import patch
+
+    from app.core.clients import proxy as proxy_module
+    from app.core.clients.proxy_websocket import _build_upstream_websocket_headers
+
+    inbound = {
+        "User-Agent": "OpenAI/Python 2.24.0",
+        "x-openai-client-version": "2.24.0",
+        "x-stainless-os": "MacOS",
+        "originator": "sdk",
+        "openai-beta": "responses_websockets=2026-02-06",
+    }
+    with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
+        headers = _build_upstream_websocket_headers(inbound, "tok", "acct-1")
+
+    assert headers["User-Agent"] == "codex_cli_rs/0.142.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10"
+    lowered = {key.lower() for key in headers}
+    assert "x-openai-client-version" not in lowered
+    assert not any(key.lower().startswith("x-stainless-") for key in headers)
+    assert "originator" not in lowered
+    assert headers["ChatGPT-Account-Id"] == "acct-1"
+    assert "chatgpt-account-id" not in headers
+    # The responses websocket beta header is still appended.
+    assert "responses_websockets=2026-02-06" in headers["openai-beta"]
+
+
+def test_responses_websocket_builder_leaves_native_codex_unchanged():
+    from app.core.clients.proxy_websocket import _build_upstream_websocket_headers
+
+    native_ua = "codex_cli_rs/0.142.0 (Mac OS 27.0.0; arm64) iTerm.app/3.6.10"
+    inbound = {"User-Agent": native_ua, "openai-beta": "responses_websockets=2026-02-06"}
+    headers = _build_upstream_websocket_headers(inbound, "tok", "acct-1")
+
+    assert headers["User-Agent"] == native_ua
+    assert headers["chatgpt-account-id"] == "acct-1"
+    assert "ChatGPT-Account-Id" not in headers


### PR DESCRIPTION
## Problem

On production (`gpt-5.5`, priority-tier keys) a large share of requests fail
with `server_is_overloaded` ("Our servers are currently overloaded. Please try
again later."). Measured over a 12h prod window:

- `gpt-5.5` overall surfaced `server_is_overloaded` on **8.94%** of requests
  (1010/11293).
- Split by the tier the backend actually applied (`actual_service_tier`):
  `default` = **0.18%** failures vs `auto` = **85.04%** failures. ~98.5% of all
  overload events were `auto`-tier requests.
- Clients sent `requested_service_tier=priority`; the ChatGPT/Codex backend
  **downgraded** a fraction to `auto`, and those are the requests that overload.

The downgrade is not uniform across clients sending the same `priority` tier:

| transport | client User-Agent | priority reqs | downgraded→auto |
|-----------|-------------------|---------------|-----------------|
| http      | `OpenAI/Python`   | 2231          | **20.3%**       |
| websocket | `codex-tui` / `codex_exec` / `Codex Desktop` | ~2000 | **2.8–6.0%** |
| http      | `OpenAI/Python` (different key) | 21  | **28.6%**       |

The same `OpenAI/Python` http path downgrades at ~20–29% regardless of which
API key sends it, while native Codex clients stay at ~3–6%. This is a
**client-fingerprint** effect, not a per-key or per-account effect.

Root cause: the ChatGPT/Codex backend whitelists first-party Codex originators
(`codex_cli_rs`, `codex_vscode`, `codex_sdk_ts`, or anything starting with
`Codex`; see `openai/codex` `codex-rs/login/src/auth/default_client.rs`
`DEFAULT_ORIGINATOR` and `codex-rs/core/src/client.rs add_originator_header`).
Non-first-party fingerprints (the `openai` Python SDK's
`User-Agent: OpenAI/Python x.y.z` plus `x-openai-client-*` headers) are treated
as second-class traffic whose `priority` tier is more likely to be downgraded to
`auto`, which the backend sheds first under load. codex-lb forwards inbound
client headers verbatim on the http path
(`_build_upstream_headers` does `headers = dict(inbound)`), so the SDK
fingerprint reaches the backend unchanged.

## Solution

Normalize **non-native http** upstream requests to the Codex CLI
(`codex_cli_rs`) client fingerprint inside `_build_upstream_headers`, matching
the official Codex CLI's `get_codex_user_agent()`:

- Set `User-Agent` to `codex_cli_rs/<version> (<os>; <arch>) <terminal>`.
  `<version>` comes from the existing `CodexVersionCache`
  (GitHub releases → npm → stale cache → `model_registry_client_version`),
  read via a new synchronous, network-free `cached_version_or_default()` so the
  hot path never blocks. `<os>/<arch>/<terminal>` are operator-configurable
  settings (defaults `Mac OS 26.5.0` / `arm64` / `iTerm.app/3.6.10`).
- Strip SDK-only fingerprint headers `x-openai-client-version`,
  `x-openai-client-os`, `x-openai-client-arch`, `x-openai-client-id`,
  `x-openai-client-user-agent`.
- Do **not** add an `originator` header (the real Codex CLI omits it for the
  default originator and lets the backend read it from the User-Agent prefix);
  strip any inbound `originator`.
- Emit the account header as PascalCase `ChatGPT-Account-Id`, matching Codex CLI
  (`codex-rs/backend-client/src/client.rs`).

A request is **native** (left untouched) when its User-Agent already starts with
a known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
`codex_vscode`, `Codex Desktop`, `Codex ...`) **or** it carries native Codex
transport headers (native `originator`, or any `x-codex-*` stream header).
websocket upstream requests use a different builder and are unaffected.

## Why this is correct as a behavior change

- `outbound-http-clients` already promises stable, persona-aware outbound
  headers (the OAuth authorize originator persona requirement). Normalizing the
  proxy's upstream client fingerprint to the same first-party Codex persona is
  consistent with that capability's intent.
- No client can depend on its raw `User-Agent` / `x-openai-client-*` reaching
  the backend: those are upstream-private transport details, not part of any
  documented codex-lb request/response contract. `request_logs.useragent` keeps
  the original client value for observability; only the upstream wire
  fingerprint changes.
- Native Codex clients are explicitly excluded, so the already-healthy native
  path cannot regress.
- Settings access in the UA builder is defensive (`getattr` with built-in
  defaults) so header construction can never raise and fail an otherwise-valid
  upstream request.

## Changes

- `app/core/clients/codex_version.py` — `CodexVersionCache.cached_version_or_default()`
  synchronous read path.
- `app/core/clients/proxy.py` — `build_codex_user_agent()`, native-client
  detection, `_normalize_non_native_upstream_fingerprint()`, wired into
  `_build_upstream_headers`.
- `app/core/config/settings.py` — `codex_fingerprint_os/arch/terminal` settings.
- `openspec/changes/normalize-upstream-codex-fingerprint/` — proposal, tasks,
  `outbound-http-clients` delta spec (`openspec validate --strict` ✓).
- Tests — `tests/unit/test_proxy_upstream_fingerprint.py` (new),
  `tests/unit/test_codex_version.py` (sync read), and updated
  `tests/unit/test_proxy_utils.py` assertions for the new behavior.

## Out of scope

- websocket upstream headers and native Codex requests.
- Per-key rate limiting, account-pool sizing, or `auto`-tier retry/backoff.
- Auto-detecting host OS/arch for the fingerprint (intentionally fixed,
  operator-overridable).

## Verification

- `openspec validate normalize-upstream-codex-fingerprint --strict` → valid.
- Targeted suites (`test_proxy_upstream_fingerprint`, `test_codex_version`) — 27 passed.
- Broader proxy/header/transport sweep — 1006 passed, 0 new failures.
- `uvx ruff check .` + `uvx ruff format --check .` + `uv run ty check` clean.
- Post-deploy validation (to confirm on prod): `auto`-tier downgrade rate on the
  http SDK path should fall toward the native ~3–6% band, lowering
  `server_is_overloaded` surfacing on `gpt-5.5`.
