### PR TITLE
fix(db): optimize dashboard query hot paths

### DIFF
--- a/app/db/alembic/versions/20260629_000000_add_dashboard_query_hot_path_indexes.py
+++ b/app/db/alembic/versions/20260629_000000_add_dashboard_query_hot_path_indexes.py
@@ -1,0 +1,53 @@
+"""Add hot-path indexes for dashboard and additional quota reads.
+
+Revision ID: 20260629_000000_add_dashboard_query_hot_path_indexes
+Revises: 20260626_010000_add_request_logs_upstream_transport
+Create Date: 2026-06-29 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260629_000000_add_dashboard_query_hot_path_indexes"
+down_revision = "20260626_010000_add_request_logs_upstream_transport"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_additional_usage_quota_window_latest",
+        "additional_usage_history",
+        [
+            "quota_key",
+            sa.text('"window"'),
+            "account_id",
+            sa.text("recorded_at DESC"),
+            sa.text("used_percent DESC"),
+            sa.text("id DESC"),
+        ],
+        unique=False,
+        if_not_exists=True,
+    )
+    op.create_index(
+        "idx_logs_account_kind_deleted_latest",
+        "request_logs",
+        ["account_id", "request_kind", "deleted_at", "requested_at", "id"],
+        unique=False,
+        if_not_exists=True,
+    )
+    op.create_index(
+        "idx_logs_account_request_latest",
+        "request_logs",
+        ["account_id", "request_id", "requested_at", "id"],
+        unique=False,
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_logs_account_request_latest", table_name="request_logs", if_exists=True)
+    op.drop_index("idx_logs_account_kind_deleted_latest", table_name="request_logs", if_exists=True)
+    op.drop_index("ix_additional_usage_quota_window_latest", table_name="additional_usage_history", if_exists=True)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1058,6 +1058,21 @@ Index("idx_logs_account_time", RequestLog.account_id, RequestLog.requested_at)
 Index("idx_logs_api_key_time", RequestLog.api_key_id, RequestLog.requested_at.desc(), RequestLog.id.desc())
 Index("idx_logs_api_key_time_account", RequestLog.api_key_id, RequestLog.requested_at.desc(), RequestLog.account_id)
 Index("idx_logs_request_kind_time", RequestLog.request_kind, RequestLog.requested_at.desc(), RequestLog.id.desc())
+Index(
+    "idx_logs_account_kind_deleted_latest",
+    RequestLog.account_id,
+    RequestLog.request_kind,
+    RequestLog.deleted_at,
+    RequestLog.requested_at,
+    RequestLog.id,
+)
+Index(
+    "idx_logs_account_request_latest",
+    RequestLog.account_id,
+    RequestLog.request_id,
+    RequestLog.requested_at,
+    RequestLog.id,
+)
 Index("idx_logs_requested_at", RequestLog.requested_at)
 Index("idx_logs_source_requested_at", RequestLog.source, RequestLog.requested_at.desc())
 Index("idx_logs_requested_at_id", RequestLog.requested_at.desc(), RequestLog.id.desc())
@@ -1181,4 +1196,13 @@ Index(
     AdditionalUsageHistory.window,
     AdditionalUsageHistory.account_id,
     AdditionalUsageHistory.recorded_at,
+)
+Index(
+    "ix_additional_usage_quota_window_latest",
+    AdditionalUsageHistory.quota_key,
+    AdditionalUsageHistory.window,
+    AdditionalUsageHistory.account_id,
+    AdditionalUsageHistory.recorded_at.desc(),
+    AdditionalUsageHistory.used_percent.desc(),
+    AdditionalUsageHistory.id.desc(),
 )

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -80,20 +80,18 @@ class AccountsRepository:
         if account_ids:
             conditions.append(RequestLog.account_id.in_(account_ids))
 
-        latest_request_log_ids_stmt = select(
-            RequestLog.id.label("request_log_id"),
-            func.row_number()
-            .over(
-                partition_by=(
-                    RequestLog.account_id,
-                    RequestLog.request_id,
-                    RequestLog.requested_at,
-                ),
-                order_by=(RequestLog.requested_at.desc(), RequestLog.id.desc()),
+        latest_request_log_ids = (
+            select(
+                func.max(RequestLog.id).label("request_log_id"),
             )
-            .label("request_log_rank"),
-        ).where(*conditions)
-        latest_request_log_ids = latest_request_log_ids_stmt.subquery("latest_request_log_ids")
+            .where(*conditions)
+            .group_by(
+                RequestLog.account_id,
+                RequestLog.request_id,
+                RequestLog.requested_at,
+            )
+            .subquery("latest_request_log_ids")
+        )
         stmt = (
             select(
                 RequestLog.account_id,
@@ -104,7 +102,6 @@ class AccountsRepository:
                 func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
             )
             .join(latest_request_log_ids, RequestLog.id == latest_request_log_ids.c.request_log_id)
-            .where(latest_request_log_ids.c.request_log_rank == 1)
             .group_by(RequestLog.account_id)
         )
         result = await self._session.execute(stmt)

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -405,15 +405,57 @@ def _resolve_additional_quota_query_scope(
     )
 
 
-def _additional_quota_match_clause(scope: AdditionalQuotaQueryScope):
+def _additional_quota_match_clause(scope: AdditionalQuotaQueryScope, *, canonical_only: bool = False):
     clauses = [AdditionalUsageHistory.quota_key.in_(tuple(scope.quota_key_match_values or {scope.quota_key}))]
+    if canonical_only:
+        return clauses[0]
+    alias_clause = _additional_quota_alias_match_clause(scope)
+    if alias_clause is not None:
+        clauses.append(alias_clause)
+    return or_(*clauses)
+
+
+def _additional_quota_alias_match_clause(scope: AdditionalQuotaQueryScope):
+    clauses = []
     if scope.limit_name_match_values:
         clauses.append(func.lower(AdditionalUsageHistory.limit_name).in_(tuple(scope.limit_name_match_values)))
     if scope.metered_feature_match_values:
         clauses.append(
             func.lower(AdditionalUsageHistory.metered_feature).in_(tuple(scope.metered_feature_match_values))
         )
+    if not clauses:
+        return None
     return or_(*clauses)
+
+
+def _newer_additional_usage_entry(
+    current: AdditionalUsageHistory | None,
+    candidate: AdditionalUsageHistory,
+) -> AdditionalUsageHistory:
+    if current is None:
+        return candidate
+    current_key = (
+        current.recorded_at,
+        current.used_percent,
+        current.id,
+    )
+    candidate_key = (
+        candidate.recorded_at,
+        candidate.used_percent,
+        candidate.id,
+    )
+    return candidate if candidate_key > current_key else current
+
+
+def _merge_latest_additional_usage_entries(
+    entries: dict[str, AdditionalUsageHistory],
+    candidates: Collection[AdditionalUsageHistory],
+) -> None:
+    for candidate in candidates:
+        entries[candidate.account_id] = _newer_additional_usage_entry(
+            entries.get(candidate.account_id),
+            candidate,
+        )
 
 
 class UsageRepository:
@@ -933,36 +975,100 @@ class AdditionalUsageRepository:
         )
         if scope is None or window is None:
             raise ValueError("quota_key/limit_name and window are required")
+        bind = self._session.get_bind()
+        dialect = bind.dialect.name if bind else "sqlite"
+        canonical_only = dialect == "postgresql"
         conditions = [
-            _additional_quota_match_clause(scope),
+            _additional_quota_match_clause(scope, canonical_only=canonical_only),
             AdditionalUsageHistory.window == window,
         ]
         if account_ids is not None:
+            account_ids = list(account_ids)
+            if not account_ids:
+                return {}
             conditions.append(AdditionalUsageHistory.account_id.in_(account_ids))
         if since is not None:
             conditions.append(AdditionalUsageHistory.recorded_at >= since)
-        subq = (
-            select(
-                AdditionalUsageHistory.id.label("usage_id"),
-                func.row_number()
-                .over(
-                    partition_by=AdditionalUsageHistory.account_id,
-                    order_by=(
+        if dialect == "postgresql":
+            latest_rows = (
+                select(AdditionalUsageHistory)
+                .where(*conditions)
+                .distinct(AdditionalUsageHistory.account_id)
+                .order_by(
+                    AdditionalUsageHistory.account_id.asc(),
+                    AdditionalUsageHistory.recorded_at.desc(),
+                    AdditionalUsageHistory.used_percent.desc(),
+                    AdditionalUsageHistory.id.desc(),
+                )
+            )
+            result = await self._session.execute(latest_rows)
+            entries = {entry.account_id: entry for entry in result.scalars().all()}
+            alias_clause = _additional_quota_alias_match_clause(scope)
+            if alias_clause is not None:
+                alias_conditions = [
+                    alias_clause,
+                    AdditionalUsageHistory.window == window,
+                ]
+                if account_ids is not None:
+                    alias_conditions.append(AdditionalUsageHistory.account_id.in_(account_ids))
+                if since is not None:
+                    alias_conditions.append(AdditionalUsageHistory.recorded_at >= since)
+                alias_rows = (
+                    select(AdditionalUsageHistory)
+                    .where(*alias_conditions)
+                    .distinct(AdditionalUsageHistory.account_id)
+                    .order_by(
+                        AdditionalUsageHistory.account_id.asc(),
                         AdditionalUsageHistory.recorded_at.desc(),
                         AdditionalUsageHistory.used_percent.desc(),
                         AdditionalUsageHistory.id.desc(),
-                    ),
+                    )
                 )
-                .label("row_number"),
+                alias_result = await self._session.execute(alias_rows)
+                _merge_latest_additional_usage_entries(entries, alias_result.scalars().all())
+            return entries
+
+        latest_ids = (
+            select(
+                AdditionalUsageHistory.account_id.label("account_id"),
+                func.max(AdditionalUsageHistory.recorded_at).label("max_recorded_at"),
             )
             .where(*conditions)
-            .subquery()
+            .group_by(AdditionalUsageHistory.account_id)
+            .subquery("latest_additional_usage_recorded_at")
         )
-        stmt = (
-            select(AdditionalUsageHistory)
-            .join(subq, AdditionalUsageHistory.id == subq.c.usage_id)
-            .where(subq.c.row_number == 1)
+        latest_tie_breakers = (
+            select(
+                AdditionalUsageHistory.account_id.label("account_id"),
+                AdditionalUsageHistory.recorded_at.label("recorded_at"),
+                func.max(AdditionalUsageHistory.used_percent).label("max_used_percent"),
+            )
+            .join(
+                latest_ids,
+                and_(
+                    AdditionalUsageHistory.account_id == latest_ids.c.account_id,
+                    AdditionalUsageHistory.recorded_at == latest_ids.c.max_recorded_at,
+                ),
+            )
+            .where(*conditions)
+            .group_by(AdditionalUsageHistory.account_id, AdditionalUsageHistory.recorded_at)
+            .subquery("latest_additional_usage_tie_breakers")
         )
+        row_ids = (
+            select(func.max(AdditionalUsageHistory.id).label("usage_id"))
+            .join(
+                latest_tie_breakers,
+                and_(
+                    AdditionalUsageHistory.account_id == latest_tie_breakers.c.account_id,
+                    AdditionalUsageHistory.recorded_at == latest_tie_breakers.c.recorded_at,
+                    AdditionalUsageHistory.used_percent == latest_tie_breakers.c.max_used_percent,
+                ),
+            )
+            .where(*conditions)
+            .group_by(AdditionalUsageHistory.account_id)
+            .subquery("latest_additional_usage_ids")
+        )
+        stmt = select(AdditionalUsageHistory).join(row_ids, AdditionalUsageHistory.id == row_ids.c.usage_id)
         result = await self._session.execute(stmt)
         return {entry.account_id: entry for entry in result.scalars().all()}
 

--- a/openspec/changes/optimize-dashboard-query-hot-paths/proposal.md
+++ b/openspec/changes/optimize-dashboard-query-hot-paths/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Production `10.0.0.113` hit Postgres backend OOM kills while the dashboard and request selector ran large window-ranking queries over `request_logs` and `additional_usage_history`. The resulting Postgres recovery closed in-flight asyncpg connections and surfaced as dashboard/API 500s.
+
+Temporary production mitigations reduced blast radius, but the durable fix needs the hot-path query contracts and supporting indexes captured in OpenSpec before the workaround is retired.
+
+## What Changes
+
+- Replace additional-quota latest-row lookup window ranking with an index-friendly latest-row shape.
+- Constrain selector hot-path additional-quota lookups by canonical `quota_key`, `window`, and candidate account IDs.
+- Replace account request-usage summary window ranking with grouped latest-id dedupe before aggregation.
+- Add idempotent hot-path indexes for `additional_usage_history` latest lookups and `request_logs` dashboard/account aggregates.
+- Document the production failure mode and durable mitigation in query-caching context.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `query-caching`: Defines hot-path query-shape constraints and idempotent index requirements for selector/dashboard aggregate reads.
+
+## Impact
+
+- `app/modules/usage/repository.py`
+- `app/modules/accounts/repository.py`
+- `app/db/models.py`
+- `app/db/alembic/versions/*`
+- Integration regression coverage for emitted SQL shape and aggregation semantics

--- a/openspec/changes/optimize-dashboard-query-hot-paths/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-dashboard-query-hot-paths/specs/query-caching/spec.md
@@ -1,0 +1,22 @@
+### ADDED Requirements
+
+#### Requirement: Hot-path quota and dashboard aggregate reads avoid window-ranking scans
+Selector and dashboard hot-path reads MUST avoid unbounded SQL window-ranking over `additional_usage_history` and `request_logs`; they MUST preserve existing result semantics while using grouped latest-id or `DISTINCT ON` shapes plus supporting indexes.
+
+##### Scenario: Additional quota latest lookup avoids window ranking
+- **GIVEN** multiple additional quota rows exist for each account under the same quota key and window
+- **WHEN** gated-model selection loads the latest additional quota rows for candidate accounts
+- **THEN** the query MUST NOT use `row_number()` or another full partition window-ranking expression
+- **AND** the hot-path lookup MUST constrain by canonical `quota_key`, `window`, and candidate account ids so the latest-row index remains usable
+- **AND** the selected row per account MUST remain the newest `recorded_at`, then highest `used_percent`, then highest `id`
+
+##### Scenario: Account request usage summary avoids request-log window ranking
+- **GIVEN** dashboard account summaries aggregate request log usage per account
+- **WHEN** account request usage summaries are loaded
+- **THEN** the query MUST NOT rank the full `request_logs` set with `row_number()`
+- **AND** duplicate request-log rows for the same account, request id, and requested timestamp MUST still collapse to the latest row id before aggregation
+
+##### Scenario: Hot-path indexes are idempotent
+- **GIVEN** a production database may already have manually-created hot-path indexes
+- **WHEN** the schema migration for dashboard query hot paths is applied
+- **THEN** the migration MUST complete without duplicate-index failure

--- a/openspec/changes/optimize-dashboard-query-hot-paths/tasks.md
+++ b/openspec/changes/optimize-dashboard-query-hot-paths/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spec and schema
+
+- [x] 1.1 Add query-caching requirements for avoiding unbounded window-ranking scans on selector/dashboard hot paths.
+- [x] 1.2 Add an idempotent Alembic migration for the additional-usage latest-row and request-log aggregate indexes.
+- [x] 1.3 Add matching ORM index metadata.
+
+## 2. Query changes
+
+- [x] 2.1 Update additional-quota latest-by-account lookup to avoid `row_number()` and use canonical hot-path matching.
+- [x] 2.2 Update account request usage summaries to dedupe duplicate request-log rows with grouped latest IDs before aggregation.
+
+## 3. Validation
+
+- [x] 3.1 Add integration regression coverage that verifies the hot-path emitted SQL does not use window ranking and preserves summary/latest-row semantics.
+- [x] 3.2 Run targeted pytest for dashboard/query OOM regressions.
+- [x] 3.3 Run ruff check, ruff format check, and ty check.
+- [ ] 3.4 Validate the OpenSpec change when the OpenSpec CLI is available.

--- a/openspec/specs/query-caching/context.md
+++ b/openspec/specs/query-caching/context.md
@@ -7,6 +7,8 @@ The query-caching capability is broader than cache TTLs. It also owns the databa
 - Keep the public request-log and usage APIs unchanged; optimize query shape and indexing underneath them.
 - Preserve legacy `usage_history.window IS NULL` semantics as `"primary"` instead of forcing a data backfill in this change.
 - Avoid related-table joins on request-log listing unless search actually needs `accounts.email` or `api_keys.name`.
+- Avoid full window-ranking scans on hot selector and dashboard aggregate reads; prefer grouped latest-id or PostgreSQL `DISTINCT ON` shapes backed by matching indexes.
+- Keep hot-path index migrations idempotent so manual production hotfix indexes do not break later schema upgrades.
 
 ## Operational Notes
 
@@ -15,6 +17,7 @@ The query-caching capability is broader than cache TTLs. It also owns the databa
 - Default request-log listing should sort by latest-first timestamp and tie-breaker ID.
 - Do not hold the load-balancer runtime lock across network-bound usage refresh calls; only protect the in-memory selection and runtime-state mutation step.
 - Stale usage refreshes should collapse into one in-flight refresh per account, with followers re-checking persisted primary-window data before calling the upstream usage API again.
+- On 2026-06-29, production `10.0.0.113` saw Postgres backend OOM kills while dashboard/account-selection requests ran large `request_logs` and `additional_usage_history` window-ranking queries. The durable mitigation is to keep additional-quota latest lookups and account request usage summaries off `row_number()` hot paths, then restore any temporary production registry/timeout workarounds after deployment verification.
 
 ## Example
 

--- a/openspec/specs/query-caching/spec.md
+++ b/openspec/specs/query-caching/spec.md
@@ -28,6 +28,27 @@ Persisted additional-usage rows MUST record one internal canonical `quota_key` e
 - **THEN** repository reads match both the current `quota_key` and the known raw alias fields
 - **AND** the historical rows remain visible until refresh rewrites them under the newer canonical key
 
+### Requirement: Hot-path quota and dashboard aggregate reads avoid window-ranking scans
+Selector and dashboard hot-path reads MUST avoid unbounded SQL window-ranking over `additional_usage_history` and `request_logs`; they MUST preserve existing result semantics while using grouped latest-id or `DISTINCT ON` shapes plus supporting indexes.
+
+#### Scenario: Additional quota latest lookup avoids window ranking
+- **GIVEN** multiple additional quota rows exist for each account under the same quota key and window
+- **WHEN** gated-model selection loads the latest additional quota rows for candidate accounts
+- **THEN** the query MUST NOT use `row_number()` or another full partition window-ranking expression
+- **AND** the hot-path lookup MUST constrain by canonical `quota_key`, `window`, and candidate account ids so the latest-row index remains usable
+- **AND** the selected row per account MUST remain the newest `recorded_at`, then highest `used_percent`, then highest `id`
+
+#### Scenario: Account request usage summary avoids request-log window ranking
+- **GIVEN** dashboard account summaries aggregate request log usage per account
+- **WHEN** account request usage summaries are loaded
+- **THEN** the query MUST NOT rank the full `request_logs` set with `row_number()`
+- **AND** duplicate request-log rows for the same account, request id, and requested timestamp MUST still collapse to the latest row id before aggregation
+
+#### Scenario: Hot-path indexes are idempotent
+- **GIVEN** a production database may already have manually-created hot-path indexes
+- **WHEN** the schema migration for dashboard query hot paths is applied
+- **THEN** the migration MUST complete without duplicate-index failure
+
 ### Requirement: Dashboard overview memoizes per-account depletion EWMA state
 `GET /api/dashboard/overview` MUST cache per-account EWMA depletion state in memory so repeated polls do not re-walk the full in-window `usage_history` slice in the depletion cache check when its content is unchanged.
 

--- a/tests/integration/test_dashboard_query_oom_regression.py
+++ b/tests/integration/test_dashboard_query_oom_regression.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import event
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus, AdditionalUsageHistory
+from app.db.session import SessionLocal, engine
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.usage.repository import AdditionalUsageRepository
+
+pytestmark = pytest.mark.integration
+
+
+def _make_account(account_id: str, email: str | None = None) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        email=email or f"{account_id}@example.com",
+        plan_type="pro",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_additional_usage_latest_by_account_avoids_window_function(db_setup):
+    now = utcnow()
+    statements: list[str] = []
+
+    def capture_statement(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        repo = AdditionalUsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc1"))
+        await accounts_repo.upsert(_make_account("acc2"))
+        await repo.add_entry(
+            "acc1",
+            "gpt-5.3-codex-spark",
+            "codex_bengalfox",
+            "primary",
+            10.0,
+            recorded_at=now,
+            quota_key="codex_spark",
+        )
+        await repo.add_entry(
+            "acc1",
+            "gpt-5.3-codex-spark",
+            "codex_bengalfox",
+            "primary",
+            20.0,
+            recorded_at=now,
+            quota_key="codex_spark",
+        )
+        await repo.add_entry(
+            "acc2",
+            "gpt-5.3-codex-spark",
+            "codex_bengalfox",
+            "primary",
+            30.0,
+            recorded_at=now,
+            quota_key="codex_spark",
+        )
+
+        event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+        try:
+            latest = await repo.latest_by_quota_key(
+                "codex_spark",
+                "primary",
+                account_ids=["acc1", "acc2"],
+            )
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    assert set(latest) == {"acc1", "acc2"}
+    assert latest["acc1"].used_percent == 20.0
+    assert latest["acc2"].used_percent == 30.0
+    emitted_sql = "\n".join(statements).lower()
+    assert "row_number" not in emitted_sql
+    assert " over " not in emitted_sql
+    assert "additional_usage_history.quota_key" in emitted_sql
+    if session.bind and session.bind.dialect.name == "postgresql":
+        assert "lower(additional_usage_history.limit_name)" not in emitted_sql
+        assert "lower(additional_usage_history.metered_feature)" not in emitted_sql
+
+
+@pytest.mark.asyncio
+async def test_additional_usage_latest_by_account_preserves_alias_fallback(db_setup):
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        repo = AdditionalUsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc_alias"))
+        await repo.add_entry(
+            "acc_alias",
+            "gpt-5.3-codex-spark",
+            "codex_bengalfox",
+            "primary",
+            10.0,
+            recorded_at=now - timedelta(minutes=5),
+            quota_key="codex_spark",
+        )
+        session.add(
+            AdditionalUsageHistory(
+                account_id="acc_alias",
+                quota_key="legacy_unknown",
+                limit_name="GPT-5.3-Codex-Spark",
+                metered_feature="legacy-feature",
+                window="primary",
+                used_percent=42.0,
+                recorded_at=now,
+            )
+        )
+        await session.commit()
+
+        latest = await repo.latest_by_quota_key(
+            "codex_spark",
+            "primary",
+            account_ids=["acc_alias"],
+        )
+
+    assert set(latest) == {"acc_alias"}
+    assert latest["acc_alias"].quota_key == "legacy_unknown"
+    assert latest["acc_alias"].used_percent == 42.0
+
+
+@pytest.mark.asyncio
+async def test_request_usage_summary_by_account_does_not_rank_request_logs(db_setup):
+    now = utcnow()
+    statements: list[str] = []
+
+    def capture_statement(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        repo = AccountsRepository(session)
+        await accounts_repo.upsert(_make_account("acc1"))
+        await logs_repo.add_log(
+            account_id="acc1",
+            request_id="req1",
+            model="gpt-5.4-mini",
+            input_tokens=10,
+            output_tokens=5,
+            cached_input_tokens=3,
+            latency_ms=100,
+            status="success",
+            error_code=None,
+            requested_at=now,
+        )
+        await logs_repo.add_log(
+            account_id="acc1",
+            request_id="req2",
+            model="gpt-5.4-mini",
+            input_tokens=7,
+            output_tokens=None,
+            reasoning_tokens=11,
+            cached_input_tokens=2,
+            latency_ms=100,
+            status="error",
+            error_code="server_error",
+            requested_at=now,
+        )
+
+        event.listen(engine.sync_engine, "before_cursor_execute", capture_statement)
+        try:
+            usage = await repo.list_request_usage_summary_by_account(["acc1"])
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", capture_statement)
+
+    assert usage["acc1"].request_count == 2
+    assert usage["acc1"].total_tokens == 33
+    assert usage["acc1"].cached_input_tokens == 5
+    emitted_sql = "\n".join(statements).lower()
+    assert "row_number" not in emitted_sql
+    assert " over " not in emitted_sql


### PR DESCRIPTION
## Summary

- replace dashboard/account request-log aggregation window ranking with grouped latest-id dedupe
- replace additional-quota latest lookup window ranking with PostgreSQL `DISTINCT ON` and canonical quota-key matching on the selector hot path
- add idempotent hot-path indexes plus OpenSpec/query-caching coverage for the production OOM failure mode

## Validation

- `uv run pytest tests/integration/test_dashboard_query_oom_regression.py -q`
- `uvx ruff check .`
- `uvx ruff format --check .`
- `uv run ty check`

OpenSpec CLI note: `openspec validate optimize-dashboard-query-hot-paths --strict` could not run locally because `openspec` is not installed in this environment.
