### PR TITLE
fix(dashboard-auth): harden local session ttl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,9 @@ CODEX_LB_FIREWALL_TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128
 CODEX_LB_DASHBOARD_AUTH_MODE=standard
 # Header to trust in trusted_header mode (Authelia commonly forwards Remote-User)
 CODEX_LB_DASHBOARD_AUTH_PROXY_HEADER=Remote-User
+# Set true only when an outer bind/publish layer restricts the dashboard to loopback
+# but the app sees a non-loopback bridge client IP.
+CODEX_LB_DASHBOARD_TRUST_LOOPBACK_HOST_HEADER_FOR_LONG_SESSIONS=false
 # Example trusted_header setup:
 # CODEX_LB_DASHBOARD_AUTH_MODE=trusted_header
 # CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS=true

--- a/app/core/auth/dashboard_session_ttl.py
+++ b/app/core/auth/dashboard_session_ttl.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from starlette.requests import HTTPConnection
+
+DEFAULT_DASHBOARD_SESSION_TTL_SECONDS = 365 * 24 * 60 * 60
+REMOTE_DASHBOARD_SESSION_TTL_SECONDS = 12 * 60 * 60
+LONG_DASHBOARD_SESSION_TTL_THRESHOLD_SECONDS = 30 * 24 * 60 * 60
+_FORWARDED_CLIENT_IP_HEADERS = (
+    "x-forwarded-for",
+    "forwarded",
+    "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
+)
+
+
+def resolve_dashboard_session_ttl_seconds(request: HTTPConnection, configured_ttl_seconds: int) -> int:
+    if configured_ttl_seconds <= LONG_DASHBOARD_SESSION_TTL_THRESHOLD_SECONDS:
+        return configured_ttl_seconds
+    if _allows_long_local_dashboard_session(request):
+        return configured_ttl_seconds
+    return REMOTE_DASHBOARD_SESSION_TTL_SECONDS
+
+
+def _allows_long_local_dashboard_session(request: HTTPConnection) -> bool:
+    from app.core.auth.dashboard_mode import DashboardAuthMode
+
+    settings = _get_settings()
+    if settings.dashboard_auth_mode != DashboardAuthMode.STANDARD:
+        return False
+    if settings.firewall_trust_proxy_headers:
+        return False
+    if _is_local_request(request):
+        return True
+    if not settings.dashboard_trust_loopback_host_header_for_long_sessions:
+        return False
+    if any(request.headers.get(header) for header in _FORWARDED_CLIENT_IP_HEADERS):
+        return False
+    return _uses_loopback_dashboard_url(request)
+
+
+def _get_settings() -> Any:
+    from app.core.config.settings import get_settings
+
+    return get_settings()
+
+
+def _is_local_request(request: HTTPConnection) -> bool:
+    from app.core.request_locality import is_local_request
+
+    return is_local_request(request)
+
+
+def _uses_loopback_dashboard_url(request: HTTPConnection) -> bool:
+    from app.core.request_locality import is_local_host
+
+    return is_local_host(request.url.hostname)

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -255,6 +255,7 @@ class Settings(BaseSettings):
     )
     firewall_ip_cache_ttl_seconds: int = Field(default=30, gt=0)
     dashboard_auth_mode: DashboardAuthMode = DashboardAuthMode.STANDARD
+    dashboard_trust_loopback_host_header_for_long_sessions: bool = False
 
     def upstream_websocket_proxy_env(self) -> Mapping[str, str | None]:
         return _configured_outbound_proxy_env()

