### PR TITLE
feat(fleet): add refresh endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -51,6 +51,7 @@ from app.modules.conversation_archive import api as conversation_archive_api
 from app.modules.dashboard import api as dashboard_api
 from app.modules.dashboard_auth import api as dashboard_auth_api
 from app.modules.firewall import api as firewall_api
+from app.modules.fleet import api as fleet_api
 from app.modules.health import api as health_api
 from app.modules.oauth import api as oauth_api
 from app.modules.proxy import api as proxy_api
@@ -404,6 +405,7 @@ def create_app() -> FastAPI:
     app.include_router(dashboard_auth_api.router)
     app.include_router(settings_api.router)
     app.include_router(firewall_api.router)
+    app.include_router(fleet_api.router)
     app.include_router(sticky_sessions_api.router)
     app.include_router(api_keys_api.router)
     app.include_router(health_api.router)

--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -369,8 +369,14 @@ def _chatgpt_account_id_from_id_token(id_token: str) -> str | None:
     return auth_claims.chatgpt_account_id or claims.chatgpt_account_id
 
 
-def _refresh_singleflight_key(encryptor: TokenEncryptor, account: Account) -> _RefreshSingleflightKey:
-    return (account.id, _refresh_token_material_fingerprint(encryptor, account.refresh_token_encrypted))
+def _refresh_singleflight_key(
+    encryptor: TokenEncryptor,
+    account: Account,
+) -> _RefreshSingleflightKey:
+    return (
+        account.id,
+        _refresh_token_material_fingerprint(encryptor, account.refresh_token_encrypted),
+    )
 
 
 def _refresh_token_material_changed(

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -68,6 +68,15 @@ class AccountsRepository:
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
+    async def list_accounts_by_ids(self, account_ids: list[str], *, refresh_existing: bool = False) -> list[Account]:
+        if not account_ids:
+            return []
+        stmt = select(Account).where(Account.id.in_(account_ids)).order_by(Account.email)
+        if refresh_existing:
+            stmt = stmt.execution_options(populate_existing=True)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
     async def list_request_usage_summary_by_account(
         self,
         account_ids: list[str] | None = None,

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -128,18 +128,35 @@ class AccountsService:
         self._encryptor = TokenEncryptor()
         self._auth_manager = auth_manager
 
-    async def list_accounts(self) -> list[AccountSummary]:
-        accounts = await self._repo.list_accounts()
+    async def list_accounts(self, *, account_ids: list[str] | None = None) -> list[AccountSummary]:
+        accounts = (
+            await self._repo.list_accounts_by_ids(account_ids)
+            if account_ids is not None
+            else await self._repo.list_accounts()
+        )
         if not accounts:
             return []
-        account_ids = [account.id for account in accounts]
-        account_id_set = set(account_ids)
-        primary_usage = await self._usage_repo.latest_by_account(window="primary") if self._usage_repo else {}
-        secondary_usage = await self._usage_repo.latest_by_account(window="secondary") if self._usage_repo else {}
-        monthly_usage = await self._usage_repo.latest_by_account(window="monthly") if self._usage_repo else {}
-        request_usage_rows = await self._repo.list_request_usage_summary_by_account(account_ids)
+        visible_account_ids = [account.id for account in accounts]
+        account_id_set = set(visible_account_ids)
+        usage_account_ids = visible_account_ids if account_ids is not None else None
+        primary_usage = (
+            await self._usage_repo.latest_by_account(window="primary", account_ids=usage_account_ids)
+            if self._usage_repo
+            else {}
+        )
+        secondary_usage = (
+            await self._usage_repo.latest_by_account(window="secondary", account_ids=usage_account_ids)
+            if self._usage_repo
+            else {}
+        )
+        monthly_usage = (
+            await self._usage_repo.latest_by_account(window="monthly", account_ids=usage_account_ids)
+            if self._usage_repo
+            else {}
+        )
+        request_usage_rows = await self._repo.list_request_usage_summary_by_account(visible_account_ids)
         limit_warmups_by_account = (
-            await self._limit_warmup_repo.latest_by_account(account_ids) if self._limit_warmup_repo else {}
+            await self._limit_warmup_repo.latest_by_account(visible_account_ids) if self._limit_warmup_repo else {}
         )
         request_usage_by_account = {
             account_id: AccountRequestUsage(
@@ -154,10 +171,18 @@ class AccountsService:
         additional_usage_repo = cast(AdditionalUsageRepository | None, self._additional_usage_repo)
         if additional_usage_repo:
             additional_quota_routing_overrides = await self._repo.additional_quota_routing_policy_overrides()
-            quota_keys = await additional_usage_repo.list_quota_keys(account_ids=account_ids)
+            quota_keys = await additional_usage_repo.list_quota_keys(account_ids=visible_account_ids)
             for quota_key in quota_keys:
-                primary_entries = await additional_usage_repo.latest_by_account(quota_key, "primary")
-                secondary_entries = await additional_usage_repo.latest_by_account(quota_key, "secondary")
+                primary_entries = await additional_usage_repo.latest_by_account(
+                    quota_key,
+                    "primary",
+                    account_ids=visible_account_ids,
+                )
+                secondary_entries = await additional_usage_repo.latest_by_account(
+                    quota_key,
+                    "secondary",
+                    account_ids=visible_account_ids,
+                )
                 for account_id in (set(primary_entries) | set(secondary_entries)) & account_id_set:
                     primary_entry = primary_entries.get(account_id)
                     secondary_entry = secondary_entries.get(account_id)

--- a/app/modules/fleet/__init__.py
+++ b/app/modules/fleet/__init__.py
@@ -1,0 +1,1 @@
+"""Fleet summary endpoints for external local dashboards."""

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -30,6 +30,7 @@ router = APIRouter(
 )
 
 _REFRESH_SKIP_STATUSES = {AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED}
+_BACKGROUND_REFRESH_TASKS: set[asyncio.Task[FleetRefreshResponse]] = set()
 
 
 def _visible_account_ids(api_key: ApiKeyData) -> list[str] | None:
@@ -104,7 +105,8 @@ async def refresh_fleet_usage(
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError:
-        task.add_done_callback(_log_cancelled_refresh_task_exception)
+        _BACKGROUND_REFRESH_TASKS.add(task)
+        task.add_done_callback(_handle_cancelled_refresh_task_done)
         raise
 
 
@@ -134,6 +136,13 @@ async def _refresh_fleet_usage_with_owned_session(visible_account_ids: list[str]
             attempted_count=len(eligible_accounts),
             generated_at=utcnow(),
         )
+
+
+def _handle_cancelled_refresh_task_done(task: asyncio.Task[FleetRefreshResponse]) -> None:
+    try:
+        _log_cancelled_refresh_task_exception(task)
+    finally:
+        _BACKGROUND_REFRESH_TASKS.discard(task)
 
 
 def _log_cancelled_refresh_task_exception(task: asyncio.Task[FleetRefreshResponse]) -> None:

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Security
 
 from app.core.auth.dependencies import set_dashboard_error_format, validate_usage_api_key
+from app.core.config.settings_cache import get_settings_cache
 from app.core.utils.time import utcnow
 from app.db.models import AccountStatus
 from app.db.session import get_background_session
@@ -29,6 +30,19 @@ def _visible_account_ids(api_key: ApiKeyData) -> list[str] | None:
     return list(api_key.assigned_account_ids) if api_key.account_assignment_scope_enabled else None
 
 
+def _usage_sections(raw: str) -> set[str]:
+    if not raw or not raw.strip():
+        return set()
+    return {section.strip() for section in raw.split(",") if section.strip()}
+
+
+async def _can_view_fleet_usage(api_key: ApiKeyData) -> bool:
+    if "account_pool_usage" not in _usage_sections(api_key.usage_sections):
+        return False
+    settings = await get_settings_cache().get()
+    return not bool(getattr(settings, "hide_upstream_quota_from_api_keys", False))
+
+
 @router.get("/summary", response_model=FleetSummaryResponse)
 async def get_fleet_summary(
     context: AccountsContext = Depends(get_accounts_context),
@@ -37,7 +51,9 @@ async def get_fleet_summary(
     """Read-only, minimal per-account capacity summary for fleet consumers."""
 
     accounts = await context.service.list_accounts(account_ids=_visible_account_ids(api_key))
-    return FleetSummaryResponse(accounts=build_fleet_account_summaries(accounts))
+    return FleetSummaryResponse(
+        accounts=build_fleet_account_summaries(accounts, include_usage=await _can_view_fleet_usage(api_key))
+    )
 
 
 @router.post("/refresh", response_model=FleetRefreshResponse)

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -14,7 +14,8 @@ from app.dependencies import AccountsContext, get_accounts_context
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.service import ApiKeyData
 from app.modules.fleet.mappers import build_fleet_account_summaries
-from app.modules.fleet.schemas import FleetRefreshResponse, FleetSummaryResponse
+from app.modules.fleet.observability import build_fleet_observability
+from app.modules.fleet.schemas import FleetObservabilityResponse, FleetRefreshResponse, FleetSummaryResponse
 from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
@@ -72,6 +73,20 @@ async def get_fleet_summary(
             include_usage=include_usage,
             persisted_status_by_account_id=persisted_status_by_account_id,
         )
+    )
+
+
+@router.get("/observability", response_model=FleetObservabilityResponse)
+async def get_fleet_observability(
+    context: AccountsContext = Depends(get_accounts_context),
+    api_key: ApiKeyData = Security(validate_usage_api_key),
+) -> FleetObservabilityResponse:
+    """Read-only pressure and sticky-session summary for fleet consumers."""
+
+    return await build_fleet_observability(
+        context.session,
+        visible_account_ids=_visible_account_ids(api_key),
+        include_usage=await _can_view_fleet_usage(api_key),
     )
 
 

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -5,7 +5,10 @@ from fastapi import APIRouter, Depends, Security
 from app.core.auth.dependencies import set_dashboard_error_format, validate_usage_api_key
 from app.core.utils.time import utcnow
 from app.db.models import AccountStatus
+from app.db.session import get_background_session
 from app.dependencies import AccountsContext, get_accounts_context
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.api_keys.service import ApiKeyData
 from app.modules.fleet.mappers import build_fleet_account_summaries
 from app.modules.fleet.schemas import FleetRefreshResponse, FleetSummaryResponse
 from app.modules.proxy.account_cache import get_account_selection_cache
@@ -16,38 +19,50 @@ from app.modules.usage.updater import UsageUpdater
 router = APIRouter(
     prefix="/api/fleet",
     tags=["fleet"],
-    dependencies=[Security(validate_usage_api_key), Depends(set_dashboard_error_format)],
+    dependencies=[Depends(set_dashboard_error_format)],
 )
 
 _REFRESH_SKIP_STATUSES = {AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED}
 
 
+def _visible_account_ids(api_key: ApiKeyData) -> list[str] | None:
+    return list(api_key.assigned_account_ids) if api_key.account_assignment_scope_enabled else None
+
+
 @router.get("/summary", response_model=FleetSummaryResponse)
 async def get_fleet_summary(
     context: AccountsContext = Depends(get_accounts_context),
+    api_key: ApiKeyData = Security(validate_usage_api_key),
 ) -> FleetSummaryResponse:
     """Read-only, minimal per-account capacity summary for fleet consumers."""
 
-    accounts = await context.service.list_accounts()
+    accounts = await context.service.list_accounts(account_ids=_visible_account_ids(api_key))
     return FleetSummaryResponse(accounts=build_fleet_account_summaries(accounts))
 
 
 @router.post("/refresh", response_model=FleetRefreshResponse)
 async def refresh_fleet_usage(
-    context: AccountsContext = Depends(get_accounts_context),
+    api_key: ApiKeyData = Security(validate_usage_api_key),
 ) -> FleetRefreshResponse:
     """Request a bounded usage refresh using codex-lb's normal refresh rules."""
 
-    usage_repo = UsageRepository(context.session)
-    additional_usage_repo = AdditionalUsageRepository(context.session)
-    accounts = await context.repository.list_accounts(refresh_existing=True)
-    eligible_accounts = [account for account in accounts if account.status not in _REFRESH_SKIP_STATUSES]
-    latest_primary = await usage_repo.latest_by_account(window="primary")
-    usage_written = await UsageUpdater(
-        usage_repo,
-        context.repository,
-        additional_usage_repo,
-    ).refresh_accounts(eligible_accounts, latest_primary)
+    visible_account_ids = _visible_account_ids(api_key)
+    async with get_background_session() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        additional_usage_repo = AdditionalUsageRepository(session)
+        accounts = (
+            await accounts_repo.list_accounts_by_ids(visible_account_ids, refresh_existing=True)
+            if visible_account_ids is not None
+            else await accounts_repo.list_accounts(refresh_existing=True)
+        )
+        eligible_accounts = [account for account in accounts if account.status not in _REFRESH_SKIP_STATUSES]
+        latest_primary = await usage_repo.latest_by_account(window="primary", account_ids=visible_account_ids)
+        usage_written = await UsageUpdater(
+            usage_repo,
+            accounts_repo,
+            additional_usage_repo,
+        ).refresh_accounts(eligible_accounts, latest_primary)
     if usage_written:
         await get_rate_limit_headers_cache().invalidate()
         get_account_selection_cache().invalidate()

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -55,9 +55,23 @@ async def get_fleet_summary(
 ) -> FleetSummaryResponse:
     """Read-only, minimal per-account capacity summary for fleet consumers."""
 
-    accounts = await context.service.list_accounts(account_ids=_visible_account_ids(api_key))
+    visible_account_ids = _visible_account_ids(api_key)
+    include_usage = await _can_view_fleet_usage(api_key)
+    accounts = await context.service.list_accounts(account_ids=visible_account_ids)
+    persisted_status_by_account_id: dict[str, str] | None = None
+    if not include_usage:
+        persisted_accounts = (
+            await context.repository.list_accounts_by_ids(visible_account_ids, refresh_existing=True)
+            if visible_account_ids is not None
+            else await context.repository.list_accounts(refresh_existing=True)
+        )
+        persisted_status_by_account_id = {account.id: account.status.value for account in persisted_accounts}
     return FleetSummaryResponse(
-        accounts=build_fleet_account_summaries(accounts, include_usage=await _can_view_fleet_usage(api_key))
+        accounts=build_fleet_account_summaries(
+            accounts,
+            include_usage=include_usage,
+            persisted_status_by_account_id=persisted_status_by_account_id,
+        )
     )
 
 
@@ -94,7 +108,7 @@ async def _refresh_fleet_usage_with_owned_session(visible_account_ids: list[str]
             usage_repo,
             accounts_repo,
             additional_usage_repo,
-        ).refresh_accounts(eligible_accounts, latest_primary)
+        ).refresh_accounts(eligible_accounts, latest_primary, own_singleflight_sessions=True)
         if usage_written:
             await get_rate_limit_headers_cache().invalidate()
             get_account_selection_cache().invalidate()

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Security
+
+from app.core.auth.dependencies import set_dashboard_error_format, validate_usage_api_key
+from app.core.utils.time import utcnow
+from app.db.models import AccountStatus
+from app.dependencies import AccountsContext, get_accounts_context
+from app.modules.fleet.mappers import build_fleet_account_summaries
+from app.modules.fleet.schemas import FleetRefreshResponse, FleetSummaryResponse
+from app.modules.proxy.account_cache import get_account_selection_cache
+from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
+from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+from app.modules.usage.updater import UsageUpdater
+
+router = APIRouter(
+    prefix="/api/fleet",
+    tags=["fleet"],
+    dependencies=[Security(validate_usage_api_key), Depends(set_dashboard_error_format)],
+)
+
+_REFRESH_SKIP_STATUSES = {AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED}
+
+
+@router.get("/summary", response_model=FleetSummaryResponse)
+async def get_fleet_summary(
+    context: AccountsContext = Depends(get_accounts_context),
+) -> FleetSummaryResponse:
+    """Read-only, minimal per-account capacity summary for fleet consumers."""
+
+    accounts = await context.service.list_accounts()
+    return FleetSummaryResponse(accounts=build_fleet_account_summaries(accounts))
+
+
+@router.post("/refresh", response_model=FleetRefreshResponse)
+async def refresh_fleet_usage(
+    context: AccountsContext = Depends(get_accounts_context),
+) -> FleetRefreshResponse:
+    """Request a bounded usage refresh using codex-lb's normal refresh rules."""
+
+    usage_repo = UsageRepository(context.session)
+    additional_usage_repo = AdditionalUsageRepository(context.session)
+    accounts = await context.repository.list_accounts(refresh_existing=True)
+    eligible_accounts = [account for account in accounts if account.status not in _REFRESH_SKIP_STATUSES]
+    latest_primary = await usage_repo.latest_by_account(window="primary")
+    usage_written = await UsageUpdater(
+        usage_repo,
+        context.repository,
+        additional_usage_repo,
+    ).refresh_accounts(eligible_accounts, latest_primary)
+    if usage_written:
+        await get_rate_limit_headers_cache().invalidate()
+        get_account_selection_cache().invalidate()
+    return FleetRefreshResponse(
+        usage_written=usage_written,
+        account_count=len(accounts),
+        attempted_count=len(eligible_accounts),
+        generated_at=utcnow(),
+    )

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+
 from fastapi import APIRouter, Depends, Security
 
 from app.core.auth.dependencies import set_dashboard_error_format, validate_usage_api_key
@@ -16,6 +19,8 @@ from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 from app.modules.usage.updater import UsageUpdater
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/api/fleet",
@@ -62,7 +67,18 @@ async def refresh_fleet_usage(
 ) -> FleetRefreshResponse:
     """Request a bounded usage refresh using codex-lb's normal refresh rules."""
 
-    visible_account_ids = _visible_account_ids(api_key)
+    task = asyncio.create_task(
+        _refresh_fleet_usage_with_owned_session(_visible_account_ids(api_key)),
+        name="fleet-usage-refresh",
+    )
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.add_done_callback(_log_cancelled_refresh_task_exception)
+        raise
+
+
+async def _refresh_fleet_usage_with_owned_session(visible_account_ids: list[str] | None) -> FleetRefreshResponse:
     async with get_background_session() as session:
         accounts_repo = AccountsRepository(session)
         usage_repo = UsageRepository(session)
@@ -79,12 +95,26 @@ async def refresh_fleet_usage(
             accounts_repo,
             additional_usage_repo,
         ).refresh_accounts(eligible_accounts, latest_primary)
-    if usage_written:
-        await get_rate_limit_headers_cache().invalidate()
-        get_account_selection_cache().invalidate()
-    return FleetRefreshResponse(
-        usage_written=usage_written,
-        account_count=len(accounts),
-        attempted_count=len(eligible_accounts),
-        generated_at=utcnow(),
-    )
+        if usage_written:
+            await get_rate_limit_headers_cache().invalidate()
+            get_account_selection_cache().invalidate()
+        return FleetRefreshResponse(
+            usage_written=usage_written,
+            account_count=len(accounts),
+            attempted_count=len(eligible_accounts),
+            generated_at=utcnow(),
+        )
+
+
+def _log_cancelled_refresh_task_exception(task: asyncio.Task[FleetRefreshResponse]) -> None:
+    if task.cancelled():
+        return
+    try:
+        exc = task.exception()
+    except asyncio.CancelledError:
+        return
+    if exc is not None:
+        logger.error(
+            "Fleet usage refresh failed after request cancellation",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -43,7 +43,8 @@ def _usage_sections(raw: str) -> set[str]:
 
 
 async def _can_view_fleet_usage(api_key: ApiKeyData) -> bool:
-    if "account_pool_usage" not in _usage_sections(api_key.usage_sections):
+    sections = _usage_sections(api_key.usage_sections)
+    if "account_pool_usage" not in sections or "upstream_limits" not in sections:
         return False
     settings = await get_settings_cache().get()
     return not bool(getattr(settings, "hide_upstream_quota_from_api_keys", False))

--- a/app/modules/fleet/mappers.py
+++ b/app/modules/fleet/mappers.py
@@ -4,15 +4,26 @@ from app.modules.accounts.schemas import AccountSummary
 from app.modules.fleet.schemas import FleetAccountSummary, FleetWindowSummary
 
 
-def fleet_account_summary_from_account(account: AccountSummary, *, include_usage: bool = True) -> FleetAccountSummary:
+def fleet_account_summary_from_account(
+    account: AccountSummary,
+    *,
+    include_usage: bool = True,
+    persisted_status_by_account_id: dict[str, str] | None = None,
+) -> FleetAccountSummary:
     """Project a dashboard account into the minimal fleet payload."""
 
     usage = account.usage
+    if include_usage:
+        status = account.status
+    elif persisted_status_by_account_id is None:
+        status = "unknown"
+    else:
+        status = persisted_status_by_account_id.get(account.account_id, "unknown")
     return FleetAccountSummary(
         account_id=account.account_id,
         display_name=account.display_name,
         email=account.email,
-        status=account.status,
+        status=status,
         plan_type=account.plan_type,
         primary=FleetWindowSummary(
             remaining_percent=usage.primary_remaining_percent if include_usage and usage is not None else None,
@@ -32,5 +43,13 @@ def build_fleet_account_summaries(
     accounts: list[AccountSummary],
     *,
     include_usage: bool = True,
+    persisted_status_by_account_id: dict[str, str] | None = None,
 ) -> list[FleetAccountSummary]:
-    return [fleet_account_summary_from_account(account, include_usage=include_usage) for account in accounts]
+    return [
+        fleet_account_summary_from_account(
+            account,
+            include_usage=include_usage,
+            persisted_status_by_account_id=persisted_status_by_account_id,
+        )
+        for account in accounts
+    ]

--- a/app/modules/fleet/mappers.py
+++ b/app/modules/fleet/mappers.py
@@ -4,7 +4,7 @@ from app.modules.accounts.schemas import AccountSummary
 from app.modules.fleet.schemas import FleetAccountSummary, FleetWindowSummary
 
 
-def fleet_account_summary_from_account(account: AccountSummary) -> FleetAccountSummary:
+def fleet_account_summary_from_account(account: AccountSummary, *, include_usage: bool = True) -> FleetAccountSummary:
     """Project a dashboard account into the minimal fleet payload."""
 
     usage = account.usage
@@ -15,18 +15,22 @@ def fleet_account_summary_from_account(account: AccountSummary) -> FleetAccountS
         status=account.status,
         plan_type=account.plan_type,
         primary=FleetWindowSummary(
-            remaining_percent=usage.primary_remaining_percent if usage is not None else None,
-            reset_at=account.reset_at_primary,
-            window_minutes=account.window_minutes_primary,
+            remaining_percent=usage.primary_remaining_percent if include_usage and usage is not None else None,
+            reset_at=account.reset_at_primary if include_usage else None,
+            window_minutes=account.window_minutes_primary if include_usage else None,
         ),
         secondary=FleetWindowSummary(
-            remaining_percent=usage.secondary_remaining_percent if usage is not None else None,
-            reset_at=account.reset_at_secondary,
-            window_minutes=account.window_minutes_secondary,
+            remaining_percent=usage.secondary_remaining_percent if include_usage and usage is not None else None,
+            reset_at=account.reset_at_secondary if include_usage else None,
+            window_minutes=account.window_minutes_secondary if include_usage else None,
         ),
-        last_refresh_at=account.last_refresh_at,
+        last_refresh_at=account.last_refresh_at if include_usage else None,
     )
 
 
-def build_fleet_account_summaries(accounts: list[AccountSummary]) -> list[FleetAccountSummary]:
-    return [fleet_account_summary_from_account(account) for account in accounts]
+def build_fleet_account_summaries(
+    accounts: list[AccountSummary],
+    *,
+    include_usage: bool = True,
+) -> list[FleetAccountSummary]:
+    return [fleet_account_summary_from_account(account, include_usage=include_usage) for account in accounts]

--- a/app/modules/fleet/mappers.py
+++ b/app/modules/fleet/mappers.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from app.modules.accounts.schemas import AccountSummary
+from app.modules.fleet.schemas import FleetAccountSummary, FleetWindowSummary
+
+
+def fleet_account_summary_from_account(account: AccountSummary) -> FleetAccountSummary:
+    """Project a dashboard account into the minimal fleet payload."""
+
+    usage = account.usage
+    return FleetAccountSummary(
+        account_id=account.account_id,
+        display_name=account.display_name,
+        email=account.email,
+        status=account.status,
+        plan_type=account.plan_type,
+        primary=FleetWindowSummary(
+            remaining_percent=usage.primary_remaining_percent if usage is not None else None,
+            reset_at=account.reset_at_primary,
+            window_minutes=account.window_minutes_primary,
+        ),
+        secondary=FleetWindowSummary(
+            remaining_percent=usage.secondary_remaining_percent if usage is not None else None,
+            reset_at=account.reset_at_secondary,
+            window_minutes=account.window_minutes_secondary,
+        ),
+        last_refresh_at=account.last_refresh_at,
+    )
+
+
+def build_fleet_account_summaries(accounts: list[AccountSummary]) -> list[FleetAccountSummary]:
+    return [fleet_account_summary_from_account(account) for account in accounts]

--- a/app/modules/fleet/observability.py
+++ b/app/modules/fleet/observability.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from sqlalchemy import and_, case, func, literal_column, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.core.config.settings_cache import get_settings_cache
+from app.core.utils.time import utcnow
+from app.db.models import Account, RequestKind, RequestLog, StickySession, StickySessionKind
+from app.modules.fleet.schemas import (
+    FleetObservabilityResponse,
+    FleetPressureAccountBreakdown,
+    FleetPressureClientBreakdown,
+    FleetPressureKindBreakdown,
+    FleetPressureMetric,
+    FleetPressureObservability,
+    FleetPressureWindow,
+    FleetStickyAccountBreakdown,
+    FleetStickyKindBreakdown,
+    FleetStickyObservability,
+)
+
+_PRESSURE_WINDOWS = (("30m", "30m", 30 * 60), ("2h", "2h", 2 * 60 * 60))
+_BREAKDOWN_LIMIT = 10
+
+
+@dataclass(slots=True)
+class _StickyAccountAccumulator:
+    account_id: str
+    email: str | None
+    total: int = 0
+    recent_count: int = 0
+    stale_count: int = 0
+    last_updated_at: datetime | None = None
+    kinds: list[FleetStickyKindBreakdown] = field(default_factory=list)
+
+    @property
+    def label(self) -> str:
+        return self.email or self.account_id
+
+
+async def build_fleet_observability(
+    session: AsyncSession,
+    *,
+    visible_account_ids: list[str] | None,
+    include_usage: bool,
+) -> FleetObservabilityResponse:
+    generated_at = utcnow()
+    if not include_usage:
+        return FleetObservabilityResponse(
+            available=False,
+            generated_at=generated_at,
+            pressure=FleetPressureObservability(available=False),
+            sticky=FleetStickyObservability(available=False),
+        )
+
+    settings = await get_settings_cache().get()
+    stale_threshold_seconds = int(settings.openai_cache_affinity_max_age_seconds)
+    return FleetObservabilityResponse(
+        generated_at=generated_at,
+        pressure=FleetPressureObservability(
+            windows=[
+                await _build_pressure_window(
+                    session,
+                    key=key,
+                    label=label,
+                    seconds=seconds,
+                    generated_at=generated_at,
+                    visible_account_ids=visible_account_ids,
+                )
+                for key, label, seconds in _PRESSURE_WINDOWS
+            ]
+        ),
+        sticky=await _build_sticky_observability(
+            session,
+            generated_at=generated_at,
+            stale_threshold_seconds=stale_threshold_seconds,
+            visible_account_ids=visible_account_ids,
+        ),
+    )
+
+
+async def _build_pressure_window(
+    session: AsyncSession,
+    *,
+    key: str,
+    label: str,
+    seconds: int,
+    generated_at: datetime,
+    visible_account_ids: list[str] | None,
+) -> FleetPressureWindow:
+    since = generated_at - timedelta(seconds=seconds)
+    conditions = _request_log_conditions(since, visible_account_ids)
+    totals = await _pressure_metrics(session, conditions)
+    return FleetPressureWindow(
+        key=key,
+        label=label,
+        seconds=seconds,
+        request_count=totals.request_count,
+        error_count=totals.error_count,
+        input_tokens=totals.input_tokens,
+        cached_input_tokens=totals.cached_input_tokens,
+        output_tokens=totals.output_tokens,
+        cost_usd=totals.cost_usd,
+        top_error_code=await _top_error_code(session, conditions),
+        by_account=await _pressure_by_account(session, conditions),
+        by_kind=await _pressure_by_kind(session, conditions),
+        by_client=await _pressure_by_client(session, conditions),
+    )
+
+
+def _request_log_conditions(
+    since: datetime,
+    visible_account_ids: list[str] | None,
+) -> list[ColumnElement[bool]]:
+    conditions: list[ColumnElement[bool]] = [
+        RequestLog.requested_at >= since,
+        RequestLog.deleted_at.is_(None),
+        func.coalesce(RequestLog.request_kind, "").not_in((RequestKind.WARMUP.value, "limit_warmup")),
+    ]
+    if visible_account_ids is not None:
+        conditions.append(RequestLog.account_id.in_(visible_account_ids))
+    return conditions
+
+
+def _metric_columns():
+    return (
+        func.count(RequestLog.id).label("request_count"),
+        func.coalesce(
+            func.sum(case((RequestLog.status != literal_column("'success'"), 1), else_=0)),
+            0,
+        ).label("error_count"),
+        func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
+        func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
+        func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
+        func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
+    )
+
+
+def _metric_from_row(row) -> FleetPressureMetric:
+    return FleetPressureMetric(
+        request_count=int(row.request_count or 0),
+        error_count=int(row.error_count or 0),
+        input_tokens=int(row.input_tokens or 0),
+        cached_input_tokens=int(row.cached_input_tokens or 0),
+        output_tokens=int(row.output_tokens or 0),
+        cost_usd=float(row.cost_usd or 0.0),
+    )
+
+
+async def _pressure_metrics(session: AsyncSession, conditions: list[ColumnElement[bool]]) -> FleetPressureMetric:
+    result = await session.execute(select(*_metric_columns()).where(and_(*conditions)))
+    return _metric_from_row(result.one())
+
+
+async def _top_error_code(session: AsyncSession, conditions: list[ColumnElement[bool]]) -> str | None:
+    result = await session.execute(
+        select(RequestLog.error_code, func.count(RequestLog.id).label("error_count"))
+        .where(
+            and_(
+                *conditions,
+                RequestLog.status != "success",
+                RequestLog.error_code.is_not(None),
+            )
+        )
+        .group_by(RequestLog.error_code)
+        .order_by(func.count(RequestLog.id).desc(), RequestLog.error_code.asc())
+        .limit(1)
+    )
+    row = result.first()
+    return str(row.error_code) if row and row.error_code else None
+
+
+async def _pressure_by_account(
+    session: AsyncSession,
+    conditions: list[ColumnElement[bool]],
+) -> list[FleetPressureAccountBreakdown]:
+    result = await session.execute(
+        select(
+            RequestLog.account_id,
+            Account.email,
+            func.max(RequestLog.requested_at).label("last_selected_at"),
+            *_metric_columns(),
+        )
+        .outerjoin(Account, Account.id == RequestLog.account_id)
+        .where(and_(*conditions, RequestLog.account_id.is_not(None)))
+        .group_by(RequestLog.account_id, Account.email)
+        .order_by(func.count(RequestLog.id).desc(), RequestLog.account_id.asc())
+        .limit(_BREAKDOWN_LIMIT)
+    )
+    rows = result.all()
+    return [
+        FleetPressureAccountBreakdown(
+            account_id=str(row.account_id),
+            email=row.email,
+            label=row.email or str(row.account_id),
+            last_selected_at=row.last_selected_at if isinstance(row.last_selected_at, datetime) else None,
+            **_metric_from_row(row).model_dump(),
+        )
+        for row in rows
+        if row.account_id
+    ]
+
+
+async def _pressure_by_kind(
+    session: AsyncSession,
+    conditions: list[ColumnElement[bool]],
+) -> list[FleetPressureKindBreakdown]:
+    kind = func.coalesce(func.nullif(RequestLog.request_kind, ""), "unknown").label("request_kind")
+    result = await session.execute(
+        select(kind, *_metric_columns())
+        .where(and_(*conditions))
+        .group_by(kind)
+        .order_by(func.count(RequestLog.id).desc(), kind.asc())
+        .limit(_BREAKDOWN_LIMIT)
+    )
+    return [
+        FleetPressureKindBreakdown(
+            name=str(row.request_kind or "unknown"),
+            request_kind=str(row.request_kind or "unknown"),
+            **_metric_from_row(row).model_dump(),
+        )
+        for row in result.all()
+    ]
+
+
+async def _pressure_by_client(
+    session: AsyncSession,
+    conditions: list[ColumnElement[bool]],
+) -> list[FleetPressureClientBreakdown]:
+    client_group = func.coalesce(
+        func.nullif(RequestLog.useragent_group, ""),
+        func.nullif(RequestLog.source, ""),
+        "unknown",
+    ).label("client_group")
+    result = await session.execute(
+        select(client_group, *_metric_columns())
+        .where(and_(*conditions))
+        .group_by(client_group)
+        .order_by(func.count(RequestLog.id).desc(), client_group.asc())
+        .limit(_BREAKDOWN_LIMIT)
+    )
+    return [
+        FleetPressureClientBreakdown(
+            name=str(row.client_group or "unknown"),
+            client_group=str(row.client_group or "unknown"),
+            **_metric_from_row(row).model_dump(),
+        )
+        for row in result.all()
+    ]
+
+
+async def _build_sticky_observability(
+    session: AsyncSession,
+    *,
+    generated_at: datetime,
+    stale_threshold_seconds: int,
+    visible_account_ids: list[str] | None,
+) -> FleetStickyObservability:
+    stale_cutoff = generated_at - timedelta(seconds=stale_threshold_seconds)
+    stale_expr = and_(
+        StickySession.kind == StickySessionKind.PROMPT_CACHE,
+        StickySession.updated_at <= stale_cutoff,
+    )
+    conditions: list[ColumnElement[bool]] = []
+    if visible_account_ids is not None:
+        conditions.append(StickySession.account_id.in_(visible_account_ids))
+
+    stmt = (
+        select(
+            StickySession.account_id,
+            Account.email,
+            StickySession.kind,
+            func.count(StickySession.key).label("total"),
+            func.coalesce(func.sum(case((stale_expr, 1), else_=0)), 0).label("stale_count"),
+            func.max(StickySession.updated_at).label("last_updated_at"),
+        )
+        .join(Account, Account.id == StickySession.account_id)
+        .group_by(StickySession.account_id, Account.email, StickySession.kind)
+        .order_by(func.count(StickySession.key).desc(), StickySession.account_id.asc())
+    )
+    if conditions:
+        stmt = stmt.where(and_(*conditions))
+
+    result = await session.execute(stmt)
+    accounts: dict[str, _StickyAccountAccumulator] = {}
+    for row in result.all():
+        if not row.account_id:
+            continue
+        account_id = str(row.account_id)
+        accumulator = accounts.setdefault(
+            account_id,
+            _StickyAccountAccumulator(
+                account_id=account_id,
+                email=row.email,
+            ),
+        )
+        total = int(row.total or 0)
+        stale_count = int(row.stale_count or 0)
+        accumulator.total += total
+        accumulator.stale_count += stale_count
+        accumulator.recent_count += max(total - stale_count, 0)
+        if isinstance(row.last_updated_at, datetime):
+            if accumulator.last_updated_at is None or row.last_updated_at > accumulator.last_updated_at:
+                accumulator.last_updated_at = row.last_updated_at
+        kind_name = _sticky_kind_name(row.kind)
+        accumulator.kinds.append(
+            FleetStickyKindBreakdown(
+                name=kind_name,
+                total=total,
+                stale_count=stale_count,
+            )
+        )
+
+    by_account = [
+        FleetStickyAccountBreakdown(
+            account_id=account.account_id,
+            email=account.email,
+            label=account.label,
+            total=account.total,
+            recent_count=account.recent_count,
+            stale_count=account.stale_count,
+            last_updated_at=account.last_updated_at,
+            kinds=account.kinds,
+        )
+        for account in sorted(accounts.values(), key=lambda item: (-item.total, item.account_id))[:_BREAKDOWN_LIMIT]
+    ]
+    total = sum(account.total for account in accounts.values())
+    stale_count = sum(account.stale_count for account in accounts.values())
+    recent_count = sum(account.recent_count for account in accounts.values())
+    return FleetStickyObservability(
+        available=bool(by_account),
+        total=total,
+        recent_count=recent_count,
+        stale_count=stale_count,
+        stale_threshold_seconds=stale_threshold_seconds,
+        truncated=len(accounts) > len(by_account),
+        by_account=by_account,
+    )
+
+
+def _sticky_kind_name(value: StickySessionKind | str) -> str:
+    if isinstance(value, StickySessionKind):
+        return value.value
+    return str(value)

--- a/app/modules/fleet/observability.py
+++ b/app/modules/fleet/observability.py
@@ -95,6 +95,9 @@ async def _build_pressure_window(
     since = generated_at - timedelta(seconds=seconds)
     conditions = _request_log_conditions(since, visible_account_ids)
     totals = await _pressure_metrics(session, conditions)
+    by_account, accounts_truncated = await _pressure_by_account(session, conditions)
+    by_kind, kinds_truncated = await _pressure_by_kind(session, conditions)
+    by_client, clients_truncated = await _pressure_by_client(session, conditions)
     return FleetPressureWindow(
         key=key,
         label=label,
@@ -105,10 +108,11 @@ async def _build_pressure_window(
         cached_input_tokens=totals.cached_input_tokens,
         output_tokens=totals.output_tokens,
         cost_usd=totals.cost_usd,
+        truncated=accounts_truncated or kinds_truncated or clients_truncated,
         top_error_code=await _top_error_code(session, conditions),
-        by_account=await _pressure_by_account(session, conditions),
-        by_kind=await _pressure_by_kind(session, conditions),
-        by_client=await _pressure_by_client(session, conditions),
+        by_account=by_account,
+        by_kind=by_kind,
+        by_client=by_client,
     )
 
 
@@ -135,7 +139,9 @@ def _metric_columns():
         ).label("error_count"),
         func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
         func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
-        func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
+        func.coalesce(func.sum(func.coalesce(RequestLog.output_tokens, RequestLog.reasoning_tokens, 0)), 0).label(
+            "output_tokens"
+        ),
         func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
     )
 
@@ -177,7 +183,7 @@ async def _top_error_code(session: AsyncSession, conditions: list[ColumnElement[
 async def _pressure_by_account(
     session: AsyncSession,
     conditions: list[ColumnElement[bool]],
-) -> list[FleetPressureAccountBreakdown]:
+) -> tuple[list[FleetPressureAccountBreakdown], bool]:
     result = await session.execute(
         select(
             RequestLog.account_id,
@@ -189,48 +195,55 @@ async def _pressure_by_account(
         .where(and_(*conditions, RequestLog.account_id.is_not(None)))
         .group_by(RequestLog.account_id, Account.email)
         .order_by(func.count(RequestLog.id).desc(), RequestLog.account_id.asc())
-        .limit(_BREAKDOWN_LIMIT)
+        .limit(_BREAKDOWN_LIMIT + 1)
     )
     rows = result.all()
-    return [
-        FleetPressureAccountBreakdown(
-            account_id=str(row.account_id),
-            email=row.email,
-            label=row.email or str(row.account_id),
-            last_selected_at=row.last_selected_at if isinstance(row.last_selected_at, datetime) else None,
-            **_metric_from_row(row).model_dump(),
-        )
-        for row in rows
-        if row.account_id
-    ]
+    return (
+        [
+            FleetPressureAccountBreakdown(
+                account_id=str(row.account_id),
+                email=row.email,
+                label=row.email or str(row.account_id),
+                last_selected_at=row.last_selected_at if isinstance(row.last_selected_at, datetime) else None,
+                **_metric_from_row(row).model_dump(),
+            )
+            for row in rows[:_BREAKDOWN_LIMIT]
+            if row.account_id
+        ],
+        len(rows) > _BREAKDOWN_LIMIT,
+    )
 
 
 async def _pressure_by_kind(
     session: AsyncSession,
     conditions: list[ColumnElement[bool]],
-) -> list[FleetPressureKindBreakdown]:
+) -> tuple[list[FleetPressureKindBreakdown], bool]:
     kind = func.coalesce(func.nullif(RequestLog.request_kind, ""), "unknown").label("request_kind")
     result = await session.execute(
         select(kind, *_metric_columns())
         .where(and_(*conditions))
         .group_by(kind)
         .order_by(func.count(RequestLog.id).desc(), kind.asc())
-        .limit(_BREAKDOWN_LIMIT)
+        .limit(_BREAKDOWN_LIMIT + 1)
     )
-    return [
-        FleetPressureKindBreakdown(
-            name=str(row.request_kind or "unknown"),
-            request_kind=str(row.request_kind or "unknown"),
-            **_metric_from_row(row).model_dump(),
-        )
-        for row in result.all()
-    ]
+    rows = result.all()
+    return (
+        [
+            FleetPressureKindBreakdown(
+                name=str(row.request_kind or "unknown"),
+                request_kind=str(row.request_kind or "unknown"),
+                **_metric_from_row(row).model_dump(),
+            )
+            for row in rows[:_BREAKDOWN_LIMIT]
+        ],
+        len(rows) > _BREAKDOWN_LIMIT,
+    )
 
 
 async def _pressure_by_client(
     session: AsyncSession,
     conditions: list[ColumnElement[bool]],
-) -> list[FleetPressureClientBreakdown]:
+) -> tuple[list[FleetPressureClientBreakdown], bool]:
     client_group = func.coalesce(
         func.nullif(RequestLog.useragent_group, ""),
         func.nullif(RequestLog.source, ""),
@@ -241,16 +254,20 @@ async def _pressure_by_client(
         .where(and_(*conditions))
         .group_by(client_group)
         .order_by(func.count(RequestLog.id).desc(), client_group.asc())
-        .limit(_BREAKDOWN_LIMIT)
+        .limit(_BREAKDOWN_LIMIT + 1)
     )
-    return [
-        FleetPressureClientBreakdown(
-            name=str(row.client_group or "unknown"),
-            client_group=str(row.client_group or "unknown"),
-            **_metric_from_row(row).model_dump(),
-        )
-        for row in result.all()
-    ]
+    rows = result.all()
+    return (
+        [
+            FleetPressureClientBreakdown(
+                name=str(row.client_group or "unknown"),
+                client_group=str(row.client_group or "unknown"),
+                **_metric_from_row(row).model_dump(),
+            )
+            for row in rows[:_BREAKDOWN_LIMIT]
+        ],
+        len(rows) > _BREAKDOWN_LIMIT,
+    )
 
 
 async def _build_sticky_observability(

--- a/app/modules/fleet/schemas.py
+++ b/app/modules/fleet/schemas.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import Field
+
+from app.modules.shared.schemas import DashboardModel
+
+
+class FleetWindowSummary(DashboardModel):
+    """One minimal capacity window for a single account."""
+
+    remaining_percent: float | None = None
+    reset_at: datetime | None = None
+    window_minutes: int | None = None
+
+
+class FleetAccountSummary(DashboardModel):
+    """Non-sensitive capacity projection for fleet consumers."""
+
+    account_id: str
+    display_name: str
+    email: str
+    status: str
+    plan_type: str
+    primary: FleetWindowSummary
+    secondary: FleetWindowSummary
+    last_refresh_at: datetime | None = None
+
+
+class FleetSummaryResponse(DashboardModel):
+    accounts: list[FleetAccountSummary] = Field(default_factory=list)
+
+
+class FleetRefreshResponse(DashboardModel):
+    ok: bool = True
+    usage_written: bool
+    account_count: int
+    attempted_count: int
+    generated_at: datetime

--- a/app/modules/fleet/schemas.py
+++ b/app/modules/fleet/schemas.py
@@ -38,3 +38,80 @@ class FleetRefreshResponse(DashboardModel):
     account_count: int
     attempted_count: int
     generated_at: datetime
+
+
+class FleetPressureMetric(DashboardModel):
+    request_count: int = 0
+    error_count: int = 0
+    input_tokens: int = 0
+    cached_input_tokens: int = 0
+    output_tokens: int = 0
+    cost_usd: float = 0.0
+
+
+class FleetPressureAccountBreakdown(FleetPressureMetric):
+    account_id: str
+    email: str | None = None
+    label: str
+    last_selected_at: datetime | None = None
+
+
+class FleetPressureKindBreakdown(FleetPressureMetric):
+    name: str
+    request_kind: str
+
+
+class FleetPressureClientBreakdown(FleetPressureMetric):
+    name: str
+    client_group: str
+
+
+class FleetPressureWindow(FleetPressureMetric):
+    key: str
+    label: str
+    seconds: int
+    truncated: bool = False
+    top_error_code: str | None = None
+    by_account: list[FleetPressureAccountBreakdown] = Field(default_factory=list)
+    by_kind: list[FleetPressureKindBreakdown] = Field(default_factory=list)
+    by_client: list[FleetPressureClientBreakdown] = Field(default_factory=list)
+
+
+class FleetPressureObservability(DashboardModel):
+    available: bool = True
+    windows: list[FleetPressureWindow] = Field(default_factory=list)
+
+
+class FleetStickyKindBreakdown(DashboardModel):
+    name: str
+    total: int = 0
+    stale_count: int = 0
+
+
+class FleetStickyAccountBreakdown(DashboardModel):
+    account_id: str
+    email: str | None = None
+    label: str
+    total: int = 0
+    recent_count: int = 0
+    stale_count: int = 0
+    last_updated_at: datetime | None = None
+    kinds: list[FleetStickyKindBreakdown] = Field(default_factory=list)
+
+
+class FleetStickyObservability(DashboardModel):
+    available: bool = True
+    total: int = 0
+    recent_count: int = 0
+    stale_count: int = 0
+    stale_threshold_seconds: int | None = None
+    truncated: bool = False
+    by_account: list[FleetStickyAccountBreakdown] = Field(default_factory=list)
+
+
+class FleetObservabilityResponse(DashboardModel):
+    available: bool = True
+    generated_at: datetime
+    source: str = "codex-lb fleet observability"
+    pressure: FleetPressureObservability = Field(default_factory=FleetPressureObservability)
+    sticky: FleetStickyObservability = Field(default_factory=FleetStickyObservability)

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -29,10 +29,12 @@ from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import get_background_session
 from app.modules.accounts.auth_manager import AccountsRepositoryPort, AuthManager
 from app.modules.accounts.background_repository import BackgroundAccountsRepository
+from app.modules.accounts.repository import AccountsRepository as SessionAccountsRepository
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
 from app.modules.usage.additional_quota_keys import canonicalize_additional_quota_key
 from app.modules.usage.background_repository import BackgroundAdditionalUsageRepository, BackgroundUsageRepository
 from app.modules.usage.repository import AdditionalUsageRepository
+from app.modules.usage.repository import UsageRepository as SessionUsageRepository
 
 logger = logging.getLogger(__name__)
 
@@ -324,6 +326,7 @@ class UsageUpdater:
                         own_singleflight_session=own_singleflight_sessions,
                     ),
                     refresh_factory,
+                    join_existing=not own_singleflight_sessions,
                 )
                 if not own_singleflight_sessions:
                     await self._sync_account_from_repo(account)
@@ -417,10 +420,15 @@ class UsageUpdater:
         *,
         interval_seconds: int,
     ) -> AccountRefreshResult:
+        @contextlib.asynccontextmanager
+        async def refresh_repo_factory():
+            async with get_background_session() as refresh_session:
+                yield SessionAccountsRepository(refresh_session)
+
         async with get_background_session() as session:
-            accounts_repo = BackgroundAccountsRepository(session)
-            usage_repo = BackgroundUsageRepository(session)
-            additional_usage_repo = BackgroundAdditionalUsageRepository(session)
+            accounts_repo = SessionAccountsRepository(session)
+            usage_repo = SessionUsageRepository(session)
+            additional_usage_repo = AdditionalUsageRepository(session)
             account = await accounts_repo.get_by_id(account_id)
             if account is None:
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
@@ -428,6 +436,7 @@ class UsageUpdater:
                 usage_repo,
                 accounts_repo,
                 additional_usage_repo,
+                auth_manager=AuthManager(accounts_repo, refresh_repo_factory=refresh_repo_factory),
             )._refresh_account_if_stale(
                 account,
                 usage_account_id=account.chatgpt_account_id,

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -225,6 +225,10 @@ class _UsageRefreshSingleflight:
 _USAGE_REFRESH_SINGLEFLIGHT = _UsageRefreshSingleflight()
 
 
+def _usage_refresh_singleflight_key(account_id: str, *, own_singleflight_session: bool = False) -> str:
+    return f"owned-session:{account_id}" if own_singleflight_session else account_id
+
+
 class UsageUpdater:
     def __init__(
         self,
@@ -311,7 +315,10 @@ class UsageUpdater:
                         )
 
                 result = await _USAGE_REFRESH_SINGLEFLIGHT.run(
-                    account.id,
+                    _usage_refresh_singleflight_key(
+                        account.id,
+                        own_singleflight_session=own_singleflight_sessions,
+                    ),
                     refresh_factory,
                 )
                 if not own_singleflight_sessions:

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import math
 import time
-from collections.abc import Awaitable, Callable, Collection
+from collections.abc import Awaitable, Callable, Collection, Hashable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Mapping, Protocol, cast
@@ -152,12 +152,12 @@ _usage_refresh_auth_cooldowns: dict[str, float] = {}
 
 class _UsageRefreshSingleflight:
     def __init__(self) -> None:
-        self._inflight: dict[str, asyncio.Task[AccountRefreshResult]] = {}
+        self._inflight: dict[Hashable, asyncio.Task[AccountRefreshResult]] = {}
         self._lock = asyncio.Lock()
 
     async def run(
         self,
-        account_id: str,
+        account_id: Hashable,
         factory: Callable[[], Awaitable[AccountRefreshResult]],
         *,
         join_existing: bool = True,
@@ -196,7 +196,7 @@ class _UsageRefreshSingleflight:
 
     def _clear_if_current(
         self,
-        key: str,
+        key: Hashable,
         task: asyncio.Task[AccountRefreshResult],
     ) -> None:
         current = self._inflight.get(key)
@@ -225,8 +225,12 @@ class _UsageRefreshSingleflight:
 _USAGE_REFRESH_SINGLEFLIGHT = _UsageRefreshSingleflight()
 
 
-def _usage_refresh_singleflight_key(account_id: str, *, own_singleflight_session: bool = False) -> str:
-    return f"owned-session:{account_id}" if own_singleflight_session else account_id
+def _usage_refresh_singleflight_key(
+    account_id: str,
+    *,
+    own_singleflight_session: bool = False,
+) -> str | tuple[str, str]:
+    return ("owned-session", account_id) if own_singleflight_session else account_id
 
 
 class UsageUpdater:

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -432,6 +432,8 @@ class UsageUpdater:
             account = await accounts_repo.get_by_id(account_id)
             if account is None:
                 return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
+            if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+                return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
             return await UsageUpdater(
                 usage_repo,
                 accounts_repo,

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -246,6 +246,8 @@ class UsageUpdater:
         self,
         accounts: list[Account],
         latest_usage: Mapping[str, UsageHistory],
+        *,
+        own_singleflight_sessions: bool = False,
     ) -> bool:
         """Refresh usage for all accounts. Returns True if usage rows were written."""
         settings = get_settings()
@@ -291,15 +293,29 @@ class UsageUpdater:
             # within the request-scoped session to avoid PK collisions and
             # flush-time warnings (SAWarning: Session.add during flush).
             try:
+                if own_singleflight_sessions:
+
+                    async def refresh_factory(account_id: str = account.id) -> AccountRefreshResult:
+                        return await self._refresh_account_if_stale_with_owned_session(
+                            account_id,
+                            interval_seconds=interval,
+                        )
+
+                else:
+
+                    async def refresh_factory(account: Account = account) -> AccountRefreshResult:
+                        return await self._refresh_account_if_stale(
+                            account,
+                            usage_account_id=account.chatgpt_account_id,
+                            interval_seconds=interval,
+                        )
+
                 result = await _USAGE_REFRESH_SINGLEFLIGHT.run(
                     account.id,
-                    lambda account=account: self._refresh_account_if_stale(
-                        account,
-                        usage_account_id=account.chatgpt_account_id,
-                        interval_seconds=interval,
-                    ),
+                    refresh_factory,
                 )
-                await self._sync_account_from_repo(account)
+                if not own_singleflight_sessions:
+                    await self._sync_account_from_repo(account)
                 refreshed = refreshed or result.usage_written
                 # Only cache when the upstream fetch actually succeeded.
                 # Transient errors (401 retry failure, 5xx, etc.) must not
@@ -383,6 +399,29 @@ class UsageUpdater:
         if usage_core.capacity_for_plan(account.plan_type, "monthly") is None:
             return None
         return await self._usage_repo.latest_entry_for_account(account.id, window="monthly")
+
+    async def _refresh_account_if_stale_with_owned_session(
+        self,
+        account_id: str,
+        *,
+        interval_seconds: int,
+    ) -> AccountRefreshResult:
+        async with get_background_session() as session:
+            accounts_repo = BackgroundAccountsRepository(session)
+            usage_repo = BackgroundUsageRepository(session)
+            additional_usage_repo = BackgroundAdditionalUsageRepository(session)
+            account = await accounts_repo.get_by_id(account_id)
+            if account is None:
+                return AccountRefreshResult(usage_written=False, fetch_succeeded=False)
+            return await UsageUpdater(
+                usage_repo,
+                accounts_repo,
+                additional_usage_repo,
+            )._refresh_account_if_stale(
+                account,
+                usage_account_id=account.chatgpt_account_id,
+                interval_seconds=interval_seconds,
+            )
 
     async def _refresh_account(
         self,

--- a/openspec/changes/add-fleet-observability-endpoint/.openspec.yaml
+++ b/openspec/changes/add-fleet-observability-endpoint/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/add-fleet-observability-endpoint/proposal.md
+++ b/openspec/changes/add-fleet-observability-endpoint/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+`claude-balances` can read codex-lb fleet summary data, but its Codex pressure
+and continuity cards currently degrade because codex-lb does not expose a
+read-only observability feed through the fleet API-key surface.
+
+## What Changes
+
+- Add API-key-authenticated `GET /api/fleet/observability`.
+- Return 30-minute and 2-hour request pressure windows from request logs.
+- Return sticky-session continuity counts grouped by account and kind.
+- Reuse fleet summary account scoping and usage-visibility policy.
+- Exclude sensitive request/session/sticky identifiers and raw error payloads.
+
+## Impact
+
+- Trusted local fleet consumers can render Codex pressure and sticky-session
+  continuity without dashboard credentials.
+- No database migration is required; the endpoint reads existing request-log and
+  sticky-session tables through current indexes.
+- Keys without `account_pool_usage` visibility, or keys blocked by the global
+  quota privacy setting, receive an empty non-sensitive observability payload.

--- a/openspec/changes/add-fleet-observability-endpoint/specs/fleet-summary/spec.md
+++ b/openspec/changes/add-fleet-observability-endpoint/specs/fleet-summary/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Fleet observability requires API key authentication
+
+The system SHALL expose `GET /api/fleet/observability` for trusted local fleet
+consumers. The route MUST require a valid Bearer API key even when global proxy
+API-key authentication is disabled.
+
+#### Scenario: Missing fleet observability key is rejected
+
+- **WHEN** a client calls `GET /api/fleet/observability` without a Bearer token
+- **THEN** the system returns 401
+- **AND** no observability payload is returned
+
+### Requirement: Fleet observability reports pressure windows
+
+The system SHALL return read-only Codex pressure windows for the last 30 minutes
+and last 2 hours. Each window SHALL include total request count, error count,
+input tokens, cached input tokens, output tokens, cost, account breakdown,
+request-kind breakdown, and client-group breakdown.
+
+#### Scenario: Valid key returns pressure windows
+
+- **WHEN** a client calls `GET /api/fleet/observability` with a valid Bearer API key
+- **THEN** the response includes `pressure.windows[]` entries for `30m` and `2h`
+- **AND** warmup traffic and soft-deleted request logs are excluded
+- **AND** account-scoped keys only include logs for assigned accounts
+
+### Requirement: Fleet observability reports sticky-session continuity
+
+The system SHALL return read-only sticky-session distribution by account and
+kind. Prompt-cache pins older than the configured cache affinity TTL SHALL count
+as stale; other sticky-session kinds SHALL not count as stale.
+
+#### Scenario: Valid key returns sticky distribution
+
+- **WHEN** sticky sessions exist for accounts visible to the key
+- **THEN** the response includes `sticky.total`, `sticky.recentCount`,
+  `sticky.staleCount`, and `sticky.byAccount[]`
+- **AND** account-scoped keys only include sticky sessions for assigned accounts
+
+### Requirement: Fleet observability excludes sensitive data
+
+Fleet observability responses MUST NOT include prompt contents, raw request IDs,
+archive request IDs, session IDs, sticky-session keys, client IP addresses, API
+key identifiers, request error messages, auth tokens, or raw credential data.
+
+#### Scenario: Sensitive fields are omitted
+
+- **WHEN** a valid client calls `GET /api/fleet/observability`
+- **THEN** no response object includes raw request identifiers, session
+  identifiers, sticky-session keys, client IP addresses, API key identifiers,
+  prompt contents, token fields, or raw error payloads
+
+### Requirement: Fleet observability follows fleet usage visibility policy
+
+The endpoint SHALL reuse the fleet summary account scoping and usage visibility
+policy. If the authenticated key cannot view account-pool usage, the endpoint
+SHALL return a successful non-sensitive payload with no pressure windows and no
+sticky-session account distribution.
+
+#### Scenario: Usage visibility disabled
+
+- **WHEN** a valid API key does not include `account_pool_usage`
+- **OR** the global API-key quota privacy setting hides upstream quota data
+- **THEN** `GET /api/fleet/observability` returns 200
+- **AND** the response does not expose request pressure or sticky-session
+  account distribution

--- a/openspec/changes/add-fleet-observability-endpoint/tasks.md
+++ b/openspec/changes/add-fleet-observability-endpoint/tasks.md
@@ -1,0 +1,18 @@
+## 1. Specification
+
+- [x] 1.1 Add `fleet-summary` OpenSpec capability delta for fleet observability.
+
+## 2. Backend API
+
+- [x] 2.1 Add minimal pressure and sticky-session observability response models.
+- [x] 2.2 Add read-only pressure aggregation for 30-minute and 2-hour windows.
+- [x] 2.3 Add read-only sticky-session continuity aggregation.
+- [x] 2.4 Add API-key-authenticated `GET /api/fleet/observability`.
+- [x] 2.5 Reuse fleet summary account scoping and usage-visibility policy.
+
+## 3. Tests
+
+- [x] 3.1 Add integration tests for missing API key rejection.
+- [x] 3.2 Add integration tests for pressure and sticky aggregation shape.
+- [x] 3.3 Add integration tests for account scoping and privacy hiding.
+- [x] 3.4 Add integration tests proving sensitive identifiers are omitted.

--- a/openspec/changes/add-fleet-refresh-endpoint/.openspec.yaml
+++ b/openspec/changes/add-fleet-refresh-endpoint/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/add-fleet-refresh-endpoint/proposal.md
+++ b/openspec/changes/add-fleet-refresh-endpoint/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+External local dashboards need a truthful way to distinguish a fresh read of codex-lb state from an upstream usage refresh attempt. The current live fleet view can read a summary, but upstream usage refresh remains background-only, so a manual refresh button in a sibling dashboard cannot ask codex-lb to refresh and report what happened.
+
+## What Changes
+
+- Add API-key-authenticated `GET /api/fleet/summary` for minimal per-account capacity state.
+- Add API-key-authenticated `POST /api/fleet/refresh` that runs the existing usage refresh path outside proxy request selection.
+- Return a minimal non-sensitive refresh outcome with `usageWritten`, `accountCount`, `attemptedCount`, and `generatedAt`.
+- Preserve existing usage-refresh freshness, cooldown, paused, reauth-required, and deactivated-account rules.
+
+## Capabilities
+
+### New Capabilities
+
+- `fleet-summary`: expose minimal account capacity for trusted local fleet consumers and let them request bounded refresh attempts.
+
+## Impact
+
+- **Backend**: new `app/modules/fleet` API, schemas, and mappers; router registration in `app/main.py`.
+- **Specs**: new `fleet-summary` capability.
+- **Tests**: integration coverage for auth, minimal projection, sensitive-field omission, and refresh outcome shape.
+- **No database migration**: no schema changes.

--- a/openspec/changes/add-fleet-refresh-endpoint/specs/fleet-summary/spec.md
+++ b/openspec/changes/add-fleet-refresh-endpoint/specs/fleet-summary/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Fleet summary requires API key authentication
+
+The system SHALL expose `GET /api/fleet/summary` for trusted local fleet consumers. The route MUST require a valid Bearer API key even when global proxy API-key authentication is disabled.
+
+#### Scenario: Missing fleet summary key is rejected
+
+- **WHEN** a client calls `GET /api/fleet/summary` without a Bearer token
+- **THEN** the system returns 401
+- **AND** no account summary payload is returned
+
+#### Scenario: Valid fleet summary key returns account capacity
+
+- **WHEN** a client calls `GET /api/fleet/summary` with a valid Bearer API key
+- **THEN** the response includes `accounts[]`
+- **AND** each account includes `accountId`, `displayName`, `email`, `status`, `planType`, `primary`, `secondary`, and `lastRefreshAt`
+- **AND** each window includes `remainingPercent`, `resetAt`, and `windowMinutes`
+
+### Requirement: Fleet summary excludes sensitive data
+
+Fleet summary responses MUST NOT include OAuth token material, auth token status, raw credit balances, request-cost detail, additional quota detail, or deactivation reasons.
+
+#### Scenario: Sensitive fields are omitted
+
+- **WHEN** a valid client calls `GET /api/fleet/summary`
+- **THEN** no response object includes token fields, `auth`, credit-balance fields, request usage, additional quotas, or deactivation reasons
+
+### Requirement: Fleet refresh requests existing usage refresh policy
+
+The system SHALL expose `POST /api/fleet/refresh` for trusted local fleet consumers. The route MUST require a valid Bearer API key even when global proxy API-key authentication is disabled. The route MUST request a usage refresh through codex-lb's existing usage refresh machinery and MUST NOT refresh inside proxy account selection.
+
+The route MUST preserve existing usage-refresh rules for disabled refresh, fresh samples, auth cooldowns, paused accounts, reauth-required accounts, and deactivated accounts.
+
+#### Scenario: Fleet refresh returns minimal outcome
+
+- **WHEN** a valid client calls `POST /api/fleet/refresh`
+- **THEN** the response includes `ok: true`, `usageWritten`, `accountCount`, `attemptedCount`, and `generatedAt`
+- **AND** the response does not include account credentials or token material
+
+#### Scenario: Fleet refresh skips unsafe account states
+
+- **GIVEN** active and paused accounts exist
+- **WHEN** a valid client calls `POST /api/fleet/refresh`
+- **THEN** active accounts are eligible for the refresh attempt
+- **AND** paused, reauth-required, and deactivated accounts are not attempted

--- a/openspec/changes/add-fleet-refresh-endpoint/tasks.md
+++ b/openspec/changes/add-fleet-refresh-endpoint/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+
+- [x] 1.1 Add `fleet-summary` OpenSpec capability delta for summary and refresh behavior.
+
+## 2. Backend API
+
+- [x] 2.1 Add a minimal fleet summary response shape.
+- [x] 2.2 Add API-key-authenticated `GET /api/fleet/summary`.
+- [x] 2.3 Add API-key-authenticated `POST /api/fleet/refresh`.
+- [x] 2.4 Reuse existing usage refresh machinery and preserve refresh policy rules.
+- [x] 2.5 Register the fleet router.
+
+## 3. Tests
+
+- [x] 3.1 Add integration tests for missing/invalid API key rejection.
+- [x] 3.2 Add integration tests for minimal projection and sensitive-field omission.
+- [x] 3.3 Add integration tests for bounded refresh response shape.

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -69,10 +70,17 @@ def _make_account(
     )
 
 
-async def _create_api_key(name: str) -> str:
+async def _create_api_key(name: str, *, assigned_account_ids: list[str] | None = None) -> str:
     async with SessionLocal() as session:
         service = ApiKeysService(ApiKeysRepository(session))
-        created = await service.create_key(ApiKeyCreateData(name=name, allowed_models=None, limits=[]))
+        created = await service.create_key(
+            ApiKeyCreateData(
+                name=name,
+                allowed_models=None,
+                limits=[],
+                assigned_account_ids=assigned_account_ids,
+            )
+        )
     return created.key
 
 
@@ -229,6 +237,39 @@ async def test_fleet_summary_omits_sensitive_fields(async_client, db_setup):
 
 
 @pytest.mark.asyncio
+async def test_fleet_summary_respects_account_scoped_api_key(async_client, db_setup):
+    await _seed_account_with_windows(
+        "acc_scope_visible",
+        "scope-visible@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    await _seed_account_with_windows(
+        "acc_scope_hidden",
+        "scope-hidden@example.com",
+        primary_used_percent=70.0,
+        secondary_used_percent=80.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    plain_key = await _create_api_key("fleet-summary-scoped-key", assigned_account_ids=["acc_scope_visible"])
+
+    response = await async_client.get(
+        "/api/fleet/summary",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [account["accountId"] for account in payload["accounts"]] == ["acc_scope_visible"]
+    raw = json.dumps(payload)
+    assert "scope-visible@example.com" in raw
+    assert "scope-hidden@example.com" not in raw
+
+
+@pytest.mark.asyncio
 async def test_fleet_refresh_requires_api_key(async_client, db_setup):
     response = await async_client.post("/api/fleet/refresh")
 
@@ -307,6 +348,8 @@ async def test_fleet_refresh_uses_route_local_usage_updater_and_invalidates_on_w
 
     refresh_calls: list[list[str]] = []
     invalidations: list[str] = []
+    updater_session_ids: list[int] = []
+    background_session_ids: list[int] = []
 
     class FakeUsageUpdater:
         def __init__(self, usage_repo, accounts_repo, additional_usage_repo):
@@ -315,6 +358,7 @@ async def test_fleet_refresh_uses_route_local_usage_updater_and_invalidates_on_w
             self.additional_usage_repo = additional_usage_repo
 
         async def refresh_accounts(self, accounts, latest_primary):
+            updater_session_ids.append(id(self.usage_repo._session))
             refresh_calls.append([account.id for account in accounts])
             assert isinstance(latest_primary, dict)
             return True
@@ -327,6 +371,13 @@ async def test_fleet_refresh_uses_route_local_usage_updater_and_invalidates_on_w
         def invalidate(self):
             invalidations.append("account_selection")
 
+    @asynccontextmanager
+    async def recording_background_session():
+        async with SessionLocal() as session:
+            background_session_ids.append(id(session))
+            yield session
+
+    monkeypatch.setattr("app.modules.fleet.api.get_background_session", recording_background_session)
     monkeypatch.setattr("app.modules.fleet.api.UsageUpdater", FakeUsageUpdater)
     monkeypatch.setattr(
         "app.modules.fleet.api.get_rate_limit_headers_cache",
@@ -348,4 +399,54 @@ async def test_fleet_refresh_uses_route_local_usage_updater_and_invalidates_on_w
     assert payload["accountCount"] == 1
     assert payload["attemptedCount"] == 1
     assert refresh_calls == [["acc_refresh_write"]]
+    assert updater_session_ids == background_session_ids
     assert invalidations == ["rate_limit_headers", "account_selection"]
+
+
+@pytest.mark.asyncio
+async def test_fleet_refresh_respects_account_scoped_api_key(async_client, db_setup, monkeypatch):
+    await _seed_account_with_windows(
+        "acc_refresh_scope_visible",
+        "refresh-scope-visible@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=10.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    await _seed_account_with_windows(
+        "acc_refresh_scope_hidden",
+        "refresh-scope-hidden@example.com",
+        primary_used_percent=20.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    plain_key = await _create_api_key(
+        "fleet-refresh-scoped-key",
+        assigned_account_ids=["acc_refresh_scope_visible"],
+    )
+    refresh_calls: list[list[str]] = []
+
+    class FakeUsageUpdater:
+        def __init__(self, usage_repo, accounts_repo, additional_usage_repo):
+            self.usage_repo = usage_repo
+            self.accounts_repo = accounts_repo
+            self.additional_usage_repo = additional_usage_repo
+
+        async def refresh_accounts(self, accounts, latest_primary):
+            refresh_calls.append([account.id for account in accounts])
+            assert set(latest_primary) <= {"acc_refresh_scope_visible"}
+            return False
+
+    monkeypatch.setattr("app.modules.fleet.api.UsageUpdater", FakeUsageUpdater)
+
+    response = await async_client.post(
+        "/api/fleet/refresh",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["accountCount"] == 1
+    assert payload["attemptedCount"] == 1
+    assert refresh_calls == [["acc_refresh_scope_visible"]]

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus
+from app.db.session import SessionLocal
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService
+from app.modules.usage.repository import UsageRepository
+
+pytestmark = pytest.mark.integration
+
+_PRIMARY_WINDOW_MINUTES = 300
+_SECONDARY_WINDOW_MINUTES = 10080
+
+_FORBIDDEN_KEYS = {
+    "auth",
+    "access",
+    "refresh",
+    "id_token",
+    "idToken",
+    "accessToken",
+    "refreshToken",
+    "access_token",
+    "refresh_token",
+    "capacity_credits_primary",
+    "capacityCreditsPrimary",
+    "remaining_credits_primary",
+    "remainingCreditsPrimary",
+    "capacity_credits_secondary",
+    "capacityCreditsSecondary",
+    "remaining_credits_secondary",
+    "remainingCreditsSecondary",
+    "request_usage",
+    "requestUsage",
+    "total_cost_usd",
+    "totalCostUsd",
+    "additional_quotas",
+    "additionalQuotas",
+    "deactivation_reason",
+    "deactivationReason",
+}
+
+
+def _make_account(
+    account_id: str,
+    email: str,
+    *,
+    status: AccountStatus = AccountStatus.ACTIVE,
+    plan_type: str = "plus",
+) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        chatgpt_account_id=None,
+        email=email,
+        plan_type=plan_type,
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=status,
+        deactivation_reason=None,
+    )
+
+
+async def _create_api_key(name: str) -> str:
+    async with SessionLocal() as session:
+        service = ApiKeysService(ApiKeysRepository(session))
+        created = await service.create_key(ApiKeyCreateData(name=name, allowed_models=None, limits=[]))
+    return created.key
+
+
+async def _seed_account_with_windows(
+    account_id: str,
+    email: str,
+    *,
+    primary_used_percent: float,
+    secondary_used_percent: float,
+    primary_reset_at: int,
+    secondary_reset_at: int,
+    status: AccountStatus = AccountStatus.ACTIVE,
+) -> None:
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        await accounts_repo.upsert(_make_account(account_id, email, status=status))
+        await usage_repo.add_entry(
+            account_id,
+            primary_used_percent,
+            window="primary",
+            reset_at=primary_reset_at,
+            window_minutes=_PRIMARY_WINDOW_MINUTES,
+        )
+        await usage_repo.add_entry(
+            account_id,
+            secondary_used_percent,
+            window="secondary",
+            reset_at=secondary_reset_at,
+            window_minutes=_SECONDARY_WINDOW_MINUTES,
+        )
+
+
+def _assert_no_forbidden_keys(node: object) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            assert key not in _FORBIDDEN_KEYS, f"sensitive key '{key}' leaked into fleet response"
+            _assert_no_forbidden_keys(value)
+    elif isinstance(node, list):
+        for item in node:
+            _assert_no_forbidden_keys(item)
+
+
+@pytest.mark.asyncio
+async def test_fleet_summary_requires_api_key(async_client, db_setup):
+    await _seed_account_with_windows(
+        "acc_noauth",
+        "noauth@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=10.0,
+        primary_reset_at=0,
+        secondary_reset_at=0,
+    )
+
+    response = await async_client.get("/api/fleet/summary")
+
+    assert response.status_code == 401
+    assert "noauth@example.com" not in response.text
+    assert "accounts" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_fleet_summary_rejects_invalid_api_key(async_client, db_setup):
+    await _seed_account_with_windows(
+        "acc_badkey",
+        "badkey@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=10.0,
+        primary_reset_at=0,
+        secondary_reset_at=0,
+    )
+
+    response = await async_client.get(
+        "/api/fleet/summary",
+        headers={"Authorization": "Bearer sk-clb-not-a-real-key"},
+    )
+
+    assert response.status_code == 401
+    assert "badkey@example.com" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_fleet_summary_returns_minimal_projection_with_valid_key(async_client, db_setup):
+    plain_key = await _create_api_key("fleet-summary-key")
+    primary_reset = 1735862400
+    secondary_reset = 1736467200
+    await _seed_account_with_windows(
+        "acc_fleet_a",
+        "fleet-a@example.com",
+        primary_used_percent=38.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=primary_reset,
+        secondary_reset_at=secondary_reset,
+    )
+
+    response = await async_client.get(
+        "/api/fleet/summary",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    accounts = payload["accounts"]
+    assert len(accounts) == 1
+    account = accounts[0]
+    assert account["accountId"] == "acc_fleet_a"
+    assert account["email"] == "fleet-a@example.com"
+    assert account["displayName"] == "fleet-a@example.com"
+    assert account["status"] == "active"
+    assert account["planType"] == "plus"
+    assert account["lastRefreshAt"] is not None
+    assert account["primary"]["remainingPercent"] == 62
+    assert account["primary"]["windowMinutes"] == _PRIMARY_WINDOW_MINUTES
+    assert account["primary"]["resetAt"] is not None
+    assert account["secondary"]["remainingPercent"] == 80
+    assert account["secondary"]["windowMinutes"] == _SECONDARY_WINDOW_MINUTES
+    assert account["secondary"]["resetAt"] is not None
+
+
+@pytest.mark.asyncio
+async def test_fleet_summary_omits_sensitive_fields(async_client, db_setup):
+    plain_key = await _create_api_key("fleet-summary-sensitive-key")
+    await _seed_account_with_windows(
+        "acc_sensitive",
+        "sensitive@example.com",
+        primary_used_percent=25.0,
+        secondary_used_percent=40.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+
+    response = await async_client.get(
+        "/api/fleet/summary",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    _assert_no_forbidden_keys(payload)
+    raw = json.dumps(payload)
+    assert "access" not in raw
+    assert "refresh" not in raw
+    account = payload["accounts"][0]
+    assert set(account.keys()) == {
+        "accountId",
+        "displayName",
+        "email",
+        "status",
+        "planType",
+        "primary",
+        "secondary",
+        "lastRefreshAt",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fleet_refresh_requires_api_key(async_client, db_setup):
+    response = await async_client.post("/api/fleet/refresh")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_fleet_refresh_reports_bounded_attempt_without_sensitive_fields(async_client, db_setup):
+    plain_key = await _create_api_key("fleet-refresh-key")
+    await _seed_account_with_windows(
+        "acc_refresh_active",
+        "refresh-active@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=10.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    await _seed_account_with_windows(
+        "acc_refresh_paused",
+        "refresh-paused@example.com",
+        primary_used_percent=20.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+        status=AccountStatus.PAUSED,
+    )
+    await _seed_account_with_windows(
+        "acc_refresh_reauth",
+        "refresh-reauth@example.com",
+        primary_used_percent=30.0,
+        secondary_used_percent=30.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+        status=AccountStatus.REAUTH_REQUIRED,
+    )
+    await _seed_account_with_windows(
+        "acc_refresh_deactivated",
+        "refresh-deactivated@example.com",
+        primary_used_percent=40.0,
+        secondary_used_percent=40.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+        status=AccountStatus.DEACTIVATED,
+    )
+
+    response = await async_client.post(
+        "/api/fleet/refresh",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["usageWritten"] is False
+    assert payload["accountCount"] == 4
+    assert payload["attemptedCount"] == 1
+    assert payload["generatedAt"] is not None
+    _assert_no_forbidden_keys(payload)
+
+
+@pytest.mark.asyncio
+async def test_fleet_refresh_uses_route_local_usage_updater_and_invalidates_on_write(
+    async_client,
+    db_setup,
+    monkeypatch,
+):
+    plain_key = await _create_api_key("fleet-refresh-updater-key")
+    await _seed_account_with_windows(
+        "acc_refresh_write",
+        "refresh-write@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=10.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+
+    refresh_calls: list[list[str]] = []
+    invalidations: list[str] = []
+
+    class FakeUsageUpdater:
+        def __init__(self, usage_repo, accounts_repo, additional_usage_repo):
+            self.usage_repo = usage_repo
+            self.accounts_repo = accounts_repo
+            self.additional_usage_repo = additional_usage_repo
+
+        async def refresh_accounts(self, accounts, latest_primary):
+            refresh_calls.append([account.id for account in accounts])
+            assert isinstance(latest_primary, dict)
+            return True
+
+    class FakeRateLimitHeadersCache:
+        async def invalidate(self):
+            invalidations.append("rate_limit_headers")
+
+    class FakeAccountSelectionCache:
+        def invalidate(self):
+            invalidations.append("account_selection")
+
+    monkeypatch.setattr("app.modules.fleet.api.UsageUpdater", FakeUsageUpdater)
+    monkeypatch.setattr(
+        "app.modules.fleet.api.get_rate_limit_headers_cache",
+        lambda: FakeRateLimitHeadersCache(),
+    )
+    monkeypatch.setattr(
+        "app.modules.fleet.api.get_account_selection_cache",
+        lambda: FakeAccountSelectionCache(),
+    )
+
+    response = await async_client.post(
+        "/api/fleet/refresh",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["usageWritten"] is True
+    assert payload["accountCount"] == 1
+    assert payload["attemptedCount"] == 1
+    assert refresh_calls == [["acc_refresh_write"]]
+    assert invalidations == ["rate_limit_headers", "account_selection"]

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -1017,6 +1017,7 @@ async def test_fleet_refresh_respects_account_scoped_api_key(async_client, db_se
 
 @pytest.mark.asyncio
 async def test_fleet_refresh_owns_session_until_shielded_refresh_finishes(db_setup, monkeypatch):
+    fleet_api._BACKGROUND_REFRESH_TASKS.clear()
     await _seed_account_with_windows(
         "acc_refresh_cancel",
         "refresh-cancel@example.com",
@@ -1094,8 +1095,16 @@ async def test_fleet_refresh_owns_session_until_shielded_refresh_finishes(db_set
     await asyncio.sleep(0)
 
     assert not session_exited.is_set()
+    assert len(fleet_api._BACKGROUND_REFRESH_TASKS) == 1
     allow_refresh_finish.set()
     await asyncio.wait_for(session_exited.wait(), timeout=1)
+    await asyncio.wait_for(_wait_for_background_refresh_tasks_to_drain(), timeout=1)
 
     assert session_was_open_during_refresh == [True]
     assert invalidations == ["rate_limit_headers", "account_selection"]
+    assert fleet_api._BACKGROUND_REFRESH_TASKS == set()
+
+
+async def _wait_for_background_refresh_tasks_to_drain() -> None:
+    while fleet_api._BACKGROUND_REFRESH_TASKS:
+        await asyncio.sleep(0)

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -70,7 +70,12 @@ def _make_account(
     )
 
 
-async def _create_api_key(name: str, *, assigned_account_ids: list[str] | None = None) -> str:
+async def _create_api_key(
+    name: str,
+    *,
+    assigned_account_ids: list[str] | None = None,
+    usage_sections: str = "upstream_limits,account_pool_usage",
+) -> str:
     async with SessionLocal() as session:
         service = ApiKeysService(ApiKeysRepository(session))
         created = await service.create_key(
@@ -79,6 +84,7 @@ async def _create_api_key(name: str, *, assigned_account_ids: list[str] | None =
                 allowed_models=None,
                 limits=[],
                 assigned_account_ids=assigned_account_ids,
+                usage_sections=usage_sections,
             )
         )
     return created.key
@@ -267,6 +273,63 @@ async def test_fleet_summary_respects_account_scoped_api_key(async_client, db_se
     raw = json.dumps(payload)
     assert "scope-visible@example.com" in raw
     assert "scope-hidden@example.com" not in raw
+
+
+@pytest.mark.asyncio
+async def test_fleet_summary_hides_usage_when_key_disables_account_pool_usage(async_client, db_setup):
+    await _seed_account_with_windows(
+        "acc_usage_hidden",
+        "usage-hidden@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    plain_key = await _create_api_key("fleet-summary-no-usage-key", usage_sections="")
+
+    response = await async_client.get(
+        "/api/fleet/summary",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    account = response.json()["accounts"][0]
+    assert account["accountId"] == "acc_usage_hidden"
+    assert account["email"] == "usage-hidden@example.com"
+    assert account["lastRefreshAt"] is None
+    assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
+    assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
+
+
+@pytest.mark.asyncio
+async def test_fleet_summary_hides_usage_when_global_api_key_quota_privacy_enabled(async_client, db_setup):
+    plain_key = await _create_api_key("fleet-summary-global-hidden-key")
+    await _seed_account_with_windows(
+        "acc_global_usage_hidden",
+        "global-usage-hidden@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+
+    settings = await async_client.put(
+        "/api/settings",
+        json={"hideUpstreamQuotaFromApiKeys": True},
+    )
+    assert settings.status_code == 200
+
+    response = await async_client.get(
+        "/api/fleet/summary",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    account = response.json()["accounts"][0]
+    assert account["accountId"] == "acc_global_usage_hidden"
+    assert account["lastRefreshAt"] is None
+    assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
+    assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -282,7 +282,7 @@ async def test_fleet_summary_hides_usage_when_key_disables_account_pool_usage(as
     await _seed_account_with_windows(
         "acc_usage_hidden",
         "usage-hidden@example.com",
-        primary_used_percent=10.0,
+        primary_used_percent=100.0,
         secondary_used_percent=20.0,
         primary_reset_at=1735862400,
         secondary_reset_at=1736467200,
@@ -298,6 +298,7 @@ async def test_fleet_summary_hides_usage_when_key_disables_account_pool_usage(as
     account = response.json()["accounts"][0]
     assert account["accountId"] == "acc_usage_hidden"
     assert account["email"] == "usage-hidden@example.com"
+    assert account["status"] == "active"
     assert account["lastRefreshAt"] is None
     assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
     assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
@@ -422,7 +423,8 @@ async def test_fleet_refresh_uses_route_local_usage_updater_and_invalidates_on_w
             self.accounts_repo = accounts_repo
             self.additional_usage_repo = additional_usage_repo
 
-        async def refresh_accounts(self, accounts, latest_primary):
+        async def refresh_accounts(self, accounts, latest_primary, *, own_singleflight_sessions=False):
+            assert own_singleflight_sessions is True
             updater_session_ids.append(id(self.usage_repo._session))
             refresh_calls.append([account.id for account in accounts])
             assert isinstance(latest_primary, dict)
@@ -498,7 +500,8 @@ async def test_fleet_refresh_respects_account_scoped_api_key(async_client, db_se
             self.accounts_repo = accounts_repo
             self.additional_usage_repo = additional_usage_repo
 
-        async def refresh_accounts(self, accounts, latest_primary):
+        async def refresh_accounts(self, accounts, latest_primary, *, own_singleflight_sessions=False):
+            assert own_singleflight_sessions is True
             refresh_calls.append([account.id for account in accounts])
             assert set(latest_primary) <= {"acc_refresh_scope_visible"}
             return False
@@ -539,7 +542,9 @@ async def test_fleet_refresh_owns_session_until_shielded_refresh_finishes(db_set
             self.accounts_repo = accounts_repo
             self.additional_usage_repo = additional_usage_repo
 
-        async def refresh_accounts(self, accounts, latest_primary):
+        async def refresh_accounts(self, accounts, latest_primary, *, own_singleflight_sessions=False):
+            assert own_singleflight_sessions is True
+
             async def shielded_refresh() -> bool:
                 refresh_started.set()
                 await allow_refresh_finish.wait()

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 import json
 from contextlib import asynccontextmanager
+from datetime import timedelta
 
 import pytest
 
+from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountStatus, RequestKind, RequestLog, StickySession, StickySessionKind
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -47,6 +49,20 @@ _FORBIDDEN_KEYS = {
     "additionalQuotas",
     "deactivation_reason",
     "deactivationReason",
+    "request_id",
+    "requestId",
+    "archive_request_id",
+    "archiveRequestId",
+    "session_id",
+    "sessionId",
+    "api_key_id",
+    "apiKeyId",
+    "client_ip",
+    "clientIp",
+    "error_message",
+    "errorMessage",
+    "failure_detail",
+    "failureDetail",
 }
 
 
@@ -122,6 +138,73 @@ async def _seed_account_with_windows(
         )
 
 
+async def _seed_request_log(
+    account_id: str,
+    request_id: str,
+    *,
+    requested_at,
+    status: str = "success",
+    error_code: str | None = None,
+    error_message: str | None = None,
+    request_kind: str = RequestKind.NORMAL.value,
+    input_tokens: int = 0,
+    cached_input_tokens: int = 0,
+    output_tokens: int = 0,
+    cost_usd: float = 0.0,
+    source: str | None = "codex",
+    useragent_group: str | None = "codex-local",
+    client_ip: str | None = None,
+    session_id: str | None = None,
+    api_key_id: str | None = None,
+    deleted_at=None,
+) -> None:
+    async with SessionLocal() as session:
+        session.add(
+            RequestLog(
+                account_id=account_id,
+                request_id=request_id,
+                archive_request_id=f"archive-{request_id}",
+                model="gpt-5",
+                request_kind=request_kind,
+                requested_at=requested_at,
+                deleted_at=deleted_at,
+                status=status,
+                error_code=error_code,
+                error_message=error_message,
+                input_tokens=input_tokens,
+                cached_input_tokens=cached_input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost_usd,
+                source=source,
+                useragent_group=useragent_group,
+                client_ip=client_ip,
+                session_id=session_id,
+                api_key_id=api_key_id,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_sticky_session(
+    account_id: str,
+    key: str,
+    *,
+    kind: StickySessionKind = StickySessionKind.PROMPT_CACHE,
+    updated_at,
+) -> None:
+    async with SessionLocal() as session:
+        session.add(
+            StickySession(
+                key=key,
+                kind=kind,
+                account_id=account_id,
+                created_at=updated_at,
+                updated_at=updated_at,
+            )
+        )
+        await session.commit()
+
+
 def _assert_no_forbidden_keys(node: object) -> None:
     if isinstance(node, dict):
         for key, value in node.items():
@@ -130,6 +213,10 @@ def _assert_no_forbidden_keys(node: object) -> None:
     elif isinstance(node, list):
         for item in node:
             _assert_no_forbidden_keys(item)
+
+
+def _window(payload: dict, key: str) -> dict:
+    return next(window for window in payload["pressure"]["windows"] if window["key"] == key)
 
 
 @pytest.mark.asyncio
@@ -333,6 +420,268 @@ async def test_fleet_summary_hides_usage_when_global_api_key_quota_privacy_enabl
     assert account["lastRefreshAt"] is None
     assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
     assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
+
+
+@pytest.mark.asyncio
+async def test_fleet_observability_requires_api_key(async_client, db_setup):
+    response = await async_client.get("/api/fleet/observability")
+
+    assert response.status_code == 401
+    assert "pressure" not in response.text
+    assert "sticky" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_fleet_observability_reports_pressure_and_sticky_without_sensitive_fields(async_client, db_setup):
+    await get_settings_cache().invalidate()
+    plain_key = await _create_api_key("fleet-observability-key")
+    await _seed_account_with_windows(
+        "acc_observe",
+        "observe@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    now = utcnow()
+    await _seed_request_log(
+        "acc_observe",
+        "req-observe-success",
+        requested_at=now - timedelta(minutes=5),
+        request_kind="prewarm",
+        input_tokens=100,
+        cached_input_tokens=70,
+        output_tokens=10,
+        cost_usd=1.0,
+        client_ip="203.0.113.15",
+        session_id="session-observe-secret",
+        api_key_id="api-key-observe-secret",
+    )
+    await _seed_request_log(
+        "acc_observe",
+        "req-observe-error",
+        requested_at=now - timedelta(minutes=10),
+        status="error",
+        error_code="rate_limit",
+        error_message="secret upstream error body",
+        input_tokens=20,
+        output_tokens=0,
+        cost_usd=0.5,
+        client_ip="203.0.113.16",
+    )
+    await _seed_request_log(
+        "acc_observe",
+        "req-observe-older",
+        requested_at=now - timedelta(minutes=45),
+        input_tokens=40,
+        cached_input_tokens=10,
+        output_tokens=5,
+        cost_usd=0.75,
+        useragent_group="worker",
+    )
+    await _seed_request_log(
+        "acc_observe",
+        "req-observe-warmup",
+        requested_at=now - timedelta(minutes=2),
+        request_kind=RequestKind.WARMUP.value,
+        input_tokens=10_000,
+        cost_usd=99.0,
+    )
+    await _seed_request_log(
+        "acc_observe",
+        "req-observe-deleted",
+        requested_at=now - timedelta(minutes=2),
+        deleted_at=now - timedelta(minutes=1),
+        input_tokens=10_000,
+        cost_usd=99.0,
+    )
+    await _seed_sticky_session(
+        "acc_observe",
+        "sticky-observe-recent-secret",
+        updated_at=now - timedelta(minutes=2),
+    )
+    await _seed_sticky_session(
+        "acc_observe",
+        "sticky-observe-stale-secret",
+        updated_at=now - timedelta(hours=1),
+    )
+    await _seed_sticky_session(
+        "acc_observe",
+        "sticky-observe-thread-secret",
+        kind=StickySessionKind.STICKY_THREAD,
+        updated_at=now - timedelta(hours=2),
+    )
+
+    response = await async_client.get(
+        "/api/fleet/observability",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    _assert_no_forbidden_keys(payload)
+    assert payload["available"] is True
+    assert payload["source"] == "codex-lb fleet observability"
+    assert payload["generatedAt"] is not None
+    assert payload["pressure"]["available"] is True
+    assert {window["key"] for window in payload["pressure"]["windows"]} == {"30m", "2h"}
+
+    thirty = _window(payload, "30m")
+    assert thirty["requestCount"] == 2
+    assert thirty["errorCount"] == 1
+    assert thirty["inputTokens"] == 120
+    assert thirty["cachedInputTokens"] == 70
+    assert thirty["outputTokens"] == 10
+    assert thirty["costUsd"] == 1.5
+    assert thirty["topErrorCode"] == "rate_limit"
+    assert thirty["byAccount"] == [
+        {
+            "accountId": "acc_observe",
+            "email": "observe@example.com",
+            "label": "observe@example.com",
+            "requestCount": 2,
+            "errorCount": 1,
+            "inputTokens": 120,
+            "cachedInputTokens": 70,
+            "outputTokens": 10,
+            "costUsd": 1.5,
+            "lastSelectedAt": thirty["byAccount"][0]["lastSelectedAt"],
+        }
+    ]
+    assert thirty["byAccount"][0]["lastSelectedAt"] is not None
+    assert {item["requestKind"]: item["requestCount"] for item in thirty["byKind"]} == {
+        "normal": 1,
+        "prewarm": 1,
+    }
+    assert thirty["byClient"][0]["clientGroup"] == "codex-local"
+    assert thirty["byClient"][0]["requestCount"] == 2
+
+    two_hour = _window(payload, "2h")
+    assert two_hour["requestCount"] == 3
+    assert two_hour["errorCount"] == 1
+    assert two_hour["inputTokens"] == 160
+    assert two_hour["cachedInputTokens"] == 80
+    assert two_hour["outputTokens"] == 15
+    assert two_hour["costUsd"] == 2.25
+
+    sticky = payload["sticky"]
+    assert sticky["available"] is True
+    assert sticky["total"] == 3
+    assert sticky["recentCount"] == 2
+    assert sticky["staleCount"] == 1
+    assert sticky["staleThresholdSeconds"] == 1800
+    assert sticky["byAccount"][0]["accountId"] == "acc_observe"
+    assert sticky["byAccount"][0]["total"] == 3
+    assert sticky["byAccount"][0]["recentCount"] == 2
+    assert sticky["byAccount"][0]["staleCount"] == 1
+    assert {kind["name"]: kind["staleCount"] for kind in sticky["byAccount"][0]["kinds"]} == {
+        "prompt_cache": 1,
+        "sticky_thread": 0,
+    }
+
+    raw = json.dumps(payload)
+    assert "req-observe" not in raw
+    assert "archive-req-observe" not in raw
+    assert "session-observe-secret" not in raw
+    assert "api-key-observe-secret" not in raw
+    assert "sticky-observe" not in raw
+    assert "203.0.113" not in raw
+    assert "secret upstream error body" not in raw
+
+
+@pytest.mark.asyncio
+async def test_fleet_observability_respects_account_scoped_api_key(async_client, db_setup):
+    await get_settings_cache().invalidate()
+    await _seed_account_with_windows(
+        "acc_observe_visible",
+        "observe-visible@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    await _seed_account_with_windows(
+        "acc_observe_hidden",
+        "observe-hidden@example.com",
+        primary_used_percent=30.0,
+        secondary_used_percent=40.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    now = utcnow()
+    await _seed_request_log("acc_observe_visible", "req-visible", requested_at=now - timedelta(minutes=5))
+    await _seed_request_log("acc_observe_hidden", "req-hidden", requested_at=now - timedelta(minutes=5))
+    await _seed_sticky_session("acc_observe_visible", "sticky-visible", updated_at=now - timedelta(minutes=5))
+    await _seed_sticky_session("acc_observe_hidden", "sticky-hidden", updated_at=now - timedelta(minutes=5))
+    plain_key = await _create_api_key(
+        "fleet-observability-scoped-key",
+        assigned_account_ids=["acc_observe_visible"],
+    )
+
+    response = await async_client.get(
+        "/api/fleet/observability",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert _window(payload, "30m")["requestCount"] == 1
+    assert _window(payload, "30m")["byAccount"][0]["accountId"] == "acc_observe_visible"
+    assert payload["sticky"]["total"] == 1
+    assert payload["sticky"]["byAccount"][0]["accountId"] == "acc_observe_visible"
+    raw = json.dumps(payload)
+    assert "acc_observe_hidden" not in raw
+    assert "observe-hidden@example.com" not in raw
+    assert "req-hidden" not in raw
+    assert "sticky-hidden" not in raw
+
+
+@pytest.mark.asyncio
+async def test_fleet_observability_hides_usage_when_key_disables_account_pool_usage(async_client, db_setup):
+    await get_settings_cache().invalidate()
+    plain_key = await _create_api_key("fleet-observability-no-usage-key", usage_sections="")
+    await _seed_account_with_windows(
+        "acc_observe_hidden_usage",
+        "observe-hidden-usage@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    now = utcnow()
+    await _seed_request_log(
+        "acc_observe_hidden_usage",
+        "req-hidden-usage",
+        requested_at=now - timedelta(minutes=5),
+    )
+    await _seed_sticky_session(
+        "acc_observe_hidden_usage",
+        "sticky-hidden-usage",
+        updated_at=now - timedelta(minutes=5),
+    )
+
+    response = await async_client.get(
+        "/api/fleet/observability",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["available"] is False
+    assert payload["pressure"] == {"available": False, "windows": []}
+    assert payload["sticky"] == {
+        "available": False,
+        "total": 0,
+        "recentCount": 0,
+        "staleCount": 0,
+        "staleThresholdSeconds": None,
+        "truncated": False,
+        "byAccount": [],
+    }
+    raw = json.dumps(payload)
+    assert "observe-hidden-usage@example.com" not in raw
+    assert "req-hidden-usage" not in raw
+    assert "sticky-hidden-usage" not in raw
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from contextlib import asynccontextmanager
 
@@ -11,7 +12,8 @@ from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
-from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService
+from app.modules.api_keys.service import ApiKeyCreateData, ApiKeyData, ApiKeysService
+from app.modules.fleet import api as fleet_api
 from app.modules.usage.repository import UsageRepository
 
 pytestmark = pytest.mark.integration
@@ -513,3 +515,87 @@ async def test_fleet_refresh_respects_account_scoped_api_key(async_client, db_se
     assert payload["accountCount"] == 1
     assert payload["attemptedCount"] == 1
     assert refresh_calls == [["acc_refresh_scope_visible"]]
+
+
+@pytest.mark.asyncio
+async def test_fleet_refresh_owns_session_until_shielded_refresh_finishes(db_setup, monkeypatch):
+    await _seed_account_with_windows(
+        "acc_refresh_cancel",
+        "refresh-cancel@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=10.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    refresh_started = asyncio.Event()
+    allow_refresh_finish = asyncio.Event()
+    session_exited = asyncio.Event()
+    session_was_open_during_refresh: list[bool] = []
+    invalidations: list[str] = []
+
+    class FakeUsageUpdater:
+        def __init__(self, usage_repo, accounts_repo, additional_usage_repo):
+            self.usage_repo = usage_repo
+            self.accounts_repo = accounts_repo
+            self.additional_usage_repo = additional_usage_repo
+
+        async def refresh_accounts(self, accounts, latest_primary):
+            async def shielded_refresh() -> bool:
+                refresh_started.set()
+                await allow_refresh_finish.wait()
+                session_was_open_during_refresh.append(not session_exited.is_set())
+                return True
+
+            return await asyncio.shield(asyncio.create_task(shielded_refresh()))
+
+    class FakeRateLimitHeadersCache:
+        async def invalidate(self):
+            invalidations.append("rate_limit_headers")
+
+    class FakeAccountSelectionCache:
+        def invalidate(self):
+            invalidations.append("account_selection")
+
+    @asynccontextmanager
+    async def recording_background_session():
+        async with SessionLocal() as session:
+            try:
+                yield session
+            finally:
+                session_exited.set()
+
+    monkeypatch.setattr(fleet_api, "get_background_session", recording_background_session)
+    monkeypatch.setattr(fleet_api, "UsageUpdater", FakeUsageUpdater)
+    monkeypatch.setattr(fleet_api, "get_rate_limit_headers_cache", lambda: FakeRateLimitHeadersCache())
+    monkeypatch.setattr(fleet_api, "get_account_selection_cache", lambda: FakeAccountSelectionCache())
+
+    request_task = asyncio.create_task(
+        fleet_api.refresh_fleet_usage(
+            api_key=ApiKeyData(
+                id="fleet-refresh-cancel-key",
+                name="fleet refresh cancel key",
+                key_prefix="fleet-refresh-cancel",
+                allowed_models=None,
+                enforced_model=None,
+                enforced_reasoning_effort=None,
+                enforced_service_tier=None,
+                expires_at=None,
+                is_active=True,
+                created_at=utcnow(),
+                last_used_at=None,
+            )
+        )
+    )
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+
+    request_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+    await asyncio.sleep(0)
+
+    assert not session_exited.is_set()
+    allow_refresh_finish.set()
+    await asyncio.wait_for(session_exited.wait(), timeout=1)
+
+    assert session_was_open_during_refresh == [True]
+    assert invalidations == ["rate_limit_headers", "account_selection"]

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -149,7 +149,8 @@ async def _seed_request_log(
     request_kind: str = RequestKind.NORMAL.value,
     input_tokens: int = 0,
     cached_input_tokens: int = 0,
-    output_tokens: int = 0,
+    output_tokens: int | None = 0,
+    reasoning_tokens: int | None = None,
     cost_usd: float = 0.0,
     source: str | None = "codex",
     useragent_group: str | None = "codex-local",
@@ -174,6 +175,7 @@ async def _seed_request_log(
                 input_tokens=input_tokens,
                 cached_input_tokens=cached_input_tokens,
                 output_tokens=output_tokens,
+                reasoning_tokens=reasoning_tokens,
                 cost_usd=cost_usd,
                 source=source,
                 useragent_group=useragent_group,
@@ -392,6 +394,58 @@ async def test_fleet_summary_hides_usage_when_key_disables_account_pool_usage(as
 
 
 @pytest.mark.asyncio
+async def test_fleet_summary_hides_usage_when_key_only_allows_upstream_limits(async_client, db_setup):
+    await _seed_account_with_windows(
+        "acc_upstream_only",
+        "upstream-only@example.com",
+        primary_used_percent=100.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    plain_key = await _create_api_key("fleet-summary-upstream-only-key", usage_sections="upstream_limits")
+
+    response = await async_client.get(
+        "/api/fleet/summary",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    account = response.json()["accounts"][0]
+    assert account["accountId"] == "acc_upstream_only"
+    assert account["email"] == "upstream-only@example.com"
+    assert account["status"] == "active"
+    assert account["lastRefreshAt"] is None
+    assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
+    assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
+
+
+@pytest.mark.asyncio
+async def test_fleet_summary_hides_usage_when_key_omits_upstream_limits(async_client, db_setup):
+    await _seed_account_with_windows(
+        "acc_usage_hidden",
+        "usage-hidden-no-upstream@example.com",
+        primary_used_percent=100.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    plain_key = await _create_api_key("fleet-summary-account-pool-only-key", usage_sections="account_pool_usage")
+
+    response = await async_client.get(
+        "/api/fleet/summary",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    account = response.json()["accounts"][0]
+    assert account["accountId"] == "acc_usage_hidden"
+    assert account["lastRefreshAt"] is None
+    assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
+    assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
+
+
+@pytest.mark.asyncio
 async def test_fleet_summary_hides_usage_when_global_api_key_quota_privacy_enabled(async_client, db_setup):
     plain_key = await _create_api_key("fleet-summary-global-hidden-key")
     await _seed_account_with_windows(
@@ -471,6 +525,15 @@ async def test_fleet_observability_reports_pressure_and_sticky_without_sensitive
     )
     await _seed_request_log(
         "acc_observe",
+        "req-observe-reasoning",
+        requested_at=now - timedelta(minutes=15),
+        input_tokens=30,
+        output_tokens=None,
+        reasoning_tokens=25,
+        cost_usd=0.25,
+    )
+    await _seed_request_log(
+        "acc_observe",
         "req-observe-older",
         requested_at=now - timedelta(minutes=45),
         input_tokens=40,
@@ -527,42 +590,42 @@ async def test_fleet_observability_reports_pressure_and_sticky_without_sensitive
     assert {window["key"] for window in payload["pressure"]["windows"]} == {"30m", "2h"}
 
     thirty = _window(payload, "30m")
-    assert thirty["requestCount"] == 2
+    assert thirty["requestCount"] == 3
     assert thirty["errorCount"] == 1
-    assert thirty["inputTokens"] == 120
+    assert thirty["inputTokens"] == 150
     assert thirty["cachedInputTokens"] == 70
-    assert thirty["outputTokens"] == 10
-    assert thirty["costUsd"] == 1.5
+    assert thirty["outputTokens"] == 35
+    assert thirty["costUsd"] == 1.75
     assert thirty["topErrorCode"] == "rate_limit"
     assert thirty["byAccount"] == [
         {
             "accountId": "acc_observe",
             "email": "observe@example.com",
             "label": "observe@example.com",
-            "requestCount": 2,
+            "requestCount": 3,
             "errorCount": 1,
-            "inputTokens": 120,
+            "inputTokens": 150,
             "cachedInputTokens": 70,
-            "outputTokens": 10,
-            "costUsd": 1.5,
+            "outputTokens": 35,
+            "costUsd": 1.75,
             "lastSelectedAt": thirty["byAccount"][0]["lastSelectedAt"],
         }
     ]
     assert thirty["byAccount"][0]["lastSelectedAt"] is not None
     assert {item["requestKind"]: item["requestCount"] for item in thirty["byKind"]} == {
-        "normal": 1,
+        "normal": 2,
         "prewarm": 1,
     }
     assert thirty["byClient"][0]["clientGroup"] == "codex-local"
-    assert thirty["byClient"][0]["requestCount"] == 2
+    assert thirty["byClient"][0]["requestCount"] == 3
 
     two_hour = _window(payload, "2h")
-    assert two_hour["requestCount"] == 3
+    assert two_hour["requestCount"] == 4
     assert two_hour["errorCount"] == 1
-    assert two_hour["inputTokens"] == 160
+    assert two_hour["inputTokens"] == 190
     assert two_hour["cachedInputTokens"] == 80
-    assert two_hour["outputTokens"] == 15
-    assert two_hour["costUsd"] == 2.25
+    assert two_hour["outputTokens"] == 40
+    assert two_hour["costUsd"] == 2.5
 
     sticky = payload["sticky"]
     assert sticky["available"] is True
@@ -587,6 +650,41 @@ async def test_fleet_observability_reports_pressure_and_sticky_without_sensitive
     assert "sticky-observe" not in raw
     assert "203.0.113" not in raw
     assert "secret upstream error body" not in raw
+
+
+@pytest.mark.asyncio
+async def test_fleet_observability_marks_pressure_window_truncated(async_client, db_setup):
+    await get_settings_cache().invalidate()
+    plain_key = await _create_api_key("fleet-observability-truncated-key")
+    now = utcnow()
+    for index in range(11):
+        account_id = f"acc_observe_truncated_{index:02d}"
+        await _seed_account_with_windows(
+            account_id,
+            f"observe-truncated-{index:02d}@example.com",
+            primary_used_percent=10.0,
+            secondary_used_percent=20.0,
+            primary_reset_at=1735862400,
+            secondary_reset_at=1736467200,
+        )
+        await _seed_request_log(
+            account_id,
+            f"req-observe-truncated-{index:02d}",
+            requested_at=now - timedelta(minutes=5),
+            input_tokens=10,
+            output_tokens=1,
+        )
+
+    response = await async_client.get(
+        "/api/fleet/observability",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    thirty = _window(response.json(), "30m")
+    assert thirty["requestCount"] == 11
+    assert thirty["truncated"] is True
+    assert len(thirty["byAccount"]) == 10
 
 
 @pytest.mark.asyncio
@@ -682,6 +780,54 @@ async def test_fleet_observability_hides_usage_when_key_disables_account_pool_us
     assert "observe-hidden-usage@example.com" not in raw
     assert "req-hidden-usage" not in raw
     assert "sticky-hidden-usage" not in raw
+
+
+@pytest.mark.asyncio
+async def test_fleet_observability_hides_usage_when_key_only_allows_upstream_limits(async_client, db_setup):
+    await get_settings_cache().invalidate()
+    plain_key = await _create_api_key("fleet-observability-upstream-only-key", usage_sections="upstream_limits")
+    await _seed_account_with_windows(
+        "acc_observe_upstream_only",
+        "observe-upstream-only@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+    )
+    now = utcnow()
+    await _seed_request_log(
+        "acc_observe_upstream_only",
+        "req-upstream-only",
+        requested_at=now - timedelta(minutes=5),
+    )
+    await _seed_sticky_session(
+        "acc_observe_upstream_only",
+        "sticky-upstream-only",
+        updated_at=now - timedelta(minutes=5),
+    )
+
+    response = await async_client.get(
+        "/api/fleet/observability",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["available"] is False
+    assert payload["pressure"] == {"available": False, "windows": []}
+    assert payload["sticky"] == {
+        "available": False,
+        "total": 0,
+        "recentCount": 0,
+        "staleCount": 0,
+        "staleThresholdSeconds": None,
+        "truncated": False,
+        "byAccount": [],
+    }
+    raw = json.dumps(payload)
+    assert "observe-upstream-only@example.com" not in raw
+    assert "req-upstream-only" not in raw
+    assert "sticky-upstream-only" not in raw
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -545,6 +545,78 @@ async def test_ensure_fresh_singleflights_refresh_admission_for_same_account(mon
 
 
 @pytest.mark.asyncio
+async def test_ensure_fresh_singleflight_coalesces_owned_and_nonowned_sessions(monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    refresh_calls = 0
+    scope_state = {"opened": False, "closed": False}
+
+    async def _fake_refresh(_: str, **_kwargs: object) -> TokenRefreshResult:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        started.set()
+        await release.wait()
+        return TokenRefreshResult(
+            access_token="new-access",
+            refresh_token="new-refresh",
+            id_token="new-id",
+            account_id="acc_sf_owner",
+            plan_type="plus",
+            email=None,
+        )
+
+    @asynccontextmanager
+    async def _refresh_scope() -> AsyncIterator[AccountsRepositoryPort]:
+        scope_state["opened"] = True
+        try:
+            yield cast(AccountsRepositoryPort, owned_repo)
+        finally:
+            scope_state["closed"] = True
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    account_payload = dict(
+        id="acc_sf_owner",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    request_account = Account(**account_payload)
+    owned_account = Account(**account_payload)
+    request_repo = _DummyRepo()
+    owned_repo = _DummyRepo()
+
+    nonowned_manager = AuthManager(cast(AccountsRepositoryPort, request_repo))
+    owned_manager = AuthManager(
+        cast(AccountsRepositoryPort, request_repo),
+        refresh_repo_factory=_refresh_scope,
+    )
+
+    nonowned_task = asyncio.create_task(nonowned_manager.ensure_fresh(request_account, force=True))
+    await started.wait()
+    owned_task = asyncio.create_task(owned_manager.ensure_fresh(owned_account, force=True))
+    await asyncio.sleep(0.01)
+
+    assert not owned_task.done()
+
+    release.set()
+    await asyncio.gather(nonowned_task, owned_task)
+
+    assert refresh_calls == 1
+    assert request_repo.tokens_payload is not None
+    assert request_repo.tokens_payload["account_id"] == "acc_sf_owner"
+    assert owned_repo.tokens_payload is None
+    assert scope_state == {"opened": False, "closed": False}
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_reuses_recent_failure_without_reissuing_refresh(monkeypatch):
     refresh_calls = 0
 

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Collection
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
@@ -71,6 +72,103 @@ async def test_usage_refresh_singleflight_cancel_all_cancels_inflight_task() -> 
         await task
     assert cancelled.is_set()
     assert usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT._inflight == {}
+
+
+@pytest.mark.asyncio
+async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _make_account("acc_owned_session", "workspace_owned")
+    refresh_started = asyncio.Event()
+    allow_refresh_finish = asyncio.Event()
+    inner_session_closed = asyncio.Event()
+    session_was_open_during_refresh: list[bool] = []
+
+    @dataclass(frozen=True, slots=True)
+    class Settings:
+        usage_refresh_enabled: bool = True
+        usage_refresh_interval_seconds: int = 0
+        usage_refresh_auth_failure_cooldown_seconds: int = 0
+
+    class OuterUsageRepository:
+        async def latest_entry_for_account(self, account_id: str, *, window: str | None = None):
+            return None
+
+        async def add_entry(
+            self,
+            account_id: str,
+            used_percent: float,
+            input_tokens: int | None = None,
+            output_tokens: int | None = None,
+            recorded_at: datetime | None = None,
+            window: str | None = None,
+            reset_at: int | None = None,
+            window_minutes: int | None = None,
+            credits_has: bool | None = None,
+            credits_unlimited: bool | None = None,
+            credits_balance: float | None = None,
+        ) -> UsageHistory | None:
+            return None
+
+    class InnerUsageRepository(OuterUsageRepository):
+        def __init__(self, session) -> None:
+            self.session = session
+
+    class InnerAdditionalUsageRepository:
+        def __init__(self, session) -> None:
+            self.session = session
+
+    class InnerAccountsRepository:
+        def __init__(self, session) -> None:
+            self.session = session
+
+        async def get_by_id(self, account_id: str):
+            return account if account_id == account.id else None
+
+    @asynccontextmanager
+    async def recording_background_session():
+        try:
+            yield object()
+        finally:
+            inner_session_closed.set()
+
+    async def fake_refresh_account_if_stale(
+        self,
+        account_arg: Account,
+        *,
+        usage_account_id: str | None,
+        interval_seconds: int,
+    ) -> usage_updater_module.AccountRefreshResult:
+        refresh_started.set()
+        await allow_refresh_finish.wait()
+        session_was_open_during_refresh.append(not inner_session_closed.is_set())
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    monkeypatch.setattr(usage_updater_module, "get_background_session", recording_background_session)
+    monkeypatch.setattr(usage_updater_module, "AccountsRepository", InnerAccountsRepository)
+    monkeypatch.setattr(usage_updater_module, "UsageRepository", InnerUsageRepository)
+    monkeypatch.setattr(usage_updater_module, "AdditionalUsageRepository", InnerAdditionalUsageRepository)
+    monkeypatch.setattr(UsageUpdater, "_refresh_account_if_stale", fake_refresh_account_if_stale)
+    monkeypatch.setattr(usage_updater_module, "get_settings", Settings)
+
+    task = asyncio.create_task(
+        UsageUpdater(OuterUsageRepository()).refresh_accounts(
+            [account],
+            {},
+            own_singleflight_sessions=True,
+        )
+    )
+    await asyncio.wait_for(refresh_started.wait(), timeout=1)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0)
+
+    assert not inner_session_closed.is_set()
+    allow_refresh_finish.set()
+    await asyncio.wait_for(inner_session_closed.wait(), timeout=1)
+    assert session_was_open_during_refresh == [True]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -198,6 +198,89 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
 
 
 @pytest.mark.asyncio
+async def test_owned_singleflight_reload_skips_account_that_became_ineligible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _make_account("acc_owned_session_paused", "workspace_owned_paused")
+    account.status = AccountStatus.PAUSED
+    refresh_called = False
+
+    @dataclass(frozen=True, slots=True)
+    class Settings:
+        usage_refresh_enabled: bool = True
+        usage_refresh_interval_seconds: int = 0
+        usage_refresh_auth_failure_cooldown_seconds: int = 0
+
+    class OuterUsageRepository:
+        async def latest_entry_for_account(self, account_id: str, *, window: str | None = None):
+            return None
+
+        async def add_entry(
+            self,
+            account_id: str,
+            used_percent: float,
+            input_tokens: int | None = None,
+            output_tokens: int | None = None,
+            recorded_at: datetime | None = None,
+            window: str | None = None,
+            reset_at: int | None = None,
+            window_minutes: int | None = None,
+            credits_has: bool | None = None,
+            credits_unlimited: bool | None = None,
+            credits_balance: float | None = None,
+        ) -> UsageHistory | None:
+            return None
+
+    class InnerUsageRepository(OuterUsageRepository):
+        def __init__(self, session) -> None:
+            self.session = session
+
+    class InnerAdditionalUsageRepository:
+        def __init__(self, session) -> None:
+            self.session = session
+
+    class InnerAccountsRepository:
+        def __init__(self, session) -> None:
+            self.session = session
+
+        async def get_by_id(self, account_id: str):
+            return account if account_id == account.id else None
+
+    @asynccontextmanager
+    async def background_session():
+        yield object()
+
+    async def fail_if_refreshed(
+        self,
+        account_arg: Account,
+        *,
+        usage_account_id: str | None,
+        interval_seconds: int,
+    ) -> usage_updater_module.AccountRefreshResult:
+        nonlocal refresh_called
+        refresh_called = True
+        return usage_updater_module.AccountRefreshResult(usage_written=True)
+
+    monkeypatch.setattr(usage_updater_module, "get_background_session", background_session)
+    monkeypatch.setattr(usage_updater_module, "SessionAccountsRepository", InnerAccountsRepository)
+    monkeypatch.setattr(usage_updater_module, "SessionUsageRepository", InnerUsageRepository)
+    monkeypatch.setattr(usage_updater_module, "AdditionalUsageRepository", InnerAdditionalUsageRepository)
+    monkeypatch.setattr(UsageUpdater, "_refresh_account_if_stale", fail_if_refreshed)
+    monkeypatch.setattr(usage_updater_module, "get_settings", Settings)
+
+    initial_snapshot = _make_account("acc_owned_session_paused", "workspace_owned_paused")
+
+    refreshed = await UsageUpdater(OuterUsageRepository()).refresh_accounts(
+        [initial_snapshot],
+        {},
+        own_singleflight_sessions=True,
+    )
+
+    assert refreshed is False
+    assert refresh_called is False
+
+
+@pytest.mark.asyncio
 async def test_usage_refresh_scheduler_stop_cancels_inflight_singleflight(monkeypatch: pytest.MonkeyPatch) -> None:
     scheduler = refresh_scheduler_module.UsageRefreshScheduler(interval_seconds=60, enabled=True)
     run_loop_task = asyncio.create_task(asyncio.sleep(3600))

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -81,6 +81,8 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
     account = _make_account("acc_owned_session", "workspace_owned")
     refresh_started = asyncio.Event()
     allow_refresh_finish = asyncio.Event()
+    non_owned_started = asyncio.Event()
+    allow_non_owned_finish = asyncio.Event()
     inner_session_closed = asyncio.Event()
     session_was_open_during_refresh: list[bool] = []
 
@@ -151,6 +153,16 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
     monkeypatch.setattr(UsageUpdater, "_refresh_account_if_stale", fake_refresh_account_if_stale)
     monkeypatch.setattr(usage_updater_module, "get_settings", Settings)
 
+    async def non_owned_refresh_factory() -> usage_updater_module.AccountRefreshResult:
+        non_owned_started.set()
+        await allow_non_owned_finish.wait()
+        return usage_updater_module.AccountRefreshResult(usage_written=False)
+
+    non_owned_task = asyncio.create_task(
+        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(account.id, non_owned_refresh_factory)
+    )
+    await asyncio.wait_for(non_owned_started.wait(), timeout=1)
+
     task = asyncio.create_task(
         UsageUpdater(OuterUsageRepository()).refresh_accounts(
             [account],
@@ -168,6 +180,8 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
     assert not inner_session_closed.is_set()
     allow_refresh_finish.set()
     await asyncio.wait_for(inner_session_closed.wait(), timeout=1)
+    allow_non_owned_finish.set()
+    await non_owned_task
     assert session_was_open_during_refresh == [True]
 
 

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -148,8 +148,8 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
         return usage_updater_module.AccountRefreshResult(usage_written=True)
 
     monkeypatch.setattr(usage_updater_module, "get_background_session", recording_background_session)
-    monkeypatch.setattr(usage_updater_module, "AccountsRepository", InnerAccountsRepository)
-    monkeypatch.setattr(usage_updater_module, "UsageRepository", InnerUsageRepository)
+    monkeypatch.setattr(usage_updater_module, "SessionAccountsRepository", InnerAccountsRepository)
+    monkeypatch.setattr(usage_updater_module, "SessionUsageRepository", InnerUsageRepository)
     monkeypatch.setattr(usage_updater_module, "AdditionalUsageRepository", InnerAdditionalUsageRepository)
     monkeypatch.setattr(UsageUpdater, "_refresh_account_if_stale", fake_refresh_account_if_stale)
     monkeypatch.setattr(usage_updater_module, "get_settings", Settings)

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -82,6 +82,7 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
     refresh_started = asyncio.Event()
     allow_refresh_finish = asyncio.Event()
     non_owned_started = asyncio.Event()
+    prefixed_non_owned_started = asyncio.Event()
     allow_non_owned_finish = asyncio.Event()
     inner_session_closed = asyncio.Event()
     session_was_open_during_refresh: list[bool] = []
@@ -153,15 +154,25 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
     monkeypatch.setattr(UsageUpdater, "_refresh_account_if_stale", fake_refresh_account_if_stale)
     monkeypatch.setattr(usage_updater_module, "get_settings", Settings)
 
-    async def non_owned_refresh_factory() -> usage_updater_module.AccountRefreshResult:
-        non_owned_started.set()
-        await allow_non_owned_finish.wait()
-        return usage_updater_module.AccountRefreshResult(usage_written=False)
+    def non_owned_refresh_factory(started: asyncio.Event):
+        async def factory() -> usage_updater_module.AccountRefreshResult:
+            started.set()
+            await allow_non_owned_finish.wait()
+            return usage_updater_module.AccountRefreshResult(usage_written=False)
+
+        return factory
 
     non_owned_task = asyncio.create_task(
-        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(account.id, non_owned_refresh_factory)
+        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(account.id, non_owned_refresh_factory(non_owned_started))
+    )
+    prefixed_non_owned_task = asyncio.create_task(
+        usage_updater_module._USAGE_REFRESH_SINGLEFLIGHT.run(
+            f"owned-session:{account.id}",
+            non_owned_refresh_factory(prefixed_non_owned_started),
+        )
     )
     await asyncio.wait_for(non_owned_started.wait(), timeout=1)
+    await asyncio.wait_for(prefixed_non_owned_started.wait(), timeout=1)
 
     task = asyncio.create_task(
         UsageUpdater(OuterUsageRepository()).refresh_accounts(
@@ -182,6 +193,7 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
     await asyncio.wait_for(inner_session_closed.wait(), timeout=1)
     allow_non_owned_finish.set()
     await non_owned_task
+    await prefixed_non_owned_task
     assert session_was_open_during_refresh == [True]
 
 


### PR DESCRIPTION
## Summary

Add API-key-authenticated fleet summary and refresh endpoints so trusted local dashboards can distinguish a read of codex-lb state from an upstream usage-refresh attempt.

## Type of change

- [x] `feat:` — new user-facing feature or capability
- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: N/A

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: openspec/changes/add-fleet-refresh-endpoint/

## Changes

- Add `GET /api/fleet/summary` with a minimal non-sensitive account/window projection.
- Add `POST /api/fleet/refresh` behind the existing always-required usage API key dependency.
- Reuse `UsageUpdater.refresh_accounts` outside proxy request selection, skip paused/reauth/deactivated accounts, and invalidate relevant caches only when usage was written.
- Add integration coverage for auth, response shape, sensitive-field omission, unsafe-state skipping, and route-local refresh behavior.

## Test plan

```
uv run pytest tests/integration/test_fleet_summary_api.py -q
uv run ruff check .
uv run ruff format --check .
uv run ty check
git diff --check
```

Also attempted:

```
openspec validate --specs
uv run openspec validate --specs
uv run pytest
```

`openspec` is not installed in this local shell (`command not found` / failed spawn). Full `uv run pytest` reached 4104 passed / 45 skipped but failed three existing account-recovery / usage-updater tests outside this change; rerunning those exact tests in isolation reproduces the same failures.

## Screenshots / output (optional)

N/A — backend/API change.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local-ci subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean. Blocked locally because the OpenSpec CLI is unavailable.
- [x] CHANGELOG is not edited by hand.
