### PR TITLE
test: update codex label workflow event assertion

### DIFF
--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -219,9 +219,8 @@ def test_workflow_prefers_privileged_token_and_enables_tolerant_apply() -> None:
     workflow = Path(".github/workflows/codex-review-labels.yml").read_text(encoding="utf-8")
 
     assert "secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token" in workflow
-    assert "pull_request_review_thread:" in workflow
-    assert "types: [resolved, unresolved]" in workflow
-    assert "github.event_name == 'pull_request_review_thread'" in workflow
+    assert "pull_request_review_thread:" not in workflow
+    assert "github.event_name == 'pull_request_review_thread'" not in workflow
     assert 'cron: "*/15 * * * *"' in workflow
     assert workflow.count("--tolerate-write-permission-errors") == 2
     assert workflow.count("--tolerate-read-errors") == 1


### PR DESCRIPTION
## Summary

Update the Codex review-label workflow unit test after removing the unsupported `pull_request_review_thread` trigger. Backend CI on PR branches caught the stale assertion because `tests/unit/test_sync_codex_ok_labels.py::test_workflow_prefers_privileged_token_and_enables_tolerant_apply` still expected the invalid event to be present.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [x] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: none

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: n/a

## Changes

- Assert the unsupported `pull_request_review_thread` workflow event stays absent.
- Keep the existing assertions for privileged token fallback, schedule, and tolerant apply flags.

## Test plan

```bash
uv run pytest tests/unit/test_sync_codex_ok_labels.py -q -k workflow_prefers_privileged_token
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
