### PR TITLE
fix(db): merge post-batch migration heads

### DIFF
--- a/app/db/alembic/versions/20260630_010000_merge_warmup_and_request_log_dashboard_heads.py
+++ b/app/db/alembic/versions/20260630_010000_merge_warmup_and_request_log_dashboard_heads.py
@@ -1,0 +1,26 @@
+"""merge warmup staggered idle and request-log dashboard heads
+
+Revision ID: 20260630_010000_merge_warmup_and_request_log_dashboard_heads
+Revises:
+- 20260630_000000_add_limit_warmup_staggered_idle
+- 20260630_000000_merge_request_log_client_ip_and_dashboard_hot_path_heads
+Create Date: 2026-06-30 01:00:00.000000
+"""
+
+from __future__ import annotations
+
+revision = "20260630_010000_merge_warmup_and_request_log_dashboard_heads"
+down_revision = (
+    "20260630_000000_add_limit_warmup_staggered_idle",
+    "20260630_000000_merge_request_log_client_ip_and_dashboard_hot_path_heads",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

- merge the two Alembic heads left after the #985/#902/#905 batch landed on `main`
- keep the migration graph single-headed for startup migration upgrade targets

## Validation

- `uv run python - <<'PY' ... ScriptDirectory.get_heads()` -> `20260630_010000_merge_warmup_and_request_log_dashboard_heads`
- `uv run pytest tests/integration/test_migrations.py -q` -> 12 passed, 3 skipped
- `uv run pytest tests/integration/test_migrations.py tests/unit/test_limit_warmup.py tests/unit/test_request_logs_repository.py tests/integration/test_usage_repository.py -q` -> 66 passed, 4 skipped
- `uv run ruff check app/db/alembic/versions/20260630_010000_merge_warmup_and_request_log_dashboard_heads.py` -> pass
- `git diff --check` -> pass