--- a/app/db/alembic/versions/20260705_000000_harden_dashboard_session_ttl.py
+++ b/app/db/alembic/versions/20260705_000000_harden_dashboard_session_ttl.py
@@ -1,0 +1,62 @@
+"""harden dashboard session ttl default
+
+Revision ID: 20260705_000000_harden_dashboard_session_ttl
+Revises: 20260701_000000_add_weekly_pace_smoothing_minutes
+Create Date: 2026-07-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260705_000000_harden_dashboard_session_ttl"
+down_revision = "20260701_000000_add_weekly_pace_smoothing_minutes"
+branch_labels = None
+depends_on = None
+
+OLD_DEFAULT_TTL_SECONDS = 43_200
+NEW_DEFAULT_TTL_SECONDS = 31_536_000
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return set()
+    return {str(column["name"]) for column in inspector.get_columns(table_name) if column.get("name") is not None}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind, "dashboard_settings")
+    if not columns or "dashboard_session_ttl_seconds" not in columns:
+        return
+
+    op.execute(
+        sa.text(
+            "UPDATE dashboard_settings "
+            "SET dashboard_session_ttl_seconds = :new_default "
+            "WHERE dashboard_session_ttl_seconds = :old_default"
+        ).bindparams(new_default=NEW_DEFAULT_TTL_SECONDS, old_default=OLD_DEFAULT_TTL_SECONDS)
+    )
+    with op.batch_alter_table("dashboard_settings") as batch_op:
+        batch_op.alter_column(
+            "dashboard_session_ttl_seconds",
+            existing_type=sa.Integer(),
+            server_default=sa.text(str(NEW_DEFAULT_TTL_SECONDS)),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind, "dashboard_settings")
+    if not columns or "dashboard_session_ttl_seconds" not in columns:
+        return
+
+    with op.batch_alter_table("dashboard_settings") as batch_op:
+        batch_op.alter_column(
+            "dashboard_session_ttl_seconds",
+            existing_type=sa.Integer(),
+            server_default=sa.text(str(OLD_DEFAULT_TTL_SECONDS)),
+        )

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -25,6 +25,8 @@ from sqlalchemy import (
 from sqlalchemy import Enum as SqlEnum
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
+from app.core.auth.dashboard_session_ttl import DEFAULT_DASHBOARD_SESSION_TTL_SECONDS
+
 
 class Base(DeclarativeBase):
     pass
@@ -469,8 +471,8 @@ class DashboardSettings(Base):
     )
     dashboard_session_ttl_seconds: Mapped[int] = mapped_column(
         Integer,
-        default=43200,
-        server_default=text("43200"),
+        default=DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+        server_default=text(str(DEFAULT_DASHBOARD_SESSION_TTL_SECONDS)),
         nullable=False,
     )
     import_without_overwrite: Mapped[bool] = mapped_column(

--- a/app/modules/dashboard_auth/api.py
+++ b/app/modules/dashboard_auth/api.py
@@ -16,6 +16,7 @@ from app.core.auth.dashboard_mode import (
     get_dashboard_request_auth,
     password_management_enabled,
 )
+from app.core.auth.dashboard_session_ttl import resolve_dashboard_session_ttl_seconds
 from app.core.auth.dependencies import require_dashboard_write_access, set_dashboard_error_format
 from app.core.bootstrap import (
     ensure_auto_bootstrap_token,
@@ -77,6 +78,7 @@ def _session_client_key(request: Request, *, prefix: str) -> str:
 
 
 async def _create_dashboard_session(
+    request: Request,
     *,
     password_verified: bool,
     totp_verified: bool,
@@ -84,7 +86,7 @@ async def _create_dashboard_session(
     guest_verified: bool = False,
 ) -> tuple[str, int]:
     settings = await get_settings_cache().get()
-    ttl_seconds = settings.dashboard_session_ttl_seconds
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(request, settings.dashboard_session_ttl_seconds)
     session_id = get_dashboard_session_store().create(
         password_verified=password_verified,
         totp_verified=totp_verified,
@@ -296,7 +298,9 @@ async def setup_password(
         raise DashboardConflictError(str(exc), code="password_already_configured") from exc
 
     await get_settings_cache().invalidate()
-    session_id, session_ttl_seconds = await _create_dashboard_session(password_verified=True, totp_verified=False)
+    session_id, session_ttl_seconds = await _create_dashboard_session(
+        request, password_verified=True, totp_verified=False
+    )
     response = _decorate_session_response(
         await context.service.get_session_state(session_id),
         request=request,
@@ -347,6 +351,7 @@ async def login_guest(
     await limiter.clear_for_key(rate_key, context.session)
 
     session_id, session_ttl_seconds = await _create_dashboard_session(
+        request,
         password_verified=False,
         totp_verified=False,
         role=DashboardRole.GUEST,
@@ -401,7 +406,9 @@ async def login_password(
 
     await limiter.clear_for_key(rate_key, context.session)
 
-    session_id, session_ttl_seconds = await _create_dashboard_session(password_verified=True, totp_verified=False)
+    session_id, session_ttl_seconds = await _create_dashboard_session(
+        request, password_verified=True, totp_verified=False
+    )
     response = _decorate_session_response(
         await context.service.get_session_state(session_id),
         request=request,
@@ -564,7 +571,8 @@ async def verify_totp(
             code="totp_rate_limited",
         ) from exc
     try:
-        session_ttl_seconds = (await get_settings_cache().get()).dashboard_session_ttl_seconds
+        configured_ttl_seconds = (await get_settings_cache().get()).dashboard_session_ttl_seconds
+        session_ttl_seconds = resolve_dashboard_session_ttl_seconds(request, configured_ttl_seconds)
         session_id, applied_ttl_seconds = await context.service.verify_totp(
             session_id=current_session_id,
             code=payload.code,

--- a/app/modules/dashboard_auth/service.py
+++ b/app/modules/dashboard_auth/service.py
@@ -387,18 +387,20 @@ class DashboardAuthService:
         AuditService.log_async("login_success", actor_ip=actor_ip, details={"method": "totp"})
         # Honor the existing password-session expiry so that a TTL change
         # mid-flow (between password login and TOTP submission) cannot extend
-        # or shorten an already-issued session. We use the state captured by
+        # an already-issued session, while still applying the TTL cap resolved
+        # for the current TOTP request. We use the state captured by
         # _require_active_password_session_with_state above so a second
         # store.get() race cannot turn a near-expiry password session into a
         # full-length ttl_seconds session.
         now = int(time())
         inherited_ttl = max(1, existing_state.expires_at - now)
+        applied_ttl = min(inherited_ttl, ttl_seconds)
         new_session_id = self._session_store.create(
             password_verified=True,
             totp_verified=True,
-            ttl_seconds=inherited_ttl,
+            ttl_seconds=applied_ttl,
         )
-        return new_session_id, inherited_ttl
+        return new_session_id, applied_ttl
 
     async def disable_totp(self, *, session_id: str | None, code: str, actor_ip: str | None = None) -> None:
         settings = await self._require_totp_verified_session(session_id)

--- a/app/modules/settings/repository.py
+++ b/app/modules/settings/repository.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth.dashboard_session_ttl import DEFAULT_DASHBOARD_SESSION_TTL_SECONDS
 from app.core.config.settings import get_settings
 from app.db.models import DashboardSettings
 
@@ -32,7 +33,7 @@ class SettingsRepository:
             relative_availability_top_k=5,
             single_account_id=None,
             openai_cache_affinity_max_age_seconds=get_settings().openai_cache_affinity_max_age_seconds,
-            dashboard_session_ttl_seconds=43200,
+            dashboard_session_ttl_seconds=DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
             warmup_model=get_settings().warmup_model,
             import_without_overwrite=True,
             totp_required_on_login=False,

--- a/frontend/src/features/settings/schemas.test.ts
+++ b/frontend/src/features/settings/schemas.test.ts
@@ -88,6 +88,7 @@ describe("DashboardSettingsSchema", () => {
     expect(parsed.routingStrategy).toBe("usage_weighted");
     expect(parsed.singleAccountId).toBeNull();
     expect(parsed.openaiCacheAffinityMaxAgeSeconds).toBe(300);
+    expect(parsed.dashboardSessionTtlSeconds).toBe(31536000);
     expect(parsed.limitWarmupEnabled).toBe(false);
     expect(parsed.limitWarmupWindows).toBe("both");
     expect(parsed.limitWarmupModel).toBe("auto");

--- a/frontend/src/features/settings/schemas.ts
+++ b/frontend/src/features/settings/schemas.ts
@@ -83,7 +83,7 @@ export const DashboardSettingsSchema = z
       .int()
       .min(3600)
       .optional()
-      .default(43200),
+      .default(31536000),
     stickyReallocationBudgetThresholdPct: z.number().min(0).max(100).optional(),
     stickyReallocationPrimaryBudgetThresholdPct: z.number().min(0).max(100).optional(),
     stickyReallocationSecondaryBudgetThresholdPct: z.number().min(0).max(100).optional(),

--- a/frontend/src/test/mocks/factories.ts
+++ b/frontend/src/test/mocks/factories.ts
@@ -441,7 +441,7 @@ export function createDashboardSettings(
 		weeklyPaceWorkingDays: "0,1,2,3,4,5,6",
 		weeklyPaceSmoothingMinutes: 30,
 		openaiCacheAffinityMaxAgeSeconds: 300,
-		dashboardSessionTtlSeconds: 43200,
+		dashboardSessionTtlSeconds: 31536000,
 		stickyReallocationBudgetThresholdPct: 95,
 		stickyReallocationPrimaryBudgetThresholdPct: 95,
 		stickyReallocationSecondaryBudgetThresholdPct: 100,

--- a/openspec/changes/harden-local-dashboard-session-ttl/.openspec.yaml
+++ b/openspec/changes/harden-local-dashboard-session-ttl/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/harden-local-dashboard-session-ttl/context.md
+++ b/openspec/changes/harden-local-dashboard-session-ttl/context.md
@@ -1,0 +1,7 @@
+## Migration
+
+Alembic revision `20260705_000000_harden_dashboard_session_ttl` changes the `dashboard_settings.dashboard_session_ttl_seconds` server default to `31536000` and updates existing rows only when they still equal the legacy default `43200`.
+
+## Guardrail
+
+The 1-year effective TTL is intentionally limited to standard dashboard auth mode when the request is socket-level local. Localhost-published Docker deployments where the container sees a bridge peer can opt in with `CODEX_LB_DASHBOARD_TRUST_LOOPBACK_HOST_HEADER_FOR_LONG_SESSIONS=true`; that override still requires a loopback dashboard URL and no forwarded-client headers. Requests that arrive through proxy-aware mode, trusted-header auth, non-loopback hosts, or the default bridge-without-override path receive the 12-hour fallback when the configured value exceeds 30 days.

--- a/openspec/changes/harden-local-dashboard-session-ttl/proposal.md
+++ b/openspec/changes/harden-local-dashboard-session-ttl/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+Local operators who keep the dashboard bound to loopback should not have to re-authenticate every day when dashboard auth is still enabled. The existing configurable session lifetime can already express a longer session, but the default remains 12 hours and applying a 1-year lifetime everywhere would be unsafe for dashboards exposed through LAN, cloud, or reverse-proxy paths.
+
+## What Changes
+
+- Change the persisted dashboard session lifetime default from 12 hours to 1 year.
+- Migrate existing dashboard settings rows that still carry the old 12-hour default to the new 1-year default, while preserving customized values.
+- Resolve the effective session TTL at issuance time: configured lifetimes above 30 days apply only to direct loopback requests in standard dashboard auth mode, or to loopback dashboard URLs when the explicit loopback-host-header override is enabled for localhost-published deployments. Remote/proxy/trusted-header requests fall back to 12 hours.
+- Keep shorter configured lifetimes intact, including on remote requests.
+
+## Impact
+
+- Affected backend modules: dashboard auth session issuance, dashboard settings defaults, and the dashboard settings migration chain.
+- Existing localhost-only deployments that never customized the setting move to annual dashboard sessions after migration.
+- Non-local or proxy-authenticated dashboard sessions do not silently receive the long TTL.

--- a/openspec/changes/harden-local-dashboard-session-ttl/specs/admin-auth/spec.md
+++ b/openspec/changes/harden-local-dashboard-session-ttl/specs/admin-auth/spec.md
@@ -1,0 +1,77 @@
+# admin-auth — Local dashboard session TTL hardening (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Dashboard password sessions use a configurable absolute lifetime
+
+The system SHALL issue dashboard password-authenticated sessions with an absolute lifetime controlled by persisted dashboard settings. The default persisted lifetime SHALL be 1 year. Configured lifetimes at or below 30 days SHALL apply to newly issued dashboard password sessions by setting both the encrypted session expiry payload and the cookie `Max-Age` to the same value.
+
+Configured lifetimes above 30 days SHALL apply only in standard dashboard auth mode when the request is socket-level local, or when an explicit loopback-host-header override is enabled and the request uses a loopback dashboard URL with no forwarded-client headers. When a request is non-loopback, proxy-aware, trusted-header authenticated, or bridge-originated without that explicit override, the system MUST issue the new session with a 12-hour effective lifetime instead of the longer configured lifetime. This fallback MUST NOT disable dashboard auth and MUST NOT rewrite the persisted setting.
+
+#### Scenario: Direct loopback dashboard login receives the 1-year default
+
+- **GIVEN** the configured dashboard session lifetime is the 1-year default
+- **AND** the dashboard request is direct loopback in standard dashboard auth mode
+- **WHEN** an admin successfully completes password authentication
+- **THEN** the newly issued dashboard session expires after 1 year
+- **AND** the cookie `Max-Age` is `31536000`
+
+#### Scenario: Localhost-published bridge login requires explicit override
+
+- **GIVEN** the configured dashboard session lifetime is the 1-year default
+- **AND** the dashboard request uses a loopback dashboard URL but the socket peer is not loopback
+- **WHEN** the explicit loopback-host-header override is disabled
+- **THEN** the newly issued dashboard session expires after 12 hours
+
+#### Scenario: Localhost-published bridge login can opt in to 1 year
+
+- **GIVEN** the configured dashboard session lifetime is the 1-year default
+- **AND** the dashboard request uses a loopback dashboard URL but the socket peer is not loopback
+- **AND** the explicit loopback-host-header override is enabled
+- **AND** no forwarded-client headers are present
+- **WHEN** an admin successfully completes password authentication
+- **THEN** the newly issued dashboard session expires after 1 year
+- **AND** the cookie `Max-Age` is `31536000`
+
+#### Scenario: Remote dashboard login falls back to 12 hours
+
+- **GIVEN** the configured dashboard session lifetime is greater than 30 days
+- **AND** the dashboard request is not direct loopback
+- **WHEN** an admin successfully completes password authentication
+- **THEN** the newly issued dashboard session expires after 12 hours
+- **AND** the cookie `Max-Age` is `43200`
+
+#### Scenario: Proxy-aware dashboard login falls back to 12 hours
+
+- **GIVEN** the configured dashboard session lifetime is greater than 30 days
+- **AND** proxy headers are trusted or trusted-header dashboard auth is in use
+- **WHEN** an admin successfully completes dashboard authentication
+- **THEN** the newly issued dashboard session expires after 12 hours
+
+#### Scenario: Shorter configured dashboard lifetime is preserved
+
+- **GIVEN** the configured dashboard session lifetime is 2 hours
+- **WHEN** an admin successfully completes password authentication
+- **THEN** the newly issued dashboard session expires after 2 hours
+
+#### Scenario: Existing dashboard sessions keep their original expiry
+
+- **WHEN** an admin changes the configured dashboard session lifetime after a session cookie has already been issued
+- **THEN** previously issued cookies continue to expire according to the expiry embedded in their encrypted payload
+- **AND** only newly issued dashboard password sessions use the updated effective lifetime
+
+### Requirement: Legacy default dashboard session TTL migration
+
+The migration for this change MUST update `dashboard_settings.dashboard_session_ttl_seconds` from `43200` to `31536000` only for rows that still carry the legacy default value. Rows with any customized value MUST remain unchanged.
+
+#### Scenario: Legacy default row migrates to 1 year
+
+- **GIVEN** a dashboard settings row has `dashboard_session_ttl_seconds = 43200`
+- **WHEN** the migration runs
+- **THEN** the row has `dashboard_session_ttl_seconds = 31536000`
+
+#### Scenario: Customized row remains unchanged
+
+- **GIVEN** a dashboard settings row has `dashboard_session_ttl_seconds = 7200`
+- **WHEN** the migration runs
+- **THEN** the row still has `dashboard_session_ttl_seconds = 7200`

--- a/openspec/changes/harden-local-dashboard-session-ttl/tasks.md
+++ b/openspec/changes/harden-local-dashboard-session-ttl/tasks.md
@@ -1,0 +1,20 @@
+## 1. Backend auth behavior
+
+- [x] 1.1 Add a shared resolver for effective dashboard session TTL.
+- [x] 1.2 Apply the resolver when issuing password, guest, and TOTP-verified dashboard sessions.
+- [x] 1.3 Clamp long configured lifetimes to 12 hours for non-loopback or proxy/trusted-header requests.
+- [x] 1.4 Preserve shorter configured lifetimes.
+- [x] 1.5 Add an explicit loopback-host-header override for localhost-published deployments where the socket peer is a bridge address.
+
+## 2. Settings default and migration
+
+- [x] 2.1 Change new dashboard settings defaults to 1 year.
+- [x] 2.2 Add an Alembic migration that updates old-default 12-hour settings rows to 1 year and preserves customized rows.
+- [x] 2.3 Update frontend fallback defaults to match the backend default.
+
+## 3. Verification
+
+- [x] 3.1 Add unit tests for direct loopback, bridge-without-override, bridge-with-override, remote, proxy, and shorter-TTL resolver behavior.
+- [x] 3.2 Add/update API tests proving cookie `Max-Age` uses the effective TTL.
+- [x] 3.3 Run focused backend and frontend validation.
+- [ ] 3.4 Run OpenSpec validation. Blocked locally: neither `openspec` nor `uv run openspec` is available in this environment.

--- a/openspec/specs/admin-auth/context.md
+++ b/openspec/specs/admin-auth/context.md
@@ -47,7 +47,7 @@ Requests from localhost (127.0.0.1, ::1) bypass bootstrap entirely — no token 
 
 ## Session Management
 
-Stateless encrypted cookies using Fernet. Session payload: `{exp, pw, tv}`. TTL: 12 hours. No server-side session storage.
+Stateless encrypted cookies using Fernet. Session payload: `{exp, pw, tv}`. Default persisted TTL: 1 year for local dashboard use. Long configured lifetimes above 30 days fall back to 12 hours for non-loopback, proxy-aware, trusted-header, or bridge-without-override requests. Localhost-published bridge deployments can opt in with `CODEX_LB_DASHBOARD_TRUST_LOOPBACK_HOST_HEADER_FOR_LONG_SESSIONS=true`, which still requires a loopback dashboard URL and no forwarded-client headers. No server-side session storage.
 
 ## Rate Limiting
 

--- a/openspec/specs/admin-auth/spec.md
+++ b/openspec/specs/admin-auth/spec.md
@@ -51,17 +51,35 @@ The system SHALL enforce both a minimum and a maximum length on dashboard passwo
 
 ### Requirement: Dashboard password sessions use a configurable absolute lifetime
 
-The system SHALL issue dashboard password-authenticated sessions with an absolute lifetime controlled by persisted dashboard settings. The default lifetime SHALL remain 12 hours. The configured lifetime SHALL apply to newly issued dashboard password sessions by setting both the encrypted session expiry payload and the cookie `Max-Age` to the same value.
+The system SHALL issue dashboard password-authenticated sessions with an absolute lifetime controlled by persisted dashboard settings. The default persisted lifetime SHALL be 1 year. Configured lifetimes at or below 30 days SHALL apply to newly issued dashboard password sessions by setting both the encrypted session expiry payload and the cookie `Max-Age` to the same value. Configured lifetimes above 30 days SHALL apply only in standard dashboard auth mode when the request is socket-level local, or when an explicit loopback-host-header override is enabled and the request uses a loopback dashboard URL with no forwarded-client headers. Non-loopback, proxy-aware, trusted-header, or bridge-without-override requests MUST receive a 12-hour effective lifetime without rewriting the persisted setting.
 
 #### Scenario: Newly issued dashboard password session honors configured lifetime
 
-- **WHEN** an admin configures a dashboard session lifetime and successfully completes password authentication
+- **WHEN** an admin configures a dashboard session lifetime and successfully completes password authentication from a socket-level local request
 - **THEN** the newly issued dashboard session expires after the configured absolute lifetime
 - **AND** the cookie `Max-Age` matches the same configured lifetime
+
+#### Scenario: Long localhost-published bridge session requires explicit override
+
+- **WHEN** an admin configures a dashboard session lifetime greater than 30 days and successfully completes password authentication through a loopback dashboard URL whose socket peer is not loopback
+- **AND** the explicit loopback-host-header override is disabled
+- **THEN** the newly issued dashboard session expires after 12 hours
+
+#### Scenario: Long localhost-published bridge session can opt in
+
+- **WHEN** an admin configures a dashboard session lifetime greater than 30 days and successfully completes password authentication through a loopback dashboard URL whose socket peer is not loopback
+- **AND** the explicit loopback-host-header override is enabled
+- **AND** no forwarded-client headers are present
+- **THEN** the newly issued dashboard session expires after the configured absolute lifetime
+
+#### Scenario: Long dashboard password session falls back for non-loopback access
+
+- **WHEN** an admin configures a dashboard session lifetime greater than 30 days and successfully completes password authentication from a non-loopback, proxy-aware, or trusted-header request
+- **THEN** the newly issued dashboard session expires after 12 hours
+- **AND** the cookie `Max-Age` is `43200`
 
 #### Scenario: Existing dashboard sessions keep their original expiry
 
 - **WHEN** an admin changes the configured dashboard session lifetime after a session cookie has already been issued
 - **THEN** previously issued cookies continue to expire according to the expiry embedded in their encrypted payload
 - **AND** only newly issued dashboard password sessions use the updated lifetime
-

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -8,6 +8,10 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.core.auth import DEFAULT_PLAN
+from app.core.auth.dashboard_session_ttl import (
+    DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    REMOTE_DASHBOARD_SESSION_TTL_SECONDS,
+)
 from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -813,6 +817,60 @@ async def test_dashboard_settings_default_flip_migration_updates_pristine_fresh_
             ).one()
             assert row[0] in (True, 1)
             assert row[1] in (True, 1)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("initial_ttl_seconds", "expected_ttl_seconds"),
+    [
+        (REMOTE_DASHBOARD_SESSION_TTL_SECONDS, DEFAULT_DASHBOARD_SESSION_TTL_SECONDS),
+        (7200, 7200),
+    ],
+)
+async def test_dashboard_session_ttl_migration_updates_only_legacy_default(
+    tmp_path,
+    initial_ttl_seconds: int,
+    expected_ttl_seconds: int,
+):
+    db_url = f"sqlite+aiosqlite:///{tmp_path / f'dashboard-session-ttl-{initial_ttl_seconds}.sqlite'}"
+    parent_revision = "20260701_000000_add_weekly_pace_smoothing_minutes"
+    target_revision = "20260705_000000_harden_dashboard_session_ttl"
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=True))
+
+    engine = create_async_engine(db_url, future=True)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with session_factory() as session:
+            await session.execute(
+                text(
+                    """
+                    UPDATE dashboard_settings
+                    SET dashboard_session_ttl_seconds = :initial_ttl_seconds
+                    WHERE id = 1
+                    """
+                ),
+                {"initial_ttl_seconds": initial_ttl_seconds},
+            )
+            await session.commit()
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, target_revision, bootstrap_legacy=False))
+
+        async with session_factory() as session:
+            ttl_seconds = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT dashboard_session_ttl_seconds
+                        FROM dashboard_settings
+                        WHERE id = 1
+                        """
+                    )
+                )
+            ).scalar_one()
+            assert ttl_seconds == expected_ttl_seconds
     finally:
         await engine.dispose()
 

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -58,7 +58,7 @@ async def test_settings_api_get_and_update(async_client):
     assert payload["relativeAvailabilityTopK"] == 5
     assert payload["singleAccountId"] is None
     assert payload["openaiCacheAffinityMaxAgeSeconds"] == 1800
