### PR TITLE
fix(proxy): strip internal responses lite header

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -76,6 +76,7 @@ from app.core.utils.request_id import get_request_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 
 CODEX_INSTALLATION_ID_HEADER = "x-codex-installation-id"
+CODEX_RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite"
 
 IGNORE_INBOUND_HEADERS = {
     "authorization",
@@ -87,6 +88,11 @@ IGNORE_INBOUND_HEADERS = {
     CODEX_INSTALLATION_ID_HEADER,
     "true-client-ip",
 }
+INTERNAL_OPENAI_UPSTREAM_HEADERS = frozenset(
+    {
+        CODEX_RESPONSES_LITE_HEADER,
+    }
+)
 
 _ERROR_TYPE_CODE_MAP = {
     "rate_limit_exceeded": "rate_limit_exceeded",
@@ -447,6 +453,8 @@ def _should_drop_inbound_header(name: str) -> bool:
     normalized = name.lower()
     if normalized in IGNORE_INBOUND_HEADERS:
         return True
+    if normalized in INTERNAL_OPENAI_UPSTREAM_HEADERS:
+        return True
     if normalized.startswith("x-forwarded-"):
         return True
     if normalized.startswith("cf-"):
@@ -579,7 +587,7 @@ def _build_upstream_headers(
     account_id: str | None,
     accept: str = "text/event-stream",
 ) -> dict[str, str]:
-    headers = dict(inbound)
+    headers = filter_inbound_headers(inbound)
     native = _is_native_codex_request(headers)
     lower_keys = {key.lower() for key in headers}
     if "x-request-id" not in lower_keys and "request-id" not in lower_keys:
@@ -636,7 +644,8 @@ def _build_upstream_websocket_headers(
             token.strip().lower() for token in value.split(",") if isinstance(value, str) and token.strip()
         )
     blocked_header_names = _HOP_BY_HOP_HEADER_NAMES | connected_header_tokens
-    headers = {key: value for key, value in inbound.items() if key.lower() not in blocked_header_names}
+    filtered = filter_inbound_headers(inbound)
+    headers = {key: value for key, value in filtered.items() if key.lower() not in blocked_header_names}
     native = _is_native_codex_request(headers)
     lower_keys = {key.lower() for key in headers}
     if "x-request-id" not in lower_keys and "request-id" not in lower_keys:

--- a/openspec/changes/strip-internal-responses-lite-header/.openspec.yaml
+++ b/openspec/changes/strip-internal-responses-lite-header/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/strip-internal-responses-lite-header/design.md
+++ b/openspec/changes/strip-internal-responses-lite-header/design.md
@@ -1,0 +1,17 @@
+# Design
+
+## Approach
+
+Add the exact lowercase `x-openai-internal-codex-responses-lite` header to the shared inbound upstream-header blocklist in `app/core/clients/proxy.py`.
+
+The shared `filter_inbound_headers()` function is already used by proxy service paths before response-create, compact, file, transcribe, warmup, codex-control, HTTP bridge, and streaming egress. The direct upstream builders will also call this shared filter so direct use of the lower-level clients cannot accidentally forward the same header.
+
+The client-facing websocket module already calls the shared filter through `filter_inbound_websocket_headers()`, so adding focused regression coverage there verifies it inherits the same blocklist.
+
+## Header Policy
+
+Only the known unsupported internal Lite header is blocked. The broader `x-openai-client-*` and `x-stainless-*` SDK fingerprint behavior stays unchanged: those headers remain available to existing normalization logic where needed.
+
+## Failure Mode
+
+Before this change, a Codex client could send `X-OpenAI-Internal-Codex-Responses-Lite: 1`; codex-lb would forward it upstream, and upstream could reject the request before model inference. After this change, the request reaches upstream without that internal header.

--- a/openspec/changes/strip-internal-responses-lite-header/proposal.md
+++ b/openspec/changes/strip-internal-responses-lite-header/proposal.md
@@ -1,0 +1,24 @@
+# Strip Internal Responses Lite Header
+
+## Summary
+
+Stop forwarding `X-OpenAI-Internal-Codex-Responses-Lite` to upstream Responses and compact endpoints.
+
+## Motivation
+
+OpenAI now rejects some Codex model requests when this internal header reaches upstream with:
+
+`This model is not supported when using X-OpenAI-Internal-Codex-Responses-Lite.`
+
+The header is client/internal control metadata, not part of the public Responses API contract. codex-lb should continue accepting clients that send it, but it must not leak the header to upstream HTTP, compact, or websocket transports.
+
+## Scope
+
+- Strip the Lite header case-insensitively from inbound headers before upstream forwarding.
+- Preserve other OpenAI SDK telemetry headers and existing Codex continuity headers.
+- Cover HTTP response-create, compact, internal auto-websocket, and client-facing websocket header builders.
+
+## Out of Scope
+
+- Changing model aliases, routing, quota, or auth behavior.
+- Reintroducing old `parallel_tool_calls` Lite-body rewriting.

--- a/openspec/changes/strip-internal-responses-lite-header/specs/responses-api-compat/spec.md
+++ b/openspec/changes/strip-internal-responses-lite-header/specs/responses-api-compat/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Internal Responses Lite header is not forwarded upstream
+
+The service MUST accept inbound Responses and compact requests that include
+`X-OpenAI-Internal-Codex-Responses-Lite`, but MUST remove that header before
+calling upstream Responses, compact, or websocket transports. Header matching
+MUST be case-insensitive. The service MUST NOT strip unrelated OpenAI SDK
+telemetry headers solely because they start with `x-openai-`.
+
+#### Scenario: HTTP and compact upstream headers omit Lite
+
+- **WHEN** a client sends a Responses or compact request with
+  `X-OpenAI-Internal-Codex-Responses-Lite: 1`
+- **THEN** the upstream HTTP request headers omit
+  `x-openai-internal-codex-responses-lite`
+- **AND** unrelated headers such as `x-openai-client-version` continue through
+  the existing fingerprint policy
+
+#### Scenario: Websocket upstream headers omit Lite
+
+- **WHEN** a client opens a Responses websocket with
+  `X-OpenAI-Internal-Codex-Responses-Lite: 1`
+- **THEN** the upstream websocket connection headers omit
+  `x-openai-internal-codex-responses-lite`
+- **AND** existing websocket beta and Codex continuity headers are preserved

--- a/openspec/changes/strip-internal-responses-lite-header/tasks.md
+++ b/openspec/changes/strip-internal-responses-lite-header/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Add OpenSpec requirement for stripping the internal Responses Lite header before upstream forwarding.
+- [x] 2. Strip the Lite header in shared inbound upstream-header filtering and direct upstream builders.
+- [x] 3. Add regression coverage for HTTP, compact/shared filtering, internal websocket, and client-facing websocket header builders.
+- [x] 4. Validate focused tests and OpenSpec artifacts.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -508,6 +508,21 @@ def test_filter_inbound_headers_strips_proxy_identity_headers():
     assert filtered["Accept"] == "text/event-stream"
 
 
+def test_filter_inbound_headers_strips_internal_responses_lite_header():
+    headers = {
+        "X-OpenAI-Internal-Codex-Responses-Lite": "1",
+        "x-openai-client-version": "2.24.0",
+        "User-Agent": "codex-test",
+    }
+
+    filtered = filter_inbound_headers(headers)
+    lowered = {key.lower() for key in filtered}
+
+    assert "x-openai-internal-codex-responses-lite" not in lowered
+    assert filtered["x-openai-client-version"] == "2.24.0"
+    assert filtered["User-Agent"] == "codex-test"
+
+
 def test_request_log_useragent_fields_extract_full_value_and_group() -> None:
     assert proxy_service._request_log_useragent_fields(
         {
@@ -565,6 +580,21 @@ def test_build_upstream_headers_preserves_native_account_header_casing():
     assert headers["chatgpt-account-id"] == "acc_2"
     assert "ChatGPT-Account-Id" not in headers
     assert headers["User-Agent"] == native_ua
+
+
+def test_build_upstream_headers_strips_internal_responses_lite_header():
+    native_ua = "codex_exec/0.142.1 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.142.1)"
+    headers = _build_upstream_headers(
+        {
+            "User-Agent": native_ua,
+            "X-OpenAI-Internal-Codex-Responses-Lite": "1",
+        },
+        "token",
+        "acc_2",
+    )
+
+    lowered = {key.lower() for key in headers}
+    assert "x-openai-internal-codex-responses-lite" not in lowered
 
 
 def test_build_upstream_headers_accept_override():
@@ -1107,6 +1137,20 @@ def test_build_upstream_websocket_headers_strip_hop_by_hop_headers_and_connectio
     assert headers["Authorization"] == "Bearer token"
     assert headers["chatgpt-account-id"] == "acc_2"
     assert headers["User-Agent"] == "codex_cli_rs/0.1.0"
+
+
+def test_build_upstream_websocket_headers_strips_internal_responses_lite_header():
+    headers = proxy_module._build_upstream_websocket_headers(
+        {
+            "User-Agent": "codex_cli_rs/0.1.0",
+            "X-OpenAI-Internal-Codex-Responses-Lite": "1",
+        },
+        "token",
+        "acc_2",
+    )
+
+    lowered = {key.lower() for key in headers}
+    assert "x-openai-internal-codex-responses-lite" not in lowered
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -1064,6 +1064,21 @@ def test_responses_websocket_builder_normalizes_non_native_sdk_fingerprint():
     assert "responses_websockets=2026-02-06" in headers["openai-beta"]
 
 
+def test_responses_websocket_builder_strips_internal_responses_lite_header():
+    from app.core.clients.proxy_websocket import _build_upstream_websocket_headers
+
+    inbound = {
+        "User-Agent": "codex_cli_rs/0.142.0 (Mac OS 27.0.0; arm64) iTerm.app/3.6.10",
+        "X-OpenAI-Internal-Codex-Responses-Lite": "1",
+        "openai-beta": "responses_websockets=2026-02-06",
+    }
+    headers = _build_upstream_websocket_headers(inbound, "tok", "acct-1")
+    lowered = {key.lower() for key in headers}
+
+    assert "x-openai-internal-codex-responses-lite" not in lowered
+    assert "responses_websockets=2026-02-06" in headers["openai-beta"]
+
+
 def test_responses_websocket_builder_leaves_native_codex_unchanged():
     from app.core.clients.proxy_websocket import _build_upstream_websocket_headers
 


### PR DESCRIPTION
## Summary

Strip `X-OpenAI-Internal-Codex-Responses-Lite` before forwarding Requests upstream so OpenAI no longer rejects Codex model calls with `This model is not supported when using X-OpenAI-Internal-Codex-Responses-Lite`.

Root cause: codex-lb accepted and forwarded the client/internal Lite header as an upstream header. OpenAI now rejects some Codex models when that internal header reaches upstream, so the proxy should consume/ignore it locally and preserve the public Responses wire contract.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Not linked; operational fix from current upstream API rejection.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/strip-internal-responses-lite-header/`

## Changes

- Adds `x-openai-internal-codex-responses-lite` to the shared inbound upstream-header blocklist.
- Ensures the direct HTTP and internal websocket upstream builders apply the shared inbound filter before forwarding.
- Adds regression coverage for shared filtering, HTTP upstream headers, internal websocket headers, and client-facing Responses websocket headers.
- Documents the new compatibility requirement in OpenSpec.

## Test plan

```bash
uv run pytest tests/unit/test_proxy_utils.py -k "filter_inbound_headers or build_upstream_headers or build_upstream_websocket_headers"
# 10 passed, 536 deselected

uv run pytest tests/unit/test_proxy_websocket_client.py -k "responses_websocket_builder"
# 3 passed, 20 deselected

uv run pytest tests/unit/test_proxy_upstream_fingerprint.py tests/unit/test_codex_upstream_paths.py
# 32 passed

uv run ruff check app/core/clients/proxy.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_websocket_client.py
# All checks passed!

uv run ruff format --check app/core/clients/proxy.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_websocket_client.py
# 3 files already formatted

openspec validate strip-internal-responses-lite-header --strict
# Change 'strip-internal-responses-lite-header' is valid

openspec validate --specs
# Totals: 30 passed, 0 failed (30 items)

git diff --check
# no output
```

## Screenshots / output (optional)

Original upstream rejection observed locally:

```text
This model is not supported when using X-OpenAI-Internal-Codex-Responses-Lite.
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
