### PR TITLE
fix(db): prevent SQLite FD retention in background refresh tasks

### DIFF
--- a/app/core/cache/invalidation.py
+++ b/app/core/cache/invalidation.py
@@ -12,6 +12,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import CacheInvalidation
+from app.db.session import close_session
 
 if TYPE_CHECKING:
     pass
@@ -97,7 +98,7 @@ class CacheInvalidationPoller:
         except Exception:
             logger.warning("cache_invalidation bump failed", exc_info=True)
         finally:
-            await session.close()
+            await close_session(session)
 
     async def _run(self) -> None:
         while not self._stop.is_set():
@@ -118,7 +119,7 @@ class CacheInvalidationPoller:
         except Exception:
             return
         finally:
-            await session.close()
+            await close_session(session)
 
         for namespace, version in rows:
             prev = self._known_versions.get(namespace)

--- a/app/core/openai/model_refresh_scheduler.py
+++ b/app/core/openai/model_refresh_scheduler.py
@@ -19,8 +19,9 @@ from app.core.openai.model_registry import (
 )
 from app.core.upstream_proxy import ResolvedUpstreamRoute, resolve_upstream_route
 from app.db.models import Account, AccountStatus
-from app.db.session import get_background_session
+from app.db.session import detach_session_objects, get_background_session
 from app.modules.accounts.auth_manager import AuthManager
+from app.modules.accounts.background_repository import BackgroundAccountsRepository
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.proxy.account_cache import get_account_selection_cache
 
@@ -87,45 +88,45 @@ class ModelRefreshScheduler:
             async with get_background_session() as session:
                 accounts_repo = AccountsRepository(session)
                 accounts = await accounts_repo.list_accounts()
-                grouped = _group_by_plan(accounts)
-                if not grouped:
-                    logger.debug("No active accounts for model registry refresh")
-                    return
+                detach_session_objects(session)
+            grouped = _group_by_plan(accounts)
+            if not grouped:
+                logger.debug("No active accounts for model registry refresh")
+                return
 
-                encryptor = TokenEncryptor()
-                per_plan_results: dict[str, list[UpstreamModel]] = {}
-                per_account_results: dict[str, tuple[str, list[UpstreamModel]]] = {}
-                active_account_plans: dict[str, str] = {}
+            encryptor = TokenEncryptor()
+            per_plan_results: dict[str, list[UpstreamModel]] = {}
+            per_account_results: dict[str, tuple[str, list[UpstreamModel]]] = {}
+            active_account_plans: dict[str, str] = {}
 
-                for plan_type, candidates in grouped.items():
-                    for account in candidates:
-                        active_account_plans[account.id] = plan_type
-                    result = await _fetch_with_failover(
-                        candidates,
-                        encryptor,
-                        accounts_repo,
-                    )
-                    if result is not None:
-                        per_plan_results[plan_type] = result.models
-                        per_account_results.update(result.account_models)
+            for plan_type, candidates in grouped.items():
+                for account in candidates:
+                    active_account_plans[account.id] = plan_type
+                result = await _fetch_with_failover(
+                    candidates,
+                    encryptor,
+                )
+                if result is not None:
+                    per_plan_results[plan_type] = result.models
+                    per_account_results.update(result.account_models)
 
-                if per_plan_results:
-                    registry = get_model_registry()
-                    await registry.update(
-                        per_plan_results,
-                        per_account_results=per_account_results,
-                        active_account_plans=active_account_plans,
-                    )
-                    snapshot = registry.get_snapshot()
-                    total_models = len(snapshot.models) if snapshot else 0
-                    logger.info(
-                        "Model registry refreshed plans=%d total_models=%d",
-                        len(per_plan_results),
-                        total_models,
-                    )
-                    get_account_selection_cache().invalidate()
-                else:
-                    logger.warning("Model registry refresh failed for all plans")
+            if per_plan_results:
+                registry = get_model_registry()
+                await registry.update(
+                    per_plan_results,
+                    per_account_results=per_account_results,
+                    active_account_plans=active_account_plans,
+                )
+                snapshot = registry.get_snapshot()
+                total_models = len(snapshot.models) if snapshot else 0
+                logger.info(
+                    "Model registry refreshed plans=%d total_models=%d",
+                    len(per_plan_results),
+                    total_models,
+                )
+                get_account_selection_cache().invalidate()
+            else:
+                logger.warning("Model registry refresh failed for all plans")
         except Exception:
             logger.exception("Model registry refresh loop failed")
 
@@ -167,14 +168,15 @@ def _compact_error_message(message: str) -> str:
 async def _fetch_with_failover(
     candidates: list[Account],
     encryptor: TokenEncryptor,
-    accounts_repo: AccountsRepository,
+    accounts_repo: AccountsRepository | None = None,
 ) -> _FetchResult | None:
     transport_recovery = _TransportRecoveryState()
     successful_results: list[list[UpstreamModel]] = []
     account_models: dict[str, tuple[str, list[UpstreamModel]]] = {}
+    auth_accounts_repo = accounts_repo or BackgroundAccountsRepository()
+    auth_manager = AuthManager(auth_accounts_repo)
 
     for account in candidates:
-        auth_manager = AuthManager(accounts_repo)
         try:
             account = await _ensure_fresh_with_transport_recovery(
                 auth_manager,

--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -6,12 +6,14 @@ import importlib
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import AsyncIterator, Protocol, cast
+from datetime import datetime
+from typing import Any, AsyncIterator, Protocol, cast
 
 from app.core.config.settings import get_settings
 from app.core.usage import capacity_for_plan
-from app.db.models import Account, AccountStatus, UsageHistory
-from app.db.session import get_background_session
+from app.db.models import Account, AccountLimitWarmup, AccountStatus, UsageHistory
+from app.db.session import detach_session_objects, get_background_session
+from app.modules.accounts.background_repository import BackgroundAccountsRepository
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.limit_warmup.repository import LimitWarmupRepository
 from app.modules.limit_warmup.service import LimitWarmupService, StreamingLimitWarmupSender
@@ -21,8 +23,8 @@ from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.settings.repository import SettingsRepository
 from app.modules.usage import updater as usage_updater_module
-from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
-from app.modules.usage.updater import UsageUpdater
+from app.modules.usage.repository import UsageRepository
+from app.modules.usage.updater import build_background_usage_updater
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +53,62 @@ class _RecoverableAccountsRepository(Protocol):
 
 class _LatestUsageRepository(Protocol):
     async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]: ...
