### PR TITLE
Fix remote dashboard bind defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ CODEX_LB_DATABASE_MIGRATE_ON_STARTUP=true
 CODEX_LB_DATABASE_SQLITE_PRE_MIGRATE_BACKUP_ENABLED=true
 CODEX_LB_DATABASE_SQLITE_PRE_MIGRATE_BACKUP_MAX_FILES=5
 
+# HTTP listener. Use 0.0.0.0 for Docker, VMs, and remote dashboards.
+# Set to 127.0.0.1 only when an outer tunnel or reverse proxy is the sole entry point.
+CODEX_LB_HOST=0.0.0.0
+
 # Upstream ChatGPT base URL (no /codex suffix)
 CODEX_LB_UPSTREAM_BASE_URL=https://chatgpt.com/backend-api
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ docker run -d --name codex-lb \
 uvx codex-lb
 ```
 
+The CLI listens on `0.0.0.0:2455` by default so Docker, VMs, and remote dashboards can reach it. For a local-only listener, run `codex-lb --host 127.0.0.1` or set `CODEX_LB_HOST=127.0.0.1`.
+
 Open [localhost:2455](http://localhost:2455) → Add account → Done.
 
 ## Remote Setup
@@ -105,6 +107,13 @@ docker run -d --name codex-lb \
 ```
 
 **Local access** (localhost) bypasses bootstrap entirely — no token needed.
+
+If `http://<server-ip>:2455/dashboard` times out, verify that the process is listening on all interfaces and that the host firewall or cloud security group allows TCP `2455`:
+
+```bash
+ss -ltnp | grep 2455
+sudo ufw status
+```
 
 ## Client Setup
 
@@ -471,6 +480,7 @@ Backup this directory to preserve your data.
 ## Troubleshooting
 
 - [Usage and quota - why does codex-lb still say `rate_limited` when Codex Desktop says reset?](openspec/specs/usage-refresh-policy/context.md)
+- Remote dashboard does not load: make sure codex-lb is bound to `0.0.0.0:2455` and TCP `2455` is open. If you intentionally bind the app to `127.0.0.1`, access it through SSH port forwarding or a reverse proxy instead of `http://<server-ip>:2455`.
 
 ## Kubernetes
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -55,7 +55,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Confirm that Codex/Codex CLI is closed and allow a non-interactive write.",
     )
 
-    parser.add_argument("--host", default=os.getenv("HOST", "127.0.0.1"))
+    parser.add_argument("--host", default=os.getenv("CODEX_LB_HOST") or os.getenv("HOST", "0.0.0.0"))
     parser.add_argument("--port", default=os.getenv("PORT", "2455"))
     parser.add_argument("--ssl-certfile", default=os.getenv("SSL_CERTFILE"))
     parser.add_argument("--ssl-keyfile", default=os.getenv("SSL_KEYFILE"))

--- a/openspec/changes/fix-remote-dashboard-bind/proposal.md
+++ b/openspec/changes/fix-remote-dashboard-bind/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+Operators running `codex-lb` directly with `uvx` or the console script can end up with a dashboard that works only from localhost. That presents as `http://<server-ip>:2455/dashboard` timing out even though the process is running, while Docker deployments already bind the service to all interfaces.
+
+## What Changes
+
+- Make the CLI server bind default match the Docker image: `0.0.0.0:2455`.
+- Add `CODEX_LB_HOST` as the project-specific environment override, while keeping `--host` as the highest-precedence explicit choice.
+- Document how to force local-only binding and how to diagnose closed remote port access.
+
+## Impact
+
+- CLI startup behavior for `codex-lb` and `uvx codex-lb`.
+- Operator docs and `.env.example`.
+- Unit tests for CLI bind-address precedence.

