### PR TITLE
feat(metrics): expose account inflight lease gauge

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -869,6 +869,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "0xSolarPunk",
+      "name": "anime girl",
+      "avatar_url": "https://avatars.githubusercontent.com/u/151763538?v=4",
+      "profile": "https://github.com/0xSolarPunk",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/core/metrics/prometheus.py
+++ b/app/core/metrics/prometheus.py
@@ -207,6 +207,13 @@ if PROMETHEUS_AVAILABLE:
         ["kind"],
         registry=REGISTRY,
     )
+    account_inflight_leases = Gauge(
+        "codex_lb_account_inflight_leases",
+        "Current in-process account pressure leases by account and kind",
+        ["account_id", "kind"],
+        registry=REGISTRY,
+        **_gauge_kwargs,
+    )
     account_cap_rejections_total = Counter(
         "codex_lb_account_cap_rejections_total",
         "Total account-local cap rejections by kind",
@@ -259,6 +266,7 @@ else:
     account_lease_acquired_total: CounterLike | None = None
     account_lease_released_total: CounterLike | None = None
     account_lease_stale_reclaimed_total: CounterLike | None = None
+    account_inflight_leases: GaugeLike | None = None
     account_cap_rejections_total: CounterLike | None = None
 
     def make_scrape_registry() -> None:
@@ -274,6 +282,7 @@ __all__ = [
     "REGISTRY",
     "active_connections",
     "account_cap_rejections_total",
+    "account_inflight_leases",
     "account_lease_acquired_total",
     "account_lease_released_total",
     "account_lease_stale_reclaimed_total",

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -40,6 +40,7 @@ from app.core.config.settings_cache import get_settings_cache
 from app.core.metrics.prometheus import (
     PROMETHEUS_AVAILABLE,
     account_cap_rejections_total,
+    account_inflight_leases,
     account_lease_acquired_total,
     account_lease_released_total,
     account_lease_stale_reclaimed_total,
@@ -236,6 +237,7 @@ class LoadBalancer:
         runtime.last_selected_at = time.time()
         runtime.version += 1
         _record_account_lease_acquired(kind)
+        _record_account_inflight_leases(account_id, runtime)
         return lease
 
     def _account_lease_allowed_locked(self, account_id: str, *, kind: AccountLeaseKind) -> bool:
@@ -260,6 +262,7 @@ class LoadBalancer:
         runtime.leased_tokens = max(0.0, runtime.leased_tokens - current.estimated_tokens)
         runtime.version += 1
         _record_account_lease_released(current.kind, reason)
+        _record_account_inflight_leases(current.account_id, runtime)
         if reason == "stale":
             _record_account_lease_stale_reclaimed(current.kind)
             logger.warning(
@@ -1759,6 +1762,14 @@ def _record_account_lease_released(kind: AccountLeaseKind, reason: str) -> None:
 def _record_account_lease_stale_reclaimed(kind: AccountLeaseKind) -> None:
     if PROMETHEUS_AVAILABLE and account_lease_stale_reclaimed_total is not None:
         account_lease_stale_reclaimed_total.labels(kind=kind).inc()
+
+
+def _record_account_inflight_leases(account_id: str, runtime: RuntimeState) -> None:
+    if PROMETHEUS_AVAILABLE and account_inflight_leases is not None:
+        account_inflight_leases.labels(account_id=account_id, kind="response_create").set(
+            runtime.inflight_response_creates
+        )
+        account_inflight_leases.labels(account_id=account_id, kind="stream").set(runtime.inflight_streams)
 
 
 def _record_account_cap_rejection(kind: AccountLeaseKind | None) -> None:

--- a/openspec/changes/add-account-inflight-lease-metrics/proposal.md
+++ b/openspec/changes/add-account-inflight-lease-metrics/proposal.md
@@ -1,0 +1,17 @@
+# Add account inflight lease metrics
+
+## Why
+
+Operators can currently see cumulative account lease acquisitions, releases, stale reclaims, and cap rejections, but not the live number of leases consuming each account-local cap. During stream-cap saturation this makes it hard to distinguish "all active streams are legitimately busy" from "leases leaked or stale state is holding the account unavailable."
+
+## What Changes
+
+- Add a Prometheus gauge for current in-process account leases by account and lease kind.
+- Update the gauge whenever the load balancer acquires, releases, or stale-reclaims an account lease.
+- Keep the metric labels bounded to account id and lease kind, and forbid request/session identifiers or credentials in labels.
+
+## Impact
+
+- Affects proxy-runtime observability only.
+- Does not change account selection or cap enforcement behavior.
+- Helps operators see active `stream` and `response_create` pressure before and during `account_stream_cap` or `account_response_create_cap` rejections.

--- a/openspec/changes/add-account-inflight-lease-metrics/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/add-account-inflight-lease-metrics/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Responses concurrency pressure is observable
+
+The service MUST expose low-cardinality logs and metrics for account-local in-flight create count, active stream count, leased token/cost pressure, cap rejections, lease stale reclaims, soft-affinity reroutes, and local-vs-upstream 429 classification. Observability MUST avoid raw prompt text, raw affinity keys, API keys, emails, request ids, session ids, and request payload content.
+
+The service MUST expose a Prometheus gauge named `codex_lb_account_inflight_leases` labeled by `account_id` and `kind`, where `kind` is either `stream` or `response_create`. The gauge value MUST equal the current in-process account lease count for that account and kind. The gauge MUST update when a lease is acquired, explicitly released, or reclaimed as stale. Gauge labels MUST NOT include raw prompt text, raw affinity keys, API keys, emails, request ids, session ids, or request payload content.
+
+#### Scenario: Local and upstream 429s are separated
+
+- **WHEN** local admission rejects a request and upstream later returns a rate limit for another request
+- **THEN** logs and metrics distinguish local overload reasons from normalized upstream `upstream_rate_limit`
+- **AND** preserved upstream wire payloads may retain upstream codes such as `rate_limit_exceeded`, `usage_limit_reached`, or `insufficient_quota`
+
+#### Scenario: Active account leases update gauge
+
+- **WHEN** the proxy acquires a `stream` lease for account `acc_1`
+- **THEN** `codex_lb_account_inflight_leases{account_id="acc_1",kind="stream"}` increases to the current active stream lease count
+- **AND** `codex_lb_account_inflight_leases{account_id="acc_1",kind="response_create"}` remains the current active response-create lease count
+
+#### Scenario: Released account leases reset gauge
+
+- **WHEN** the proxy explicitly releases or stale-reclaims the last active `stream` lease for account `acc_1`
+- **THEN** `codex_lb_account_inflight_leases{account_id="acc_1",kind="stream"}` is set to `0`

--- a/openspec/changes/add-account-inflight-lease-metrics/tasks.md
+++ b/openspec/changes/add-account-inflight-lease-metrics/tasks.md
@@ -1,0 +1,15 @@
+## 1. OpenSpec
+
+- [x] 1.1 Define the account inflight lease metric contract.
+
+## 2. Backend
+
+- [x] 2.1 Add the Prometheus account inflight lease gauge.
+- [x] 2.2 Update the gauge from account lease acquire, release, and stale reclaim paths.
+
+## 3. Validation
+
+- [x] 3.1 Add metrics registry coverage.
+- [x] 3.2 Add load-balancer lease lifecycle coverage.
+- [ ] 3.3 Run OpenSpec validation when the CLI is available locally (`openspec` and `uv run openspec` are unavailable in this environment).
+- [x] 3.4 Run targeted tests, ruff, format check, and diff check.

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -136,6 +136,24 @@ def _usage_row_with_percent(
     return row
 
 
+class _FakeGaugeChild:
+    def __init__(self, values: dict[tuple[str, str], float], account_id: str, kind: str) -> None:
+        self._values = values
+        self._account_id = account_id
+        self._kind = kind
+
+    def set(self, value: float) -> None:
+        self._values[(self._account_id, self._kind)] = value
+
+
+class _FakeAccountInflightGauge:
+    def __init__(self) -> None:
+        self.values: dict[tuple[str, str], float] = {}
+
+    def labels(self, *, account_id: str, kind: str) -> _FakeGaugeChild:
+        return _FakeGaugeChild(self.values, account_id, kind)
+
+
 @pytest.mark.asyncio
 async def test_select_account_100_concurrent_calls_avoid_serial_persist_latency(
     monkeypatch: pytest.MonkeyPatch,
@@ -242,6 +260,35 @@ async def test_stale_reclaim_still_recovers_old_response_create_lease(
 
     assert replacement_lease is not None
     assert await balancer.account_pressure_snapshot(account.id) == (1, 0, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_account_inflight_lease_metric_tracks_acquire_and_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _make_account("acc-inflight-metric")
+    balancer = LoadBalancer(lambda: _repo_factory(_StubAccountsRepository([account]), _StubUsageRepository({}, {})))
+    gauge = _FakeAccountInflightGauge()
+    monkeypatch.setattr(load_balancer_module, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(load_balancer_module, "account_inflight_leases", gauge)
+
+    stream_lease = await balancer.acquire_account_lease(account.id, kind="stream")
+    assert stream_lease is not None
+    assert gauge.values[(account.id, "response_create")] == 0
+    assert gauge.values[(account.id, "stream")] == 1
+
+    response_create_lease = await balancer.acquire_account_lease(account.id, kind="response_create")
+    assert response_create_lease is not None
+    assert gauge.values[(account.id, "response_create")] == 1
+    assert gauge.values[(account.id, "stream")] == 1
+
+    await balancer.release_account_lease(stream_lease)
+    assert gauge.values[(account.id, "response_create")] == 1
+    assert gauge.values[(account.id, "stream")] == 0
+
+    await balancer.release_account_lease(response_create_lease)
+    assert gauge.values[(account.id, "response_create")] == 0
+    assert gauge.values[(account.id, "stream")] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -24,6 +24,9 @@ class _MetricChild:
     def dec(self, amount: float = 1.0) -> None:
         self.value -= amount
 
+    def set(self, value: float) -> None:
+        self.value = value
+
     def observe(self, amount: float) -> None:
         self.observations.append(amount)
 
@@ -129,6 +132,8 @@ def test_prometheus_metrics_defined_when_dependency_available(monkeypatch: pytes
     assert prometheus_module.continuity_owner_resolution_total.labelnames == ("surface", "source", "outcome")
     assert prometheus_module.continuity_fail_closed_total.name == "codex_lb_continuity_fail_closed_total"
     assert prometheus_module.continuity_fail_closed_total.labelnames == ("surface", "reason")
+    assert prometheus_module.account_inflight_leases.name == "codex_lb_account_inflight_leases"
+    assert prometheus_module.account_inflight_leases.labelnames == ("account_id", "kind")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a live Prometheus gauge for account-local inflight pressure leases so operators can see current `stream` and `response_create` lease counts instead of inferring saturation from cap rejections alone.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: N/A

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/add-account-inflight-lease-metrics/`

## Changes

- Adds `codex_lb_account_inflight_leases{account_id,kind}` to the Prometheus registry.
- Updates the gauge from account lease acquire, explicit release, and stale reclaim paths.
- Adds unit coverage for metric registration and acquire/release gauge behavior.

## Test plan

```bash
uv run pytest tests/unit/test_metrics.py tests/unit/test_load_balancer_concurrency.py
# 16 passed

uv run ruff check app/core/metrics/prometheus.py app/modules/proxy/load_balancer.py tests/unit/test_metrics.py tests/unit/test_load_balancer_concurrency.py
# All checks passed!

uv run ruff format --check app/core/metrics/prometheus.py app/modules/proxy/load_balancer.py tests/unit/test_metrics.py tests/unit/test_load_balancer_concurrency.py
# 4 files already formatted

git diff --check
# passed
```

OpenSpec validation note: `openspec` is not installed in this local environment. Both `openspec validate add-account-inflight-lease-metrics --strict` and `uv run openspec validate add-account-inflight-lease-metrics --strict` failed with missing executable / failed spawn.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
