### PR TITLE
fix(proxy): fallback v1 usage limits to upstream quotas

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -847,13 +847,16 @@ async def v1_usage(
     if usage is None:
         raise ProxyAuthError("Invalid API key")
 
+    own_limits = [_to_v1_usage_limit_response(limit) for limit in usage.limits]
+    upstream_limits = [] if hide_upstream_limits else _ordered_aggregate_limits(aggregate_limits)
+
     return V1UsageResponse(
         request_count=usage.request_count,
         total_tokens=usage.total_tokens,
         cached_input_tokens=usage.cached_input_tokens,
         total_cost_usd=usage.total_cost_usd,
-        limits=[_to_v1_usage_limit_response(limit) for limit in usage.limits],
-        upstream_limits=[] if hide_upstream_limits else _ordered_aggregate_limits(aggregate_limits),
+        limits=own_limits or upstream_limits,
+        upstream_limits=upstream_limits,
         account_pool_usage=account_pool_usage,
     )
 

--- a/openspec/changes/v1-usage-limits-upstream-fallback/proposal.md
+++ b/openspec/changes/v1-usage-limits-upstream-fallback/proposal.md
@@ -1,0 +1,24 @@
+# v1-usage-limits-upstream-fallback
+
+## Why
+
+Legacy `/v1/usage` consumers (for example, OpenCodeBar-style status widgets) only read the `limits[]` array and ignore `upstream_limits[]`. When an API key has no self-service limits configured, those clients render "no limits" even though the aggregate upstream Codex quota windows are already computed and exposed to the same caller via `upstream_limits[]`. The information is visible either way; only the legacy field stays empty.
+
+## What Changes
+
+- `GET /v1/usage` populates the legacy `limits[]` array with the already-visible aggregate upstream quota windows (`upstream_limits[]`) when the authenticated API key has no limits of its own.
+- Explicit API-key limits stay preferred: when the key has configured limits, `limits[]` contains only those limits, exactly as before.
+- `upstream_limits[]` itself is unchanged, and visibility rules are unchanged: when upstream quota details are hidden from the key (for example via `hide_upstream_quota_from_api_keys`), `limits[]` stays empty rather than leaking hidden data.
+
+## Scope
+
+- Backend `/v1/usage` response assembly only.
+- No database schema changes.
+- No frontend changes.
+- No new data exposure: the fallback only mirrors quota windows the caller can already read from `upstream_limits[]`.
+
+## Impact
+
+- Modified capability: `api-keys` (requirement "API keys can read their own `/v1/usage`").
+- Code: `app/modules/proxy/api.py` (`v1_usage` handler).
+- Tests: `tests/integration/test_v1_usage.py` regression coverage for the mirrored `limits[]` payload.

--- a/openspec/changes/v1-usage-limits-upstream-fallback/specs/api-keys/spec.md
+++ b/openspec/changes/v1-usage-limits-upstream-fallback/specs/api-keys/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: API keys can read their own `/v1/usage`
+
+The system SHALL expose `GET /v1/usage` for self-service usage lookup by API-key clients. The route MUST require a valid API key in the `Authorization` header using the Bearer authentication scheme even when `api_key_auth_enabled` is false globally. The response MUST include only data for the authenticated key and explicitly visible aggregate upstream quota sections, and MUST return:
+
+- `request_count`
+- `total_tokens`
+- `cached_input_tokens`
+- `total_cost_usd`
+- `limits[]` containing limits configured on the authenticated API key, with `limit_type`, `limit_window`, `max_value`, `current_value`, `remaining_value`, `model_filter`, `reset_at`, and `source`. When no API-key limits are configured and aggregate upstream quota details are visible to the caller, `limits[]` MAY mirror those aggregate upstream credit windows for legacy client compatibility.
+- `upstream_limits[]` containing aggregate upstream Codex credit windows when available, with the same fields and `source: "aggregate"`
+
+Validation failures MUST use the existing OpenAI error envelope used by `/v1/*` routes.
+
+#### Scenario: Missing API key is rejected
+
+- **WHEN** a client calls `GET /v1/usage` without a Bearer token
+- **THEN** the system returns 401 in the OpenAI error format
+
+#### Scenario: Invalid API key is rejected
+
+- **WHEN** a client calls `GET /v1/usage` with an unknown, expired, or inactive Bearer key
+- **THEN** the system returns 401 in the OpenAI error format
+
+#### Scenario: Key with no usage returns zero totals
+
+- **WHEN** a valid API key with no request-log usage calls `GET /v1/usage`
+- **THEN** the system returns `request_count: 0`, `total_tokens: 0`, `cached_input_tokens: 0`, `total_cost_usd: 0.0`
+
+#### Scenario: Usage is scoped to the authenticated key
+
+- **WHEN** multiple API keys have request-log history and one of them calls `GET /v1/usage`
+- **THEN** the response includes only the usage totals and limits for that authenticated key
+
+#### Scenario: Upstream limits are separate from API-key limits
+
+- **WHEN** an API key with its own limit calls `GET /v1/usage`
+- **AND** upstream Codex aggregate usage data exists
+- **THEN** `limits[]` contains the API-key limit values
+- **AND** `upstream_limits[]` contains the aggregate Codex credit windows
+
+#### Scenario: Upstream limits are mirrored for legacy clients without API-key limits
+
+- **WHEN** an API key without its own limits calls `GET /v1/usage`
+- **AND** upstream Codex aggregate usage data is visible to the key
+- **THEN** `upstream_limits[]` contains the aggregate Codex credit windows
+- **AND** `limits[]` contains the same aggregate Codex credit windows for legacy client compatibility
+
+#### Scenario: Self-usage works while global proxy auth is disabled
+
+- **WHEN** `api_key_auth_enabled` is false and a client calls `GET /v1/usage` with a valid Bearer key
+- **THEN** the system still authenticates that key and returns the self-usage payload

--- a/openspec/changes/v1-usage-limits-upstream-fallback/tasks.md
+++ b/openspec/changes/v1-usage-limits-upstream-fallback/tasks.md
@@ -1,0 +1,6 @@
+## Tasks
+
+- [x] Fall back `limits[]` in `GET /v1/usage` to the visible aggregate upstream quota windows when the authenticated API key has no configured limits, keeping explicit API-key limits preferred.
+- [x] Keep `upstream_limits[]` and upstream-quota visibility rules unchanged, so hidden upstream quota never leaks through the fallback.
+- [x] Update the `api-keys` spec requirement and scenarios for the legacy `limits[]` fallback.
+- [x] Add regression coverage in `tests/integration/test_v1_usage.py` asserting `limits[]` mirrors `upstream_limits[]` for keys without their own limits.

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -568,13 +568,13 @@ The system MUST recognize `gpt-5.4-mini` pricing when computing request costs. S
 
 ### Requirement: API keys can read their own `/v1/usage`
 
-The system SHALL expose `GET /v1/usage` for self-service usage lookup by API-key clients. The route MUST require a valid API key in the `Authorization` header using the Bearer authentication scheme even when `api_key_auth_enabled` is false globally. The response MUST include only data for the authenticated key and MUST return:
+The system SHALL expose `GET /v1/usage` for self-service usage lookup by API-key clients. The route MUST require a valid API key in the `Authorization` header using the Bearer authentication scheme even when `api_key_auth_enabled` is false globally. The response MUST include only data for the authenticated key and explicitly visible aggregate upstream quota sections, and MUST return:
 
 - `request_count`
 - `total_tokens`
 - `cached_input_tokens`
 - `total_cost_usd`
-- `limits[]` containing only limits configured on the authenticated API key, with `limit_type`, `limit_window`, `max_value`, `current_value`, `remaining_value`, `model_filter`, `reset_at`, and `source`
+- `limits[]` containing limits configured on the authenticated API key, with `limit_type`, `limit_window`, `max_value`, `current_value`, `remaining_value`, `model_filter`, `reset_at`, and `source`. When no API-key limits are configured and aggregate upstream quota details are visible to the caller, `limits[]` MAY mirror those aggregate upstream credit windows for legacy client compatibility.
 - `upstream_limits[]` containing aggregate upstream Codex credit windows when available, with the same fields and `source: "aggregate"`
 
 Validation failures MUST use the existing OpenAI error envelope used by `/v1/*` routes.
@@ -605,6 +605,13 @@ Validation failures MUST use the existing OpenAI error envelope used by `/v1/*` 
 - **AND** upstream Codex aggregate usage data exists
 - **THEN** `limits[]` contains the API-key limit values
 - **AND** `upstream_limits[]` contains the aggregate Codex credit windows
+
+#### Scenario: Upstream limits are mirrored for legacy clients without API-key limits
+
+- **WHEN** an API key without its own limits calls `GET /v1/usage`
+- **AND** upstream Codex aggregate usage data is visible to the key
+- **THEN** `upstream_limits[]` contains the aggregate Codex credit windows
+- **AND** `limits[]` contains the same aggregate Codex credit windows for legacy client compatibility
 
 #### Scenario: Self-usage works while global proxy auth is disabled
 

--- a/tests/integration/test_v1_usage.py
+++ b/tests/integration/test_v1_usage.py
@@ -468,7 +468,6 @@ async def test_v1_usage_returns_aggregate_credit_limits_when_upstream_usage_exis
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["limits"] == []
     assert payload["upstream_limits"][0] == {
         "limit_type": "credits",
         "limit_window": "5h",
@@ -491,6 +490,7 @@ async def test_v1_usage_returns_aggregate_credit_limits_when_upstream_usage_exis
     }
     assert payload["upstream_limits"][0]["reset_at"].endswith("Z")
     assert payload["upstream_limits"][1]["reset_at"].endswith("Z")
+    assert payload["limits"] == payload["upstream_limits"]
 
 
 @pytest.mark.asyncio
@@ -733,7 +733,6 @@ async def test_v1_usage_ignores_paused_and_deactivated_accounts_in_aggregate_cre
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["limits"] == []
     assert payload["upstream_limits"] == [
         {
             "limit_type": "credits",
@@ -756,3 +755,4 @@ async def test_v1_usage_ignores_paused_and_deactivated_accounts_in_aggregate_cre
             "source": "aggregate",
         },
     ]
+    assert payload["limits"] == payload["upstream_limits"]


### PR DESCRIPTION
## Summary
- Populate `/v1/usage` `limits` from visible upstream aggregate quotas when an API key has no self-service limits configured.
- Keep explicit API-key limits preferred when present.
- Keep upstream quota hiding intact by reusing the already-hidden `upstream_limits` value for the fallback.

## Why
Some status-bar clients (including OpenCode Bar) only read the legacy `limits` field. After upstream quotas moved to `upstream_limits`, API keys without explicit self-service limits return `limits: []`, so those clients show 0%/no quota even though aggregate upstream quota data is available.

This preserves the newer separate `upstream_limits` field while keeping legacy clients compatible.

## Tests
- `.venv/bin/python -m pytest tests/integration/test_v1_usage.py`