-    assert payload["dashboardSessionTtlSeconds"] == 43200
+    assert payload["dashboardSessionTtlSeconds"] == 31536000
     assert payload["httpResponsesSessionBridgePromptCacheIdleTtlSeconds"] == 3600
     assert payload["httpResponsesSessionBridgeGatewaySafeMode"] is False
     assert payload["stickyReallocationBudgetThresholdPct"] == 95.0

--- a/tests/integration/test_settings_audit_changed_fields.py
+++ b/tests/integration/test_settings_audit_changed_fields.py
@@ -46,7 +46,7 @@ def _default_put_body() -> dict[str, Any]:
             180,
             "openai_cache_affinity_max_age_seconds",
         ),
-        ("dashboardSessionTtlSeconds", 31536000, "dashboard_session_ttl_seconds"),
+        ("dashboardSessionTtlSeconds", 604800, "dashboard_session_ttl_seconds"),
         (
             "httpResponsesSessionBridgePromptCacheIdleTtlSeconds",
             1800,

--- a/tests/unit/test_dashboard_auth_api.py
+++ b/tests/unit/test_dashboard_auth_api.py
@@ -8,6 +8,12 @@ import pytest
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
 
+from app.core.auth.dashboard_access import DashboardRole
+from app.core.auth.dashboard_mode import DashboardAuthMode
+from app.core.auth.dashboard_session_ttl import (
+    DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    REMOTE_DASHBOARD_SESSION_TTL_SECONDS,
+)
 from app.core.exceptions import DashboardAuthError
 from app.dependencies import DashboardAuthContext
 from app.modules.dashboard_auth.api import disable_totp, login_password, verify_totp
@@ -33,7 +39,7 @@ def _build_request(path: str) -> Request:
     )
 
 