--- a/openspec/changes/fix-remote-dashboard-bind/specs/deployment-networking/spec.md
+++ b/openspec/changes/fix-remote-dashboard-bind/specs/deployment-networking/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: CLI HTTP listener defaults to remote-capable binding
+
+The CLI server entrypoint and packaged Docker entrypoint MUST bind the main HTTP listener to `0.0.0.0` by default so Docker, VM, and remote-dashboard deployments are reachable through a published or firewall-opened TCP `2455` port. The CLI MUST allow operators to force local-only binding with `--host 127.0.0.1` or `CODEX_LB_HOST=127.0.0.1`. The Docker entrypoint MUST honor `CODEX_LB_HOST` and `PORT` while keeping `0.0.0.0:2455` as its default. When both `CODEX_LB_HOST` and the generic `HOST` environment variable are set, `CODEX_LB_HOST` MUST take precedence. When `--host` is provided, it MUST take precedence over environment defaults.
+
+#### Scenario: Direct CLI run is reachable through a published remote port
+
+- **WHEN** an operator starts `codex-lb` without a host override
+- **THEN** the server binds the main HTTP listener to `0.0.0.0`
+- **AND** remote reachability is controlled by the operating-system firewall, cloud security group, or outer publish layer rather than by a loopback-only app bind
+
+#### Scenario: Local-only bind remains available
+
+- **WHEN** an operator starts `codex-lb --host 127.0.0.1`
+- **THEN** the server binds the main HTTP listener to `127.0.0.1`
+
+#### Scenario: Project-specific host env wins
+
+- **GIVEN** `CODEX_LB_HOST=0.0.0.0`
+- **AND** `HOST=127.0.0.1`
+- **WHEN** an operator starts `codex-lb`
+- **THEN** the server binds the main HTTP listener to `0.0.0.0`

--- a/openspec/changes/fix-remote-dashboard-bind/tasks.md
+++ b/openspec/changes/fix-remote-dashboard-bind/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Default CLI HTTP binding to `0.0.0.0`.
+- [x] 1.2 Add `CODEX_LB_HOST` as the project-specific environment override while preserving `--host` precedence.
+- [x] 1.3 Make the Docker entrypoint honor the same host and port environment defaults.
+
+## 2. Documentation
+
+- [x] 2.1 Document the default remote-capable bind address and local-only override.
+- [x] 2.2 Add remote dashboard timeout troubleshooting notes.
+
+## 3. Verification
+
+- [x] 3.1 Add unit coverage for default bind behavior.
+- [x] 3.2 Add unit coverage for `CODEX_LB_HOST` and CLI override precedence.

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -9,4 +9,7 @@ fi
 # run migrations again inside the app process.
 export CODEX_LB_DATABASE_MIGRATE_ON_STARTUP=false
 
-exec python -m app.cli --host 0.0.0.0 --port 2455
+host="${CODEX_LB_HOST:-${HOST:-0.0.0.0}}"
+port="${PORT:-2455}"
+
+exec python -m app.cli --host "$host" --port "$port"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -37,6 +37,55 @@ def test_main_passes_timestamped_log_config(monkeypatch):
     assert kwargs["timeout_keep_alive"] == 7200
 
 
+def test_main_binds_all_interfaces_by_default(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(sys, "argv", ["codex-lb"])
+    monkeypatch.delenv("CODEX_LB_HOST", raising=False)
+    monkeypatch.delenv("HOST", raising=False)
+    monkeypatch.setattr(cli, "_load_uvicorn", lambda: SimpleNamespace(run=fake_run))
+
+    cli.main()
+
+    assert captured["kwargs"]["host"] == "0.0.0.0"
+
+
+def test_main_prefers_codex_lb_host_env(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(sys, "argv", ["codex-lb"])
+    monkeypatch.setenv("HOST", "127.0.0.1")
+    monkeypatch.setenv("CODEX_LB_HOST", "0.0.0.0")
+    monkeypatch.setattr(cli, "_load_uvicorn", lambda: SimpleNamespace(run=fake_run))
+
+    cli.main()
+
+    assert captured["kwargs"]["host"] == "0.0.0.0"
+
+
+def test_main_allows_cli_host_override(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(sys, "argv", ["codex-lb", "--host", "127.0.0.1"])
+    monkeypatch.setattr(cli, "_load_uvicorn", lambda: SimpleNamespace(run=fake_run))
+
+    cli.main()
+
+    assert captured["kwargs"]["host"] == "127.0.0.1"
+
+
 def test_main_passes_custom_keep_alive_timeout(monkeypatch):
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
- default the CLI HTTP listener to `0.0.0.0` so direct `uvx codex-lb` runs are reachable on remote hosts
- add `CODEX_LB_HOST` precedence and make the Docker entrypoint honor host/port env overrides
- document remote dashboard timeout checks and record the deployment-networking OpenSpec delta

## Verification
- `git diff --check`
- Not run: `uv run pytest tests/unit/test_cli.py` because this Windows workspace does not have Python, uv, or Docker installed.