### PR TITLE
ci: remove unsupported review-thread workflow trigger

### DIFF
--- a/.github/workflows/codex-review-labels.yml
+++ b/.github/workflows/codex-review-labels.yml
@@ -10,8 +10,6 @@ on:
     types: [created, edited]
   pull_request_review:
     types: [submitted, edited, dismissed]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
   schedule:
     - cron: "*/15 * * * *"
 
@@ -35,7 +33,6 @@ jobs:
       ${{
         github.event_name == 'pull_request_target' ||
         github.event_name == 'pull_request_review' ||
-        github.event_name == 'pull_request_review_thread' ||
         (github.event_name == 'issue_comment' && github.event.issue.pull_request)
       }}
 


### PR DESCRIPTION
## Summary

Remove the unsupported `pull_request_review_thread` trigger from the Codex review label workflow. GitHub Actions rejects that event before starting jobs, which creates instant zero-job failures such as https://github.com/ozpool/codex-lb/actions/runs/28460055073 and the matching upstream PR runs.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [x] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: none

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: n/a

## Changes

- Remove `pull_request_review_thread` from the workflow trigger list.
- Remove the matching dead `if:` branch from the PR-sync job guard.

## Test plan

```bash
python3 - <<'PY'
import yaml
from pathlib import Path
p = Path('.github/workflows/codex-review-labels.yml')
yaml.safe_load(p.read_text())
print('yaml ok')
PY
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [ ] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
