### PR TITLE
feat(request-ui): add showing elapsed time to request details

### DIFF
--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -152,6 +152,7 @@ describe("RecentRequestsTable", () => {
     expect(within(dialog).getByTestId("request-archive-panel")).toHaveTextContent("Archive for archive-req-1");
     expect(within(dialog).getByText("rate_limit_exceeded")).toBeInTheDocument();
     expect(dialog.textContent).toContain("Rate limit reached while processing this request");
+    expect(within(dialog).getByText("1.0 s")).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Copy Request ID" }));
@@ -760,6 +761,7 @@ describe("RecentRequestsTable", () => {
     expect(clientIpField).not.toBeNull();
     expect(clientIpField).toHaveTextContent("Client IP");
     expect(clientIpField).toHaveTextContent("—");
+    expect(within(dialog).getByText("1 ms")).toBeInTheDocument();
   });
 
   it("hides the cost section for total-only cost breakdown rows", () => {

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -32,6 +32,7 @@ import {
   formatCompactNumber,
   formatCurrency,
   formatModelLabel,
+  formatElapsed,
   formatSlug,
   formatTimeLong,
 } from "@/utils/formatters";
@@ -359,6 +360,7 @@ export function RecentRequestsTable({
                 <RequestDetailField label="Model" value={selectedRequest ? formatModelLabel(selectedRequest.model, selectedRequest.reasoningEffort, selectedRequest.actualServiceTier ?? selectedRequest.serviceTier) : "—"} mono />
                 <RequestDetailField label="Request kind" value={selectedRequest ? (REQUEST_KIND_LABELS[selectedRequest.requestKind] ?? selectedRequest.requestKind) : "—"} />
                 <RequestDetailField label="Plan" value={selectedRequest?.planType ? formatSlug(selectedRequest.planType) : "—"} />
+                <RequestDetailField label="Elapsed" value={formatElapsed(selectedRequest?.latencyMs ?? null)} />
               </div>
               <div className="grid gap-3 sm:grid-cols-3">
                 <RequestDetailField label="Transport" value={selectedRequest?.transport ? (TRANSPORT_LABELS[selectedRequest.transport] ?? selectedRequest.transport) : "—"} />

--- a/frontend/src/utils/formatters.test.ts
+++ b/frontend/src/utils/formatters.test.ts
@@ -9,6 +9,7 @@ import {
   formatCachedTokensMeta,
   formatLocalDateTimeSeconds,
   formatCompactNumber,
+  formatElapsed,
   formatCountdown,
   formatCurrency,
   formatIdTokenLabel,
@@ -126,6 +127,16 @@ describe("formatters", () => {
 
     expect(formatLocalDateTimeSeconds(iso)).toBe(expected);
     expect(formatLocalDateTimeSeconds("bad-date")).toBe("--");
+  });
+  
+it("formats elapsed latency values", () => {
+    expect(formatElapsed(500)).toBe("500 ms");
+    expect(formatElapsed(999)).toBe("999 ms");
+    expect(formatElapsed(1000)).toBe("1.0 s");
+    expect(formatElapsed(1500)).toBe("1.5 s");
+    expect(formatElapsed(3400)).toBe("3.4 s");
+    expect(formatElapsed(null)).toBe("—");
+    expect(formatElapsed(undefined)).toBe("—");
   });
 
   it("formats relative and countdown values", () => {

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -243,6 +243,16 @@ export function formatChartDateTime(iso: string | null | undefined): string {
   return date ? getChartDateTimeFormatter().format(date) : "--";
 }
 
+export function formatElapsed(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) {
+    return "—";
+  }
+  if (ms < 1000) {
+    return `${ms} ms`;
+  }
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
 export function formatRelative(ms: number): string {
   const minutes = Math.ceil(ms / 60_000);
   if (minutes < 60) {

--- a/openspec/changes/show-request-detail-elapsed-latency/.openspec.yaml
+++ b/openspec/changes/show-request-detail-elapsed-latency/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-27

--- a/openspec/changes/show-request-detail-elapsed-latency/design.md
+++ b/openspec/changes/show-request-detail-elapsed-latency/design.md
@@ -1,0 +1,26 @@
+## Context
+
+The request detail dialog already renders Plan, Status, Model, etc. from `RequestLog` data. `latencyMs` is available in the typed response but not displayed. Adding it is a one-field addition with a format helper.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show `latencyMs` as `Elapsed` in the request detail dialog next to `Plan`
+
+**Non-Goals:**
+- Latency columns in the table rows
+- TTFT (`latencyFirstTokenMs`) display
+- Latency charting or aggregation
+
+## Decisions
+
+**Formatter: `formatElapsed(ms)`**
+- `< 1000 ms` → `"500 ms"` (whole number, ms unit)
+- `>= 1000 ms` → `"1.5 s"` (one decimal, s unit)
+- `null | undefined` → `"—"` (em dash, consistent with other fields)
+
+**Placement**: In the existing `<RequestDetailField>` grid next to `Plan`, matching the user's request and keeping related metadata together.
+
+## Risks / Trade-offs
+
+- None. Purely additive display of already-fetched data.

--- a/openspec/changes/show-request-detail-elapsed-latency/proposal.md
+++ b/openspec/changes/show-request-detail-elapsed-latency/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Operators inspecting request details currently cannot see request latency in the detail dialog. The `latency_ms` field is already persisted and available in the API response but not rendered anywhere. Adding it next to the `Plan` field gives operators immediate visibility into response times.
+
+## What Changes
+
+- Add `formatElapsed(ms)` formatter that shows `<1000 ms` or `X.X s`
+- Render `Elapsed` field in the request detail dialog, adjacent to `Plan`
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: request detail dialog SHALL display latency as `Elapsed` next to `Plan`
+
+## Impact
+
+- `frontend/src/utils/formatters.ts` — new `formatElapsed` function
+- `frontend/src/features/dashboard/components/recent-requests-table.tsx` — new `Elapsed` field in dialog

--- a/openspec/changes/show-request-detail-elapsed-latency/specs/frontend-architecture/spec.md
+++ b/openspec/changes/show-request-detail-elapsed-latency/specs/frontend-architecture/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Request detail dialog displays elapsed latency
+The dashboard request-log `View Details` dialog SHALL display `latency_ms` as an `Elapsed` field next to the `Plan` field. The display value SHALL use `ms` units for values under 1000 ms and `s` units (to one decimal) for values 1000 ms or greater. When `latency_ms` is null, the field SHALL render an em dash (`—`).
+
+#### Scenario: Latency under one second shown in ms
+- **WHEN** a request log detail dialog opens and the row has `latency_ms: 500`
+- **THEN** the dialog displays `500 ms` in the `Elapsed` field
+
+#### Scenario: Latency at or above one second shown in seconds
+- **WHEN** a request log detail dialog opens and the row has `latency_ms: 1500`
+- **THEN** the dialog displays `1.5 s` in the `Elapsed` field
+
+#### Scenario: Missing latency renders em dash
+- **WHEN** a request log detail dialog opens and the row has `latency_ms: null`
+- **THEN** the dialog displays `—` in the `Elapsed` field

--- a/openspec/changes/show-request-detail-elapsed-latency/tasks.md
+++ b/openspec/changes/show-request-detail-elapsed-latency/tasks.md
@@ -1,0 +1,11 @@
+## 1. Formatter
+
+- [ ] 1.1 Add `formatElapsed(ms)` to `frontend/src/utils/formatters.ts`
+- [ ] 1.2 Add `formatElapsed` unit tests covering ms, s, and null/undefined
+
+## 2. Dashboard UI
+
+- [ ] 2.1 Add `Elapsed` field to the request detail dialog grid next to `Plan` in `recent-requests-table.tsx`
+- [ ] 2.2 Add dialog assertion tests verifying elapsed renders for ms, s, and missing values
+- [ ] 2.3 Export `formatElapsed` from the formatters import block in `recent-requests-table.tsx`
+- [ ] 2.4 Confirm TypeScript compiles and all existing tests pass


### PR DESCRIPTION
## Summary

Adds `Elapsed` latency display to the request detail dialog in the dashboard, allowing operators to see response times directly in the request details view.

## Type of change

- [x] `feat:` — new user-facing feature or capability

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/show-request-detail-elapsed-latency/`

## Changes

- Add `formatElapsed(ms)` formatter (`frontend/src/utils/formatters.ts`)
- Render `Elapsed` field in request detail dialog next to `Plan` (`frontend/src/features/dashboard/components/recent-requests-table.tsx`)
- Add formatter unit tests covering ms, s, and null/undefined (`frontend/src/utils/formatters.test.ts`)
- Add dialog assertion tests for elapsed rendering (`frontend/src/features/dashboard/components/recent-requests-table.test.tsx`)

## Test plan

```
# cd frontend && npx vitest run src/utils/formatters.test.ts --reporter=verbose
 ✓ 13 passed

# cd frontend && npx vitest run src/features/dashboard/components/recent-requests-table.test.tsx --reporter=verbose
 ✓ 14 passed

# cd frontend && npx tsc --noEmit
 (clean)
```

<img width="502" height="318" alt="螢幕截圖 2026-06-28 02 25 01" src="https://github.com/user-attachments/assets/dbc35cc6-d6a3-4c16-994f-74c55511a34b" />
