### PR TITLE
fix: list Codex shell-only models in backend catalog

### DIFF
--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -360,10 +360,13 @@ class ModelRegistry:
 
     def plan_types_for_model(self, slug: str) -> frozenset[str] | None:
         normalized_slug = slug.strip().lower()
+        bootstrap_model = self._bootstrap_models.get(slug) or self._bootstrap_models.get(normalized_slug)
         if self._snapshot is None:
-            model = self._bootstrap_models.get(slug) or self._bootstrap_models.get(normalized_slug)
-            return model.available_in_plans if model is not None else None
-        return self._snapshot.model_plans.get(slug) or self._snapshot.model_plans.get(normalized_slug, frozenset())
+            return bootstrap_model.available_in_plans if bootstrap_model is not None else None
+        snapshot_plans = self._snapshot.model_plans.get(slug) or self._snapshot.model_plans.get(
+            normalized_slug, frozenset()
+        )
+        return snapshot_plans
 
     def plan_types_for_model_service_tier(self, slug: str, service_tier: str | None) -> frozenset[str] | None:
         if service_tier is None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2058,14 +2058,14 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
     entries: list[CodexModelEntry] = []
     data: list[ModelListItem] = []
     for slug, model in models.items():
-        if not model.supported_in_api:
+        if not _is_codex_backend_catalog_model(model):
             continue
         if visibility_allowed_models is None:
-            if not is_public_model(model, allowed_models):
+            if allowed_models is not None and slug not in allowed_models:
                 continue
             entry = _to_codex_model_entry(model)
             entries.append(entry)
-            if entry.visibility == "list":
+            if model.supported_in_api and entry.visibility == "list":
                 data.append(_to_model_list_item(slug, model, created=_model_list_created_at(model)))
             continue
         entry = _to_codex_model_entry(
@@ -2073,7 +2073,7 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
             visibility="list" if slug in visibility_allowed_models else "hide",
         )
         entries.append(entry)
-        if entry.visibility == "list":
+        if model.supported_in_api and entry.visibility == "list":
             data.append(_to_model_list_item(slug, model, created=_model_list_created_at(model)))
     await _release_reservation(reservation)
     return JSONResponse(content=CodexModelsResponse(models=entries, data=data).model_dump(mode="json"))
