### PR TITLE
fix(proxy): stop local rate-limit selection retry loops

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -215,7 +215,10 @@ def _http_bridge_account_capacity_wait_seconds(exc: ProxyResponseError) -> float
     code, message = _proxy_error_code_message(exc)
     if code in {"account_response_create_cap", "account_stream_cap", "capacity_exhausted_active_sessions"}:
         return None
-    return _account_selection_recovery_sleep_seconds_from_message(message)
+    return _account_selection_recovery_sleep_seconds_from_message(
+        message,
+        error_code=code,
+    )
 
 
 def _http_bridge_capacity_wait_plan(

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -41,7 +41,12 @@ _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS = 10.0
 _ACCOUNT_SELECTION_RETRY_HINT_RE = re.compile(r"try again in\s+([0-9]+(?:\.[0-9]+)?)s", re.IGNORECASE)
 
 
-def _account_selection_recovery_sleep_seconds_from_message(message: str | None) -> float | None:
+def _account_selection_recovery_sleep_seconds_from_message(
+    message: str | None,
+    *,
+    error_code: str | None = None,
+    suppress_uncoded_local_selector_hint: bool = False,
+) -> float | None:
     message = (message or "").strip()
     if not message:
         return None
@@ -53,6 +58,10 @@ def _account_selection_recovery_sleep_seconds_from_message(message: str | None) 
         or "no accounts with a plan" in lowered
         or "no accounts with available additional quota" in lowered
         or "no fresh additional quota data" in lowered
+        or (
+            (error_code == "no_accounts" or (suppress_uncoded_local_selector_hint and error_code is None))
+            and lowered.startswith("rate limit exceeded. try again in")
+        )
     ):
         return None
 
@@ -74,7 +83,11 @@ def _account_selection_recovery_sleep_seconds_from_message(message: str | None) 
 
 
 def _account_selection_recovery_sleep_seconds(selection: AccountSelection) -> float | None:
-    return _account_selection_recovery_sleep_seconds_from_message(selection.error_message)
+    return _account_selection_recovery_sleep_seconds_from_message(
+        selection.error_message,
+        error_code=selection.error_code,
+        suppress_uncoded_local_selector_hint=selection.account is None,
+    )
 
 
 def _account_capacity_wait_payload(

--- a/openspec/changes/fix-local-rate-limit-selection-loop/proposal.md
+++ b/openspec/changes/fix-local-rate-limit-selection-loop/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+Single-account pools can hit an upstream 429, persist a local cooldown, and then immediately re-enter the streaming account-capacity wait path because the local balancer error text includes `Try again in Ns`. That local no-account result is not upstream recovery evidence and can create long-lived retry loops instead of failing fast.
+
+## What Changes
+
+- Treat the local balancer `Rate limit exceeded. Try again in ...` message as a terminal no-account selection failure for account-capacity recovery.
+- Preserve bounded recovery waits for non-local retry hints such as upstream/workspace capacity guidance.
+- Add focused regression coverage for both paths.
+
+## Impact
+
+- Single-account local cooldown exhaustion returns through the normal no-account/rate-limit error path instead of sleeping and retrying the same local failure.
+- Multi-account and genuine recoverable upstream capacity waits are unchanged.

--- a/openspec/changes/fix-local-rate-limit-selection-loop/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-local-rate-limit-selection-loop/specs/responses-api-compat/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Streaming Responses requests use a bounded retry budget
+When a streaming `/v1/responses` request encounters upstream instability, the proxy MUST enforce a configurable total request budget across selection, token refresh, account-capacity recovery waits, and upstream stream attempts. Each upstream stream attempt MUST clamp its connect timeout, idle timeout, and total request timeout to the remaining request budget.
+
+#### Scenario: Remaining budget constrains all stream attempt timeouts
+- **WHEN** account selection, account-capacity recovery, or token refresh leaves only part of the request budget available before a stream attempt starts
+- **THEN** the proxy limits the upstream connect timeout, SSE idle timeout, and upstream request total timeout to that same remaining budget
+- **AND** the client receives `response.failed` with `upstream_request_timeout` once that budget is exhausted instead of waiting through the full configured stream windows
+
+#### Scenario: Forced refresh retry recomputes all attempt timeouts
+- **WHEN** a first stream attempt fails with an authentication error that triggers a forced token refresh and retry
+- **THEN** the proxy recomputes the remaining request budget after the refresh
+- **AND** the retry attempt reapplies connect, idle, and total timeout limits from that recomputed budget
+
+#### Scenario: Recoverable account-capacity wait is bounded by the request budget
+- **WHEN** account selection reports a recoverable retry hint such as temporary rate-limit or stream-capacity exhaustion
+- **AND** the streaming request still has remaining request budget
+- **THEN** the proxy may wait for at most the smaller of the recovery hint and the remaining request budget before retrying selection
+- **AND** if the budget is exhausted before an account becomes available, the request fails through the normal no-account or rate-limit error path instead of starting a fresh full-budget wait
+
+#### Scenario: Local balancer rate-limit exhaustion is not treated as recoverable capacity
+- **WHEN** account selection reports the local balancer message `Rate limit exceeded. Try again in Ns`
+- **AND** the selection result is a local no-account failure with `no_accounts` or no explicit error code
+- **THEN** the proxy does not enter an account-capacity recovery wait from that local retry hint
+- **AND** the request returns through the normal no-account or rate-limit error path instead of repeatedly retrying the same local selection failure

--- a/openspec/changes/fix-local-rate-limit-selection-loop/tasks.md
+++ b/openspec/changes/fix-local-rate-limit-selection-loop/tasks.md
@@ -1,0 +1,4 @@
+- [x] Ignore the local balancer `Rate limit exceeded. Try again in ...` selector message in account-capacity recovery.
+- [x] Keep generic retry hints recoverable and bounded.
+- [x] Run targeted backend tests and lint.
+- [x] Validate the OpenSpec change.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -102,6 +102,30 @@ def test_http_bridge_account_capacity_wait_treats_workspace_spend_cap_as_recover
     assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) == 30.0
 
 
