### PR TITLE
feat(images): add route observability

### DIFF
--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import time
+from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.exception_handlers import (
@@ -29,6 +31,7 @@ from app.core.exceptions import (
     ProxyUpstreamError,
 )
 from app.core.runtime_logging import log_error_response
+from app.modules.proxy.images_observability import ImageRoute, record_images_route_observability
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +66,39 @@ def _error_format(request: Request) -> str | None:
     if path.startswith("/v1/") or path.startswith("/backend-api/"):
         return "openai"
     return None
+
+
+async def _record_image_request_validation_error(request: Request) -> None:
+    path = request.url.path
+    route: ImageRoute | None = None
+    if path == "/v1/images/generations":
+        route = "generations"
+    elif path == "/v1/images/edits":
+        route = "edits"
+    if route is None:
+        return
+
+    model: str | None = None
+    stream = False
+    if route == "generations":
+        try:
+            payload: Any = await request.json()
+        except Exception:
+            payload = None
+        if isinstance(payload, dict):
+            model_value = payload.get("model")
+            if isinstance(model_value, str) and model_value:
+                model = model_value
+            stream = payload.get("stream") is True
+
+    record_images_route_observability(
+        route=route,
+        model=model,
+        stream=stream,
+        status=400,
+        outcome="invalid_request",
+        started_at=time.perf_counter(),
+    )
 
 
 def add_exception_handlers(app: FastAPI) -> None:
@@ -153,6 +189,7 @@ def add_exception_handlers(app: FastAPI) -> None:
                 first_message or "Invalid request payload",
                 category="openai_error_response",
             )
+            await _record_image_request_validation_error(request)
             return JSONResponse(status_code=400, content=error)
         return await request_validation_exception_handler(request, exc)
 

--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import FastAPI, Request
@@ -34,6 +35,8 @@ from app.core.runtime_logging import log_error_response
 from app.modules.proxy.images_observability import ImageRoute, record_images_route_observability
 
 logger = logging.getLogger(__name__)
+
+_IMAGE_ROUTE_STARTED_AT_STATE = "_codex_lb_image_route_started_at"
 
 _OPENAI_EXCEPTION_TYPES: tuple[type[AppError], ...] = (
     ProxyAuthError,
@@ -68,18 +71,18 @@ def _error_format(request: Request) -> str | None:
     return None
 
 
-async def _record_image_request_validation_error(request: Request) -> None:
-    path = request.url.path
-    route: ImageRoute | None = None
+def _image_route_from_path(path: str) -> ImageRoute | None:
     if path == "/v1/images/generations":
-        route = "generations"
-    elif path == "/v1/images/edits":
-        route = "edits"
-    if route is None:
-        return
+        return "generations"
+    if path == "/v1/images/edits":
+        return "edits"
+    return None
 
+
+async def _image_request_model_and_stream(request: Request, route: ImageRoute) -> tuple[str | None, bool]:
     model: str | None = None
     stream = False
+
     if route == "generations":
         try:
             payload: Any = await request.json()
@@ -90,18 +93,55 @@ async def _record_image_request_validation_error(request: Request) -> None:
             if isinstance(model_value, str) and model_value:
                 model = model_value
             stream = payload.get("stream") is True
+        return model, stream
+
+    try:
+        form = await request.form()
+    except Exception:
+        return model, stream
+    model_value = form.get("model")
+    if isinstance(model_value, str) and model_value:
+        model = model_value
+    stream = form.get("stream") in {"true", "True", "1", "yes", "on"}
+    return model, stream
+
+
+async def _record_image_route_exception_observability(
+    request: Request,
+    *,
+    status: int,
+    outcome: str,
+) -> None:
+    path = request.url.path
+    route = _image_route_from_path(path)
+    if route is None:
+        return
+
+    model, stream = await _image_request_model_and_stream(request, route)
+    started_at = getattr(request.state, _IMAGE_ROUTE_STARTED_AT_STATE, None)
+    if not isinstance(started_at, float):
+        started_at = time.perf_counter()
 
     record_images_route_observability(
         route=route,
         model=model,
         stream=stream,
-        status=400,
-        outcome="invalid_request",
-        started_at=time.perf_counter(),
+        status=status,
+        outcome=outcome,
+        started_at=started_at,
     )
 
 
 def add_exception_handlers(app: FastAPI) -> None:
+    @app.middleware("http")
+    async def _image_route_started_at_middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if _image_route_from_path(request.url.path) is not None:
+            setattr(request.state, _IMAGE_ROUTE_STARTED_AT_STATE, time.perf_counter())
+        return await call_next(request)
+
     # --- Domain exceptions: OpenAI envelope ---
 
     for exc_cls in _OPENAI_EXCEPTION_TYPES:
@@ -117,6 +157,12 @@ def add_exception_handlers(app: FastAPI) -> None:
                 exc.message,
                 category="openai_error_response",
             )
+            if isinstance(exc, ProxyAuthError):
+                await _record_image_route_exception_observability(
+                    request,
+                    status=exc.status_code,
+                    outcome="auth_error",
+                )
             return JSONResponse(
                 status_code=exc.status_code,
                 content=openai_error(exc.code, exc.message, error_type=error_type),
@@ -189,7 +235,11 @@ def add_exception_handlers(app: FastAPI) -> None:
                 first_message or "Invalid request payload",
                 category="openai_error_response",
             )
-            await _record_image_request_validation_error(request)
+            await _record_image_route_exception_observability(
+                request,
+                status=400,
+                outcome="invalid_request",
+            )
             return JSONResponse(status_code=400, content=error)
         return await request_validation_exception_handler(request, exc)
 

--- a/app/core/metrics/prometheus.py
+++ b/app/core/metrics/prometheus.py
@@ -73,6 +73,18 @@ if PROMETHEUS_AVAILABLE:
         "Upstream request duration",
         registry=REGISTRY,
     )
