### PR TITLE
docs: explain routing strategy tradeoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ Load balancer for ChatGPT accounts. Pool multiple accounts, track usage, manage 
 </tr>
 </table>
 
+## Routing Strategy Guide
+
+The dashboard setting **Routing strategy** controls how eligible accounts are selected for each request. No strategy can guarantee account-safety outcomes; conservative use still depends on staying within OpenAI terms, using normal request volumes, and avoiding traffic patterns that would be unusual for your accounts.
+
+For low-volume, policy-compliant personal use, start with **Capacity weighted** or **Relative availability** and keep sticky threads enabled. Those strategies preserve session locality while avoiding sudden all-traffic shifts to a single account.
+
+| Routing strategy | Behavior | Trade-offs and recommended use |
+|---|---|---|
+| Capacity weighted | Prefers accounts with more usable quota headroom. | Good default for mixed pools and normal compliant usage. |
+| Relative availability | Draws from the strongest available accounts with configurable weighting. | Smooths distribution while still preferring healthier accounts. |
+| Usage weighted | Reacts to observed recent usage. | Useful when usage history should influence selection, but less direct than capacity-based routing. |
+| Round robin | Cycles evenly through eligible accounts. | Simple and predictable, but ignores quota shape and reset timing. |
+| Fill first | Uses one account heavily before moving on. | Best for controlled drain tests; less conservative for everyday traffic. |
+| Sequential drain | Drains accounts in a fixed order. | Useful for maintenance or explicit account rotation, not a normal safety-first default. |
+| Reset drain | Prioritizes capacity near reset windows. | Helps consume expiring quota, but can create timing-shaped bursts. |
+| Single account | Pins all traffic to one selected active account. | Useful for isolation and debugging; no load balancing. |
+
 ## Quick Start
 
 ```bash

--- a/frontend/src/features/settings/components/routing-settings.test.tsx
+++ b/frontend/src/features/settings/components/routing-settings.test.tsx
@@ -479,6 +479,14 @@ describe("RoutingSettings", () => {
     expect(screen.getAllByText("Fill first").length).toBeGreaterThan(0);
   });
 
+  it("explains routing strategy trade-offs and account-safety guidance", () => {
+    render(<RoutingSettings settings={BASE_SETTINGS} busy={false} onSave={vi.fn().mockResolvedValue(undefined)} />);
+
+    expect(screen.getByText("Strategy guide")).toBeInTheDocument();
+    expect(screen.getByText(/Good default for compliant mixed-account pools/i)).toBeInTheDocument();
+    expect(screen.getByText(/No strategy can guarantee account-safety outcomes/i)).toBeInTheDocument();
+  });
+
   it("saves staggered idle warm-up when limit warm-up is enabled", async () => {
     const user = userEvent.setup();
     const onSave = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/features/settings/components/routing-settings.tsx
+++ b/frontend/src/features/settings/components/routing-settings.tsx
@@ -384,6 +384,27 @@ export function RoutingSettings({
               </SelectContent>
             </Select>
           </div>
+          <div className="space-y-2 px-3 pb-3 text-xs text-muted-foreground">
+            <p className="font-medium text-foreground">{t("settings.routing.strategy.guideTitle")}</p>
+            <dl className="grid gap-2 md:grid-cols-2">
+              {[
+                "capacityWeighted",
+                "relativeAvailability",
+                "usageWeighted",
+                "roundRobin",
+                "fillFirst",
+                "sequentialDrain",
+                "resetDrain",
+                "singleAccount",
+              ].map((strategy) => (
+                <div key={strategy} className="space-y-0.5">
+                  <dt className="font-medium text-foreground">{t(`settings.routing.strategy.${strategy}`)}</dt>
+                  <dd>{t(`settings.routing.strategy.guide.${strategy}`)}</dd>
+                </div>
+              ))}
+            </dl>
+            <p>{t("settings.routing.strategy.safetyNote")}</p>
+          </div>
 
           <div className="space-y-3 p-3">
             <div>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -160,7 +160,19 @@
         "resetDrain": "Reset drain",
         "singleAccount": "Single account",
         "usageWeighted": "Usage weighted",
-        "roundRobin": "Round robin"
+        "roundRobin": "Round robin",
+        "guideTitle": "Strategy guide",
+        "guide": {
+          "capacityWeighted": "Good default for compliant mixed-account pools; prefers accounts with more usable quota headroom.",
+          "relativeAvailability": "Similar to capacity weighted, but smooths selection through a weighted draw over the strongest available accounts.",
+          "usageWeighted": "Spreads traffic by observed usage and can react to recent consumption patterns.",
+          "roundRobin": "Cycles evenly through eligible accounts without considering quota shape.",
+          "fillFirst": "Uses one account heavily before moving on; useful for controlled drain tests, but less conservative for normal traffic.",
+          "sequentialDrain": "Drains accounts in a fixed order. Prefer for maintenance windows, not everyday blended usage.",
+          "resetDrain": "Prioritizes accounts around quota reset timing so expiring capacity is consumed first.",
+          "singleAccount": "Pins all routed traffic to one selected active account."
+        },
+        "safetyNote": "No strategy can guarantee account-safety outcomes. For low-volume policy-compliant use, prefer capacity weighted or relative availability with sticky threads enabled so traffic stays steady and session-local."
       },
       "stickyThreads": {
         "label": "Sticky threads",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -160,7 +160,19 @@
         "resetDrain": "按重置消耗",
         "singleAccount": "单账户",
         "usageWeighted": "按用量加权",
-        "roundRobin": "轮询"
+        "roundRobin": "轮询",
+        "guideTitle": "策略指南",
+        "guide": {
+          "capacityWeighted": "适合作为合规混合账户池的默认选择；优先使用可用配额余量更多的账户。",
+          "relativeAvailability": "类似按容量加权，但会在最可用的候选账户中做平滑加权抽取。",
+          "usageWeighted": "根据已观察到的用量分散流量，并可响应近期消耗变化。",
+          "roundRobin": "在符合条件的账户间均匀轮换，不考虑配额形态。",
+          "fillFirst": "先集中使用一个账户再切换；适合受控消耗测试，不太适合日常保守流量。",
+          "sequentialDrain": "按固定顺序消耗账户。更适合维护窗口，不适合作为日常混合策略。",
+          "resetDrain": "围绕配额重置时间排序，让即将失效的容量优先被使用。",
+          "singleAccount": "将所有路由流量固定到一个选定的活跃账户。"
+        },
+        "safetyNote": "任何策略都不能保证账户安全结果。对于低流量、合规使用，优先选择按容量加权或相对可用性，并启用粘性会话，让流量更平稳且保持在同一会话本地。"
       },
       "stickyThreads": {
         "label": "粘性会话",

--- a/openspec/changes/add-routing-strategy-guide/proposal.md
+++ b/openspec/changes/add-routing-strategy-guide/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+Operators can choose between several routing strategies, but the dashboard and README do not explain when each one is appropriate. That makes it easy to pick a strategy that works against the intended pool behavior.
+
+## What Changes
+
+- Add operator-facing guidance for each routing strategy in the README.
+- Surface a compact strategy guide in the Routing settings UI below the strategy selector.
+- Include a safety note for strategies that intentionally concentrate traffic.
+
+## Impact
+
+- README operator guidance.
+- Dashboard Routing settings UI and i18n strings.
+- Frontend regression coverage for the rendered guide.

--- a/openspec/changes/add-routing-strategy-guide/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-routing-strategy-guide/specs/frontend-architecture/spec.md
@@ -1,0 +1,10 @@
+## MODIFIED Requirements
+
+### Requirement: Settings page
+
+The Settings page SHALL include sections for: routing settings (sticky threads, reset priority, prompt-cache affinity TTL, routing strategy guidance), password management (setup/change/remove), TOTP management (setup/disable), API key auth toggle, API key management (table, create, edit, delete, regenerate), and sticky-session administration.
+
+#### Scenario: Routing strategy guide is visible
+- **WHEN** the Routing settings section renders
+- **THEN** it shows operator guidance for the available routing strategies
+- **AND** it identifies strategies that intentionally concentrate traffic so operators can choose them deliberately

--- a/openspec/changes/add-routing-strategy-guide/tasks.md
+++ b/openspec/changes/add-routing-strategy-guide/tasks.md
@@ -1,0 +1,11 @@
+## 1. Operator guidance
+
+- [x] 1.1 Document routing strategy trade-offs in the README.
+- [x] 1.2 Add a compact dashboard guide for the configured routing strategies.
+- [x] 1.3 Include safety wording for concentrated-traffic strategies.
+
+## 2. Verification
+
+- [x] 2.1 Add frontend coverage for the strategy guide.
+- [x] 2.2 Run focused frontend tests and lint.
+- [x] 2.3 Validate the OpenSpec change.


### PR DESCRIPTION
## Summary
- add a compact dashboard guide for each routing strategy and its account-safety trade-offs
- add README guidance for conservative routing defaults
- cover the new dashboard guidance in the routing settings component test

Closes #1059

## Tests
- `cd frontend && bun run test -- src/features/settings/components/routing-settings.test.tsx`
- `cd frontend && bun run lint -- src/features/settings/components/routing-settings.tsx src/features/settings/components/routing-settings.test.tsx`
- `openspec validate add-routing-strategy-guide --strict`
