### PR TITLE
chore: release v1.21.0-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.20.2-beta.1"  # x-release-please-version
+__version__ = "1.21.0-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.20.2-beta.1
-appVersion: 1.20.2-beta.1
+version: 1.21.0-beta.1
+appVersion: 1.21.0-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.20.2-beta.1",
+  "version": "1.21.0-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.20.2-beta.1"
+version = "1.21.0-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.20.2b1"
+version = "1.21.0-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.21.0-beta.1 for the 1.21.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.21.0-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1087; no manual beta workflow dispatch is required.

## Changes since v1.20.1
- fix(quota-planner): normalize decision datetimes for persistence (#1034) (9f5ae7c)
- fix(proxy): avoid shielded-future log on startup probe timeout (#1076) (
21c03e)
- fix(ci): ignore stale and resolved Codex inline findings (#981) (
384e9b)
- fix(models): hide unsupported API models (#887) (
c5714c)
- fix(dashboard): correct weekly credits pace display (#955) (
30b363)
- fix(proxy): normalize non-native upstream requests to Codex CLI fingerprint (#1089) (
8616e4)
- feat: smart HTTP→upstream transport routing (sticky vs single-shot) (#1093) (
2e124d)
- feat: expose upstream transport observability (#1096) (
cd0160)
- feat(proxy): repair account-bound egress routing (#875) (
1bee4e)
- fix(proxy): oauth blocked when bindings lack route (#1064) (
1f6b5d)
- feat(reset-credits): add banked rate-limit reset credits (#1053) (
ef1d61)
- fix(db): optimize dashboard query hot paths (#1107) (
1d3f6c)
- fix(frontend): persist dashboard account list sort (#1115) (
04dd33)
- feat(frontend): restore Simplified Chinese i18n (#995) (
4ac2d5)
- feat(usage-api): expose configurable usage details (#832) (
244c43)
- feat(request-logs): record client IP (#985) (
18d006)
- perf(usage): avoid repeated history cache scans (#902) (
1cf319)
- feat(warmup): add staggered idle limit prestart (#905) (
39cf65)
- fix(db): merge post-batch migration heads (#1116) (
a2290f)
- feat(request-ui): add showing elapsed time to request details (#1103) (
b1d675)
- fix(zod): add the zod schema with new enum introduced at #875 (#1102) (
cde624)
- fix(retry): honor minute/hour and compound retry-after hints (#1052) (
b19914)
- fix(usage): sync paid-plan upgrades on workspace-less accounts (#1098) (
65556c)
- fix(proxy): strip unsafe HTTP headers before owner-bridge forward (#1036) (
6d0e62)
- fix(proxy): strip internal responses lite header (#1099) (
6d6be7)
- fix(ui): stabilize account layout and API key dialog (#1062) (
9e4f76)
- fix(models): aggregate service tiers across accounts (#1106) (
a1831d)
- fix(http-bridge): clean stale inflight session futures (#1044) (
ea1109)
- fix(websocket): avoid fresh retry for tool-output deltas (#1042) (
a7ec8d)
- feat(usage): support Codex usage reset credits (#1105) (
12b909)
- fix(proxy): set parallel_tool_calls to false for compaction requests (#1054) (
f21230)
- fix(proxy): clarify account stream cap overload (#1122) (
3cc0db)
- fix(proxy): stop local rate-limit selection retry loops (#1121) (
9de900)
- fix(db): prevent SQLite FD retention in background refresh tasks (#1127) (
b37b7b)
- fix(quota-planner): normalize datetimes before database use (#1043) (
9e3819)
- fix(dashboard-auth): harden local session ttl (#1137) (
6fe3b3)
- fix: list Codex shell-only models in backend catalog (#1138) (
5316df)
- feat(accounts): test bound proxy pools (#1124) (
5b830e)
- feat(metrics): expose account inflight lease gauge (#1148) (
23a78b)
- feat(fleet): add refresh endpoint (#1128) (
1d22d6)
- feat: add openai-compatible model sources (#1129) (
d34591)
- fix(account-ui): fix overflow on account list page (#1149) (
fb3698)
- feat(automations): scheduled cycles, grouped runs, and run details UI (#438) (
100f6d)
- feat(images): add route observability (#1123) (
8015bb)
- feat(proxy): add TTFT phase observability (
bdd571)
- fix(models): serve the Codex catalog on /v1/models for Codex clients (#1163) (
a83d6d)
- fix(proxy): fallback v1 usage limits to upstream quotas (#1151) (
cfe6dd)
- fix(proxy): preserve Responses Lite additional tools (#1161) (
f746a8)
- feat(models): add GPT-5.6 bootstrap catalog with upstream-verified metadata (#1176) (
64bb2b)
- fix(proxy): support Codex image edit routes (#1160) (
1bfc5c)
- fix(model-sources): default Codex catalog context and capability-gated tool filtering (#1152) (
d02417)
- fix(proxy): synthesize interrupted custom tool call outputs (#1175) (
264dd0)
- fix(proxy): preserve all non-message system and developer input items (#1172) (
af6b51)
- fix(proxy): preserve model_messages in catalog response (#1178) (
3ccdc3)
- fix(ci): ignore superseded same-head check suites (#1170) (
b0f5ea)
- fix(proxy): harden native Responses Lite continuity (#1164) (
ffd529)

## Release-candidate validation
Validated candidate: 0d978a194e83007c302cfb2fe44ce20e22c704b4

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates
- [x] Frontend tests/build
- [x] Wheel/package validation
- [x] Docker/container smoke
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required

Validation evidence (2026-07-10, candidate 0d978a19):
- Backend/frontend/package/docker CI matrix green on the candidate SHA (31 checks; only the guard itself pending this checklist).
- Wheel built via `make package`: `codex_lb-1.21.0b1` — fresh-venv install, `codex-lb --help` OK, `importlib.metadata.version == 1.21.0b1`, frontend assets verified in wheel.
- Docker image built at the SHA; container boot clean (Alembic through `20260709_000000_add_ttft_phase_observability`), `GET /health/live` 200 `{"status":"ok"}`, dashboard root 200, zero tracebacks.
- `uv run pytest tests/unit -q`: 3268 passed, 3 skipped at the SHA; ruff + ty clean against the frozen lock.
- Live upstream smoke not required for this beta: the Responses-Lite fix train was field-confirmed on real gpt-5.6-sol traffic during review (#1161).

## Install after publish
```bash
uvx --from "codex-lb==1.21.0b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.21.0-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.21.0-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.21.0.