+    image_requests_total = Counter(
+        "codex_lb_image_requests_total",
+        "Total OpenAI-compatible image route requests",
+        ["route", "model", "stream", "status", "outcome"],
+        registry=REGISTRY,
+    )
+    image_request_duration_seconds = Histogram(
+        "codex_lb_image_request_duration_seconds",
+        "OpenAI-compatible image route request duration",
+        ["route", "model", "stream", "status", "outcome"],
+        registry=REGISTRY,
+    )
 
     _gauge_kwargs: dict[str, str] = {}
     if MULTIPROCESS_MODE:
@@ -244,6 +256,8 @@ else:
     upstream_requests_total: CounterLike | None = None
     upstream_transport_decisions_total: CounterLike | None = None
     upstream_request_duration_seconds: HistogramLike | None = None
+    image_requests_total: CounterLike | None = None
+    image_request_duration_seconds: HistogramLike | None = None
     active_connections: GaugeLike | None = None
     rate_limit_hits_total: CounterLike | None = None
     circuit_breaker_state: GaugeLike | None = None
@@ -303,6 +317,8 @@ __all__ = [
     "circuit_breaker_state",
     "continuity_fail_closed_total",
     "continuity_owner_resolution_total",
+    "image_request_duration_seconds",
+    "image_requests_total",
     "make_scrape_registry",
     "mark_process_dead",
     "prometheus_client",

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1722,7 +1722,7 @@ async def _proxy_images_generation_request(
             model=effective_model,
             stream=stream_requested,
             status=400,
-            outcome="invalid_model",
+            outcome="invalid_request",
             started_at=started_at,
         )
         return _logged_error_json_response(
@@ -1785,16 +1785,6 @@ async def _proxy_images_generation_request(
             stream=stream_requested,
             status=429,
             outcome="rate_limited",
-            started_at=started_at,
-        )
-        raise
-    except ProxyAuthError:
-        record_images_route_observability(
-            route=route,
-            model=public_model,
-            stream=stream_requested,
-            status=401,
-            outcome="auth_error",
             started_at=started_at,
         )
         raise
@@ -2037,7 +2027,7 @@ async def _proxy_images_edit_request(
             model=effective_model,
             stream=stream_requested,
             status=400,
-            outcome="invalid_model",
+            outcome="invalid_request",
             started_at=started_at,
         )
         return _logged_error_json_response(
@@ -2097,16 +2087,6 @@ async def _proxy_images_edit_request(
             stream=stream_requested,
             status=429,
             outcome="rate_limited",
-            started_at=started_at,
-        )
-        raise
-    except ProxyAuthError:
-        record_images_route_observability(
-            route=route,
-            model=public_model,
-            stream=stream_requested,
-            status=401,
-            outcome="auth_error",
             started_at=started_at,
         )
         raise

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -61,7 +61,12 @@ from app.core.errors import (
     openai_error,
     response_failed_event,
 )
-from app.core.exceptions import ProxyAuthError, ProxyRateLimitError, ProxyUpstreamError
+from app.core.exceptions import (
+    ProxyAuthError,
+    ProxyModelNotAllowed,
+    ProxyRateLimitError,
+    ProxyUpstreamError,
+)
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, bridge_public_contract_error_total
 from app.core.middleware.api_firewall import _parse_trusted_proxy_networks, resolve_connection_client_ip
 from app.core.openai.chat_requests import ChatCompletionsRequest
@@ -128,6 +133,7 @@ from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.helpers import _rate_limit_details
 from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
+from app.modules.proxy.images_observability import record_images_route_observability
 from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     enforce_strict_function_tools_format,
@@ -1454,6 +1460,28 @@ async def v1_images_generations(
     )
 
 
+def _coerce_image_form_stream_for_observability(stream: str | None) -> bool:
+    if stream is None:
+        return False
+    return stream.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def _record_images_edit_early_rejection(
+    *,
+    model: str | None,
+    stream: bool,
+    started_at: float,
+) -> None:
+    record_images_route_observability(
+        route="edits",
+        model=model,
+        stream=stream,
+        status=400,
+        outcome="invalid_request",
+        started_at=started_at,
+    )
+
+
 @v1_router.post("/images/edits", response_model=None)
 async def v1_images_edits(
     request: Request,
@@ -1485,6 +1513,7 @@ async def v1_images_edits(
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
+    started_at = time.perf_counter()
     raw_form: dict[str, object] = {
         "model": model,
         "prompt": prompt,
@@ -1517,6 +1546,11 @@ async def v1_images_edits(
     try:
         form_payload = V1ImagesEditsForm.model_validate(raw_form)
     except ValidationError as exc:
+        _record_images_edit_early_rejection(
+            model=model,
+            stream=_coerce_image_form_stream_for_observability(stream),
+            started_at=started_at,
+        )
         return _logged_error_json_response(request, 400, openai_validation_error(exc))
 
     # Merge ``image`` and ``image[]`` into a single ordered list. Both
@@ -1528,6 +1562,11 @@ async def v1_images_edits(
     if image_brackets:
         merged_images.extend(image_brackets)
     if not merged_images:
+        _record_images_edit_early_rejection(
+            model=form_payload.model,
+            stream=bool(form_payload.stream),
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
             400,
@@ -1544,6 +1583,11 @@ async def v1_images_edits(
         finally:
             await upload.close()
         if not data:
+            _record_images_edit_early_rejection(
+                model=form_payload.model,
+                stream=bool(form_payload.stream),
+                started_at=started_at,
+            )
             return _logged_error_json_response(
                 request,
                 400,
@@ -1561,6 +1605,11 @@ async def v1_images_edits(
         finally:
             await mask.close()
         if not data:
+            _record_images_edit_early_rejection(
+                model=form_payload.model,
+                stream=bool(form_payload.stream),
+                started_at=started_at,
+            )
             return _logged_error_json_response(
                 request,
                 400,
@@ -1578,6 +1627,7 @@ async def v1_images_edits(
         mask=mask_payload,
         context=context,
         api_key=api_key,
+        started_at=started_at,
     )
 
 
@@ -1650,6 +1700,9 @@ async def _proxy_images_generation_request(
     context: ProxyContext,
     api_key: ApiKeyData | None,
 ) -> Response:
+    started_at = time.perf_counter()
+    route: Literal["generations"] = "generations"
+    stream_requested = bool(payload.stream)
     # Apply the API key's enforced model BEFORE running the cross-field
     # validation matrix. Otherwise a request that passes validation
     # under the client-supplied ``model`` (e.g. gpt-image-2 with a 16-
@@ -1664,6 +1717,14 @@ async def _proxy_images_generation_request(
         requested_model or settings.images_default_model,
     )
     if not images_service_module.is_supported_image_model(effective_model):
+        record_images_route_observability(
+            route=route,
+            model=effective_model,
+            stream=stream_requested,
+            status=400,
+            outcome="invalid_model",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
             400,
@@ -1683,6 +1744,14 @@ async def _proxy_images_generation_request(
     try:
         payload = images_service_module.validate_generations_payload(payload)
     except ClientPayloadError as exc:
+        record_images_route_observability(
+            route=route,
+            model=effective_model,
+            stream=stream_requested,
+            status=400,
+            outcome="invalid_request",
+            started_at=started_at,
+        )
         return _logged_error_json_response(request, 400, openai_client_payload_error(exc))
 
     public_model = payload.model
@@ -1691,21 +1760,57 @@ async def _proxy_images_generation_request(
 
     try:
         validate_model_access(api_key, effective_model)
-    except Exception:
-        # Re-raise so the global handler maps to 403.
+    except ProxyModelNotAllowed:
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=403,
+            outcome="model_not_allowed",
+            started_at=started_at,
+        )
         raise
 
     rate_limit_headers = await _rate_limit_headers_for_request(context, api_key)
-    reservation = await _enforce_request_limits(
-        api_key,
-        request_model=effective_model,
-        request_service_tier=None,
-    )
+    try:
+        reservation = await _enforce_request_limits(
+            api_key,
+            request_model=effective_model,
+            request_service_tier=None,
+        )
+    except ProxyRateLimitError:
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=429,
+            outcome="rate_limited",
+            started_at=started_at,
+        )
+        raise
+    except ProxyAuthError:
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=401,
+            outcome="auth_error",
+            started_at=started_at,
+        )
+        raise
 
     try:
         responses_payload = images_service_module.images_generation_to_responses_request(payload, host_model=host_model)
     except ValidationError as exc:
         await _release_reservation(reservation)
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=400,
+            outcome="invalid_request",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
             400,
@@ -1755,6 +1860,14 @@ async def _proxy_images_generation_request(
         on_error=lambda: _release_reservation(reservation),
     )
     if prime_error is not None:
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=prime_error.status_code,
+            outcome="upstream_error",
+            started_at=started_at,
+        )
         return prime_error
     assert primed_upstream is not None
 
@@ -1767,6 +1880,9 @@ async def _proxy_images_generation_request(
             try:
                 async for chunk in translated:
                     yield chunk.encode("utf-8") if isinstance(chunk, str) else chunk
+            except ProxyResponseError:
+                captured["image_stream_outcome"] = "upstream_error"
+                raise
             finally:
                 # Run the request-log model rewrite even when the stream
                 # is cancelled mid-flight (e.g. client disconnect). Without
@@ -1791,6 +1907,17 @@ async def _proxy_images_generation_request(
                     output_tokens=_output if isinstance(_output, int) else None,
                     cached_input_tokens=_cached if isinstance(_cached, int) else None,
                 )
+                stream_outcome = captured.get("image_stream_outcome")
+                if not isinstance(stream_outcome, str):
+                    stream_outcome = "stream_closed"
+                record_images_route_observability(
+                    route=route,
+                    model=public_model,
+                    stream=True,
+                    status=200,
+                    outcome=stream_outcome,
+                    started_at=started_at,
+                )
 
         return StreamingResponse(
             _stream_with_log_rewrite(),
@@ -1805,6 +1932,14 @@ async def _proxy_images_generation_request(
         )
     except ProxyResponseError as exc:
         await _release_reservation(reservation)
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=False,
+            status=exc.status_code,
+            outcome="upstream_error",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
             exc.status_code,
@@ -1827,21 +1962,47 @@ async def _proxy_images_generation_request(
     )
 
     if error_envelope is not None:
+        error_status = _status_for_image_error_envelope(error_envelope)
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=False,
+            status=error_status,
+            outcome="image_error",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
-            _status_for_image_error_envelope(error_envelope),
+            error_status,
             error_envelope,
             headers=rate_limit_headers,
         )
     assert response_payload is not None
     images_result = images_service_module.images_response_from_responses(response_payload)
     if not isinstance(images_result, V1ImageResponse):
+        image_status = _status_for_image_error_envelope(images_result)
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=False,
+            status=image_status,
+            outcome="image_error",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
-            _status_for_image_error_envelope(images_result),
+            image_status,
             images_result,
             headers=rate_limit_headers,
         )
+    record_images_route_observability(
+        route=route,
+        model=public_model,
+        stream=False,
+        status=200,
+        outcome="success",
+        started_at=started_at,
+    )
     return JSONResponse(
         content=images_result.model_dump(mode="json", exclude_none=True),
         headers=rate_limit_headers,
@@ -1856,7 +2017,10 @@ async def _proxy_images_edit_request(
     mask: tuple[bytes, str | None] | None,
     context: ProxyContext,
     api_key: ApiKeyData | None,
+    started_at: float,
 ) -> Response:
+    route: Literal["edits"] = "edits"
+    stream_requested = bool(payload.stream)
     # Apply the API key's enforced model BEFORE validating the
     # cross-field matrix, so the matrix is checked against the model we
     # will actually send upstream. See the matching comment in
@@ -1868,6 +2032,14 @@ async def _proxy_images_edit_request(
         requested_model or settings.images_default_model,
     )
     if not images_service_module.is_supported_image_model(effective_model):
+        record_images_route_observability(
+            route=route,
+            model=effective_model,
+            stream=stream_requested,
+            status=400,
+            outcome="invalid_model",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
             400,
@@ -1884,20 +2056,60 @@ async def _proxy_images_edit_request(
     try:
         payload = images_service_module.validate_edits_payload(payload)
     except ClientPayloadError as exc:
+        record_images_route_observability(
+            route=route,
+            model=effective_model,
+            stream=stream_requested,
+            status=400,
+            outcome="invalid_request",
+            started_at=started_at,
+        )
         return _logged_error_json_response(request, 400, openai_client_payload_error(exc))
 
     public_model = payload.model
     assert public_model is not None
     host_model = settings.images_host_model
 
-    validate_model_access(api_key, effective_model)
+    try:
+        validate_model_access(api_key, effective_model)
+    except ProxyModelNotAllowed:
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=403,
+            outcome="model_not_allowed",
+            started_at=started_at,
+        )
+        raise
 
     rate_limit_headers = await _rate_limit_headers_for_request(context, api_key)
-    reservation = await _enforce_request_limits(
-        api_key,
-        request_model=effective_model,
-        request_service_tier=None,
-    )
+    try:
+        reservation = await _enforce_request_limits(
+            api_key,
+            request_model=effective_model,
+            request_service_tier=None,
+        )
+    except ProxyRateLimitError:
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=429,
+            outcome="rate_limited",
+            started_at=started_at,
+        )
+        raise
+    except ProxyAuthError:
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=401,
+            outcome="auth_error",
+            started_at=started_at,
+        )
+        raise
 
     try:
         responses_payload = images_service_module.images_edit_to_responses_request(
@@ -1908,6 +2120,14 @@ async def _proxy_images_edit_request(
         )
     except (ValidationError, ValueError) as exc:
         await _release_reservation(reservation)
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=400,
+            outcome="invalid_request",
+            started_at=started_at,
+        )
         if isinstance(exc, ValidationError):
             return _logged_error_json_response(
                 request,
@@ -1945,6 +2165,14 @@ async def _proxy_images_edit_request(
         on_error=lambda: _release_reservation(reservation),
     )
     if prime_error is not None:
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=stream_requested,
+            status=prime_error.status_code,
+            outcome="upstream_error",
+            started_at=started_at,
+        )
         return prime_error
     assert primed_upstream is not None
 
@@ -1957,6 +2185,9 @@ async def _proxy_images_edit_request(
             try:
                 async for chunk in translated:
                     yield chunk.encode("utf-8") if isinstance(chunk, str) else chunk
+            except ProxyResponseError:
+                captured["image_stream_outcome"] = "upstream_error"
+                raise
             finally:
                 # Run the request-log model rewrite even when the stream
                 # is cancelled mid-flight (e.g. client disconnect). Without
@@ -1981,6 +2212,17 @@ async def _proxy_images_edit_request(
                     output_tokens=_output if isinstance(_output, int) else None,
                     cached_input_tokens=_cached if isinstance(_cached, int) else None,
                 )
+                stream_outcome = captured.get("image_stream_outcome")
+                if not isinstance(stream_outcome, str):
+                    stream_outcome = "stream_closed"
+                record_images_route_observability(
+                    route=route,
+                    model=public_model,
+                    stream=True,
+                    status=200,
+                    outcome=stream_outcome,
+                    started_at=started_at,
+                )
 
         return StreamingResponse(
             _stream_with_log_rewrite(),
@@ -1995,6 +2237,14 @@ async def _proxy_images_edit_request(
         )
     except ProxyResponseError as exc:
         await _release_reservation(reservation)
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=False,
+            status=exc.status_code,
+            outcome="upstream_error",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
             exc.status_code,
@@ -2017,21 +2267,47 @@ async def _proxy_images_edit_request(
     )
 
     if error_envelope is not None:
+        error_status = _status_for_image_error_envelope(error_envelope)
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=False,
+            status=error_status,
+            outcome="image_error",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
-            _status_for_image_error_envelope(error_envelope),
+            error_status,
             error_envelope,
             headers=rate_limit_headers,
         )
     assert response_payload is not None
     images_result = images_service_module.images_response_from_responses(response_payload)
     if not isinstance(images_result, V1ImageResponse):
+        image_status = _status_for_image_error_envelope(images_result)
+        record_images_route_observability(
+            route=route,
+            model=public_model,
+            stream=False,
+            status=image_status,
+            outcome="image_error",
+            started_at=started_at,
+        )
         return _logged_error_json_response(
             request,
-            _status_for_image_error_envelope(images_result),
+            image_status,
             images_result,
             headers=rate_limit_headers,
         )
+    record_images_route_observability(
+        route=route,
+        model=public_model,
+        stream=False,
+        status=200,
+        outcome="success",
+        started_at=started_at,
+    )
     return JSONResponse(
         content=images_result.model_dump(mode="json", exclude_none=True),
         headers=rate_limit_headers,

--- a/app/modules/proxy/images_observability.py
+++ b/app/modules/proxy/images_observability.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Literal
+
+from app.core.metrics.prometheus import (
+    PROMETHEUS_AVAILABLE,
+    image_request_duration_seconds,
+    image_requests_total,
+)
+from app.core.openai.images import is_supported_image_model
+
+logger = logging.getLogger("app.modules.proxy.api")
+
+ImageRoute = Literal["generations", "edits"]
+
+
+def _bounded_model_label(model: str | None) -> str:
+    if model is None or not model:
+        return "unknown"
+    if is_supported_image_model(model):
+        return model
+    return "invalid"
+
+
+def record_images_route_observability(
+    *,
+    route: ImageRoute,
+    model: str | None,
+    stream: bool,
+    status: int,
+    outcome: str,
+    started_at: float,
+) -> None:
+    duration_seconds = max(time.perf_counter() - started_at, 0.0)
+    model_label = _bounded_model_label(model)
+    status_label = str(status)
+    stream_label = "true" if stream else "false"
+    if PROMETHEUS_AVAILABLE and image_requests_total is not None and image_request_duration_seconds is not None:
+        labels = {
+            "route": route,
+            "model": model_label,
+            "stream": stream_label,
+            "status": status_label,
+            "outcome": outcome,
+        }
+        image_requests_total.labels(**labels).inc()
+        image_request_duration_seconds.labels(**labels).observe(duration_seconds)
+    logger.log(
+        logging.INFO if status < 400 else logging.WARNING,
+        "images_route_complete route=%s model=%s stream=%s status=%s outcome=%s duration_ms=%.2f",
+        route,
+        model_label,
+        stream_label,
+        status,
+        outcome,
+        duration_seconds * 1000.0,
+    )

--- a/app/modules/proxy/images_service.py
+++ b/app/modules/proxy/images_service.py
@@ -733,6 +733,8 @@ async def translate_responses_stream_to_images_stream(
                 continue
             status = item.get("status")
             if isinstance(status, str) and status == "failed":
+                if captured is not None:
+                    captured["image_stream_outcome"] = "image_error"
                 yield format_sse_event(_failed_image_item_error_event(item))
                 terminal_emitted = True
                 completion_pending = False
@@ -769,7 +771,11 @@ async def translate_responses_stream_to_images_stream(
                     yield format_sse_event(event)
                 pending_completed_events.clear()
                 terminal_emitted = True
+                if captured is not None:
+                    captured["image_stream_outcome"] = "success"
             elif not terminal_emitted:
+                if captured is not None:
+                    captured["image_stream_outcome"] = "image_error"
                 yield format_sse_event(
                     _build_error_event(
                         "image_generation_failed",
@@ -782,6 +788,8 @@ async def translate_responses_stream_to_images_stream(
 
         if event_type == _UPSTREAM_RESPONSE_INCOMPLETE_EVENT:
             if not terminal_emitted:
+                if captured is not None:
+                    captured["image_stream_outcome"] = "image_error"
                 yield format_sse_event(
                     _build_error_event(
                         "image_generation_failed",
@@ -793,12 +801,16 @@ async def translate_responses_stream_to_images_stream(
             break
 
         if event_type == _UPSTREAM_RESPONSE_FAILED_EVENT:
+            if captured is not None:
+                captured["image_stream_outcome"] = "image_error"
             yield format_sse_event(_response_failed_to_error_event(payload))
             terminal_emitted = True
             completion_pending = False
             break
 
         if event_type == _UPSTREAM_ERROR_EVENT:
+            if captured is not None:
+                captured["image_stream_outcome"] = "image_error"
             yield format_sse_event(_error_event_to_error_event(payload))
             terminal_emitted = True
             completion_pending = False
@@ -818,8 +830,12 @@ async def translate_responses_stream_to_images_stream(
             yield format_sse_event(event)
         pending_completed_events.clear()
         terminal_emitted = True
+        if captured is not None:
+            captured["image_stream_outcome"] = "truncated_with_image"
 
     if completion_pending and not terminal_emitted:
+        if captured is not None:
+            captured["image_stream_outcome"] = "truncated"
         yield format_sse_event(
             _build_error_event(
                 "image_generation_failed",

--- a/openspec/changes/add-images-route-observability/.openspec.yaml
+++ b/openspec/changes/add-images-route-observability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/add-images-route-observability/proposal.md
+++ b/openspec/changes/add-images-route-observability/proposal.md
@@ -1,0 +1,21 @@
+# Add image route observability
+
+## Why
+
+Operators need bounded route-completion telemetry for `/v1/images/generations`
+and `/v1/images/edits` so image-route failures, policy rejections, and latency
+are visible without logging prompts, uploaded images, or upstream payloads.
+
+## What Changes
+
+- Emit `images_route_complete` logs for image generation and edit requests.
+- Record Prometheus counters and duration histograms with bounded labels:
+  route, public image model, stream flag, HTTP status, and outcome.
+- Classify validation, model-policy, upstream, image-generation, and streaming
+  outcomes without including request content or binary data in labels/logs.
+
+## Impact
+
+- **Spec**: `images-api-compat`
+- **Behavior**: image routes gain completion logs and metrics for success and
+  failure paths.

--- a/openspec/changes/add-images-route-observability/specs/images-api-compat/spec.md
+++ b/openspec/changes/add-images-route-observability/specs/images-api-compat/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Image routes expose bounded operational observability
+
+The system SHALL emit structured route-completion logs and Prometheus metrics
+for `/v1/images/generations` and `/v1/images/edits`. Observability labels MUST
+be bounded to route, effective public model, stream flag, HTTP status, and
+outcome, and MUST NOT include prompts, image bytes, file names, access tokens,
+or raw upstream payloads.
+
+#### Scenario: Successful image request records completion telemetry
+
+- **WHEN** an `/v1/images/generations` or `/v1/images/edits` request completes
+  successfully
+- **THEN** the service emits an `images_route_complete` log line with the public
+  image route, public model, stream flag, status, outcome, and duration
+- **AND** increments `codex_lb_image_requests_total` and observes
+  `codex_lb_image_request_duration_seconds` with the same bounded labels
+
+#### Scenario: Failed image request records completion telemetry
+
+- **WHEN** an image request is rejected by validation or mapped from an
+  upstream/image-generation error
+- **THEN** the service emits the same bounded `images_route_complete` fields
+  with a non-success outcome
+- **AND** increments the image request counter and duration histogram without
+  logging prompt or binary image content

--- a/openspec/changes/add-images-route-observability/tasks.md
+++ b/openspec/changes/add-images-route-observability/tasks.md
@@ -1,0 +1,17 @@
+## 1. Spec Delta
+
+- [x] 1.1 Add an `images-api-compat` requirement for bounded image-route
+  completion observability.
+- [x] 1.2 Cover successful and failed image-route telemetry.
+
+## 2. Implementation
+
+- [x] 2.1 Emit bounded `images_route_complete` logs.
+- [x] 2.2 Publish image-route Prometheus counters and duration histograms.
+- [x] 2.3 Record validation, policy, upstream, image, and streaming outcomes.
+
+## 3. Verification
+
+- [x] 3.1 Add integration coverage for image-route observability.
+- [x] 3.2 Run targeted image-route integration tests.
+- [x] 3.3 Run `uv run openspec validate add-images-route-observability --strict`.

--- a/openspec/specs/images-api-compat/spec.md
+++ b/openspec/specs/images-api-compat/spec.md
@@ -100,3 +100,19 @@ The system SHALL apply API-key allowed-model policy and model-scoped usage limit
 
 - **WHEN** an `/v1/images/*` request completes successfully against an internal host Responses model (for example `gpt-5.5`)
 - **THEN** the resulting `request_logs` row has `model` equal to the publicly requested value (for example `gpt-image-2`) so dashboards and usage views surface the user-visible model rather than the internal host model
+
+### Requirement: Image routes expose bounded operational observability
+
+The system SHALL emit structured route-completion logs and Prometheus metrics for `/v1/images/generations` and `/v1/images/edits`. Observability labels MUST be bounded to route, effective public model, stream flag, HTTP status, and outcome, and MUST NOT include prompts, image bytes, file names, access tokens, or raw upstream payloads.
+
+#### Scenario: Successful image request records completion telemetry
+
+- **WHEN** an `/v1/images/generations` or `/v1/images/edits` request completes successfully
+- **THEN** the service emits an `images_route_complete` log line with the public image route, public model, stream flag, status, outcome, and duration
+- **AND** increments `codex_lb_image_requests_total` and observes `codex_lb_image_request_duration_seconds` with the same bounded labels
+
+#### Scenario: Failed image request records completion telemetry
+
+- **WHEN** an image request is rejected by validation or mapped from an upstream/image-generation error
+- **THEN** the service emits the same bounded `images_route_complete` fields with a non-success outcome
+- **AND** increments the image request counter and duration histogram without logging prompt or binary image content

--- a/tests/integration/test_proxy_images.py
+++ b/tests/integration/test_proxy_images.py
@@ -55,6 +55,19 @@ async def _import_account(async_client, account_id: str, email: str) -> None:
     assert response.status_code == 200
 
 
+async def _enable_api_key_auth(async_client) -> None:
+    response = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert response.status_code == 200
+
+
 def _sse(payload: dict[str, object]) -> str:
     return f"data: {json.dumps(payload)}\n\n"
 
@@ -167,6 +180,22 @@ async def test_images_generations_quota_rejection_records_route_observability(as
         "images_route_complete route=generations model=gpt-image-2 stream=false status=429 outcome=rate_limited"
         in caplog.text
     )
+
+
+@pytest.mark.asyncio
+async def test_images_generations_auth_rejection_records_route_observability(async_client, caplog):
+    await _enable_api_key_auth(async_client)
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/generations",
+            json={"model": "gpt-image-2", "prompt": "a red circle"},
+        )
+
+    assert response.status_code == 401
+    message = "images_route_complete route=generations model=gpt-image-2 stream=false status=401 outcome=auth_error"
+    assert message in caplog.text
+    assert caplog.text.count(message) == 1
 
 
 @pytest.mark.asyncio
@@ -675,6 +704,23 @@ async def test_images_edits_missing_image_records_route_observability(async_clie
     assert response.status_code == 400
     body = response.json()
     assert body["error"]["param"] == "image"
+    assert (
+        "images_route_complete route=edits model=gpt-image-2 stream=false status=400 outcome=invalid_request"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_images_edits_validation_error_records_supplied_model(async_client, caplog):
+    image_bytes = b"\x89PNG\r\n\x1a\n"
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/edits",
+            data={"model": "gpt-image-2"},
+            files={"image": ("source.png", image_bytes, "image/png")},
+        )
+
+    assert response.status_code == 400
     assert (
         "images_route_complete route=edits model=gpt-image-2 stream=false status=400 outcome=invalid_request"
         in caplog.text

--- a/tests/integration/test_proxy_images.py
+++ b/tests/integration/test_proxy_images.py
@@ -11,12 +11,16 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 from typing import Any, cast
 
 import pytest
+from starlette.responses import JSONResponse
 
+import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
 from app.core.config.settings import Settings
+from app.core.exceptions import ProxyModelNotAllowed, ProxyRateLimitError
 from app.db.models import DashboardSettings
 
 pytestmark = pytest.mark.integration
@@ -103,14 +107,66 @@ def _disable_http_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_images_generations_unsupported_model_returns_400(async_client):
-    response = await async_client.post(
-        "/v1/images/generations",
-        json={"model": "dall-e-3", "prompt": "a red circle"},
-    )
+async def test_images_generations_unsupported_model_returns_400(async_client, caplog):
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/generations",
+            json={"model": "dall-e-3", "prompt": "a red circle"},
+        )
     assert response.status_code == 400
     body = response.json()
     assert body["error"]["type"] == "invalid_request_error"
+    assert (
+        "images_route_complete route=generations model=invalid stream=false status=400 outcome=invalid_request"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_images_generations_model_policy_rejection_records_route_observability(
+    async_client,
+    monkeypatch,
+    caplog,
+):
+    def reject_model_access(*args, **kwargs):
+        del args, kwargs
+        raise ProxyModelNotAllowed("This API key does not have access to model 'gpt-image-2'")
+
+    monkeypatch.setattr(proxy_api_module, "validate_model_access", reject_model_access)
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/generations",
+            json={"model": "gpt-image-2", "prompt": "a red circle"},
+        )
+    assert response.status_code == 403
+    body = response.json()
+    assert body["error"]["type"] == "permission_error"
+    assert (
+        "images_route_complete route=generations model=gpt-image-2 stream=false status=403 outcome=model_not_allowed"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_images_generations_quota_rejection_records_route_observability(async_client, monkeypatch, caplog):
+    async def reject_request_limits(*args, **kwargs):
+        del args, kwargs
+        raise ProxyRateLimitError("API key quota exceeded")
+
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", reject_request_limits)
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/generations",
+            json={"model": "gpt-image-2", "prompt": "a red circle"},
+        )
+
+    assert response.status_code == 429
+    assert (
+        "images_route_complete route=generations model=gpt-image-2 stream=false status=429 outcome=rate_limited"
+        in caplog.text
+    )
 
 
 @pytest.mark.asyncio
@@ -167,7 +223,7 @@ async def test_images_generations_no_accounts_returns_5xx(async_client):
 
 
 @pytest.mark.asyncio
-async def test_images_generations_returns_envelope_on_success(async_client, monkeypatch):
+async def test_images_generations_returns_envelope_on_success(async_client, monkeypatch, caplog):
     await _import_account(async_client, "acc_images_basic", "img-basic@example.com")
 
     captured: dict[str, object] = {}
@@ -215,16 +271,17 @@ async def test_images_generations_returns_envelope_on_success(async_client, monk
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
 
-    response = await async_client.post(
-        "/v1/images/generations",
-        json={
-            "model": "gpt-image-2",
-            "prompt": "tiny red circle on white",
-            "n": 1,
-            "size": "1024x1024",
-            "quality": "low",
-        },
-    )
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/generations",
+            json={
+                "model": "gpt-image-2",
+                "prompt": "tiny red circle on white",
+                "n": 1,
+                "size": "1024x1024",
+                "quality": "low",
+            },
+        )
 
     assert response.status_code == 200, response.text
     body = response.json()
@@ -240,6 +297,10 @@ async def test_images_generations_returns_envelope_on_success(async_client, monk
     assert image_tool["model"] == "gpt-image-2"
     assert image_tool["size"] == "1024x1024"
     assert image_tool["quality"] == "low"
+    assert (
+        "images_route_complete route=generations model=gpt-image-2 stream=false status=200 outcome=success"
+        in caplog.text
+    )
 
 
 @pytest.mark.asyncio
@@ -333,7 +394,95 @@ async def test_images_generations_streaming_emits_canonical_events(async_client,
 
 
 @pytest.mark.asyncio
-async def test_images_generations_failed_image_returns_5xx(async_client, monkeypatch):
+async def test_images_generations_streaming_records_image_errors(async_client, monkeypatch, caplog):
+    await _import_account(async_client, "acc_images_stream_error", "img-stream-error@example.com")
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, kwargs
+        yield _sse({"type": "response.created", "response": {"id": "resp_stream_error"}})
+        yield _sse(
+            {
+                "type": "response.failed",
+                "response": {
+                    "status": "failed",
+                    "error": {
+                        "code": "content_policy_violation",
+                        "message": "blocked",
+                        "type": "invalid_request_error",
+                    },
+                },
+            }
+        )
+
+    async def fake_ensure_fresh(self, account, **kwargs):
+        del self, kwargs
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.api"):
+        async with async_client.stream(
+            "POST",
+            "/v1/images/generations",
+            json={
+                "model": "gpt-image-2",
+                "prompt": "blocked",
+                "stream": True,
+                "size": "1024x1024",
+                "quality": "low",
+            },
+        ) as resp:
+            assert resp.status_code == 200
+            body = await resp.aread()
+
+    assert b"content_policy_violation" in body
+    assert (
+        "images_route_complete route=generations model=gpt-image-2 stream=true status=200 outcome=image_error"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_images_generations_streaming_records_post_prime_upstream_errors(async_client, monkeypatch, caplog):
+    from app.core.clients.proxy import ProxyResponseError
+
+    await _import_account(async_client, "acc_images_stream_late_error", "img-stream-late-error@example.com")
+
+    async def fake_stream_responses(self, payload, headers, **kwargs):
+        del self, payload, headers, kwargs
+        yield _sse({"type": "response.created", "response": {"id": "resp_stream_late_error"}})
+        raise ProxyResponseError(
+            status_code=503,
+            payload={"error": {"message": "late boom", "type": "server_error", "code": "upstream_error"}},
+        )
+
+    monkeypatch.setattr(proxy_module.ProxyService, "stream_responses", fake_stream_responses)
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.api"):
+        with pytest.raises(ProxyResponseError):
+            async with async_client.stream(
+                "POST",
+                "/v1/images/generations",
+                json={
+                    "model": "gpt-image-2",
+                    "prompt": "late failure",
+                    "stream": True,
+                    "size": "1024x1024",
+                    "quality": "low",
+                },
+            ) as resp:
+                assert resp.status_code == 200
+                await resp.aread()
+
+    assert (
+        "images_route_complete route=generations model=gpt-image-2 stream=true status=200 outcome=upstream_error"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_images_generations_failed_image_returns_5xx(async_client, monkeypatch, caplog):
     await _import_account(async_client, "acc_images_failed", "img-failed@example.com")
 
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
@@ -361,14 +510,17 @@ async def test_images_generations_failed_image_returns_5xx(async_client, monkeyp
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
 
-    response = await async_client.post(
-        "/v1/images/generations",
-        json={"model": "gpt-image-2", "prompt": "blocked"},
-    )
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/generations",
+            json={"model": "gpt-image-2", "prompt": "blocked"},
+        )
 
     assert response.status_code in (400, 502)
     body = response.json()
     assert body["error"]["code"] in {"content_policy_violation", "image_generation_failed"}
+    assert "images_route_complete route=generations model=gpt-image-2 stream=false" in caplog.text
+    assert "outcome=image_error" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -448,6 +600,32 @@ async def test_images_edits_basic_round_trip(async_client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_images_edits_passes_outer_started_at_after_file_reads(async_client, monkeypatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_proxy_images_edit_request(**kwargs):
+        captured.update(kwargs)
+        return JSONResponse({"ok": True})
+
+    monkeypatch.setattr(proxy_api_module.time, "perf_counter", lambda: 123.456)
+    monkeypatch.setattr(proxy_api_module, "_proxy_images_edit_request", fake_proxy_images_edit_request)
+
+    image_bytes = b"\x89PNG\r\n\x1a\n"
+    response = await async_client.post(
+        "/v1/images/edits",
+        data={
+            "model": "gpt-image-2",
+            "prompt": "hi",
+        },
+        files={"image": ("source.png", image_bytes, "image/png")},
+    )
+
+    assert response.status_code == 200
+    assert captured["started_at"] == 123.456
+    assert captured["images"] == [(image_bytes, "image/png")]
+
+
+@pytest.mark.asyncio
 async def test_images_edits_input_fidelity_rejected_on_gpt_image_2(async_client):
     image_bytes = b"\x89PNG\r\n\x1a\n"
     response = await async_client.post(
@@ -465,19 +643,68 @@ async def test_images_edits_input_fidelity_rejected_on_gpt_image_2(async_client)
 
 
 @pytest.mark.asyncio
-async def test_images_edits_unsupported_model(async_client):
+async def test_images_edits_unsupported_model(async_client, caplog):
     image_bytes = b"\x89PNG\r\n\x1a\n"
-    response = await async_client.post(
-        "/v1/images/edits",
-        data={
-            "model": "dall-e-3",
-            "prompt": "hi",
-        },
-        files={"image": ("source.png", image_bytes, "image/png")},
-    )
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/edits",
+            data={
+                "model": "bad-model-for-observability-cardinality",
+                "prompt": "hi",
+            },
+            files={"image": ("source.png", image_bytes, "image/png")},
+        )
     assert response.status_code == 400
     body = response.json()
     assert body["error"]["type"] == "invalid_request_error"
+    assert (
+        "images_route_complete route=edits model=invalid stream=false status=400 outcome=invalid_request" in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_images_edits_missing_image_records_route_observability(async_client, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/edits",
+            data={
+                "model": "gpt-image-2",
+                "prompt": "hi",
+            },
+        )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["param"] == "image"
+    assert (
+        "images_route_complete route=edits model=gpt-image-2 stream=false status=400 outcome=invalid_request"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_images_edits_quota_rejection_records_route_observability(async_client, monkeypatch, caplog):
+    async def reject_request_limits(*args, **kwargs):
+        del args, kwargs
+        raise ProxyRateLimitError("API key quota exceeded")
+
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", reject_request_limits)
+
+    image_bytes = b"\x89PNG\r\n\x1a\n"
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/edits",
+            data={
+                "model": "gpt-image-2",
+                "prompt": "hi",
+            },
+            files={"image": ("source.png", image_bytes, "image/png")},
+        )
+
+    assert response.status_code == 429
+    assert (
+        "images_route_complete route=edits model=gpt-image-2 stream=false status=429 outcome=rate_limited"
+        in caplog.text
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -134,6 +134,22 @@ def test_prometheus_metrics_defined_when_dependency_available(monkeypatch: pytes
     assert prometheus_module.continuity_fail_closed_total.labelnames == ("surface", "reason")
     assert prometheus_module.account_inflight_leases.name == "codex_lb_account_inflight_leases"
     assert prometheus_module.account_inflight_leases.labelnames == ("account_id", "kind")
+    assert prometheus_module.image_requests_total.name == "codex_lb_image_requests_total"
+    assert prometheus_module.image_requests_total.labelnames == (
+        "route",
+        "model",
+        "stream",
+        "status",
+        "outcome",
+    )
+    assert prometheus_module.image_request_duration_seconds.name == "codex_lb_image_request_duration_seconds"
+    assert prometheus_module.image_request_duration_seconds.labelnames == (
+        "route",
+        "model",
+        "stream",
+        "status",
+        "outcome",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Refs Soju06/codex-lb#620.

## Summary

- add bounded Prometheus telemetry for `/v1/images/generations` and `/v1/images/edits`
- emit structured `images_route_complete` logs for image route success/error exits without prompts, image bytes, file names, tokens, or raw upstream payloads
- document the Images API observability contract in the images compatibility spec

## Validation

- `uv run pytest tests/integration/test_proxy_images.py::test_images_generations_returns_envelope_on_success tests/integration/test_proxy_images.py::test_images_generations_failed_image_returns_5xx tests/unit/test_metrics.py::test_prometheus_metrics_defined_when_dependency_available -q`
- `make lint`
- `git diff --check`