-def _build_login_request(path: str) -> Request:
+def _build_login_request(path: str, *, client_host: str = "203.0.113.10", host: str = "lb.example") -> Request:
     return Request(
         {
             "type": "http",
@@ -43,9 +49,19 @@ def _build_login_request(path: str) -> Request:
             "path": path,
             "raw_path": path.encode(),
             "query_string": b"",
-            "headers": [],
-            "client": ("127.0.0.1", 12345),
+            "headers": [(b"host", host.encode())],
+            "client": (client_host, 12345),
+            "server": (host.split(":", 1)[0], 80),
         }
+    )
+
+
+def _runtime_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        dashboard_auth_mode=DashboardAuthMode.STANDARD,
+        firewall_trust_proxy_headers=False,
+        firewall_trusted_proxy_cidrs=[],
+        dashboard_trust_loopback_host_header_for_long_sessions=False,
     )
 
 
@@ -115,7 +131,12 @@ async def test_login_password_uses_configured_dashboard_session_ttl_for_cookie()
     )
     session_store = SimpleNamespace(
         create=Mock(return_value="session-1"),
-        get=lambda _sid: SimpleNamespace(password_verified=True, totp_verified=False),
+        get=lambda _sid: SimpleNamespace(
+            password_verified=True,
+            totp_verified=False,
+            role=DashboardRole.ADMIN,
+            guest_verified=False,
+        ),
     )
     context = cast(
         DashboardAuthContext,
@@ -149,5 +170,143 @@ async def test_login_password_uses_configured_dashboard_session_ttl_for_cookie()
     assert isinstance(response, JSONResponse)
     assert response.headers["set-cookie"]
     assert "Max-Age=7200" in response.headers["set-cookie"]
+    session_store.create.assert_called_once_with(
+        password_verified=True,
+        totp_verified=False,
+        ttl_seconds=7200,
+        role=DashboardRole.ADMIN,
+        guest_verified=False,
+    )
+    limiter.check_and_increment.assert_awaited_once()
+    limiter.clear_for_key.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_login_password_uses_one_year_ttl_for_direct_loopback_dashboard_request():
+    limiter = SimpleNamespace(
+        check_and_increment=AsyncMock(),
+        clear_for_key=AsyncMock(),
+    )
+    session_store = SimpleNamespace(
+        create=Mock(return_value="session-1"),
+        get=lambda _sid: SimpleNamespace(
+            password_verified=True,
+            totp_verified=False,
+            role=DashboardRole.ADMIN,
+            guest_verified=False,
+        ),
+    )
+    context = cast(
+        DashboardAuthContext,
+        SimpleNamespace(
+            service=SimpleNamespace(
+                verify_password=AsyncMock(),
+                get_session_state=AsyncMock(
+                    return_value=DashboardAuthSessionResponse(
+                        authenticated=True,
+                        password_required=True,
+                        totp_required_on_login=False,
+                        totp_configured=False,
+                    )
+                ),
+            ),
+            session=object(),
+        ),
+    )
+    settings = SimpleNamespace(
+        password_hash="hash",
+        dashboard_session_ttl_seconds=DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    )
+    settings_cache = SimpleNamespace(get=AsyncMock(return_value=settings))
+    runtime_settings = _runtime_settings()
+
+    with (
+        patch("app.core.auth.dashboard_session_ttl._get_settings", return_value=runtime_settings),
+        patch("app.core.request_locality.get_settings", return_value=runtime_settings),
+        patch("app.modules.dashboard_auth.api.get_password_rate_limiter", return_value=limiter),
+        patch("app.modules.dashboard_auth.api.get_dashboard_session_store", return_value=session_store),
+        patch("app.modules.dashboard_auth.api.get_settings_cache", return_value=settings_cache),
+    ):
+        response = await login_password(
+            _build_login_request(
+                "/api/dashboard-auth/password/login",
+                client_host="127.0.0.1",
+                host="127.0.0.1:2455",
+            ),
+            PasswordLoginRequest(password="password123"),
+            context,
+        )
+
+    assert isinstance(response, JSONResponse)
+    assert f"Max-Age={DEFAULT_DASHBOARD_SESSION_TTL_SECONDS}" in response.headers["set-cookie"]
+    session_store.create.assert_called_once_with(
+        password_verified=True,
+        totp_verified=False,
+        ttl_seconds=DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+        role=DashboardRole.ADMIN,
+        guest_verified=False,
+    )
+    limiter.check_and_increment.assert_awaited_once()
+    limiter.clear_for_key.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_login_password_caps_non_loopback_dashboard_session_ttl():
+    limiter = SimpleNamespace(
+        check_and_increment=AsyncMock(),
+        clear_for_key=AsyncMock(),
+    )
+    session_store = SimpleNamespace(
+        create=Mock(return_value="session-1"),
+        get=lambda _sid: SimpleNamespace(
+            password_verified=True,
+            totp_verified=False,
+            role=DashboardRole.ADMIN,
+            guest_verified=False,
+        ),
+    )
+    context = cast(
+        DashboardAuthContext,
+        SimpleNamespace(
+            service=SimpleNamespace(
+                verify_password=AsyncMock(),
+                get_session_state=AsyncMock(
+                    return_value=DashboardAuthSessionResponse(
+                        authenticated=True,
+                        password_required=True,
+                        totp_required_on_login=False,
+                        totp_configured=False,
+                    )
+                ),
+            ),
+            session=object(),
+        ),
+    )
+    settings = SimpleNamespace(password_hash="hash", dashboard_session_ttl_seconds=90 * 24 * 60 * 60)
+    settings_cache = SimpleNamespace(get=AsyncMock(return_value=settings))
+    runtime_settings = _runtime_settings()
+
+    with (
+        patch("app.core.auth.dashboard_session_ttl._get_settings", return_value=runtime_settings),
+        patch("app.core.request_locality.get_settings", return_value=runtime_settings),
+        patch("app.modules.dashboard_auth.api.get_password_rate_limiter", return_value=limiter),
+        patch("app.modules.dashboard_auth.api.get_dashboard_session_store", return_value=session_store),
+        patch("app.modules.dashboard_auth.api.get_settings_cache", return_value=settings_cache),
+    ):
+        response = await login_password(
+            _build_login_request("/api/dashboard-auth/password/login"),
+            PasswordLoginRequest(password="password123"),
+            context,
+        )
+
+    assert isinstance(response, JSONResponse)
+    assert f"Max-Age={REMOTE_DASHBOARD_SESSION_TTL_SECONDS}" in response.headers["set-cookie"]
+    session_store.create.assert_called_once_with(
+        password_verified=True,
+        totp_verified=False,
+        ttl_seconds=REMOTE_DASHBOARD_SESSION_TTL_SECONDS,
+        role=DashboardRole.ADMIN,
+        guest_verified=False,
+    )
     limiter.check_and_increment.assert_awaited_once()
     limiter.clear_for_key.assert_awaited_once()

--- a/tests/unit/test_dashboard_auth_password_service.py
+++ b/tests/unit/test_dashboard_auth_password_service.py
@@ -230,6 +230,52 @@ async def test_verify_totp_inherits_existing_password_session_expiry(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_verify_totp_caps_inherited_password_session_to_requested_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import pyotp
+
+    import app.core.auth.totp as totp_module
+    import app.modules.dashboard_auth.service as service_module
+    from app.core.crypto import TokenEncryptor
+
+    current = {"value": 1_700_000_000}
+    monkeypatch.setattr(service_module, "time", lambda: current["value"])
+    monkeypatch.setattr(totp_module, "time", lambda: current["value"])
+
+    repository = _FakeRepository()
+    store = DashboardSessionStore()
+    service = DashboardAuthService(repository, store)
+    await service.setup_password("password123")
+
+    secret = pyotp.random_base32()
+    encryptor = TokenEncryptor()
+    repository.settings.totp_secret_encrypted = encryptor.encrypt(secret)
+
+    long_password_ttl = 365 * 24 * 60 * 60
+    remote_request_ttl = 12 * 60 * 60
+    password_session_id = store.create(
+        password_verified=True,
+        totp_verified=False,
+        ttl_seconds=long_password_ttl,
+    )
+
+    code = pyotp.TOTP(secret).at(current["value"])
+    new_session_id, applied_ttl = await service.verify_totp(
+        session_id=password_session_id,
+        code=code,
+        ttl_seconds=remote_request_ttl,
+    )
+
+    assert applied_ttl == remote_request_ttl
+    state = store.get(new_session_id)
+    assert state is not None
+    assert state.password_verified is True
+    assert state.totp_verified is True
+    assert state.expires_at == current["value"] + remote_request_ttl
+
+
+@pytest.mark.asyncio
 async def test_verify_totp_does_not_call_session_store_get_twice(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_dashboard_session_ttl.py
+++ b/tests/unit/test_dashboard_session_ttl.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+
+import app.core.auth.dashboard_session_ttl as dashboard_session_ttl
+import app.core.request_locality as request_locality
+from app.core.auth.dashboard_mode import DashboardAuthMode
+from app.core.auth.dashboard_session_ttl import (
+    DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    REMOTE_DASHBOARD_SESSION_TTL_SECONDS,
+    resolve_dashboard_session_ttl_seconds,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _settings(
+    *,
+    trust_proxy_headers: bool = False,
+    trust_loopback_host_header: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        dashboard_auth_mode=DashboardAuthMode.STANDARD,
+        firewall_trust_proxy_headers=trust_proxy_headers,
+        firewall_trusted_proxy_cidrs=[],
+        dashboard_trust_loopback_host_header_for_long_sessions=trust_loopback_host_header,
+    )
+
+
+def _request(
+    *,
+    client_host: str,
+    host: str,
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/api/dashboard-auth/password/login",
+            "raw_path": b"/api/dashboard-auth/password/login",
+            "query_string": b"",
+            "headers": [(b"host", host.encode()), *(headers or [])],
+            "client": (client_host, 12345),
+            "server": (host.split(":", 1)[0], 2455),
+        }
+    )
+
+
+def _patch_settings(monkeypatch: pytest.MonkeyPatch, settings: SimpleNamespace) -> None:
+    monkeypatch.setattr(dashboard_session_ttl, "_get_settings", lambda: settings)
+    monkeypatch.setattr(request_locality, "get_settings", lambda: settings)
+
+
+def test_long_dashboard_session_ttl_applies_to_direct_loopback_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_settings(monkeypatch, _settings())
+
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(
+        _request(client_host="127.0.0.1", host="localhost:2455"),
+        DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    )
+
+    assert ttl_seconds == DEFAULT_DASHBOARD_SESSION_TTL_SECONDS
+
+
+def test_long_dashboard_session_ttl_clamps_for_remote_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_settings(monkeypatch, _settings())
+
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(
+        _request(client_host="203.0.113.10", host="lb.example"),
+        DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    )
+
+    assert ttl_seconds == REMOTE_DASHBOARD_SESSION_TTL_SECONDS
+
+
+def test_long_dashboard_session_ttl_clamps_for_bridge_ip_without_explicit_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_settings(monkeypatch, _settings())
+
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(
+        _request(client_host="172.17.0.1", host="127.0.0.1:2455"),
+        DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    )
+
+    assert ttl_seconds == REMOTE_DASHBOARD_SESSION_TTL_SECONDS
+
+
+def test_long_dashboard_session_ttl_accepts_loopback_host_header_with_explicit_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_settings(monkeypatch, _settings(trust_loopback_host_header=True))
+
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(
+        _request(client_host="172.17.0.1", host="127.0.0.1:2455"),
+        DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    )
+
+    assert ttl_seconds == DEFAULT_DASHBOARD_SESSION_TTL_SECONDS
+
+
+def test_long_dashboard_session_ttl_clamps_when_proxy_headers_are_trusted(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_settings(monkeypatch, _settings(trust_proxy_headers=True))
+
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(
+        _request(
+            client_host="127.0.0.1",
+            host="localhost:2455",
+            headers=[(b"x-forwarded-for", b"127.0.0.1")],
+        ),
+        DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    )
+
+    assert ttl_seconds == REMOTE_DASHBOARD_SESSION_TTL_SECONDS
+
+
+def test_shorter_configured_dashboard_session_ttl_is_preserved_for_remote_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_settings(monkeypatch, _settings())
+
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(
+        _request(client_host="203.0.113.10", host="lb.example"),
+        7200,
+    )
+
+    assert ttl_seconds == 7200


### PR DESCRIPTION
## Summary

- changes the persisted dashboard session TTL default from 12 hours to 1 year
- migrates existing dashboard settings rows only when they still have the legacy 12-hour default
- resolves the effective session TTL at login time so long sessions apply only to local/loopback-safe dashboard access
- adds an explicit opt-in for localhost-published Docker/bridge deployments: `CODEX_LB_DASHBOARD_TRUST_LOOPBACK_HOST_HEADER_FOR_LONG_SESSIONS=true`

Refs AGE-2946.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest tests/unit/test_dashboard_session_ttl.py tests/unit/test_dashboard_auth_api.py tests/integration/test_settings_api.py tests/integration/test_settings_audit_changed_fields.py::test_settings_audit_records_single_changed_field tests/integration/test_migrations.py tests/unit/test_db_migrate.py -q` — 106 passed, 3 skipped
- `cd frontend && bun run typecheck`
- `cd frontend && bun run lint`
- `cd frontend && bun run test -- src/features/settings/schemas.test.ts` — 15 passed

Full-suite note:

- `uv run pytest -q` still has 3 failures: two account recovery tests and one usage freshness test.
- I reproduced those same 3 failures on clean `origin/main` at `9e3819a7`, so they are baseline failures, not introduced by this branch.

OpenSpec note:

- `openspec` validation could not run locally because neither `openspec` nor `uv run openspec` is available in this environment.
