### PR TITLE
fix(proxy): clarify account stream cap overload

### DIFF
--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -424,9 +424,9 @@ class LoadBalancer:
                     )
                     selection_states = _filter_states_for_account_caps(states, lease_kind=lease_kind)
                     if not selection_states and states:
-                        result = SelectionResult(None, "No available accounts")
-                        error_message = result.error_message
                         selection_error_code = _account_cap_error_code(lease_kind)
+                        error_message = _account_cap_error_message(lease_kind)
+                        result = SelectionResult(None, error_message)
                         logger.warning(
                             "Account cap exhausted during selection lease_kind=%s reason=%s candidates=%s",
                             lease_kind,
@@ -616,8 +616,8 @@ class LoadBalancer:
                     states if hard_sticky else _filter_states_for_account_caps(states, lease_kind=lease_kind)
                 )
                 if not selection_states and states:
-                    result = SelectionResult(None, "No available accounts")
                     selection_error_code = _account_cap_error_code(lease_kind)
+                    result = SelectionResult(None, _account_cap_error_message(lease_kind))
                     logger.warning(
                         "Account cap exhausted during sticky selection lease_kind=%s reason=%s candidates=%s",
                         lease_kind,
@@ -680,8 +680,8 @@ class LoadBalancer:
                             if lease_kind is not None:
                                 if not self._account_lease_allowed_locked(selected.id, kind=lease_kind):
                                     selected_snapshot = None
-                                    error_message = "No available accounts"
                                     selection_error_code = _account_cap_error_code(lease_kind)
+                                    error_message = _account_cap_error_message(lease_kind)
                                 else:
                                     selected_lease = self._acquire_account_lease_locked(
                                         selected.id,
@@ -1726,6 +1726,20 @@ def _account_cap_error_code(lease_kind: AccountLeaseKind | None) -> str | None:
     if lease_kind == "stream":
         return "account_stream_cap"
     return None
+
+
+def _account_cap_error_message(lease_kind: AccountLeaseKind | None) -> str:
+    settings = get_settings()
+    if lease_kind == "response_create":
+        cap = int(getattr(settings, "proxy_account_response_create_limit", 0))
+        return f"Account response-create capacity is exhausted; per-account limit is {cap}"
+    if lease_kind == "stream":
+        cap = int(getattr(settings, "proxy_account_stream_limit", 0))
+        return (
+            f"Account stream capacity is exhausted; per-account limit is {cap}. "
+            "Increase CODEX_LB_PROXY_ACCOUNT_STREAM_LIMIT or wait for active streams to finish."
+        )
+    return "Account capacity is exhausted"
 
 
 def _record_account_lease_acquired(kind: AccountLeaseKind) -> None:

--- a/openspec/changes/clarify-account-stream-cap-overload/proposal.md
+++ b/openspec/changes/clarify-account-stream-cap-overload/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+Account-local stream cap exhaustion already returns the stable `account_stream_cap` code, but the selection message can still be formatted as `No available accounts` and then expanded into a degraded-upstream message. Operators then see "all upstream accounts are unavailable" even though the real action is to wait for streams to finish or raise the per-account stream cap.
+
+## What Changes
+
+- Return an account-cap-specific message when every otherwise eligible account is filtered by a local account cap.
+- Preserve the stable `account_stream_cap` / `account_response_create_cap` reason codes.
+- Keep true empty-pool failures on the existing no-account/degraded path.
+
+## Impact
+
+- Stream-cap failures become local-overload diagnostics instead of ambiguous upstream-unavailability messages.
+- No routing limits or default cap values change.

--- a/openspec/changes/clarify-account-stream-cap-overload/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/clarify-account-stream-cap-overload/specs/proxy-admission-control/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Local overload reasons are stable and distinguishable
+
+Local Responses overload failures MUST expose stable low-cardinality reason fields in logs and metrics so operators can distinguish `bridge_queue_full`, `response_create_gate_timeout`, `hard_affinity_saturated`, `previous_response_owner_unavailable`, `global_admission_timeout`, `capacity_exhausted_active_sessions`, `account_response_create_cap`, and `account_stream_cap`. These local reasons MUST NOT be reported as upstream rate limits or generic upstream unavailability.
+
+#### Scenario: Bridge queue saturation is not ambiguous
+
+- **WHEN** a local HTTP bridge queue rejects a request
+- **THEN** logs and metrics use the stable reason `bridge_queue_full`
+- **AND** they do not use the ambiguous alias `queue_full`
+
+#### Scenario: Account cap rejection is local overload
+
+- **WHEN** every eligible account is unavailable because of account-local caps
+- **THEN** the HTTP response is a local overload response with `Retry-After`
+- **AND** logs and metrics identify `account_response_create_cap` or `account_stream_cap`
+- **AND** the error message identifies the exhausted account-local cap instead of saying all upstream accounts are unavailable

--- a/openspec/changes/clarify-account-stream-cap-overload/tasks.md
+++ b/openspec/changes/clarify-account-stream-cap-overload/tasks.md
@@ -1,0 +1,4 @@
+- [x] Return cap-specific account selection messages for local account caps.
+- [x] Cover stream-cap message behavior in load balancer tests.
+- [x] Run targeted backend tests and lint.
+- [x] Validate the OpenSpec change.

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -311,6 +311,11 @@ async def test_account_stream_cap_returns_stable_local_reason_until_released() -
 
     assert capped.account is None
     assert capped.error_code == "account_stream_cap"
+    assert capped.error_message == (
+        "Account stream capacity is exhausted; per-account limit is 8. "
+        "Increase CODEX_LB_PROXY_ACCOUNT_STREAM_LIMIT or wait for active streams to finish."
+    )
+    assert "all upstream accounts are unavailable" not in capped.error_message
 
     await balancer.release_account_lease(leases[0])
     recovered = await balancer.select_account(
@@ -422,6 +427,8 @@ async def test_bound_codex_session_sticky_fails_closed_when_pinned_account_is_sa
 
     assert selected.account is None
     assert selected.error_code == "account_stream_cap"
+    assert selected.error_message is not None
+    assert "Account stream capacity is exhausted" in selected.error_message
     assert sticky_repo.account_id == account_a.id
 
     for lease in saturated_leases:


### PR DESCRIPTION
## Summary

- return an account-cap-specific selection message when local account stream capacity is exhausted
- keep true empty-pool failures on the existing no-account/degraded path
- add OpenSpec coverage and load-balancer regressions for the operator-facing message

This keeps the default stream cap unchanged; it makes `account_stream_cap` failures explain the actual local cap and mention `CODEX_LB_PROXY_ACCOUNT_STREAM_LIMIT`.

Closes Soju06/codex-lb#1092.

## Validation

- `uv run pytest tests/unit/test_load_balancer_concurrency.py tests/unit/test_proxy_utils.py -q`
- `uv run ruff check app/modules/proxy/load_balancer.py tests/unit/test_load_balancer_concurrency.py`
- `openspec validate clarify-account-stream-cap-overload --strict`
- `git diff --check`
