### PR TITLE
feat(usage): support Codex usage reset credits

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -23,6 +23,16 @@
       ]
     },
     {
+      "login": "codemoo",
+      "name": "Hwanmoo Yong",
+      "avatar_url": "https://avatars.githubusercontent.com/u/16550088?v=4",
+      "profile": "https://github.com/codemoo",
+      "contributions": [
+        "code",
+        "test"
+      ]
+    },
+    {
       "login": "JKamsker",
       "name": "Jonas Kamsker",
       "avatar_url": "https://avatars.githubusercontent.com/u/11245306?v=4",

--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -9,6 +9,7 @@ from fastapi import Request, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.requests import HTTPConnection
 
+from app.core.auth import generate_unique_account_id
 from app.core.auth.api_key_cache import get_api_key_cache
 from app.core.auth.dashboard_access import (
     DashboardPermission,
@@ -26,6 +27,7 @@ from app.core.exceptions import DashboardAuthError, DashboardPermissionError, Pr
 from app.core.request_locality import is_local_request
 from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_upstream_route
 from app.core.utils.time import utcnow
+from app.db.models import AccountStatus
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -35,6 +37,11 @@ from app.modules.dashboard_auth.service import DASHBOARD_SESSION_COOKIE, get_das
 logger = logging.getLogger(__name__)
 
 _bearer = HTTPBearer(description="API key (e.g. sk-clb-…)", auto_error=False)
+_CODEX_USAGE_IDENTITY_INACTIVE_WORKSPACE_STATUSES = {
+    AccountStatus.PAUSED,
+    AccountStatus.REAUTH_REQUIRED,
+    AccountStatus.DEACTIVATED,
+}
 
 
 # --- Error format markers ---
@@ -269,6 +276,7 @@ async def validate_codex_usage_identity(request: Request) -> ApiKeyData | None:
         if account is None:
             raise ProxyAuthError("Unknown or inactive chatgpt-account-id")
         local_account_id = account.id
+        local_account_email = account.email
         try:
             route = await resolve_upstream_route(
                 session,
@@ -295,6 +303,30 @@ async def validate_codex_usage_identity(request: Request) -> ApiKeyData | None:
         if exc.status_code in (401, 403):
             raise ProxyAuthError("Invalid ChatGPT token or chatgpt-account-id") from exc
         raise ProxyUpstreamError("Unable to validate ChatGPT credentials at this time") from exc
+    if usage_payload is not None and (usage_payload.workspace_id or usage_payload.workspace_label):
+        expected_account_id = generate_unique_account_id(
+            account_id,
+            local_account_email,
+            usage_payload.workspace_id,
+            usage_payload.workspace_label,
+        )
+        async with get_background_session() as session:
+            accounts_repo = AccountsRepository(session)
+            workspace_account = await accounts_repo.get_by_id(expected_account_id)
+            if workspace_account is not None and workspace_account.chatgpt_account_id == account_id:
+                if workspace_account.status in _CODEX_USAGE_IDENTITY_INACTIVE_WORKSPACE_STATUSES:
+                    raise ProxyAuthError("Unknown or inactive chatgpt-account-id")
+                local_account_id = workspace_account.id
+                try:
+                    route = await resolve_upstream_route(
+                        session,
+                        account_id=local_account_id,
+                        operation="usage_identity",
+                        scope="account",
+                        encryptor=TokenEncryptor(),
+                    )
+                except UpstreamProxyRouteError as exc:
+                    raise ProxyUpstreamError("Unable to resolve upstream proxy route for ChatGPT credentials") from exc
     request.state.codex_usage_identity_access_token = token
     request.state.codex_usage_identity_chatgpt_account_id = account_id
     request.state.codex_usage_identity_account_id = local_account_id

--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -268,10 +268,11 @@ async def validate_codex_usage_identity(request: Request) -> ApiKeyData | None:
         account = await accounts_repo.get_active_by_chatgpt_account_id(account_id)
         if account is None:
             raise ProxyAuthError("Unknown or inactive chatgpt-account-id")
+        local_account_id = account.id
         try:
             route = await resolve_upstream_route(
                 session,
-                account_id=account.id,
+                account_id=local_account_id,
                 operation="usage_identity",
                 scope="account",
                 encryptor=TokenEncryptor(),
@@ -280,7 +281,7 @@ async def validate_codex_usage_identity(request: Request) -> ApiKeyData | None:
             raise ProxyUpstreamError("Unable to resolve upstream proxy route for ChatGPT credentials") from exc
 
     try:
-        await fetch_usage(
+        usage_payload = await fetch_usage(
             access_token=token,
             account_id=account_id,
             route=route,
@@ -294,6 +295,11 @@ async def validate_codex_usage_identity(request: Request) -> ApiKeyData | None:
         if exc.status_code in (401, 403):
             raise ProxyAuthError("Invalid ChatGPT token or chatgpt-account-id") from exc
         raise ProxyUpstreamError("Unable to validate ChatGPT credentials at this time") from exc
+    request.state.codex_usage_identity_access_token = token
+    request.state.codex_usage_identity_chatgpt_account_id = account_id
+    request.state.codex_usage_identity_account_id = local_account_id
+    request.state.codex_usage_identity_route = route
+    request.state.codex_usage_identity_payload = usage_payload
     return None
 
 

--- a/app/core/clients/rate_limit_reset_credits.py
+++ b/app/core/clients/rate_limit_reset_credits.py
@@ -173,6 +173,7 @@ async def consume_reset_credit(
     account_id: str | None,
     credit_id: str,
     *,
+    redeem_request_id: str | None = None,
     base_url: str | None = None,
     timeout_seconds: float | None = None,
     max_retries: int | None = None,
@@ -193,8 +194,8 @@ async def consume_reset_credit(
         account_id,
         extra={"Content-Type": "application/json"},
     )
-    redeem_request_id = str(uuid.uuid4())
-    body = {"credit_id": credit_id, "redeem_request_id": redeem_request_id}
+    effective_redeem_request_id = redeem_request_id or str(uuid.uuid4())
+    body = {"credit_id": credit_id, "redeem_request_id": effective_redeem_request_id}
     retry_options = _retry_options(retries + 1)
     require_route_or_direct_egress_opt_in(
         route=route,

--- a/app/core/clients/usage.py
+++ b/app/core/clients/usage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Literal
 
 import aiohttp
 from aiohttp_retry import ExponentialRetry, RetryClient
@@ -50,6 +51,13 @@ class UsageFetchError(Exception):
         self.status_code = status_code
         self.message = message
         self.code = code
+
+
+class ConsumeRateLimitResetCreditResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    code: Literal["reset", "nothing_to_reset", "no_credit", "already_redeemed"]
+    windows_reset: int = 0
 
 
 async def fetch_usage(
@@ -124,6 +132,64 @@ async def fetch_usage(
         raise UsageFetchError(0, f"Usage fetch failed: {exc}") from exc
 
 
+async def consume_rate_limit_reset_credit(
+    *,
+    access_token: str,
+    account_id: str,
+    redeem_request_id: str,
+    base_url: str | None = None,
+    timeout_seconds: float | None = None,
+    max_retries: int | None = None,
+    client: RetryClient | None = None,
+    route: ResolvedUpstreamRoute | None = None,
+    codex_client: CodexClient | None = None,
+    allow_direct_egress: bool = False,
+) -> ConsumeRateLimitResetCreditResponse:
+    settings = get_settings()
+    usage_base = base_url or settings.upstream_base_url
+    url = _rate_limit_reset_url(usage_base)
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds or settings.usage_fetch_timeout_seconds)
+    retries = max_retries if max_retries is not None else settings.usage_fetch_max_retries
+    headers = _usage_headers(access_token, account_id)
+    payload = {"redeem_request_id": redeem_request_id}
+    retry_options = _retry_options(retries + 1)
+    require_route_or_direct_egress_opt_in(
+        route=route,
+        allow_direct_egress=allow_direct_egress,
+        operation="usage limit reset consume",
+    )
+
+    try:
+        if route is not None:
+            return await _consume_rate_limit_reset_via_codex(
+                url=url,
+                route=route,
+                headers=headers,
+                payload=payload,
+                timeout_seconds=timeout_seconds or settings.usage_fetch_timeout_seconds,
+                retries=retries,
+                codex_client=codex_client,
+            )
+        async with lease_retry_client(client) as retry_client:
+            async with retry_client.request(
+                "POST",
+                url,
+                headers=headers,
+                json=payload,
+                timeout=timeout,
+                retry_options=retry_options,
+            ) as resp:
+                data = await _safe_json(resp)
+                return _consume_rate_limit_reset_response_or_raise(data, resp.status)
+    except (aiohttp.ClientError, asyncio.TimeoutError, CodexTransportError) as exc:
+        logger.warning(
+            "Usage limit reset consume error request_id=%s error=%s",
+            get_request_id(),
+            exc,
+        )
+        raise UsageFetchError(0, f"Usage limit reset consume failed: {exc}") from exc
+
+
 async def _fetch_usage_via_codex(
     *,
     url: str,
@@ -166,6 +232,50 @@ async def _fetch_usage_via_codex(
     raise RuntimeError("unreachable usage retry state")
 
 
+async def _consume_rate_limit_reset_via_codex(
+    *,
+    url: str,
+    route: ResolvedUpstreamRoute,
+    headers: dict[str, str],
+    payload: dict[str, str],
+    timeout_seconds: float,
+    retries: int,
+    codex_client: CodexClient | None,
+) -> ConsumeRateLimitResetCreditResponse:
+    attempts = max(1, retries + 1)
+    owns_codex_client = codex_client is None
+    active_codex_client = codex_client or CodexClient(create_codex_session())
+    try:
+        for attempt in range(attempts):
+            try:
+                resp = await active_codex_client.request(
+                    "POST",
+                    url,
+                    route=route,
+                    headers=headers,
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+            except CodexTransportError:
+                if attempt < attempts - 1:
+                    await asyncio.sleep(_retry_delay_seconds(attempt))
+                    continue
+                raise
+
+            data = await _safe_codex_json(resp)
+            status = _codex_response_status(resp)
+            if status in RETRYABLE_STATUS and attempt < attempts - 1:
+                await asyncio.sleep(_retry_delay_seconds(attempt))
+                continue
+            return _consume_rate_limit_reset_response_or_raise(data, status)
+    finally:
+        if owns_codex_client:
+            close = getattr(active_codex_client, "close", None)
+            if callable(close):
+                await close()
+    raise RuntimeError("unreachable usage limit reset retry state")
+
+
 def _usage_payload_or_raise(data: JsonObject, status: int) -> UsagePayload:
     if status >= 400:
         code = _extract_error_code(data)
@@ -186,6 +296,31 @@ def _usage_payload_or_raise(data: JsonObject, status: int) -> UsagePayload:
             get_request_id(),
         )
         raise UsageFetchError(502, "Invalid usage payload") from exc
+
+
+def _consume_rate_limit_reset_response_or_raise(
+    data: JsonObject,
+    status: int,
+) -> ConsumeRateLimitResetCreditResponse:
+    if status >= 400:
+        code = _extract_error_code(data)
+        message = _extract_error_message(data) or f"Usage limit reset consume failed ({status})"
+        logger.warning(
+            "Usage limit reset consume failed request_id=%s status=%s code=%s message=%s",
+            get_request_id(),
+            status,
+            code,
+            message,
+        )
+        raise UsageFetchError(status, message, code=code)
+    try:
+        return ConsumeRateLimitResetCreditResponse.model_validate(data)
+    except ValidationError as exc:
+        logger.warning(
+            "Usage limit reset consume invalid payload request_id=%s",
+            get_request_id(),
+        )
+        raise UsageFetchError(502, "Invalid usage limit reset payload") from exc
 
 
 def _codex_response_status(response: object) -> int:
@@ -218,6 +353,13 @@ def _usage_url(base_url: str) -> str:
     if "/backend-api" not in normalized:
         normalized = f"{normalized}/backend-api"
     return f"{normalized}/wham/usage"
+
+
+def _rate_limit_reset_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if "/backend-api" not in normalized:
+        normalized = f"{normalized}/backend-api"
+    return f"{normalized}/wham/rate-limit-reset-credits/consume"
 
 
 def _usage_headers(access_token: str, account_id: str | None) -> dict[str, str]:

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -84,6 +84,11 @@ class DashboardRateLimitError(AppError):
         super().__init__(message, code=code)
 
 
+class DashboardUpstreamError(AppError):
+    status_code = 502
+    code = "upstream_error"
+
+
 class DashboardServiceUnavailableError(AppError):
     status_code = 503
     code = "service_unavailable"

--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -21,6 +21,7 @@ from app.core.exceptions import (
     DashboardPermissionError,
     DashboardRateLimitError,
     DashboardServiceUnavailableError,
+    DashboardUpstreamError,
     DashboardValidationError,
     ProxyAuthError,
     ProxyModelNotAllowed,
@@ -47,6 +48,7 @@ _DASHBOARD_EXCEPTION_TYPES: tuple[type[AppError], ...] = (
     DashboardValidationError,
     DashboardRateLimitError,
     DashboardServiceUnavailableError,
+    DashboardUpstreamError,
 )
 
 

--- a/app/core/usage/models.py
+++ b/app/core/usage/models.py
@@ -27,7 +27,7 @@ class CreditsPayload(BaseModel):
     balance: str | None = None
 
 
-class RateLimitResetCreditsSummary(BaseModel):
+class RateLimitResetCreditsPayload(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     available_count: int | None = None
@@ -50,5 +50,5 @@ class UsagePayload(BaseModel):
     seat_type: str | None = None
     rate_limit: RateLimitPayload | None = None
     credits: CreditsPayload | None = None
-    rate_limit_reset_credits: RateLimitResetCreditsSummary | None = None
+    rate_limit_reset_credits: RateLimitResetCreditsPayload | None = None
     additional_rate_limits: list[AdditionalRateLimitPayload] | None = None

--- a/app/modules/accounts/api.py
+++ b/app/modules/accounts/api.py
@@ -9,7 +9,14 @@ from app.core.auth.dependencies import (
     validate_dashboard_session,
 )
 from app.core.auth.refresh import RefreshError
-from app.core.exceptions import DashboardBadRequestError, DashboardConflictError, DashboardNotFoundError
+from app.core.clients.usage import UsageFetchError
+from app.core.exceptions import (
+    DashboardBadRequestError,
+    DashboardConflictError,
+    DashboardNotFoundError,
+    DashboardUpstreamError,
+)
+from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.dependencies import AccountsContext, get_accounts_context
 from app.modules.accounts.repository import AccountIdentityConflictError
 from app.modules.accounts.schemas import (
@@ -32,8 +39,16 @@ from app.modules.accounts.schemas import (
     AccountTrendsResponse,
     AccountUpdateRequest,
     AccountUpdateResponse,
+    AccountUsageResetConsumeResponse,
+    AccountUsageResetCreditsResponse,
 )
-from app.modules.accounts.service import AccountNotProbableError, AccountStateTransitionError, InvalidAuthJsonError
+from app.modules.accounts.service import (
+    AccountNotProbableError,
+    AccountStateTransitionError,
+    AccountUsageResetConsumeUnavailableError,
+    AccountUsageResetCreditsUnavailableError,
+    InvalidAuthJsonError,
+)
 
 router = APIRouter(
     prefix="/api/accounts",
@@ -58,6 +73,66 @@ async def get_account_trends(
     result = await context.service.get_account_trends(account_id)
     if not result:
         raise DashboardNotFoundError("Account not found", code="account_not_found")
+    return result
+
+
+@router.get("/{account_id}/usage-reset-credits", response_model=AccountUsageResetCreditsResponse)
+async def get_account_usage_reset_credits(
+    account_id: str,
+    context: AccountsContext = Depends(get_accounts_context),
+) -> AccountUsageResetCreditsResponse:
+    try:
+        result = await context.service.get_usage_reset_credits(account_id)
+    except AccountUsageResetCreditsUnavailableError as exc:
+        raise DashboardConflictError(str(exc), code="account_usage_reset_credits_unavailable") from exc
+    except UpstreamProxyRouteError as exc:
+        raise DashboardUpstreamError(
+            f"Unable to resolve upstream proxy route for usage reset credits: {exc.reason}",
+            code="upstream_proxy_unavailable",
+        ) from exc
+    except UsageFetchError as exc:
+        raise DashboardUpstreamError(
+            f"Usage reset credits fetch failed: {exc.message}",
+            code="usage_reset_credits_fetch_failed",
+        ) from exc
+    if not result:
+        raise DashboardNotFoundError("Account not found", code="account_not_found")
+    return result
+
+
+@router.post("/{account_id}/usage-reset-credits/consume", response_model=AccountUsageResetConsumeResponse)
+async def consume_account_usage_reset_credit(
+    request: Request,
+    account_id: str,
+    _write_access=Depends(require_dashboard_write_access),
+    context: AccountsContext = Depends(get_accounts_context),
+) -> AccountUsageResetConsumeResponse:
+    try:
+        result = await context.service.consume_usage_reset_credit(account_id)
+    except AccountUsageResetConsumeUnavailableError as exc:
+        raise DashboardConflictError(str(exc), code="account_usage_reset_consume_unavailable") from exc
+    except UpstreamProxyRouteError as exc:
+        raise DashboardUpstreamError(
+            f"Unable to resolve upstream proxy route for usage reset: {exc.reason}",
+            code="upstream_proxy_unavailable",
+        ) from exc
+    except UsageFetchError as exc:
+        raise DashboardUpstreamError(
+            f"Usage reset consume failed: {exc.message}",
+            code="usage_reset_consume_failed",
+        ) from exc
+    if result is None:
+        raise DashboardNotFoundError("Account not found", code="account_not_found")
+    AuditService.log_async(
+        "account_usage_reset_consumed",
+        actor_ip=request.client.host if request.client else None,
+        details={
+            "account_id": result.account_id,
+            "code": result.code,
+            "windows_reset": result.windows_reset,
+            "usage_written": result.usage_written,
+        },
+    )
     return result
 
 

--- a/app/modules/accounts/api.py
+++ b/app/modules/accounts/api.py
@@ -39,6 +39,7 @@ from app.modules.accounts.schemas import (
     AccountTrendsResponse,
     AccountUpdateRequest,
     AccountUpdateResponse,
+    AccountUsageResetConsumeRequest,
     AccountUsageResetConsumeResponse,
     AccountUsageResetCreditsResponse,
 )
@@ -104,11 +105,15 @@ async def get_account_usage_reset_credits(
 async def consume_account_usage_reset_credit(
     request: Request,
     account_id: str,
+    payload: AccountUsageResetConsumeRequest | None = None,
     _write_access=Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountUsageResetConsumeResponse:
     try:
-        result = await context.service.consume_usage_reset_credit(account_id)
+        result = await context.service.consume_usage_reset_credit(
+            account_id,
+            redeem_request_id=payload.redeem_request_id if payload is not None else None,
+        )
     except AccountUsageResetConsumeUnavailableError as exc:
         raise DashboardConflictError(str(exc), code="account_usage_reset_consume_unavailable") from exc
     except UpstreamProxyRouteError as exc:

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -32,6 +32,15 @@ class AccountRequestUsage(DashboardModel):
     total_cost_usd: float = 0.0
 
 
+class AccountUsageResetCredits(DashboardModel):
+    available_count: int = Field(ge=0)
+
+
+class AccountUsageResetCreditsResponse(DashboardModel):
+    account_id: str
+    rate_limit_reset_credits: AccountUsageResetCredits
+
+
 class AccountTokenStatus(DashboardModel):
     expires_at: datetime | None = None
     state: str | None = None
@@ -221,6 +230,20 @@ class AccountProbeResponse(DashboardModel):
     status: str
     account_id: str
     probe_status_code: int
+    primary_used_percent_before: float | None = None
+    primary_used_percent_after: float | None = None
+    secondary_used_percent_before: float | None = None
+    secondary_used_percent_after: float | None = None
+    account_status_before: str
+    account_status_after: str
+
+
+class AccountUsageResetConsumeResponse(DashboardModel):
+    status: str
+    account_id: str
+    code: str
+    windows_reset: int = 0
+    usage_written: bool
     primary_used_percent_before: float | None = None
     primary_used_percent_after: float | None = None
     secondary_used_percent_before: float | None = None

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from app.modules.shared.schemas import DashboardModel
 
@@ -236,6 +236,20 @@ class AccountProbeResponse(DashboardModel):
     secondary_used_percent_after: float | None = None
     account_status_before: str
     account_status_after: str
+
+
+class AccountUsageResetConsumeRequest(DashboardModel):
+    redeem_request_id: str | None = None
+
+    @field_validator("redeem_request_id")
+    @classmethod
+    def normalize_redeem_request_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("redeem_request_id must not be empty")
+        return normalized
 
 
 class AccountUsageResetConsumeResponse(DashboardModel):

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -68,6 +68,7 @@ from app.modules.proxy.account_cache import (
     get_account_selection_cache,
     mark_account_routing_unavailable,
 )
+from app.modules.rate_limit_reset_credits.store import get_rate_limit_reset_credits_store
 from app.modules.usage.additional_quota_keys import (
     get_additional_display_label_for_quota_key,
     get_additional_quota_routing_policy,
@@ -230,7 +231,7 @@ class AccountsService:
         account = await self._repo.get_by_id(account_id)
         if account is None:
             return None
-        if account.status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+        if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
             raise AccountUsageResetCreditsUnavailableError(
                 f"Account is {account.status.value} and cannot fetch usage reset credits",
             )
@@ -284,7 +285,12 @@ class AccountsService:
                 allow_direct_egress=retry_route is None,
             )
 
-    async def consume_usage_reset_credit(self, account_id: str) -> AccountUsageResetConsumeResponse | None:
+    async def consume_usage_reset_credit(
+        self,
+        account_id: str,
+        *,
+        redeem_request_id: str | None = None,
+    ) -> AccountUsageResetConsumeResponse | None:
         account = await self._repo.get_by_id(account_id)
         if account is None:
             return None
@@ -304,7 +310,11 @@ class AccountsService:
 
         primary_before, secondary_before = await self._latest_usage_percents(account_id)
         status_before = account.status.value
-        upstream_response = await self._consume_usage_reset_credit(account)
+        upstream_response, account = await self._consume_usage_reset_credit(
+            account, redeem_request_id=redeem_request_id
+        )
+        if upstream_response.code in ("reset", "already_redeemed", "no_credit", "nothing_to_reset"):
+            await get_rate_limit_reset_credits_store().invalidate(account_id)
 
         usage_written = False
         if upstream_response.code in ("reset", "already_redeemed") and self._usage_repo and self._usage_updater:
@@ -328,21 +338,27 @@ class AccountsService:
             account_status_after=refreshed.status.value,
         )
 
-    async def _consume_usage_reset_credit(self, account: Account) -> ConsumeRateLimitResetCreditResponse:
+    async def _consume_usage_reset_credit(
+        self,
+        account: Account,
+        *,
+        redeem_request_id: str | None = None,
+    ) -> tuple[ConsumeRateLimitResetCreditResponse, Account]:
         chatgpt_account_id = account.chatgpt_account_id
         if not chatgpt_account_id:
             raise AccountUsageResetConsumeUnavailableError("Account is missing ChatGPT account identity")
-        redeem_request_id = str(uuid4())
+        effective_redeem_request_id = redeem_request_id or str(uuid4())
         access_token = self._encryptor.decrypt(account.access_token_encrypted)
         route = await self._resolve_usage_reset_credit_route(account, operation="usage_reset_credits_consume")
         try:
-            return await consume_rate_limit_reset_credit(
+            response = await consume_rate_limit_reset_credit(
                 access_token=access_token,
                 account_id=chatgpt_account_id,
-                redeem_request_id=redeem_request_id,
+                redeem_request_id=effective_redeem_request_id,
                 route=route,
                 allow_direct_egress=route is None,
             )
+            return response, account
         except UsageFetchError as exc:
             if exc.status_code != 401 or self._auth_manager is None:
                 raise
@@ -356,13 +372,14 @@ class AccountsService:
                 raise AccountUsageResetConsumeUnavailableError("Account is missing ChatGPT account identity") from exc
             access_token = self._encryptor.decrypt(account.access_token_encrypted)
             retry_route = await self._resolve_usage_reset_credit_route(account, operation="usage_reset_credits_consume")
-            return await consume_rate_limit_reset_credit(
+            response = await consume_rate_limit_reset_credit(
                 access_token=access_token,
                 account_id=account.chatgpt_account_id,
-                redeem_request_id=redeem_request_id,
+                redeem_request_id=effective_redeem_request_id,
                 route=retry_route,
                 allow_direct_egress=retry_route is None,
             )
+            return response, account
 
     async def _resolve_usage_reset_credit_route(
         self,

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -5,6 +5,7 @@ import json
 import logging
 from datetime import timedelta
 from typing import cast
+from uuid import uuid4
 
 import aiohttp
 from pydantic import ValidationError
@@ -19,15 +20,24 @@ from app.core.auth import (
     token_expiry_epoch_ms,
 )
 from app.core.auth.api_key_cache import get_api_key_cache
+from app.core.auth.refresh import RefreshError
 from app.core.cache.invalidation import NAMESPACE_API_KEY, get_cache_invalidation_poller
 from app.core.clients.http import lease_http_session
+from app.core.clients.usage import (
+    ConsumeRateLimitResetCreditResponse,
+    UsageFetchError,
+    consume_rate_limit_reset_credit,
+    fetch_usage,
+)
 from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
-from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_upstream_route
+from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError, resolve_upstream_route
 from app.core.upstream_proxy.resolver import _is_missing_upstream_proxy_schema
+from app.core.usage.models import UsagePayload
 from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
 from app.db.models import Account, AccountStatus, DashboardSettings
+from app.db.session import get_background_session
 from app.modules.accounts.auth_manager import AuthManager
 from app.modules.accounts.mappers import build_account_summaries, build_account_usage_trends
 from app.modules.accounts.repository import AccountsRepository
@@ -44,6 +54,9 @@ from app.modules.accounts.schemas import (
     AccountRequestUsage,
     AccountSummary,
     AccountTrendsResponse,
+    AccountUsageResetConsumeResponse,
+    AccountUsageResetCredits,
+    AccountUsageResetCreditsResponse,
     CodexAuthJson,
     CodexAuthTokens,
     OpenCodeAuthJson,
@@ -87,6 +100,14 @@ class AccountNotProbableError(Exception):
 
 class AccountStateTransitionError(Exception):
     """Raised when an operator action is not valid for the account state."""
+
+
+class AccountUsageResetCreditsUnavailableError(Exception):
+    """Raised when a dashboard account cannot read upstream reset credits."""
+
+
+class AccountUsageResetConsumeUnavailableError(Exception):
+    """Raised when a dashboard account cannot consume upstream reset credits."""
 
 
 class AccountsService:
@@ -204,6 +225,159 @@ class AccountsService:
             secondary=trend.secondary if trend else [],
             secondary_scheduled=trend.secondary_scheduled if trend else [],
         )
+
+    async def get_usage_reset_credits(self, account_id: str) -> AccountUsageResetCreditsResponse | None:
+        account = await self._repo.get_by_id(account_id)
+        if account is None:
+            return None
+        if account.status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+            raise AccountUsageResetCreditsUnavailableError(
+                f"Account is {account.status.value} and cannot fetch usage reset credits",
+            )
+        if self._auth_manager is not None:
+            try:
+                account = await self._auth_manager.ensure_fresh(account)
+            except RefreshError as exc:
+                raise AccountUsageResetCreditsUnavailableError(
+                    f"Account credentials could not be refreshed: {exc.message}",
+                ) from exc
+        if not account.chatgpt_account_id:
+            raise AccountUsageResetCreditsUnavailableError("Account is missing ChatGPT account identity")
+
+        payload = await self._fetch_usage_payload_for_reset_credits(account)
+        reset_credits = payload.rate_limit_reset_credits
+        available_count = reset_credits.available_count if reset_credits is not None else None
+        return AccountUsageResetCreditsResponse(
+            account_id=account.id,
+            rate_limit_reset_credits=AccountUsageResetCredits(
+                available_count=max(0, int(available_count or 0)),
+            ),
+        )
+
+    async def _fetch_usage_payload_for_reset_credits(self, account: Account) -> UsagePayload:
+        access_token = self._encryptor.decrypt(account.access_token_encrypted)
+        route = await self._resolve_usage_reset_credit_route(account, operation="usage_reset_credits_read")
+        try:
+            return await fetch_usage(
+                access_token=access_token,
+                account_id=account.chatgpt_account_id,
+                route=route,
+                allow_direct_egress=route is None,
+            )
+        except UsageFetchError as exc:
+            if exc.status_code != 401 or self._auth_manager is None:
+                raise
+            try:
+                account = await self._auth_manager.ensure_fresh(account, force=True)
+            except RefreshError as refresh_exc:
+                raise AccountUsageResetCreditsUnavailableError(
+                    f"Account credentials could not be refreshed: {refresh_exc.message}",
+                ) from refresh_exc
+            if not account.chatgpt_account_id:
+                raise AccountUsageResetCreditsUnavailableError("Account is missing ChatGPT account identity") from exc
+            access_token = self._encryptor.decrypt(account.access_token_encrypted)
+            retry_route = await self._resolve_usage_reset_credit_route(account, operation="usage_reset_credits_read")
+            return await fetch_usage(
+                access_token=access_token,
+                account_id=account.chatgpt_account_id,
+                route=retry_route,
+                allow_direct_egress=retry_route is None,
+            )
+
+    async def consume_usage_reset_credit(self, account_id: str) -> AccountUsageResetConsumeResponse | None:
+        account = await self._repo.get_by_id(account_id)
+        if account is None:
+            return None
+        if account.status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+            raise AccountUsageResetConsumeUnavailableError(
+                f"Account is {account.status.value} and cannot consume usage reset credits",
+            )
+        if self._auth_manager is not None:
+            try:
+                account = await self._auth_manager.ensure_fresh(account)
+            except RefreshError as exc:
+                raise AccountUsageResetConsumeUnavailableError(
+                    f"Account credentials could not be refreshed: {exc.message}",
+                ) from exc
+        if not account.chatgpt_account_id:
+            raise AccountUsageResetConsumeUnavailableError("Account is missing ChatGPT account identity")
+
+        primary_before, secondary_before = await self._latest_usage_percents(account_id)
+        status_before = account.status.value
+        upstream_response = await self._consume_usage_reset_credit(account)
+
+        usage_written = False
+        if upstream_response.code in ("reset", "already_redeemed") and self._usage_repo and self._usage_updater:
+            usage_written = await self._usage_updater.force_refresh(account, ignore_refresh_disabled=True)
+            get_account_selection_cache().invalidate()
+
+        refreshed = await self._repo.get_by_id(account_id) or account
+        primary_after, secondary_after = await self._latest_usage_percents(account_id)
+
+        return AccountUsageResetConsumeResponse(
+            status="reset",
+            account_id=account_id,
+            code=upstream_response.code,
+            windows_reset=upstream_response.windows_reset,
+            usage_written=usage_written,
+            primary_used_percent_before=primary_before,
+            primary_used_percent_after=primary_after,
+            secondary_used_percent_before=secondary_before,
+            secondary_used_percent_after=secondary_after,
+            account_status_before=status_before,
+            account_status_after=refreshed.status.value,
+        )
+
+    async def _consume_usage_reset_credit(self, account: Account) -> ConsumeRateLimitResetCreditResponse:
+        chatgpt_account_id = account.chatgpt_account_id
+        if not chatgpt_account_id:
+            raise AccountUsageResetConsumeUnavailableError("Account is missing ChatGPT account identity")
+        redeem_request_id = str(uuid4())
+        access_token = self._encryptor.decrypt(account.access_token_encrypted)
+        route = await self._resolve_usage_reset_credit_route(account, operation="usage_reset_credits_consume")
+        try:
+            return await consume_rate_limit_reset_credit(
+                access_token=access_token,
+                account_id=chatgpt_account_id,
+                redeem_request_id=redeem_request_id,
+                route=route,
+                allow_direct_egress=route is None,
+            )
+        except UsageFetchError as exc:
+            if exc.status_code != 401 or self._auth_manager is None:
+                raise
+            try:
+                account = await self._auth_manager.ensure_fresh(account, force=True)
+            except RefreshError as refresh_exc:
+                raise AccountUsageResetConsumeUnavailableError(
+                    f"Account credentials could not be refreshed: {refresh_exc.message}",
+                ) from refresh_exc
+            if not account.chatgpt_account_id:
+                raise AccountUsageResetConsumeUnavailableError("Account is missing ChatGPT account identity") from exc
+            access_token = self._encryptor.decrypt(account.access_token_encrypted)
+            retry_route = await self._resolve_usage_reset_credit_route(account, operation="usage_reset_credits_consume")
+            return await consume_rate_limit_reset_credit(
+                access_token=access_token,
+                account_id=account.chatgpt_account_id,
+                redeem_request_id=redeem_request_id,
+                route=retry_route,
+                allow_direct_egress=retry_route is None,
+            )
+
+    async def _resolve_usage_reset_credit_route(
+        self,
+        account: Account,
+        *,
+        operation: str,
+    ) -> ResolvedUpstreamRoute | None:
+        async with get_background_session() as session:
+            return await resolve_upstream_route(
+                session,
+                account_id=account.id,
+                operation=operation,
+                scope="account",
+                encryptor=self._encryptor,
+            )
 
     async def export_opencode_auth(self, account_id: str) -> AccountOpenCodeAuthExportResponse | None:
         account = await self._repo.get_by_id(account_id)
@@ -519,7 +693,7 @@ class AccountsService:
         )
 
         if self._usage_repo and self._usage_updater:
-            await self._usage_updater.force_refresh(probe_account)
+            await self._usage_updater.force_refresh(probe_account, ignore_refresh_disabled=True)
             get_account_selection_cache().invalidate()
 
         refreshed = await self._repo.get_by_id(account_id) or account

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -288,7 +288,7 @@ class AccountsService:
         account = await self._repo.get_by_id(account_id)
         if account is None:
             return None
-        if account.status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+        if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
             raise AccountUsageResetConsumeUnavailableError(
                 f"Account is {account.status.value} and cannot consume usage reset credits",
             )

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6,6 +6,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from datetime import datetime, timezone
 from json import JSONDecodeError
 from typing import Any, Final, Literal, cast
@@ -46,6 +47,10 @@ from app.core.clients.rate_limit_reset_credits import (
     ResetCreditItem,
     consume_reset_credit,
 )
+from app.core.clients.usage import (
+    ConsumeRateLimitResetCreditResponse as UpstreamConsumeRateLimitResetCreditResponse,
+)
+from app.core.clients.usage import UsageFetchError, consume_rate_limit_reset_credit
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
@@ -56,7 +61,7 @@ from app.core.errors import (
     openai_error,
     response_failed_event,
 )
-from app.core.exceptions import ProxyAuthError, ProxyRateLimitError
+from app.core.exceptions import ProxyAuthError, ProxyRateLimitError, ProxyUpstreamError
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, bridge_public_contract_error_total
 from app.core.middleware.api_firewall import _parse_trusted_proxy_networks, resolve_connection_client_ip
 from app.core.openai.chat_requests import ChatCompletionsRequest
@@ -138,6 +143,8 @@ from app.modules.proxy.schemas import (
     AccountPoolUsageResponse,
     CodexModelEntry,
     CodexModelsResponse,
+    ConsumeRateLimitResetCreditRequest,
+    ConsumeRateLimitResetCreditResponse,
     FileCreateRequest,
     ModelListItem,
     ModelListResponse,
@@ -157,6 +164,7 @@ from app.modules.proxy.schemas import (
 )
 from app.modules.proxy.types import (
     CreditStatusDetailsData,
+    RateLimitResetCreditsData,
     RateLimitStatusPayloadData,
     RateLimitWindowSnapshotData,
 )
@@ -1204,6 +1212,24 @@ def _codex_usage_credit_snapshot(
         approx_local_messages=None,
         approx_cloud_messages=None,
     )
+
+
+def _codex_usage_reset_credits_from_request(request: Request) -> RateLimitResetCreditsData | None:
+    usage_payload = getattr(request.state, "codex_usage_identity_payload", None)
+    summary = getattr(usage_payload, "rate_limit_reset_credits", None)
+    if summary is None:
+        return None
+    return RateLimitResetCreditsData(available_count=max(0, int(summary.available_count or 0)))
+
+
+def _attach_codex_usage_reset_credits(
+    payload: RateLimitStatusPayloadData,
+    request: Request,
+) -> RateLimitStatusPayloadData:
+    reset_credits = _codex_usage_reset_credits_from_request(request)
+    if reset_credits is None:
+        return payload
+    return replace(payload, rate_limit_reset_credits=reset_credits)
 
 
 async def _build_aggregate_credit_limits(session: AsyncSession) -> dict[str, V1UsageLimitResponse]:
@@ -2997,15 +3023,104 @@ async def _transcribe_request(
 @usage_router.get("/api/codex/usage", response_model=RateLimitStatusPayload)
 @usage_router.get("/api/codex/usage/", response_model=RateLimitStatusPayload, include_in_schema=False)
 async def codex_usage(
+    request: Request,
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Depends(validate_codex_usage_identity),
 ) -> RateLimitStatusPayload:
     payload = (
         await _build_codex_usage_payload_for_api_key(api_key)
         if api_key is not None
-        else await context.service.get_rate_limit_payload()
+        else _attach_codex_usage_reset_credits(await context.service.get_rate_limit_payload(), request)
     )
     return RateLimitStatusPayload.from_data(payload)
+
+
+@usage_router.post(
+    "/api/codex/rate-limit-reset-credits/consume",
+    response_model=ConsumeRateLimitResetCreditResponse,
+)
+@usage_router.post(
+    "/api/codex/rate-limit-reset-credits/consume/",
+    response_model=ConsumeRateLimitResetCreditResponse,
+    include_in_schema=False,
+)
+async def codex_consume_rate_limit_reset_credit(
+    request: Request,
+    payload: ConsumeRateLimitResetCreditRequest = Body(...),
+    api_key: ApiKeyData | None = Depends(validate_codex_usage_identity),
+) -> ConsumeRateLimitResetCreditResponse | JSONResponse:
+    if api_key is not None:
+        raise ProxyAuthError("ChatGPT authentication required for usage limit reset credits")
+    redeem_request_id = payload.redeem_request_id.strip()
+    if not redeem_request_id:
+        return _logged_error_json_response(
+            request,
+            400,
+            openai_error(
+                "invalid_request_error",
+                "redeem_request_id must not be empty",
+                error_type="invalid_request_error",
+            ),
+        )
+
+    upstream_response = await _consume_rate_limit_reset_credit_for_request(
+        request,
+        redeem_request_id=redeem_request_id,
+    )
+    if upstream_response.code in {"reset", "already_redeemed"}:
+        await _force_refresh_codex_usage_identity_account(request)
+    return ConsumeRateLimitResetCreditResponse.model_validate(upstream_response.model_dump())
+
+
+async def _consume_rate_limit_reset_credit_for_request(
+    request: Request,
+    *,
+    redeem_request_id: str,
+) -> UpstreamConsumeRateLimitResetCreditResponse:
+    access_token = _request_state_str(request, "codex_usage_identity_access_token")
+    chatgpt_account_id = _request_state_str(request, "codex_usage_identity_chatgpt_account_id")
+    if access_token is None or chatgpt_account_id is None:
+        raise ProxyAuthError("ChatGPT authentication required for usage limit reset credits")
+    route = getattr(request.state, "codex_usage_identity_route", None)
+    try:
+        return await consume_rate_limit_reset_credit(
+            access_token=access_token,
+            account_id=chatgpt_account_id,
+            redeem_request_id=redeem_request_id,
+            route=route,
+            allow_direct_egress=route is None,
+        )
+    except UsageFetchError as exc:
+        if exc.status_code == 429:
+            raise ProxyRateLimitError(exc.message) from exc
+        if exc.status_code in (401, 403):
+            raise ProxyAuthError("Invalid ChatGPT token or chatgpt-account-id") from exc
+        raise ProxyUpstreamError("Unable to consume ChatGPT usage reset at this time") from exc
+
+
+async def _force_refresh_codex_usage_identity_account(request: Request) -> None:
+    account_id = _request_state_str(request, "codex_usage_identity_account_id")
+    if account_id is None:
+        return
+    async with get_background_session() as session:
+        accounts_repo = AccountsRepository(session)
+        account = await accounts_repo.get_by_id(account_id)
+        if account is None:
+            return
+        updater = UsageUpdater(
+            UsageRepository(session),
+            accounts_repo,
+            AdditionalUsageRepository(session),
+        )
+        await updater.force_refresh(account, ignore_refresh_disabled=True)
+
+
+def _request_state_str(request: Request, name: str) -> str | None:
+    value = getattr(request.state, name, None)
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
 
 
 async def _prepend_first(first: str | None, stream: AsyncIterator[str]) -> AsyncIterator[str]:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3112,7 +3112,9 @@ async def _force_refresh_codex_usage_identity_account(request: Request) -> None:
             accounts_repo,
             AdditionalUsageRepository(session),
         )
-        await updater.force_refresh(account, ignore_refresh_disabled=True)
+        usage_written = await updater.force_refresh(account, ignore_refresh_disabled=True)
+        if usage_written:
+            get_account_selection_cache().invalidate()
 
 
 def _request_state_str(request: Request, name: str) -> str | None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3067,6 +3067,9 @@ async def codex_consume_rate_limit_reset_credit(
         request,
         redeem_request_id=redeem_request_id,
     )
+    account_id = _request_state_str(request, "codex_usage_identity_account_id")
+    if account_id is not None:
+        await get_rate_limit_reset_credits_store().invalidate(account_id)
     if upstream_response.code in {"reset", "already_redeemed"}:
         await _force_refresh_codex_usage_identity_account(request)
     return ConsumeRateLimitResetCreditResponse.model_validate(upstream_response.model_dump())
@@ -3102,6 +3105,7 @@ async def _force_refresh_codex_usage_identity_account(request: Request) -> None:
     account_id = _request_state_str(request, "codex_usage_identity_account_id")
     if account_id is None:
         return
+    access_token = _request_state_str(request, "codex_usage_identity_access_token")
     async with get_background_session() as session:
         accounts_repo = AccountsRepository(session)
         account = await accounts_repo.get_by_id(account_id)
@@ -3112,7 +3116,11 @@ async def _force_refresh_codex_usage_identity_account(request: Request) -> None:
             accounts_repo,
             AdditionalUsageRepository(session),
         )
-        usage_written = await updater.force_refresh(account, ignore_refresh_disabled=True)
+        usage_written = await updater.force_refresh(
+            account,
+            ignore_refresh_disabled=True,
+            access_token_override=access_token,
+        )
         if usage_written:
             get_account_selection_cache().invalidate()
 

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -9,6 +9,7 @@ from app.core.types import JsonValue
 from app.modules.proxy.types import (
     AdditionalRateLimitData,
     CreditStatusDetailsData,
+    RateLimitResetCreditsData,
     RateLimitStatusDetailsData,
     RateLimitStatusPayloadData,
     RateLimitWindowSnapshotData,
@@ -111,12 +112,23 @@ class AdditionalRateLimitStatus(BaseModel):
         )
 
 
+class RateLimitResetCredits(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    available_count: int
+
+    @classmethod
+    def from_data(cls, data: RateLimitResetCreditsData) -> "RateLimitResetCredits":
+        return cls(available_count=data.available_count)
+
+
 class RateLimitStatusPayload(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     plan_type: str
     rate_limit: RateLimitStatusDetails | None = None
     credits: CreditStatusDetails | None = None
+    rate_limit_reset_credits: RateLimitResetCredits | None = None
     additional_rate_limits: list[AdditionalRateLimitStatus] = []
 
     @classmethod
@@ -125,8 +137,26 @@ class RateLimitStatusPayload(BaseModel):
             plan_type=data.plan_type,
             rate_limit=RateLimitStatusDetails.from_data(data.rate_limit) if data.rate_limit else None,
             credits=CreditStatusDetails.from_data(data.credits) if data.credits else None,
+            rate_limit_reset_credits=(
+                RateLimitResetCredits.from_data(data.rate_limit_reset_credits)
+                if data.rate_limit_reset_credits
+                else None
+            ),
             additional_rate_limits=[AdditionalRateLimitStatus.from_data(arl) for arl in data.additional_rate_limits],
         )
+
+
+class ConsumeRateLimitResetCreditRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    redeem_request_id: str
+
+
+class ConsumeRateLimitResetCreditResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    code: str
+    windows_reset: int = 0
 
 
 class ReasoningLevelSchema(BaseModel):

--- a/app/modules/proxy/types.py
+++ b/app/modules/proxy/types.py
@@ -32,6 +32,11 @@ class CreditStatusDetailsData:
 
 
 @dataclass(frozen=True)
+class RateLimitResetCreditsData:
+    available_count: int
+
+
+@dataclass(frozen=True)
 class AdditionalRateLimitData:
     limit_name: str
     metered_feature: str
@@ -45,4 +50,5 @@ class RateLimitStatusPayloadData:
     plan_type: str
     rate_limit: RateLimitStatusDetailsData | None = None
     credits: CreditStatusDetailsData | None = None
+    rate_limit_reset_credits: RateLimitResetCreditsData | None = None
     additional_rate_limits: list[AdditionalRateLimitData] = field(default_factory=list)

--- a/app/modules/rate_limit_reset_credits/api.py
+++ b/app/modules/rate_limit_reset_credits/api.py
@@ -42,6 +42,7 @@ from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteErr
 from app.db.models import Account, AccountStatus
 from app.dependencies import AccountsContext, get_accounts_context
 from app.modules.accounts.auth_manager import AuthManager
+from app.modules.accounts.schemas import AccountUsageResetConsumeRequest
 from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.rate_limit_reset_credits.store import (
     RateLimitResetCreditsStore,
@@ -131,6 +132,7 @@ async def get_rate_limit_reset_credits(
 async def consume_rate_limit_reset_credit(
     request: Request,
     account_id: str,
+    payload: AccountUsageResetConsumeRequest | None = None,
     _write_access=Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> ConsumeResetCreditResponseSchema:
@@ -149,6 +151,7 @@ async def consume_rate_limit_reset_credit(
             auth_manager=context.service._auth_manager,
             refresh_usage=_build_refresh_usage_callback(context),
             resolve_route=_resolve_reset_credit_route,
+            redeem_request_id=payload.redeem_request_id if payload is not None else None,
         )
     except RefreshError as exc:
         if exc.is_permanent:
@@ -188,6 +191,7 @@ async def _redeem_soonest_reset_credit(
     auth_manager: AuthManager | None = None,
     refresh_usage: RefreshUsageFn | None = None,
     resolve_route: ResolveRouteFn | None = None,
+    redeem_request_id: str | None = None,
 ) -> _RedeemResetCreditOutcome:
     _assert_account_can_redeem_reset_credit(account)
     effective_fetch_fn = fetch_fn or fetch_reset_credits
@@ -203,6 +207,7 @@ async def _redeem_soonest_reset_credit(
             auth_manager=auth_manager,
             refresh_usage=refresh_usage,
             resolve_route=resolve_route,
+            redeem_request_id=redeem_request_id,
         )
 
 
@@ -241,6 +246,7 @@ async def _redeem_soonest_reset_credit_locked(
     auth_manager: AuthManager | None,
     refresh_usage: RefreshUsageFn | None,
     resolve_route: ResolveRouteFn | None,
+    redeem_request_id: str | None,
 ) -> _RedeemResetCreditOutcome:
     redeem_account = account
     if auth_manager is not None:
@@ -248,7 +254,10 @@ async def _redeem_soonest_reset_credit_locked(
 
     cached_snapshot = store.get(account.id)
     cached_credit = _select_soonest_available_credit(cached_snapshot)
-    if cached_credit is None:
+    pending_credit_id = (
+        store.get_redeem_request_credit_id(account.id, redeem_request_id) if redeem_request_id is not None else None
+    )
+    if cached_credit is None and pending_credit_id is None:
         raise DashboardConflictError("No available reset credit", code="no_available_reset_credit")
 
     access_token = encryptor.decrypt(redeem_account.access_token_encrypted)
@@ -267,15 +276,25 @@ async def _redeem_soonest_reset_credit_locked(
         raise _translate_fetch_error(exc) from exc
 
     credit = _select_soonest_available_credit_from_response(credits_response)
-    if credit is None:
+    if pending_credit_id is not None:
+        credit_id = pending_credit_id
+    elif credit is None:
         await store.set(account.id, build_snapshot(credits_response))
-        raise DashboardConflictError("No available reset credit", code="no_available_reset_credit")
+        if cached_credit is None or redeem_request_id is None:
+            raise DashboardConflictError("No available reset credit", code="no_available_reset_credit")
+        credit_id = cached_credit.id
+        await store.remember_redeem_request(account.id, redeem_request_id, credit_id)
+    else:
+        credit_id = credit.id
+        if redeem_request_id is not None:
+            await store.remember_redeem_request(account.id, redeem_request_id, credit_id)
 
     try:
         result = await effective_consume_fn(
             access_token,
             redeem_account.chatgpt_account_id,
-            credit.id,
+            credit_id,
+            redeem_request_id=redeem_request_id,
             route=route,
             allow_direct_egress=route is None,
         )

--- a/app/modules/rate_limit_reset_credits/store.py
+++ b/app/modules/rate_limit_reset_credits/store.py
@@ -18,6 +18,7 @@ class RateLimitResetCreditsStore:
 
     def __init__(self) -> None:
         self._snapshots: dict[str, RateLimitResetCreditsSnapshot] = {}
+        self._pending_redeems: dict[tuple[str, str], str] = {}
         self._lock = anyio.Lock()
         self._clear_generation = 0
         self._account_generations: dict[str, int] = {}
@@ -70,10 +71,18 @@ class RateLimitResetCreditsStore:
     def get(self, account_id: str) -> RateLimitResetCreditsSnapshot | None:
         return self._snapshots.get(account_id)
 
+    async def remember_redeem_request(self, account_id: str, redeem_request_id: str, credit_id: str) -> None:
+        async with self._lock:
+            self._pending_redeems[(account_id, redeem_request_id)] = credit_id
+
+    def get_redeem_request_credit_id(self, account_id: str, redeem_request_id: str) -> str | None:
+        return self._pending_redeems.get((account_id, redeem_request_id))
+
     async def invalidate(self, account_id: str | None = None) -> None:
         async with self._lock:
             if account_id is None:
                 self._snapshots.clear()
+                self._pending_redeems.clear()
                 self._clear_generation += 1
                 return
             self._snapshots.pop(account_id, None)

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -314,7 +314,13 @@ class UsageUpdater:
                 continue
         return refreshed
 
-    async def force_refresh(self, account: Account, *, ignore_refresh_disabled: bool = False) -> bool:
+    async def force_refresh(
+        self,
+        account: Account,
+        *,
+        ignore_refresh_disabled: bool = False,
+        access_token_override: str | None = None,
+    ) -> bool:
         """Refresh one account regardless of cached/fresh usage rows."""
         settings = get_settings()
         if not settings.usage_refresh_enabled and not ignore_refresh_disabled:
@@ -327,6 +333,7 @@ class UsageUpdater:
                 lambda: self._refresh_account(
                     account,
                     usage_account_id=account.chatgpt_account_id,
+                    access_token_override=access_token_override,
                 ),
                 join_existing=False,
             )
@@ -377,8 +384,9 @@ class UsageUpdater:
         account: Account,
         *,
         usage_account_id: str | None,
+        access_token_override: str | None = None,
     ) -> AccountRefreshResult:
-        access_token = self._encryptor.decrypt(account.access_token_encrypted)
+        access_token = access_token_override or self._encryptor.decrypt(account.access_token_encrypted)
         payload: UsagePayload | None = None
         try:
             route = await _resolve_upstream_route_for_account(account, operation="usage_refresh")
@@ -399,6 +407,9 @@ class UsageUpdater:
         except UsageFetchError as exc:
             if _should_deactivate_for_usage_error(exc):
                 await self._deactivate_for_client_error(account, exc)
+                return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
+            if access_token_override is not None:
+                _mark_usage_refresh_auth_cooldown(account.id, exc.status_code)
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
             if exc.status_code != 401 or not self._auth_manager:
                 _mark_usage_refresh_auth_cooldown(account.id, exc.status_code)

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -314,10 +314,10 @@ class UsageUpdater:
                 continue
         return refreshed
 
-    async def force_refresh(self, account: Account) -> bool:
+    async def force_refresh(self, account: Account, *, ignore_refresh_disabled: bool = False) -> bool:
         """Refresh one account regardless of cached/fresh usage rows."""
         settings = get_settings()
-        if not settings.usage_refresh_enabled:
+        if not settings.usage_refresh_enabled and not ignore_refresh_disabled:
             return False
         if account.status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
             return False

--- a/frontend/src/features/accounts/api.ts
+++ b/frontend/src/features/accounts/api.ts
@@ -12,6 +12,8 @@ import {
   AccountsResponseSchema,
   AccountRoutingPolicyUpdateRequestSchema,
   AccountRoutingPolicyUpdateResponseSchema,
+  AccountUsageResetConsumeResponseSchema,
+  AccountUsageResetCreditsResponseSchema,
   AccountTrendsResponseSchema,
   AccountProbeRequestSchema,
   AccountProbeResponseSchema,
@@ -100,6 +102,20 @@ export function getAccountTrends(accountId: string) {
   return get(
     `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/trends`,
     AccountTrendsResponseSchema,
+  );
+}
+
+export function getAccountUsageResetCredits(accountId: string) {
+  return get(
+    `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/usage-reset-credits`,
+    AccountUsageResetCreditsResponseSchema,
+  );
+}
+
+export function consumeAccountUsageResetCredit(accountId: string) {
+  return post(
+    `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/usage-reset-credits/consume`,
+    AccountUsageResetConsumeResponseSchema,
   );
 }
 

--- a/frontend/src/features/accounts/api.ts
+++ b/frontend/src/features/accounts/api.ts
@@ -12,6 +12,7 @@ import {
   AccountsResponseSchema,
   AccountRoutingPolicyUpdateRequestSchema,
   AccountRoutingPolicyUpdateResponseSchema,
+  AccountUsageResetConsumeRequestSchema,
   AccountUsageResetConsumeResponseSchema,
   AccountUsageResetCreditsResponseSchema,
   AccountTrendsResponseSchema,
@@ -28,7 +29,10 @@ import {
   RateLimitResetCreditsSnapshotSchema,
   RuntimeConnectAddressResponseSchema,
 } from "@/features/accounts/schemas";
-import type { AccountRoutingPolicy } from "@/features/accounts/schemas";
+import type {
+  AccountRoutingPolicy,
+  AccountUsageResetConsumeRequest,
+} from "@/features/accounts/schemas";
 
 const ACCOUNTS_BASE_PATH = "/api/accounts";
 const OAUTH_BASE_PATH = "/api/oauth";
@@ -112,10 +116,15 @@ export function getAccountUsageResetCredits(accountId: string) {
   );
 }
 
-export function consumeAccountUsageResetCredit(accountId: string) {
+export function consumeAccountUsageResetCredit(
+  accountId: string,
+  payload?: AccountUsageResetConsumeRequest,
+) {
+  const validated = payload === undefined ? undefined : AccountUsageResetConsumeRequestSchema.parse(payload);
   return post(
     `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/usage-reset-credits/consume`,
     AccountUsageResetConsumeResponseSchema,
+    validated ? { body: validated } : undefined,
   );
 }
 
@@ -142,10 +151,15 @@ export function getRateLimitResetCredits(accountId: string) {
   );
 }
 
-export function consumeRateLimitResetCredit(accountId: string) {
+export function consumeRateLimitResetCredit(
+  accountId: string,
+  payload?: AccountUsageResetConsumeRequest,
+) {
+  const validated = payload === undefined ? undefined : AccountUsageResetConsumeRequestSchema.parse(payload);
   return post(
     `${ACCOUNTS_BASE_PATH}/${encodeURIComponent(accountId)}/rate-limit-reset-credits/consume`,
     ConsumeRateLimitResetCreditResponseSchema,
+    validated ? { body: validated } : undefined,
   );
 }
 

--- a/frontend/src/features/accounts/components/account-detail.test.tsx
+++ b/frontend/src/features/accounts/components/account-detail.test.tsx
@@ -25,6 +25,7 @@ describe("AccountDetail", () => {
         onPause={vi.fn()}
         onResume={vi.fn()}
         onProbe={vi.fn()}
+        onResetUsage={vi.fn()}
         onSetAlias={vi.fn().mockResolvedValue(undefined)}
         onDelete={vi.fn()}
         onReauth={vi.fn()}
@@ -55,6 +56,7 @@ describe("AccountDetail", () => {
         onPause={vi.fn()}
         onResume={vi.fn()}
         onProbe={vi.fn()}
+        onResetUsage={vi.fn()}
         onSetAlias={onSetAlias}
         onDelete={vi.fn()}
         onReauth={vi.fn()}
@@ -67,10 +69,12 @@ describe("AccountDetail", () => {
         upstreamProxyAdmin={createUpstreamProxyAdmin({
           bindings: [{ accountId: "acc_primary", poolId: "pool_primary", isActive: true }],
         })}
+        resetCredits={{ availableCount: 1 }}
       />,
     );
 
     expect(screen.getByRole("button", { name: "Edit alias" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Reset usage" })).toBeDisabled();
     expect(screen.getByRole("switch", { name: "Enable account proxy binding" })).toBeDisabled();
     expect(screen.getByRole("combobox", { name: "Account proxy pool" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Save binding" })).toBeDisabled();

--- a/frontend/src/features/accounts/components/account-detail.test.tsx
+++ b/frontend/src/features/accounts/components/account-detail.test.tsx
@@ -79,4 +79,30 @@ describe("AccountDetail", () => {
     expect(screen.getByRole("combobox", { name: "Account proxy pool" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Save binding" })).toBeDisabled();
   });
+
+  it("disables usage reset for paused accounts", () => {
+    const account = createAccountSummary({ status: "paused" });
+
+    renderWithClient(
+      <AccountDetail
+        account={account}
+        busy={false}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onProbe={vi.fn()}
+        onResetUsage={vi.fn()}
+        onSetAlias={vi.fn().mockResolvedValue(undefined)}
+        onDelete={vi.fn()}
+        onReauth={vi.fn()}
+        onExportAuth={vi.fn()}
+        onResetCredit={vi.fn()}
+        onLimitWarmupChange={vi.fn()}
+        onRoutingPolicyChange={vi.fn()}
+        onSecurityWorkAuthorizedChange={vi.fn()}
+        resetCredits={{ availableCount: 2 }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Reset usage" })).toBeDisabled();
+  });
 });

--- a/frontend/src/features/accounts/components/account-detail.tsx
+++ b/frontend/src/features/accounts/components/account-detail.tsx
@@ -102,7 +102,8 @@ export function AccountDetail({
   const seatLabel = account.seatType ? ` | ${formatSlug(account.seatType)}` : "";
   const operatorRecoveryAction =
     account.status === "reauth_required" || account.status === "deactivated";
-  const usageResetDisabled = busy || readOnly || operatorRecoveryAction || (resetCredits?.availableCount ?? 0) <= 0;
+  const usageResetDisabled =
+    busy || readOnly || account.status === "paused" || operatorRecoveryAction || (resetCredits?.availableCount ?? 0) <= 0;
 
   return (
     <div

--- a/frontend/src/features/accounts/components/account-detail.tsx
+++ b/frontend/src/features/accounts/components/account-detail.tsx
@@ -13,6 +13,7 @@ import { AccountUsagePanel } from "@/features/accounts/components/account-usage-
 import type {
   AccountRoutingPolicy,
   AccountSummary,
+  AccountUsageResetCredits,
 } from "@/features/accounts/schemas";
 import { useAccountTrends } from "@/features/accounts/hooks/use-accounts";
 import type { AccountProxyBindingRequest, UpstreamProxyAdmin } from "@/features/settings/schemas";
@@ -27,6 +28,7 @@ export type AccountDetailProps = {
   onPause: (accountId: string) => void;
   onResume: (accountId: string) => void;
   onProbe: (accountId: string) => void;
+  onResetUsage: (accountId: string) => void;
   onSetAlias: (accountId: string, alias: string | null) => Promise<unknown>;
   onDelete: (accountId: string) => void;
   onReauth: () => void;
@@ -40,6 +42,9 @@ export type AccountDetailProps = {
   onSecurityWorkAuthorizedChange: (accountId: string, enabled: boolean) => void;
   upstreamProxyAdmin?: UpstreamProxyAdmin | null;
   onProxyBindingSave?: (accountId: string, payload: AccountProxyBindingRequest) => Promise<unknown>;
+  resetCredits?: AccountUsageResetCredits | null;
+  resetCreditsLoading?: boolean;
+  resetCreditsUnavailable?: boolean;
 };
 
 export function AccountDetail({
@@ -50,6 +55,7 @@ export function AccountDetail({
   onPause,
   onResume,
   onProbe,
+  onResetUsage,
   onSetAlias,
   onDelete,
   onReauth,
@@ -60,6 +66,9 @@ export function AccountDetail({
   onSecurityWorkAuthorizedChange,
   upstreamProxyAdmin = null,
   onProxyBindingSave,
+  resetCredits = null,
+  resetCreditsLoading = false,
+  resetCreditsUnavailable = false,
 }: AccountDetailProps) {
   const { data: trends } = useAccountTrends(account?.accountId ?? null);
   const blurred = usePrivacyStore((s) => s.blurred);
@@ -91,6 +100,9 @@ export function AccountDetail({
   const idSuffix = showAccountId ? ` (${compactId})` : "";
   const workspaceLabel = account.chatgptAccountId || account.workspaceLabel || account.workspaceId || "Personal / unknown workspace";
   const seatLabel = account.seatType ? ` | ${formatSlug(account.seatType)}` : "";
+  const operatorRecoveryAction =
+    account.status === "reauth_required" || account.status === "deactivated";
+  const usageResetDisabled = busy || readOnly || operatorRecoveryAction || (resetCredits?.availableCount ?? 0) <= 0;
 
   return (
     <div
@@ -138,7 +150,15 @@ export function AccountDetail({
           onSave={onProxyBindingSave}
         />
       ) : null}
-      <AccountUsagePanel account={account} trends={trends} />
+      <AccountUsagePanel
+        account={account}
+        trends={trends}
+        resetCredits={resetCredits}
+        resetCreditsLoading={resetCreditsLoading}
+        resetCreditsUnavailable={resetCreditsUnavailable}
+        resetDisabled={usageResetDisabled}
+        onReset={onResetUsage}
+      />
       <AccountTokenInfo account={account} />
       <AccountActions
         account={account}

--- a/frontend/src/features/accounts/components/account-usage-panel.test.tsx
+++ b/frontend/src/features/accounts/components/account-usage-panel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { AccountUsagePanel } from "@/features/accounts/components/account-usage-panel";
@@ -110,6 +110,40 @@ describe("AccountUsagePanel", () => {
     expect(screen.getByText("Request logs total")).toBeInTheDocument();
     expect(screen.getByText(/\$0\.13/)).toBeInTheDocument();
     expect(screen.getByText(/51\.48K tok/)).toBeInTheDocument();
+  });
+
+  it("renders usage reset credit availability when provided", () => {
+    const account = createAccountSummary();
+
+    render(
+      <AccountUsagePanel
+        account={account}
+        trends={null}
+        resetCredits={{ availableCount: 3 }}
+      />,
+    );
+
+    expect(screen.getByText("Usage resets")).toBeInTheDocument();
+    expect(screen.getByText("3 available")).toBeInTheDocument();
+  });
+
+  it("renders a usage reset action when provided", () => {
+    const account = createAccountSummary({ accountId: "acc_reset" });
+    const onReset = vi.fn();
+
+    render(
+      <AccountUsagePanel
+        account={account}
+        trends={null}
+        resetCredits={{ availableCount: 1 }}
+        onReset={onReset}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset usage" }));
+
+    expect(onReset).toHaveBeenCalledWith("acc_reset");
+    expect(onReset).toHaveBeenCalledTimes(1);
   });
 
   it("shows the weekly plan legend when scheduled trend data exists", () => {

--- a/frontend/src/features/accounts/components/account-usage-panel.tsx
+++ b/frontend/src/features/accounts/components/account-usage-panel.tsx
@@ -1,9 +1,14 @@
 import { lazy, Suspense } from "react";
-import { Clock, Flame } from "lucide-react";
+import { Clock, Flame, RotateCcw } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { AccountTrendChartProps } from "@/features/accounts/components/account-trend-chart";
-import type { AccountSummary, AccountTrendsResponse } from "@/features/accounts/schemas";
+import type {
+  AccountSummary,
+  AccountTrendsResponse,
+  AccountUsageResetCredits,
+} from "@/features/accounts/schemas";
 import { quotaBarColor, quotaBarTrack } from "@/utils/account-status";
 import {
   formatCompactNumber,
@@ -23,6 +28,11 @@ const AccountTrendChart = lazy(() =>
 export type AccountUsagePanelProps = {
   account: AccountSummary;
   trends?: AccountTrendsResponse | null;
+  resetCredits?: AccountUsageResetCredits | null;
+  resetCreditsLoading?: boolean;
+  resetCreditsUnavailable?: boolean;
+  resetDisabled?: boolean;
+  onReset?: (accountId: string) => void;
 };
 
 function QuotaRow({
@@ -135,7 +145,69 @@ const ADDITIONAL_ROUTING_POLICY_LABELS: Record<string, string> = {
   preserve: "Preserve",
 };
 
-export function AccountUsagePanel({ account, trends }: AccountUsagePanelProps) {
+function ResetCreditsRow({
+  accountId,
+  resetCredits,
+  loading,
+  unavailable,
+  resetDisabled,
+  onReset,
+}: {
+  accountId: string;
+  resetCredits?: AccountUsageResetCredits | null;
+  loading?: boolean;
+  unavailable?: boolean;
+  resetDisabled?: boolean;
+  onReset?: (accountId: string) => void;
+}) {
+  if (resetCredits == null && !loading && !unavailable) {
+    return null;
+  }
+
+  const availableCount = resetCredits?.availableCount ?? 0;
+  const valueLabel =
+    loading && resetCredits == null
+      ? "Checking..."
+      : unavailable && resetCredits == null
+        ? "Unavailable"
+        : `${availableCount} available`;
+
+  return (
+    <div className="flex items-center justify-between rounded-md border bg-background/60 px-3 py-2 text-xs">
+      <span className="flex min-w-0 items-center gap-2 text-muted-foreground">
+        <RotateCcw className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="truncate font-medium">Usage resets</span>
+      </span>
+      <span className="flex shrink-0 items-center gap-2">
+        <span className="tabular-nums font-semibold">{valueLabel}</span>
+        {onReset ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-6 gap-1 px-1.5 text-[11px]"
+            aria-label="Reset usage"
+            onClick={() => onReset(accountId)}
+            disabled={resetDisabled || availableCount <= 0}
+          >
+            <RotateCcw className="h-3 w-3" aria-hidden="true" />
+            Reset
+          </Button>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+export function AccountUsagePanel({
+  account,
+  trends,
+  resetCredits,
+  resetCreditsLoading,
+  resetCreditsUnavailable,
+  resetDisabled = false,
+  onReset,
+}: AccountUsagePanelProps) {
   const primary = account.usage?.primaryRemainingPercent ?? null;
   const secondary = account.usage?.secondaryRemainingPercent ?? null;
   const monthly = account.usage?.monthlyRemainingPercent ?? null;
@@ -165,6 +237,14 @@ export function AccountUsagePanel({ account, trends }: AccountUsagePanelProps) {
           </>
         )}
       </div>
+      <ResetCreditsRow
+        accountId={account.accountId}
+        resetCredits={resetCredits}
+        loading={resetCreditsLoading}
+        unavailable={resetCreditsUnavailable}
+        resetDisabled={resetDisabled}
+        onReset={onReset}
+      />
       <div className="rounded-md border bg-background/60 px-3 py-2">
         <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Request logs total</p>
         {hasRequestUsage ? (

--- a/frontend/src/features/accounts/components/accounts-page.test.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 
@@ -9,6 +10,11 @@ import type { AccountSummary } from "@/features/accounts/schemas";
 vi.mock("@/features/accounts/hooks/use-accounts", () => ({
   useAccounts: vi.fn(),
   useAccountTrends: vi.fn(() => ({ data: null })),
+  useAccountUsageResetCredits: vi.fn(() => ({
+    data: { rateLimitResetCredits: { availableCount: 3 } },
+    isFetching: false,
+    error: null,
+  })),
 }));
 
 vi.mock("@/features/accounts/hooks/use-oauth", () => ({
@@ -105,6 +111,7 @@ describe("AccountsPage", () => {
       pauseMutation: idleMutation(),
       resumeMutation: idleMutation(),
       probeMutation: idleMutation(),
+      usageResetMutation: idleMutation(),
       deleteMutation: idleMutation(),
       exportAuthMutation: idleMutation(),
       setAliasMutation: idleMutation(),
@@ -146,6 +153,7 @@ describe("AccountsPage", () => {
       pauseMutation: idleMutation(),
       resumeMutation: idleMutation(),
       probeMutation: idleMutation(),
+      usageResetMutation: idleMutation(),
       deleteMutation: idleMutation(),
       exportAuthMutation: idleMutation(),
       setAliasMutation: idleMutation(),
@@ -170,5 +178,127 @@ describe("AccountsPage", () => {
       "min-w-0",
       "truncate",
     );
+  });
+
+  it("confirms before resetting selected account usage", async () => {
+    const user = userEvent.setup();
+    const resetUsage = vi.fn().mockResolvedValue({
+      status: "reset",
+      accountId: "acc-reset",
+      code: "reset",
+      windowsReset: 2,
+      usageWritten: true,
+      primaryUsedPercentBefore: 100,
+      primaryUsedPercentAfter: 2,
+      secondaryUsedPercentBefore: 80,
+      secondaryUsedPercentAfter: 0,
+      accountStatusBefore: "rate_limited",
+      accountStatusAfter: "active",
+    });
+
+    mockedUseAccounts.mockReturnValue({
+      accountsQuery: {
+        data: [
+          account({
+            accountId: "acc-reset",
+            email: "reset@example.com",
+            displayName: "Resettable",
+            resetAtSecondary: "2026-01-01T13:00:00.000Z",
+            windowMinutesSecondary: 10_080,
+          }),
+        ],
+        error: null,
+        refetch: vi.fn(),
+      },
+      importMutation: idleMutation(),
+      pauseMutation: idleMutation(),
+      resumeMutation: idleMutation(),
+      probeMutation: idleMutation(),
+      usageResetMutation: {
+        isPending: false,
+        error: null,
+        mutateAsync: resetUsage,
+      },
+      deleteMutation: idleMutation(),
+      exportAuthMutation: idleMutation(),
+      setAliasMutation: idleMutation(),
+      limitWarmupMutation: idleMutation(),
+      routingPolicyMutation: idleMutation(),
+      updateMutation: idleMutation(),
+    } as unknown as ReturnType<typeof useAccounts>);
+
+    render(
+      <MemoryRouter>
+        <AccountsPage />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reset usage" }));
+
+    const dialog = await screen.findByRole("alertdialog", { name: "Reset usage" });
+    expect(resetUsage).not.toHaveBeenCalled();
+
+    await user.click(within(dialog).getByRole("button", { name: "Reset" }));
+
+    await waitFor(() => {
+      expect(resetUsage).toHaveBeenCalledWith({ accountId: "acc-reset" });
+    });
+  });
+
+  it("keeps force probe as an immediate action", async () => {
+    const user = userEvent.setup();
+    const probe = vi.fn().mockResolvedValue({
+      status: "probed",
+      accountId: "acc-probe",
+      probeStatusCode: 200,
+      primaryUsedPercentBefore: 10,
+      primaryUsedPercentAfter: 9,
+      secondaryUsedPercentBefore: 20,
+      secondaryUsedPercentAfter: 19,
+      accountStatusBefore: "active",
+      accountStatusAfter: "active",
+    });
+
+    mockedUseAccounts.mockReturnValue({
+      accountsQuery: {
+        data: [
+          account({
+            accountId: "acc-probe",
+            email: "probe@example.com",
+            displayName: "Probe account",
+            resetAtSecondary: "2026-01-01T13:00:00.000Z",
+            windowMinutesSecondary: 10_080,
+          }),
+        ],
+        error: null,
+        refetch: vi.fn(),
+      },
+      importMutation: idleMutation(),
+      pauseMutation: idleMutation(),
+      resumeMutation: idleMutation(),
+      probeMutation: {
+        isPending: false,
+        error: null,
+        mutateAsync: probe,
+      },
+      usageResetMutation: idleMutation(),
+      deleteMutation: idleMutation(),
+      exportAuthMutation: idleMutation(),
+      setAliasMutation: idleMutation(),
+      limitWarmupMutation: idleMutation(),
+      routingPolicyMutation: idleMutation(),
+      updateMutation: idleMutation(),
+    } as unknown as ReturnType<typeof useAccounts>);
+
+    render(
+      <MemoryRouter>
+        <AccountsPage />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Force probe" }));
+
+    expect(probe).toHaveBeenCalledWith({ accountId: "acc-probe" });
+    expect(screen.queryByRole("alertdialog", { name: "Reset usage" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -12,7 +12,10 @@ import { AccountsSkeleton } from "@/features/accounts/components/accounts-skelet
 import { ImportDialog } from "@/features/accounts/components/import-dialog";
 import { ResetCreditConfirmDialog } from "@/features/accounts/components/reset-credit-confirm-dialog";
 import { AuthExportDialog } from "@/features/accounts/components/auth-export-dialog";
-import { useAccounts } from "@/features/accounts/hooks/use-accounts";
+import {
+  useAccounts,
+  useAccountUsageResetCredits,
+} from "@/features/accounts/hooks/use-accounts";
 import {
   DEFAULT_ACCOUNT_SORT_MODE,
   sortAccountsForDisplay,
@@ -41,6 +44,7 @@ export function AccountsPage() {
     resumeMutation,
     setAliasMutation,
     probeMutation,
+    usageResetMutation,
     limitWarmupMutation,
     updateMutation,
     deleteMutation,
@@ -56,6 +60,7 @@ export function AccountsPage() {
   const deleteDialog = useDialogState<string>();
   type ResetCreditDialogTarget = { accountId: string; availableResetCredits: number };
   const resetCreditDialog = useDialogState<ResetCreditDialogTarget>();
+  const usageResetDialog = useDialogState<string>();
   const exportDialog = useDialogState<AccountAuthExportResponse>();
   const [deleteHistory, setDeleteHistory] = useState(false);
 
@@ -101,6 +106,7 @@ export function AccountsPage() {
         : null,
     [accounts, resolvedSelectedAccountId],
   );
+  const resetCreditsQuery = useAccountUsageResetCredits(selectedAccount?.accountId ?? null);
 
   const mutationBusy =
     importMutation.isPending ||
@@ -108,6 +114,7 @@ export function AccountsPage() {
     resumeMutation.isPending ||
     setAliasMutation.isPending ||
     probeMutation.isPending ||
+    usageResetMutation.isPending ||
     limitWarmupMutation.isPending ||
     deleteMutation.isPending ||
     routingPolicyMutation.isPending ||
@@ -121,6 +128,7 @@ export function AccountsPage() {
     getErrorMessageOrNull(resumeMutation.error) ||
     getErrorMessageOrNull(setAliasMutation.error) ||
     getErrorMessageOrNull(probeMutation.error) ||
+    getErrorMessageOrNull(usageResetMutation.error) ||
     getErrorMessageOrNull(limitWarmupMutation.error) ||
     getErrorMessageOrNull(deleteMutation.error) ||
     getErrorMessageOrNull(routingPolicyMutation.error) ||
@@ -173,9 +181,8 @@ export function AccountsPage() {
             readOnly={!canWrite}
             onPause={(accountId) => void pauseMutation.mutateAsync(accountId)}
             onResume={(accountId) => void resumeMutation.mutateAsync(accountId)}
-            onProbe={(accountId) =>
-              void probeMutation.mutateAsync({ accountId })
-            }
+            onProbe={(accountId) => void probeMutation.mutateAsync({ accountId })}
+            onResetUsage={(accountId) => usageResetDialog.show(accountId)}
             onSetAlias={(accountId, alias) =>
               setAliasMutation.mutateAsync({ accountId, alias })
             }
@@ -188,12 +195,12 @@ export function AccountsPage() {
                 .catch(() => null);
             }}
             onResetCredit={(accountId) => {
-            const account = accountsQuery.data?.find((item) => item.accountId === accountId);
-            resetCreditDialog.show({
-              accountId,
-              availableResetCredits: account?.availableResetCredits ?? 0,
-            });
-          }}
+              const account = accountsQuery.data?.find((item) => item.accountId === accountId);
+              resetCreditDialog.show({
+                accountId,
+                availableResetCredits: account?.availableResetCredits ?? 0,
+              });
+            }}
             onLimitWarmupChange={(accountId, enabled) =>
               void limitWarmupMutation.mutateAsync({ accountId, enabled })
             }
@@ -213,6 +220,9 @@ export function AccountsPage() {
             onProxyBindingSave={(accountId, payload) =>
               accountBindingMutation.mutateAsync({ accountId, payload })
             }
+            resetCredits={resetCreditsQuery.data?.rateLimitResetCredits ?? null}
+            resetCreditsLoading={resetCreditsQuery.isFetching}
+            resetCreditsUnavailable={!!resetCreditsQuery.error}
           />
         </div>
       )}
@@ -296,6 +306,25 @@ export function AccountsPage() {
           </label>
         </div>
       </ConfirmDialog>
+
+      <ConfirmDialog
+        open={usageResetDialog.open}
+        title="Reset usage"
+        description="This consumes one upstream usage reset credit for the selected account, then fetches fresh usage."
+        confirmLabel="Reset"
+        cancelLabel="Cancel"
+        onOpenChange={usageResetDialog.onOpenChange}
+        onConfirm={() => {
+          if (!usageResetDialog.data) {
+            return;
+          }
+          void usageResetMutation
+            .mutateAsync({ accountId: usageResetDialog.data })
+            .finally(() => {
+              usageResetDialog.hide();
+            });
+        }}
+      />
 
       <LoadingOverlay
         visible={!!accountsQuery.data && mutationBusy}

--- a/frontend/src/features/accounts/components/reset-credit-confirm-dialog.test.tsx
+++ b/frontend/src/features/accounts/components/reset-credit-confirm-dialog.test.tsx
@@ -1,8 +1,8 @@
+import { HttpResponse, http } from "msw";
+import type { ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactElement } from "react";
-import { HttpResponse, http } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
 import { ResetCreditConfirmDialog } from "@/features/accounts/components/reset-credit-confirm-dialog";
@@ -138,6 +138,57 @@ describe("ResetCreditConfirmDialog", () => {
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
     // Failure leaves the dialog open for retry.
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("reuses one redeem request id when retrying while the dialog stays open", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const bodies: unknown[] = [];
+    server.use(
+      http.get(SNAPSHOT_URL, snapshotResponse),
+      http.post(CONSUME_URL, async ({ request }) => {
+        bodies.push(await request.json());
+        if (bodies.length === 1) {
+          return HttpResponse.json(
+            {
+              error: {
+                code: "temporary_upstream_error",
+                message: "Upstream response was lost",
+              },
+            },
+            { status: 502 },
+          );
+        }
+        return HttpResponse.json({
+          code: "rate_limit_reset",
+          windowsReset: 1,
+          redeemedAt: "2026-01-01T12:00:00.000Z",
+        });
+      }),
+    );
+
+    renderWithClient(
+      <ResetCreditConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        accountId="acc_primary"
+      />,
+    );
+
+    expect(await screen.findByText("1 free rate limit reset")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Redeem credit" }));
+    await vi.waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith("Upstream response was lost"),
+    );
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    await user.click(screen.getByRole("button", { name: "Redeem credit" }));
+    await vi.waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).toEqual({ redeemRequestId: expect.any(String) });
+    expect(bodies[1]).toEqual(bodies[0]);
   });
 
   it("shows a loading state while the reset-credit snapshot is fetching", () => {

--- a/frontend/src/features/accounts/components/reset-credit-confirm-dialog.tsx
+++ b/frontend/src/features/accounts/components/reset-credit-confirm-dialog.tsx
@@ -7,6 +7,7 @@ import type { RateLimitResetCreditItem } from "@/features/accounts/schemas";
 import { cn } from "@/lib/utils";
 import { getErrorMessage } from "@/utils/errors";
 import { formatLocalDateTimeSeconds, formatSingleUnitRemaining } from "@/utils/formatters";
+import { useEffect, useRef } from "react";
 
 export type ResetCreditConfirmDialogProps = {
   open: boolean;
@@ -69,6 +70,10 @@ function CreditExpiryLine({
   );
 }
 
+function createRedeemRequestId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `dashboard-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 export function ResetCreditConfirmDialog({
   open,
   onOpenChange,
@@ -76,6 +81,7 @@ export function ResetCreditConfirmDialog({
   summaryAvailableCount = 0,
 }: ResetCreditConfirmDialogProps) {
   const { resetCreditConsumeMutation } = useAccountMutations();
+  const redeemRequestIdRef = useRef<string | null>(null);
   const snapshotQuery = useRateLimitResetCredits(accountId, open);
   const snapshotLoading = snapshotQuery.isPending;
   const snapshotError = snapshotQuery.isError;
@@ -94,12 +100,19 @@ export function ResetCreditConfirmDialog({
   const confirmDisabled =
     pending || !accountId || snapshotLoading || snapshotError || availableCount <= 0;
 
+  useEffect(() => {
+    if (!open) {
+      redeemRequestIdRef.current = null;
+    }
+  }, [open]);
+
   const handleConfirm = () => {
     if (!accountId || pending) {
       return;
     }
+    redeemRequestIdRef.current = redeemRequestIdRef.current ?? createRedeemRequestId();
     void resetCreditConsumeMutation
-      .mutateAsync(accountId)
+      .mutateAsync({ accountId, redeemRequestId: redeemRequestIdRef.current })
       .then(() => {
         onOpenChange(false);
       })
@@ -114,6 +127,9 @@ export function ResetCreditConfirmDialog({
     // mid-request. It closes once the promise settles.
     if (!next && pending) {
       return;
+    }
+    if (!next) {
+      redeemRequestIdRef.current = null;
     }
     onOpenChange(next);
   };

--- a/frontend/src/features/accounts/hooks/use-accounts.test.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.test.ts
@@ -3,7 +3,10 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type PropsWithChildren } from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { useAccounts } from "@/features/accounts/hooks/use-accounts";
+import {
+  useAccounts,
+  useAccountUsageResetCredits,
+} from "@/features/accounts/hooks/use-accounts";
 
 function createTestQueryClient(): QueryClient {
   return new QueryClient({
@@ -39,6 +42,9 @@ describe("useAccounts", () => {
     await result.current.probeMutation.mutateAsync({
       accountId: firstAccountId as string,
     });
+    await result.current.usageResetMutation.mutateAsync({
+      accountId: firstAccountId as string,
+    });
     const routingPolicyResult = await result.current.routingPolicyMutation.mutateAsync({
       accountId: firstAccountId as string,
       routingPolicy: "preserve",
@@ -53,8 +59,12 @@ describe("useAccounts", () => {
     await waitFor(() => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "list"] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "trends"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["accounts", "usage-reset-credits"] });
       expect(invalidateSpy).toHaveBeenCalledWith({
         queryKey: ["accounts", "trends", firstAccountId],
+      });
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["accounts", "usage-reset-credits", firstAccountId],
       });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "projections"] });
@@ -77,7 +87,26 @@ describe("useAccounts", () => {
 
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["accounts", "list"] });
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["accounts", "trends"] });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["accounts", "usage-reset-credits"] });
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "projections"] });
+  });
+
+  it("does not permanently poll usage reset credits", async () => {
+    const queryClient = createTestQueryClient();
+    const accountId = "acc_primary";
+
+    const { result } = renderHook(() => useAccountUsageResetCredits(accountId), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const query = queryClient.getQueryCache().find({
+      queryKey: ["accounts", "usage-reset-credits", accountId],
+    });
+    const refetchInterval = (query?.options as { refetchInterval?: unknown } | undefined)
+      ?.refetchInterval;
+    expect(refetchInterval).toBeUndefined();
   });
 });

--- a/frontend/src/features/accounts/hooks/use-accounts.test.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.test.ts
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
 import { createElement, type PropsWithChildren } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -7,6 +8,7 @@ import {
   useAccounts,
   useAccountUsageResetCredits,
 } from "@/features/accounts/hooks/use-accounts";
+import { server } from "@/test/mocks/server";
 
 function createTestQueryClient(): QueryClient {
   return new QueryClient({
@@ -29,6 +31,26 @@ describe("useAccounts", () => {
   it("loads accounts and invalidates related queries after mutations", async () => {
     const queryClient = createTestQueryClient();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    let usageResetBody: unknown;
+    server.use(
+      http.post("/api/accounts/:accountId/usage-reset-credits/consume", async ({ params, request }) => {
+        const accountId = String(params.accountId);
+        usageResetBody = await request.json();
+        return HttpResponse.json({
+          status: "reset",
+          accountId,
+          code: "reset",
+          windowsReset: 2,
+          usageWritten: true,
+          primaryUsedPercentBefore: 99,
+          primaryUsedPercentAfter: 1,
+          secondaryUsedPercentBefore: 80,
+          secondaryUsedPercentAfter: 1,
+          accountStatusBefore: "rate_limited",
+          accountStatusAfter: "active",
+        });
+      }),
+    );
     const { result } = renderHook(() => useAccounts(), {
       wrapper: createWrapper(queryClient),
     });
@@ -44,6 +66,9 @@ describe("useAccounts", () => {
     });
     await result.current.usageResetMutation.mutateAsync({
       accountId: firstAccountId as string,
+    });
+    expect(usageResetBody).toEqual({
+      redeemRequestId: expect.any(String),
     });
     const routingPolicyResult = await result.current.routingPolicyMutation.mutateAsync({
       accountId: firstAccountId as string,
@@ -90,6 +115,97 @@ describe("useAccounts", () => {
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["accounts", "usage-reset-credits"] });
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "overview"] });
     expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ["dashboard", "projections"] });
+  });
+
+  it("reuses the dashboard usage reset redemption id after a failed attempt", async () => {
+    const queryClient = createTestQueryClient();
+    const usageResetBodies: unknown[] = [];
+    server.use(
+      http.post("/api/accounts/:accountId/usage-reset-credits/consume", async ({ params, request }) => {
+        const accountId = String(params.accountId);
+        usageResetBodies.push(await request.json());
+        if (usageResetBodies.length === 1) {
+          return HttpResponse.json(
+            {
+              error: {
+                code: "upstream_timeout",
+                message: "Upstream response was lost",
+              },
+            },
+            { status: 504 },
+          );
+        }
+        return HttpResponse.json({
+          status: "already_redeemed",
+          accountId,
+          code: "already_redeemed",
+          windowsReset: 1,
+          usageWritten: true,
+          primaryUsedPercentBefore: 99,
+          primaryUsedPercentAfter: 1,
+          secondaryUsedPercentBefore: 80,
+          secondaryUsedPercentAfter: 1,
+          accountStatusBefore: "rate_limited",
+          accountStatusAfter: "active",
+        });
+      }),
+    );
+    const { result } = renderHook(() => useAccounts(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.accountsQuery.isSuccess).toBe(true));
+
+    await expect(
+      result.current.usageResetMutation.mutateAsync({ accountId: "acc_primary" }),
+    ).rejects.toThrow("Upstream response was lost");
+    await result.current.usageResetMutation.mutateAsync({ accountId: "acc_primary" });
+
+    expect(usageResetBodies).toHaveLength(2);
+    expect(usageResetBodies[0]).toEqual({
+      redeemRequestId: expect.any(String),
+    });
+    expect(usageResetBodies[1]).toEqual(usageResetBodies[0]);
+  });
+
+  it("does not reuse a failed dashboard usage reset redemption id for another account", async () => {
+    const queryClient = createTestQueryClient();
+    const usageResetBodies: unknown[] = [];
+    server.use(
+      http.post("/api/accounts/:accountId/usage-reset-credits/consume", async ({ request }) => {
+        usageResetBodies.push(await request.json());
+        return HttpResponse.json(
+          {
+            error: {
+              code: "upstream_timeout",
+              message: "Upstream response was lost",
+            },
+          },
+          { status: 504 },
+        );
+      }),
+    );
+    const { result } = renderHook(() => useAccounts(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.accountsQuery.isSuccess).toBe(true));
+
+    await expect(
+      result.current.usageResetMutation.mutateAsync({ accountId: "acc_primary" }),
+    ).rejects.toThrow("Upstream response was lost");
+    await expect(
+      result.current.usageResetMutation.mutateAsync({ accountId: "acc_secondary" }),
+    ).rejects.toThrow("Upstream response was lost");
+
+    expect(usageResetBodies).toHaveLength(2);
+    expect(usageResetBodies[0]).toEqual({
+      redeemRequestId: expect.any(String),
+    });
+    expect(usageResetBodies[1]).toEqual({
+      redeemRequestId: expect.any(String),
+    });
+    expect(usageResetBodies[1]).not.toEqual(usageResetBodies[0]);
   });
 
   it("does not permanently poll usage reset credits", async () => {

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -3,9 +3,11 @@ import { toast } from "sonner";
 
 import {
   consumeRateLimitResetCredit,
+  consumeAccountUsageResetCredit,
   deleteAccount,
   exportAccountAuth,
   getAccountTrends,
+  getAccountUsageResetCredits,
   getRateLimitResetCredits,
   importAccount,
   listAccounts,
@@ -17,7 +19,46 @@ import {
   updateAccountLimitWarmup,
   updateAccountRoutingPolicy,
 } from "@/features/accounts/api";
-import type { AccountRoutingPolicy } from "@/features/accounts/schemas";
+import type {
+  AccountRoutingPolicy,
+  AccountUsageResetConsumeResponse,
+} from "@/features/accounts/schemas";
+
+async function invalidateAccountRelatedQueries(queryClient: ReturnType<typeof useQueryClient>, accountId?: string) {
+  const invalidations = [
+    queryClient.invalidateQueries({ queryKey: ["accounts", "list"] }),
+    queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] }),
+    queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] }),
+  ];
+  if (accountId) {
+    invalidations.push(queryClient.invalidateQueries({ queryKey: ["accounts", "trends", accountId] }));
+    invalidations.push(queryClient.invalidateQueries({ queryKey: ["accounts", "usage-reset-credits", accountId] }));
+  } else {
+    invalidations.push(queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] }));
+    invalidations.push(queryClient.invalidateQueries({ queryKey: ["accounts", "usage-reset-credits"] }));
+  }
+  await Promise.all(invalidations);
+}
+
+function usageResetToastMessage(data: AccountUsageResetConsumeResponse): string {
+  const changed =
+    data.primaryUsedPercentBefore !== data.primaryUsedPercentAfter ||
+    data.secondaryUsedPercentBefore !== data.secondaryUsedPercentAfter ||
+    data.accountStatusBefore !== data.accountStatusAfter;
+  if (data.code === "reset") {
+    return changed ? "Usage reset applied" : "Usage reset applied; upstream values are unchanged";
+  }
+  if (data.code === "already_redeemed") {
+    return "Usage reset was already applied";
+  }
+  if (data.code === "no_credit") {
+    return "No usage reset credits available";
+  }
+  if (data.code === "nothing_to_reset") {
+    return "Nothing to reset";
+  }
+  return "Usage reset request completed";
+}
 
 /**
  * Account mutation actions without the polling query.
@@ -31,10 +72,7 @@ export function useAccountMutations() {
     mutationFn: importAccount,
     onSuccess: () => {
       toast.success("Account imported");
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Import failed");
@@ -45,10 +83,7 @@ export function useAccountMutations() {
     mutationFn: pauseAccount,
     onSuccess: () => {
       toast.success("Account paused");
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Pause failed");
@@ -59,10 +94,7 @@ export function useAccountMutations() {
     mutationFn: reactivateAccount,
     onSuccess: () => {
       toast.success("Account resumed");
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Resume failed");
@@ -74,10 +106,7 @@ export function useAccountMutations() {
       setAccountAlias(accountId, alias),
     onSuccess: () => {
       toast.success("Account alias updated");
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Alias update failed");
@@ -89,10 +118,7 @@ export function useAccountMutations() {
       deleteAccount(accountId, deleteHistory),
     onSuccess: () => {
       toast.success("Account deleted");
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Delete failed");
@@ -104,16 +130,21 @@ export function useAccountMutations() {
       probeAccount(accountId, model ? { model } : undefined),
     onSuccess: (_data, variables) => {
       toast.success("Account probed");
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({
-        queryKey: ["accounts", "trends", variables.accountId],
-      });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient, variables.accountId);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Probe failed");
+    },
+  });
+
+  const usageResetMutation = useMutation({
+    mutationFn: ({ accountId }: { accountId: string }) => consumeAccountUsageResetCredit(accountId),
+    onSuccess: async (data, variables) => {
+      await invalidateAccountRelatedQueries(queryClient, variables.accountId);
+      toast.success(usageResetToastMessage(data));
+    },
+    onError: (error: Error) => {
+      toast.error(error.message || "Usage reset failed");
     },
   });
 
@@ -122,10 +153,7 @@ export function useAccountMutations() {
       updateAccountLimitWarmup(accountId, enabled),
     onSuccess: (data) => {
       toast.success(data.enabled ? "Limit warm-up enabled" : "Limit warm-up disabled");
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Limit warm-up update failed");
@@ -144,10 +172,7 @@ export function useAccountMutations() {
       const label =
         data.routingPolicy === "normal" ? "normal" : data.routingPolicy.replace("_", "-");
       toast.success(`Account routing policy set to ${label}`);
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Routing policy update failed");
@@ -169,10 +194,7 @@ export function useAccountMutations() {
       updateAccount(accountId, { securityWorkAuthorized }),
     onSuccess: () => {
       toast.success("Account updated");
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "list"] });
-      void queryClient.invalidateQueries({ queryKey: ["accounts", "trends"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "overview"] });
-      void queryClient.invalidateQueries({ queryKey: ["dashboard", "projections"] });
+      void invalidateAccountRelatedQueries(queryClient);
     },
     onError: (error: Error) => {
       toast.error(error.message || "Update failed");
@@ -204,6 +226,7 @@ export function useAccountMutations() {
     setAliasMutation,
     deleteMutation,
     probeMutation,
+    usageResetMutation,
     exportAuthMutation,
     limitWarmupMutation,
     routingPolicyMutation,
@@ -232,6 +255,15 @@ export function useAccountTrends(accountId: string | null) {
     staleTime: 5 * 60_000,
     refetchInterval: 5 * 60_000,
     refetchIntervalInBackground: false,
+  });
+}
+
+export function useAccountUsageResetCredits(accountId: string | null) {
+  return useQuery({
+    queryKey: ["accounts", "usage-reset-credits", accountId],
+    queryFn: () => getAccountUsageResetCredits(accountId!),
+    enabled: !!accountId,
+    staleTime: 60_000,
   });
 }
 

--- a/frontend/src/features/accounts/hooks/use-accounts.ts
+++ b/frontend/src/features/accounts/hooks/use-accounts.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRef } from "react";
 import { toast } from "sonner";
 
 import {
@@ -60,6 +61,10 @@ function usageResetToastMessage(data: AccountUsageResetConsumeResponse): string 
   return "Usage reset request completed";
 }
 
+function createRedeemRequestId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `dashboard-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 /**
  * Account mutation actions without the polling query.
  * Use this when you need account actions but already have account data
@@ -67,6 +72,10 @@ function usageResetToastMessage(data: AccountUsageResetConsumeResponse): string 
  */
 export function useAccountMutations() {
   const queryClient = useQueryClient();
+  const usageResetRedeemRequestRef = useRef<{
+    accountId: string;
+    redeemRequestId: string;
+  } | null>(null);
 
   const importMutation = useMutation({
     mutationFn: importAccount,
@@ -138,8 +147,19 @@ export function useAccountMutations() {
   });
 
   const usageResetMutation = useMutation({
-    mutationFn: ({ accountId }: { accountId: string }) => consumeAccountUsageResetCredit(accountId),
+    mutationFn: ({ accountId }: { accountId: string }) => {
+      if (usageResetRedeemRequestRef.current?.accountId !== accountId) {
+        usageResetRedeemRequestRef.current = {
+          accountId,
+          redeemRequestId: createRedeemRequestId(),
+        };
+      }
+      return consumeAccountUsageResetCredit(accountId, {
+        redeemRequestId: usageResetRedeemRequestRef.current.redeemRequestId,
+      });
+    },
     onSuccess: async (data, variables) => {
+      usageResetRedeemRequestRef.current = null;
       await invalidateAccountRelatedQueries(queryClient, variables.accountId);
       toast.success(usageResetToastMessage(data));
     },
@@ -202,7 +222,8 @@ export function useAccountMutations() {
   });
 
   const resetCreditConsumeMutation = useMutation({
-    mutationFn: (accountId: string) => consumeRateLimitResetCredit(accountId),
+    mutationFn: ({ accountId, redeemRequestId }: { accountId: string; redeemRequestId?: string }) =>
+      consumeRateLimitResetCredit(accountId, redeemRequestId ? { redeemRequestId } : undefined),
     onSuccess: (data) => {
       const resetCount = data.windowsReset ?? 0;
       toast.success(

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -216,6 +216,10 @@ export const AccountProbeResponseSchema = z.object({
   accountStatusAfter: z.string(),
 });
 
+export const AccountUsageResetConsumeRequestSchema = z.object({
+  redeemRequestId: z.string().trim().min(1).optional(),
+});
+
 export const AccountUsageResetConsumeResponseSchema = z.object({
   status: z.string(),
   accountId: z.string(),
@@ -355,6 +359,9 @@ export type AccountUsageResetCreditsResponse = z.infer<
   typeof AccountUsageResetCreditsResponseSchema
 >;
 export type AccountProbeResponse = z.infer<typeof AccountProbeResponseSchema>;
+export type AccountUsageResetConsumeRequest = z.infer<
+  typeof AccountUsageResetConsumeRequestSchema
+>;
 export type AccountUsageResetConsumeResponse = z.infer<
   typeof AccountUsageResetConsumeResponseSchema
 >;

--- a/frontend/src/features/accounts/schemas.ts
+++ b/frontend/src/features/accounts/schemas.ts
@@ -18,6 +18,15 @@ const AccountRequestUsageSchema = z.object({
   totalCostUsd: z.number().nonnegative(),
 });
 
+export const AccountUsageResetCreditsSchema = z.object({
+  availableCount: z.number().int().nonnegative(),
+});
+
+export const AccountUsageResetCreditsResponseSchema = z.object({
+  accountId: z.string(),
+  rateLimitResetCredits: AccountUsageResetCreditsSchema,
+});
+
 const AccountTokenStatusSchema = z.object({
   expiresAt: z.iso.datetime({ offset: true }).nullable().optional(),
   state: z.string().nullable().optional(),
@@ -207,6 +216,20 @@ export const AccountProbeResponseSchema = z.object({
   accountStatusAfter: z.string(),
 });
 
+export const AccountUsageResetConsumeResponseSchema = z.object({
+  status: z.string(),
+  accountId: z.string(),
+  code: z.string(),
+  windowsReset: z.number().int().nonnegative(),
+  usageWritten: z.boolean(),
+  primaryUsedPercentBefore: z.number().nullable(),
+  primaryUsedPercentAfter: z.number().nullable(),
+  secondaryUsedPercentBefore: z.number().nullable(),
+  secondaryUsedPercentAfter: z.number().nullable(),
+  accountStatusBefore: z.string(),
+  accountStatusAfter: z.string(),
+});
+
 const AccountRoutingPolicySchema = z.enum(["normal", "burn_first", "preserve"]);
 
 export const AccountAliasRequestSchema = z.object({
@@ -325,7 +348,16 @@ export type AccountAdditionalWindow = z.infer<
 export type AccountAdditionalQuota = z.infer<
   typeof AccountAdditionalQuotaSchema
 >;
+export type AccountUsageResetCredits = z.infer<
+  typeof AccountUsageResetCreditsSchema
+>;
+export type AccountUsageResetCreditsResponse = z.infer<
+  typeof AccountUsageResetCreditsResponseSchema
+>;
 export type AccountProbeResponse = z.infer<typeof AccountProbeResponseSchema>;
+export type AccountUsageResetConsumeResponse = z.infer<
+  typeof AccountUsageResetConsumeResponseSchema
+>;
 export type AccountTrendsResponse = z.infer<typeof AccountTrendsResponseSchema>;
 export type OpenCodeAuthJson = z.infer<typeof OpenCodeAuthJsonSchema>;
 export type CodexAuthJson = z.infer<typeof CodexAuthJsonSchema>;

--- a/frontend/src/test/mocks/handler-coverage.test.ts
+++ b/frontend/src/test/mocks/handler-coverage.test.ts
@@ -40,6 +40,8 @@ const EXPECTED_ENDPOINTS = [
 	"PUT /api/accounts/:accountId/limit-warmup",
 	"PUT /api/accounts/:accountId/routing-policy",
 	"GET /api/accounts/:accountId/trends",
+	"GET /api/accounts/:accountId/usage-reset-credits",
+	"POST /api/accounts/:accountId/usage-reset-credits/consume",
 	"POST /api/accounts/:accountId/export",
 	"POST /api/accounts/:accountId/export/auth",
 	"DELETE /api/accounts/:accountId",

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -605,6 +605,45 @@ export const handlers = [
     return HttpResponse.json(createAccountTrends(accountId));
   }),
 
+  http.get("/api/accounts/:accountId/usage-reset-credits", ({ params }) => {
+    const accountId = String(params.accountId);
+    const account = findAccount(accountId);
+    if (!account) {
+      return HttpResponse.json(
+        { error: { code: "account_not_found", message: "Account not found" } },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json({
+      accountId,
+      rateLimitResetCredits: { availableCount: 3 },
+    });
+  }),
+
+  http.post("/api/accounts/:accountId/usage-reset-credits/consume", ({ params }) => {
+    const accountId = String(params.accountId);
+    const account = findAccount(accountId);
+    if (!account) {
+      return HttpResponse.json(
+        { error: { code: "account_not_found", message: "Account not found" } },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json({
+      status: "reset",
+      accountId,
+      code: "reset",
+      windowsReset: 2,
+      usageWritten: true,
+      primaryUsedPercentBefore: 99,
+      primaryUsedPercentAfter: 1,
+      secondaryUsedPercentBefore: 80,
+      secondaryUsedPercentAfter: 0,
+      accountStatusBefore: account.status,
+      accountStatusAfter: account.status,
+    });
+  }),
+
   http.post("/api/accounts/:accountId/probe", ({ params }) => {
     const accountId = String(params.accountId);
     const account = findAccount(accountId);

--- a/openspec/changes/support-codex-usage-reset/context.md
+++ b/openspec/changes/support-codex-usage-reset/context.md
@@ -1,0 +1,41 @@
+# Codex Usage Reset Context
+
+Codex CLI 0.142.x reads reset-credit availability from the top-level
+`rate_limit_reset_credits` object returned by `/api/codex/usage`. When the user
+chooses to redeem a reset, the client posts `redeem_request_id` to
+`/api/codex/rate-limit-reset-credits/consume`.
+
+codex-lb should not maintain its own earned-reset balance. Upstream ChatGPT is
+the authority for both availability and consume outcome. codex-lb only validates
+that the caller's ChatGPT bearer token is tied to a registered active account,
+forwards the request through the same upstream route policy as usage validation,
+and refreshes local usage after a reset succeeds.
+
+The dashboard accounts page should also treat upstream as authoritative. The
+selected account detail view can fetch the selected account's current
+`rate_limit_reset_credits.available_count` directly from upstream usage using
+the stored account tokens and existing upstream route policy, rather than adding
+local reset-credit storage.
+
+Usage panel reset actions intentionally consume an upstream reset credit first,
+then use a usage-only force-refresh path: the operator confirms the Reset
+action, codex-lb posts a generated `redeem_request_id` upstream using the
+selected account tokens, codex-lb fetches upstream usage for the selected
+account, and the dashboard invalidates account-related queries. It does not
+send model probe traffic.
+
+The dashboard should not make reset updates feel immediate by permanently
+shortening polling or adding a reset-credit polling loop. Freshness comes from
+explicit reset actions and query invalidation after successful writes.
+
+Example consume payload:
+
+```json
+{ "redeem_request_id": "2f8c5d19-6c54-4f92-98a2-b20166f44ed8" }
+```
+
+Example upstream response preserved by codex-lb:
+
+```json
+{ "code": "reset", "windows_reset": 2 }
+```

--- a/openspec/changes/support-codex-usage-reset/design.md
+++ b/openspec/changes/support-codex-usage-reset/design.md
@@ -1,0 +1,37 @@
+## Context
+
+Codex CLI 0.142.x reads reset-credit availability from the top-level
+`rate_limit_reset_credits` object on `/api/codex/usage` and redeems a credit by
+posting `redeem_request_id` to `/api/codex/rate-limit-reset-credits/consume`.
+codex-lb already validates ChatGPT usage callers by calling upstream usage with
+the caller bearer token and registered `chatgpt-account-id`, but it discarded the
+reset-credit summary and had no compatible consume route.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve upstream reset-credit availability for ChatGPT-authenticated Codex usage callers.
+- Forward reset redemption through the same upstream route policy used for usage validation.
+- Let dashboard operators consume one selected account reset credit after confirmation.
+- Refresh codex-lb's local usage snapshot after upstream reports a successful or idempotently successful reset.
+
+**Non-Goals:**
+
+- Do not create local reset-credit accounting.
+- Do not let codex-lb API-key callers consume ChatGPT account reset credits.
+- Do not change aggregate usage-window semantics.
+
+## Decisions
+
+- Upstream ChatGPT remains the source of truth for reset-credit availability and consume outcome. codex-lb only preserves the availability summary and returns the upstream consume response.
+- The consume endpoint reuses `validate_codex_usage_identity` so the bearer token, `chatgpt-account-id`, local account id, upstream route, and upstream usage payload are resolved once at the request boundary.
+- The upstream client posts `redeem_request_id` to `/wham/rate-limit-reset-credits/consume`, matching the existing ChatGPT backend usage path rather than introducing separate local state.
+- Dashboard reset actions generate their own `redeem_request_id` server-side and reuse stored account tokens; they do not require exposing ChatGPT bearer tokens to the browser.
+- `reset` and `already_redeemed` both trigger a forced local usage refresh because both outcomes mean the redemption request has settled upstream.
+
+## Risks / Trade-offs
+
+- Upstream contract drift could change consume response codes -> typed validation raises an upstream error instead of inventing fallback behavior.
+- A successful upstream reset followed by local refresh failure could leave codex-lb briefly stale -> the next scheduled usage refresh still reconciles from upstream.
+- Revalidating usage before consume adds one upstream call -> it keeps caller identity and route ownership consistent with existing Codex usage auth.

--- a/openspec/changes/support-codex-usage-reset/proposal.md
+++ b/openspec/changes/support-codex-usage-reset/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Recent Codex clients can show earned usage limit reset credits in `/usage` and
+offer an action to redeem one. codex-lb currently mirrors usage windows but
+drops the upstream reset-credit summary and has no endpoint for the redemption
+request, so Codex can tell the user resets exist without being able to consume
+one through codex-lb.
+
+## What Changes
+
+- Preserve upstream `rate_limit_reset_credits.available_count` on the
+  `/api/codex/usage` response for authenticated ChatGPT callers.
+- Add a Codex-compatible reset redemption endpoint at
+  `/api/codex/rate-limit-reset-credits/consume`.
+- Add a dashboard account detail Reset action that consumes one upstream reset
+  credit for the selected account after operator confirmation.
+- Forward redemption to upstream using the caller's ChatGPT bearer token,
+  `chatgpt-account-id`, existing upstream proxy routing, and the caller-provided
+  `redeem_request_id`.
+- After a successful or idempotently successful reset, force-refresh codex-lb's
+  persisted usage snapshot for the matching account.
+
+## Impact
+
+- Affects Codex usage/read and reset-credit consume flows.
+- Does not add local reset-credit accounting; upstream remains the source of
+  truth.
+- Adds regression coverage for response shape, authentication, upstream
+  forwarding, and local post-reset refresh.

--- a/openspec/changes/support-codex-usage-reset/specs/frontend-architecture/spec.md
+++ b/openspec/changes/support-codex-usage-reset/specs/frontend-architecture/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Account usage panel supports confirmed usage reset
+
+The Accounts page selected-account Usage panel SHALL expose a Reset action
+inside the Usage resets row when reset-credit availability is shown. The action
+SHALL require operator confirmation, SHALL consume one upstream usage reset
+credit for the selected account, SHALL force-fetch upstream usage after a
+successful or idempotently successful consume without sending model probe
+traffic, and SHALL refresh account-related dashboard queries after success. The
+dashboard SHALL NOT reduce or add permanent polling intervals to make this
+reset appear sooner.
+
+#### Scenario: Confirmed account usage reset consumes one credit
+
+- **GIVEN** an active selected account is visible on the Accounts page
+- **AND** the selected account has at least one available usage reset credit
+- **WHEN** the operator clicks the Usage panel Reset action
+- **AND** confirms the dialog
+- **THEN** the dashboard sends a usage reset consume request for the selected account
+- **AND** codex-lb does not send a model probe request
+- **AND** account-related usage, trend, reset-credit, and dashboard summary
+  queries are invalidated after success
+- **AND** no reset-credit availability query is configured with a permanent
+  refetch interval
+
+#### Scenario: Dismissed account usage reset does not consume a credit
+
+- **GIVEN** an active selected account is visible on the Accounts page
+- **WHEN** the operator clicks the Usage panel Reset action
+- **AND** cancels the dialog
+- **THEN** the dashboard does not send a usage reset consume request

--- a/openspec/changes/support-codex-usage-reset/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/support-codex-usage-reset/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Codex usage exposes reset-credit availability
+
+codex-lb SHALL include upstream reset-credit availability on Codex usage
+responses when ChatGPT usage identity validation returns earned usage limit
+reset credits, without altering aggregate usage-window semantics.
+
+#### Scenario: Usage response carries reset credits
+
+- **GIVEN** a registered active `chatgpt-account-id`
+- **AND** upstream `/wham/usage` returns `rate_limit_reset_credits.available_count`
+- **WHEN** the caller requests `/api/codex/usage` with a ChatGPT bearer token
+- **THEN** codex-lb returns a successful Codex usage payload
+- **AND** the top-level `rate_limit_reset_credits.available_count` equals the upstream value
+
+### Requirement: Codex usage can consume upstream reset credits
+
+codex-lb SHALL expose a Codex-compatible endpoint for consuming one upstream
+usage limit reset credit. The endpoint SHALL require ChatGPT caller identity,
+forward the caller's bearer token and `chatgpt-account-id`, preserve the
+caller-provided `redeem_request_id`, and return the upstream consume outcome.
+
+#### Scenario: Reset credit consume succeeds
+
+- **GIVEN** a registered active `chatgpt-account-id`
+- **AND** upstream reset-credit consume returns `code: reset`
+- **WHEN** the caller posts to `/api/codex/rate-limit-reset-credits/consume` with `redeem_request_id`
+- **THEN** codex-lb returns `code: reset`
+- **AND** codex-lb force-refreshes the matching account usage snapshot
+- **AND** the force-refresh runs even when background usage refresh scheduling is disabled
+
+#### Scenario: API-key caller cannot consume ChatGPT reset credits
+
+- **GIVEN** a codex-lb API key caller without ChatGPT caller identity
+- **WHEN** the caller posts to `/api/codex/rate-limit-reset-credits/consume`
+- **THEN** codex-lb rejects the request as unauthenticated for ChatGPT reset credits
+
+#### Scenario: Empty redemption id is rejected
+
+- **GIVEN** a registered active `chatgpt-account-id`
+- **WHEN** the caller posts to `/api/codex/rate-limit-reset-credits/consume` with an empty `redeem_request_id`
+- **THEN** codex-lb rejects the request without forwarding it upstream
+
+### Requirement: Account details expose reset-credit availability
+
+codex-lb SHALL expose upstream usage limit reset-credit availability for a
+selected dashboard account without creating local reset-credit accounting.
+
+#### Scenario: Dashboard account detail shows reset credits
+
+- **GIVEN** a registered active account with a `chatgpt-account-id`
+- **AND** upstream `/wham/usage` returns `rate_limit_reset_credits.available_count`
+- **WHEN** the dashboard requests the account's reset-credit summary
+- **THEN** codex-lb returns the selected account id
+- **AND** `rate_limit_reset_credits.available_count` equals the upstream value
+
+### Requirement: Dashboard account details can consume reset credits
+
+codex-lb SHALL expose a dashboard write-authorized endpoint for consuming one
+upstream usage limit reset credit for a selected account. The endpoint SHALL use
+the selected account's stored ChatGPT access token and `chatgpt-account-id`,
+generate a non-empty `redeem_request_id`, return the upstream consume outcome,
+and force-refresh the matching account usage snapshot after successful or
+idempotently successful consume.
+
+#### Scenario: Dashboard reset credit consume succeeds
+
+- **GIVEN** a registered active dashboard account with a `chatgpt-account-id`
+- **AND** upstream reset-credit consume returns `code: reset`
+- **WHEN** the dashboard posts to the selected account reset-credit consume endpoint
+- **THEN** codex-lb forwards a non-empty `redeem_request_id` upstream
+- **AND** codex-lb returns `code: reset`
+- **AND** codex-lb force-refreshes the matching account usage snapshot
+- **AND** the force-refresh runs even when background usage refresh scheduling is disabled
+
+#### Scenario: Read-only dashboard cannot consume reset credits
+
+- **GIVEN** a read-only dashboard session
+- **WHEN** the dashboard posts to the selected account reset-credit consume endpoint
+- **THEN** codex-lb rejects the request without consuming a reset credit

--- a/openspec/changes/support-codex-usage-reset/tasks.md
+++ b/openspec/changes/support-codex-usage-reset/tasks.md
@@ -1,0 +1,21 @@
+## 1. Codex Usage Reset Credits
+
+- [x] 1.1 Extend usage payload schemas to carry reset-credit availability.
+- [x] 1.2 Add an upstream client helper for consuming a reset credit.
+- [x] 1.3 Expose reset-credit availability on `/api/codex/usage`.
+- [x] 1.4 Add `/api/codex/rate-limit-reset-credits/consume` with ChatGPT caller auth.
+- [x] 1.5 Force-refresh matching account usage after successful/idempotent consume.
+
+## 2. Verification
+
+- [x] 2.1 Add integration coverage for availability and consume flows.
+- [x] 2.2 Run focused backend tests.
+- [x] 2.3 Run OpenSpec validation when the CLI is available.
+
+## 3. Dashboard Account Detail
+
+- [x] 3.1 Add dashboard account reset-credit availability contract and endpoint.
+- [x] 3.2 Render reset-credit availability on the selected account usage panel.
+- [x] 3.3 Add focused dashboard backend/frontend coverage and rebuild assets.
+- [x] 3.4 Add a confirmed Usage panel Reset action that consumes a reset credit and uses usage-only force refresh.
+- [x] 3.5 Ensure probe/consume-triggered usage refresh bypasses scheduler-disabled mode.

--- a/tests/integration/test_accounts_api.py
+++ b/tests/integration/test_accounts_api.py
@@ -199,6 +199,45 @@ async def test_account_usage_reset_consume_consumes_credit_and_refreshes(async_c
 
 
 @pytest.mark.asyncio
+async def test_account_usage_reset_consume_rejects_paused_account(async_client, monkeypatch):
+    email = "reset-consume-paused-dashboard@example.com"
+    raw_account_id = "acc_reset_consume_paused_dashboard"
+    payload = {
+        "email": email,
+        "chatgpt_account_id": raw_account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+    }
+    auth_json = {
+        "tokens": {
+            "idToken": _encode_jwt(payload),
+            "accessToken": "access-reset-consume-paused-dashboard",
+            "refreshToken": "refresh-reset-consume-paused-dashboard",
+            "accountId": raw_account_id,
+        },
+    }
+
+    async def should_not_consume(**_: object) -> ConsumeRateLimitResetCreditResponse:
+        raise AssertionError("paused account should not consume upstream reset credits")
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+    pause_response = await async_client.post(f"/api/accounts/{expected_account_id}/pause")
+    assert pause_response.status_code == 200
+
+    monkeypatch.setattr(
+        "app.modules.accounts.service.consume_rate_limit_reset_credit",
+        should_not_consume,
+    )
+
+    reset = await async_client.post(f"/api/accounts/{expected_account_id}/usage-reset-credits/consume")
+
+    assert reset.status_code == 409
+    assert reset.json()["error"]["code"] == "account_usage_reset_consume_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_reactivate_missing_account_returns_404(async_client):
     response = await async_client.post("/api/accounts/missing/reactivate")
     assert response.status_code == 404

--- a/tests/integration/test_accounts_api.py
+++ b/tests/integration/test_accounts_api.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import base64
 import json
+from copy import copy
+from datetime import datetime
 
 import pytest
 
 from app.core.auth import DEFAULT_EMAIL, generate_unique_account_id, parse_auth_json
-from app.core.clients.usage import ConsumeRateLimitResetCreditResponse
+from app.core.clients.rate_limit_reset_credits import RateLimitResetCreditsSnapshot, ResetCreditItem
+from app.core.clients.usage import ConsumeRateLimitResetCreditResponse, UsageFetchError
+from app.core.crypto import TokenEncryptor
 from app.core.usage.models import UsagePayload
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
+from app.modules.rate_limit_reset_credits.store import get_rate_limit_reset_credits_store
 
 pytestmark = pytest.mark.integration
 
@@ -18,6 +23,19 @@ def _encode_jwt(payload: dict) -> str:
     raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     body = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
     return f"header.{body}.sig"
+
+
+def _reset_credit_snapshot(credit_id: str) -> RateLimitResetCreditsSnapshot:
+    credit = ResetCreditItem(
+        id=credit_id,
+        status="available",
+        expires_at=datetime.fromisoformat("2026-07-12T00:00:00+00:00"),
+    )
+    return RateLimitResetCreditsSnapshot(
+        available_count=1,
+        nearest_expires_at=credit.expires_at,
+        credits=[credit],
+    )
 
 
 @pytest.mark.asyncio
@@ -137,6 +155,43 @@ async def test_account_usage_reset_credits_defaults_missing_upstream_summary_to_
 
 
 @pytest.mark.asyncio
+async def test_account_usage_reset_credits_rejects_paused_account(async_client, monkeypatch):
+    email = "reset-credits-paused@example.com"
+    raw_account_id = "acc_reset_credits_paused"
+    payload = {
+        "email": email,
+        "chatgpt_account_id": raw_account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+    }
+    auth_json = {
+        "tokens": {
+            "idToken": _encode_jwt(payload),
+            "accessToken": "access-reset-credits-paused",
+            "refreshToken": "refresh-reset-credits-paused",
+            "accountId": raw_account_id,
+        },
+    }
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fail_fetch_usage(**_: object) -> UsagePayload:
+        raise AssertionError("paused account should not fetch upstream reset credits")
+
+    monkeypatch.setattr("app.modules.accounts.service.fetch_usage", fail_fetch_usage)
+
+    pause_response = await async_client.post(f"/api/accounts/{expected_account_id}/pause")
+    assert pause_response.status_code == 200
+
+    credits = await async_client.get(f"/api/accounts/{expected_account_id}/usage-reset-credits")
+
+    assert credits.status_code == 409
+    assert credits.json()["error"]["code"] == "account_usage_reset_credits_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_account_usage_reset_consume_consumes_credit_and_refreshes(async_client, monkeypatch):
     email = "reset-consume-dashboard@example.com"
     raw_account_id = "acc_reset_consume_dashboard"
@@ -180,6 +235,7 @@ async def test_account_usage_reset_consume_consumes_credit_and_refreshes(async_c
         stub_consume_rate_limit_reset_credit,
     )
     monkeypatch.setattr("app.modules.accounts.service.UsageUpdater", StubUsageUpdater)
+    await get_rate_limit_reset_credits_store().set(expected_account_id, _reset_credit_snapshot("credit-dashboard"))
 
     reset = await async_client.post(f"/api/accounts/{expected_account_id}/usage-reset-credits/consume")
 
@@ -196,6 +252,124 @@ async def test_account_usage_reset_consume_consumes_credit_and_refreshes(async_c
     assert call["route"] is None
     assert call["allow_direct_egress"] is True
     assert refreshed_account_ids == [f"{expected_account_id}:True"]
+    assert get_rate_limit_reset_credits_store().get(expected_account_id) is None
+
+
+@pytest.mark.asyncio
+async def test_account_usage_reset_consume_refreshes_usage_with_post_401_account(async_client, monkeypatch):
+    email = "reset-consume-post-401-dashboard@example.com"
+    raw_account_id = "acc_reset_consume_post_401_dashboard"
+    payload = {
+        "email": email,
+        "chatgpt_account_id": raw_account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+    }
+    auth_json = {
+        "tokens": {
+            "idToken": _encode_jwt(payload),
+            "accessToken": "access-reset-consume-stale-dashboard",
+            "refreshToken": "refresh-reset-consume-post-401-dashboard",
+            "accountId": raw_account_id,
+        },
+    }
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    encryptor = TokenEncryptor()
+    consume_access_tokens: list[str] = []
+    refreshed_access_tokens: list[str] = []
+
+    async def stub_consume_rate_limit_reset_credit(**kwargs: object) -> ConsumeRateLimitResetCreditResponse:
+        access_token = str(kwargs["access_token"])
+        consume_access_tokens.append(access_token)
+        if len(consume_access_tokens) == 1:
+            raise UsageFetchError(401, "expired access token")
+        return ConsumeRateLimitResetCreditResponse.model_validate({"code": "reset", "windows_reset": 1})
+
+    class StubAuthManager:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def ensure_fresh(self, account: Account, *, force: bool = False) -> Account:
+            if not force:
+                return account
+            refreshed = copy(account)
+            refreshed.access_token_encrypted = encryptor.encrypt("access-reset-consume-refreshed-dashboard")
+            return refreshed
+
+    class StubUsageUpdater:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def force_refresh(self, account: Account, *, ignore_refresh_disabled: bool = False) -> bool:
+            assert ignore_refresh_disabled is True
+            refreshed_access_tokens.append(encryptor.decrypt(account.access_token_encrypted))
+            return True
+
+    monkeypatch.setattr("app.dependencies.AuthManager", StubAuthManager)
+    monkeypatch.setattr(
+        "app.modules.accounts.service.consume_rate_limit_reset_credit",
+        stub_consume_rate_limit_reset_credit,
+    )
+    monkeypatch.setattr("app.modules.accounts.service.UsageUpdater", StubUsageUpdater)
+
+    reset = await async_client.post(f"/api/accounts/{expected_account_id}/usage-reset-credits/consume")
+
+    assert reset.status_code == 200, reset.text
+    assert reset.json()["code"] == "reset"
+    assert consume_access_tokens == [
+        "access-reset-consume-stale-dashboard",
+        "access-reset-consume-refreshed-dashboard",
+    ]
+    assert refreshed_access_tokens == ["access-reset-consume-refreshed-dashboard"]
+
+
+@pytest.mark.asyncio
+async def test_account_usage_reset_consume_forwards_redeem_request_id(async_client, monkeypatch):
+    email = "reset-consume-retry-dashboard@example.com"
+    raw_account_id = "acc_reset_consume_retry_dashboard"
+    payload = {
+        "email": email,
+        "chatgpt_account_id": raw_account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+    }
+    auth_json = {
+        "tokens": {
+            "idToken": _encode_jwt(payload),
+            "accessToken": "access-reset-consume-retry-dashboard",
+            "refreshToken": "refresh-reset-consume-retry-dashboard",
+            "accountId": raw_account_id,
+        },
+    }
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    consume_calls: list[dict[str, object]] = []
+
+    async def stub_consume_rate_limit_reset_credit(**kwargs: object) -> ConsumeRateLimitResetCreditResponse:
+        consume_calls.append(kwargs)
+        return ConsumeRateLimitResetCreditResponse.model_validate({"code": "already_redeemed", "windows_reset": 0})
+
+    monkeypatch.setattr(
+        "app.modules.accounts.service.consume_rate_limit_reset_credit",
+        stub_consume_rate_limit_reset_credit,
+    )
+
+    reset = await async_client.post(
+        f"/api/accounts/{expected_account_id}/usage-reset-credits/consume",
+        json={"redeemRequestId": " dashboard-retry-id "},
+    )
+
+    assert reset.status_code == 200, reset.text
+    assert reset.json()["code"] == "already_redeemed"
+    assert len(consume_calls) == 1
+    assert consume_calls[0]["redeem_request_id"] == "dashboard-retry-id"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_accounts_api.py
+++ b/tests/integration/test_accounts_api.py
@@ -6,6 +6,8 @@ import json
 import pytest
 
 from app.core.auth import DEFAULT_EMAIL, generate_unique_account_id, parse_auth_json
+from app.core.clients.usage import ConsumeRateLimitResetCreditResponse
+from app.core.usage.models import UsagePayload
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
 
@@ -49,6 +51,151 @@ async def test_import_and_list_accounts(async_client):
     assert list_response.status_code == 200
     accounts = list_response.json()["accounts"]
     assert any(account["accountId"] == expected_account_id for account in accounts)
+
+
+@pytest.mark.asyncio
+async def test_account_usage_reset_credits_fetches_selected_account(async_client, monkeypatch):
+    email = "reset-credits@example.com"
+    raw_account_id = "acc_reset_credits"
+    payload = {
+        "email": email,
+        "chatgpt_account_id": raw_account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+    }
+    auth_json = {
+        "tokens": {
+            "idToken": _encode_jwt(payload),
+            "accessToken": "access-reset-credits",
+            "refreshToken": "refresh-reset-credits",
+            "accountId": raw_account_id,
+        },
+    }
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    captured: dict[str, str | None] = {}
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: object) -> UsagePayload:
+        captured["access_token"] = access_token
+        captured["account_id"] = account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit_reset_credits": {"available_count": 3},
+            },
+        )
+
+    monkeypatch.setattr("app.modules.accounts.service.fetch_usage", stub_fetch_usage)
+
+    credits = await async_client.get(f"/api/accounts/{expected_account_id}/usage-reset-credits")
+
+    assert credits.status_code == 200
+    assert credits.json() == {
+        "accountId": expected_account_id,
+        "rateLimitResetCredits": {"availableCount": 3},
+    }
+    assert captured == {
+        "access_token": "access-reset-credits",
+        "account_id": raw_account_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_account_usage_reset_credits_defaults_missing_upstream_summary_to_zero(async_client, monkeypatch):
+    email = "reset-credits-zero@example.com"
+    raw_account_id = "acc_reset_credits_zero"
+    payload = {
+        "email": email,
+        "chatgpt_account_id": raw_account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+    }
+    auth_json = {
+        "tokens": {
+            "idToken": _encode_jwt(payload),
+            "accessToken": "access-reset-credits-zero",
+            "refreshToken": "refresh-reset-credits-zero",
+            "accountId": raw_account_id,
+        },
+    }
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def stub_fetch_usage(**_: object) -> UsagePayload:
+        return UsagePayload.model_validate({})
+
+    monkeypatch.setattr("app.modules.accounts.service.fetch_usage", stub_fetch_usage)
+
+    credits = await async_client.get(f"/api/accounts/{expected_account_id}/usage-reset-credits")
+
+    assert credits.status_code == 200
+    assert credits.json()["rateLimitResetCredits"] == {"availableCount": 0}
+
+
+@pytest.mark.asyncio
+async def test_account_usage_reset_consume_consumes_credit_and_refreshes(async_client, monkeypatch):
+    email = "reset-consume-dashboard@example.com"
+    raw_account_id = "acc_reset_consume_dashboard"
+    payload = {
+        "email": email,
+        "chatgpt_account_id": raw_account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+    }
+    auth_json = {
+        "tokens": {
+            "idToken": _encode_jwt(payload),
+            "accessToken": "access-reset-consume-dashboard",
+            "refreshToken": "refresh-reset-consume-dashboard",
+            "accountId": raw_account_id,
+        },
+    }
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    consume_calls: list[dict[str, object]] = []
+
+    async def stub_consume_rate_limit_reset_credit(**kwargs: object) -> ConsumeRateLimitResetCreditResponse:
+        consume_calls.append(kwargs)
+        return ConsumeRateLimitResetCreditResponse.model_validate({"code": "reset", "windows_reset": 2})
+
+    refreshed_account_ids: list[str] = []
+
+    class StubUsageUpdater:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def force_refresh(self, account: Account, *, ignore_refresh_disabled: bool = False) -> bool:
+            refreshed_account_ids.append(f"{account.id}:{ignore_refresh_disabled}")
+            return True
+
+    monkeypatch.setattr(
+        "app.modules.accounts.service.consume_rate_limit_reset_credit",
+        stub_consume_rate_limit_reset_credit,
+    )
+    monkeypatch.setattr("app.modules.accounts.service.UsageUpdater", StubUsageUpdater)
+
+    reset = await async_client.post(f"/api/accounts/{expected_account_id}/usage-reset-credits/consume")
+
+    assert reset.status_code == 200, reset.text
+    assert reset.json()["code"] == "reset"
+    assert reset.json()["windowsReset"] == 2
+    assert reset.json()["usageWritten"] is True
+    assert len(consume_calls) == 1
+    call = consume_calls[0]
+    assert call["access_token"] == "access-reset-consume-dashboard"
+    assert call["account_id"] == raw_account_id
+    assert isinstance(call["redeem_request_id"], str)
+    assert call["redeem_request_id"]
+    assert call["route"] is None
+    assert call["allow_direct_egress"] is True
+    assert refreshed_account_ids == [f"{expected_account_id}:True"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -132,6 +132,10 @@ async def _assert_guest_write_denied(client: AsyncClient) -> None:
     assert blocked_limit_warmup.status_code == 403
     assert blocked_limit_warmup.json()["error"]["code"] == "read_only_access"
 
+    blocked_usage_reset = await client.post("/api/accounts/missing/usage-reset-credits/consume")
+    assert blocked_usage_reset.status_code == 403
+    assert blocked_usage_reset.json()["error"]["code"] == "read_only_access"
+
     blocked_proxy_endpoint = await client.post(
         "/api/settings/upstream-proxy/endpoints",
         json={"name": "Guest Proxy", "scheme": "http", "host": "proxy.internal", "port": 8080},

--- a/tests/integration/test_codex_usage_api.py
+++ b/tests/integration/test_codex_usage_api.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 import pytest
 
+from app.core.clients.rate_limit_reset_credits import RateLimitResetCreditsSnapshot, ResetCreditItem
 from app.core.clients.usage import ConsumeRateLimitResetCreditResponse
 from app.core.crypto import TokenEncryptor
 from app.core.usage.models import UsagePayload
@@ -14,6 +15,7 @@ from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService, LimitRuleInput
 from app.modules.proxy.account_cache import get_account_selection_cache
+from app.modules.rate_limit_reset_credits.store import get_rate_limit_reset_credits_store
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
 pytestmark = pytest.mark.integration
@@ -25,12 +27,16 @@ def _make_account(
     *,
     chatgpt_account_id: str | None = None,
     plan_type: str = "plus",
+    workspace_id: str | None = None,
+    workspace_label: str | None = None,
 ) -> Account:
     encryptor = TokenEncryptor()
     return Account(
         id=account_id,
         chatgpt_account_id=chatgpt_account_id,
         email=email,
+        workspace_id=workspace_id,
+        workspace_label=workspace_label,
         plan_type=plan_type,
         access_token_encrypted=encryptor.encrypt("access"),
         refresh_token_encrypted=encryptor.encrypt("refresh"),
@@ -38,6 +44,19 @@ def _make_account(
         last_refresh=utcnow(),
         status=AccountStatus.ACTIVE,
         deactivation_reason=None,
+    )
+
+
+def _reset_credit_snapshot(credit_id: str) -> RateLimitResetCreditsSnapshot:
+    credit = ResetCreditItem(
+        id=credit_id,
+        status="available",
+        expires_at=utcnow() + timedelta(days=7),
+    )
+    return RateLimitResetCreditsSnapshot(
+        available_count=1,
+        nearest_expires_at=credit.expires_at,
+        credits=[credit],
     )
 
 
@@ -686,14 +705,21 @@ async def test_codex_usage_reset_consume_forwards_and_refreshes(async_client, db
         def __init__(self, *args: object, **kwargs: object) -> None:
             pass
 
-        async def force_refresh(self, account: Account, *, ignore_refresh_disabled: bool = False) -> bool:
-            refreshed_account_ids.append(f"{account.id}:{ignore_refresh_disabled}")
+        async def force_refresh(
+            self,
+            account: Account,
+            *,
+            ignore_refresh_disabled: bool = False,
+            access_token_override: str | None = None,
+        ) -> bool:
+            refreshed_account_ids.append(f"{account.id}:{ignore_refresh_disabled}:{access_token_override}")
             return True
 
     monkeypatch.setattr("app.core.auth.dependencies.fetch_usage", stub_fetch_usage)
     monkeypatch.setattr("app.modules.proxy.api.consume_rate_limit_reset_credit", stub_consume_rate_limit_reset_credit)
     monkeypatch.setattr("app.modules.proxy.api.UsageUpdater", StubUsageUpdater)
     cache_generation = get_account_selection_cache().generation
+    await get_rate_limit_reset_credits_store().set("acc_reset_consume", _reset_credit_snapshot("credit-codex"))
 
     response = await async_client.post(
         "/api/codex/rate-limit-reset-credits/consume",
@@ -714,8 +740,74 @@ async def test_codex_usage_reset_consume_forwards_and_refreshes(async_client, db
             "allow_direct_egress": True,
         }
     ]
-    assert refreshed_account_ids == ["acc_reset_consume:True"]
+    assert refreshed_account_ids == ["acc_reset_consume:True:chatgpt-token"]
     assert get_account_selection_cache().generation > cache_generation
+    assert get_rate_limit_reset_credits_store().get("acc_reset_consume") is None
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_reset_consume_refreshes_matched_workspace_account(async_client, db_setup, monkeypatch):
+    raw_chatgpt_account_id = "workspace_reset_multi"
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        await accounts_repo.upsert(
+            _make_account(
+                "workspace_reset_multi_default",
+                "reset-multi@example.com",
+                chatgpt_account_id=raw_chatgpt_account_id,
+            )
+        )
+        await accounts_repo.upsert(
+            _make_account(
+                "workspace_reset_multi_29c4834a",
+                "reset-multi@example.com",
+                chatgpt_account_id=raw_chatgpt_account_id,
+                workspace_id="team-alpha",
+                workspace_label="Team Alpha",
+            )
+        )
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: object) -> UsagePayload:
+        assert access_token == "chatgpt-token"
+        assert account_id == raw_chatgpt_account_id
+        return UsagePayload.model_validate({"plan_type": "plus", "workspace_id": "team-alpha"})
+
+    async def stub_consume_rate_limit_reset_credit(**_: object) -> ConsumeRateLimitResetCreditResponse:
+        return ConsumeRateLimitResetCreditResponse.model_validate({"code": "reset", "windows_reset": 1})
+
+    refreshed_account_ids: list[str] = []
+
+    class StubUsageUpdater:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def force_refresh(
+            self,
+            account: Account,
+            *,
+            ignore_refresh_disabled: bool = False,
+            access_token_override: str | None = None,
+        ) -> bool:
+            del ignore_refresh_disabled
+            assert access_token_override == "chatgpt-token"
+            refreshed_account_ids.append(account.id)
+            return True
+
+    monkeypatch.setattr("app.core.auth.dependencies.fetch_usage", stub_fetch_usage)
+    monkeypatch.setattr("app.modules.proxy.api.consume_rate_limit_reset_credit", stub_consume_rate_limit_reset_credit)
+    monkeypatch.setattr("app.modules.proxy.api.UsageUpdater", StubUsageUpdater)
+
+    response = await async_client.post(
+        "/api/codex/rate-limit-reset-credits/consume",
+        headers={
+            "Authorization": "Bearer chatgpt-token",
+            "chatgpt-account-id": raw_chatgpt_account_id,
+        },
+        json={"redeem_request_id": "redeem-workspace"},
+    )
+
+    assert response.status_code == 200
+    assert refreshed_account_ids == ["workspace_reset_multi_29c4834a"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_codex_usage_api.py
+++ b/tests/integration/test_codex_usage_api.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 import pytest
 
+from app.core.clients.usage import ConsumeRateLimitResetCreditResponse
 from app.core.crypto import TokenEncryptor
 from app.core.usage.models import UsagePayload
 from app.core.utils.time import utcnow
@@ -620,3 +621,138 @@ async def test_codex_usage_api_key_ignores_aggregate_workspace_limits(async_clie
     assert payload["rate_limit"]["primary_window"]["used_percent"] == 5
     assert payload["rate_limit"]["secondary_window"]["used_percent"] == 10
     assert payload["credits"]["balance"] == "450"
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_exposes_reset_credit_availability(async_client, db_setup, monkeypatch):
+    raw_chatgpt_account_id = "workspace_reset_available"
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        await accounts_repo.upsert(
+            _make_account(
+                "acc_reset_available",
+                "reset-available@example.com",
+                chatgpt_account_id=raw_chatgpt_account_id,
+            )
+        )
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: object) -> UsagePayload:
+        assert access_token == "chatgpt-token"
+        assert account_id == raw_chatgpt_account_id
+        return UsagePayload.model_validate(
+            {
+                "plan_type": "plus",
+                "rate_limit_reset_credits": {"available_count": 3},
+            }
+        )
+
+    monkeypatch.setattr("app.core.auth.dependencies.fetch_usage", stub_fetch_usage)
+
+    response = await async_client.get(
+        "/api/codex/usage",
+        headers={
+            "Authorization": "Bearer chatgpt-token",
+            "chatgpt-account-id": raw_chatgpt_account_id,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["rate_limit_reset_credits"] == {"available_count": 3}
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_reset_consume_forwards_and_refreshes(async_client, db_setup, monkeypatch):
+    raw_chatgpt_account_id = "workspace_reset_consume"
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        await accounts_repo.upsert(
+            _make_account("acc_reset_consume", "reset-consume@example.com", chatgpt_account_id=raw_chatgpt_account_id)
+        )
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: object) -> UsagePayload:
+        assert access_token == "chatgpt-token"
+        assert account_id == raw_chatgpt_account_id
+        return UsagePayload.model_validate({"plan_type": "plus"})
+
+    consume_calls: list[dict[str, object]] = []
+
+    async def stub_consume_rate_limit_reset_credit(**kwargs: object) -> ConsumeRateLimitResetCreditResponse:
+        consume_calls.append(kwargs)
+        return ConsumeRateLimitResetCreditResponse.model_validate({"code": "reset", "windows_reset": 2})
+
+    refreshed_account_ids: list[str] = []
+
+    class StubUsageUpdater:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def force_refresh(self, account: Account, *, ignore_refresh_disabled: bool = False) -> bool:
+            refreshed_account_ids.append(f"{account.id}:{ignore_refresh_disabled}")
+            return True
+
+    monkeypatch.setattr("app.core.auth.dependencies.fetch_usage", stub_fetch_usage)
+    monkeypatch.setattr("app.modules.proxy.api.consume_rate_limit_reset_credit", stub_consume_rate_limit_reset_credit)
+    monkeypatch.setattr("app.modules.proxy.api.UsageUpdater", StubUsageUpdater)
+
+    response = await async_client.post(
+        "/api/codex/rate-limit-reset-credits/consume",
+        headers={
+            "Authorization": "Bearer chatgpt-token",
+            "chatgpt-account-id": raw_chatgpt_account_id,
+        },
+        json={"redeem_request_id": "redeem-123"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"code": "reset", "windows_reset": 2}
+    assert consume_calls == [
+        {
+            "access_token": "chatgpt-token",
+            "account_id": raw_chatgpt_account_id,
+            "redeem_request_id": "redeem-123",
+            "route": None,
+            "allow_direct_egress": True,
+        }
+    ]
+    assert refreshed_account_ids == ["acc_reset_consume:True"]
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_reset_consume_rejects_api_key_callers(async_client, db_setup):
+    _, plain_key = await _create_api_key(name="reset-api-key")
+
+    response = await async_client.post(
+        "/api/codex/rate-limit-reset-credits/consume",
+        headers={"Authorization": f"Bearer {plain_key}"},
+        json={"redeem_request_id": "redeem-123"},
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_codex_usage_reset_consume_rejects_empty_redeem_request_id(async_client, db_setup, monkeypatch):
+    raw_chatgpt_account_id = "workspace_reset_empty"
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        await accounts_repo.upsert(
+            _make_account("acc_reset_empty", "reset-empty@example.com", chatgpt_account_id=raw_chatgpt_account_id)
+        )
+
+    async def stub_fetch_usage(**_: object) -> UsagePayload:
+        return UsagePayload.model_validate({"plan_type": "plus"})
+
+    async def should_not_consume(**_: object) -> ConsumeRateLimitResetCreditResponse:
+        raise AssertionError("empty redeem_request_id should not be forwarded upstream")
+
+    monkeypatch.setattr("app.core.auth.dependencies.fetch_usage", stub_fetch_usage)
+    monkeypatch.setattr("app.modules.proxy.api.consume_rate_limit_reset_credit", should_not_consume)
+
+    response = await async_client.post(
+        "/api/codex/rate-limit-reset-credits/consume",
+        headers={
+            "Authorization": "Bearer chatgpt-token",
+            "chatgpt-account-id": raw_chatgpt_account_id,
+        },
+        json={"redeem_request_id": "  "},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request_error"

--- a/tests/integration/test_codex_usage_api.py
+++ b/tests/integration/test_codex_usage_api.py
@@ -13,6 +13,7 @@ from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService, LimitRuleInput
+from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
 pytestmark = pytest.mark.integration
@@ -692,6 +693,7 @@ async def test_codex_usage_reset_consume_forwards_and_refreshes(async_client, db
     monkeypatch.setattr("app.core.auth.dependencies.fetch_usage", stub_fetch_usage)
     monkeypatch.setattr("app.modules.proxy.api.consume_rate_limit_reset_credit", stub_consume_rate_limit_reset_credit)
     monkeypatch.setattr("app.modules.proxy.api.UsageUpdater", StubUsageUpdater)
+    cache_generation = get_account_selection_cache().generation
 
     response = await async_client.post(
         "/api/codex/rate-limit-reset-credits/consume",
@@ -713,6 +715,7 @@ async def test_codex_usage_reset_consume_forwards_and_refreshes(async_client, db
         }
     ]
     assert refreshed_account_ids == ["acc_reset_consume:True"]
+    assert get_account_selection_cache().generation > cache_generation
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_rate_limit_reset_credits_api.py
+++ b/tests/integration/test_rate_limit_reset_credits_api.py
@@ -102,12 +102,14 @@ async def test_consume_active_account_returns_success_with_mocked_upstream(async
         access_token: str,
         account_id: str | None,
         credit_id: str,
+        redeem_request_id: str | None = None,
         **kwargs: Any,
     ) -> ConsumeResetCreditResponse:
         captured.update(
             {
                 "consume_account_id": account_id,
                 "consume_credit_id": credit_id,
+                "redeem_request_id": redeem_request_id,
                 "consume_had_token": bool(access_token),
             }
         )
@@ -138,7 +140,10 @@ async def test_consume_active_account_returns_success_with_mocked_upstream(async
 
     await get_rate_limit_reset_credits_store().set(account_id, _snapshot([_credit("credit-1")]))
 
-    response = await async_client.post(f"/api/accounts/{account_id}/rate-limit-reset-credits/consume")
+    response = await async_client.post(
+        f"/api/accounts/{account_id}/rate-limit-reset-credits/consume",
+        json={"redeemRequestId": " dashboard-retry-id "},
+    )
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["code"] == "reset"
@@ -150,6 +155,7 @@ async def test_consume_active_account_returns_success_with_mocked_upstream(async
     assert captured["fetch_had_token"] is True
     assert captured["consume_account_id"] == "acc_reset_active"
     assert captured["consume_credit_id"] == "credit-1"
+    assert captured["redeem_request_id"] == "dashboard-retry-id"
     assert captured["consume_had_token"] is True
 
 

--- a/tests/unit/test_accounts_service_probe.py
+++ b/tests/unit/test_accounts_service_probe.py
@@ -139,7 +139,7 @@ async def test_probe_account_captures_before_after_snapshot(monkeypatch):
     assert service._usage_updater is not None
     force_refresh_mock = service._usage_updater.force_refresh
     assert isinstance(force_refresh_mock, AsyncMock)
-    force_refresh_mock.assert_awaited_once_with(account)
+    force_refresh_mock.assert_awaited_once_with(account, ignore_refresh_disabled=True)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_auth_dependencies_upstream_proxy.py
+++ b/tests/unit/test_auth_dependencies_upstream_proxy.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.core.auth import dependencies as auth_dependencies
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute, UpstreamProxyRouteError
+from app.core.usage.models import UsagePayload
 from app.db.models import Account, AccountStatus
 
 pytestmark = pytest.mark.unit
@@ -74,6 +75,196 @@ async def test_validate_codex_usage_identity_passes_resolved_route(monkeypatch: 
     assert request.state.codex_usage_identity_chatgpt_account_id == "chatgpt_1"
     assert request.state.codex_usage_identity_account_id == "acc_1"
     assert request.state.codex_usage_identity_route is route
+
+
+@pytest.mark.asyncio
+async def test_validate_codex_usage_identity_reresolves_route_for_workspace_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _account()
+    workspace_account = _account()
+    workspace_account.id = auth_dependencies.generate_unique_account_id(
+        account.chatgpt_account_id,
+        account.email,
+        "ws_1",
+        "Team",
+    )
+    request = SimpleNamespace(
+        headers={"Authorization": "Bearer access", "chatgpt-account-id": "chatgpt_1"},
+        state=SimpleNamespace(),
+    )
+    owner_route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="owner_pool",
+        endpoint=ResolvedProxyEndpoint("owner_ep", "http", "owner-proxy.test", 8080),
+    )
+    workspace_route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="workspace_pool",
+        endpoint=ResolvedProxyEndpoint("workspace_ep", "http", "workspace-proxy.test", 8080),
+    )
+    resolved_account_ids: list[str] = []
+
+    class Repo:
+        def __init__(self, session: object) -> None:
+            pass
+
+        async def get_active_by_chatgpt_account_id(self, chatgpt_account_id: str) -> Account | None:
+            return account if chatgpt_account_id == "chatgpt_1" else None
+
+        async def get_by_id(self, account_id: str) -> Account | None:
+            return workspace_account if account_id == workspace_account.id else None
+
+    @asynccontextmanager
+    async def session_context():
+        yield object()
+
+    async def resolve_route(*args: object, **kwargs: object) -> ResolvedUpstreamRoute:
+        account_id = cast(str, kwargs["account_id"])
+        resolved_account_ids.append(account_id)
+        return workspace_route if account_id == workspace_account.id else owner_route
+
+    async def fetch_usage(*args: object, **kwargs: object) -> UsagePayload:
+        assert kwargs["route"] is owner_route
+        return UsagePayload(workspace_id="ws_1", workspace_label="Team")
+
+    monkeypatch.setattr(auth_dependencies, "get_background_session", session_context)
+    monkeypatch.setattr(auth_dependencies, "AccountsRepository", Repo)
+    monkeypatch.setattr(auth_dependencies, "resolve_upstream_route", resolve_route)
+    monkeypatch.setattr(auth_dependencies, "fetch_usage", fetch_usage)
+
+    result = await auth_dependencies.validate_codex_usage_identity(cast(Any, request))
+
+    assert result is None
+    assert resolved_account_ids == ["acc_1", workspace_account.id]
+    assert request.state.codex_usage_identity_account_id == workspace_account.id
+    assert request.state.codex_usage_identity_route is workspace_route
+
+
+@pytest.mark.parametrize("status", [AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED])
+@pytest.mark.asyncio
+async def test_validate_codex_usage_identity_reresolves_route_for_limited_workspace_account(
+    monkeypatch: pytest.MonkeyPatch,
+    status: AccountStatus,
+) -> None:
+    account = _account()
+    workspace_account = _account()
+    workspace_account.id = auth_dependencies.generate_unique_account_id(
+        account.chatgpt_account_id,
+        account.email,
+        "ws_1",
+        "Team",
+    )
+    workspace_account.status = status
+    request = SimpleNamespace(
+        headers={"Authorization": "Bearer access", "chatgpt-account-id": "chatgpt_1"},
+        state=SimpleNamespace(),
+    )
+    owner_route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="owner_pool",
+        endpoint=ResolvedProxyEndpoint("owner_ep", "http", "owner-proxy.test", 8080),
+    )
+    workspace_route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="workspace_pool",
+        endpoint=ResolvedProxyEndpoint("workspace_ep", "http", "workspace-proxy.test", 8080),
+    )
+    resolved_account_ids: list[str] = []
+
+    class Repo:
+        def __init__(self, session: object) -> None:
+            pass
+
+        async def get_active_by_chatgpt_account_id(self, chatgpt_account_id: str) -> Account | None:
+            return account if chatgpt_account_id == "chatgpt_1" else None
+
+        async def get_by_id(self, account_id: str) -> Account | None:
+            return workspace_account if account_id == workspace_account.id else None
+
+    @asynccontextmanager
+    async def session_context():
+        yield object()
+
+    async def resolve_route(*args: object, **kwargs: object) -> ResolvedUpstreamRoute:
+        account_id = cast(str, kwargs["account_id"])
+        resolved_account_ids.append(account_id)
+        return workspace_route if account_id == workspace_account.id else owner_route
+
+    async def fetch_usage(*args: object, **kwargs: object) -> UsagePayload:
+        assert kwargs["route"] is owner_route
+        return UsagePayload(workspace_id="ws_1", workspace_label="Team")
+
+    monkeypatch.setattr(auth_dependencies, "get_background_session", session_context)
+    monkeypatch.setattr(auth_dependencies, "AccountsRepository", Repo)
+    monkeypatch.setattr(auth_dependencies, "resolve_upstream_route", resolve_route)
+    monkeypatch.setattr(auth_dependencies, "fetch_usage", fetch_usage)
+
+    result = await auth_dependencies.validate_codex_usage_identity(cast(Any, request))
+
+    assert result is None
+    assert resolved_account_ids == ["acc_1", workspace_account.id]
+    assert request.state.codex_usage_identity_account_id == workspace_account.id
+    assert request.state.codex_usage_identity_route is workspace_route
+
+
+@pytest.mark.asyncio
+async def test_validate_codex_usage_identity_rejects_inactive_workspace_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _account()
+    workspace_account = _account()
+    workspace_account.id = auth_dependencies.generate_unique_account_id(
+        account.chatgpt_account_id,
+        account.email,
+        "ws_1",
+        "Team",
+    )
+    workspace_account.status = AccountStatus.PAUSED
+    request = SimpleNamespace(
+        headers={"Authorization": "Bearer access", "chatgpt-account-id": "chatgpt_1"},
+        state=SimpleNamespace(),
+    )
+    owner_route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="owner_pool",
+        endpoint=ResolvedProxyEndpoint("owner_ep", "http", "owner-proxy.test", 8080),
+    )
+    resolved_account_ids: list[str] = []
+
+    class Repo:
+        def __init__(self, session: object) -> None:
+            pass
+
+        async def get_active_by_chatgpt_account_id(self, chatgpt_account_id: str) -> Account | None:
+            return account if chatgpt_account_id == "chatgpt_1" else None
+
+        async def get_by_id(self, account_id: str) -> Account | None:
+            return workspace_account if account_id == workspace_account.id else None
+
+    @asynccontextmanager
+    async def session_context():
+        yield object()
+
+    async def resolve_route(*args: object, **kwargs: object) -> ResolvedUpstreamRoute:
+        resolved_account_ids.append(cast(str, kwargs["account_id"]))
+        return owner_route
+
+    async def fetch_usage(*args: object, **kwargs: object) -> UsagePayload:
+        assert kwargs["route"] is owner_route
+        return UsagePayload(workspace_id="ws_1", workspace_label="Team")
+
+    monkeypatch.setattr(auth_dependencies, "get_background_session", session_context)
+    monkeypatch.setattr(auth_dependencies, "AccountsRepository", Repo)
+    monkeypatch.setattr(auth_dependencies, "resolve_upstream_route", resolve_route)
+    monkeypatch.setattr(auth_dependencies, "fetch_usage", fetch_usage)
+
+    with pytest.raises(auth_dependencies.ProxyAuthError):
+        await auth_dependencies.validate_codex_usage_identity(cast(Any, request))
+
+    assert resolved_account_ids == ["acc_1"]
+    assert not hasattr(request.state, "codex_usage_identity_account_id")
+    assert not hasattr(request.state, "codex_usage_identity_route")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_auth_dependencies_upstream_proxy.py
+++ b/tests/unit/test_auth_dependencies_upstream_proxy.py
@@ -28,6 +28,10 @@ def _account() -> Account:
 @pytest.mark.asyncio
 async def test_validate_codex_usage_identity_passes_resolved_route(monkeypatch: pytest.MonkeyPatch) -> None:
     account = _account()
+    request = SimpleNamespace(
+        headers={"Authorization": "Bearer access", "chatgpt-account-id": "chatgpt_1"},
+        state=SimpleNamespace(),
+    )
     route = ResolvedUpstreamRoute(
         mode="account_bound",
         pool_id="pool_1",
@@ -59,15 +63,17 @@ async def test_validate_codex_usage_identity_passes_resolved_route(monkeypatch: 
     monkeypatch.setattr(auth_dependencies, "resolve_upstream_route", resolve_route)
     monkeypatch.setattr(auth_dependencies, "fetch_usage", fetch_usage)
 
-    result = await auth_dependencies.validate_codex_usage_identity(
-        cast(Any, SimpleNamespace(headers={"Authorization": "Bearer access", "chatgpt-account-id": "chatgpt_1"}))
-    )
+    result = await auth_dependencies.validate_codex_usage_identity(cast(Any, request))
 
     assert result is None
     assert calls["lookup"] == "chatgpt_1"
     assert calls["resolve_kwargs"]["account_id"] == "acc_1"
     assert calls["resolve_kwargs"]["operation"] == "usage_identity"
     assert calls["fetch_kwargs"]["route"] is route
+    assert request.state.codex_usage_identity_access_token == "access"
+    assert request.state.codex_usage_identity_chatgpt_account_id == "chatgpt_1"
+    assert request.state.codex_usage_identity_account_id == "acc_1"
+    assert request.state.codex_usage_identity_route is route
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_rate_limit_reset_credits_api.py
+++ b/tests/unit/test_rate_limit_reset_credits_api.py
@@ -338,6 +338,154 @@ async def test_redeem_replaces_stale_cached_snapshot_when_fresh_fetch_has_no_ava
 
 
 @pytest.mark.asyncio
+async def test_redeem_retries_same_request_id_when_fresh_fetch_has_no_available_credit() -> None:
+    store = RateLimitResetCreditsStore()
+    await store.set("acc_1", _snapshot([_credit("cached")], available_count=1))
+
+    captured: dict[str, Any] = {}
+
+    async def consume_fn(
+        access_token: str,
+        account_id: str | None,
+        credit_id: str,
+        **kwargs: Any,
+    ) -> ConsumeResetCreditResponse:
+        captured.update(
+            {
+                "access_token": access_token,
+                "account_id": account_id,
+                "credit_id": credit_id,
+                "redeem_request_id": kwargs.get("redeem_request_id"),
+            }
+        )
+        return ConsumeResetCreditResponse.model_validate(
+            {
+                "code": "already_redeemed",
+                "credit": {"id": credit_id, "status": "redeemed", "redeemed_at": "2026-06-13T13:12:31Z"},
+                "windows_reset": 0,
+            }
+        )
+
+    result = await _redeem_soonest_reset_credit(
+        account=_account(),
+        store=store,
+        encryptor=StubEncryptor(),
+        fetch_fn=_static_fetch_fn(_response([], available_count=0)),
+        consume_fn=consume_fn,
+        redeem_request_id="retry-id",
+    )
+
+    assert captured == {
+        "access_token": "decrypted-access-token",
+        "account_id": "workspace-1",
+        "credit_id": "cached",
+        "redeem_request_id": "retry-id",
+    }
+    assert result.response.code == "already_redeemed"
+    assert result.available_count_before == 0
+    assert result.available_count_after == 0
+    assert store.get("acc_1") is None
+
+
+@pytest.mark.asyncio
+async def test_redeem_retries_same_request_id_after_local_credit_vanishes() -> None:
+    store = RateLimitResetCreditsStore()
+    await store.remember_redeem_request("acc_1", "retry-id", "vanished")
+    await store.set("acc_1", _snapshot([], available_count=0))
+
+    captured: dict[str, Any] = {}
+
+    async def consume_fn(
+        access_token: str,
+        account_id: str | None,
+        credit_id: str,
+        **kwargs: Any,
+    ) -> ConsumeResetCreditResponse:
+        captured.update(
+            {
+                "access_token": access_token,
+                "account_id": account_id,
+                "credit_id": credit_id,
+                "redeem_request_id": kwargs.get("redeem_request_id"),
+            }
+        )
+        return ConsumeResetCreditResponse.model_validate(
+            {
+                "code": "already_redeemed",
+                "credit": {"id": credit_id, "status": "redeemed", "redeemed_at": "2026-06-13T13:12:31Z"},
+                "windows_reset": 0,
+            }
+        )
+
+    result = await _redeem_soonest_reset_credit(
+        account=_account(),
+        store=store,
+        encryptor=StubEncryptor(),
+        fetch_fn=_static_fetch_fn(_response([], available_count=0)),
+        consume_fn=consume_fn,
+        redeem_request_id="retry-id",
+    )
+
+    assert captured == {
+        "access_token": "decrypted-access-token",
+        "account_id": "workspace-1",
+        "credit_id": "vanished",
+        "redeem_request_id": "retry-id",
+    }
+    assert result.response.code == "already_redeemed"
+    assert store.get("acc_1") is None
+
+
+@pytest.mark.asyncio
+async def test_redeem_retries_same_request_id_preserves_original_credit_when_another_is_available() -> None:
+    store = RateLimitResetCreditsStore()
+    await store.remember_redeem_request("acc_1", "retry-id", "original")
+    await store.set("acc_1", _snapshot([_credit("new-cached")], available_count=1))
+
+    captured: dict[str, Any] = {}
+
+    async def consume_fn(
+        access_token: str,
+        account_id: str | None,
+        credit_id: str,
+        **kwargs: Any,
+    ) -> ConsumeResetCreditResponse:
+        captured.update(
+            {
+                "access_token": access_token,
+                "account_id": account_id,
+                "credit_id": credit_id,
+                "redeem_request_id": kwargs.get("redeem_request_id"),
+            }
+        )
+        return ConsumeResetCreditResponse.model_validate(
+            {
+                "code": "already_redeemed",
+                "credit": {"id": credit_id, "status": "redeemed", "redeemed_at": "2026-06-13T13:12:31Z"},
+                "windows_reset": 0,
+            }
+        )
+
+    result = await _redeem_soonest_reset_credit(
+        account=_account(),
+        store=store,
+        encryptor=StubEncryptor(),
+        fetch_fn=_static_fetch_fn(_response([_credit("new-fresh")], available_count=1)),
+        consume_fn=consume_fn,
+        redeem_request_id="retry-id",
+    )
+
+    assert captured == {
+        "access_token": "decrypted-access-token",
+        "account_id": "workspace-1",
+        "credit_id": "original",
+        "redeem_request_id": "retry-id",
+    }
+    assert result.response.code == "already_redeemed"
+    assert store.get_redeem_request_credit_id("acc_1", "retry-id") == "original"
+
+
+@pytest.mark.asyncio
 async def test_redeem_consumes_fresh_available_credit_when_cached_credit_disappears_upstream() -> None:
     store = RateLimitResetCreditsStore()
     await store.set("acc_1", _snapshot([_credit("stale")], available_count=1))

--- a/tests/unit/test_rate_limit_reset_credits_client.py
+++ b/tests/unit/test_rate_limit_reset_credits_client.py
@@ -356,6 +356,31 @@ async def test_consume_reset_credit_generates_fresh_redeem_request_id_each_call(
 
 
 @pytest.mark.asyncio
+async def test_consume_reset_credit_uses_supplied_redeem_request_id() -> None:
+    state = ClientState()
+    client = StubRetryClient(
+        [StubResponse(200, {"code": "reset", "credit": {"id": "x"}, "windows_reset": 1}, "")],
+        state,
+    )
+
+    await consume_reset_credit(
+        "access-token",
+        None,
+        "RateLimitResetCredit_test",
+        redeem_request_id="dashboard-retry-id",
+        base_url="http://upstream.test/backend-api",
+        timeout_seconds=2.0,
+        max_retries=0,
+        client=cast(Any, client),
+        allow_direct_egress=True,
+    )
+
+    assert state.json_body is not None
+    assert state.json_body["credit_id"] == "RateLimitResetCredit_test"
+    assert state.json_body["redeem_request_id"] == "dashboard-retry-id"
+
+
+@pytest.mark.asyncio
 async def test_consume_reset_credit_does_not_retry_when_max_retries_omitted(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = get_settings()
     original_retries = settings.usage_fetch_max_retries

--- a/tests/unit/test_usage_client.py
+++ b/tests/unit/test_usage_client.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 
 import pytest
 
-from app.core.clients.usage import UsageFetchError, fetch_usage
+from app.core.clients.usage import UsageFetchError, consume_rate_limit_reset_credit, fetch_usage
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
 
 pytestmark = pytest.mark.unit
@@ -29,8 +29,11 @@ class StubResponse:
 @dataclass
 class UsageClientState:
     calls: int = 0
+    method: str | None = None
+    url: str | None = None
     auth: str | None = None
     account: str | None = None
+    payload: dict[str, str] | None = None
 
 
 class StubRequestContext:
@@ -38,12 +41,18 @@ class StubRequestContext:
         self,
         responses: list[StubResponse],
         state: UsageClientState,
+        method: str,
+        url: str,
         headers: dict[str, str],
+        payload: dict[str, str] | None,
         retry_options: object | None,
     ) -> None:
         self._responses = responses
         self._state = state
+        self._method = method
+        self._url = url
         self._headers = headers
+        self._payload = payload
         self._retry_options = retry_options
 
     async def __aenter__(self) -> StubResponse:
@@ -54,8 +63,11 @@ class StubRequestContext:
             index = min(self._state.calls, len(self._responses) - 1)
             response = self._responses[index]
             self._state.calls += 1
+            self._state.method = self._method
+            self._state.url = self._url
             self._state.auth = self._headers.get("Authorization")
             self._state.account = self._headers.get("chatgpt-account-id")
+            self._state.payload = self._payload
             if response.status in statuses and attempt < attempts - 1:
                 continue
             return response
@@ -77,10 +89,11 @@ class StubRetryClient:
         method: str,
         url: str,
         headers: dict[str, str] | None = None,
+        json: dict[str, str] | None = None,
         timeout: object | None = None,
         retry_options: object | None = None,
     ) -> StubRequestContext:
-        return StubRequestContext(self._responses, self._state, headers or {}, retry_options)
+        return StubRequestContext(self._responses, self._state, method, url, headers or {}, json, retry_options)
 
 
 class StubCodexResponse:
@@ -187,6 +200,69 @@ async def test_fetch_usage_uses_resolved_codex_route() -> None:
     assert client.calls[0]["route"] is route
     assert client.calls[0]["method"] == "GET"
     assert client.calls[0]["url"] == "http://usage.test/backend-api/wham/usage"
+
+
+@pytest.mark.asyncio
+async def test_consume_rate_limit_reset_credit_posts_payload_direct() -> None:
+    state = UsageClientState()
+    client = StubRetryClient(
+        [StubResponse(200, {"code": "reset", "windows_reset": 2}, "")],
+        state,
+    )
+
+    data = await consume_rate_limit_reset_credit(
+        access_token="access-token",
+        account_id="acc_test",
+        redeem_request_id="redeem-123",
+        base_url="http://usage.test",
+        max_retries=0,
+        timeout_seconds=1.0,
+        client=cast(Any, client),
+        allow_direct_egress=True,
+    )
+
+    assert data.code == "reset"
+    assert data.windows_reset == 2
+    assert state.calls == 1
+    assert state.method == "POST"
+    assert state.url == "http://usage.test/backend-api/wham/rate-limit-reset-credits/consume"
+    assert state.auth == "Bearer access-token"
+    assert state.account == "acc_test"
+    assert state.payload == {"redeem_request_id": "redeem-123"}
+
+
+@pytest.mark.asyncio
+async def test_consume_rate_limit_reset_credit_uses_resolved_codex_route() -> None:
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_1",
+        endpoint=ResolvedProxyEndpoint("ep_1", "http", "proxy.test", 8080),
+    )
+    client = StubCodexClient(
+        [
+            StubCodexResponse(
+                200,
+                {"code": "already_redeemed", "windows_reset": 0},
+            )
+        ]
+    )
+
+    data = await consume_rate_limit_reset_credit(
+        access_token="access-token",
+        account_id="acc_test",
+        redeem_request_id="redeem-123",
+        base_url="http://usage.test/backend-api",
+        max_retries=0,
+        timeout_seconds=1.0,
+        route=route,
+        codex_client=cast(Any, client),
+    )
+
+    assert data.code == "already_redeemed"
+    assert client.calls[0]["route"] is route
+    assert client.calls[0]["method"] == "POST"
+    assert client.calls[0]["url"] == "http://usage.test/backend-api/wham/rate-limit-reset-credits/consume"
+    assert client.calls[0]["json"] == {"redeem_request_id": "redeem-123"}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -527,6 +527,7 @@ async def test_force_refresh_bypasses_fresh_usage_cache(monkeypatch: pytest.Monk
     refresh_account.assert_awaited_once_with(
         account,
         usage_account_id=account.chatgpt_account_id,
+        access_token_override=None,
     )
     sync_account.assert_awaited_once_with(account)
     get_settings.cache_clear()
@@ -580,6 +581,7 @@ async def test_force_refresh_does_not_join_stale_refresh_singleflight(monkeypatc
     force_refresh_account.assert_awaited_once_with(
         account,
         usage_account_id=account.chatgpt_account_id,
+        access_token_override=None,
     )
     assert sync_account.await_count == 2
     sync_account.assert_awaited_with(account)
@@ -659,6 +661,7 @@ async def test_force_refresh_bypasses_auth_failure_cooldown(monkeypatch: pytest.
     refresh_account.assert_awaited_once_with(
         account,
         usage_account_id=account.chatgpt_account_id,
+        access_token_override=None,
     )
     sync_account.assert_awaited_once_with(account)
     assert usage_updater_module._is_usage_refresh_in_cooldown(account.id) is False
@@ -704,6 +707,7 @@ async def test_force_refresh_can_ignore_usage_refresh_disabled(monkeypatch: pyte
     refresh_account.assert_awaited_once_with(
         account,
         usage_account_id=account.chatgpt_account_id,
+        access_token_override=None,
     )
     sync_account.assert_awaited_once_with(account)
     get_settings.cache_clear()
@@ -750,6 +754,32 @@ async def test_usage_updater_includes_chatgpt_account_id_even_when_shared(monkey
     await updater.refresh_accounts([acc_a, acc_b, acc_c], latest_usage={})
 
     assert [call["account_id"] for call in calls] == [shared, shared, "workspace_unique"]
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_uses_access_token_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    calls: list[dict[str, Any]] = []
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        calls.append({"access_token": access_token, "account_id": account_id})
+        return UsagePayload.model_validate({"plan_type": "plus"})
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=None)
+    account = _make_account("acc_override", "workspace_override")
+
+    refreshed = await updater.force_refresh(account, ignore_refresh_disabled=True, access_token_override="caller-token")
+
+    assert refreshed is False
+    assert calls == [{"access_token": "caller-token", "account_id": "workspace_override"}]
+    get_settings.cache_clear()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -684,6 +684,32 @@ async def test_force_refresh_respects_usage_refresh_disabled(monkeypatch: pytest
 
 
 @pytest.mark.asyncio
+async def test_force_refresh_can_ignore_usage_refresh_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "false")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+    updater = UsageUpdater(StubUsageRepository())
+    account = _make_account("acc_force_probe_disabled_override", "workspace_force_probe_disabled_override")
+    refresh_account = AsyncMock(
+        return_value=usage_updater_module.AccountRefreshResult(usage_written=True),
+    )
+    sync_account = AsyncMock()
+    monkeypatch.setattr(updater, "_refresh_account", refresh_account)
+    monkeypatch.setattr(updater, "_sync_account_from_repo", sync_account)
+
+    refreshed = await updater.force_refresh(account, ignore_refresh_disabled=True)
+
+    assert refreshed is True
+    refresh_account.assert_awaited_once_with(
+        account,
+        usage_account_id=account.chatgpt_account_id,
+    )
+    sync_account.assert_awaited_once_with(account)
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
 async def test_usage_updater_includes_chatgpt_account_id_even_when_shared(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings


### PR DESCRIPTION
## Summary

- Preserve upstream Codex usage reset-credit availability on `/api/codex/usage` and add the Codex-compatible consume endpoint.
- Add dashboard account reset-credit endpoints plus a confirmed, small `Reset` action in the Usage resets row.
- Force-refresh usage after successful/idempotent reset-credit consumption without adding permanent polling or changing Force probe behavior.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal change, no behavior change, no API change
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Closes Soju06/codex-lb#1014.

Related to Soju06/codex-lb#1004; this PR adds per-account visibility and manual reset consumption, but bulk/all-account reset prompting is out of scope.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/support-codex-usage-reset/`

## Changes

- Extend usage payload models/client code to carry `rate_limit_reset_credits.available_count` and consume reset credits with caller-provided `redeem_request_id`.
- Add `POST /api/codex/rate-limit-reset-credits/consume` for ChatGPT-authenticated callers, rejecting API-key callers and forwarding upstream responses.
- Add dashboard read/write account endpoints for usage reset credits; consume requires dashboard write access.
- Render Usage resets availability in the account Usage panel and place a confirmed `Reset` button in that row.
- After successful or idempotent reset consumption, trigger a usage-only force refresh and invalidate the relevant dashboard queries.
- Keep scope limited: no database migrations, no schema storage changes, no changelog/docs edits, no Force probe confirmation change, and no permanent polling.

## Test plan

```
.venv/bin/python -m pytest tests/unit/test_usage_client.py tests/unit/test_usage_updater.py tests/unit/test_accounts_service_probe.py tests/integration/test_codex_usage_api.py tests/integration/test_accounts_api.py tests/integration/test_accounts_api_probe.py tests/integration/test_auth_middleware.py
# 151 passed

.venv/bin/ruff check app/core/auth/dependencies.py app/core/clients/usage.py app/core/exceptions.py app/core/handlers/exceptions.py app/core/usage/models.py app/modules/accounts/api.py app/modules/accounts/schemas.py app/modules/accounts/service.py app/modules/proxy/api.py app/modules/proxy/schemas.py app/modules/proxy/types.py app/modules/usage/updater.py tests/integration/test_accounts_api.py tests/integration/test_auth_middleware.py tests/integration/test_codex_usage_api.py tests/unit/test_accounts_service_probe.py tests/unit/test_usage_client.py tests/unit/test_usage_updater.py
# All checks passed!

cd frontend && npm run test -- src/features/accounts/components/account-detail.test.tsx src/features/accounts/components/account-usage-panel.test.tsx src/features/accounts/components/accounts-page.test.tsx src/features/accounts/hooks/use-accounts.test.ts src/test/mocks/handler-coverage.test.ts
# 5 files passed, 19 tests passed

cd frontend && npm run lint && npm run build
# passed

openspec validate support-codex-usage-reset --strict
# Change 'support-codex-usage-reset' is valid

openspec validate --specs
# Totals: 30 passed, 0 failed

openspec status --change support-codex-usage-reset --json
openspec instructions apply --change support-codex-usage-reset --json
# spec-driven artifacts present; tasks 13/13 complete; state=all_done

git diff --check upstream/main...HEAD
# passed
```

Additional current-head retry-id validation after the latest review fix:

```
cd frontend && ./node_modules/.bin/vitest run src/features/accounts/hooks/use-accounts.test.ts --testTimeout=20000 --pool=forks
# 1 file passed, 5 tests passed

cd frontend && ./node_modules/.bin/eslint src/features/accounts/hooks/use-accounts.ts src/features/accounts/hooks/use-accounts.test.ts
# passed

cd frontend && ./node_modules/.bin/tsc -b --pretty false
# passed

git diff --check
# passed
```

## Screenshots / output (optional)

Dev dashboard smoke after rebuilding frontend assets and restarting the dev app:

```
local_2460=200 type=text/html; charset=utf-8 bytes=1132
external_dev=200 type=text/html; charset=utf-8 bytes=1132
asset_assets/index-BEaFBtC0.js=200 type=text/javascript; charset=utf-8 bytes=598478
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above, or marked it N/A.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and OpenSpec task verification is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