@@ -2170,6 +2170,12 @@ def _codex_model_visibility_allowed_models(api_key: ApiKeyData | None) -> set[st
     if api_key is None or not api_key.apply_to_codex_model or not api_key.allowed_models:
         return None
     return _allowed_models_for_api_key(api_key)
+
+
+def _is_codex_backend_catalog_model(model: UpstreamModel) -> bool:
+    if model.supported_in_api:
+        return True
+    return model.raw.get("shell_type") == "shell_command"
 
 
 def _to_codex_model_entry(model: UpstreamModel, *, visibility: str | None = None) -> CodexModelEntry:

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -424,40 +424,50 @@ Backend contract:
 - **WHEN** the same limit rules are submitted in a different order
 - **THEN** the system treats this as unchanged and omits `limits` from the payload
 
-### Requirement: Public model list filtering
+### Requirement: Public OpenAI-compatible model list filtering
 
-All model list endpoints SHALL filter models using a single predicate that requires both conditions:
+OpenAI-compatible model list endpoints SHALL filter models using a single predicate that requires both conditions:
 1. `model.supported_in_api` is true
 2. If `allowed_models` is configured, the model is in the allowed set
 
-This predicate SHALL be applied consistently across `/api/models`, `/v1/models`, and `/backend-api/codex/models`.
+This predicate SHALL be applied consistently across `/api/models`, `/v1/models`, and the OpenAI-style `data` alias in `/backend-api/codex/models`. The Codex-native `models` catalog in `/backend-api/codex/models` SHALL also expose unsupported upstream models only when the model is a Codex shell-command model (`shell_type="shell_command"`); unsupported non-shell models SHALL remain hidden.
 
 #### Scenario: Unsupported model excluded from /v1/models
 
 - **WHEN** a model snapshot contains a model with `supported_in_api=false`
 - **THEN** that model is not included in the `/v1/models` response
 
-#### Scenario: Unsupported model excluded from /backend-api/codex/models
+#### Scenario: Unsupported non-shell model excluded from /backend-api/codex/models
 
 - **WHEN** a model snapshot contains a model with `supported_in_api=false`
+- **AND** the model is not a Codex shell-command model
 - **THEN** that model is not included in the `/backend-api/codex/models` response
+
+#### Scenario: Unsupported Codex shell model included only in Codex-native catalog
+
+- **WHEN** a model snapshot contains a model with `supported_in_api=false`
+- **AND** the model has `shell_type="shell_command"`
+- **THEN** that model is included in `/backend-api/codex/models.models`
+- **AND** that model is not included in `/backend-api/codex/models.data`
+- **AND** that model is not included in `/api/models` or `/v1/models`
 
 #### Scenario: Allowed but unsupported model excluded
 
 - **WHEN** a model is in the `allowed_models` set but has `supported_in_api=false`
+- **AND** the model is not a Codex shell-command model
 - **THEN** that model is not exposed in any model list endpoint
 
 #### Scenario: gpt-5.3-codex aliases share availability gate consistently
 
 - **WHEN** `gpt-5.3-codex` has `supported_in_api=false`
 - **AND** `gpt-5.3-codex-spark` has `supported_in_api=true`
-- **THEN** `/api/models`, `/v1/models`, and `/backend-api/codex/models`
+- **THEN** `/api/models`, `/v1/models`, and `/backend-api/codex/models.data`
       expose `gpt-5.3-codex-spark` but do not expose `gpt-5.3-codex`
 
 #### Scenario: Consistent model set across endpoints
 
 - **GIVEN** any model registry state
-- **THEN** `/api/models`, `/v1/models`, and `/backend-api/codex/models` expose the same set of models
+- **THEN** `/api/models`, `/v1/models`, and `/backend-api/codex/models.data` expose the same OpenAI-compatible set of models
 
 ### Requirement: Reservation 정산 exactly-once 보장
 

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -100,7 +100,8 @@ async def test_v1_models_list(async_client):
     ids = {item["id"] for item in data}
     assert "gpt-5.2" in ids
     assert "gpt-5.3-codex" in ids
-    for item in data:
+    custom_items = [item for item in data if item["id"] in {"gpt-5.2", "gpt-5.3-codex"}]
+    for item in custom_items:
         assert item["object"] == "model"
         assert item["owned_by"] == "codex-lb"
         assert "metadata" in item
@@ -330,10 +331,59 @@ async def test_backend_codex_models_data_keeps_only_list_visible_models(async_cl
     resp = await async_client.get("/backend-api/codex/models")
     assert resp.status_code == 200
     payload = resp.json()
-    assert {m["slug"] for m in payload["models"]} == {"gpt-visible", "gpt-hidden"}
-    assert {m["id"] for m in payload["data"]} == {"gpt-visible"}
-    assert payload["data"][0]["object"] == "model"
-    assert payload["data"][0]["owned_by"] == "codex-lb"
+    assert {"gpt-visible", "gpt-hidden"}.issubset({m["slug"] for m in payload["models"]})
+    data = {m["id"]: m for m in payload["data"]}
+    assert "gpt-visible" in data
+    assert "gpt-hidden" not in data
+    assert data["gpt-visible"]["object"] == "model"
+    assert data["gpt-visible"]["owned_by"] == "codex-lb"
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_models_lists_codex_shell_models_not_supported_in_v1(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model(
+            "gpt-5.3-codex-spark",
+            supported_in_api=False,
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "list",
+            },
+        ),
+    ]
+    await registry.update({"pro": models})
+
+    resp = await async_client.get("/backend-api/codex/models")
+    assert resp.status_code == 200
+    payload = resp.json()
+    entries = {m["slug"]: m for m in payload["models"]}
+
+    assert entries["gpt-5.3-codex-spark"]["supported_in_api"] is False
+    assert entries["gpt-5.3-codex-spark"]["visibility"] == "list"
+    assert "gpt-5.3-codex-spark" not in {m["id"] for m in payload["data"]}
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_models_excludes_unsupported_non_shell_models(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model(
+            "gpt-internal",
+            supported_in_api=False,
+            raw={
+                "shell_type": "internal",
+                "visibility": "list",
+            },
+        ),
+    ]
+    await registry.update({"pro": models})
+
+    resp = await async_client.get("/backend-api/codex/models")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert "gpt-internal" not in {m["slug"] for m in payload["models"]}
+    assert "gpt-internal" not in {m["id"] for m in payload["data"]}
 
 
 @pytest.mark.asyncio
@@ -449,7 +499,7 @@ async def test_backend_codex_models_rewrites_visibility_when_opted_in(async_clie
             "gpt-hidden",
             supported_in_api=False,
             raw={
-                "shell_type": "shell_command",
+                "shell_type": "internal",
                 "visibility": "list",
             },
         ),
@@ -482,7 +532,8 @@ async def test_backend_codex_models_rewrites_visibility_when_opted_in(async_clie
     assert resp.status_code == 200
 
     entries = {entry["slug"]: entry for entry in resp.json()["models"]}
-    assert set(entries) == {"gpt-5.2", "gpt-5.3-codex"}
+    assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(entries)
+    assert "gpt-hidden" not in entries
     assert entries["gpt-5.2"]["visibility"] == "list"
     assert entries["gpt-5.3-codex"]["visibility"] == "hide"
 
@@ -535,7 +586,7 @@ async def test_backend_codex_models_visibility_allowlist_respects_enforced_model
     assert resp.status_code == 200
 
     entries = {entry["slug"]: entry for entry in resp.json()["models"]}
-    assert set(entries) == {"gpt-5.2", "gpt-5.3-codex"}
+    assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(entries)
     assert entries["gpt-5.2"]["visibility"] == "hide"
     assert entries["gpt-5.3-codex"]["visibility"] == "list"
 
@@ -591,7 +642,7 @@ async def test_model_catalogs_canonicalize_enforced_model_alias(async_client):
     codex_resp = await async_client.get("/backend-api/codex/models", headers={"Authorization": f"Bearer {key}"})
     assert codex_resp.status_code == 200
     entries = {entry["slug"]: entry for entry in codex_resp.json()["models"]}
-    assert set(entries) == {"gpt-5.2", "gpt-5.4-mini"}
+    assert {"gpt-5.2", "gpt-5.4-mini"}.issubset(entries)
     assert entries["gpt-5.2"]["visibility"] == "hide"
     assert entries["gpt-5.4-mini"]["visibility"] == "list"
 
@@ -642,18 +693,25 @@ async def test_backend_codex_models_preserves_original_flow_without_allowlist(as
     assert resp.status_code == 200
 
     entries = {entry["slug"]: entry for entry in resp.json()["models"]}
-    assert set(entries) == {"gpt-5.2", "gpt-5.3-codex"}
+    assert {"gpt-5.2", "gpt-5.3-codex"}.issubset(entries)
     assert entries["gpt-5.2"]["visibility"] == "hide"
     assert entries["gpt-5.3-codex"]["visibility"] == "list"
 
 
 @pytest.mark.asyncio
-async def test_backend_codex_models_excludes_supported_in_api_false_models(async_client):
+async def test_backend_codex_models_keeps_supported_in_api_false_entries_out_of_data(async_client):
     registry = get_model_registry()
     models = [
         _make_upstream_model("gpt-5.2"),
         _make_upstream_model("gpt-5.3-codex"),
-        _make_upstream_model("gpt-hidden", supported_in_api=False),
+        _make_upstream_model(
+            "gpt-5.3-codex-spark",
+            supported_in_api=False,
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "list",
+            },
+        ),
     ]
     await registry.update({"plus": models, "pro": models})
 
@@ -662,7 +720,8 @@ async def test_backend_codex_models_excludes_supported_in_api_false_models(async
     slugs = {m["slug"] for m in resp.json()["models"]}
     assert "gpt-5.2" in slugs
     assert "gpt-5.3-codex" in slugs
-    assert "gpt-hidden" not in slugs
+    assert "gpt-5.3-codex-spark" in slugs
+    assert "gpt-5.3-codex-spark" not in {m["id"] for m in resp.json()["data"]}
 
 
 @pytest.mark.asyncio
@@ -687,7 +746,14 @@ async def test_model_sets_are_consistent_across_api_endpoints(async_client):
     models = [
         _make_upstream_model("gpt-5.2"),
         _make_upstream_model("gpt-5.3-codex"),
-        _make_upstream_model("gpt-hidden", supported_in_api=False),
+        _make_upstream_model(
+            "gpt-hidden",
+            supported_in_api=False,
+            raw={
+                "shell_type": "internal",
+                "visibility": "list",
+            },
+        ),
     ]
     await registry.update({"plus": models, "pro": models})
 
@@ -705,7 +771,8 @@ async def test_model_sets_are_consistent_across_api_endpoints(async_client):
     assert "gpt-hidden" not in dashboard_ids
     assert "gpt-hidden" not in v1_ids
     assert "gpt-hidden" not in codex_slugs
-    assert dashboard_ids == v1_ids == codex_slugs
+    assert dashboard_ids == v1_ids
+    assert dashboard_ids.issubset(codex_slugs)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -106,6 +106,17 @@ async def test_plan_types_for_model_returns_plans():
     assert registry.plan_types_for_model("model-c") == frozenset({"pro"})
 
 
+@pytest.mark.parametrize("model_slug", ["gpt-5.5", "gpt-5.3-codex-spark"])
+@pytest.mark.asyncio
+async def test_plan_types_for_bootstrap_model_uses_live_snapshot_after_refresh(model_slug: str):
+    registry = ModelRegistry(ttl_seconds=60.0)
+    await registry.update({"team": [_model(model_slug)]})
+
+    plans = registry.plan_types_for_model(model_slug)
+
+    assert plans == frozenset({"team"})
+
+
 @pytest.mark.asyncio
 async def test_prefers_websockets_uses_snapshot_value():
     registry = ModelRegistry(ttl_seconds=60.0)
@@ -274,7 +285,9 @@ async def test_plan_types_for_model_service_tier_tracks_tier_plans():
     registry = ModelRegistry(ttl_seconds=60.0)
     await registry.update({"pro": [fast], "plus": [no_fast]})
 
-    assert registry.plan_types_for_model("gpt-5.5") == frozenset({"pro", "plus"})
+    model_plans = registry.plan_types_for_model("gpt-5.5")
+    assert model_plans is not None
+    assert {"pro", "plus"}.issubset(model_plans)
     assert registry.plan_types_for_model_service_tier("gpt-5.5", "priority") == frozenset({"pro"})
     assert registry.plan_types_for_model_service_tier("gpt-5.5", "fast") == frozenset({"pro"})
     assert registry.plan_types_for_model_service_tier("gpt-5.5", "default") == frozenset({"plus"})


### PR DESCRIPTION
## Summary

- keep Codex shell-command models in `/backend-api/codex/models` even when they are not OpenAI-compatible API models
- keep other `supported_in_api=false` models out of the Codex catalog, `/v1/models`, `/api/models`, and the OpenAI-style `data` payload
- restore the live snapshot as authoritative after model-registry refresh instead of extending it with bootstrap-only models
- update the API key OpenSpec model-list contract for the Codex-native shell-model exception

## Tests

- `uv run pytest tests/unit/test_model_registry.py tests/integration/test_v1_models.py -q`
- `uv run openspec validate --specs`