+
+
+class _BackgroundLimitWarmupRepository:
+    async def latest_by_account(self, account_ids: list[str]) -> dict[str, AccountLimitWarmup]:
+        async with get_background_session() as session:
+            attempts = await LimitWarmupRepository(session).latest_by_account(account_ids)
+            detach_session_objects(session)
+            return attempts
+
+    async def try_create_attempt(
+        self,
+        *,
+        account_id: str,
+        window: str,
+        reset_at: int,
+        model: str,
+        attempted_at: datetime,
+        status: str = "pending",
+    ) -> AccountLimitWarmup | None:
+        async with get_background_session() as session:
+            attempt = await LimitWarmupRepository(session).try_create_attempt(
+                account_id=account_id,
+                window=window,
+                reset_at=reset_at,
+                model=model,
+                attempted_at=attempted_at,
+                status=status,
+            )
+            detach_session_objects(session)
+            return attempt
+
+    async def complete_attempt(
+        self,
+        attempt_id: int,
+        *,
+        status: str,
+        completed_at: datetime,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> AccountLimitWarmup | None:
+        async with get_background_session() as session:
+            attempt = await LimitWarmupRepository(session).complete_attempt(
+                attempt_id,
+                status=status,
+                completed_at=completed_at,
+                error_code=error_code,
+                error_message=error_message,
+            )
+            detach_session_objects(session)
+            return attempt
+
+
+class _BackgroundRequestLogsRepository:
+    async def add_log(self, *args: Any, **kwargs: Any) -> object:
+        async with get_background_session() as session:
+            return await RequestLogsRepository(session).add_log(*args, **kwargs)
 
 
 def _get_leader_election() -> _LeaderElectionLike:
@@ -100,58 +158,66 @@ class UsageRefreshScheduler:
         if not await _get_leader_election().try_acquire():
             return float(self.interval_seconds)
         async with self._lock:
+            account_count = 0
             try:
                 async with get_background_session() as session:
                     usage_repo = UsageRepository(session)
                     accounts_repo = AccountsRepository(session)
-                    additional_usage_repo = AdditionalUsageRepository(session)
-                    settings_repo = SettingsRepository(session)
-                    warmup_repo = LimitWarmupRepository(session)
-                    request_logs_repo = RequestLogsRepository(session)
                     before_primary = await usage_repo.latest_by_account(window="primary")
                     before_secondary = await usage_repo.latest_by_account(window="secondary")
                     accounts = _ordered_usage_refresh_accounts(await accounts_repo.list_accounts())
                     selected_account, cycle_complete = self._select_next_account(accounts)
-                    if selected_account is None:
-                        await _invalidate_usage_refresh_caches()
-                        return float(self.interval_seconds)
-                    updater = UsageUpdater(usage_repo, accounts_repo, additional_usage_repo)
-                    refresh_started_at = usage_updater_module.utcnow()
-                    usage_written = await updater.refresh_accounts([selected_account], before_primary)
-                    if usage_written:
+                    detach_session_objects(session)
+                account_count = len(accounts)
+                if selected_account is None:
+                    await _invalidate_usage_refresh_caches()
+                    return float(self.interval_seconds)
+
+                updater = build_background_usage_updater()
+                refresh_started_at = usage_updater_module.utcnow()
+                usage_written = await updater.refresh_accounts([selected_account], before_primary)
+                if usage_written:
+                    async with get_background_session() as session:
+                        usage_repo = UsageRepository(session)
+                        accounts_repo = AccountsRepository(session)
+                        settings_repo = SettingsRepository(session)
                         after_primary = await usage_repo.latest_by_account(window="primary")
                         after_secondary = await usage_repo.latest_by_account(window="secondary")
                         dashboard_settings = await settings_repo.get_or_create()
-                        warmup_service = LimitWarmupService(
-                            warmup_repo,
-                            request_logs_repo,
-                            sender=StreamingLimitWarmupSender(
-                                accounts_repo,
-                                accounts_repo_factory=_background_accounts_repo,
-                            ),
-                        )
                         refreshed_accounts = await accounts_repo.list_accounts(refresh_existing=True)
-                        await warmup_service.run_after_usage_refresh(
-                            accounts=refreshed_accounts,
-                            settings=dashboard_settings,
-                            before_primary=before_primary,
-                            before_secondary=before_secondary,
-                            after_primary=after_primary,
-                            after_secondary=after_secondary,
-                            refresh_started_at=refresh_started_at,
-                            usage_refresh_interval_seconds=self.interval_seconds,
-                        )
+                        detach_session_objects(session)
+                    warmup_service = LimitWarmupService(
+                        cast(Any, _BackgroundLimitWarmupRepository()),
+                        cast(Any, _BackgroundRequestLogsRepository()),
+                        sender=StreamingLimitWarmupSender(
+                            cast(AccountsRepository, BackgroundAccountsRepository()),
+                            accounts_repo_factory=_background_accounts_repo,
+                        ),
+                    )
+                    await warmup_service.run_after_usage_refresh(
+                        accounts=refreshed_accounts,
+                        settings=dashboard_settings,
+                        before_primary=before_primary,
+                        before_secondary=before_secondary,
+                        after_primary=after_primary,
+                        after_secondary=after_secondary,
+                        refresh_started_at=refresh_started_at,
+                        usage_refresh_interval_seconds=self.interval_seconds,
+                    )
+                    async with get_background_session() as session:
+                        usage_repo = UsageRepository(session)
+                        accounts_repo = AccountsRepository(session)
                         await reconcile_recoverable_account_statuses(
                             accounts_repo=accounts_repo,
                             usage_repo=usage_repo,
                             accounts=refreshed_accounts,
                         )
-                    if cycle_complete:
-                        await _invalidate_usage_refresh_caches()
+                if cycle_complete:
+                    await _invalidate_usage_refresh_caches()
             except Exception:
                 logger.exception("Usage refresh loop failed")
                 return float(self.interval_seconds)
-        return _usage_refresh_slice_seconds(self.interval_seconds, len(accounts))
+        return _usage_refresh_slice_seconds(self.interval_seconds, account_count)
 
     def _select_next_account(self, accounts: list[Account]) -> tuple[Account | None, bool]:
         if not accounts:

--- a/app/core/usage/reset_credits_refresh_scheduler.py
+++ b/app/core/usage/reset_credits_refresh_scheduler.py
@@ -16,7 +16,7 @@ from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError
 from app.db.models import Account, AccountStatus
-from app.db.session import get_background_session
+from app.db.session import detach_session_objects, get_background_session
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.rate_limit_reset_credits.store import (
     RateLimitResetCreditsStore,
@@ -70,13 +70,14 @@ class RateLimitResetCreditsRefreshScheduler:
                 async with get_background_session() as session:
                     accounts_repo = AccountsRepository(session)
                     accounts = await accounts_repo.list_accounts()
-                    await refresh_reset_credits_for_accounts(
-                        accounts=accounts,
-                        encryptor=TokenEncryptor(),
-                        store=get_rate_limit_reset_credits_store(),
-                        fetch_fn=fetch_reset_credits,
-                        resolve_route=_resolve_reset_credits_refresh_route,
-                    )
+                    detach_session_objects(session)
+                await refresh_reset_credits_for_accounts(
+                    accounts=accounts,
+                    encryptor=TokenEncryptor(),
+                    store=get_rate_limit_reset_credits_store(),
+                    fetch_fn=fetch_reset_credits,
+                    resolve_route=_resolve_reset_credits_refresh_route,
+                )
             except Exception:
                 logger.exception("Reset credits refresh loop failed")
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -63,6 +63,13 @@ def _postgres_async_engine_kwargs(url: str, *, background: bool) -> dict[str, ob
     return kwargs
 
 
+def _sqlite_file_async_engine_kwargs() -> dict[str, object]:
+    return {
+        "poolclass": NullPool,
+        "connect_args": {"timeout": _SQLITE_BUSY_TIMEOUT_SECONDS},
+    }
+
+
 def _database_pool_size(*, background: bool) -> int:
     if background:
         return _settings.database_background_pool_size or _settings.database_pool_size
@@ -103,10 +110,7 @@ if _is_sqlite_url(_settings.database_url):
         engine = create_async_engine(
             _settings.database_url,
             echo=False,
-            pool_size=_settings.database_pool_size,
-            max_overflow=_settings.database_max_overflow,
-            pool_timeout=_settings.database_pool_timeout_seconds,
-            connect_args={"timeout": _SQLITE_BUSY_TIMEOUT_SECONDS},
+            **_sqlite_file_async_engine_kwargs(),
         )
     _configure_sqlite_engine(engine.sync_engine, enable_wal=not is_sqlite_memory)
 else:
@@ -181,6 +185,17 @@ async def _safe_close(session: AsyncSession) -> None:
         return
 
 
+async def close_session(session: AsyncSession) -> None:
+    if session.in_transaction():
+        await _safe_rollback(session)
+    await _safe_close(session)
+
+
+def detach_session_objects(session: AsyncSession) -> None:
+    """Detach loaded ORM rows that must outlive this session boundary."""
+    session.expunge_all()
+
+
 def _load_migration_entrypoints() -> tuple[
     Callable[[str], "MigrationState"],
     Callable[[str], Awaitable["MigrationRunResult"]],
@@ -218,10 +233,7 @@ def init_background_db(url: str | None = None) -> None:
         _background_engine = create_async_engine(
             db_url,
             echo=False,
-            pool_size=_database_pool_size(background=True),
-            max_overflow=_database_max_overflow(background=True),
-            pool_timeout=_settings.database_pool_timeout_seconds,
-            connect_args={"timeout": _SQLITE_BUSY_TIMEOUT_SECONDS},
+            **_sqlite_file_async_engine_kwargs(),
         )
         _configure_sqlite_engine(_background_engine.sync_engine, enable_wal=not is_sqlite_memory)
     else:
@@ -248,9 +260,7 @@ async def get_background_session() -> AsyncIterator[AsyncSession]:
         await _safe_rollback(session)
         raise
     finally:
-        if session.in_transaction():
-            await _safe_rollback(session)
-        await _safe_close(session)
+        await close_session(session)
 
 
 @asynccontextmanager
@@ -274,9 +284,7 @@ async def get_session() -> AsyncIterator[AsyncSession]:
         await _safe_rollback(session)
         raise
     finally:
-        if session.in_transaction():
-            await _safe_rollback(session)
-        await _safe_close(session)
+        await close_session(session)
 
 
 async def init_db() -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -42,7 +42,7 @@ from app.core.resilience.bulkhead import BulkheadMiddleware, get_bulkhead
 from app.core.resilience.memory_monitor import configure as configure_memory_monitor
 from app.core.usage.refresh_scheduler import build_usage_refresh_scheduler
 from app.core.usage.reset_credits_refresh_scheduler import build_rate_limit_reset_credits_scheduler
-from app.db.session import SessionLocal, close_db, init_background_db, init_db
+from app.db.session import SessionLocal, close_db, close_session, init_background_db, init_db
 from app.modules.accounts import api as accounts_api
 from app.modules.api_keys import api as api_keys_api
 from app.modules.api_keys.reset_scheduler import build_api_key_limit_reset_scheduler
@@ -451,7 +451,7 @@ async def _ensure_bridge_durable_schema_ready(settings) -> bool:
     try:
         missing_tables = await missing_durable_bridge_tables(session)
     finally:
-        await session.close()
+        await close_session(session)
     if not missing_tables:
         return True
     missing = ", ".join(missing_tables)

--- a/app/modules/accounts/background_repository.py
+++ b/app/modules/accounts/background_repository.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.db.models import Account, AccountStatus
+from app.db.session import detach_session_objects, get_background_session
+from app.modules.accounts.repository import AccountsRepository
+
+_UNSET = object()
+
+
+class BackgroundAccountsRepository:
+    async def get_by_id(self, account_id: str) -> Account | None:
+        async with get_background_session() as session:
+            account = await AccountsRepository(session).get_by_id(account_id)
+            detach_session_objects(session)
+            return account
+
+    async def list_accounts(self, *, refresh_existing: bool = False) -> list[Account]:
+        async with get_background_session() as session:
+            accounts = await AccountsRepository(session).list_accounts(refresh_existing=refresh_existing)
+            detach_session_objects(session)
+            return accounts
+
+    async def update_status(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None | object = _UNSET,
+    ) -> bool:
+        async with get_background_session() as session:
+            repo = AccountsRepository(session)
+            if blocked_at is _UNSET:
+                return await repo.update_status(account_id, status, deactivation_reason, reset_at)
+            return await repo.update_status(account_id, status, deactivation_reason, reset_at, blocked_at)
+
+    async def update_status_if_current(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None | object = _UNSET,
+        *,
+        expected_status: AccountStatus,
+        expected_deactivation_reason: str | None = None,
+        expected_reset_at: int | None = None,
+        expected_blocked_at: int | None | object = _UNSET,
+    ) -> bool:
+        async with get_background_session() as session:
+            repo = AccountsRepository(session)
+            kwargs = {
+                "expected_status": expected_status,
+                "expected_deactivation_reason": expected_deactivation_reason,
+                "expected_reset_at": expected_reset_at,
+            }
+            if expected_blocked_at is not _UNSET:
+                kwargs["expected_blocked_at"] = expected_blocked_at
+            if blocked_at is _UNSET:
+                return await repo.update_status_if_current(
+                    account_id,
+                    status,
+                    deactivation_reason,
+                    reset_at,
+                    **kwargs,
+                )
+            return await repo.update_status_if_current(
+                account_id,
+                status,
+                deactivation_reason,
+                reset_at,
+                blocked_at,
+                **kwargs,
+            )
+
+    async def update_tokens(
+        self,
+        account_id: str,
+        access_token_encrypted: bytes,
+        refresh_token_encrypted: bytes,
+        id_token_encrypted: bytes,
+        last_refresh: datetime,
+        plan_type: str | None = None,
+        email: str | None = None,
+        chatgpt_account_id: str | None = None,
+        workspace_id: str | None = None,
+        workspace_label: str | None = None,
+        seat_type: str | None = None,
+    ) -> bool:
+        async with get_background_session() as session:
+            return await AccountsRepository(session).update_tokens(
+                account_id,
+                access_token_encrypted=access_token_encrypted,
+                refresh_token_encrypted=refresh_token_encrypted,
+                id_token_encrypted=id_token_encrypted,
+                last_refresh=last_refresh,
+                plan_type=plan_type,
+                email=email,
+                chatgpt_account_id=chatgpt_account_id,
+                workspace_id=workspace_id,
+                workspace_label=workspace_label,
+                seat_type=seat_type,
+            )
+
+    async def workspace_slot_taken(
+        self,
+        *,
+        account_id: str,
+        email: str,
+        chatgpt_account_id: str | None,
+        workspace_id: str,
+    ) -> bool:
+        async with get_background_session() as session:
+            return await AccountsRepository(session).workspace_slot_taken(
+                account_id=account_id,
+                email=email,
+                chatgpt_account_id=chatgpt_account_id,
+                workspace_id=workspace_id,
+            )

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import HttpBridgeSessionState
+from app.db.session import close_session
 from app.modules.proxy.durable_bridge_repository import (
     DurableBridgeRepository,
     DurableBridgeSessionSnapshot,
@@ -262,7 +263,7 @@ class DurableBridgeSessionCoordinator:
         try:
             yield session
         finally:
-            await session.close()
+            await close_session(session)
 
 
 def _to_lookup(snapshot: DurableBridgeSessionSnapshot) -> DurableBridgeLookup:

--- a/app/modules/proxy/ring_membership.py
+++ b/app/modules/proxy/ring_membership.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.time import utcnow
 from app.db.models import BridgeRingMember
+from app.db.session import close_session
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -212,7 +213,7 @@ class RingMembershipService:
         try:
             yield session
         finally:
-            await session.close()
+            await close_session(session)
 
 
 def _bridge_ring_metadata_json(endpoint_base_url: str | None) -> str | None:

--- a/app/modules/usage/background_repository.py
+++ b/app/modules/usage/background_repository.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+from datetime import datetime
+
+from app.db.models import UsageHistory
+from app.db.session import detach_session_objects, get_background_session
+from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+
+
+class BackgroundUsageRepository:
+    async def latest_entry_for_account(
+        self,
+        account_id: str,
+        *,
+        window: str | None = None,
+    ) -> UsageHistory | None:
+        async with get_background_session() as session:
+            entry = await UsageRepository(session).latest_entry_for_account(account_id, window=window)
+            detach_session_objects(session)
+            return entry
+
+    async def add_entry(
+        self,
+        account_id: str,
+        used_percent: float,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        recorded_at: datetime | None = None,
+        window: str | None = None,
+        reset_at: int | None = None,
+        window_minutes: int | None = None,
+        credits_has: bool | None = None,
+        credits_unlimited: bool | None = None,
+        credits_balance: float | None = None,
+    ) -> UsageHistory | None:
+        async with get_background_session() as session:
+            entry = await UsageRepository(session).add_entry(
+                account_id=account_id,
+                used_percent=used_percent,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                recorded_at=recorded_at,
+                window=window,
+                reset_at=reset_at,
+                window_minutes=window_minutes,
+                credits_has=credits_has,
+                credits_unlimited=credits_unlimited,
+                credits_balance=credits_balance,
+            )
+            detach_session_objects(session)
+            return entry
+
+
+class BackgroundAdditionalUsageRepository:
+    async def add_entry(
+        self,
+        account_id: str,
+        limit_name: str,
+        metered_feature: str,
+        window: str,
+        used_percent: float,
+        reset_at: int | None = None,
+        window_minutes: int | None = None,
+        recorded_at: datetime | None = None,
+        quota_key: str | None = None,
+    ) -> None:
+        async with get_background_session() as session:
+            await AdditionalUsageRepository(session).add_entry(
+                account_id=account_id,
+                limit_name=limit_name,
+                metered_feature=metered_feature,
+                window=window,
+                used_percent=used_percent,
+                reset_at=reset_at,
+                window_minutes=window_minutes,
+                recorded_at=recorded_at,
+                quota_key=quota_key,
+            )
+
+    async def delete_for_account(self, account_id: str) -> None:
+        async with get_background_session() as session:
+            await AdditionalUsageRepository(session).delete_for_account(account_id)
+
+    async def delete_for_account_and_quota_key(self, account_id: str, quota_key: str) -> None:
+        async with get_background_session() as session:
+            await AdditionalUsageRepository(session).delete_for_account_and_quota_key(account_id, quota_key)
+
+    async def delete_for_account_and_limit(self, account_id: str, limit_name: str) -> None:
+        async with get_background_session() as session:
+            await AdditionalUsageRepository(session).delete_for_account_and_limit(account_id, limit_name)
+
+    async def delete_for_account_quota_key_window(
+        self,
+        account_id: str,
+        quota_key: str,
+        window: str,
+    ) -> None:
+        async with get_background_session() as session:
+            await AdditionalUsageRepository(session).delete_for_account_quota_key_window(account_id, quota_key, window)
+
+    async def delete_for_account_limit_window(
+        self,
+        account_id: str,
+        limit_name: str,
+        window: str,
+    ) -> None:
+        async with get_background_session() as session:
+            await AdditionalUsageRepository(session).delete_for_account_limit_window(account_id, limit_name, window)
+
+    async def list_quota_keys(
+        self,
+        *,
+        account_ids: Collection[str] | None = None,
+        since: datetime | None = None,
+    ) -> list[str]:
+        async with get_background_session() as session:
+            return await AdditionalUsageRepository(session).list_quota_keys(account_ids=account_ids, since=since)
+
+    async def list_limit_names(
+        self,
+        *,
+        account_ids: Collection[str] | None = None,
+        since: datetime | None = None,
+    ) -> list[str]:
+        async with get_background_session() as session:
+            return await AdditionalUsageRepository(session).list_limit_names(account_ids=account_ids, since=since)
+
+    async def latest_recorded_at_for_account(self, account_id: str) -> datetime | None:
+        async with get_background_session() as session:
+            return await AdditionalUsageRepository(session).latest_recorded_at_for_account(account_id)

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Collection
+from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime
 from hashlib import sha256
@@ -344,7 +345,7 @@ def _latest_by_account_sqlite(
     """
 
     latest: dict[str, UsageHistory] = {}
-    with sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as conn:
+    with closing(sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)) as conn:
         conn.execute("PRAGMA query_only=ON")
         conn.execute("PRAGMA busy_timeout=30000")
         accounts = [str(row[0]) for row in conn.execute(account_sql, account_params)]
@@ -411,7 +412,7 @@ def _additional_latest_by_account_sqlite(
     """
 
     latest: dict[str, AdditionalUsageHistory] = {}
-    with sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as conn:
+    with closing(sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)) as conn:
         conn.execute("PRAGMA query_only=ON")
         conn.execute("PRAGMA busy_timeout=30000")
         accounts_params = [*scope_params, window, *account_params, *since_params]
@@ -431,7 +432,7 @@ def _bulk_history_since_sqlite(
     since: datetime,
 ) -> dict[str, list[UsageHistorySnapshot]]:
     cache_key = _bulk_history_cache_key(db_path, account_ids, window)
-    with sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES) as conn:
+    with closing(sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)) as conn:
         conn.execute("PRAGMA query_only=ON")
         conn.execute("PRAGMA busy_timeout=30000")
         with _BULK_HISTORY_SQLITE_CACHE_LOCK:

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -28,8 +28,10 @@ from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
 from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManager
+from app.modules.accounts.background_repository import BackgroundAccountsRepository
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
 from app.modules.usage.additional_quota_keys import canonicalize_additional_quota_key
+from app.modules.usage.background_repository import BackgroundAdditionalUsageRepository, BackgroundUsageRepository
 from app.modules.usage.repository import AdditionalUsageRepository
 
 logger = logging.getLogger(__name__)
@@ -229,13 +231,16 @@ class UsageUpdater:
         usage_repo: UsageRepositoryPort,
         accounts_repo: AccountsRepositoryPort | None = None,
         additional_usage_repo: AdditionalUsageRepositoryPort | AdditionalUsageRepository | None = None,
+        *,
+        auth_manager: AuthManager | None = None,
     ) -> None:
         self._usage_repo = usage_repo
         self._accounts_repo = accounts_repo
         self._additional_usage_repo = additional_usage_repo
-        self._accounts_repo = accounts_repo
         self._encryptor = TokenEncryptor()
-        self._auth_manager = AuthManager(accounts_repo) if accounts_repo else None
+        self._auth_manager = (
+            auth_manager if auth_manager is not None else AuthManager(accounts_repo) if accounts_repo else None
+        )
 
     async def refresh_accounts(
         self,
@@ -748,6 +753,16 @@ class UsageUpdater:
         account.deactivation_reason = stored.deactivation_reason
         account.reset_at = stored.reset_at
         account.blocked_at = stored.blocked_at
+
+
+def build_background_usage_updater() -> UsageUpdater:
+    accounts_repo = BackgroundAccountsRepository()
+    return UsageUpdater(
+        BackgroundUsageRepository(),
+        accounts_repo=accounts_repo,
+        additional_usage_repo=BackgroundAdditionalUsageRepository(),
+        auth_manager=AuthManager(accounts_repo),
+    )
 
 
 def _credits_snapshot(payload: UsagePayload) -> tuple[bool | None, bool | None, float | None]:

--- a/openspec/changes/fix-sqlite-background-fd-leak/proposal.md
+++ b/openspec/changes/fix-sqlite-background-fd-leak/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+File-backed SQLite deployments can retain idle file descriptors when background
+refresh loops use SQLAlchemy's default async SQLite queue pool and keep
+`AsyncSession` objects open across upstream network I/O. Long-running usage,
+model-registry, and reset-credits refreshes can then accumulate open database,
+WAL, and socket descriptors until the host approaches file descriptor pressure.
+
+## What Changes
+
+- Use `NullPool` for file-backed SQLite main and background engines while
+  preserving `:memory:` handling and SQLite PRAGMAs.
+- Treat database pool size/overflow controls as pooled-backend controls; they do
+  not apply to file-backed SQLite engines.
+- Add a shared manual-session close helper that rolls back active transactions
+  and shields session close from cancellation.
+- Refactor usage, model-registry, and reset-credits refresh scheduling so
+  account/usage/settings reads happen in short sessions and upstream fetches run
+  after those sessions have closed.
+
+## Impact
+
+- **SQLite FD pressure**: file-backed SQLite no longer holds idle pooled DB/WAL
+  descriptors, and refresh loops no longer retain read sessions while waiting on
+  external APIs.
+- **PostgreSQL**: pool behavior and pool controls are unchanged.
+- **API compatibility**: no response schema or external API behavior changes.

--- a/openspec/changes/fix-sqlite-background-fd-leak/specs/database-backends/spec.md
+++ b/openspec/changes/fix-sqlite-background-fd-leak/specs/database-backends/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: File-backed SQLite engines do not retain idle pooled descriptors
+
+File-backed SQLite main and background async engines MUST use non-pooled connection semantics.
+
+SQLite `:memory:` databases MUST preserve the existing shared-engine behavior
+for background sessions so schema state remains visible to background tasks.
+
+Pool controls (`database_pool_size`, `database_max_overflow`,
+`database_background_pool_size`, `database_background_max_overflow`, and
+`database_pool_timeout_seconds`) SHALL constrain pooled backends only. They
+SHALL NOT be passed to file-backed SQLite engines.
+
+#### Scenario: File SQLite uses NullPool
+
+- **GIVEN** `database_url` resolves to a file-backed SQLite database
+- **WHEN** the application creates its main or background async engine
+- **THEN** the engine is configured with `NullPool`
+- **AND** `pool_size`, `max_overflow`, and `pool_timeout` are not passed
+- **AND** existing SQLite PRAGMAs and busy timeout behavior remain enabled
+
+#### Scenario: PostgreSQL pooling is unchanged
+
+- **GIVEN** `database_url` resolves to PostgreSQL
+- **WHEN** the application creates its main or background async engine
+- **THEN** PostgreSQL pool sizing, overflow, pre-ping, and recycle controls remain configured as before
+
+## MODIFIED Requirements
+
+### Requirement: Detached background tasks own their database session lifetime
+
+Detached background tasks MUST own database session lifetime independently from cancellable callers.
+
+A background task that is intentionally decoupled from its caller's lifetime
+(for example a singleflight refresh kept alive with `asyncio.shield` so
+concurrent waiters share one in-flight operation) MUST NOT perform database work
+through a session whose lifetime is owned by the cancellable caller. Such a task
+MUST acquire its own session (via `get_background_session()` or an equivalent
+caller-independent factory), use it, and release it entirely within the task.
+
+Background refresh schedulers MUST also avoid holding an `AsyncSession` while
+performing upstream network I/O. Usage refresh, model-registry refresh, and
+reset-credits refresh MUST perform account/usage/settings reads in short
+sessions, close those sessions, perform upstream fetches, and reacquire short
+sessions only for required database writes.
+
+#### Scenario: Client disconnect during token refresh does not strand a connection
+
+- **GIVEN** a proxy request triggers an account token refresh through `AuthManager.ensure_fresh`
+- **AND** the refresh runs as a detached singleflight task held alive by `asyncio.shield`
+- **AND** the request that initiated it is bound to a request-scoped background session
+- **WHEN** the client disconnects mid-refresh and the request task is cancelled
+- **THEN** the refresh task MUST complete its token/status writes against its own session, acquired independently of the cancelled request
+- **AND** the request-scoped session MUST close without being used by the refresh task after close
+- **AND** no background-pool connection is left checked out after the refresh task finishes
+
+#### Scenario: Non-cancellable callers without network I/O retain the bound-session path
+
+- **GIVEN** a caller whose session is not tied to a client-cancellable request
+- **AND** the caller does not hold that session across external network I/O
+- **AND** that caller invokes `AuthManager.ensure_fresh` without supplying a refresh session factory
+- **WHEN** a token refresh runs
+- **THEN** the refresh MAY use the caller's bound session
+- **AND** behavior is unchanged from before this requirement
+
+#### Scenario: Accumulated leak no longer exhausts the background pool
+
+- **GIVEN** repeated client disconnects during token refreshes over an extended period
+- **WHEN** each disconnect-during-refresh occurs
+- **THEN** each refresh task releases its connection back to the background pool
+- **AND** the background engine pool (`database_background_pool_size` + `database_background_max_overflow`) is not driven to exhaustion by stranded refresh connections
+- **AND** `/backend-api/codex/*` requests do not begin returning `500` from `QueuePool limit ... connection timed out` as a result of this path
+
+#### Scenario: Usage refresh fetch runs after the read session closes
+
+- **GIVEN** usage refresh selects an account from the database
+- **WHEN** it calls the upstream usage endpoint
+- **THEN** the session used to read latest usage, accounts, and settings has already closed
+- **AND** usage rows, account status changes, and warm-up attempt/log writes use separate short sessions
+
+#### Scenario: Model registry refresh fetch runs after the account read session closes
+
+- **GIVEN** model registry refresh reads active accounts from the database
+- **WHEN** it calls the upstream model discovery endpoint
+- **THEN** the account-list session has already closed
+- **AND** token refresh and route resolution use independent short sessions when database access is required
+
+#### Scenario: Reset-credits refresh fetch runs after the account read session closes
+
+- **GIVEN** reset-credits refresh reads accounts from the database
+- **WHEN** it calls the upstream reset-credits endpoint
+- **THEN** the account-list session has already closed
+- **AND** route resolution uses an independent short session when database access is required

--- a/openspec/changes/fix-sqlite-background-fd-leak/tasks.md
+++ b/openspec/changes/fix-sqlite-background-fd-leak/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+
+- [x] 1.1 Configure file-backed SQLite main/background async engines with `NullPool`.
+- [x] 1.2 Add a shared rollback + shielded close helper for manually-created sessions.
+- [x] 1.3 Replace manual session close paths with the shared helper.
+- [x] 1.4 Refactor usage, model-registry, and reset-credits background refreshes so upstream network I/O does not hold the account/usage read session.
+
+## 2. Tests
+
+- [x] 2.1 Cover SQLite file-engine kwargs and PostgreSQL pool-control preservation.
+- [x] 2.2 Cover rollback-before-close manual session cleanup.
+- [x] 2.3 Cover usage/model/reset-credits refresh session closure before upstream fetch.
+- [x] 2.4 Cover usage refresh cancellation closing the read session.
+
+## 3. Validation
+
+- [x] 3.1 Run focused unit tests.
+- [x] 3.2 Run ruff checks.
+- [x] 3.3 Validate OpenSpec specs.

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -16,8 +16,11 @@ from app.modules.accounts.repository import AccountsRepository
 from app.modules.usage.repository import (
     AdditionalUsageRepository,
     UsageRepository,
+    _additional_latest_by_account_sqlite,
     _bulk_history_since_sqlite,
     _clear_bulk_history_since_sqlite_cache,
+    _latest_by_account_sqlite,
+    _resolve_additional_quota_query_scope,
 )
 
 pytestmark = pytest.mark.integration
@@ -41,6 +44,30 @@ def _make_account(account_id: str) -> Account:
 def _dialect_name(session: AsyncSession) -> str:
     bind = session.get_bind()
     return bind.dialect.name if bind is not None else "sqlite"
+
+
+class _TrackedSqliteConnection:
+    def __init__(self, conn: sqlite3.Connection, closed: list[bool]) -> None:
+        self._conn = conn
+        self._closed = closed
+
+    def close(self) -> None:
+        self._closed.append(True)
+        self._conn.close()
+
+    def __getattr__(self, name: str):
+        return getattr(self._conn, name)
+
+
+def _track_sqlite_connect_close(monkeypatch):
+    closed: list[bool] = []
+    original_connect = sqlite3.connect
+
+    def connect(*args, **kwargs):
+        return _TrackedSqliteConnection(original_connect(*args, **kwargs), closed)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+    return closed
 
 
 @pytest.mark.asyncio
@@ -392,6 +419,123 @@ def test_bulk_history_since_sqlite_cache_reuses_superset_and_picks_up_appends(tm
     assert [row.id for row in second["acc1"]] == [2, 4]
     assert [row.id for row in second["acc2"]] == [3]
 
+    _clear_bulk_history_since_sqlite_cache()
+
+
+def test_latest_by_account_sqlite_closes_direct_connection(tmp_path, monkeypatch):
+    db_path = tmp_path / "usage.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("create table accounts (id text primary key)")
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                recorded_at text not null,
+                window text,
+                used_percent real not null,
+                input_tokens integer,
+                output_tokens integer,
+                reset_at integer,
+                window_minutes integer,
+                credits_has integer,
+                credits_unlimited integer,
+                credits_balance real
+            )
+            """
+        )
+        conn.execute("insert into accounts (id) values ('acc1')")
+        conn.execute(
+            """
+            insert into usage_history
+                (id, account_id, recorded_at, window, used_percent)
+            values (1, 'acc1', '2026-01-01 00:00:00', 'primary', 10.0)
+            """
+        )
+        conn.commit()
+
+    closed = _track_sqlite_connect_close(monkeypatch)
+
+    result = _latest_by_account_sqlite(str(db_path), "primary", None)
+
+    assert result["acc1"].used_percent == 10.0
+    assert closed == [True]
+
+
+def test_additional_latest_by_account_sqlite_closes_direct_connection(tmp_path, monkeypatch):
+    db_path = tmp_path / "usage.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table additional_usage_history (
+                id integer primary key,
+                account_id text not null,
+                quota_key text not null,
+                limit_name text not null,
+                metered_feature text not null,
+                window text not null,
+                used_percent real not null,
+                reset_at integer,
+                window_minutes integer,
+                recorded_at text not null
+            )
+            """
+        )
+        conn.execute(
+            """
+            insert into additional_usage_history
+                (id, account_id, quota_key, limit_name, metered_feature, window, used_percent, recorded_at)
+            values (1, 'acc1', 'codex_spark', 'Codex Spark', 'codex_spark', 'primary', 20.0,
+                    '2026-01-01 00:00:00')
+            """
+        )
+        conn.commit()
+    scope = _resolve_additional_quota_query_scope(quota_key="codex_spark")
+    assert scope is not None
+    closed = _track_sqlite_connect_close(monkeypatch)
+
+    result = _additional_latest_by_account_sqlite(str(db_path), scope, "primary", None, None)
+
+    assert result["acc1"].used_percent == 20.0
+    assert closed == [True]
+
+
+def test_bulk_history_since_sqlite_closes_direct_connection(tmp_path, monkeypatch):
+    db_path = tmp_path / "usage.db"
+    _clear_bulk_history_since_sqlite_cache()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                used_percent real not null,
+                recorded_at text not null,
+                reset_at real,
+                window_minutes integer,
+                window text
+            )
+            """
+        )
+        conn.execute(
+            """
+            insert into usage_history
+                (id, account_id, used_percent, recorded_at, reset_at, window_minutes, window)
+            values (1, 'acc1', 30.0, '2026-01-01 00:00:00', 1000.0, 10080, 'secondary')
+            """
+        )
+        conn.commit()
+    closed = _track_sqlite_connect_close(monkeypatch)
+
+    result = _bulk_history_since_sqlite(
+        str(db_path),
+        ["acc1"],
+        "secondary",
+        datetime(2026, 1, 1, 0, 0, 0),
+    )
+
+    assert [row.id for row in result["acc1"]] == [1]
+    assert closed == [True]
     _clear_bulk_history_since_sqlite_cache()
 
 

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -6,13 +6,16 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
 import app.db.session as session_module
+from app.db.models import Account, AccountStatus, Base
 from app.db.sqlite_utils import IntegrityCheck, SqliteIntegrityCheckMode
 
 
@@ -242,6 +245,108 @@ def test_postgres_engine_kwargs_use_nullpool_under_test_db_url(monkeypatch) -> N
     assert kwargs["poolclass"] is NullPool
     assert "pool_pre_ping" not in kwargs
     assert "pool_recycle" not in kwargs
+
+
+def test_sqlite_file_engine_kwargs_use_nullpool_without_pool_controls(monkeypatch) -> None:
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url="sqlite+aiosqlite:///store.db",
+            database_pool_size=15,
+            database_max_overflow=10,
+            database_pool_timeout_seconds=30.0,
+        ),
+    )
+
+    kwargs = session_module._sqlite_file_async_engine_kwargs()
+
+    assert kwargs["poolclass"] is NullPool
+    assert kwargs["connect_args"] == {"timeout": 30.0}
+    assert "pool_size" not in kwargs
+    assert "max_overflow" not in kwargs
+    assert "pool_timeout" not in kwargs
+
+
+def test_postgres_engine_kwargs_keep_pool_controls(monkeypatch) -> None:
+    monkeypatch.delenv("CODEX_LB_TEST_DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url="postgresql+asyncpg://u:p@h/db",
+            database_pool_size=12,
+            database_max_overflow=4,
+            database_pool_timeout_seconds=11.0,
+            database_pool_recycle_seconds=900,
+        ),
+    )
+
+    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db", background=False)
+
+    assert kwargs["pool_pre_ping"] is True
+    assert kwargs["pool_recycle"] == 900
+    assert kwargs["pool_size"] == 12
+    assert kwargs["max_overflow"] == 4
+    assert kwargs["pool_timeout"] == 11.0
+
+
+@pytest.mark.asyncio
+async def test_close_session_rolls_back_open_transaction_before_close() -> None:
+    calls: list[str] = []
+
+    class _Session:
+        def in_transaction(self) -> bool:
+            return True
+
+        async def rollback(self) -> None:
+            calls.append("rollback")
+
+        async def close(self) -> None:
+            calls.append("close")
+
+    await session_module.close_session(cast(Any, _Session()))
+
+    assert calls == ["rollback", "close"]
+
+
+@pytest.mark.asyncio
+async def test_detach_session_objects_keeps_loaded_fields_available_after_rollback() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        async with session_factory() as session:
+            session.add(
+                Account(
+                    id="acc_detached",
+                    chatgpt_account_id="workspace-detached",
+                    email="detached@example.com",
+                    plan_type="plus",
+                    access_token_encrypted=b"access",
+                    refresh_token_encrypted=b"refresh",
+                    id_token_encrypted=b"id",
+                    last_refresh=datetime(2026, 1, 1),
+                    status=AccountStatus.ACTIVE,
+                )
+            )
+            await session.commit()
+
+        async with session_factory() as session:
+            account = await session.get(Account, "acc_detached")
+            assert account is not None
+            assert account.status == AccountStatus.ACTIVE
+            session_module.detach_session_objects(session)
+            await session.rollback()
+
+        assert account.id == "acc_detached"
+        assert account.status == AccountStatus.ACTIVE
+        assert account.chatgpt_account_id == "workspace-detached"
+        assert account.access_token_encrypted == b"access"
+    finally:
+        await engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_model_refresh_scheduler.py
+++ b/tests/unit/test_model_refresh_scheduler.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 from datetime import datetime
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -350,3 +351,70 @@ async def test_fetch_with_failover_does_not_warn_after_successful_auth_retry(
     assert result.account_models == {account.id: (account.plan_type, expected_models)}
     assert fetch_models_for_plan.await_count == 2
     assert "Model fetch failed" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_refresh_once_closes_account_read_session_before_fetch_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _account()
+    session_closed = False
+
+    class _Leader:
+        async def try_acquire(self) -> bool:
+            return True
+
+    class _Session:
+        def expunge_all(self) -> None:
+            return None
+
+    @contextlib.asynccontextmanager
+    async def _background_session():
+        nonlocal session_closed
+        session_closed = False
+        try:
+            yield _Session()
+        finally:
+            session_closed = True
+
+    class _AccountsRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def list_accounts(self) -> list[Account]:
+            return [account]
+
+    class _AuthManager:
+        def __init__(self, _repo: object) -> None:
+            pass
+
+        async def ensure_fresh(self, account: Account, *, force: bool = False) -> Account:
+            return account
+
+    class _Registry:
+        async def update(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        def get_snapshot(self) -> SimpleNamespace:
+            return SimpleNamespace(models={"gpt-5.4": object()})
+
+    async def _fetch_models_for_plan(access_token: str, account_id: str | None, **kwargs: Any) -> list[UpstreamModel]:
+        assert session_closed is True
+        return [_model("gpt-5.4")]
+
+    monkeypatch.setattr(scheduler_module, "_get_leader_election", lambda: _Leader())
+    monkeypatch.setattr(scheduler_module, "get_background_session", _background_session)
+    monkeypatch.setattr(scheduler_module, "AccountsRepository", _AccountsRepo)
+    monkeypatch.setattr(scheduler_module, "AuthManager", _AuthManager)
+    monkeypatch.setattr(scheduler_module, "fetch_models_for_plan", _fetch_models_for_plan)
+    monkeypatch.setattr(scheduler_module, "get_model_registry", lambda: _Registry())
+    monkeypatch.setattr(
+        scheduler_module,
+        "get_account_selection_cache",
+        lambda: SimpleNamespace(invalidate=lambda: None),
+    )
+    monkeypatch.setattr(scheduler_module, "TokenEncryptor", lambda: SimpleNamespace(decrypt=lambda _value: "access"))
+    monkeypatch.setattr(scheduler_module, "_resolve_upstream_route_for_account", AsyncMock(return_value=None))
+
+    scheduler = scheduler_module.ModelRefreshScheduler(interval_seconds=60, enabled=True)
+    await scheduler._refresh_once()

--- a/tests/unit/test_rate_limit_reset_credits_scheduler.py
+++ b/tests/unit/test_rate_limit_reset_credits_scheduler.py
@@ -316,6 +316,9 @@ async def test_refresh_once_caches_snapshots_on_each_replica(monkeypatch: pytest
         async def __aexit__(self, exc_type, exc, tb) -> None:
             return None
 
+        def expunge_all(self) -> None:
+            captured.append("expunge_all")
+
     @asynccontextmanager
     async def _fake_background_session():
         captured.append("session_opened")
@@ -340,3 +343,44 @@ async def test_refresh_once_caches_snapshots_on_each_replica(monkeypatch: pytest
     assert snapshot is not None
     assert snapshot.available_count == 7
     assert account.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_refresh_once_closes_account_read_session_before_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    account = _make_account("acc_session")
+    store = RateLimitResetCreditsStore()
+    session_closed = False
+
+    class _FakeRepo:
+        async def list_accounts(self) -> list[Account]:
+            return [account]
+
+    class _FakeSession:
+        def expunge_all(self) -> None:
+            return None
+
+    @asynccontextmanager
+    async def _fake_background_session():
+        nonlocal session_closed
+        session_closed = False
+        try:
+            yield _FakeSession()
+        finally:
+            session_closed = True
+
+    async def fetch_fn(access_token: str, account_id: str | None, **kwargs: Any) -> ResetCreditsResponse:
+        assert session_closed is True
+        return _response(available_count=8)
+
+    monkeypatch.setattr(scheduler_module, "get_background_session", _fake_background_session)
+    monkeypatch.setattr(scheduler_module, "AccountsRepository", lambda session: _FakeRepo())
+    monkeypatch.setattr(scheduler_module, "TokenEncryptor", lambda: StubEncryptor())
+    monkeypatch.setattr(scheduler_module, "get_rate_limit_reset_credits_store", lambda: store)
+    monkeypatch.setattr(scheduler_module, "fetch_reset_credits", fetch_fn)
+
+    scheduler = RateLimitResetCreditsRefreshScheduler(interval_seconds=60)
+    await scheduler._refresh_once()
+
+    snapshot = store.get(account.id)
+    assert snapshot is not None
+    assert snapshot.available_count == 8

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, cast
 
@@ -718,3 +720,122 @@ async def test_reconcile_recoverable_account_statuses_keeps_rate_limited_when_re
     assert account.status == AccountStatus.RATE_LIMITED
     assert account.reset_at == past_reset
     assert account.blocked_at == blocked_at
+
+
+@pytest.mark.asyncio
+async def test_refresh_once_closes_read_session_before_usage_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    account = _make_account("acc_scheduler", status=AccountStatus.ACTIVE)
+    session_closed = False
+    fetch_started = asyncio.Event()
+    release_fetch = asyncio.Event()
+
+    class _Leader:
+        async def try_acquire(self) -> bool:
+            return True
+
+    class _UsageRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+            return {}
+
+    class _AccountsRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def list_accounts(self, *, refresh_existing: bool = False) -> list[Account]:
+            return [account]
+
+    class _Updater:
+        async def refresh_accounts(
+            self,
+            accounts: list[Account],
+            latest_usage: dict[str, UsageHistory],
+        ) -> bool:
+            assert accounts == [account]
+            assert latest_usage == {}
+            assert session_closed is True
+            fetch_started.set()
+            await release_fetch.wait()
+            return False
+
+    class _Session:
+        def expunge_all(self) -> None:
+            return None
+
+    @asynccontextmanager
+    async def _background_session():
+        nonlocal session_closed
+        session_closed = False
+        try:
+            yield _Session()
+        finally:
+            session_closed = True
+
+    monkeypatch.setattr(refresh_scheduler_module, "_get_leader_election", lambda: _Leader())
+    monkeypatch.setattr(refresh_scheduler_module, "get_background_session", _background_session)
+    monkeypatch.setattr(refresh_scheduler_module, "UsageRepository", _UsageRepo)
+    monkeypatch.setattr(refresh_scheduler_module, "AccountsRepository", _AccountsRepo)
+    monkeypatch.setattr(refresh_scheduler_module, "build_background_usage_updater", lambda: _Updater())
+
+    scheduler = refresh_scheduler_module.UsageRefreshScheduler(interval_seconds=60, enabled=True)
+    refresh_task = asyncio.create_task(scheduler._refresh_once())
+    await fetch_started.wait()
+
+    assert session_closed is True
+    release_fetch.set()
+    assert await refresh_task == 60.0
+
+
+@pytest.mark.asyncio
+async def test_refresh_once_cancellation_closes_read_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_closed = asyncio.Event()
+    listed_accounts = asyncio.Event()
+    release_list_accounts = asyncio.Event()
+
+    class _Leader:
+        async def try_acquire(self) -> bool:
+            return True
+
+    class _UsageRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+            return {}
+
+    class _AccountsRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def list_accounts(self, *, refresh_existing: bool = False) -> list[Account]:
+            listed_accounts.set()
+            await release_list_accounts.wait()
+            return []
+
+    class _Session:
+        def expunge_all(self) -> None:
+            return None
+
+    @asynccontextmanager
+    async def _background_session():
+        try:
+            yield _Session()
+        finally:
+            session_closed.set()
+
+    monkeypatch.setattr(refresh_scheduler_module, "_get_leader_election", lambda: _Leader())
+    monkeypatch.setattr(refresh_scheduler_module, "get_background_session", _background_session)
+    monkeypatch.setattr(refresh_scheduler_module, "UsageRepository", _UsageRepo)
+    monkeypatch.setattr(refresh_scheduler_module, "AccountsRepository", _AccountsRepo)
+
+    scheduler = refresh_scheduler_module.UsageRefreshScheduler(interval_seconds=60, enabled=True)
+    task = asyncio.create_task(scheduler._refresh_once())
+    await listed_accounts.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await asyncio.wait_for(session_closed.wait(), timeout=1)


### PR DESCRIPTION
## Summary

Fixes SQLite file descriptor retention in file-backed SQLite deployments by disabling pooled SQLite file connections and shortening DB session lifetimes in background refresh paths. This targets the observed FD pressure path where long-running usage/model/reset-credits refresh work can keep database resources alive while waiting on upstream network I/O.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: Related to #1063. Also adjacent to the closed QueuePool exhaustion report in #672. This PR avoids using auto-close keywords because #1063 may include environment-specific database access failures beyond FD retention.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-sqlite-background-fd-leak/`

## Changes

- Configure file-backed SQLite main/background async engines with `NullPool`, while preserving existing PostgreSQL pooling and SQLite `:memory:` behavior.
- Add a shared rollback + shielded `close_session()` helper for manual `AsyncSession` close paths.
- Refactor usage refresh so account/usage/settings reads happen in short sessions, upstream usage fetch runs after those sessions close, and writes/warm-up/logging use independent short sessions.
- Refactor model registry refresh so model fetch/token refresh no longer holds the account-list read session.
- Refactor reset-credits refresh so upstream reset-credit fetch no longer holds the account-list read session.
- Add background repository wrappers for short-session account and usage writes.
- Explicitly close raw SQLite fast-path connections in the usage repository.
- Add regression coverage for SQLite engine kwargs, PostgreSQL pool preservation, manual session close cleanup, background scheduler session boundaries, cancellation cleanup, and raw SQLite connection close behavior.

## Runtime evidence

Two local runtime observations pointed at descriptor retention in the background refresh paths, not normal request concurrency:

- Before mitigation, Prometheus/Grafana showed `node_sockstat_sockets_used` increasing monotonically over several days, reaching approximately 1.29M active socket descriptors while real-time TCP connections stayed low.
- After deploying an earlier partial mitigation (file-backed SQLite `NullPool` plus manual session close cleanup only), `codex-lb` still grew to `fd_total=7236` after 3h52m: `store.db=4825`, `store.db-wal=2392`, and sockets only 7. Disabling `CODEX_LB_MODEL_REGISTRY_ENABLED` and `CODEX_LB_USAGE_REFRESH_ENABLED` then stabilized FD usage at 16-24 within a 5-minute observation window, with SQLite DB/WAL descriptors returning to 0-4.

That isolated the remaining leak surface to background refresh work holding or repeatedly creating SQLite resources. After deploying this branch locally, the process smoke check showed no retained `store.db`, `store.db-wal`, or `store.db-shm` descriptors after health/API probes.

## Rationale

SQLAlchemy documents that file-based SQLite uses a queue pool for async SQLite in recent 2.x releases, and `NullPool` is the documented non-retaining pool implementation. Python's `sqlite3.Connection` context manager handles transaction commit/rollback but does not close the connection, so raw SQLite fast paths also need explicit close semantics.

References:

- https://docs.sqlalchemy.org/en/latest/changelog/whatsnew_20.html#the-sqlite-dialect-uses-queuepool-for-file-based-databases
- https://docs.sqlalchemy.org/en/latest/core/pooling.html#sqlalchemy.pool.NullPool
- https://docs.sqlalchemy.org/en/latest/orm/session_basics.html#closing
- https://docs.python.org/3/library/sqlite3.html#how-to-use-the-connection-context-manager

## Test plan

```bash
PATH="$PWD/.venv/bin:$PATH" make lint
uv run ty check
uv run pytest tests/integration/test_usage_repository.py tests/unit/test_additional_usage_repo.py tests/unit/test_db_session.py tests/unit/test_usage_refresh_scheduler_recovery.py tests/unit/test_model_refresh_scheduler.py tests/unit/test_rate_limit_reset_credits_scheduler.py
openspec validate --specs
openspec validate fix-sqlite-background-fd-leak --strict
git diff --check
```

Results:

- `make lint`: passed, including architecture check, ruff check, and ruff format check.
- `uv run ty check`: passed.
- Focused pytest: `111 passed, 1 skipped`.
- `openspec validate --specs`: `30 passed, 0 failed`.
- `openspec validate fix-sqlite-background-fd-leak --strict`: passed.
- `git diff --check`: passed.

## Screenshots / output (optional)

Local file-backed SQLite runtime smoke after deploying this branch showed the service healthy and no retained DB/WAL/SHM descriptors in the running process:

- `/health/ready`: `database=ok`
- `fd_total=19`
- `socket=8`
- `store.db=0`
- `store.db-wal=0`
- `store.db-shm=0`

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).