+def test_http_bridge_account_capacity_wait_honors_upstream_rate_limit_retry_hint() -> None:
+    exc = ProxyResponseError(
+        429,
+        openai_error(
+            "rate_limit_exceeded",
+            "Rate limit exceeded. Try again in 120s",
+        ),
+    )
+
+    assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) == 120.0
+
+
+def test_http_bridge_account_capacity_wait_ignores_local_no_accounts_retry_hint() -> None:
+    exc = ProxyResponseError(
+        429,
+        openai_error(
+            "no_accounts",
+            "Rate limit exceeded. Try again in 120s",
+        ),
+    )
+
+    assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) is None
+
+
 def _make_api_key(
     *,
     key_id: str,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -79,11 +79,31 @@ def test_websocket_archive_request_context_clears_unmatched_frame_request_id():
 def test_account_selection_recovery_sleep_uses_retry_hint_with_bounds():
     selection = AccountSelection(
         account=None,
-        error_message="Rate limit exceeded. Try again in 9999s",
+        error_message="Account capacity temporarily unavailable. Try again in 9999s",
         error_code="no_accounts",
     )
 
     assert _account_selection_recovery_sleep_seconds(selection) == 300.0
+
+
+def test_account_selection_recovery_sleep_ignores_local_rate_limit_retry_hint():
+    selection = AccountSelection(
+        account=None,
+        error_message="Rate limit exceeded. Try again in 120s",
+        error_code="no_accounts",
+    )
+
+    assert _account_selection_recovery_sleep_seconds(selection) is None
+
+
+def test_account_selection_recovery_sleep_ignores_uncoded_local_rate_limit_retry_hint():
+    selection = AccountSelection(
+        account=None,
+        error_message="Rate limit exceeded. Try again in 120s",
+        error_code=None,
+    )
+
+    assert _account_selection_recovery_sleep_seconds(selection) is None
 
 
 def test_account_selection_recovery_sleep_treats_workspace_spend_cap_as_recoverable():
@@ -164,7 +184,7 @@ async def test_account_selection_recovery_sleep_clamps_to_remaining_budget(monke
     waited = await _sleep_for_account_selection_recovery(
         AccountSelection(
             account=None,
-            error_message="Rate limit exceeded. Try again in 120s",
+            error_message="Account capacity temporarily unavailable. Try again in 120s",
             error_code="no_accounts",
         ),
         request_id="req_budget_clamp",
@@ -188,7 +208,7 @@ async def test_account_selection_recovery_sleep_refuses_exhausted_budget(monkeyp
     waited = await _sleep_for_account_selection_recovery(
         AccountSelection(
             account=None,
-            error_message="Rate limit exceeded. Try again in 120s",
+            error_message="Account capacity temporarily unavailable. Try again in 120s",
             error_code="no_accounts",
         ),
         request_id="req_budget_exhausted",


### PR DESCRIPTION
## Summary

- stop treating the local balancer `Rate limit exceeded. Try again in ...` no-account message as a recoverable account-capacity wait
- keep bounded recovery waits for non-local retry hints
- add an OpenSpec delta and regression coverage for the local-rate-limit loop

Closes Soju06/codex-lb#1078.

## Validation

- `uv run pytest tests/unit/test_proxy_utils.py -q`
- `uv run ruff check app/modules/proxy/_service/support.py tests/unit/test_proxy_utils.py`
- `openspec validate fix-local-rate-limit-selection-loop --strict`
- `git diff --check`
